### PR TITLE
fix(segmentation): correct BACnet flow control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Finding 8: confirmed EventNotification delivery now uses the server TSM with timeout and retry handling instead of fire-and-forget sends.
 - Fixed Finding 8: server-side confirmed notification acknowledgments are keyed by `(peer, invoke_id)` so responses from different peers cannot collide on a shared invoke ID.
 
+### Spec Compliance - Segmentation (ASHRAE 135-2020 Clauses 5, 20.1.2.4, 20.1.2.5, 20.1.6.x)
+
+- Fixed Finding 1: `split_payload` now errors when a payload would require more than the 256 sequence numbers representable by BACnet segmentation instead of falling back to an oversized unsegmented payload.
+- Fixed Finding 2: segmented ComplexACK responses now honor the client's `max-segments-accepted` value and abort with `BUFFER_OVERFLOW` when the response cannot fit.
+- Fixed Finding 3: server-side segmented ConfirmedRequest receive state now validates proposed window size, ACKs only at the negotiated window boundary or final segment, and sends negative SegmentACKs for sequence gaps.
+- Fixed Finding 5: negative SegmentACK retransmission now resumes at `ack_seq + 1` on both client and server send paths.
+- Fixed Finding 9: routed confirmed requests now enter the segmented send path when they exceed the local APDU limit, and routed responses are matched with a routed endpoint TSM key instead of only the next-hop router MAC.
+
+### Changed
+
+- **API break**: `bacnet-encoding::segmentation::split_payload` now returns `Result<Vec<Bytes>, Error>` so callers must handle zero-payload-capacity and over-256-segment failures explicitly.
+
 ### Workspace reorganization
 
 The HTTP/MCP gateway and BTL compliance test harness were extracted into dedicated repositories. The remaining workspace focuses purely on the BACnet protocol stack: types, encoding, services, transport, network, client, server, objects, plus the Python and WASM bindings and the CLI.
@@ -27,7 +39,7 @@ The HTTP/MCP gateway and BTL compliance test harness were extracted into dedicat
 - `examples/docker/Dockerfile.btl` and `examples/docker/docker-compose.btl.yml` (BTL Docker assets — now in the BTL harness repo).
 
 ### Notes
-- Library crates' API is unchanged from 0.8.1. Consumers of `bacnet-types`, `bacnet-encoding`, `bacnet-services`, `bacnet-transport`, `bacnet-network`, `bacnet-client`, `bacnet-objects`, `bacnet-server` can upgrade with no source changes.
+- Library crate APIs changed from 0.8.1 where called out in this changelog.
 - Python (`rusty-bacnet`) and WASM (`bacnet-wasm`) bindings unchanged.
 - CLI (`bacnet-cli`) unchanged.
 

