### PR TITLE
fix(ci): stop dev push runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev]
+    branches: [main]
     tags: ["v*"]
   pull_request:
     branches: [main, dev]
@@ -25,7 +25,7 @@ permissions:
   id-token: write
 
 # =============================================================================
-# Tier 1 — CI (runs on every push and PR)
+# Tier 1 — CI (runs on PRs to main/dev, pushes to main, and v* tags)
 # =============================================================================
 
 jobs:


### PR DESCRIPTION
## Summary

- Remove `dev` from the CI workflow `push.branches` filter.
- Keep `pull_request.branches: [main, dev]` unchanged so PRs targeting `dev` still run CI.
- Keep push CI for `main` and `v*` tags.

## Reason

Merging PR #25 into `dev` started a second CI run on the merge commit after the PR checks had already passed. That duplicate `dev` push run was cancelled manually; this change prevents future PR landings on `dev` from starting the same redundant workflow.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'`
- `git diff --check`

Runtime impact: none; workflow trigger only.
