### PR TITLE
test(annex-j): add BVLL codec evidence

### DIFF
--- a/conformance/bacnet-135-2020.json
+++ b/conformance/bacnet-135-2020.json
@@ -1,9 +1,9 @@
 {
   "standard": "ANSI/ASHRAE Standard 135-2020",
   "reviewed_at": "2026-06-28",
-  "repo_sha": "c7af6a68b20339ad009597c76f539b54222fe1f7",
-  "review_scope": "Initial ledger seed and public-claim guard only; no runtime protocol behavior changes.",
-  "addenda_errata_status": "Not checked in this initial local seed; re-check current addenda/errata before each protocol PR.",
+  "repo_sha": "1308e4a7c6b67a1d225a112201f9381c6f9f006d",
+  "review_scope": "Annex J J-01 BVLL codec evidence update; no runtime protocol behavior changes.",
+  "addenda_errata_status": "Local Standard 135-2020 Annex J.2 text checked for this tranche; current addenda/errata still require follow-up review before strengthening support claims.",
   "status_taxonomy": [
     "in-progress",
     "implementation-present-needs-conformance-tests",
@@ -219,14 +219,23 @@
       "id": "BACNET-J-BVLC-FUNCTION-CODES",
       "standard_anchor": "Annex J.2",
       "priority": "P0",
-      "requirement_summary": "BACnet/IPv4 BVLC type, function code, and length handling is table-tested for every exposed function.",
+      "requirement_summary": "BACnet/IPv4 BVLC type, Annex J.2 function code, and length handling is table-tested through Original-Broadcast-NPDU, with deleted-value passthrough tracked separately.",
       "status": "implementation-present-needs-conformance-tests",
       "code_anchors": ["crates/bacnet-transport/src/bvll.rs", "crates/bacnet-types/src/enums/bvll.rs"],
-      "positive_tests": ["crates/bacnet-transport/src/bvll.rs"],
-      "negative_tests": ["crates/bacnet-transport/src/bvll.rs"],
+      "positive_tests": [
+        "crates/bacnet-transport/src/bvll.rs::annex_j_bvlc_function_constants_are_stable",
+        "crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough"
+      ],
+      "negative_tests": [
+        "crates/bacnet-transport/src/bvll.rs::decode_wrong_type",
+        "crates/bacnet-transport/src/bvll.rs::decode_length_shorter_than_header_errors",
+        "crates/bacnet-transport/src/bvll.rs::decode_length_exceeds_data",
+        "crates/bacnet-transport/src/bvll.rs::decode_preserves_unknown_bvlc_function_code",
+        "crates/bacnet-transport/src/bvll.rs::decode_slices_payload_to_declared_length"
+      ],
       "benchmarks": ["benchmarks/benches/bip_latency.rs", "benchmarks/benches/bip_throughput.rs"],
       "public_claims": ["README BACnet/IP feature", "README transports table: BACnet/IP"],
-      "notes": "Needs explicit all-function table and malformed length/type cases."
+      "notes": "J-01 now covers Annex J.2 function constants through 0x0B, representative frames, wrong type, short/overlong declared lengths, unknown function passthrough, and the current decoder policy for bytes beyond the declared BVLC Length. SECURE_BVLL 0x0C is tested only as deleted-value passthrough. Function-specific management payload semantics remain for J-02/J-03."
     },
     {
       "id": "BACNET-J-ORIGINAL-UNICAST-NPDU",
@@ -235,11 +244,11 @@
       "requirement_summary": "Original-Unicast-NPDU frames preserve exact BVLC length, payload validation, and source/reply semantics.",
       "status": "implementation-present-needs-negative-tests",
       "code_anchors": ["crates/bacnet-transport/src/bvll.rs", "crates/bacnet-transport/src/bip"],
-      "positive_tests": [],
-      "negative_tests": [],
+      "positive_tests": ["crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough"],
+      "negative_tests": ["crates/bacnet-transport/src/bvll.rs::decode_slices_payload_to_declared_length"],
       "benchmarks": ["benchmarks/benches/bip_latency.rs"],
       "public_claims": ["README BACnet/IP feature"],
-      "notes": "Needs malformed and reply-path tests."
+      "notes": "Generic BVLL envelope coverage exists; source/reply path and NPDU semantic tests remain."
     },
     {
       "id": "BACNET-J-ORIGINAL-BROADCAST-NPDU",
@@ -248,11 +257,11 @@
       "requirement_summary": "Original-Broadcast-NPDU frames are encoded, decoded, and routed according to BACnet/IP broadcast semantics.",
       "status": "implementation-present-needs-negative-tests",
       "code_anchors": ["crates/bacnet-transport/src/bvll.rs", "crates/bacnet-transport/src/bip"],
-      "positive_tests": [],
-      "negative_tests": [],
+      "positive_tests": ["crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough"],
+      "negative_tests": ["crates/bacnet-transport/src/bvll.rs::decode_slices_payload_to_declared_length"],
       "benchmarks": ["benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["README BACnet/IP feature"],
-      "notes": "Needs local, remote, and global broadcast tests."
+      "notes": "Generic BVLL envelope coverage exists; local, remote, and global broadcast behavior tests remain."
     },
     {
       "id": "BACNET-J-FORWARDED-NPDU",
@@ -261,11 +270,14 @@
       "requirement_summary": "Forwarded-NPDU includes a valid originating BACnet/IP MAC and preserves source-address semantics.",
       "status": "implementation-present-needs-negative-tests",
       "code_anchors": ["crates/bacnet-transport/src/bvll.rs", "crates/bacnet-transport/src/bbmd.rs"],
-      "positive_tests": [],
-      "negative_tests": [],
+      "positive_tests": [
+        "crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough",
+        "crates/bacnet-transport/src/bvll.rs::encode_decode_forwarded_npdu"
+      ],
+      "negative_tests": ["crates/bacnet-transport/src/bvll.rs::decode_forwarded_too_short_for_address"],
       "benchmarks": ["benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["README BACnet/IP feature", "docs/CLI.md BBMD commands"],
-      "notes": "Needs truncated-originating-address and echo/loop-prevention tests."
+      "notes": "Generic originating-address parsing and truncated-address rejection are covered; BBMD echo/loop-prevention and source semantics remain."
     },
     {
       "id": "BACNET-J-BBMD-BDT",

--- a/crates/bacnet-transport/src/bvll.rs
+++ b/crates/bacnet-transport/src/bvll.rs
@@ -163,6 +163,246 @@ pub fn decode_bip_mac(mac: &[u8]) -> Result<([u8; 4], u16), Error> {
 mod tests {
     use super::*;
 
+    struct BvlcCodecCase {
+        name: &'static str,
+        function: BvlcFunction,
+        payload: &'static [u8],
+        expected_payload: &'static [u8],
+        expected_origin: Option<([u8; 4], u16)>,
+    }
+
+    const SAMPLE_NPDU: &[u8] = &[0x01, 0x20];
+    const SAMPLE_BDT_ENTRY: &[u8] = &[192, 0, 2, 10, 0xBA, 0xC0, 255, 255, 255, 0];
+    const SAMPLE_FDT_ENTRY: &[u8] = &[192, 0, 2, 20, 0xBA, 0xC0, 0x00, 0x3C, 0x00, 0x5A];
+    const SAMPLE_BIP_ADDRESS: &[u8] = &[192, 0, 2, 30, 0xBA, 0xC0];
+
+    fn encode_standard_frame(function: BvlcFunction, payload: &[u8]) -> BytesMut {
+        let mut buf = BytesMut::new();
+        encode_bvll(&mut buf, function, payload).expect("valid BVLL encoding");
+        buf
+    }
+
+    #[test]
+    fn annex_j_bvlc_function_constants_are_stable() {
+        let expected_annex_j_functions = [
+            ("BVLC_RESULT", BvlcFunction::BVLC_RESULT, 0x00),
+            (
+                "WRITE_BROADCAST_DISTRIBUTION_TABLE",
+                BvlcFunction::WRITE_BROADCAST_DISTRIBUTION_TABLE,
+                0x01,
+            ),
+            (
+                "READ_BROADCAST_DISTRIBUTION_TABLE",
+                BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE,
+                0x02,
+            ),
+            (
+                "READ_BROADCAST_DISTRIBUTION_TABLE_ACK",
+                BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK,
+                0x03,
+            ),
+            ("FORWARDED_NPDU", BvlcFunction::FORWARDED_NPDU, 0x04),
+            (
+                "REGISTER_FOREIGN_DEVICE",
+                BvlcFunction::REGISTER_FOREIGN_DEVICE,
+                0x05,
+            ),
+            (
+                "READ_FOREIGN_DEVICE_TABLE",
+                BvlcFunction::READ_FOREIGN_DEVICE_TABLE,
+                0x06,
+            ),
+            (
+                "READ_FOREIGN_DEVICE_TABLE_ACK",
+                BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK,
+                0x07,
+            ),
+            (
+                "DELETE_FOREIGN_DEVICE_TABLE_ENTRY",
+                BvlcFunction::DELETE_FOREIGN_DEVICE_TABLE_ENTRY,
+                0x08,
+            ),
+            (
+                "DISTRIBUTE_BROADCAST_TO_NETWORK",
+                BvlcFunction::DISTRIBUTE_BROADCAST_TO_NETWORK,
+                0x09,
+            ),
+            (
+                "ORIGINAL_UNICAST_NPDU",
+                BvlcFunction::ORIGINAL_UNICAST_NPDU,
+                0x0A,
+            ),
+            (
+                "ORIGINAL_BROADCAST_NPDU",
+                BvlcFunction::ORIGINAL_BROADCAST_NPDU,
+                0x0B,
+            ),
+        ];
+
+        assert!(BvlcFunction::ALL_NAMED.len() >= expected_annex_j_functions.len());
+        for ((actual_name, actual_function), (name, function, raw)) in BvlcFunction::ALL_NAMED
+            .iter()
+            .take(expected_annex_j_functions.len())
+            .zip(expected_annex_j_functions)
+        {
+            assert_eq!(*actual_name, name);
+            assert_eq!(*actual_function, function);
+            assert_eq!(actual_function.to_raw(), raw);
+            assert_eq!(BvlcFunction::from_raw(raw), function);
+        }
+    }
+
+    #[test]
+    fn deleted_secure_bvll_function_is_exposed_as_passthrough() {
+        assert_eq!(BvlcFunction::SECURE_BVLL.to_raw(), 0x0C);
+        assert_eq!(BvlcFunction::from_raw(0x0C), BvlcFunction::SECURE_BVLL);
+    }
+
+    #[test]
+    fn decode_annex_j_bvlc_functions_and_deleted_secure_passthrough() {
+        let cases = [
+            BvlcCodecCase {
+                name: "BVLC-Result",
+                function: BvlcFunction::BVLC_RESULT,
+                payload: &[0x00, 0x00],
+                expected_payload: &[0x00, 0x00],
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Write-BDT",
+                function: BvlcFunction::WRITE_BROADCAST_DISTRIBUTION_TABLE,
+                payload: SAMPLE_BDT_ENTRY,
+                expected_payload: SAMPLE_BDT_ENTRY,
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Read-BDT",
+                function: BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE,
+                payload: &[],
+                expected_payload: &[],
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Read-BDT-Ack",
+                function: BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK,
+                payload: &[],
+                expected_payload: &[],
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Forwarded-NPDU",
+                function: BvlcFunction::FORWARDED_NPDU,
+                payload: SAMPLE_NPDU,
+                expected_payload: SAMPLE_NPDU,
+                expected_origin: Some(([192, 0, 2, 40], 0xBAC0)),
+            },
+            BvlcCodecCase {
+                name: "Register-Foreign-Device",
+                function: BvlcFunction::REGISTER_FOREIGN_DEVICE,
+                payload: &[0x00, 0x3C],
+                expected_payload: &[0x00, 0x3C],
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Read-FDT",
+                function: BvlcFunction::READ_FOREIGN_DEVICE_TABLE,
+                payload: &[],
+                expected_payload: &[],
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Read-FDT-Ack",
+                function: BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK,
+                payload: SAMPLE_FDT_ENTRY,
+                expected_payload: SAMPLE_FDT_ENTRY,
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Delete-FDT-Entry",
+                function: BvlcFunction::DELETE_FOREIGN_DEVICE_TABLE_ENTRY,
+                payload: SAMPLE_BIP_ADDRESS,
+                expected_payload: SAMPLE_BIP_ADDRESS,
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Distribute-Broadcast-To-Network",
+                function: BvlcFunction::DISTRIBUTE_BROADCAST_TO_NETWORK,
+                payload: SAMPLE_NPDU,
+                expected_payload: SAMPLE_NPDU,
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Original-Unicast-NPDU",
+                function: BvlcFunction::ORIGINAL_UNICAST_NPDU,
+                payload: SAMPLE_NPDU,
+                expected_payload: SAMPLE_NPDU,
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Original-Broadcast-NPDU",
+                function: BvlcFunction::ORIGINAL_BROADCAST_NPDU,
+                payload: SAMPLE_NPDU,
+                expected_payload: SAMPLE_NPDU,
+                expected_origin: None,
+            },
+            BvlcCodecCase {
+                name: "Secure-BVLL passthrough",
+                function: BvlcFunction::SECURE_BVLL,
+                payload: &[],
+                expected_payload: &[],
+                expected_origin: None,
+            },
+        ];
+
+        for case in cases {
+            let frame = if let Some((ip, port)) = case.expected_origin {
+                let mut buf = BytesMut::new();
+                encode_bvll_forwarded(&mut buf, ip, port, case.payload)
+                    .expect("valid Forwarded-NPDU encoding");
+                buf
+            } else {
+                encode_standard_frame(case.function, case.payload)
+            };
+            let declared_length = u16::from_be_bytes([frame[2], frame[3]]) as usize;
+            assert_eq!(declared_length, frame.len(), "{}", case.name);
+
+            let msg = decode_bvll(&frame).unwrap_or_else(|err| panic!("{}: {err}", case.name));
+            assert_eq!(msg.function, case.function, "{}", case.name);
+            assert_eq!(msg.payload, case.expected_payload, "{}", case.name);
+            assert_eq!(
+                msg.originating_ip,
+                case.expected_origin.map(|(ip, _)| ip),
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                msg.originating_port,
+                case.expected_origin.map(|(_, port)| port),
+                "{}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn decode_preserves_unknown_bvlc_function_code() {
+        let msg = decode_bvll(&[0x81, 0x7F, 0x00, 0x06, 0xAA, 0xBB]).unwrap();
+        assert_eq!(msg.function, BvlcFunction::from_raw(0x7F));
+        assert_eq!(msg.payload, Bytes::from_static(&[0xAA, 0xBB]));
+        assert!(msg.originating_ip.is_none());
+        assert!(msg.originating_port.is_none());
+    }
+
+    #[test]
+    fn decode_slices_payload_to_declared_length() {
+        // Current decoder policy: ignore datagram bytes after the declared BVLC length.
+        let msg =
+            decode_bvll(&[0x81, 0x0A, 0x00, 0x06, 0x01, 0x00, 0xDE, 0xAD, 0xBE, 0xEF]).unwrap();
+
+        assert_eq!(msg.function, BvlcFunction::ORIGINAL_UNICAST_NPDU);
+        assert_eq!(msg.payload, Bytes::from_static(&[0x01, 0x00]));
+    }
+
     #[test]
     fn encode_decode_unicast() {
         let npdu = vec![0x01, 0x00, 0x10, 0x02, 0x03];
@@ -291,6 +531,11 @@ mod tests {
     fn decode_length_exceeds_data() {
         // Claim length is 100, but only 4 bytes of data
         assert!(decode_bvll(&[0x81, 0x0A, 0x00, 0x64]).is_err());
+    }
+
+    #[test]
+    fn decode_length_shorter_than_header_errors() {
+        assert!(decode_bvll(&[0x81, 0x0A, 0x00, 0x03]).is_err());
     }
 
     #[test]

--- a/docs/conformance/standard-135-2020-ledger.md
+++ b/docs/conformance/standard-135-2020-ledger.md
@@ -6,10 +6,10 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020.
 - Reviewed at: 2026-06-28.
-- Repository SHA reviewed: `c7af6a68b20339ad009597c76f539b54222fe1f7`.
+- Repository SHA reviewed: `1308e4a7c6b67a1d225a112201f9381c6f9f006d`.
 - Machine-readable source: `conformance/bacnet-135-2020.json`.
-- Initial scope: seed ledger and public-claim guard only; no runtime protocol behavior changes.
-- Addenda/errata status: not checked in this initial seed. Re-check current addenda and errata before each protocol PR.
+- Current scope: Annex J J-01 BVLL codec evidence update; no runtime protocol behavior changes.
+- Addenda/errata status: local Standard 135-2020 Annex J.2 text checked for this tranche; current addenda and errata still require follow-up review before strengthening support claims.
 
 ## Status Taxonomy
 
@@ -83,10 +83,10 @@
 
 | Row ID | Anchor | Priority | Status | Evidence |
 |---|---|---|---|---|
-| `BACNET-J-BVLC-FUNCTION-CODES` | Annex J.2 | P0 | `implementation-present-needs-conformance-tests` | BVLL codec and enum paths exist. |
-| `BACNET-J-ORIGINAL-UNICAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | B/IP BVLL and transport paths exist. |
-| `BACNET-J-ORIGINAL-BROADCAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Broadcast B/IP paths exist; broadcast semantics need tests. |
-| `BACNET-J-FORWARDED-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Forwarded-NPDU and BBMD paths exist; origin handling needs tests. |
+| `BACNET-J-BVLC-FUNCTION-CODES` | Annex J.2 | P0 | `implementation-present-needs-conformance-tests` | J-01 covers Annex J.2 constants through `0x0B`, representative frames, malformed type/length, unknown function passthrough, deleted-value passthrough, and current decoder policy for extra bytes beyond BVLC Length. |
+| `BACNET-J-ORIGINAL-UNICAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic BVLL envelope coverage exists; B/IP source/reply semantics need tests. |
+| `BACNET-J-ORIGINAL-BROADCAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic BVLL envelope coverage exists; broadcast semantics need tests. |
+| `BACNET-J-FORWARDED-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic originating-address parsing and truncated-address rejection are covered; BBMD source/loop behavior needs tests. |
 | `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | P0 | `implementation-present-needs-conformance-tests` | BBMD/BDT paths exist; lifecycle tests remain open. |
 | `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | P0 | `implementation-present-needs-conformance-tests` | FDT paths exist; TTL/delete/rejection tests remain open. |
 
@@ -125,4 +125,4 @@
 
 ## Follow-Up Backlog
 
-Rows not marked `supported-with-clause-evidence` are follow-up work. The next tranche should harden Annex J BVLL/BACnet/IP rows with table-driven positive and negative tests, then update this ledger and the generated draft summaries.
+Rows not marked `supported-with-clause-evidence` are follow-up work. The next Annex J tranche should harden BVLC-Result and management-function typed result handling, then continue BBMD/BDT/FDT lifecycle evidence.

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -4,9 +4,9 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020
 - Reviewed at: 2026-06-28
-- Repository SHA reviewed: `c7af6a68b20339ad009597c76f539b54222fe1f7`
-- Scope: Initial ledger seed and public-claim guard only; no runtime protocol behavior changes.
-- Addenda/errata: Not checked in this initial local seed; re-check current addenda/errata before each protocol PR.
+- Repository SHA reviewed: `1308e4a7c6b67a1d225a112201f9381c6f9f006d`
+- Scope: Annex J J-01 BVLL codec evidence update; no runtime protocol behavior changes.
+- Addenda/errata: Local Standard 135-2020 Annex J.2 text checked for this tranche; current addenda/errata still require follow-up review before strengthening support claims.
 
 ## Counts
 


### PR DESCRIPTION
## Summary
- add table-driven Annex J.2 BVLL codec tests for function constants `0x00..0x0B`, representative frames, and Forwarded-NPDU origin parsing
- pin malformed envelope behavior for wrong BVLC type, declared length shorter than header, declared length longer than buffer, unknown function passthrough, and current policy for bytes beyond declared BVLC Length
- update the Standard 135-2020 conformance ledger and generated support summary without changing any row to `supported-with-clause-evidence`

## Standard Anchors
- ANSI/ASHRAE 135-2020 Annex J.2 BVLL/BVLC header and function formats
- Annex J.2.13 is deleted in 135-2020, so `SECURE_BVLL`/`0x0C` is tested only as deleted-value passthrough, not as Annex J.2 support

## Verification
- `cargo fmt --all --check`
- `cargo test -p bacnet-transport --locked bvll`
- `cargo test -p bacnet-integration-tests --test conformance_ledger --locked --quiet`
- `python3 scripts/generate-conformance-docs.py --check`
- `git diff --check`

Cargo emitted existing missing-doc warnings during targeted test builds; tests passed.

## Scope And Limits
- No runtime protocol behavior changes.
- `conformance/bacnet-135-2020.json` records the reviewed `dev` runtime snapshot (`1308e4a7c6b67a1d225a112201f9381c6f9f006d`) because this PR adds tests/docs only.
- BBMD/BDT/FDT lifecycle, typed BVLC-Result handling, DBTN authorization, source/reply semantics, and loop prevention remain follow-up work.
- No benchmark run; this is conformance evidence only.

## Review
- Carver: read-only Annex J boundary review, confirmed J-01 codec scope and that BBMD/FDT semantics should remain later work.
- Raman: final diff review found no blockers; requested tighter trailing-byte wording, which is included here.
