### PR TITLE
fix(codecs): tighten APDU/BVLL/BVLC validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.0]
 
+### Spec Compliance - Codec Strictness (ASHRAE 135-2020 Clauses 20.1.2.7, 20.1.2.8, 20.1.6.x)
+
+- Fixed Finding 4: ConfirmedRequest max-APDU and SegmentACK window fields are now validated instead of silently accepting reserved or out-of-range wire values.
+- Fixed Finding 6: BVLL/BVLC encoders now reject frame lengths that cannot fit in the 16-bit BACnet length field instead of truncating.
+- Fixed Finding 7: fixed-width primitive decoders now reject incorrect lengths and trailing bytes for ObjectIdentifier, Date, Time, Real, Double, and overlong application-tag values.
+
+### Changed
+
+- **API break**: APDU/BVLL/BVLC encoder entry points now return `Result` where wire-length or field validation can fail.
+- **Behavior change**: primitive decoder strictness now rejects malformed encodings that were previously accepted with trailing bytes.
+
 ### Workspace reorganization
 
 The HTTP/MCP gateway and BTL compliance test harness were extracted into dedicated repositories. The remaining workspace focuses purely on the BACnet protocol stack: types, encoding, services, transport, network, client, server, objects, plus the Python and WASM bindings and the CLI.
@@ -22,7 +33,7 @@ The HTTP/MCP gateway and BTL compliance test harness were extracted into dedicat
 - `examples/docker/Dockerfile.btl` and `examples/docker/docker-compose.btl.yml` (BTL Docker assets — now in the BTL harness repo).
 
 ### Notes
-- Library crates' API is unchanged from 0.8.1. Consumers of `bacnet-types`, `bacnet-encoding`, `bacnet-services`, `bacnet-transport`, `bacnet-network`, `bacnet-client`, `bacnet-objects`, `bacnet-server` can upgrade with no source changes.
+- Library crate APIs changed from 0.8.1 where called out in this changelog.
 - Python (`rusty-bacnet`) and WASM (`bacnet-wasm`) bindings unchanged.
 - CLI (`bacnet-cli`) unchanged.
 

--- a/benchmarks/benches/encoding.rs
+++ b/benchmarks/benches/encoding.rs
@@ -92,7 +92,7 @@ fn bench_encode_apdu_confirmed(c: &mut Criterion) {
     c.bench_function("encode_apdu_confirmed_request", |b| {
         b.iter(|| {
             let mut buf = BytesMut::with_capacity(64);
-            encode_apdu(&mut buf, &apdu);
+            encode_apdu(&mut buf, &apdu).expect("valid APDU encoding");
             black_box(buf);
         })
     });
@@ -112,7 +112,7 @@ fn bench_decode_apdu_confirmed(c: &mut Criterion) {
         service_request: Bytes::from(vec![0u8; 20]),
     });
     let mut buf = BytesMut::new();
-    encode_apdu(&mut buf, &apdu);
+    encode_apdu(&mut buf, &apdu).expect("valid APDU encoding");
     let data = Bytes::from(buf.to_vec());
 
     c.bench_function("decode_apdu_confirmed_request", |b| {
@@ -148,7 +148,7 @@ fn bench_full_stack_encode(c: &mut Criterion) {
                 service_request: Bytes::from(svc_buf.to_vec()),
             });
             let mut apdu_buf = BytesMut::with_capacity(64);
-            encode_apdu(&mut apdu_buf, &apdu);
+            encode_apdu(&mut apdu_buf, &apdu).expect("valid APDU encoding");
 
             let npdu = Npdu {
                 payload: Bytes::from(apdu_buf.to_vec()),

--- a/crates/bacnet-cli/src/decode.rs
+++ b/crates/bacnet-cli/src/decode.rs
@@ -277,7 +277,7 @@ mod tests {
         // Encode APDU
         let mut apdu_buf = BytesMut::new();
         if let Some(apdu) = apdu_data {
-            apdu::encode_apdu(&mut apdu_buf, apdu);
+            apdu::encode_apdu(&mut apdu_buf, apdu).expect("valid APDU encoding");
         }
 
         // Build NPDU with APDU as payload
@@ -289,7 +289,7 @@ mod tests {
 
         // Wrap in BVLC
         let mut bvlc_buf = BytesMut::new();
-        bvll::encode_bvll(&mut bvlc_buf, function, &npdu_buf);
+        bvll::encode_bvll(&mut bvlc_buf, function, &npdu_buf).expect("valid BVLL encoding");
         bvlc_buf.to_vec()
     }
 
@@ -454,7 +454,8 @@ mod tests {
         // BVLC-Result is a management frame with no NPDU.
         // Payload: 2-byte result code (0x0000 = success).
         let mut buf = BytesMut::new();
-        bvll::encode_bvll(&mut buf, BvlcFunction::BVLC_RESULT, &[0x00, 0x00]);
+        bvll::encode_bvll(&mut buf, BvlcFunction::BVLC_RESULT, &[0x00, 0x00])
+            .expect("valid BVLL encoding");
         let data = buf.to_vec();
 
         let packet = decode_packet(&data).unwrap();

--- a/crates/bacnet-client/src/client.rs
+++ b/crates/bacnet-client/src/client.rs
@@ -17,8 +17,8 @@ use tokio::time::{timeout, Duration};
 use tracing::{debug, warn};
 
 use bacnet_encoding::apdu::{
-    self, encode_apdu, AbortPdu, Apdu, ConfirmedRequest as ConfirmedRequestPdu,
-    SegmentAck as SegmentAckPdu, SimpleAck,
+    self, encode_apdu, validate_max_apdu_length, AbortPdu, Apdu,
+    ConfirmedRequest as ConfirmedRequestPdu, SegmentAck as SegmentAckPdu, SimpleAck,
 };
 use bacnet_encoding::npdu::NpduAddress;
 use bacnet_network::layer::NetworkLayer;
@@ -520,6 +520,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     pub async fn start(mut config: ClientConfig, transport: T) -> Result<Self, Error> {
         let transport_max = transport.max_apdu_length();
         config.max_apdu_length = config.max_apdu_length.min(transport_max);
+        validate_max_apdu_length(config.max_apdu_length)?;
+        if !(1..=127).contains(&config.proposed_window_size) {
+            return Err(Error::Encoding(format!(
+                "invalid proposed-window-size {}; expected 1..=127",
+                config.proposed_window_size
+            )));
+        }
 
         let mut network = NetworkLayer::new(transport);
         let mut apdu_rx = network.start().await?;
@@ -577,7 +584,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                             abort_reason: bacnet_types::enums::AbortReason::TSM_TIMEOUT,
                         });
                         let mut buf = BytesMut::with_capacity(4);
-                        encode_apdu(&mut buf, &abort);
+                        if let Err(e) = encode_apdu(&mut buf, &abort) {
+                            warn!(error = %e, "Failed to encode segmented receive timeout Abort");
+                            continue;
+                        }
                         let _ = network_dispatch
                             .send_apdu(&buf, &key.0, false, NetworkPriority::NORMAL)
                             .await;
@@ -711,7 +721,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                 service_choice: req.service_choice,
                             });
                             let mut buf = BytesMut::with_capacity(4);
-                            encode_apdu(&mut buf, &ack);
+                            if let Err(e) = encode_apdu(&mut buf, &ack) {
+                                warn!(error = %e, "Failed to encode SimpleAck for COV notification");
+                                return;
+                            }
                             if let Err(e) = network
                                 .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
                                 .await
@@ -827,7 +840,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 abort_reason: bacnet_types::enums::AbortReason::SEGMENTATION_NOT_SUPPORTED,
             });
             let mut buf = BytesMut::with_capacity(4);
-            encode_apdu(&mut buf, &abort);
+            if let Err(e) = encode_apdu(&mut buf, &abort) {
+                warn!(error = %e, "Failed to encode segmentation-not-supported Abort");
+                return;
+            }
             let _ = network
                 .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
                 .await;
@@ -887,7 +903,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 actual_window_size: proposed_ws,
             });
             let mut buf = BytesMut::with_capacity(4);
-            encode_apdu(&mut buf, &neg_ack);
+            if let Err(e) = encode_apdu(&mut buf, &neg_ack) {
+                warn!(error = %e, "Failed to encode negative SegmentAck");
+                return;
+            }
             if let Err(e) = network
                 .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
                 .await
@@ -917,7 +936,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 actual_window_size: proposed_ws,
             });
             let mut buf = BytesMut::with_capacity(4);
-            encode_apdu(&mut buf, &seg_ack);
+            if let Err(e) = encode_apdu(&mut buf, &seg_ack) {
+                warn!(error = %e, "Failed to encode SegmentAck");
+                return;
+            }
             if let Err(e) = network
                 .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
                 .await
@@ -1065,7 +1087,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         });
 
         let mut buf = BytesMut::with_capacity(6 + service_data.len());
