### PR TITLE
chore(release): publish 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3]
+
+### Added
+- **Interactive shell session state**: `target` command to set/show/clear default target address; `status` command shows transport, local address, BBMD registration, and discovered device count
+- **BBMD auto-renewal** in interactive shell: `register` stores registration and spawns background task to renew at 80% TTL; `unregister` cancels renewal; shown in `status` output
+- **Missing shell commands** now available interactively: `ack-alarm`/`ack`, `time-sync`/`ts`, `create-object`, `delete-object`, `read-range`/`rr`
+- **Shell `discover --bbmd`**: register as foreign device and discover in one step (BIP shell only)
+- **Colored terminal output** via `owo-colors`: green for success/values, red for errors, yellow for warnings, cyan for addresses, dimmed for metadata
+- Default target auto-prepend: commands like `read`, `write`, `subscribe` use the session default target when no target argument is given
+- Discovery progress feedback: "Waiting Ns for responses..." status line during WhoIs
+
+### Changed
+- Deduplicated `format_mac()` and `device_info()` into `output.rs` (removed from `discover.rs` and `router.rs`)
+- Removed dead code: `is_tty()`, `print_ok()`, `print_value()` from output module
+- BIP shell separated from generic shell for type-safe BBMD command dispatch
+
+### Fixed
+- Interactive `discover --target` returning "No devices found" on subsequent calls (removed stale HashSet filter)
+- Unused import `use bacnet_encoding::npdu::Npdu` in `bacnet-network/src/layer.rs`
+
 ## [0.6.2]
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-benchmarks"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -292,7 +292,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-cli"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -305,6 +305,7 @@ dependencies = [
  "comfy-table",
  "ctrlc",
  "libc",
+ "owo-colors",
  "pcap",
  "rustls",
  "rustls-native-certs",
@@ -320,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-client"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-encoding",
  "bacnet-network",
@@ -336,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-encoding"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-types",
  "bytes",
@@ -345,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-integration-tests"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -361,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-java"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -380,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-network"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-encoding",
  "bacnet-transport",
@@ -392,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-objects"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -402,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-encoding",
  "bacnet-network",
@@ -418,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-services"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -428,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-transport"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -446,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-types"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bitflags 2.11.0",
  "smallvec",
@@ -455,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-wasm"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-encoding",
  "bacnet-services",
@@ -1071,6 +1072,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,8 +1209,21 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1251,6 +1271,15 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -1402,13 +1431,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -1489,6 +1524,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1801,6 +1842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +1995,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2131,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radix_trie"
@@ -2284,7 +2347,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-bacnet"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -2549,12 +2612,12 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2630,7 +2693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3037,6 +3100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "uniffi"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "uniffi-bindgen"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "uniffi",
 ]
@@ -3236,6 +3305,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,6 +3410,40 @@ name = "wasm-bindgen-test-shared"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe29135b180b72b04c74aa97b2b4a2ef275161eff9a6c7955ea9eaedc7e1d4e"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "web-sys"
@@ -3503,7 +3615,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3512,16 +3624,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3539,31 +3642,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3582,12 +3668,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3598,12 +3678,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3618,22 +3692,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3648,12 +3710,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,22 +3722,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3694,12 +3738,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3715,6 +3753,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "x509-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 rust-version = "1.93"
 license = "MIT"
@@ -47,14 +47,14 @@ keywords = ["bacnet", "building-automation", "ashrae", "iot", "protocol"]
 categories = ["network-programming", "embedded"]
 
 [workspace.dependencies]