--- a/crates/bacnet-client/src/client.rs
+++ b/crates/bacnet-client/src/client.rs
@@ -2467,7 +2467,7 @@ mod tests {
         apdu: Apdu,
     ) {
         let mut apdu_buf = BytesMut::new();
-        encode_apdu(&mut apdu_buf, &apdu);
+        encode_apdu(&mut apdu_buf, &apdu).expect("valid APDU encoding");
         let npdu = Npdu {
             source: Some(NpduAddress {
                 network: source_network,

--- a/crates/bacnet-client/src/client.rs
+++ b/crates/bacnet-client/src/client.rs
@@ -231,6 +231,8 @@ pub struct DeviceWriteResult {
 /// In-progress segmented receive state.
 struct SegmentedReceiveState {
     receiver: SegmentReceiver,
+    /// Immediate MAC used to send SegmentAck/Abort PDUs.
+    reply_mac: MacAddr,
     /// Next expected sequence number (for gap detection).
     expected_next_seq: u8,
     /// Timestamp of last received segment (for reaping stale sessions).
@@ -244,7 +246,7 @@ struct SegmentedReceiveState {
 /// Timeout for idle segmented reassembly sessions.
 const SEG_RECEIVER_TIMEOUT: Duration = Duration::from_secs(4);
 
-/// Key for tracking in-progress segmented receives: (source_mac, invoke_id).
+/// Key for tracking in-progress segmented receives: (correlation_mac, invoke_id).
 type SegKey = (MacAddr, u8);
 
 /// BACnet client with low-level and high-level request APIs.
@@ -486,6 +488,7 @@ impl ScClientBuilder {
 }
 
 /// Routing target for confirmed requests.
+#[derive(Clone, Copy)]
 enum ConfirmedTarget<'a> {
     Local {
         mac: &'a [u8],
@@ -498,12 +501,34 @@ enum ConfirmedTarget<'a> {
 }
 
 impl<'a> ConfirmedTarget<'a> {
-    /// The MAC used for TSM transaction matching.
-    fn tsm_mac(&self) -> &[u8] {
+    /// The key used for TSM transaction matching.
+    fn tsm_mac(&self) -> MacAddr {
         match self {
-            Self::Local { mac } => mac,
-            Self::Routed { router_mac, .. } => router_mac,
+            Self::Local { mac } => MacAddr::from_slice(mac),
+            Self::Routed {
+                dest_network,
+                dest_mac,
+                ..
+            } => routed_tsm_mac(*dest_network, dest_mac),
         }
+    }
+}
+
+fn routed_tsm_mac(network: u16, mac: &[u8]) -> MacAddr {
+    let mut key = MacAddr::new();
+    key.extend_from_slice(&[0xFF, b'R']);
+    key.extend_from_slice(&network.to_be_bytes());
+    key.push(mac.len() as u8);
+    key.extend_from_slice(mac);
+    key
+}
+
+fn response_tsm_mac(source_mac: &[u8], source_network: &Option<NpduAddress>) -> MacAddr {
+    match source_network {
+        Some(address) if !address.mac_address.is_empty() => {
+            routed_tsm_mac(address.network, &address.mac_address)
+        }
+        _ => MacAddr::from_slice(source_mac),
     }
 }
 
@@ -570,7 +595,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     .map(|(key, _)| key.clone())
                     .collect();
                 for key in &stale_keys {
-                    if let Some(_state) = seg_state.remove(key) {
+                    if let Some(state) = seg_state.remove(key) {
                         let abort = Apdu::Abort(AbortPdu {
                             sent_by_server: false,
                             invoke_id: key.1,
@@ -579,7 +604,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         let mut buf = BytesMut::with_capacity(4);
                         encode_apdu(&mut buf, &abort);
                         let _ = network_dispatch
-                            .send_apdu(&buf, &key.0, false, NetworkPriority::NORMAL)
+                            .send_apdu(&buf, &state.reply_mac, false, NetworkPriority::NORMAL)
                             .await;
                     }
                 }
@@ -633,11 +658,12 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         apdu: Apdu,
         segmented_response_accepted: bool,
     ) {
+        let tsm_mac = response_tsm_mac(source_mac, source_network);
         match apdu {
             Apdu::SimpleAck(ack) => {
                 debug!(invoke_id = ack.invoke_id, "Received SimpleAck");
                 let mut tsm = tsm.lock().await;
-                tsm.complete_transaction(source_mac, ack.invoke_id, TsmResponse::SimpleAck);
+                tsm.complete_transaction(&tsm_mac, ack.invoke_id, TsmResponse::SimpleAck);
             }
             Apdu::ComplexAck(ack) => {
                 if ack.segmented {
@@ -646,6 +672,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         network,
                         seg_state,
                         source_mac,
+                        source_network,
                         ack,
                         segmented_response_accepted,
                     )
@@ -654,7 +681,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     debug!(invoke_id = ack.invoke_id, "Received ComplexAck");
                     let mut tsm = tsm.lock().await;
                     tsm.complete_transaction(
-                        source_mac,
+                        &tsm_mac,
                         ack.invoke_id,
                         TsmResponse::ComplexAck {
                             service_data: ack.service_ack,
@@ -666,7 +693,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 debug!(invoke_id = err.invoke_id, "Received Error PDU");
                 let mut tsm = tsm.lock().await;
                 tsm.complete_transaction(
-                    source_mac,
+                    &tsm_mac,
                     err.invoke_id,
                     TsmResponse::Error {
                         class: err.error_class.to_raw() as u32,
@@ -678,7 +705,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 debug!(invoke_id = rej.invoke_id, "Received Reject PDU");
                 let mut tsm = tsm.lock().await;
                 tsm.complete_transaction(
-                    source_mac,
+                    &tsm_mac,
                     rej.invoke_id,
                     TsmResponse::Reject {
                         reason: rej.reject_reason.to_raw(),
@@ -689,7 +716,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 debug!(invoke_id = abt.invoke_id, "Received Abort PDU");
                 let mut tsm = tsm.lock().await;
                 tsm.complete_transaction(
-                    source_mac,
+                    &tsm_mac,
                     abt.invoke_id,
                     TsmResponse::Abort {
                         reason: abt.abort_reason.to_raw(),
@@ -785,7 +812,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 }
             }
             Apdu::SegmentAck(sa) => {
-                let key = (MacAddr::from_slice(source_mac), sa.invoke_id);
+                let key = (tsm_mac, sa.invoke_id);
                 let senders = seg_ack_senders.lock().await;
                 if let Some(tx) = senders.get(&key) {
                     let _ = tx.try_send(sa);
@@ -806,11 +833,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         network: &Arc<NetworkLayer<T>>,
         seg_state: &mut HashMap<SegKey, SegmentedReceiveState>,
         source_mac: &[u8],
+        source_network: &Option<NpduAddress>,
         ack: bacnet_encoding::apdu::ComplexAck,
         segmented_response_accepted: bool,
     ) {
         let seq = ack.sequence_number.unwrap_or(0);
-        let key = (MacAddr::from_slice(source_mac), ack.invoke_id);
+        let tsm_mac = response_tsm_mac(source_mac, source_network);
+        let key = (tsm_mac.clone(), ack.invoke_id);
 
         debug!(
             invoke_id = ack.invoke_id,
@@ -849,6 +878,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             .entry(key.clone())
             .or_insert_with(|| SegmentedReceiveState {
                 receiver: SegmentReceiver::new(),
+                reply_mac: MacAddr::from_slice(source_mac),
                 expected_next_seq: 0,
                 last_activity: Instant::now(),
                 window_position: 0,
@@ -939,7 +969,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     );
                     let mut tsm = tsm.lock().await;
                     tsm.complete_transaction(
-                        source_mac,
+                        &tsm_mac,
                         ack.invoke_id,
                         TsmResponse::ComplexAck {
                             service_data: Bytes::from(service_data),
@@ -1010,46 +1040,59 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         service_data: &[u8],
     ) -> Result<Bytes, Error> {
         let tsm_mac = target.tsm_mac();
+        let unsegmented_apdu_size = 4 + service_data.len();
 
-        if let ConfirmedTarget::Local { mac } = &target {
-            let unsegmented_apdu_size = 4 + service_data.len();
-            let (remote_max_apdu, remote_max_segments) = {
-                let dt = self.device_table.lock().await;
-                let device = dt.get_by_mac(mac);
-                let max_apdu = device
-                    .map(|d| d.max_apdu_length as u16)
-                    .unwrap_or(self.config.max_apdu_length);
-                let max_seg = device.and_then(|d| d.max_segments_accepted);
-                (max_apdu, max_seg)
-            };
-            if unsegmented_apdu_size > remote_max_apdu as usize {
-                return self
-                    .segmented_confirmed_request(
-                        mac,
-                        service_choice,
-                        service_data,
-                        remote_max_apdu,
-                        remote_max_segments,
-                    )
-                    .await;
+        match target {
+            ConfirmedTarget::Local { mac } => {
+                let (remote_max_apdu, remote_max_segments) = {
+                    let dt = self.device_table.lock().await;
+                    let device = dt.get_by_mac(mac);
+                    let max_apdu = device
+                        .map(|d| d.max_apdu_length as u16)
+                        .unwrap_or(self.config.max_apdu_length);
+                    let max_seg = device.and_then(|d| d.max_segments_accepted);
+                    (max_apdu, max_seg)
+                };
+                if unsegmented_apdu_size > remote_max_apdu as usize {
+                    return self
+                        .segmented_confirmed_request(
+                            target,
+                            service_choice,
+                            service_data,
+                            remote_max_apdu,
+                            remote_max_segments,
+                        )
+                        .await;
+                }
+            }
+            ConfirmedTarget::Routed { .. } => {
+                let remote_max_apdu = self.config.max_apdu_length;
+                if unsegmented_apdu_size > remote_max_apdu as usize {
+                    return self
+                        .segmented_confirmed_request(
+                            target,
+                            service_choice,
+                            service_data,
+                            remote_max_apdu,
+                            None,
+                        )
+                        .await;
+                }
             }
         }
 
         let (invoke_id, rx) = {
             let mut tsm = self.tsm.lock().await;
-            let invoke_id = tsm.allocate_invoke_id(tsm_mac).ok_or_else(|| {
+            let invoke_id = tsm.allocate_invoke_id(&tsm_mac).ok_or_else(|| {
                 Error::Encoding("all invoke IDs exhausted for destination".into())
             })?;
-            let rx = tsm.register_transaction(MacAddr::from_slice(tsm_mac), invoke_id);
+            let rx = tsm.register_transaction(tsm_mac.clone(), invoke_id);
             (invoke_id, rx)
         };
 
         // Guard cleans up invoke ID if this task is cancelled/aborted
-        let mut guard = crate::tsm::TsmGuard::new(
-            std::sync::Arc::clone(&self.tsm),
-            MacAddr::from_slice(tsm_mac),
-            invoke_id,
-        );
+        let mut guard =
+            crate::tsm::TsmGuard::new(std::sync::Arc::clone(&self.tsm), tsm_mac.clone(), invoke_id);
 
         let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
             segmented: false,
@@ -1099,7 +1142,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             if let Err(e) = send_result {
                 guard.mark_completed();
                 let mut tsm = self.tsm.lock().await;
-                tsm.cancel_transaction(tsm_mac, invoke_id);
+                tsm.cancel_transaction(&tsm_mac, invoke_id);
                 return Err(e);
             }
 
@@ -1123,7 +1166,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     if attempts > max_retries {
                         guard.mark_completed();
                         let mut tsm = self.tsm.lock().await;
-                        tsm.cancel_transaction(tsm_mac, invoke_id);
+                        tsm.cancel_transaction(&tsm_mac, invoke_id);
                         return Err(Error::Timeout(timeout_duration));
                     }
                     debug!(
@@ -1137,25 +1180,49 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         }
     }
 
+    async fn send_confirmed_target_apdu(
+        &self,
+        target: ConfirmedTarget<'_>,
+        apdu: &[u8],
+    ) -> Result<(), Error> {
+        match target {
+            ConfirmedTarget::Local { mac } => {
+                self.network
+                    .send_apdu(apdu, mac, true, NetworkPriority::NORMAL)
+                    .await
+            }
+            ConfirmedTarget::Routed {
+                router_mac,
+                dest_network,
+                dest_mac,
+            } => {
+                self.network
+                    .send_apdu_routed(
+                        apdu,
+                        dest_network,
+                        dest_mac,
+                        router_mac,
+                        true,
+                        NetworkPriority::NORMAL,
+                    )
+                    .await
+            }
+        }
+    }
+
     /// Send a confirmed request using segmented transfer with windowed flow control.
     async fn segmented_confirmed_request(
         &self,
-        destination_mac: &[u8],
+        target: ConfirmedTarget<'_>,
         service_choice: ConfirmedServiceChoice,
         service_data: &[u8],
         remote_max_apdu: u16,
         remote_max_segments: Option<u32>,
     ) -> Result<Bytes, Error> {
+        let tsm_mac = target.tsm_mac();
         let max_seg_size = max_segment_payload(remote_max_apdu, SegmentedPduType::ConfirmedRequest);
-        let segments = split_payload(service_data, max_seg_size);
+        let segments = split_payload(service_data, max_seg_size)?;
         let total_segments = segments.len();
-
-        if total_segments > 256 {
-            return Err(Error::Segmentation(format!(
-                "payload requires {} segments, maximum is 256",
-                total_segments
-            )));
-        }
 
         if let Some(max_seg) = remote_max_segments {
             if total_segments > max_seg as usize {
@@ -1175,16 +1242,16 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 
         let (invoke_id, rx) = {
             let mut tsm = self.tsm.lock().await;
-            let invoke_id = tsm.allocate_invoke_id(destination_mac).ok_or_else(|| {
+            let invoke_id = tsm.allocate_invoke_id(&tsm_mac).ok_or_else(|| {
                 Error::Encoding("all invoke IDs exhausted for destination".into())
             })?;
-            let rx = tsm.register_transaction(MacAddr::from_slice(destination_mac), invoke_id);
+            let rx = tsm.register_transaction(tsm_mac.clone(), invoke_id);
             (invoke_id, rx)
         };
 
         let (seg_ack_tx, mut seg_ack_rx) = mpsc::channel(16);
         {
-            let key = (MacAddr::from_slice(destination_mac), invoke_id);
+            let key = (tsm_mac.clone(), invoke_id);
             self.seg_ack_senders.lock().await.insert(key, seg_ack_tx);
         }
 
@@ -1222,9 +1289,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     let mut buf = BytesMut::with_capacity(remote_max_apdu as usize);
                     encode_apdu(&mut buf, &pdu);
 
-                    self.network
-                        .send_apdu(&buf, destination_mac, true, NetworkPriority::NORMAL)
-                        .await?;
+                    self.send_confirmed_target_apdu(target, &buf).await?;
 
                     debug!(seq, is_last, "Sent segment");
                 }
@@ -1272,14 +1337,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     let mut buf = BytesMut::with_capacity(remote_max_apdu as usize);
                                     encode_apdu(&mut buf, &pdu);
 
-                                    self.network
-                                        .send_apdu(
-                                            &buf,
-                                            destination_mac,
-                                            true,
-                                            NetworkPriority::NORMAL,
-                                        )
-                                        .await?;
+                                    self.send_confirmed_target_apdu(target, &buf).await?;
                                 }
                             }
                         }
@@ -1310,7 +1368,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                             "too many negative SegmentAck retransmissions".into(),
                         ));
                     }
-                    next_seq = ack_seq;
+                    next_seq = ack_seq + 1;
                 } else {
                     neg_ack_retries = 0;
                     next_seq = ack_seq + 1;
@@ -1325,7 +1383,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         .await;
 
         {
-            let key = (MacAddr::from_slice(destination_mac), invoke_id);
+            let key = (tsm_mac.clone(), invoke_id);
             self.seg_ack_senders.lock().await.remove(&key);
         }
 
@@ -1333,7 +1391,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             Ok(response) => response,
             Err(e) => {
                 let mut tsm = self.tsm.lock().await;
-                tsm.cancel_transaction(destination_mac, invoke_id);
+                tsm.cancel_transaction(&tsm_mac, invoke_id);
                 return Err(e);
             }
         };
@@ -2363,6 +2421,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 mod tests {
     use super::*;
     use bacnet_encoding::apdu::{ComplexAck, SimpleAck};
+    use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+    use bacnet_transport::loopback::LoopbackTransport;
+    use bacnet_transport::port::TransportPort;
     use std::net::Ipv4Addr;
     use tokio::time::Duration;
 
@@ -2374,6 +2435,28 @@ mod tests {
             .build()
             .await
             .unwrap()
+    }
+
+    async fn send_routed_response<T: TransportPort>(
+        transport: &T,
+        client_mac: &[u8],
+        source_network: u16,
+        source_mac: &[u8],
+        apdu: Apdu,
+    ) {
+        let mut apdu_buf = BytesMut::new();
+        encode_apdu(&mut apdu_buf, &apdu);
+        let npdu = Npdu {
+            source: Some(NpduAddress {
+                network: source_network,
+                mac_address: MacAddr::from_slice(source_mac),
+            }),
+            payload: apdu_buf.freeze(),
+            ..Npdu::default()
+        };
+        let mut npdu_buf = BytesMut::new();
+        encode_npdu(&mut npdu_buf, &npdu).unwrap();
+        transport.send_unicast(&npdu_buf, client_mac).await.unwrap();
     }
 
     #[tokio::test]
@@ -2739,6 +2822,105 @@ mod tests {
 
         b_handle.await.unwrap();
         client.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn routed_segmented_request_uses_routed_tsm_key() {
+        let client_mac = vec![0x01];
+        let router_mac = vec![0x02];
+        let remote_network = 100;
+        let remote_mac = vec![0x03];
+        let (client_transport, mut router_transport) =
+            LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+        let mut router_rx = router_transport.start().await.unwrap();
+
+        let mut client = BACnetClient::generic_builder()
+            .transport(client_transport)
+            .apdu_timeout_ms(2000)
+            .max_apdu_length(50)
+            .build()
+            .await
+            .unwrap();
+
+        let service_data: Vec<u8> = (0u8..100).collect();
+        let expected_data = service_data.clone();
+        let router_mac_for_request = router_mac.clone();
+        let remote_mac_for_request = remote_mac.clone();
+
+        let request_task = tokio::spawn(async move {
+            let result = client
+                .confirmed_request_routed(
+                    &router_mac_for_request,
+                    remote_network,
+                    &remote_mac_for_request,
+                    ConfirmedServiceChoice::WRITE_PROPERTY,
+                    &service_data,
+                )
+                .await;
+            client.stop().await.unwrap();
+            result
+        });
+
+        let mut all_service_data = Vec::new();
+        let invoke_id = loop {
+            let received = timeout(Duration::from_secs(2), router_rx.recv())
+                .await
+                .expect("router timed out waiting for routed segment")
+                .expect("router channel closed");
+            assert_eq!(&received.source_mac[..], &client_mac[..]);
+
+            let npdu = decode_npdu(received.npdu).unwrap();
+            let destination = npdu.destination.expect("routed NPDU destination");
+            assert_eq!(destination.network, remote_network);
+            assert_eq!(&destination.mac_address[..], &remote_mac[..]);
+
+            let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+            let Apdu::ConfirmedRequest(req) = decoded else {
+                panic!("Expected ConfirmedRequest, got {:?}", decoded);
+            };
+            assert!(req.segmented, "expected routed request to be segmented");
+            let seq = req.sequence_number.unwrap();
+            all_service_data.extend_from_slice(&req.service_request);
+
+            let seg_ack = Apdu::SegmentAck(SegmentAckPdu {
+                negative_ack: false,
+                sent_by_server: true,
+                invoke_id: req.invoke_id,
+                sequence_number: seq,
+                actual_window_size: 1,
+            });
+            send_routed_response(
+                &router_transport,
+                &client_mac,
+                remote_network,
+                &remote_mac,
+                seg_ack,
+            )
+            .await;
+
+            if !req.more_follows {
+                break req.invoke_id;
+            }
+        };
+
+        assert_eq!(all_service_data, expected_data);
+
+        let ack = Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        });
+        send_routed_response(
+            &router_transport,
+            &client_mac,
+            remote_network,
+            &remote_mac,
+            ack,
+        )
+        .await;
+
+        let result = request_task.await.unwrap();
+        assert!(result.unwrap().is_empty());
+        router_transport.stop().await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/bacnet-encoding/src/segmentation.rs
+++ b/crates/bacnet-encoding/src/segmentation.rs
@@ -33,21 +33,26 @@ pub fn max_segment_payload(max_apdu_length: u16, pdu_type: SegmentedPduType) -> 
 /// Split a payload into segments of at most `max_segment_size` bytes.
 ///
 /// Always returns at least one segment (possibly empty).
-/// If the payload would produce more than 256 segments (the BACnet sequence
-/// number limit), falls back to returning the entire payload as a single
-/// unsegmented segment.
-pub fn split_payload(payload: &[u8], max_segment_size: usize) -> Vec<Bytes> {
-    if max_segment_size == 0 || payload.is_empty() {
-        return vec![Bytes::copy_from_slice(payload)];
+pub fn split_payload(payload: &[u8], max_segment_size: usize) -> Result<Vec<Bytes>, Error> {
+    if payload.is_empty() {
+        return Ok(vec![Bytes::new()]);
+    }
+    if max_segment_size == 0 {
+        return Err(Error::Segmentation(
+            "non-empty payload cannot be segmented with max segment size 0".into(),
+        ));
     }
     let segments: Vec<Bytes> = payload
         .chunks(max_segment_size)
         .map(Bytes::copy_from_slice)
         .collect();
     if segments.len() > 256 {
-        return vec![Bytes::copy_from_slice(payload)];
+        return Err(Error::Segmentation(format!(
+            "payload requires {} segments, maximum is 256",
+            segments.len()
+        )));
     }
-    segments
+    Ok(segments)
 }
 
 /// Collects received segments for reassembly.
@@ -155,7 +160,7 @@ mod tests {
     #[test]
     fn split_payload_fits_single_segment() {
         let payload = vec![0u8; 100];
-        let segments = split_payload(&payload, 200);
+        let segments = split_payload(&payload, 200).unwrap();
         assert_eq!(segments.len(), 1);
         assert_eq!(segments[0], payload);
     }
@@ -163,7 +168,7 @@ mod tests {
     #[test]
     fn split_payload_exact_fit() {
         let payload = vec![0u8; 200];
-        let segments = split_payload(&payload, 100);
+        let segments = split_payload(&payload, 100).unwrap();
         assert_eq!(segments.len(), 2);
         assert_eq!(segments[0].len(), 100);
         assert_eq!(segments[1].len(), 100);
@@ -172,7 +177,7 @@ mod tests {
     #[test]
     fn split_payload_remainder() {
         let payload = vec![0u8; 250];
-        let segments = split_payload(&payload, 100);
+        let segments = split_payload(&payload, 100).unwrap();
         assert_eq!(segments.len(), 3);
         assert_eq!(segments[0].len(), 100);
         assert_eq!(segments[1].len(), 100);
@@ -181,7 +186,7 @@ mod tests {
 
     #[test]
     fn split_empty_payload() {
-        let segments = split_payload(&[], 100);
+        let segments = split_payload(&[], 100).unwrap();
         assert_eq!(segments.len(), 1);
         assert!(segments[0].is_empty());
     }
@@ -189,7 +194,7 @@ mod tests {
     #[test]
     fn reassemble_ordered_segments() {
         let original = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        let segments = split_payload(&original, 3);
+        let segments = split_payload(&original, 3).unwrap();
         assert_eq!(segments.len(), 4); // 3+3+3+1
 
         let mut receiver = SegmentReceiver::new();
@@ -221,8 +226,12 @@ mod tests {
 
     #[test]
     fn split_payload_zero_segment_size() {
-        // Should not panic — returns entire payload as single segment
-        let result = split_payload(&[1, 2, 3], 0);
-        assert_eq!(result, vec![vec![1, 2, 3]]);
+        assert!(split_payload(&[1, 2, 3], 0).is_err());
+    }
+
+    #[test]
+    fn split_payload_over_256_segments_errors() {
+        let payload = vec![0u8; 257];
+        assert!(split_payload(&payload, 1).is_err());
     }
 }

--- a/crates/bacnet-integration-tests/tests/server.rs
+++ b/crates/bacnet-integration-tests/tests/server.rs
@@ -805,7 +805,7 @@ async fn send_raw_apdu(
     apdu: Apdu,
 ) {
     let mut buf = BytesMut::new();
-    encode_apdu(&mut buf, &apdu);
+    encode_apdu(&mut buf, &apdu).expect("valid APDU encoding");
     raw_network
         .send_apdu(&buf, server_mac, true, NetworkPriority::NORMAL)
         .await
@@ -997,7 +997,7 @@ async fn server_aborts_segmented_request_with_invalid_window_size() {
         Bytes::copy_from_slice(&payload[..payload.len() / 2]),
     );
     let mut buf = BytesMut::new();
-    encode_apdu(&mut buf, &seg0);
+    encode_apdu(&mut buf, &seg0).expect("valid APDU encoding");
     buf[4] = 0;
     raw_network
         .send_apdu(&buf, &server_mac, true, NetworkPriority::NORMAL)

--- a/crates/bacnet-integration-tests/tests/server.rs
+++ b/crates/bacnet-integration-tests/tests/server.rs
@@ -1,6 +1,8 @@
 //! End-to-end integration tests: real BACnetClient ↔ real BACnetServer over loopback UDP.
 
 use bacnet_client::client::BACnetClient;
+use bacnet_encoding::apdu::{encode_apdu, Apdu, ConfirmedRequest as ConfirmedRequestPdu};
+use bacnet_network::layer::NetworkLayer;
 use bacnet_objects::analog::AnalogInputObject;
 use bacnet_objects::binary::BinaryValueObject;
 use bacnet_objects::database::ObjectDatabase;
@@ -8,11 +10,15 @@ use bacnet_objects::device::{DeviceConfig, DeviceObject};
 use bacnet_objects::traits::BACnetObject;
 use bacnet_server::server::BACnetServer;
 use bacnet_transport::bip::BipTransport;
-use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{
+    AbortReason, ConfirmedServiceChoice, NetworkPriority, ObjectType, PropertyIdentifier,
+};
 use bacnet_types::primitives::ObjectIdentifier;
 use bacnet_types::MacAddr;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use std::net::Ipv4Addr;
+use std::sync::Arc;
+use tokio::time::Duration;
 
 /// Build a server with a Device, an AnalogInput, and a BinaryValue.
 async fn make_server() -> BACnetServer<BipTransport> {
@@ -758,6 +764,54 @@ async fn server_segments_large_rpm_response() {
 // Server Rx Segmentation integration tests
 // ---------------------------------------------------------------------------
 
+fn read_property_service_payload() -> Vec<u8> {
+    use bacnet_services::read_property::ReadPropertyRequest;
+
+    let ai_oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let rp_req = ReadPropertyRequest {
+        object_identifier: ai_oid,
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+    };
+    let mut service_buf = BytesMut::new();
+    rp_req.encode(&mut service_buf);
+    service_buf.to_vec()
+}
+
+fn segmented_read_property_pdu(
+    invoke_id: u8,
+    seq: u8,
+    more_follows: bool,
+    proposed_window_size: Option<u8>,
+    service_request: Bytes,
+) -> Apdu {
+    Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+        segmented: true,
+        more_follows,
+        segmented_response_accepted: true,
+        max_segments: None,
+        max_apdu_length: 1476,
+        invoke_id,
+        sequence_number: Some(seq),
+        proposed_window_size,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_request,
+    })
+}
+
+async fn send_raw_apdu(
+    raw_network: &Arc<NetworkLayer<BipTransport>>,
+    server_mac: &[u8],
+    apdu: Apdu,
+) {
+    let mut buf = BytesMut::new();
+    encode_apdu(&mut buf, &apdu);
+    raw_network
+        .send_apdu(&buf, server_mac, true, NetworkPriority::NORMAL)
+        .await
+        .unwrap();
+}
+
 /// When a client sends a segmented ConfirmedRequest (ReadProperty split across
 /// two segments), the server should reassemble it, process the full request,
 /// and return a correct ReadPropertyACK.
@@ -919,6 +973,164 @@ async fn server_handles_segmented_request() {
         got_response,
         "Should have received ReadPropertyACK response"
     );
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn server_aborts_segmented_request_with_invalid_window_size() {
+    let mut server = make_server().await;
+    let server_mac = server.local_mac().to_vec();
+
+    let raw_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::LOCALHOST);
+    let mut raw_network = NetworkLayer::new(raw_transport);
+    let mut raw_rx = raw_network.start().await.unwrap();
+    let raw_network = Arc::new(raw_network);
+
+    let payload = read_property_service_payload();
+    let invoke_id = 43;
+    let seg0 = segmented_read_property_pdu(
+        invoke_id,
+        0,
+        true,
+        Some(1),
+        Bytes::copy_from_slice(&payload[..payload.len() / 2]),
+    );
+    let mut buf = BytesMut::new();
+    encode_apdu(&mut buf, &seg0);
+    buf[4] = 0;
+    raw_network
+        .send_apdu(&buf, &server_mac, true, NetworkPriority::NORMAL)
+        .await
+        .unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(3), raw_rx.recv())
+        .await
+        .expect("Timed out waiting for Abort")
+        .expect("Channel closed while waiting for Abort");
+    let decoded = bacnet_encoding::apdu::decode_apdu(received.apdu).unwrap();
+    match decoded {
+        Apdu::Abort(abort) => {
+            assert!(abort.sent_by_server);
+            assert_eq!(abort.invoke_id, invoke_id);
+            assert_eq!(abort.abort_reason, AbortReason::WINDOW_SIZE_OUT_OF_RANGE);
+        }
+        other => panic!("Expected Abort, got {:?}", other),
+    }
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn server_naks_segmented_request_gap_with_last_good_sequence() {
+    let mut server = make_server().await;
+    let server_mac = server.local_mac().to_vec();
+
+    let raw_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::LOCALHOST);
+    let mut raw_network = NetworkLayer::new(raw_transport);
+    let mut raw_rx = raw_network.start().await.unwrap();
+    let raw_network = Arc::new(raw_network);
+
+    let payload = read_property_service_payload();
+    let third = payload.len() / 3;
+    let invoke_id = 44;
+    let seg0 = segmented_read_property_pdu(
+        invoke_id,
+        0,
+        true,
+        Some(2),
+        Bytes::copy_from_slice(&payload[..third]),
+    );
+    send_raw_apdu(&raw_network, &server_mac, seg0).await;
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), raw_rx.recv())
+            .await
+            .is_err(),
+        "server should not ACK before the negotiated window boundary"
+    );
+
+    let seg2 = segmented_read_property_pdu(
+        invoke_id,
+        2,
+        true,
+        Some(2),
+        Bytes::copy_from_slice(&payload[third * 2..]),
+    );
+    send_raw_apdu(&raw_network, &server_mac, seg2).await;
+
+    let received = tokio::time::timeout(Duration::from_secs(3), raw_rx.recv())
+        .await
+        .expect("Timed out waiting for negative SegmentAck")
+        .expect("Channel closed while waiting for negative SegmentAck");
+    let decoded = bacnet_encoding::apdu::decode_apdu(received.apdu).unwrap();
+    match decoded {
+        Apdu::SegmentAck(sa) => {
+            assert!(sa.sent_by_server);
+            assert!(sa.negative_ack);
+            assert_eq!(sa.invoke_id, invoke_id);
+            assert_eq!(sa.sequence_number, 0);
+            assert_eq!(sa.actual_window_size, 2);
+        }
+        other => panic!("Expected SegmentAck, got {:?}", other),
+    }
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn server_acks_segmented_request_at_window_boundary() {
+    let mut server = make_server().await;
+    let server_mac = server.local_mac().to_vec();
+
+    let raw_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::LOCALHOST);
+    let mut raw_network = NetworkLayer::new(raw_transport);
+    let mut raw_rx = raw_network.start().await.unwrap();
+    let raw_network = Arc::new(raw_network);
+
+    let payload = read_property_service_payload();
+    let mid = payload.len() / 2;
+    let invoke_id = 45;
+
+    let seg0 = segmented_read_property_pdu(
+        invoke_id,
+        0,
+        true,
+        Some(2),
+        Bytes::copy_from_slice(&payload[..mid]),
+    );
+    send_raw_apdu(&raw_network, &server_mac, seg0).await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), raw_rx.recv())
+            .await
+            .is_err(),
+        "server should wait for the second segment before ACKing a two-segment window"
+    );
+
+    let seg1 = segmented_read_property_pdu(
+        invoke_id,
+        1,
+        true,
+        Some(2),
+        Bytes::copy_from_slice(&payload[mid..]),
+    );
+    send_raw_apdu(&raw_network, &server_mac, seg1).await;
+
+    let received = tokio::time::timeout(Duration::from_secs(3), raw_rx.recv())
+        .await
+        .expect("Timed out waiting for SegmentAck")
+        .expect("Channel closed while waiting for SegmentAck");
+    let decoded = bacnet_encoding::apdu::decode_apdu(received.apdu).unwrap();
+    match decoded {
+        Apdu::SegmentAck(sa) => {
+            assert!(sa.sent_by_server);
+            assert!(!sa.negative_ack);
+            assert_eq!(sa.invoke_id, invoke_id);
+            assert_eq!(sa.sequence_number, 1);
+            assert_eq!(sa.actual_window_size, 2);
+        }
+        other => panic!("Expected SegmentAck, got {:?}", other),
+    }
 
     server.stop().await.unwrap();
 }

--- a/crates/bacnet-server/src/server.rs
+++ b/crates/bacnet-server/src/server.rs
@@ -320,6 +320,16 @@ impl BipServerBuilder {
 /// Key for tracking in-progress segmented sends: (source_mac, invoke_id).
 type SegKey = (MacAddr, u8);
 
+struct SegmentedRequestState {
+    receiver: SegmentReceiver,
+    first_req: bacnet_encoding::apdu::ConfirmedRequest,
+    last_activity: Instant,
+    expected_seq: u8,
+    last_acked_seq: u8,
+    window_pos: u8,
+    actual_window_size: u8,
+}
+
 /// BACnet server with APDU dispatch and service handling.
 pub struct BACnetServer<T: TransportPort> {
     #[allow(dead_code)]
@@ -546,19 +556,12 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
         let dispatch_task = tokio::spawn(async move {
             let mut apdu_rx = apdu_rx;
-            let mut seg_receivers: HashMap<
-                SegKey,
-                (
-                    SegmentReceiver,
-                    bacnet_encoding::apdu::ConfirmedRequest,
-                    Instant,
-                ),
-            > = HashMap::new();
+            let mut seg_receivers: HashMap<SegKey, SegmentedRequestState> = HashMap::new();
 
             while let Some(received) = apdu_rx.recv().await {
                 let now = Instant::now();
-                seg_receivers.retain(|_key, (_rx, _req, last_activity)| {
-                    now.duration_since(*last_activity) < SEG_RECEIVER_TIMEOUT
+                seg_receivers.retain(|_key, state| {
+                    now.duration_since(state.last_activity) < SEG_RECEIVER_TIMEOUT
                 });
 
                 match apdu::decode_apdu(received.apdu.clone()) {
@@ -570,9 +573,39 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 let seq = req.sequence_number.unwrap_or(0);
                                 let key: SegKey = (source_mac.clone(), req.invoke_id);
 
+                                let mut ack_to_send: Option<SegmentAckPdu> = None;
+                                let mut final_total: Option<usize> = None;
+
                                 if seq == 0 {
-                                    // Reject if too many concurrent segmented sessions
-                                    if seg_receivers.len() >= MAX_SEG_RECEIVERS {
+                                    let proposed_window_size =
+                                        req.proposed_window_size.unwrap_or(0);
+                                    if !(1..=127).contains(&proposed_window_size) {
+                                        warn!(
+	                                            invoke_id = req.invoke_id,
+	                                            proposed_window_size,
+	                                            "Rejecting segmented request with invalid proposed window size"
+	                                        );
+                                        let abort_pdu = Apdu::Abort(AbortPdu {
+                                            sent_by_server: true,
+                                            invoke_id: req.invoke_id,
+                                            abort_reason: AbortReason::WINDOW_SIZE_OUT_OF_RANGE,
+                                        });
+                                        let mut abort_buf = BytesMut::new();
+                                        encode_apdu(&mut abort_buf, &abort_pdu);
+                                        let _ = network_dispatch
+                                            .send_apdu(
+                                                &abort_buf,
+                                                &source_mac,
+                                                false,
+                                                NetworkPriority::NORMAL,
+                                            )
+                                            .await;
+                                        continue;
+                                    }
+
+                                    if !seg_receivers.contains_key(&key)
+                                        && seg_receivers.len() >= MAX_SEG_RECEIVERS
+                                    {
                                         let abort_pdu = Apdu::Abort(AbortPdu {
                                             sent_by_server: true,
                                             invoke_id: req.invoke_id,
@@ -590,6 +623,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                             .await;
                                         continue;
                                     }
+
                                     let mut receiver = SegmentReceiver::new();
                                     if let Err(e) =
                                         receiver.receive(seq, req.service_request.clone())
@@ -597,27 +631,80 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                         warn!(error = %e, "Rejecting oversized segment");
                                         continue;
                                     }
-                                    seg_receivers.insert(
-                                        key.clone(),
-                                        (receiver, req.clone(), Instant::now()),
-                                    );
-                                } else if let Some((receiver, _, last_activity)) =
-                                    seg_receivers.get_mut(&key)
-                                {
-                                    if let Err(e) =
-                                        receiver.receive(seq, req.service_request.clone())
-                                    {
-                                        warn!(error = %e, "Rejecting oversized segment");
-                                        continue;
+                                    let actual_window_size = proposed_window_size;
+                                    let mut state = SegmentedRequestState {
+                                        receiver,
+                                        first_req: req.clone(),
+                                        last_activity: Instant::now(),
+                                        expected_seq: 1,
+                                        last_acked_seq: 0,
+                                        window_pos: 1,
+                                        actual_window_size,
+                                    };
+                                    let should_ack =
+                                        !req.more_follows || state.window_pos >= actual_window_size;
+                                    if should_ack {
+                                        state.window_pos = 0;
+                                        ack_to_send = Some(SegmentAckPdu {
+                                            negative_ack: false,
+                                            sent_by_server: true,
+                                            invoke_id: req.invoke_id,
+                                            sequence_number: seq,
+                                            actual_window_size,
+                                        });
                                     }
-                                    *last_activity = Instant::now();
+                                    if !req.more_follows {
+                                        final_total = Some(1);
+                                    }
+                                    seg_receivers.insert(key.clone(), state);
+                                } else if let Some(state) = seg_receivers.get_mut(&key) {
+                                    state.last_activity = Instant::now();
+                                    if seq != state.expected_seq {
+                                        warn!(
+                                            invoke_id = req.invoke_id,
+                                            expected = state.expected_seq,
+                                            received = seq,
+                                            "Segment gap detected, sending negative SegmentAck"
+                                        );
+                                        ack_to_send = Some(SegmentAckPdu {
+                                            negative_ack: true,
+                                            sent_by_server: true,
+                                            invoke_id: req.invoke_id,
+                                            sequence_number: state.last_acked_seq,
+                                            actual_window_size: state.actual_window_size,
+                                        });
+                                    } else {
+                                        if let Err(e) =
+                                            state.receiver.receive(seq, req.service_request.clone())
+                                        {
+                                            warn!(error = %e, "Rejecting oversized segment");
+                                            continue;
+                                        }
+                                        state.expected_seq = seq.wrapping_add(1);
+                                        state.last_acked_seq = seq;
+                                        state.window_pos += 1;
+                                        let should_ack = !req.more_follows
+                                            || state.window_pos >= state.actual_window_size;
+                                        if should_ack {
+                                            state.window_pos = 0;
+                                            ack_to_send = Some(SegmentAckPdu {
+                                                negative_ack: false,
+                                                sent_by_server: true,
+                                                invoke_id: req.invoke_id,
+                                                sequence_number: seq,
+                                                actual_window_size: state.actual_window_size,
+                                            });
+                                        }
+                                        if !req.more_follows {
+                                            final_total = Some(seq as usize + 1);
+                                        }
+                                    }
                                 } else {
                                     warn!(
-                                        invoke_id = req.invoke_id,
-                                        seq = seq,
-                                        "Received non-initial segment without \
-                                         prior segment 0, aborting"
-                                    );
+	                                        invoke_id = req.invoke_id,
+	                                        seq = seq,
+	                                        "Received non-initial segment without prior segment 0, aborting"
+	                                    );
                                     let abort_pdu = Apdu::Abort(AbortPdu {
                                         sent_by_server: true,
                                         invoke_id: req.invoke_id,
@@ -636,37 +723,29 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                     continue;
                                 }
 
-                                let seg_ack = Apdu::SegmentAck(SegmentAckPdu {
-                                    negative_ack: false,
-                                    sent_by_server: true,
-                                    invoke_id: req.invoke_id,
-                                    sequence_number: seq,
-                                    actual_window_size: 1,
-                                });
-                                let mut ack_buf = BytesMut::new();
-                                encode_apdu(&mut ack_buf, &seg_ack);
-                                if let Err(e) = network_dispatch
-                                    .send_apdu(
-                                        &ack_buf,
-                                        &source_mac,
-                                        false,
-                                        NetworkPriority::NORMAL,
-                                    )
-                                    .await
-                                {
-                                    warn!(
-                                        error = %e,
-                                        "Failed to send SegmentAck for \
-                                         segmented request"
-                                    );
+                                if let Some(seg_ack) = ack_to_send {
+                                    let seg_ack = Apdu::SegmentAck(seg_ack);
+                                    let mut ack_buf = BytesMut::new();
+                                    encode_apdu(&mut ack_buf, &seg_ack);
+                                    if let Err(e) = network_dispatch
+                                        .send_apdu(
+                                            &ack_buf,
+                                            &source_mac,
+                                            false,
+                                            NetworkPriority::NORMAL,
+                                        )
+                                        .await
+                                    {
+                                        warn!(
+                                            error = %e,
+                                            "Failed to send SegmentAck for segmented request"
+                                        );
+                                    }
                                 }
 
-                                if !req.more_follows {
-                                    if let Some((receiver, first_req, _)) =
-                                        seg_receivers.remove(&key)
-                                    {
-                                        let total = receiver.received_count();
-                                        match receiver.reassemble(total) {
+                                if let Some(total) = final_total {
+                                    if let Some(state) = seg_receivers.remove(&key) {
+                                        match state.receiver.reassemble(total) {
                                             Ok(full_data) => {
                                                 let reassembled =
                                                     bacnet_encoding::apdu::ConfirmedRequest {
@@ -675,12 +754,17 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                                         sequence_number: None,
                                                         proposed_window_size: None,
                                                         service_request: Bytes::from(full_data),
-                                                        invoke_id: first_req.invoke_id,
-                                                        service_choice: first_req.service_choice,
-                                                        max_apdu_length: first_req.max_apdu_length,
-                                                        segmented_response_accepted: first_req
+                                                        invoke_id: state.first_req.invoke_id,
+                                                        service_choice: state
+                                                            .first_req
+                                                            .service_choice,
+                                                        max_apdu_length: state
+                                                            .first_req
+                                                            .max_apdu_length,
+                                                        segmented_response_accepted: state
+                                                            .first_req
                                                             .segmented_response_accepted,
-                                                        max_segments: first_req.max_segments,
+                                                        max_segments: state.first_req.max_segments,
                                                     };
                                                 debug!(
                                                     invoke_id = reassembled.invoke_id,
@@ -689,36 +773,33 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                                     "Reassembled segmented ConfirmedRequest"
                                                 );
                                                 Self::dispatch(
-                                                    &db_dispatch,
-                                                    &network_dispatch,
-                                                    &cov_dispatch,
-                                                    &seg_ack_dispatch,
-                                                    &cov_in_flight_dispatch,
-                                                    &server_tsm_dispatch,
-                                                    &comm_state_dispatch,
-                                                    &dcc_timer_dispatch,
-                                                    &config_dispatch,
-                                                    &source_mac,
-                                                    Apdu::ConfirmedRequest(reassembled),
-                                                    received
-                                                        .take()
-                                                        .unwrap_or_else(|| {
-                                                        warn!("received consumed twice — using empty fallback");
-                                                        bacnet_network::layer::ReceivedApdu {
-                                                            apdu: bytes::Bytes::new(),
-                                                            source_mac: bacnet_types::MacAddr::new(),
-                                                            source_network: None,
-                                                            reply_tx: None,
-                                                        }
-                                                    }),
-                                                )
-                                                .await;
+	                                                    &db_dispatch,
+	                                                    &network_dispatch,
+	                                                    &cov_dispatch,
+	                                                    &seg_ack_dispatch,
+	                                                    &cov_in_flight_dispatch,
+	                                                    &server_tsm_dispatch,
+	                                                    &comm_state_dispatch,
+	                                                    &dcc_timer_dispatch,
+	                                                    &config_dispatch,
+	                                                    &source_mac,
+	                                                    Apdu::ConfirmedRequest(reassembled),
+	                                                    received.take().unwrap_or_else(|| {
+	                                                        warn!("received consumed twice - using empty fallback");
+	                                                        bacnet_network::layer::ReceivedApdu {
+	                                                            apdu: bytes::Bytes::new(),
+	                                                            source_mac: bacnet_types::MacAddr::new(),
+	                                                            source_network: None,
+	                                                            reply_tx: None,
+	                                                        }
+	                                                    }),
+	                                                )
+	                                                .await;
                                             }
                                             Err(e) => {
                                                 warn!(
                                                     error = %e,
-                                                    "Failed to reassemble \
-                                                     segmented request"
+                                                    "Failed to reassemble segmented request"
                                                 );
                                             }
                                         }
@@ -1080,6 +1161,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let service_choice = req.service_choice;
         let client_max_apdu = req.max_apdu_length;
         let client_accepts_segmented = req.segmented_response_accepted;
+        let client_max_segments = req.max_segments;
         let mut written_oids: Vec<ObjectIdentifier> = Vec::new();
 
         let state = comm_state.load(Ordering::Acquire);
@@ -1397,6 +1479,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             service_choice,
                             &service_ack_data,
                             client_max_apdu,
+                            client_max_segments,
                         )
                         .await;
                     });
@@ -1499,6 +1582,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Splits the service ack data into segments that fit within the client's
     /// max APDU length, sends each segment, and waits for SegmentAck from
     /// the client before sending the next (window size 1).
+    #[allow(clippy::too_many_arguments)]
     async fn send_segmented_complex_ack(
         network: &Arc<NetworkLayer<T>>,
         seg_ack_senders: &Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
@@ -1507,12 +1591,49 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         service_choice: ConfirmedServiceChoice,
         service_ack_data: &[u8],
         client_max_apdu: u16,
+        client_max_segments: Option<u8>,
     ) {
         let max_seg_size = max_segment_payload(client_max_apdu, SegmentedPduType::ComplexAck);
-        let segments = split_payload(service_ack_data, max_seg_size);
+        let segments = match split_payload(service_ack_data, max_seg_size) {
+            Ok(segments) => segments,
+            Err(e) => {
+                warn!(error = %e, "Response requires too many segments, aborting");
+                let abort = Apdu::Abort(AbortPdu {
+                    sent_by_server: true,
+                    invoke_id,
+                    abort_reason: AbortReason::BUFFER_OVERFLOW,
+                });
+                let mut buf = BytesMut::new();
+                encode_apdu(&mut buf, &abort);
+                let _ = network
+                    .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
+                    .await;
+                return;
+            }
+        };
         let total_segments = segments.len();
 
-        if total_segments > 255 {
+        if let Some(max_segments) = client_max_segments {
+            if total_segments > max_segments as usize {
+                warn!(
+                    total_segments,
+                    max_segments, "Response exceeds client's max-segments-accepted, aborting"
+                );
+                let abort = Apdu::Abort(AbortPdu {
+                    sent_by_server: true,
+                    invoke_id,
+                    abort_reason: AbortReason::BUFFER_OVERFLOW,
+                });
+                let mut buf = BytesMut::new();
+                encode_apdu(&mut buf, &abort);
+                let _ = network
+                    .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
+                    .await;
+                return;
+            }
+        }
+
+        if total_segments > 256 {
             warn!(
                 total_segments,
                 "Response requires too many segments, aborting"
@@ -1606,10 +1727,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                     .await;
                                 break;
                             }
-                            let requested = ack.sequence_number as usize;
-                            if requested >= total_segments {
+                            let acknowledged = ack.sequence_number as usize;
+                            let requested = acknowledged + 1;
+                            if requested > total_segments {
                                 tracing::warn!(
-                                    seq = requested,
+                                    seq = acknowledged,
                                     total = total_segments,
                                     "negative SegmentAck requests out-of-range sequence, aborting"
                                 );


### PR DESCRIPTION
## Summary

Findings 1, 2, 3, 5, 9 from the BACnet 135-2020 code review:

- **Finding 1** — `split_payload` returns `Err` when the payload would exceed the 256-segment sequence space, instead of silently falling back to a single oversized segment.
- **Finding 2** — Server enforces the client's advertised `max-segments-accepted` for `ComplexACK` segmentation; aborts with `BUFFER_OVERFLOW` when the response requires more segments than the client said it can accept.
- **Finding 3** — Segmented `ConfirmedRequest` receive FSM validates `proposed-window-size` (rejects `0` or `>127` with `WINDOW_SIZE_OUT_OF_RANGE`), tracks expected sequence + window state, sends negative `SegmentACK` for out-of-order segments, completes on final-sequence rather than count.
- **Finding 5** — Negative `SegmentACK` retransmission resumes at `ack_seq.wrapping_add(1)` on both client and server (was `ack_seq`).
- **Finding 9** — Routed confirmed requests now flow through the segmented path with TSM correlation keyed on the routed endpoint.

## Spec

ASHRAE 135-2020 Clause 5 (segmentation/TSM flow control), Clauses 20.1.2.4, 20.1.2.5, 20.1.6.x.

## Sequencing

**Stacked on `codex/c-confirmed-notification-tsm`** — Finding 9's routed-segmentation work depends on the `(peer, invoke_id)` TSM keying introduced by Finding 8 (Group C). PR base will auto-update to `dev` once C merges.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm`
- [x] `RUSTFLAGS="-Dwarnings" cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets`

CHANGELOG entry in this branch.