-        encode_apdu(&mut buf, &pdu);
+        encode_apdu(&mut buf, &pdu)?;
 
         let timeout_duration = Duration::from_millis(self.config.apdu_timeout_ms);
         let max_retries = self.config.apdu_retries;
@@ -1220,7 +1242,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     });
 
                     let mut buf = BytesMut::with_capacity(remote_max_apdu as usize);
-                    encode_apdu(&mut buf, &pdu);
+                    encode_apdu(&mut buf, &pdu)?;
 
                     self.network
                         .send_apdu(&buf, destination_mac, true, NetworkPriority::NORMAL)
@@ -1270,7 +1292,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     });
 
                                     let mut buf = BytesMut::with_capacity(remote_max_apdu as usize);
-                                    encode_apdu(&mut buf, &pdu);
+                                    encode_apdu(&mut buf, &pdu)?;
 
                                     self.network
                                         .send_apdu(
@@ -1360,7 +1382,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         });
 
         let mut buf = BytesMut::with_capacity(2 + service_data.len());
-        encode_apdu(&mut buf, &pdu);
+        encode_apdu(&mut buf, &pdu)?;
 
         self.network
             .send_apdu(&buf, destination_mac, false, NetworkPriority::NORMAL)
@@ -1379,7 +1401,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         });
 
         let mut buf = BytesMut::with_capacity(2 + service_data.len());
-        encode_apdu(&mut buf, &pdu);
+        encode_apdu(&mut buf, &pdu)?;
 
         self.network
             .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
@@ -1398,7 +1420,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         });
 
         let mut buf = BytesMut::with_capacity(2 + service_data.len());
-        encode_apdu(&mut buf, &pdu);
+        encode_apdu(&mut buf, &pdu)?;
 
         self.network
             .broadcast_global_apdu(&buf, false, NetworkPriority::NORMAL)
@@ -1418,7 +1440,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         });
 
         let mut buf = BytesMut::with_capacity(2 + service_data.len());
-        encode_apdu(&mut buf, &pdu);
+        encode_apdu(&mut buf, &pdu)?;
 
         self.network
             .broadcast_to_network(&buf, dest_network, false, NetworkPriority::NORMAL)
@@ -2384,6 +2406,18 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn client_rejects_invalid_max_apdu_length() {
+        let result = BACnetClient::builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .max_apdu_length(1000)
+            .build()
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn confirmed_request_simple_ack() {
         let mut client_a = make_client().await;
 
@@ -2405,7 +2439,7 @@ mod tests {
                     service_choice: req.service_choice,
                 });
                 let mut buf = BytesMut::new();
-                encode_apdu(&mut buf, &ack);
+                encode_apdu(&mut buf, &ack).unwrap();
                 net_b
                     .send_apdu(&buf, &received.source_mac, false, NetworkPriority::NORMAL)
                     .await
@@ -2457,7 +2491,7 @@ mod tests {
                     service_ack: Bytes::from_static(&[0xDE, 0xAD, 0xBE, 0xEF]),
                 });
                 let mut buf = BytesMut::new();
-                encode_apdu(&mut buf, &ack);
+                encode_apdu(&mut buf, &ack).unwrap();
                 net_b
                     .send_apdu(&buf, &received.source_mac, false, NetworkPriority::NORMAL)
                     .await
@@ -2529,7 +2563,7 @@ mod tests {
                     service_ack: seg.clone(),
                 });
                 let mut buf = BytesMut::new();
-                encode_apdu(&mut buf, &ack);
+                encode_apdu(&mut buf, &ack).unwrap();
                 net_b
                     .send_apdu(&buf, &received.source_mac, false, NetworkPriority::NORMAL)
                     .await
@@ -2611,7 +2645,7 @@ mod tests {
                         actual_window_size: 1,
                     });
                     let mut buf = BytesMut::new();
-                    encode_apdu(&mut buf, &seg_ack);
+                    encode_apdu(&mut buf, &seg_ack).unwrap();
                     net_b
                         .send_apdu(&buf, &received.source_mac, false, NetworkPriority::NORMAL)
                         .await
@@ -2630,7 +2664,7 @@ mod tests {
                 service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
             });
             let mut buf = BytesMut::new();
-            encode_apdu(&mut buf, &ack);
+            encode_apdu(&mut buf, &ack).unwrap();
             net_b
                 .send_apdu(&buf, &client_mac, false, NetworkPriority::NORMAL)
                 .await
@@ -2699,7 +2733,7 @@ mod tests {
                         actual_window_size: 1,
                     });
                     let mut buf = BytesMut::new();
-                    encode_apdu(&mut buf, &seg_ack);
+                    encode_apdu(&mut buf, &seg_ack).unwrap();
                     net_b
                         .send_apdu(&buf, &received.source_mac, false, NetworkPriority::NORMAL)
                         .await
@@ -2721,7 +2755,7 @@ mod tests {
                 service_ack: Bytes::from_static(&[0xCA, 0xFE]),
             });
             let mut buf = BytesMut::new();
-            encode_apdu(&mut buf, &ack);
+            encode_apdu(&mut buf, &ack).unwrap();
             net_b
                 .send_apdu(&buf, &client_mac, false, NetworkPriority::NORMAL)
                 .await

--- a/crates/bacnet-client/tests/integration.rs
+++ b/crates/bacnet-client/tests/integration.rs
@@ -80,7 +80,7 @@ async fn full_read_property_round_trip() {
                 service_ack: Bytes::from(ack_buf.to_vec()),
             });
             let mut buf = BytesMut::new();
-            encode_apdu(&mut buf, &complex_ack);
+            encode_apdu(&mut buf, &complex_ack).expect("valid APDU encoding");
 
             net_b
                 .send_apdu(&buf, &received.source_mac, false, NetworkPriority::NORMAL)
@@ -168,7 +168,7 @@ async fn device_discovery_via_iam() {
         service_request: Bytes::from(service_buf.to_vec()),
     });
     let mut buf = BytesMut::new();
-    encode_apdu(&mut buf, &pdu);
+    encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
     net_b
         .send_apdu(&buf, client.local_mac(), false, NetworkPriority::NORMAL)