-bacnet-types = { version = "0.6.2", path = "crates/bacnet-types" }
-bacnet-encoding = { version = "0.6.2", path = "crates/bacnet-encoding" }
-bacnet-services = { version = "0.6.2", path = "crates/bacnet-services" }
-bacnet-transport = { version = "0.6.2", path = "crates/bacnet-transport" }
-bacnet-network = { version = "0.6.2", path = "crates/bacnet-network" }
-bacnet-client = { version = "0.6.2", path = "crates/bacnet-client" }
-bacnet-objects = { version = "0.6.2", path = "crates/bacnet-objects" }
-bacnet-server = { version = "0.6.2", path = "crates/bacnet-server" }
+bacnet-types = { version = "0.6.3", path = "crates/bacnet-types" }
+bacnet-encoding = { version = "0.6.3", path = "crates/bacnet-encoding" }
+bacnet-services = { version = "0.6.3", path = "crates/bacnet-services" }
+bacnet-transport = { version = "0.6.3", path = "crates/bacnet-transport" }
+bacnet-network = { version = "0.6.3", path = "crates/bacnet-network" }
+bacnet-client = { version = "0.6.3", path = "crates/bacnet-client" }
+bacnet-objects = { version = "0.6.3", path = "crates/bacnet-objects" }
+bacnet-server = { version = "0.6.3", path = "crates/bacnet-server" }
 thiserror = "2"
 bitflags = "2"
 bytes = "1"

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ dependencyResolutionManagement {
 
 // build.gradle.kts
 dependencies {
-    implementation("io.github.jscott3201:bacnet-java:0.6.2")
+    implementation("io.github.jscott3201:bacnet-java:0.6.3")
 }
 ```
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bacnet-benchmarks"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 publish = false
 

--- a/crates/bacnet-cli/Cargo.toml
+++ b/crates/bacnet-cli/Cargo.toml
@@ -40,6 +40,7 @@ rustls-pki-types = { version = "1", optional = true }
 pcap = { version = "2", optional = true }
 ctrlc = { version = "3", optional = true }
 libc = { version = "0.2", optional = true }
+owo-colors = "4.3.0"
 
 [features]
 default = []

--- a/crates/bacnet-cli/src/commands/device.rs
+++ b/crates/bacnet-cli/src/commands/device.rs
@@ -1,5 +1,5 @@
 //! Device management commands: DeviceCommunicationControl, ReinitializeDevice, GetEventInformation,
-//! AcknowledgeAlarm, CreateObject, DeleteObject.
+//! AcknowledgeAlarm, CreateObject, DeleteObject, TimeSync.
 
 use bacnet_client::client::BACnetClient;
 use bacnet_transport::port::TransportPort;
@@ -7,6 +7,67 @@ use bacnet_types::enums::{EnableDisable, ObjectType, ReinitializedState};
 use bacnet_types::primitives::ObjectIdentifier;
 
 use crate::output::{self, OutputFormat};
+
+/// Synchronize time with a remote device.
+pub async fn time_sync_cmd<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    mac: &[u8],
+    utc: bool,
+    format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| format!("system time error: {e}"))?;
+    let secs = now.as_secs();
+
+    // Convert epoch seconds to date/time components.
+    // Days since 1970-01-01.
+    let days = secs / 86400;
+    let day_secs = (secs % 86400) as u32;
+
+    let hour = (day_secs / 3600) as u8;
+    let minute = ((day_secs % 3600) / 60) as u8;
+    let second = (day_secs % 60) as u8;
+    let hundredths = ((now.subsec_millis() / 10) % 100) as u8;
+
+    // Civil date from days since epoch (algorithm from Howard Hinnant).
+    let z = days as i64 + 719468;
+    let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u8;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u8;
+    let y = if m <= 2 { y + 1 } else { y };
+
+    // Day of week: 1970-01-01 was Thursday (BACnet: 4).
+    let dow = ((days + 3) % 7 + 1) as u8; // 1=Monday..7=Sunday
+
+    let date = bacnet_types::primitives::Date {
+        year: (y - 1900) as u8,
+        month: m,
+        day: d,
+        day_of_week: dow,
+    };
+    let time = bacnet_types::primitives::Time {
+        hour,
+        minute,
+        second,
+        hundredths,
+    };
+
+    if utc {
+        client.utc_time_synchronization(mac, date, time).await?;
+    } else {
+        // For local time sync we also use UTC since we don't have
+        // a timezone library. Document this limitation.
+        client.time_synchronization(mac, date, time).await?;
+    }
+    output::print_success("Time synchronized", format);
+    Ok(())
+}
 
 /// Parse an action string into an `EnableDisable` value.
 fn parse_enable_disable(action: &str) -> Result<EnableDisable, String> {

--- a/crates/bacnet-cli/src/commands/discover.rs
+++ b/crates/bacnet-cli/src/commands/discover.rs
@@ -1,38 +1,30 @@
 //! Discovery commands: WhoIs and WhoHas.
 
-use std::collections::HashSet;
-use std::net::Ipv4Addr;
-
 use bacnet_client::client::BACnetClient;
-use bacnet_client::discovery::DiscoveredDevice;
 use bacnet_services::who_has::WhoHasObject;
 use bacnet_transport::port::TransportPort;
 
-use crate::output::{self, DeviceInfo, OutputFormat};
+use crate::output::{self, device_info, DeviceInfo, OutputFormat};
 
-/// Format a BIP MAC address (6 bytes: 4 IP + 2 port) as `ip:port`.
-/// Falls back to hex display for non-BIP MACs.
-fn format_mac(mac: &[u8]) -> String {
-    if mac.len() == 6 {
-        let ip = Ipv4Addr::new(mac[0], mac[1], mac[2], mac[3]);
-        let port = u16::from_be_bytes([mac[4], mac[5]]);
-        format!("{ip}:{port}")
-    } else {
-        mac.iter()
-            .map(|b| format!("{b:02x}"))
-            .collect::<Vec<_>>()
-            .join(":")
-    }
-}
-
-fn device_info(d: &DiscoveredDevice) -> DeviceInfo {
-    DeviceInfo {
-        instance: d.object_identifier.instance_number(),
-        address: format_mac(d.mac_address.as_slice()),
-        vendor_id: d.vendor_id,
-        max_apdu: d.max_apdu_length,
-        segmentation: format!("{}", d.segmentation_supported),
-    }
+/// Collect device infos from the client's discovered device table,
+/// optionally filtering by instance range.
+async fn collect_devices<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    low: Option<u32>,
+    high: Option<u32>,
+) -> Vec<DeviceInfo> {
+    let devices = client.discovered_devices().await;
+    devices
+        .iter()
+        .filter(|d| {
+            let inst = d.object_identifier.instance_number();
+            match (low, high) {
+                (Some(lo), Some(hi)) => inst >= lo && inst <= hi,
+                _ => true,
+            }
+        })
+        .map(device_info)
+        .collect()
 }
 
 /// Send a WhoIs broadcast and display discovered devices after waiting.
@@ -43,24 +35,10 @@ pub async fn discover<T: TransportPort + 'static>(
     wait_secs: u64,
     format: OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Snapshot existing devices before the scan.
-    let before: HashSet<u32> = client
-        .discovered_devices()
-        .await
-        .iter()
-        .map(|d| d.object_identifier.instance_number())
-        .collect();
-
     client.who_is(low, high).await?;
+    output::print_waiting(wait_secs);
     tokio::time::sleep(std::time::Duration::from_secs(wait_secs)).await;
-
-    let devices = client.discovered_devices().await;
-    let infos: Vec<DeviceInfo> = devices
-        .iter()
-        .filter(|d| !before.contains(&d.object_identifier.instance_number()))
-        .map(device_info)
-        .collect();
-    output::print_devices(&infos, format);
+    output::print_devices(&collect_devices(client, low, high).await, format);
     Ok(())
 }
 
@@ -73,23 +51,10 @@ pub async fn discover_directed<T: TransportPort + 'static>(
     wait_secs: u64,
     format: OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let before: HashSet<u32> = client
-        .discovered_devices()
-        .await
-        .iter()
-        .map(|d| d.object_identifier.instance_number())
-        .collect();
-
     client.who_is_directed(target_mac, low, high).await?;
+    output::print_waiting(wait_secs);
     tokio::time::sleep(std::time::Duration::from_secs(wait_secs)).await;
-
-    let devices = client.discovered_devices().await;
-    let infos: Vec<DeviceInfo> = devices
-        .iter()
-        .filter(|d| !before.contains(&d.object_identifier.instance_number()))
-        .map(device_info)
-        .collect();
-    output::print_devices(&infos, format);
+    output::print_devices(&collect_devices(client, low, high).await, format);
     Ok(())
 }
 
@@ -102,23 +67,10 @@ pub async fn discover_network<T: TransportPort + 'static>(
     wait_secs: u64,
     format: OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let before: HashSet<u32> = client
-        .discovered_devices()
-        .await
-        .iter()
-        .map(|d| d.object_identifier.instance_number())
-        .collect();
-
     client.who_is_network(dnet, low, high).await?;
+    output::print_waiting(wait_secs);
     tokio::time::sleep(std::time::Duration::from_secs(wait_secs)).await;
-
-    let devices = client.discovered_devices().await;
-    let infos: Vec<DeviceInfo> = devices
-        .iter()
-        .filter(|d| !before.contains(&d.object_identifier.instance_number()))
-        .map(device_info)
-        .collect();
-    output::print_devices(&infos, format);
+    output::print_devices(&collect_devices(client, low, high).await, format);
     Ok(())
 }
 

--- a/crates/bacnet-cli/src/commands/router.rs
+++ b/crates/bacnet-cli/src/commands/router.rs
@@ -3,11 +3,10 @@
 use std::net::Ipv4Addr;
 
 use bacnet_client::client::BACnetClient;
-use bacnet_client::discovery::DiscoveredDevice;
 use bacnet_transport::bip::BipTransport;
 use bacnet_transport::port::TransportPort;
 
-use crate::output::{self, DeviceInfo, OutputFormat};
+use crate::output::{self, device_info, DeviceInfo, OutputFormat};
 
 /// Display all cached discovered devices from the client's device table.
 pub async fn devices_cmd<T: TransportPort + 'static>(
@@ -18,29 +17,6 @@ pub async fn devices_cmd<T: TransportPort + 'static>(
     let infos: Vec<DeviceInfo> = devices.iter().map(device_info).collect();
     output::print_devices(&infos, format);
     Ok(())
-}
-
-fn device_info(d: &DiscoveredDevice) -> DeviceInfo {
-    DeviceInfo {
-        instance: d.object_identifier.instance_number(),
-        address: format_mac(d.mac_address.as_slice()),
-        vendor_id: d.vendor_id,
-        max_apdu: d.max_apdu_length,
-        segmentation: format!("{}", d.segmentation_supported),
-    }
-}
-
-fn format_mac(mac: &[u8]) -> String {
-    if mac.len() == 6 {
-        let ip = Ipv4Addr::new(mac[0], mac[1], mac[2], mac[3]);
-        let port = u16::from_be_bytes([mac[4], mac[5]]);
-        format!("{ip}:{port}")
-    } else {
-        mac.iter()
-            .map(|b| format!("{b:02x}"))
-            .collect::<Vec<_>>()
-            .join(":")
-    }
 }
 
 /// Send Who-Is-Router-To-Network.

--- a/crates/bacnet-cli/src/main.rs
+++ b/crates/bacnet-cli/src/main.rs
@@ -18,6 +18,7 @@ mod decode;
 mod output;
 mod parse;
 mod resolve;
+mod session;
 mod shell;
 mod transport;
 
@@ -645,61 +646,7 @@ async fn execute_command<T: TransportPort + 'static>(
         }
         Command::TimeSync { target, utc } => {
             let mac = resolve_target_mac(client, target).await?;
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map_err(|e| format!("system time error: {e}"))?;
-            let secs = now.as_secs();
-
-            // Convert epoch seconds to date/time components.
-            // Days since 1970-01-01.
-            let days = secs / 86400;
-            let day_secs = (secs % 86400) as u32;
-
-            let hour = (day_secs / 3600) as u8;
-            let minute = ((day_secs % 3600) / 60) as u8;
-            let second = (day_secs % 60) as u8;
-            let hundredths = ((now.subsec_millis() / 10) % 100) as u8;
-
-            // Civil date from days since epoch (algorithm from Howard Hinnant).
-            let z = days as i64 + 719468;
-            let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
-            let doe = (z - era * 146097) as u64;
-            let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-            let y = yoe as i64 + era * 400;
-            let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-            let mp = (5 * doy + 2) / 153;
-            let d = (doy - (153 * mp + 2) / 5 + 1) as u8;
-            let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u8;
-            let y = if m <= 2 { y + 1 } else { y };
-
-            // Day of week: 1970-01-01 was Thursday (BACnet: 4).
-            let dow = ((days + 3) % 7 + 1) as u8; // 1=Monday..7=Sunday
-
-            let utc_date = bacnet_types::primitives::Date {
-                year: (y - 1900) as u8,
-                month: m,
-                day: d,
-                day_of_week: dow,
-            };
-            let utc_time = bacnet_types::primitives::Time {
-                hour,
-                minute,
-                second,
-                hundredths,
-            };
-
-            if *utc {
-                client
-                    .utc_time_synchronization(&mac, utc_date, utc_time)
-                    .await?;
-            } else {
-                // For local time sync we also use UTC since we don't have
-                // a timezone library. Document this limitation.
-                client
-                    .time_synchronization(&mac, utc_date, utc_time)
-                    .await?;
-            }
-            output::print_success("Time synchronized", format);
+            commands::device::time_sync_cmd(client, &mac, *utc, format).await?;
         }
     }
     Ok(())
@@ -894,7 +841,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut client = transport::build_bip_client(&args).await?;
         match &cli.command {
             None | Some(Command::Shell) => {
-                run(client, &cli, format, false).await?;
+                shell::run_bip_shell(client, format).await?;
             }
             Some(cmd) => {
                 if !execute_bip_command(&client, cmd, format).await? {

--- a/crates/bacnet-cli/src/main.rs
+++ b/crates/bacnet-cli/src/main.rs
@@ -100,7 +100,7 @@ enum Command {
         #[arg(long, default_value_t = 3)]
         wait: u64,
         /// Send directed WhoIs to a specific address instead of broadcasting.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "dnet")]
         target: Option<String>,
         /// Register as foreign device with a BBMD before discovering.
         #[arg(long)]
@@ -433,7 +433,7 @@ async fn execute_command<T: TransportPort + 'static>(
                 let mac = resolve::parse_target(target_str)
                     .and_then(|t| match t {
                         resolve::Target::Mac(m) => Ok(m),
-                        _ => Err("--target requires an IP address, not a device instance".into()),
+                        _ => Err("--target requires an IP address, not a device instance or routed address".into()),
                     })
                     .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
                 commands::discover::discover_directed(client, &mac, low, high, *wait, format)
@@ -760,7 +760,7 @@ async fn execute_bip_command(
                 let mac = resolve::parse_target(target_str)
                     .and_then(|t| match t {
                         resolve::Target::Mac(m) => Ok(m),
-                        _ => Err("--target requires an IP address, not a device instance".into()),
+                        _ => Err("--target requires an IP address, not a device instance or routed address".into()),
                     })
                     .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
                 commands::discover::discover_directed(client, &mac, low, high, *wait, format)

--- a/crates/bacnet-cli/src/output.rs
+++ b/crates/bacnet-cli/src/output.rs
@@ -3,15 +3,12 @@
 //! Supports table (human-readable) and JSON output formats with automatic
 //! TTY detection.
 
-use bacnet_types::primitives::PropertyValue;
-use serde::Serialize;
-use std::io::IsTerminal;
+use std::net::Ipv4Addr;
 
-/// Check whether stdout is connected to a terminal.
-#[allow(dead_code)]
-pub fn is_tty() -> bool {
-    std::io::stdout().is_terminal()
-}
+use bacnet_client::discovery::DiscoveredDevice;
+use bacnet_types::primitives::PropertyValue;
+use owo_colors::OwoColorize;
+use serde::Serialize;
 
 /// Output format for CLI results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,12 +34,38 @@ pub struct DeviceInfo {
     pub segmentation: String,
 }
 
+/// Format a BIP MAC address (6 bytes: 4 IP + 2 port) as `ip:port`.
+/// Falls back to hex display for non-BIP MACs.
+pub fn format_mac(mac: &[u8]) -> String {
+    if mac.len() == 6 {
+        let ip = Ipv4Addr::new(mac[0], mac[1], mac[2], mac[3]);
+        let port = u16::from_be_bytes([mac[4], mac[5]]);
+        format!("{ip}:{port}")
+    } else {
+        mac.iter()
+            .map(|b| format!("{b:02x}"))
+            .collect::<Vec<_>>()
+            .join(":")
+    }
+}
+
+/// Convert a `DiscoveredDevice` into a `DeviceInfo` for display.
+pub fn device_info(d: &DiscoveredDevice) -> DeviceInfo {
+    DeviceInfo {
+        instance: d.object_identifier.instance_number(),
+        address: format_mac(d.mac_address.as_slice()),
+        vendor_id: d.vendor_id,
+        max_apdu: d.max_apdu_length,
+        segmentation: format!("{}", d.segmentation_supported),
+    }
+}
+
 /// Print a list of discovered devices.
 pub fn print_devices(devices: &[DeviceInfo], format: OutputFormat) {
     match format {
         OutputFormat::Table => {
             if devices.is_empty() {
-                println!("No devices found.");
+                println!("{}", "No devices found.".yellow());
                 return;
             }
             let mut table = comfy_table::Table::new();
@@ -63,6 +86,7 @@ pub fn print_devices(devices: &[DeviceInfo], format: OutputFormat) {
                 ]);
             }
             println!("{table}");
+            println!("{}", format!("Found {} device(s)", devices.len()).green());
         }
         OutputFormat::Json => {
             let json = serde_json::to_string_pretty(devices).expect("serialize devices");
@@ -167,7 +191,7 @@ pub fn print_read_result(
         OutputFormat::Table => {
             let mut table = comfy_table::Table::new();
             table.set_header(vec!["Object", "Property", "Value"]);
-            table.add_row(vec![object, &prop_display, value]);
+            table.add_row(vec![object, &prop_display, &format!("{}", value.green())]);
             println!("{table}");
         }
         OutputFormat::Json => {
@@ -197,7 +221,12 @@ pub fn print_rpm_table(entries: &[(String, String, Option<u32>, String)], format
                     Some(i) => format!("{prop}[{i}]"),
                     None => prop.clone(),
                 };
-                table.add_row(vec![obj.as_str(), &prop_display, val.as_str()]);
+                let colored_val = if val.starts_with("ERROR") {
+                    format!("{}", val.red())
+                } else {
+                    format!("{}", val.green())
+                };
+                table.add_row(vec![obj.as_str(), &prop_display, &colored_val]);
             }
             println!("{table}");
         }
@@ -224,33 +253,10 @@ pub fn print_rpm_table(entries: &[(String, String, Option<u32>, String)], format
     }
 }
 
-/// Print a single generic value.
-#[allow(dead_code)]
-pub fn print_value(value: &str, format: OutputFormat) {
-    match format {
-        OutputFormat::Table => {
-            println!("{value}");
-        }
-        OutputFormat::Json => {
-            let result = serde_json::json!({ "value": value });
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&result).expect("serialize value")
-            );
-        }
-    }
-}
-
-/// Print a success message to stderr.
-#[allow(dead_code)]
-pub fn print_ok(msg: &str) {
-    eprintln!("OK: {msg}");
-}
-
 /// Print a success/status message.
 pub fn print_success(msg: &str, format: OutputFormat) {
     match format {
-        OutputFormat::Table => println!("{msg}"),
+        OutputFormat::Table => println!("{}", msg.green()),
         OutputFormat::Json => {
             let result = serde_json::json!({ "status": "ok", "message": msg });
             println!(
@@ -261,9 +267,14 @@ pub fn print_success(msg: &str, format: OutputFormat) {
     }
 }
 
+/// Print a waiting/progress message to stderr.
+pub fn print_waiting(secs: u64) {
+    eprintln!("{}", format!("Waiting {secs}s for responses...").dimmed());
+}
+
 /// Print an error message to stderr.
 pub fn print_error(msg: &str) {
-    eprintln!("ERROR: {msg}");
+    eprintln!("{} {}", "ERROR:".red().bold(), msg.red());
 }
 
 #[cfg(test)]

--- a/crates/bacnet-cli/src/session.rs
+++ b/crates/bacnet-cli/src/session.rs
@@ -1,0 +1,104 @@
+//! Session state for the interactive shell.
+//!
+//! Tracks default target, BBMD registration, and other per-session state.
+
+use owo_colors::OwoColorize;
+use tokio::task::JoinHandle;
+
+/// Per-session state shared across shell commands.
+pub struct Session {
+    /// Default target address (MAC bytes) set via `target` command.
+    pub default_target: Option<Vec<u8>>,
+    /// Human-readable default target string for display.
+    pub default_target_display: Option<String>,
+    /// Active BBMD registration info.
+    pub bbmd_registration: Option<BbmdRegistration>,
+    /// Background task handle for BBMD auto-renewal.
+    bbmd_renewal_task: Option<JoinHandle<()>>,
+}
+
+/// Active BBMD foreign device registration.
+pub struct BbmdRegistration {
+    /// BBMD address (MAC bytes) for future use (e.g. unregister).
+    #[allow(dead_code)]
+    pub bbmd_mac: Vec<u8>,
+    /// Human-readable BBMD address.
+    pub bbmd_display: String,
+    /// TTL in seconds.
+    pub ttl: u16,
+}
+
+impl Session {
+    pub fn new() -> Self {
+        Self {
+            default_target: None,
+            default_target_display: None,
+            bbmd_registration: None,
+            bbmd_renewal_task: None,
+        }
+    }
+
+    /// Set the default target.
+    pub fn set_target(&mut self, mac: Vec<u8>, display: String) {
+        self.default_target = Some(mac);
+        self.default_target_display = Some(display);
+    }
+
+    /// Clear the default target.
+    pub fn clear_target(&mut self) {
+        self.default_target = None;
+        self.default_target_display = None;
+    }
+
+    /// Register BBMD and start auto-renewal background task.
+    /// `renew_fn` is called at 80% of TTL to re-register.
+    pub fn set_bbmd_registration(
+        &mut self,
+        bbmd_mac: Vec<u8>,
+        bbmd_display: String,
+        ttl: u16,
+        renew_fn: impl Fn() -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), String>> + Send>>
+            + Send
+            + 'static,
+    ) {
+        // Cancel any existing renewal task
+        self.cancel_bbmd_renewal();
+
+        self.bbmd_registration = Some(BbmdRegistration {
+            bbmd_mac,
+            bbmd_display,
+            ttl,
+        });
+
+        // Spawn renewal task at 80% of TTL
+        let renewal_interval = std::time::Duration::from_secs((ttl as u64) * 80 / 100);
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(renewal_interval).await;
+                match renew_fn().await {
+                    Ok(()) => {
+                        eprintln!("{}", "[BBMD registration renewed]".dimmed());
+                    }
+                    Err(e) => {
+                        eprintln!("{}", format!("[BBMD renewal failed: {e}]").red());
+                    }
+                }
+            }
+        });
+        self.bbmd_renewal_task = Some(handle);
+    }
+
+    /// Cancel BBMD registration and renewal task.
+    pub fn cancel_bbmd_renewal(&mut self) {
+        if let Some(handle) = self.bbmd_renewal_task.take() {
+            handle.abort();
+        }
+        self.bbmd_registration = None;
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        self.cancel_bbmd_renewal();
+    }
+}

--- a/crates/bacnet-cli/src/shell.rs
+++ b/crates/bacnet-cli/src/shell.rs
@@ -4,6 +4,7 @@
 //! plus command history via rustyline.
 
 use bacnet_client::client::BACnetClient;
+use bacnet_transport::bip::BipTransport;
 use bacnet_transport::port::TransportPort;
 use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
@@ -12,7 +13,10 @@ use rustyline::hint::HistoryHinter;
 use rustyline::validate::Validator;
 use rustyline::{CompletionType, Config, Context, Editor, Helper};
 
+use owo_colors::OwoColorize;
+
 use crate::output::OutputFormat;
+use crate::session::Session;
 use crate::{commands, output, parse, resolve};
 
 /// All recognized shell commands.
@@ -29,15 +33,29 @@ const COMMANDS: &[&str] = &[
     "wp",
     "writem",
     "wpm",
+    "read-range",
+    "rr",
     "subscribe",
     "cov",
     "control",
     "dcc",
     "reinit",
     "alarms",
+    "ack-alarm",
+    "ack",
+    "time-sync",
+    "ts",
+    "create-object",
+    "delete-object",
     "devices",
+    "register",
+    "unregister",
+    "bdt",
+    "fdt",
     "file-read",
     "file-write",
+    "target",
+    "status",
     "help",
     "exit",
     "quit",
@@ -167,6 +185,144 @@ fn tokenize(line: &str) -> Vec<String> {
     tokens
 }
 
+/// Commands that take a target address as the first positional argument.
+const TARGET_COMMANDS: &[&str] = &[
+    "read",
+    "rp",
+    "readm",
+    "rpm",
+    "write",
+    "wp",
+    "writem",
+    "wpm",
+    "subscribe",
+    "cov",
+    "control",
+    "dcc",
+    "reinit",
+    "alarms",
+    "file-read",
+    "file-write",
+    "ack-alarm",
+    "ack",
+    "time-sync",
+    "ts",
+    "create-object",
+    "delete-object",
+    "read-range",
+    "rr",
+    "register",
+    "unregister",
+    "bdt",
+    "fdt",
+];
+
+/// If the first arg is not a valid target (e.g. it's an object specifier like "ai:1"),
+/// prepend the session's default target so the handler receives the expected arg order.
+fn maybe_prepend_default_target(args: &[String], session: &Session) -> Vec<String> {
+    if args.is_empty() {
+        // No args — supply default target as the only arg if set.
+        if let Some(ref display) = session.default_target_display {
+            return vec![display.clone()];
+        }
+        return vec![];
+    }
+    // If the first arg is NOT a valid target, prepend the default.
+    if resolve::parse_target(&args[0]).is_err() {
+        if let Some(ref display) = session.default_target_display {
+            let mut new_args = vec![display.clone()];
+            new_args.extend_from_slice(args);
+            return new_args;
+        }
+    }
+    args.to_vec()
+}
+
+/// Handle the `target` command: show, set, or clear the default target.
+fn handle_target(args: &[String], session: &mut Session) {
+    if args.is_empty() {
+        match &session.default_target_display {
+            Some(display) => println!("Default target: {}", display.cyan()),
+            None => println!(
+                "{}",
+                "No default target set. Use 'target <addr>' to set one.".dimmed()
+            ),
+        }
+        return;
+    }
+    if args[0] == "clear" {
+        session.clear_target();
+        println!("{}", "Default target cleared.".green());
+        return;
+    }
+    let target_str = &args[0];
+    match resolve::parse_target(target_str) {
+        Ok(_) => {
+            session.set_target(vec![], target_str.clone());
+            println!("Default target set to: {}", target_str.cyan());
+        }
+        Err(e) => {
+            output::print_error(&format!("invalid target: {e}"));
+        }
+    }
+}
+
+/// Handle the `status` command: show session and transport state.
+async fn handle_status<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    session: &Session,
+    transport_name: &str,
+) {
+    println!("{} {}", "Transport:".dimmed(), transport_name);
+
+    let mac = client.local_mac();
+    if mac.len() == 6 {
+        let ip = std::net::Ipv4Addr::new(mac[0], mac[1], mac[2], mac[3]);
+        let port = u16::from_be_bytes([mac[4], mac[5]]);
+        println!(
+            "{} {}",
+            "Local address:".dimmed(),
+            format!("{ip}:{port}").cyan()
+        );
+    } else if mac.len() == 18 {
+        let mut ip_bytes = [0u8; 16];
+        ip_bytes.copy_from_slice(&mac[..16]);
+        let ip = std::net::Ipv6Addr::from(ip_bytes);
+        let port = u16::from_be_bytes([mac[16], mac[17]]);
+        println!(
+            "{} {}",
+            "Local address:".dimmed(),
+            format!("[{ip}]:{port}").cyan()
+        );
+    } else {
+        println!("{} {mac:02x?}", "Local MAC:".dimmed());
+    }
+
+    match &session.default_target_display {
+        Some(display) => println!("{} {}", "Default target:".dimmed(), display.cyan()),
+        None => println!("{} {}", "Default target:".dimmed(), "(none)".dimmed()),
+    }
+
+    match &session.bbmd_registration {
+        Some(reg) => {
+            println!(
+                "{} {} {}",
+                "BBMD registered:".dimmed(),
+                reg.bbmd_display.cyan(),
+                format!("(TTL {}s, auto-renewing)", reg.ttl).dimmed()
+            );
+        }
+        None => println!("{} {}", "BBMD registered:".dimmed(), "(none)".dimmed()),
+    }
+
+    let devices = client.discovered_devices().await;
+    println!(
+        "{} {}",
+        "Discovered:".dimmed(),
+        format!("{} device(s)", devices.len()).green()
+    );
+}
+
 /// Resolve a target string to a MAC address, looking up device instances from
 /// the client's discovered device table.
 async fn resolve_target_mac<T: TransportPort + 'static>(
@@ -197,9 +353,11 @@ Commands:
   discover [low-high] [--wait N]     Discover devices (WhoIs broadcast)
     [--target ADDR]                   Send directed WhoIs to a specific address
     [--dnet N]                        Target a specific remote network number
+    [--bbmd ADDR] [--ttl N]           Register as foreign device before discover (BIP only)
   find <name> [--wait N]             Find objects by name (WhoHas)
   read <target> <object> <property>  Read a property (e.g., read 192.168.1.10 ai:1 pv)
   readm <target> <specs...>          Read multiple properties (RPM)
+  read-range <target> <object> [prop]  Read a range (e.g., rr 10.0.1.5 trend-log:1)
   write <target> <obj> <prop> <val>  Write a property (e.g., write 10.0.1.5 av:1 pv 72.5)
   writem <target> <obj> <prop=val,...>  Write multiple properties (WPM)
   file-read <target> <instance>         Read a file (AtomicReadFile)
@@ -208,27 +366,114 @@ Commands:
   control <target> <action>          Device communication control (enable/disable)
   reinit <target> <state>            Reinitialize device (coldstart/warmstart)
   alarms <target>                    Get event/alarm summary
+  ack-alarm <target> <obj> --state N Acknowledge an alarm
+  time-sync <target> [--utc]         Synchronize time with a device
+  create-object <target> <object>    Create an object on a remote device
+  delete-object <target> <object>    Delete an object on a remote device
   devices                            List cached discovered devices
+  register <bbmd> [--ttl N]          Register as foreign device with BBMD (BIP only)
+  unregister <bbmd>                  Unregister from BBMD (BIP only)
+  bdt <bbmd>                         Read BBMD broadcast distribution table (BIP only)
+  fdt <bbmd>                         Read BBMD foreign device table (BIP only)
+  target [<addr>|clear]              Show/set/clear default target
+  status                             Show session and transport state
   help                               Show this help message
   exit / quit                        Exit the shell
 
-Aliases: whois=discover, whohas=find, rp=read, rpm=readm, wp=write, wpm=writem, cov=subscribe, dcc=control
+Aliases: whois=discover, whohas=find, rp=read, rpm=readm, rr=read-range, wp=write, wpm=writem,
+         cov=subscribe, dcc=control, ack=ack-alarm, ts=time-sync
 
 Targets: IP address (192.168.1.10), IP:port (10.0.1.5:47809), or device instance (1234)
+         When a default target is set, commands that take a target can omit it.
 Objects: type:instance (ai:1, analog-input:1, binary-value:3)
 Properties: name or abbreviation (present-value, pv, object-name, on, ol[3])"
     );
 }
 
-/// Run the interactive BACnet shell.
-///
-/// Reads commands from the user, dispatches them to the appropriate command
-/// handler, and loops until the user types `exit`, `quit`, or presses Ctrl-D.
-pub async fn run_shell<T: TransportPort + 'static>(
-    mut client: BACnetClient<T>,
-    is_sc: bool,
+/// Dispatch a common (transport-agnostic) command.
+/// Returns `true` if the command was recognized and handled.
+async fn dispatch_common<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    cmd: &str,
+    args: &[String],
+    session: &mut Session,
     format: OutputFormat,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> bool {
+    // For commands that take a target, try to prepend the default target
+    // when the first arg doesn't look like a target address.
+    let resolved_args;
+    let effective_args = if TARGET_COMMANDS.contains(&cmd) {
+        resolved_args = maybe_prepend_default_target(args, session);
+        &resolved_args
+    } else {
+        args
+    };
+
+    match cmd {
+        "discover" | "whois" => {
+            handle_discover(client, args, format).await;
+        }
+        "find" | "whohas" => {
+            handle_find(client, args, format).await;
+        }
+        "read" | "rp" => {
+            handle_read(client, effective_args, format).await;
+        }
+        "readm" | "rpm" => {
+            handle_readm(client, effective_args, format).await;
+        }
+        "write" | "wp" => {
+            handle_write(client, effective_args, format).await;
+        }
+        "writem" | "wpm" => {
+            handle_writem(client, effective_args, format).await;
+        }
+        "subscribe" | "cov" => {
+            handle_subscribe(client, effective_args, format).await;
+        }
+        "control" | "dcc" => {
+            handle_control(client, effective_args, format).await;
+        }
+        "reinit" => {
+            handle_reinit(client, effective_args, format).await;
+        }
+        "alarms" => {
+            handle_alarms(client, effective_args, format).await;
+        }
+        "devices" => {
+            if let Err(e) = commands::router::devices_cmd(client, format).await {
+                output::print_error(&e.to_string());
+            }
+        }
+        "file-read" => {
+            handle_file_read(client, effective_args, format).await;
+        }
+        "file-write" => {
+            handle_file_write(client, effective_args, format).await;
+        }
+        "ack-alarm" | "ack" => {
+            handle_ack_alarm(client, effective_args, format).await;
+        }
+        "time-sync" | "ts" => {
+            handle_time_sync(client, effective_args, format).await;
+        }
+        "create-object" => {
+            handle_create_object(client, effective_args, format).await;
+        }
+        "delete-object" => {
+            handle_delete_object(client, effective_args, format).await;
+        }
+        "read-range" | "rr" => {
+            handle_read_range(client, effective_args, format).await;
+        }
+        _ => return false,
+    }
+    true
+}
+
+/// Set up the readline editor with history and tab completion.
+fn setup_readline(
+) -> Result<Editor<ShellHelper, rustyline::history::DefaultHistory>, Box<dyn std::error::Error>> {
     let config = Config::builder()
         .completion_type(CompletionType::List)
         .behavior(rustyline::Behavior::PreferTerm)
@@ -237,11 +482,28 @@ pub async fn run_shell<T: TransportPort + 'static>(
     let mut rl = Editor::with_config(config)?;
     rl.set_helper(Some(helper));
 
-    let history_path = std::env::var("HOME")
-        .map(|h| std::path::PathBuf::from(h).join(".bacnet_history"))
-        .unwrap_or_else(|_| std::path::PathBuf::from(".bacnet_history"));
+    let history_path = history_path();
     let _ = rl.load_history(&history_path);
+    Ok(rl)
+}
 
+fn history_path() -> std::path::PathBuf {
+    std::env::var("HOME")
+        .map(|h| std::path::PathBuf::from(h).join(".bacnet_history"))
+        .unwrap_or_else(|_| std::path::PathBuf::from(".bacnet_history"))
+}
+
+/// Run the interactive BACnet shell (non-BIP transports: SC, BIP6).
+///
+/// BBMD commands are not available. For BIP transport, use `run_bip_shell`.
+pub async fn run_shell<T: TransportPort + 'static>(
+    mut client: BACnetClient<T>,
+    is_sc: bool,
+    format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut rl = setup_readline()?;
+    let mut session = Session::new();
+    let transport_name = if is_sc { "BACnet/SC" } else { "BACnet/IP" };
     let prompt = if is_sc { "bacnet[sc]> " } else { "bacnet> " };
 
     println!(
@@ -265,62 +527,26 @@ pub async fn run_shell<T: TransportPort + 'static>(
                 match cmd.as_str() {
                     "exit" | "quit" => break,
                     "help" => print_help(),
-                    "discover" | "whois" => {
-                        handle_discover(&client, args, format).await;
+                    "target" => handle_target(args, &mut session),
+                    "status" => {
+                        handle_status(&client, &session, transport_name).await;
                     }
-                    "find" | "whohas" => {
-                        handle_find(&client, args, format).await;
-                    }
-                    "read" | "rp" => {
-                        handle_read(&client, args, format).await;
-                    }
-                    "readm" | "rpm" => {
-                        handle_readm(&client, args, format).await;
-                    }
-                    "write" | "wp" => {
-                        handle_write(&client, args, format).await;
-                    }
-                    "writem" | "wpm" => {
-                        handle_writem(&client, args, format).await;
-                    }
-                    "subscribe" | "cov" => {
-                        handle_subscribe(&client, args, format).await;
-                    }
-                    "control" | "dcc" => {
-                        handle_control(&client, args, format).await;
-                    }
-                    "reinit" => {
-                        handle_reinit(&client, args, format).await;
-                    }
-                    "alarms" => {
-                        handle_alarms(&client, args, format).await;
-                    }
-                    "devices" => {
-                        if let Err(e) = commands::router::devices_cmd(&client, format).await {
-                            output::print_error(&e.to_string());
-                        }
-                    }
-                    "file-read" => {
-                        handle_file_read(&client, args, format).await;
-                    }
-                    "file-write" => {
-                        handle_file_write(&client, args, format).await;
+                    "register" | "unregister" | "bdt" | "fdt" => {
+                        output::print_error(
+                            "BBMD commands are only available on BACnet/IP transport",
+                        );
                     }
                     _ => {
-                        output::print_error(&format!(
-                            "Unknown command: '{cmd}'. Type 'help' for available commands."
-                        ));
+                        if !dispatch_common(&client, &cmd, args, &mut session, format).await {
+                            output::print_error(&format!(
+                                "Unknown command: '{cmd}'. Type 'help' for available commands."
+                            ));
+                        }
                     }
                 }
             }
-            Err(ReadlineError::Interrupted) => {
-                // Ctrl-C: cancel current line, continue loop.
-                continue;
-            }
-            Err(ReadlineError::Eof) => {
-                // Ctrl-D: exit.
-                break;
-            }
+            Err(ReadlineError::Interrupted) => continue,
+            Err(ReadlineError::Eof) => break,
             Err(err) => {
                 output::print_error(&format!("readline error: {err}"));
                 break;
@@ -328,8 +554,96 @@ pub async fn run_shell<T: TransportPort + 'static>(
         }
     }
 
-    let _ = rl.save_history(&history_path);
+    let _ = rl.save_history(&history_path());
     client.stop().await?;
+    Ok(())
+}
+
+/// Run the interactive BACnet shell with BIP transport (supports BBMD commands).
+pub async fn run_bip_shell(
+    client: BACnetClient<BipTransport>,
+    format: OutputFormat,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut rl = setup_readline()?;
+    let mut session = Session::new();
+    let client = std::sync::Arc::new(client);
+
+    println!(
+        "BACnet CLI v{}. Type 'help' for commands, 'exit' to quit.",
+        env!("CARGO_PKG_VERSION")
+    );
+
+    loop {
+        match rl.readline("bacnet> ") {
+            Ok(line) => {
+                let line = line.trim().to_string();
+                if line.is_empty() {
+                    continue;
+                }
+                let _ = rl.add_history_entry(&line);
+
+                let tokens = tokenize(&line);
+                let cmd = tokens[0].to_ascii_lowercase();
+                let args = &tokens[1..];
+
+                match cmd.as_str() {
+                    "exit" | "quit" => break,
+                    "help" => print_help(),
+                    "target" => handle_target(args, &mut session),
+                    "status" => {
+                        handle_status(&*client, &session, "BACnet/IP").await;
+                    }
+                    "discover" | "whois" => {
+                        handle_bip_discover(&client, args, format).await;
+                    }
+                    "register" => {
+                        handle_bip_register(&client, args, &mut session, format).await;
+                    }
+                    "unregister" => {
+                        let effective = maybe_prepend_default_target(args, &session);
+                        handle_unregister(&client, &effective, format).await;
+                        // If we just unregistered from our tracked BBMD, cancel renewal.
+                        if !effective.is_empty() {
+                            if let Some(ref reg) = session.bbmd_registration {
+                                if reg.bbmd_display == effective[0] {
+                                    session.cancel_bbmd_renewal();
+                                }
+                            }
+                        }
+                    }
+                    "bdt" => {
+                        let effective = maybe_prepend_default_target(args, &session);
+                        handle_bdt(&client, &effective, format).await;
+                    }
+                    "fdt" => {
+                        let effective = maybe_prepend_default_target(args, &session);
+                        handle_fdt(&client, &effective, format).await;
+                    }
+                    _ => {
+                        if !dispatch_common(&*client, &cmd, args, &mut session, format).await {
+                            output::print_error(&format!(
+                                "Unknown command: '{cmd}'. Type 'help' for available commands."
+                            ));
+                        }
+                    }
+                }
+            }
+            Err(ReadlineError::Interrupted) => continue,
+            Err(ReadlineError::Eof) => break,
+            Err(err) => {
+                output::print_error(&format!("readline error: {err}"));
+                break;
+            }
+        }
+    }
+
+    let _ = rl.save_history(&history_path());
+    // Unwrap the Arc to call stop(). If there are outstanding references
+    // (shouldn't happen in normal flow), we just log and move on.
+    match std::sync::Arc::try_unwrap(client) {
+        Ok(mut c) => c.stop().await?,
+        Err(_) => eprintln!("Warning: could not stop client (outstanding references)"),
+    }
     Ok(())
 }
 
@@ -434,7 +748,9 @@ async fn handle_discover<T: TransportPort + 'static>(
                     .await
             }
             Ok(_) => {
-                output::print_error("--target requires an IP address, not a device instance or routed address");
+                output::print_error(
+                    "--target requires an IP address, not a device instance or routed address",
+                );
                 return;
             }
             Err(e) => {
@@ -1081,6 +1397,578 @@ async fn handle_writem<T: TransportPort + 'static>(
     }
 
     if let Err(e) = commands::write::write_property_multiple_cmd(client, &mac, specs, format).await
+    {
+        output::print_error(&e.to_string());
+    }
+}
+
+#[allow(dead_code)] // Superseded by handle_bip_register for session-aware registration.
+async fn handle_register(
+    client: &BACnetClient<BipTransport>,
+    args: &[String],
+    format: OutputFormat,
+) {
+    if args.is_empty() {
+        output::print_error("Usage: register <bbmd-address> [--ttl N]");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    let mut ttl: u16 = 300;
+    let mut i = 1;
+    while i < args.len() {
+        if args[i] == "--ttl" {
+            if i + 1 < args.len() {
+                match args[i + 1].parse::<u16>() {
+                    Ok(t) => ttl = t,
+                    Err(_) => {
+                        output::print_error("--ttl requires a numeric value");
+                        return;
+                    }
+                }
+                i += 2;
+                continue;
+            } else {
+                output::print_error("--ttl requires a value");
+                return;
+            }
+        }
+        i += 1;
+    }
+
+    if let Err(e) = commands::router::register_cmd(client, &mac, ttl, format).await {
+        output::print_error(&e.to_string());
+    }
+}
+
+/// Handle register in BIP shell with auto-renewal via session.
+async fn handle_bip_register(
+    client: &std::sync::Arc<BACnetClient<BipTransport>>,
+    args: &[String],
+    session: &mut Session,
+    format: OutputFormat,
+) {
+    if args.is_empty() {
+        output::print_error("Usage: register <bbmd-address> [--ttl N]");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    let mut ttl: u16 = 300;
+    let mut i = 1;
+    while i < args.len() {
+        if args[i] == "--ttl" {
+            if i + 1 < args.len() {
+                match args[i + 1].parse::<u16>() {
+                    Ok(t) => ttl = t,
+                    Err(_) => {
+                        output::print_error("--ttl requires a numeric value");
+                        return;
+                    }
+                }
+                i += 2;
+                continue;
+            } else {
+                output::print_error("--ttl requires a value");
+                return;
+            }
+        }
+        i += 1;
+    }
+
+    if let Err(e) = commands::router::register_cmd(client, &mac, ttl, format).await {
+        output::print_error(&e.to_string());
+        return;
+    }
+
+    // Set up auto-renewal in the session.
+    let bbmd_display = args[0].clone();
+    let renewal_mac = mac.clone();
+    let renewal_client = std::sync::Arc::clone(client);
+    session.set_bbmd_registration(mac, bbmd_display, ttl, move || {
+        let client = std::sync::Arc::clone(&renewal_client);
+        let mac = renewal_mac.clone();
+        Box::pin(async move {
+            client
+                .register_foreign_device_bvlc(&mac, ttl)
+                .await
+                .map(|_| ())
+                .map_err(|e| e.to_string())
+        })
+    });
+}
+
+async fn handle_unregister(
+    client: &BACnetClient<BipTransport>,
+    args: &[String],
+    format: OutputFormat,
+) {
+    if args.is_empty() {
+        output::print_error("Usage: unregister <bbmd-address>");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    if let Err(e) = commands::router::unregister_cmd(client, &mac, format).await {
+        output::print_error(&e.to_string());
+    }
+}
+
+async fn handle_bdt(client: &BACnetClient<BipTransport>, args: &[String], format: OutputFormat) {
+    if args.is_empty() {
+        output::print_error("Usage: bdt <bbmd-address>");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    if let Err(e) = commands::router::bdt_cmd(client, &mac, format).await {
+        output::print_error(&e.to_string());
+    }
+}
+
+async fn handle_fdt(client: &BACnetClient<BipTransport>, args: &[String], format: OutputFormat) {
+    if args.is_empty() {
+        output::print_error("Usage: fdt <bbmd-address>");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    if let Err(e) = commands::router::fdt_cmd(client, &mac, format).await {
+        output::print_error(&e.to_string());
+    }
+}
+
+/// BIP-specific discover handler that supports --bbmd for foreign device registration.
+async fn handle_bip_discover(
+    client: &std::sync::Arc<BACnetClient<BipTransport>>,
+    args: &[String],
+    format: OutputFormat,
+) {
+    let mut low = None;
+    let mut high = None;
+    let mut wait_secs = 3;
+    let mut target: Option<String> = None;
+    let mut dnet: Option<u16> = None;
+    let mut bbmd: Option<String> = None;
+    let mut ttl: u16 = 300;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--wait" => {
+                if i + 1 < args.len() {
+                    match args[i + 1].parse::<u64>() {
+                        Ok(w) => wait_secs = w,
+                        Err(_) => {
+                            output::print_error("--wait requires a numeric value");
+                            return;
+                        }
+                    }
+                    i += 2;
+                    continue;
+                } else {
+                    output::print_error("--wait requires a value");
+                    return;
+                }
+            }
+            "--target" => {
+                if i + 1 < args.len() {
+                    target = Some(args[i + 1].clone());
+                    i += 2;
+                    continue;
+                } else {
+                    output::print_error("--target requires an address");
+                    return;
+                }
+            }
+            "--dnet" => {
+                if i + 1 < args.len() {
+                    match args[i + 1].parse::<u16>() {
+                        Ok(n) => dnet = Some(n),
+                        Err(_) => {
+                            output::print_error("--dnet requires a network number");
+                            return;
+                        }
+                    }
+                    i += 2;
+                    continue;
+                } else {
+                    output::print_error("--dnet requires a value");
+                    return;
+                }
+            }
+            "--bbmd" => {
+                if i + 1 < args.len() {
+                    bbmd = Some(args[i + 1].clone());
+                    i += 2;
+                    continue;
+                } else {
+                    output::print_error("--bbmd requires an address");
+                    return;
+                }
+            }
+            "--ttl" => {
+                if i + 1 < args.len() {
+                    match args[i + 1].parse::<u16>() {
+                        Ok(t) => ttl = t,
+                        Err(_) => {
+                            output::print_error("--ttl requires a numeric value");
+                            return;
+                        }
+                    }
+                    i += 2;
+                    continue;
+                } else {
+                    output::print_error("--ttl requires a value");
+                    return;
+                }
+            }
+            s if s.starts_with("--") => {
+                output::print_error(&format!("unknown option: '{s}'"));
+                return;
+            }
+            _ => {
+                if let Some((lo, hi)) = args[i].split_once('-') {
+                    match (lo.parse::<u32>(), hi.parse::<u32>()) {
+                        (Ok(l), Ok(h)) => {
+                            if l > h {
+                                output::print_error(&format!(
+                                    "invalid range: low ({l}) > high ({h})"
+                                ));
+                                return;
+                            }
+                            low = Some(l);
+                            high = Some(h);
+                        }
+                        _ => {
+                            output::print_error(&format!(
+                                "invalid range: '{}', expected 'low-high'",
+                                args[i]
+                            ));
+                            return;
+                        }
+                    }
+                } else {
+                    output::print_error(&format!(
+                        "unexpected argument: '{}'. Use 'discover [low-high] [--wait N] [--target ADDR] [--dnet N] [--bbmd ADDR] [--ttl N]'",
+                        args[i]
+                    ));
+                    return;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    if let Some(bbmd_addr) = &bbmd {
+        let bbmd_mac = match resolve::parse_target(bbmd_addr) {
+            Ok(resolve::Target::Mac(m)) => m,
+            Ok(_) => {
+                output::print_error("--bbmd requires an IP address, not a device instance");
+                return;
+            }
+            Err(e) => {
+                output::print_error(&e);
+                return;
+            }
+        };
+        match client.register_foreign_device_bvlc(&bbmd_mac, ttl).await {
+            Ok(result) => {
+                eprintln!(
+                    "{}",
+                    format!("Registered as foreign device with BBMD: {result:?}").green()
+                );
+            }
+            Err(e) => {
+                output::print_error(&format!("BBMD registration failed: {e}"));
+                return;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
+    let result = if let Some(target_str) = &target {
+        match resolve::parse_target(target_str) {
+            Ok(resolve::Target::Mac(mac)) => {
+                commands::discover::discover_directed(client, &mac, low, high, wait_secs, format)
+                    .await
+            }
+            Ok(_) => {
+                output::print_error(
+                    "--target requires an IP address, not a device instance or routed address",
+                );
+                return;
+            }
+            Err(e) => {
+                output::print_error(&e);
+                return;
+            }
+        }
+    } else if let Some(network) = dnet {
+        commands::discover::discover_network(client, network, low, high, wait_secs, format).await
+    } else {
+        commands::discover::discover(client, low, high, wait_secs, format).await
+    };
+
+    if let Err(e) = result {
+        output::print_error(&e.to_string());
+    }
+}
+
+async fn handle_ack_alarm<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    args: &[String],
+    format: OutputFormat,
+) {
+    if args.len() < 2 {
+        output::print_error("Usage: ack-alarm <target> <object> --state N [--source S]");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    let (object_type, instance) = match parse::parse_object_specifier(&args[1]) {
+        Ok(v) => v,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    let mut state: Option<u32> = None;
+    let mut source = "bacnet-cli".to_string();
+
+    let mut i = 2;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--state" => {
+                if i + 1 < args.len() {
+                    match args[i + 1].parse::<u32>() {
+                        Ok(s) => state = Some(s),
+                        Err(_) => {
+                            output::print_error("--state requires a numeric value");
+                            return;
+                        }
+                    }
+                    i += 2;
+                    continue;
+                } else {
+                    output::print_error("--state requires a value");
+                    return;
+                }
+            }
+            "--source" => {
+                if i + 1 < args.len() {
+                    source = args[i + 1].clone();
+                    i += 2;
+                    continue;
+                } else {
+                    output::print_error("--source requires a value");
+                    return;
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let state = match state {
+        Some(s) => s,
+        None => {
+            output::print_error("--state is required");
+            return;
+        }
+    };
+
+    if let Err(e) = commands::device::acknowledge_alarm_cmd(
+        client,
+        &mac,
+        object_type,
+        instance,
+        state,
+        &source,
+        format,
+    )
+    .await
+    {
+        output::print_error(&e.to_string());
+    }
+}
+
+async fn handle_time_sync<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    args: &[String],
+    format: OutputFormat,
+) {
+    if args.is_empty() {
+        output::print_error("Usage: time-sync <target> [--utc]");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    let utc = args[1..].iter().any(|a| a == "--utc");
+
+    if let Err(e) = commands::device::time_sync_cmd(client, &mac, utc, format).await {
+        output::print_error(&e.to_string());
+    }
+}
+
+async fn handle_create_object<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    args: &[String],
+    format: OutputFormat,
+) {
+    if args.len() < 2 {
+        output::print_error("Usage: create-object <target> <object>");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    let (object_type, instance) = match parse::parse_object_specifier(&args[1]) {
+        Ok(v) => v,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    if let Err(e) =
+        commands::device::create_object_cmd(client, &mac, object_type, instance, format).await
+    {
+        output::print_error(&e.to_string());
+    }
+}
+
+async fn handle_delete_object<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    args: &[String],
+    format: OutputFormat,
+) {
+    if args.len() < 2 {
+        output::print_error("Usage: delete-object <target> <object>");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    let (object_type, instance) = match parse::parse_object_specifier(&args[1]) {
+        Ok(v) => v,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    if let Err(e) =
+        commands::device::delete_object_cmd(client, &mac, object_type, instance, format).await
+    {
+        output::print_error(&e.to_string());
+    }
+}
+
+async fn handle_read_range<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    args: &[String],
+    format: OutputFormat,
+) {
+    if args.len() < 2 {
+        output::print_error("Usage: read-range <target> <object> [property]");
+        return;
+    }
+
+    let mac = match resolve_target_mac(client, &args[0]).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    let (object_type, instance) = match parse::parse_object_specifier(&args[1]) {
+        Ok(v) => v,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    let prop_str = if args.len() > 2 {
+        &args[2]
+    } else {
+        "log-buffer"
+    };
+    let (property, index) = match parse::parse_property(prop_str) {
+        Ok(v) => v,
+        Err(e) => {
+            output::print_error(&e);
+            return;
+        }
+    };
+
+    if let Err(e) =
+        commands::read::read_range_cmd(client, &mac, object_type, instance, property, index, format)
+            .await
     {
         output::print_error(&e.to_string());
     }

--- a/crates/bacnet-cli/src/shell.rs
+++ b/crates/bacnet-cli/src/shell.rs
@@ -434,7 +434,7 @@ async fn handle_discover<T: TransportPort + 'static>(
                     .await
             }
             Ok(_) => {
-                output::print_error("--target requires an IP address, not a device instance");
+                output::print_error("--target requires an IP address, not a device instance or routed address");
                 return;
             }
             Err(e) => {

--- a/crates/bacnet-client/src/client.rs
+++ b/crates/bacnet-client/src/client.rs
@@ -1176,6 +1176,26 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             .await
     }
 
+    /// Broadcast an unconfirmed request to a specific remote network.
+    pub async fn broadcast_network_unconfirmed(
+        &self,
+        service_choice: UnconfirmedServiceChoice,
+        service_data: &[u8],
+        dest_network: u16,
+    ) -> Result<(), Error> {
+        let pdu = Apdu::UnconfirmedRequest(bacnet_encoding::apdu::UnconfirmedRequest {
+            service_choice,
+            service_request: Bytes::copy_from_slice(service_data),
+        });
+
+        let mut buf = BytesMut::with_capacity(2 + service_data.len());
+        encode_apdu(&mut buf, &pdu);
+
+        self.network
+            .broadcast_to_network(&buf, dest_network, false, NetworkPriority::NORMAL)
+            .await
+    }
+
     // -----------------------------------------------------------------------
     // High-level API
     // -----------------------------------------------------------------------
@@ -1323,16 +1343,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let mut buf = BytesMut::new();
         request.encode(&mut buf);
 
-        let pdu = Apdu::UnconfirmedRequest(bacnet_encoding::apdu::UnconfirmedRequest {
-            service_choice: UnconfirmedServiceChoice::WHO_IS,
-            service_request: Bytes::copy_from_slice(&buf),
-        });
-
-        let mut apdu_buf = BytesMut::with_capacity(2 + buf.len());
-        encode_apdu(&mut apdu_buf, &pdu);
-
-        self.network
-            .send_apdu(&apdu_buf, destination_mac, false, NetworkPriority::NORMAL)
+        self.unconfirmed_request(destination_mac, UnconfirmedServiceChoice::WHO_IS, &buf)
             .await
     }
 
@@ -1355,16 +1366,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let mut buf = BytesMut::new();
         request.encode(&mut buf);
 
-        let pdu = Apdu::UnconfirmedRequest(bacnet_encoding::apdu::UnconfirmedRequest {
-            service_choice: UnconfirmedServiceChoice::WHO_IS,
-            service_request: Bytes::copy_from_slice(&buf),
-        });
-
-        let mut apdu_buf = BytesMut::with_capacity(2 + buf.len());
-        encode_apdu(&mut apdu_buf, &pdu);
-
-        self.network
-            .broadcast_to_network(&apdu_buf, dest_network, false, NetworkPriority::NORMAL)
+        self.broadcast_network_unconfirmed(UnconfirmedServiceChoice::WHO_IS, &buf, dest_network)
             .await
     }
 

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -473,7 +473,6 @@ mod tests {
 
     #[test]
     fn broadcast_to_network_rejects_dnet_ffff() {
-        use bacnet_encoding::npdu::Npdu;
         use bacnet_types::enums::NetworkPriority;
 
         let transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
@@ -489,6 +488,9 @@ mod tests {
         });
         assert!(result.is_err());
         let err_msg = format!("{}", result.unwrap_err());
-        assert!(err_msg.contains("0xFFFF"), "Error should mention 0xFFFF: {err_msg}");
+        assert!(
+            err_msg.contains("0xFFFF"),
+            "Error should mention 0xFFFF: {err_msg}"
+        );
     }
 }

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -200,6 +200,11 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
         expecting_reply: bool,
         priority: NetworkPriority,
     ) -> Result<(), Error> {
+        if dest_network == 0xFFFF {
+            return Err(Error::Encoding(
+                "dest_network 0xFFFF is reserved for global broadcasts; use broadcast_global_apdu instead".into(),
+            ));
+        }
         let npdu = Npdu {
             is_network_message: false,
             expecting_reply,
@@ -433,5 +438,57 @@ mod tests {
         assert_eq!(dest.mac_address.as_slice(), &[1, 2, 3, 4, 5, 6]);
         assert_eq!(decoded.hop_count, 255);
         assert!(decoded.expecting_reply);
+    }
+
+    #[test]
+    fn broadcast_to_network_encodes_specific_dnet() {
+        use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu, NpduAddress};
+        use bacnet_types::enums::NetworkPriority;
+
+        // Verify the NPDU format that broadcast_to_network would produce:
+        // specific DNET with empty DADR (broadcast on that network)
+        let npdu = Npdu {
+            is_network_message: false,
+            expecting_reply: false,
+            priority: NetworkPriority::NORMAL,
+            destination: Some(NpduAddress {
+                network: 42,
+                mac_address: MacAddr::new(),
+            }),
+            source: None,
+            hop_count: 255,
+            payload: Bytes::from_static(&[0xCC]),
+            ..Npdu::default()
+        };
+
+        let mut buf = bytes::BytesMut::new();
+        encode_npdu(&mut buf, &npdu).unwrap();
+        let decoded = decode_npdu(Bytes::from(buf)).unwrap();
+        let dest = decoded.destination.unwrap();
+        assert_eq!(dest.network, 42);
+        assert!(dest.mac_address.is_empty()); // broadcast: no specific MAC
+        assert_eq!(decoded.hop_count, 255);
+        assert!(!decoded.expecting_reply);
+    }
+
+    #[test]
+    fn broadcast_to_network_rejects_dnet_ffff() {
+        use bacnet_encoding::npdu::Npdu;
+        use bacnet_types::enums::NetworkPriority;
+
+        let transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+        let net = NetworkLayer::new(transport);
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let result = rt.block_on(async {
+            net.broadcast_to_network(&[0xAA], 0xFFFF, false, NetworkPriority::NORMAL)
+                .await
+        });
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("0xFFFF"), "Error should mention 0xFFFF: {err_msg}");
     }
 }

--- a/examples/kotlin/BipClientServer.kt
+++ b/examples/kotlin/BipClientServer.kt
@@ -9,8 +9,8 @@
  *
  * Usage:
  *   // Add rusty-bacnet JAR to classpath, then:
- *   kotlinc -cp rusty-bacnet-0.6.2.jar BipClientServer.kt -include-runtime -d example.jar
- *   java -cp example.jar:rusty-bacnet-0.6.2.jar BipClientServerKt
+ *   kotlinc -cp rusty-bacnet-0.6.3.jar BipClientServer.kt -include-runtime -d example.jar
+ *   java -cp example.jar:rusty-bacnet-0.6.3.jar BipClientServerKt
  */
 
 import kotlinx.coroutines.delay

--- a/examples/kotlin/README.md
+++ b/examples/kotlin/README.md
@@ -11,7 +11,7 @@ cd ../../java
 ./build-local.sh --release
 ```
 
-The JAR will be at `java/build/libs/rusty-bacnet-0.6.2.jar`.
+The JAR will be at `java/build/libs/rusty-bacnet-0.6.3.jar`.
 
 ## Examples
 
@@ -31,7 +31,7 @@ These examples use the Kotlin scripting approach. Ensure JDK 21+ and `kotlinc` a
 # Add example as a mainClass in java/build.gradle.kts
 
 # Option 2: Compile and run directly
-JAR=../../java/build/libs/rusty-bacnet-0.6.2.jar
+JAR=../../java/build/libs/rusty-bacnet-0.6.3.jar
 kotlinc -cp "$JAR" BipClientServer.kt -include-runtime -d example.jar
 java -cp "example.jar:$JAR" BipClientServerKt
 

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 group=io.github.jscott3201
-version=0.6.2
+version=0.6.3


### PR DESCRIPTION
### Added
- **Interactive shell session state**: `target` command to set/show/clear default target address; `status` command shows transport, local address, BBMD registration, and discovered device count
- **BBMD auto-renewal** in interactive shell: `register` stores registration and spawns background task to renew at 80% TTL; `unregister` cancels renewal; shown in `status` output
- **Missing shell commands** now available interactively: `ack-alarm`/`ack`, `time-sync`/`ts`, `create-object`, `delete-object`, `read-range`/`rr`
- **Shell `discover --bbmd`**: register as foreign device and discover in one step (BIP shell only)
- **Colored terminal output** via `owo-colors`: green for success/values, red for errors, yellow for warnings, cyan for addresses, dimmed for metadata
- Default target auto-prepend: commands like `read`, `write`, `subscribe` use the session default target when no target argument is given
- Discovery progress feedback: "Waiting Ns for responses..." status line during WhoIs

### Changed
- Deduplicated `format_mac()` and `device_info()` into `output.rs` (removed from `discover.rs` and `router.rs`)
- Removed dead code: `is_tty()`, `print_ok()`, `print_value()` from output module
- BIP shell separated from generic shell for type-safe BBMD command dispatch

### Fixed
- Interactive `discover --target` returning "No devices found" on subsequent calls (removed stale HashSet filter)
- Unused import `use bacnet_encoding::npdu::Npdu` in `bacnet-network/src/layer.rs`