### PR TITLE
fix(bip): use configured B/IP port for gateway client transport

### DIFF
--- a/crates/bacnet-gateway/src/builder.rs
+++ b/crates/bacnet-gateway/src/builder.rs
@@ -131,7 +131,7 @@ impl GatewayBuilder {
         let db = server.database().clone();
 
         // Create client transport (also needs foreign device config for broadcast routing).
-        let mut client_transport = BipTransport::new(interface, 0, broadcast);
+        let mut client_transport = BipTransport::new(interface, bip.port, broadcast);
         if let Some(ref fdc) = fd_config {
             client_transport.register_as_foreign_device(fdc.clone());
         }


### PR DESCRIPTION
## Summary

- Gateway client transport was hardcoded to port `0` in `builder.rs:134`, causing the OS to assign a random ephemeral port for outgoing BACnet/IP requests
- The server transport on line 93 correctly used `bip.port` from the gateway config
- This one-line fix passes `bip.port` to the client transport as well

## The bug

```rust
// Before — binds to random ephemeral port
let mut client_transport = BipTransport::new(interface, 0, broadcast);

// After — uses configured port (default 47808)
let mut client_transport = BipTransport::new(interface, bip.port, broadcast);
```

## Impact

Outgoing BACnet requests originated from a random port instead of the configured BACnet/IP port (typically 47808). Devices responding to the standard port would not reach the client, breaking request/response communication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)