--- a/crates/bacnet-encoding/src/apdu.rs
+++ b/crates/bacnet-encoding/src/apdu.rs
@@ -63,29 +63,47 @@ fn decode_max_segments(value: u8) -> Option<u8> {
 /// Decoded max-APDU-length values indexed by the 4-bit field.
 const MAX_APDU_DECODE: [u16; 6] = [50, 128, 206, 480, 1024, 1476];
 
+/// Return true when `value` is one of the BACnet max-APDU-length encodings
+/// defined by ASHRAE 135-2020 Clause 20.1.2.5.
+pub fn is_valid_max_apdu_length(value: u16) -> bool {
+    matches!(value, 50 | 128 | 206 | 480 | 1024 | 1476)
+}
+
+/// Validate a locally configured max-APDU-length value.
+pub fn validate_max_apdu_length(value: u16) -> Result<(), Error> {
+    if is_valid_max_apdu_length(value) {
+        Ok(())
+    } else {
+        Err(Error::Encoding(format!(
+            "invalid max-APDU-length {value}; expected one of 50, 128, 206, 480, 1024, 1476"
+        )))
+    }
+}
+
 /// Encode a max-APDU-length to a 4-bit field.
-fn encode_max_apdu(value: u16) -> u8 {
+fn encode_max_apdu(value: u16) -> Result<u8, Error> {
+    validate_max_apdu_length(value)?;
     match value {
-        50 => 0,
-        128 => 1,
-        206 => 2,
-        480 => 3,
-        1024 => 4,
-        _ => 5, // 1476 (default)
+        50 => Ok(0),
+        128 => Ok(1),
+        206 => Ok(2),
+        480 => Ok(3),
+        1024 => Ok(4),
+        1476 => Ok(5),
+        _ => unreachable!("validated max-APDU-length"),
     }
 }
 
 /// Decode a 4-bit max-APDU-length field.
-fn decode_max_apdu(value: u8) -> u16 {
+fn decode_max_apdu(value: u8) -> Result<u16, Error> {
     let idx = (value & 0x0F) as usize;
     if idx < MAX_APDU_DECODE.len() {
-        MAX_APDU_DECODE[idx]
+        Ok(MAX_APDU_DECODE[idx])
     } else {
-        tracing::warn!(
-            value = idx,
-            "Reserved max-APDU-length field value, defaulting to 1476"
-        );
-        1476
+        Err(Error::decoding(
+            1,
+            format!("reserved max-APDU-length field value {idx}"),
+        ))
     }
 }
 
@@ -187,20 +205,35 @@ pub enum Apdu {
 // ---------------------------------------------------------------------------
 
 /// Encode an APDU to wire format.
-pub fn encode_apdu(buf: &mut BytesMut, apdu: &Apdu) {
+pub fn encode_apdu(buf: &mut BytesMut, apdu: &Apdu) -> Result<(), Error> {
     match apdu {
         Apdu::ConfirmedRequest(pdu) => encode_confirmed_request(buf, pdu),
-        Apdu::UnconfirmedRequest(pdu) => encode_unconfirmed_request(buf, pdu),
-        Apdu::SimpleAck(pdu) => encode_simple_ack(buf, pdu),
+        Apdu::UnconfirmedRequest(pdu) => {
+            encode_unconfirmed_request(buf, pdu);
+            Ok(())
+        }
+        Apdu::SimpleAck(pdu) => {
+            encode_simple_ack(buf, pdu);
+            Ok(())
+        }
         Apdu::ComplexAck(pdu) => encode_complex_ack(buf, pdu),
         Apdu::SegmentAck(pdu) => encode_segment_ack(buf, pdu),
-        Apdu::Error(pdu) => encode_error(buf, pdu),
-        Apdu::Reject(pdu) => encode_reject(buf, pdu),
-        Apdu::Abort(pdu) => encode_abort(buf, pdu),
+        Apdu::Error(pdu) => {
+            encode_error(buf, pdu);
+            Ok(())
+        }
+        Apdu::Reject(pdu) => {
+            encode_reject(buf, pdu);
+            Ok(())
+        }
+        Apdu::Abort(pdu) => {
+            encode_abort(buf, pdu);
+            Ok(())
+        }
     }
 }
 
-fn encode_confirmed_request(buf: &mut BytesMut, pdu: &ConfirmedRequest) {
+fn encode_confirmed_request(buf: &mut BytesMut, pdu: &ConfirmedRequest) -> Result<(), Error> {
     let mut byte0 = PduType::CONFIRMED_REQUEST.to_raw() << 4;
     if pdu.segmented {
         byte0 |= 0x08;
@@ -213,18 +246,23 @@ fn encode_confirmed_request(buf: &mut BytesMut, pdu: &ConfirmedRequest) {
     }
     buf.put_u8(byte0);
 
-    let byte1 = (encode_max_segments(pdu.max_segments) << 4) | encode_max_apdu(pdu.max_apdu_length);
+    let byte1 =
+        (encode_max_segments(pdu.max_segments) << 4) | encode_max_apdu(pdu.max_apdu_length)?;
     buf.put_u8(byte1);
 
     buf.put_u8(pdu.invoke_id);
 
     if pdu.segmented {
         buf.put_u8(pdu.sequence_number.unwrap_or(0));
-        buf.put_u8(pdu.proposed_window_size.unwrap_or(1).clamp(1, 127));
+        buf.put_u8(valid_window_size(
+            "ConfirmedRequest proposed-window-size",
+            pdu.proposed_window_size.unwrap_or(1),
+        )?);
     }
 
     buf.put_u8(pdu.service_choice.to_raw());
     buf.put_slice(&pdu.service_request);
+    Ok(())
 }
 
 fn encode_unconfirmed_request(buf: &mut BytesMut, pdu: &UnconfirmedRequest) {
@@ -239,7 +277,7 @@ fn encode_simple_ack(buf: &mut BytesMut, pdu: &SimpleAck) {
     buf.put_u8(pdu.service_choice.to_raw());
 }
 
-fn encode_complex_ack(buf: &mut BytesMut, pdu: &ComplexAck) {
+fn encode_complex_ack(buf: &mut BytesMut, pdu: &ComplexAck) -> Result<(), Error> {
     let mut byte0 = PduType::COMPLEX_ACK.to_raw() << 4;
     if pdu.segmented {
         byte0 |= 0x08;
@@ -253,14 +291,18 @@ fn encode_complex_ack(buf: &mut BytesMut, pdu: &ComplexAck) {
 
     if pdu.segmented {
         buf.put_u8(pdu.sequence_number.unwrap_or(0));
-        buf.put_u8(pdu.proposed_window_size.unwrap_or(1).clamp(1, 127));
+        buf.put_u8(valid_window_size(
+            "ComplexAck proposed-window-size",
+            pdu.proposed_window_size.unwrap_or(1),
+        )?);
     }
 
     buf.put_u8(pdu.service_choice.to_raw());
     buf.put_slice(&pdu.service_ack);
+    Ok(())
 }
 
-fn encode_segment_ack(buf: &mut BytesMut, pdu: &SegmentAck) {
+fn encode_segment_ack(buf: &mut BytesMut, pdu: &SegmentAck) -> Result<(), Error> {
     let mut byte0 = PduType::SEGMENT_ACK.to_raw() << 4;
     if pdu.negative_ack {
         byte0 |= 0x02;
@@ -271,7 +313,21 @@ fn encode_segment_ack(buf: &mut BytesMut, pdu: &SegmentAck) {
     buf.put_u8(byte0);
     buf.put_u8(pdu.invoke_id);
     buf.put_u8(pdu.sequence_number);
-    buf.put_u8(pdu.actual_window_size.clamp(1, 127));
+    buf.put_u8(valid_window_size(
+        "SegmentACK actual-window-size",
+        pdu.actual_window_size,
+    )?);
+    Ok(())
+}
+
+fn valid_window_size(field: &str, value: u8) -> Result<u8, Error> {
+    if (1..=127).contains(&value) {
+        Ok(value)
+    } else {
+        Err(Error::Encoding(format!(
+            "{field} {value} outside BACnet range 1..=127"
+        )))
+    }
 }
 
 fn encode_error(buf: &mut BytesMut, pdu: &ErrorPdu) {
@@ -350,7 +406,7 @@ fn decode_confirmed_request(data: Bytes) -> Result<ConfirmedRequest, Error> {
 
     let byte1 = data[1];
     let max_segments = decode_max_segments((byte1 >> 4) & 0x07);
-    let max_apdu_length = decode_max_apdu(byte1 & 0x0F);
+    let max_apdu_length = decode_max_apdu(byte1 & 0x0F)?;
 
     let invoke_id = data[2];
     let mut offset = 3;
@@ -474,17 +530,17 @@ fn decode_segment_ack(data: Bytes) -> Result<SegmentAck, Error> {
     let byte0 = data[0];
     let raw_window = data[3];
     if raw_window == 0 || raw_window > 127 {
-        tracing::warn!(
-            actual_window_size = raw_window,
-            "SegmentAck window size out of range (1-127), clamping"
-        );
+        return Err(Error::decoding(
+            3,
+            format!("SegmentACK actual-window-size {raw_window} outside range 1..=127"),
+        ));
     }
     Ok(SegmentAck {
         negative_ack: byte0 & 0x02 != 0,
         sent_by_server: byte0 & 0x01 != 0,
         invoke_id: data[1],
         sequence_number: data[2],
-        actual_window_size: raw_window.clamp(1, 127),
+        actual_window_size: raw_window,
     })
 }
 
@@ -581,7 +637,7 @@ mod tests {
 
     fn encode_to_vec(apdu: &Apdu) -> Vec<u8> {
         let mut buf = BytesMut::with_capacity(64);
-        encode_apdu(&mut buf, apdu);
+        encode_apdu(&mut buf, apdu).unwrap();
         buf.to_vec()
     }
 
@@ -604,14 +660,27 @@ mod tests {
 
     #[test]
     fn max_apdu_round_trip() {
-        assert_eq!(decode_max_apdu(encode_max_apdu(50)), 50);
-        assert_eq!(decode_max_apdu(encode_max_apdu(128)), 128);
-        assert_eq!(decode_max_apdu(encode_max_apdu(206)), 206);
-        assert_eq!(decode_max_apdu(encode_max_apdu(480)), 480);
-        assert_eq!(decode_max_apdu(encode_max_apdu(1024)), 1024);
-        assert_eq!(decode_max_apdu(encode_max_apdu(1476)), 1476);
-        // Unknown value defaults to 1476
-        assert_eq!(decode_max_apdu(encode_max_apdu(9999)), 1476);
+        for value in [50, 128, 206, 480, 1024, 1476] {
+            assert_eq!(
+                decode_max_apdu(encode_max_apdu(value).unwrap()).unwrap(),
+                value
+            );
+        }
+        assert!(encode_max_apdu(9999).is_err());
+    }
+
+    #[test]
+    fn decode_max_apdu_reserved_value_errors() {
+        for value in 6..=15 {
+            assert!(decode_max_apdu(value).is_err());
+        }
+    }
+
+    #[test]
+    fn decode_confirmed_request_reserved_max_apdu_errors() {
+        // Low nibble 0x06 is reserved by ASHRAE 135-2020 Clause 20.1.2.5.
+        let data = Bytes::from_static(&[0x00, 0x06, 0x01, 0x0C]);
+        assert!(decode_apdu(data).is_err());
     }
 
     // --- ConfirmedRequest ---
@@ -782,6 +851,47 @@ mod tests {
         assert_eq!(encoded.len(), 4);
         let decoded = decode_apdu(Bytes::from(encoded)).unwrap();
         assert_eq!(apdu, decoded);
+    }
+
+    #[test]
+    fn encode_segment_ack_invalid_window_errors() {
+        for actual_window_size in [0, 128] {
+            let apdu = Apdu::SegmentAck(SegmentAck {
+                negative_ack: false,
+                sent_by_server: false,
+                invoke_id: 1,
+                sequence_number: 0,
+                actual_window_size,
+            });
+            let mut buf = BytesMut::new();
+            assert!(encode_apdu(&mut buf, &apdu).is_err());
+        }
+    }
+
+    #[test]
+    fn decode_segment_ack_invalid_window_errors() {
+        assert!(decode_apdu(Bytes::from_static(&[0x40, 0x01, 0x00, 0x00])).is_err());
+        assert!(decode_apdu(Bytes::from_static(&[0x40, 0x01, 0x00, 0x80])).is_err());
+    }
+
+    #[test]
+    fn encode_segmented_proposed_window_invalid_errors() {
+        for proposed_window_size in [0, 128] {
+            let apdu = Apdu::ConfirmedRequest(ConfirmedRequest {
+                segmented: true,
+                more_follows: false,
+                segmented_response_accepted: false,
+                max_segments: None,
+                max_apdu_length: 1476,
+                invoke_id: 1,
+                sequence_number: Some(0),
+                proposed_window_size: Some(proposed_window_size),
+                service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+                service_request: Bytes::new(),
+            });
+            let mut buf = BytesMut::new();
+            assert!(encode_apdu(&mut buf, &apdu).is_err());
+        }
     }
 
     #[test]

--- a/crates/bacnet-encoding/src/primitives.rs
+++ b/crates/bacnet-encoding/src/primitives.rs
@@ -122,8 +122,11 @@ pub fn encode_real(buf: &mut BytesMut, value: f32) {
 
 /// Decode an IEEE-754 single-precision float from 4 big-endian bytes.
 pub fn decode_real(data: &[u8]) -> Result<f32, Error> {
-    if data.len() < 4 {
-        return Err(Error::buffer_too_short(4, data.len()));
+    if data.len() != 4 {
+        return Err(Error::decoding(
+            0,
+            format!("Real expects exactly 4 bytes, got {}", data.len()),
+        ));
     }
     Ok(f32::from_be_bytes([data[0], data[1], data[2], data[3]]))
 }
@@ -137,8 +140,11 @@ pub fn encode_double(buf: &mut BytesMut, value: f64) {
 
 /// Decode an IEEE-754 double-precision float from 8 big-endian bytes.
 pub fn decode_double(data: &[u8]) -> Result<f64, Error> {
-    if data.len() < 8 {
-        return Err(Error::buffer_too_short(8, data.len()));
+    if data.len() != 8 {
+        return Err(Error::decoding(
+            0,
+            format!("Double expects exactly 8 bytes, got {}", data.len()),
+        ));
     }
     let bytes: [u8; 8] = [
         data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
@@ -802,6 +808,25 @@ mod tests {
         let mut buf = BytesMut::new();
         encode_double(&mut buf, core::f64::consts::PI);
         assert_eq!(decode_double(&buf).unwrap(), core::f64::consts::PI);
+    }
+
+    #[test]
+    fn fixed_width_application_values_reject_overlong_tags() {
+        for (tag, len) in [
+            (app_tag::REAL, 5),
+            (app_tag::DOUBLE, 9),
+            (app_tag::DATE, 5),
+            (app_tag::TIME, 5),
+            (app_tag::OBJECT_IDENTIFIER, 5),
+        ] {
+            let mut bytes = BytesMut::new();
+            tags::encode_tag(&mut bytes, tag, TagClass::Application, len);
+            bytes.extend_from_slice(&vec![0; len as usize]);
+            assert!(
+                decode_application_value(&bytes, 0).is_err(),
+                "tag {tag} with length {len} should be rejected"
+            );
+        }
     }
 
     // --- Character string ---

--- a/crates/bacnet-integration-tests/tests/server.rs
+++ b/crates/bacnet-integration-tests/tests/server.rs
@@ -813,7 +813,7 @@ async fn server_handles_segmented_request() {
     });
 
     let mut buf = BytesMut::new();
-    encode_apdu(&mut buf, &seg0);
+    encode_apdu(&mut buf, &seg0).expect("valid APDU encoding");
     raw_network
         .send_apdu(
             &buf,
@@ -855,7 +855,7 @@ async fn server_handles_segmented_request() {
     });
 
     let mut buf = BytesMut::new();
-    encode_apdu(&mut buf, &seg1);
+    encode_apdu(&mut buf, &seg1).expect("valid APDU encoding");
     raw_network
         .send_apdu(
             &buf,
@@ -1223,7 +1223,7 @@ async fn iam_routed_back_to_remote_whois_requester() {
         service_request: Bytes::new(),
     });
     let mut apdu_buf = bytes::BytesMut::new();
-    encode_apdu(&mut apdu_buf, &who_is_apdu);
+    encode_apdu(&mut apdu_buf, &who_is_apdu).expect("valid APDU encoding");
 
     // Wrap in an NPDU with source routing: SNET=100, SADR=[10,20,30]
     // This simulates a WhoIs that was forwarded by a router from network 100.
@@ -1317,7 +1317,7 @@ async fn iam_broadcast_for_local_whois() {
         service_request: Bytes::new(),
     });
     let mut apdu_buf = bytes::BytesMut::new();
-    encode_apdu(&mut apdu_buf, &who_is_apdu);
+    encode_apdu(&mut apdu_buf, &who_is_apdu).expect("valid APDU encoding");
 
     // Wrap in an NPDU without source routing
     let npdu = Npdu {

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -357,7 +357,7 @@ mod tests {
             service_request: Bytes::new(),
         });
         let mut apdu_buf = BytesMut::new();
-        encode_apdu(&mut apdu_buf, &who_is_apdu);
+        encode_apdu(&mut apdu_buf, &who_is_apdu).expect("valid APDU encoding");
 
         net_a
             .send_apdu(&apdu_buf, net_b.local_mac(), false, NetworkPriority::NORMAL)

--- a/crates/bacnet-server/src/server.rs
+++ b/crates/bacnet-server/src/server.rs
@@ -17,9 +17,9 @@ use tokio::time::Duration;
 use tracing::{debug, warn};
 
 use bacnet_encoding::apdu::{
-    self, encode_apdu, AbortPdu, Apdu, ComplexAck, ConfirmedRequest as ConfirmedRequestPdu,
-    ErrorPdu, RejectPdu, SegmentAck as SegmentAckPdu, SimpleAck,
-    UnconfirmedRequest as UnconfirmedRequestPdu,
+    self, encode_apdu, validate_max_apdu_length, AbortPdu, Apdu, ComplexAck,
+    ConfirmedRequest as ConfirmedRequestPdu, ErrorPdu, RejectPdu, SegmentAck as SegmentAckPdu,
+    SimpleAck, UnconfirmedRequest as UnconfirmedRequestPdu,
 };
 use bacnet_encoding::primitives::encode_property_value;
 use bacnet_encoding::segmentation::{
@@ -505,6 +505,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     ) -> Result<Self, Error> {
         let transport_max = transport.max_apdu_length() as u32;
         config.max_apdu_length = config.max_apdu_length.min(transport_max);
+        let max_apdu = u16::try_from(config.max_apdu_length).map_err(|_| {
+            Error::Encoding(format!(
+                "invalid max_apdu_length {}; expected one of 50, 128, 206, 480, 1024, 1476",
+                config.max_apdu_length
+            ))
+        })?;
+        validate_max_apdu_length(max_apdu)?;
 
         if config.vendor_id == 0 {
             warn!("vendor_id is 0 (ASHRAE reserved); set a valid vendor ID for production use");
@@ -570,7 +577,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                             abort_reason: AbortReason::BUFFER_OVERFLOW,
                                         });
                                         let mut abort_buf = BytesMut::new();
-                                        encode_apdu(&mut abort_buf, &abort_pdu);
+                                        encode_apdu(&mut abort_buf, &abort_pdu)
+                                            .expect("valid APDU encoding");
                                         let _ = network_dispatch
                                             .send_apdu(
                                                 &abort_buf,
@@ -615,7 +623,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                         abort_reason: AbortReason::INVALID_APDU_IN_THIS_STATE,
                                     });
                                     let mut abort_buf = BytesMut::new();
-                                    encode_apdu(&mut abort_buf, &abort_pdu);
+                                    encode_apdu(&mut abort_buf, &abort_pdu)
+                                        .expect("valid APDU encoding");
                                     let _ = network_dispatch
                                         .send_apdu(
                                             &abort_buf,
@@ -635,7 +644,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                     actual_window_size: 1,
                                 });
                                 let mut ack_buf = BytesMut::new();
-                                encode_apdu(&mut ack_buf, &seg_ack);
+                                encode_apdu(&mut ack_buf, &seg_ack).expect("valid APDU encoding");
                                 if let Err(e) = network_dispatch
                                     .send_apdu(
                                         &ack_buf,
@@ -1345,7 +1354,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
         if let Apdu::ComplexAck(ref ack) = response {
             let mut full_buf = BytesMut::new();
-            encode_apdu(&mut full_buf, &response);
+            encode_apdu(&mut full_buf, &response).expect("valid APDU encoding");
 
             if full_buf.len() > client_max_apdu as usize {
                 if !client_accepts_segmented {
@@ -1355,7 +1364,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         abort_reason: AbortReason::SEGMENTATION_NOT_SUPPORTED,
                     });
                     let mut buf = BytesMut::new();
-                    encode_apdu(&mut buf, &abort);
+                    encode_apdu(&mut buf, &abort).expect("valid APDU encoding");
                     if let Err(e) = network
                         .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
                         .await
@@ -1402,7 +1411,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         }
 
         let mut buf = BytesMut::new();
-        encode_apdu(&mut buf, &response);
+        encode_apdu(&mut buf, &response).expect("valid APDU encoding");
 
         if let Some(tx) = reply_tx {
             use bacnet_encoding::npdu::{encode_npdu, Npdu};
@@ -1486,7 +1495,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 abort_reason: AbortReason::BUFFER_OVERFLOW,
             });
             let mut buf = BytesMut::new();
-            encode_apdu(&mut buf, &abort);
+            encode_apdu(&mut buf, &abort).expect("valid APDU encoding");
             let _ = network
                 .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
                 .await;
@@ -1524,7 +1533,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             });
 
             let mut buf = BytesMut::with_capacity(client_max_apdu as usize);
-            encode_apdu(&mut buf, &pdu);
+            encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
             if let Err(e) = network
                 .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
@@ -1558,7 +1567,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                     abort_reason: AbortReason::TSM_TIMEOUT,
                                 });
                                 let mut abort_buf = BytesMut::new();
-                                encode_apdu(&mut abort_buf, &abort);
+                                encode_apdu(&mut abort_buf, &abort).expect("valid APDU encoding");
                                 let _ = network
                                     .send_apdu(
                                         &abort_buf,
@@ -1601,7 +1610,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             abort_reason: AbortReason::TSM_TIMEOUT,
                         });
                         let mut abort_buf = BytesMut::new();
-                        encode_apdu(&mut abort_buf, &abort);
+                        encode_apdu(&mut abort_buf, &abort).expect("valid APDU encoding");
                         let _ = network
                             .send_apdu(&abort_buf, source_mac, false, NetworkPriority::NORMAL)
                             .await;
@@ -1680,7 +1689,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     });
 
                     let mut buf = BytesMut::new();
-                    encode_apdu(&mut buf, &pdu);
+                    encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
                     if let Some(ref source_net) = received.source_network {
                         if let Err(e) = network
@@ -1724,7 +1733,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             });
 
                             let mut buf = BytesMut::new();
-                            encode_apdu(&mut buf, &pdu);
+                            encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
                             if let Err(e) = network
                                 .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
@@ -1901,7 +1910,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             });
 
             let mut buf = BytesMut::new();
-            encode_apdu(&mut buf, &pdu);
+            encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
             if let Err(e) = network
                 .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
@@ -1937,7 +1946,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     });
 
                     let mut buf = BytesMut::new();
-                    encode_apdu(&mut buf, &pdu);
+                    encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
                     match recipient {
                         bacnet_types::constructed::BACnetRecipient::Address(addr) => {
@@ -1964,7 +1973,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     });
 
                     let mut buf = BytesMut::new();
-                    encode_apdu(&mut buf, &pdu);
+                    encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
                     match recipient {
                         bacnet_types::constructed::BACnetRecipient::Address(addr) => {
@@ -2145,7 +2154,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 });
 
                 let mut buf = BytesMut::new();
-                encode_apdu(&mut buf, &pdu);
+                encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
                 if let Some(pv) = current_pv {
                     let mut table = cov_table.write().await;
@@ -2227,7 +2236,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 });
 
                 let mut buf = BytesMut::new();
-                encode_apdu(&mut buf, &pdu);
+                encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
                 if let Err(e) = network
                     .send_apdu(&buf, &sub.subscriber_mac, false, NetworkPriority::NORMAL)
@@ -2285,6 +2294,18 @@ mod tests {
     fn server_config_time_sync_callback_default_is_none() {
         let config = ServerConfig::default();
         assert!(config.on_time_sync.is_none());
+    }
+
+    #[tokio::test]
+    async fn server_rejects_invalid_max_apdu_length() {
+        let config = ServerConfig {
+            max_apdu_length: 1000,
+            ..ServerConfig::default()
+        };
+        let transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+
+        let result = BACnetServer::start(config, ObjectDatabase::new(), transport).await;
+        assert!(result.is_err());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/bacnet-transport/src/bip.rs
+++ b/crates/bacnet-transport/src/bip.rs
@@ -165,7 +165,7 @@ impl BipTransport {
         }
 
         let mut buf = BytesMut::with_capacity(4 + payload.len());
-        encode_bvll(&mut buf, function, payload);
+        encode_bvll(&mut buf, function, payload)?;
         socket.send_to(&buf, dest).await.map_err(Error::Transport)?;
 
         match tokio::time::timeout(Self::BVLC_RESPONSE_TIMEOUT, rx).await {
@@ -449,7 +449,7 @@ impl TransportPort for BipTransport {
         let dest = SocketAddrV4::new(Ipv4Addr::from(ip), port);
 
         let mut buf = BytesMut::with_capacity(4 + npdu.len());
-        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_UNICAST_NPDU, npdu);
+        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_UNICAST_NPDU, npdu)?;
 
         socket.send_to(&buf, dest).await.map_err(Error::Transport)?;
 
@@ -466,7 +466,7 @@ impl TransportPort for BipTransport {
                 &mut buf,
                 BvlcFunction::DISTRIBUTE_BROADCAST_TO_NETWORK,
                 npdu,
-            );
+            )?;
             socket
                 .send_to(&buf, bbmd_addr)
                 .await
@@ -477,7 +477,7 @@ impl TransportPort for BipTransport {
         let dest = SocketAddrV4::new(self.broadcast_address, self.port);
 
         let mut buf = BytesMut::with_capacity(4 + npdu.len());
-        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_BROADCAST_NPDU, npdu);
+        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_BROADCAST_NPDU, npdu)?;
 
         socket.send_to(&buf, dest).await.map_err(Error::Transport)?;
 
@@ -493,7 +493,10 @@ impl TransportPort for BipTransport {
 async fn send_register_foreign_device(socket: &UdpSocket, bbmd_addr: SocketAddrV4, ttl: u16) {
     let payload = ttl.to_be_bytes().to_vec();
     let mut buf = BytesMut::with_capacity(6);
-    encode_bvll(&mut buf, BvlcFunction::REGISTER_FOREIGN_DEVICE, &payload);
+    if let Err(e) = encode_bvll(&mut buf, BvlcFunction::REGISTER_FOREIGN_DEVICE, &payload) {
+        warn!(error = %e, "Failed to encode Register-Foreign-Device");
+        return;
+    }
     if let Err(e) = socket.send_to(&buf, bbmd_addr).await {
         warn!(error = %e, "Failed to send Register-Foreign-Device");
     } else {
@@ -564,8 +567,12 @@ async fn handle_bvll_message(msg: &bvll::BvllMessage, sender: ([u8; 4], u16), ct
                 // Re-broadcast on local subnet as Forwarded-NPDU.
                 let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
                 let mut buf = BytesMut::with_capacity(10 + msg.payload.len());
-                encode_bvll_forwarded(&mut buf, sender.0, sender.1, &msg.payload);
-                let _ = ctx.socket.send_to(&buf, dest).await;
+                match encode_bvll_forwarded(&mut buf, sender.0, sender.1, &msg.payload) {
+                    Ok(()) => {
+                        let _ = ctx.socket.send_to(&buf, dest).await;
+                    }
+                    Err(e) => warn!(error = %e, "Failed to encode Forwarded-NPDU rebroadcast"),
+                }
             }
         }
 
@@ -628,8 +635,12 @@ async fn handle_bvll_message(msg: &bvll::BvllMessage, sender: ([u8; 4], u16), ct
                 // Re-broadcast on local subnet as Forwarded-NPDU
                 let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
                 let mut buf = BytesMut::with_capacity(10 + msg.payload.len());
-                encode_bvll_forwarded(&mut buf, orig_ip, orig_port, &msg.payload);
-                let _ = ctx.socket.send_to(&buf, dest).await;
+                match encode_bvll_forwarded(&mut buf, orig_ip, orig_port, &msg.payload) {
+                    Ok(()) => {
+                        let _ = ctx.socket.send_to(&buf, dest).await;
+                    }
+                    Err(e) => warn!(error = %e, "Failed to encode Forwarded-NPDU rebroadcast"),
+                }
             } else {
                 // Non-BBMD: use originating address as source_mac (spec J.2.5).
                 if ctx
@@ -691,8 +702,12 @@ async fn handle_bvll_message(msg: &bvll::BvllMessage, sender: ([u8; 4], u16), ct
                 // Broadcast locally as Forwarded-NPDU
                 let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
                 let mut buf = BytesMut::with_capacity(10 + msg.payload.len());
-                encode_bvll_forwarded(&mut buf, sender.0, sender.1, &msg.payload);
-                let _ = ctx.socket.send_to(&buf, dest).await;
+                match encode_bvll_forwarded(&mut buf, sender.0, sender.1, &msg.payload) {
+                    Ok(()) => {
+                        let _ = ctx.socket.send_to(&buf, dest).await;
+                    }
+                    Err(e) => warn!(error = %e, "Failed to encode Forwarded-NPDU broadcast"),
+                }
             } else {
                 // Non-BBMD: reject with NAK (spec J.4.5)
                 send_bvlc_result(
@@ -743,13 +758,17 @@ async fn handle_bvll_message(msg: &bvll::BvllMessage, sender: ([u8; 4], u16), ct
                 let mut payload = BytesMut::new();
                 state.encode_bdt(&mut payload);
                 let mut buf = BytesMut::with_capacity(4 + payload.len());
-                encode_bvll(
+                match encode_bvll(
                     &mut buf,
                     BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK,
                     &payload,
-                );
-                let dest = SocketAddrV4::new(Ipv4Addr::from(sender.0), sender.1);
-                let _ = ctx.socket.send_to(&buf, dest).await;
+                ) {
+                    Ok(()) => {
+                        let dest = SocketAddrV4::new(Ipv4Addr::from(sender.0), sender.1);
+                        let _ = ctx.socket.send_to(&buf, dest).await;
+                    }
+                    Err(e) => warn!(error = %e, "Failed to encode Read-BDT-Ack"),
+                }
             } else {
                 send_bvlc_result(
                     &ctx.socket,
@@ -841,13 +860,17 @@ async fn handle_bvll_message(msg: &bvll::BvllMessage, sender: ([u8; 4], u16), ct
                 state.encode_fdt(&mut payload);
                 drop(state);
                 let mut buf = BytesMut::with_capacity(4 + payload.len());
-                encode_bvll(
+                match encode_bvll(
                     &mut buf,
                     BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK,
                     &payload,
-                );
-                let dest = SocketAddrV4::new(Ipv4Addr::from(sender.0), sender.1);
-                let _ = ctx.socket.send_to(&buf, dest).await;
+                ) {
+                    Ok(()) => {
+                        let dest = SocketAddrV4::new(Ipv4Addr::from(sender.0), sender.1);
+                        let _ = ctx.socket.send_to(&buf, dest).await;
+                    }
+                    Err(e) => warn!(error = %e, "Failed to encode Read-FDT-Ack"),
+                }
             } else {
                 send_bvlc_result(
                     &ctx.socket,
@@ -974,7 +997,10 @@ async fn handle_bvll_message(msg: &bvll::BvllMessage, sender: ([u8; 4], u16), ct
 async fn send_bvlc_result(socket: &UdpSocket, dest: ([u8; 4], u16), code: BvlcResultCode) {
     let payload = code.to_raw().to_be_bytes().to_vec();
     let mut buf = BytesMut::with_capacity(6);
-    encode_bvll(&mut buf, BvlcFunction::BVLC_RESULT, &payload);
+    if let Err(e) = encode_bvll(&mut buf, BvlcFunction::BVLC_RESULT, &payload) {
+        warn!(error = %e, "Failed to encode BVLC-Result");
+        return;
+    }
     let addr = SocketAddrV4::new(Ipv4Addr::from(dest.0), dest.1);
     let _ = socket.send_to(&buf, addr).await;
 }
@@ -994,7 +1020,10 @@ async fn forward_npdu(
         return;
     }
     let mut buf = BytesMut::with_capacity(10 + npdu.len());
-    encode_bvll_forwarded(&mut buf, orig_ip, orig_port, npdu);
+    if let Err(e) = encode_bvll_forwarded(&mut buf, orig_ip, orig_port, npdu) {
+        warn!(error = %e, "Failed to encode Forwarded-NPDU");
+        return;
+    }
     let frame = buf.freeze();
 
     for (i, &(ip, port)) in targets.iter().enumerate() {

--- a/crates/bacnet-transport/src/bip6.rs
+++ b/crates/bacnet-transport/src/bip6.rs
@@ -124,19 +124,20 @@ pub fn encode_bvlc6(
     function: Bvlc6Function,
     source_vmac: &Bip6Vmac,
     npdu: &[u8],
-) {
+) -> Result<(), Error> {
     let total_length = BVLC6_HEADER_LENGTH + npdu.len();
-    debug_assert!(
-        total_length <= u16::MAX as usize,
-        "BVLC6 frame length overflow"
-    );
-    let wire_length = (total_length as u64).min(u16::MAX as u64) as u16;
+    if total_length > u16::MAX as usize {
+        return Err(Error::Encoding(format!(
+            "BVLC6 frame length {total_length} exceeds 16-bit BVLC length field"
+        )));
+    }
     buf.reserve(total_length);
     buf.put_u8(BVLC6_TYPE);
     buf.put_u8(function.to_byte());
-    buf.put_u16(wire_length);
+    buf.put_u16(total_length as u16);
     buf.put_slice(source_vmac);
     buf.put_slice(npdu);
+    Ok(())
 }
 
 /// Decode a BVLC-IPv6 frame from raw bytes.
@@ -214,25 +215,30 @@ pub fn encode_bvlc6_original_unicast(
     source_vmac: &Bip6Vmac,
     dest_vmac: &Bip6Vmac,
     npdu: &[u8],
-) {
+) -> Result<(), Error> {
     let total_length = BVLC6_UNICAST_HEADER_LENGTH + npdu.len();
-    debug_assert!(
-        total_length <= u16::MAX as usize,
-        "BVLC6 unicast frame length overflow"
-    );
-    let wire_length = (total_length as u64).min(u16::MAX as u64) as u16;
+    if total_length > u16::MAX as usize {
+        return Err(Error::Encoding(format!(
+            "BVLC6 Original-Unicast-NPDU length {total_length} exceeds 16-bit BVLC length field"
+        )));
+    }
     buf.reserve(total_length);
     buf.put_u8(BVLC6_TYPE);
     buf.put_u8(Bvlc6Function::OriginalUnicast.to_byte());
-    buf.put_u16(wire_length);
+    buf.put_u16(total_length as u16);
     buf.put_slice(source_vmac);
     buf.put_slice(dest_vmac);
     buf.put_slice(npdu);
+    Ok(())
 }
 
 /// Encode a BVLC-IPv6 Original-Broadcast-NPDU frame.
-pub fn encode_bvlc6_original_broadcast(buf: &mut BytesMut, source_vmac: &Bip6Vmac, npdu: &[u8]) {
-    encode_bvlc6(buf, Bvlc6Function::OriginalBroadcast, source_vmac, npdu);
+pub fn encode_bvlc6_original_broadcast(
+    buf: &mut BytesMut,
+    source_vmac: &Bip6Vmac,
+    npdu: &[u8],
+) -> Result<(), Error> {
+    encode_bvlc6(buf, Bvlc6Function::OriginalBroadcast, source_vmac, npdu)
 }
 
 /// Encode a BVLC-IPv6 Virtual-Address-Resolution frame (7 bytes, no payload).
@@ -245,7 +251,8 @@ pub fn encode_virtual_address_resolution(source_vmac: &Bip6Vmac) -> BytesMut {
         Bvlc6Function::VirtualAddressResolution,
         source_vmac,
         &[], // no payload
-    );
+    )
+    .expect("empty Virtual-Address-Resolution frame fits in BVLC6 length field");
     buf
 }
 
@@ -495,12 +502,15 @@ async fn send_register_foreign_device_v6(
     source_vmac: &Bip6Vmac,
 ) {
     let mut buf = BytesMut::with_capacity(BVLC6_HEADER_LENGTH + 2);
-    encode_bvlc6(
+    if let Err(e) = encode_bvlc6(
         &mut buf,
         Bvlc6Function::RegisterForeignDevice,
         source_vmac,
         &ttl.to_be_bytes(),
-    );
+    ) {
+        warn!(error = %e, "BIP6: failed to encode Register-Foreign-Device");
+        return;
+    }
     if let Err(e) = socket.send_to(&buf, bbmd_addr).await {
         warn!(error = %e, "BIP6: failed to send Register-Foreign-Device");
     } else {
@@ -972,7 +982,7 @@ impl TransportPort for Bip6Transport {
             .lookup_by_addr(&dest)
             .await
             .unwrap_or([0; 3]);
-        encode_bvlc6_original_unicast(&mut buf, &source_vmac, &dest_vmac, npdu);
+        encode_bvlc6_original_unicast(&mut buf, &source_vmac, &dest_vmac, npdu)?;
 
         socket.send_to(&buf, dest).await.map_err(Error::Transport)?;
 
@@ -998,7 +1008,7 @@ impl TransportPort for Bip6Transport {
                 Bvlc6Function::DistributeBroadcastToNetwork,
                 &source_vmac,
                 npdu,
-            );
+            )?;
             socket
                 .send_to(&buf, bbmd_addr)
                 .await
@@ -1008,7 +1018,7 @@ impl TransportPort for Bip6Transport {
 
         let dest = SocketAddrV6::new(self.broadcast_scope.multicast_addr(), self.port, 0, 0);
         let mut buf = BytesMut::with_capacity(BVLC6_HEADER_LENGTH + npdu.len());
-        encode_bvlc6_original_broadcast(&mut buf, &source_vmac, npdu);
+        encode_bvlc6_original_broadcast(&mut buf, &source_vmac, npdu)?;
 
         socket.send_to(&buf, dest).await.map_err(Error::Transport)?;
 
@@ -1030,7 +1040,8 @@ mod tests {
         let dst_vmac: Bip6Vmac = [0x0A, 0x0B, 0x0C];
         let npdu = vec![0x01, 0x00, 0xAA];
         let mut buf = BytesMut::new();
-        encode_bvlc6_original_unicast(&mut buf, &src_vmac, &dst_vmac, &npdu);
+        encode_bvlc6_original_unicast(&mut buf, &src_vmac, &dst_vmac, &npdu)
+            .expect("valid BVLC6 unicast encoding");
         assert_eq!(buf[0], BVLC6_TYPE);
         assert_eq!(buf[1], Bvlc6Function::OriginalUnicast.to_byte());
         let len = u16::from_be_bytes([buf[2], buf[3]]);
@@ -1045,8 +1056,26 @@ mod tests {
         let vmac: Bip6Vmac = [0x01; 3];
         let npdu = vec![0xBB];
         let mut buf = BytesMut::new();
-        encode_bvlc6_original_broadcast(&mut buf, &vmac, &npdu);
+        encode_bvlc6_original_broadcast(&mut buf, &vmac, &npdu)
+            .expect("valid BVLC6 broadcast encoding");
         assert_eq!(buf[1], Bvlc6Function::OriginalBroadcast.to_byte());
+    }
+
+    #[test]
+    fn encode_bvlc6_oversized_payload_errors() {
+        let vmac: Bip6Vmac = [0x01; 3];
+        let npdu = vec![0; u16::MAX as usize - BVLC6_HEADER_LENGTH + 1];
+        let mut buf = BytesMut::new();
+        assert!(encode_bvlc6(&mut buf, Bvlc6Function::OriginalBroadcast, &vmac, &npdu).is_err());
+    }
+
+    #[test]
+    fn encode_bvlc6_unicast_oversized_payload_errors() {
+        let src_vmac: Bip6Vmac = [0x01, 0x02, 0x03];
+        let dst_vmac: Bip6Vmac = [0x0A, 0x0B, 0x0C];
+        let npdu = vec![0; u16::MAX as usize - BVLC6_UNICAST_HEADER_LENGTH + 1];
+        let mut buf = BytesMut::new();
+        assert!(encode_bvlc6_original_unicast(&mut buf, &src_vmac, &dst_vmac, &npdu).is_err());
     }
 
     #[test]
@@ -1055,7 +1084,8 @@ mod tests {
         let dst_vmac: Bip6Vmac = [0x0A, 0x0B, 0x0C];
         let npdu = vec![0x01, 0x00, 0xAA, 0xBB];
         let mut buf = BytesMut::new();
-        encode_bvlc6_original_unicast(&mut buf, &src_vmac, &dst_vmac, &npdu);
+        encode_bvlc6_original_unicast(&mut buf, &src_vmac, &dst_vmac, &npdu)
+            .expect("valid BVLC6 unicast encoding");
         let decoded = decode_bvlc6(&buf).unwrap();
         assert_eq!(decoded.function, Bvlc6Function::OriginalUnicast);
         assert_eq!(decoded.source_vmac, src_vmac);
@@ -1275,7 +1305,8 @@ mod tests {
             Bvlc6Function::ForwardedNpdu,
             &sender_vmac,
             &forwarded_payload,
-        );
+        )
+        .expect("valid BVLC6 encoding");
 
         let frame = decode_bvlc6(&buf).unwrap();
         assert_eq!(frame.function, Bvlc6Function::ForwardedNpdu);
@@ -1310,7 +1341,8 @@ mod tests {
             Bvlc6Function::ForwardedNpdu,
             &bbmd_vmac,
             &forwarded_payload,
-        );
+        )
+        .expect("valid BVLC6 encoding");
 
         // Send directly to the transport's bound address using a separate socket
         let sender = UdpSocket::bind("[::1]:0").await.unwrap();

--- a/crates/bacnet-transport/src/bvll.rs
+++ b/crates/bacnet-transport/src/bvll.rs
@@ -40,39 +40,48 @@ pub struct BvllMessage {
 
 /// Encode a standard BVLL frame (all functions except Forwarded-NPDU).
 ///
-/// Panics in debug builds if total frame exceeds u16::MAX. In release,
-/// the length field is capped at u16::MAX.
-pub fn encode_bvll(buf: &mut BytesMut, function: BvlcFunction, payload: &[u8]) {
+/// Returns an error if the total frame cannot be represented by the BVLC
+/// 16-bit length field.
+pub fn encode_bvll(
+    buf: &mut BytesMut,
+    function: BvlcFunction,
+    payload: &[u8],
+) -> Result<(), Error> {
     let total_length = BVLL_HEADER_LENGTH + payload.len();
-    debug_assert!(
-        total_length <= u16::MAX as usize,
-        "BVLL frame length {} exceeds u16::MAX",
-        total_length
-    );
-    let wire_length = (total_length as u64).min(u16::MAX as u64) as u16;
+    if total_length > u16::MAX as usize {
+        return Err(Error::Encoding(format!(
+            "BVLL frame length {total_length} exceeds 16-bit BVLC length field"
+        )));
+    }
     buf.reserve(total_length);
     buf.put_u8(BVLC_TYPE_BACNET_IP);
     buf.put_u8(function.to_raw());
-    buf.put_u16(wire_length);
+    buf.put_u16(total_length as u16);
     buf.put_slice(payload);
+    Ok(())
 }
 
 /// Encode a Forwarded-NPDU BVLL frame with originating address.
-pub fn encode_bvll_forwarded(buf: &mut BytesMut, ip: [u8; 4], port: u16, npdu: &[u8]) {
+pub fn encode_bvll_forwarded(
+    buf: &mut BytesMut,
+    ip: [u8; 4],
+    port: u16,
+    npdu: &[u8],
+) -> Result<(), Error> {
     let total_length = BVLL_HEADER_LENGTH + FORWARDED_ADDR_LENGTH + npdu.len();
-    debug_assert!(
-        total_length <= u16::MAX as usize,
-        "BVLL forwarded frame length {} exceeds u16::MAX",
-        total_length
-    );
-    let wire_length = (total_length as u64).min(u16::MAX as u64) as u16;
+    if total_length > u16::MAX as usize {
+        return Err(Error::Encoding(format!(
+            "BVLL Forwarded-NPDU length {total_length} exceeds 16-bit BVLC length field"
+        )));
+    }
     buf.reserve(total_length);
     buf.put_u8(BVLC_TYPE_BACNET_IP);
     buf.put_u8(BvlcFunction::FORWARDED_NPDU.to_raw());
-    buf.put_u16(wire_length);
+    buf.put_u16(total_length as u16);
     buf.put_slice(&ip);
     buf.put_u16(port);
     buf.put_slice(npdu);
+    Ok(())
 }
 
 /// Decode a BVLL frame from raw bytes.
@@ -158,7 +167,8 @@ mod tests {
     fn encode_decode_unicast() {
         let npdu = vec![0x01, 0x00, 0x10, 0x02, 0x03];
         let mut buf = BytesMut::new();
-        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_UNICAST_NPDU, &npdu);
+        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_UNICAST_NPDU, &npdu)
+            .expect("valid BVLL encoding");
 
         assert_eq!(buf[0], 0x81);
         assert_eq!(buf[1], 0x0A);
@@ -176,7 +186,8 @@ mod tests {
     fn encode_decode_broadcast() {
         let npdu = vec![0x01, 0x00];
         let mut buf = BytesMut::new();
-        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_BROADCAST_NPDU, &npdu);
+        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_BROADCAST_NPDU, &npdu)
+            .expect("valid BVLL encoding");
 
         let msg = decode_bvll(&buf).unwrap();
         assert_eq!(msg.function, BvlcFunction::ORIGINAL_BROADCAST_NPDU);
@@ -190,7 +201,7 @@ mod tests {
         let port = 0xBAC0;
 
         let mut buf = BytesMut::new();
-        encode_bvll_forwarded(&mut buf, ip, port, &npdu);
+        encode_bvll_forwarded(&mut buf, ip, port, &npdu).expect("valid BVLL forwarded encoding");
 
         assert_eq!(buf[0], 0x81);
         assert_eq!(buf[1], 0x04);
@@ -211,7 +222,8 @@ mod tests {
         // BVLC-Result with 2-byte result code (successful completion)
         let result_code = 0x0000u16.to_be_bytes().to_vec();
         let mut buf = BytesMut::new();
-        encode_bvll(&mut buf, BvlcFunction::BVLC_RESULT, &result_code);
+        encode_bvll(&mut buf, BvlcFunction::BVLC_RESULT, &result_code)
+            .expect("valid BVLL encoding");
 
         let msg = decode_bvll(&buf).unwrap();
         assert_eq!(msg.function, BvlcFunction::BVLC_RESULT);
@@ -223,7 +235,8 @@ mod tests {
         // 2-byte TTL in seconds
         let ttl = 60u16.to_be_bytes().to_vec();
         let mut buf = BytesMut::new();
-        encode_bvll(&mut buf, BvlcFunction::REGISTER_FOREIGN_DEVICE, &ttl);
+        encode_bvll(&mut buf, BvlcFunction::REGISTER_FOREIGN_DEVICE, &ttl)
+            .expect("valid BVLL encoding");
 
         let msg = decode_bvll(&buf).unwrap();
         assert_eq!(msg.function, BvlcFunction::REGISTER_FOREIGN_DEVICE);
@@ -238,7 +251,8 @@ mod tests {
             &mut buf,
             BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE,
             &[],
-        );
+        )
+        .expect("valid BVLL encoding");
 
         let msg = decode_bvll(&buf).unwrap();
         assert_eq!(
@@ -246,6 +260,20 @@ mod tests {
             BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE
         );
         assert!(msg.payload.is_empty());
+    }
+
+    #[test]
+    fn encode_bvll_oversized_payload_errors() {
+        let payload = vec![0; u16::MAX as usize - BVLL_HEADER_LENGTH + 1];
+        let mut buf = BytesMut::new();
+        assert!(encode_bvll(&mut buf, BvlcFunction::ORIGINAL_UNICAST_NPDU, &payload).is_err());
+    }
+
+    #[test]
+    fn encode_bvll_forwarded_oversized_payload_errors() {
+        let payload = vec![0; u16::MAX as usize - BVLL_HEADER_LENGTH - FORWARDED_ADDR_LENGTH + 1];
+        let mut buf = BytesMut::new();
+        assert!(encode_bvll_forwarded(&mut buf, [127, 0, 0, 1], 0xBAC0, &payload).is_err());
     }
 
     #[test]
@@ -293,7 +321,8 @@ mod tests {
         // NPDU: 01 20 FF FF 00 FF (version=1, dest=FFFF:broadcast, hop=255)
         let npdu = vec![0x01, 0x20, 0xFF, 0xFF, 0x00, 0xFF];
         let mut buf = BytesMut::new();
-        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_BROADCAST_NPDU, &npdu);
+        encode_bvll(&mut buf, BvlcFunction::ORIGINAL_BROADCAST_NPDU, &npdu)
+            .expect("valid BVLL encoding");
 
         assert_eq!(&buf[..4], &[0x81, 0x0B, 0x00, 0x0A]);
         assert_eq!(&buf[4..], &npdu);

--- a/crates/bacnet-types/src/primitives.rs
+++ b/crates/bacnet-types/src/primitives.rs
@@ -85,8 +85,14 @@ impl ObjectIdentifier {
 
     /// Decode from the 4-byte BACnet wire format (big-endian).
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 4 {
-            return Err(Error::buffer_too_short(4, data.len()));
+        if data.len() != 4 {
+            return Err(Error::decoding(
+                0,
+                format!(
+                    "ObjectIdentifier expects exactly 4 bytes, got {}",
+                    data.len()
+                ),
+            ));
         }
         let value = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
         let type_raw = (value >> 22) & 0x3FF;
@@ -147,8 +153,11 @@ impl Date {
 
     /// Decode from 4 bytes.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 4 {
-            return Err(Error::buffer_too_short(4, data.len()));
+        if data.len() != 4 {
+            return Err(Error::decoding(
+                0,
+                format!("Date expects exactly 4 bytes, got {}", data.len()),
+            ));
         }
         Ok(Self {
             year: data[0],
@@ -198,8 +207,11 @@ impl Time {
 
     /// Decode from 4 bytes.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 4 {
-            return Err(Error::buffer_too_short(4, data.len()));
+        if data.len() != 4 {
+            return Err(Error::decoding(
+                0,
+                format!("Time expects exactly 4 bytes, got {}", data.len()),
+            ));
         }
         Ok(Self {
             hour: data[0],
@@ -375,6 +387,11 @@ mod tests {
     }
 
     #[test]
+    fn object_identifier_overlong_errors() {
+        assert!(ObjectIdentifier::decode(&[0x00, 0x00, 0x00, 0x01, 0xFF]).is_err());
+    }
+
+    #[test]
     fn date_encode_decode_round_trip() {
         let date = Date {
             year: 124, // 2024
@@ -400,6 +417,11 @@ mod tests {
     }
 
     #[test]
+    fn date_overlong_errors() {
+        assert!(Date::decode(&[124, 6, 15, 6, 0]).is_err());
+    }
+
+    #[test]
     fn time_encode_decode_round_trip() {
         let time = Time {
             hour: 14,
@@ -410,6 +432,11 @@ mod tests {
         let bytes = time.encode();
         let decoded = Time::decode(&bytes).unwrap();
         assert_eq!(time, decoded);
+    }
+
+    #[test]
+    fn time_overlong_errors() {
+        assert!(Time::decode(&[14, 30, 45, 50, 0]).is_err());
     }
 
     #[test]
@@ -462,13 +489,11 @@ mod tests {
     }
 
     #[test]
-    fn object_identifier_decode_extra_bytes_ignored() {
-        // If we have more than 4 bytes, only the first 4 are used
+    fn object_identifier_decode_extra_bytes_errors() {
         let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 42).unwrap();
         let mut bytes = oid.encode().to_vec();
-        bytes.extend_from_slice(&[0xFF, 0xFF]); // extra garbage
-        let decoded = ObjectIdentifier::decode(&bytes).unwrap();
-        assert_eq!(decoded, oid);
+        bytes.extend_from_slice(&[0xFF, 0xFF]);
+        assert!(ObjectIdentifier::decode(&bytes).is_err());
     }
 
     #[test]

--- a/crates/bacnet-wasm/src/codec.rs
+++ b/crates/bacnet-wasm/src/codec.rs
@@ -316,7 +316,7 @@ fn encode_confirmed_pdu(
 
     let mut buf = BytesMut::new();
     npdu::encode_npdu(&mut buf, &npdu).map_err(js_err)?;
-    apdu::encode_apdu(&mut buf, &Apdu::ConfirmedRequest(confirmed));
+    apdu::encode_apdu(&mut buf, &Apdu::ConfirmedRequest(confirmed)).map_err(js_err)?;
     Ok(buf.to_vec())
 }
 
@@ -337,7 +337,7 @@ fn encode_unconfirmed_pdu(
 
     let mut buf = BytesMut::new();
     npdu::encode_npdu(&mut buf, &npdu).map_err(js_err)?;
-    apdu::encode_apdu(&mut buf, &Apdu::UnconfirmedRequest(unconfirmed));
+    apdu::encode_apdu(&mut buf, &Apdu::UnconfirmedRequest(unconfirmed)).map_err(js_err)?;
     Ok(buf.to_vec())
 }
 


### PR DESCRIPTION
## Summary

Findings 4, 6, 7 from the BACnet 135-2020 code review:

- **Finding 4** — BVLL/BVLC encoders return errors when frame length exceeds the 16-bit wire length field, replacing release-build silent truncation.
- **Finding 6** — APDU codecs reject reserved max-APDU values and invalid SegmentACK window sizes instead of silently coercing them.
- **Finding 7** — Fixed-width primitive/application-tag decoders require exact lengths (Real=4, Double=8, Date=4, Time=4, ObjectIdentifier=4) rather than `>= N`.

## Spec

ASHRAE 135-2020 Clauses 20.1.2.7 (max-APDU encoding), 20.1.2.8 (segmentation flags), 20.1.6.x (SegmentACK sequence/window).

## API breaks (intentional for 0.9.0)

- `encode_bvll`, `encode_bvll_forwarded`, IPv6 BVLC encoders → `Result<(), Error>`.
- Primitive `decode_*` reject overlong slices.
- Reserved max-APDU values surface as decode errors.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm`
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets`

## Sequencing

Independent. Mergeable any order relative to D / C / A / schedule.

CHANGELOG entry in this branch.