### PR TITLE
perf(notification): optimize payload buffer handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0]
 
+### Performance
+
+- Fixed Finding 10: notification send paths now freeze `BytesMut` payload buffers directly instead of copying them through `to_vec()` before constructing `Bytes`.
+
 ### Workspace reorganization
 
 The HTTP/MCP gateway and BTL compliance test harness were extracted into dedicated repositories. The remaining workspace focuses purely on the BACnet protocol stack: types, encoding, services, transport, network, client, server, objects, plus the Python and WASM bindings and the CLI.

--- a/crates/bacnet-server/src/server.rs
+++ b/crates/bacnet-server/src/server.rs
@@ -1676,7 +1676,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
                     let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
                         service_choice: UnconfirmedServiceChoice::I_AM,
-                        service_request: Bytes::from(service_buf.to_vec()),
+                        service_request: service_buf.freeze(),
                     });
 
                     let mut buf = BytesMut::new();
@@ -1720,7 +1720,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         } else {
                             let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
                                 service_choice: UnconfirmedServiceChoice::I_HAVE,
-                                service_request: Bytes::from(service_buf.to_vec()),
+                                service_request: service_buf.freeze(),
                             });
 
                             let mut buf = BytesMut::new();
@@ -1897,7 +1897,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
             let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
                 service_choice: UnconfirmedServiceChoice::UNCONFIRMED_EVENT_NOTIFICATION,
-                service_request: Bytes::from(service_buf.to_vec()),
+                service_request: service_buf.freeze(),
             });
 
             let mut buf = BytesMut::new();
@@ -1920,7 +1920,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     continue;
                 }
 
-                let service_bytes = Bytes::from(service_buf.to_vec());
+                let service_bytes = service_buf.freeze();
 
                 if *confirmed {
                     let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
@@ -2141,7 +2141,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     sequence_number: None,
                     proposed_window_size: None,
                     service_choice: ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION,
-                    service_request: Bytes::from(service_buf.to_vec()),
+                    service_request: service_buf.freeze(),
                 });
 
                 let mut buf = BytesMut::new();
@@ -2223,7 +2223,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             } else {
                 let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
                     service_choice: UnconfirmedServiceChoice::UNCONFIRMED_COV_NOTIFICATION,
-                    service_request: Bytes::from(service_buf.to_vec()),
+                    service_request: service_buf.freeze(),
                 });
 
                 let mut buf = BytesMut::new();


### PR DESCRIPTION
## Summary

Finding 10 from the BACnet 135-2020 code review: notification send paths now `freeze()` `BytesMut` service buffers directly instead of copying through `to_vec()` before constructing `Bytes`. Zero-copy ownership transfer for confirmed and unconfirmed notification paths.

## Sites changed

`crates/bacnet-server/src/server.rs:1679, :1723, :1900, :1923, :2144, :2226`

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm`
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets`

## Sequencing

Independent of the other review-fix branches. Mergeable any order relative to B / C / A. (A is stacked on C; D / B / C / schedule have no inter-dependencies.)

CHANGELOG entry in this branch.