### PR TITLE
fix(annex-j): harden BVLC result handling

### DIFF
--- a/conformance/bacnet-135-2020.json
+++ b/conformance/bacnet-135-2020.json
@@ -1,7 +1,7 @@
 {
   "standard": "ANSI/ASHRAE Standard 135-2020",
   "reviewed_at": "2026-06-28",
-  "repo_sha": "e8abd2d605bea2336dbb1016017eaf2d892343f8",
+  "repo_sha": "8961537a43f82dfa7675f2fd00c76f7de699f892",
   "review_scope": "Annex J J-02 BVLC-Result typed handling evidence update; management response parsing and diagnostics hardened.",
   "addenda_errata_status": "Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes found for this tranche.",
   "status_taxonomy": [

--- a/conformance/bacnet-135-2020.json
+++ b/conformance/bacnet-135-2020.json
@@ -1,9 +1,9 @@
 {
   "standard": "ANSI/ASHRAE Standard 135-2020",
   "reviewed_at": "2026-06-28",
-  "repo_sha": "1308e4a7c6b67a1d225a112201f9381c6f9f006d",
-  "review_scope": "Annex J J-01 BVLL codec evidence update; no runtime protocol behavior changes.",
-  "addenda_errata_status": "Local Standard 135-2020 Annex J.2 text checked for this tranche; current addenda/errata still require follow-up review before strengthening support claims.",
+  "repo_sha": "e8abd2d605bea2336dbb1016017eaf2d892343f8",
+  "review_scope": "Annex J J-02 BVLC-Result typed handling evidence update; management response parsing and diagnostics hardened.",
+  "addenda_errata_status": "Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes found for this tranche.",
   "status_taxonomy": [
     "in-progress",
     "implementation-present-needs-conformance-tests",
@@ -219,23 +219,28 @@
       "id": "BACNET-J-BVLC-FUNCTION-CODES",
       "standard_anchor": "Annex J.2",
       "priority": "P0",
-      "requirement_summary": "BACnet/IPv4 BVLC type, Annex J.2 function code, and length handling is table-tested through Original-Broadcast-NPDU, with deleted-value passthrough tracked separately.",
+      "requirement_summary": "BACnet/IPv4 BVLC type, Annex J.2 function code, length handling, and BVLC-Result result-code parsing are table-tested, with deleted-value passthrough tracked separately.",
       "status": "implementation-present-needs-conformance-tests",
-      "code_anchors": ["crates/bacnet-transport/src/bvll.rs", "crates/bacnet-types/src/enums/bvll.rs"],
+      "code_anchors": ["crates/bacnet-transport/src/bvll.rs", "crates/bacnet-transport/src/bip/mod.rs", "crates/bacnet-types/src/enums/bvll.rs"],
       "positive_tests": [
         "crates/bacnet-transport/src/bvll.rs::annex_j_bvlc_function_constants_are_stable",
-        "crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough"
+        "crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough",
+        "crates/bacnet-transport/src/bip/tests.rs::decode_bvlc_result_code_accepts_named_and_unknown_codes",
+        "crates/bacnet-transport/src/bip/tests.rs::pending_bvlc_response_requires_sender_and_expected_function"
       ],
       "negative_tests": [
         "crates/bacnet-transport/src/bvll.rs::decode_wrong_type",
         "crates/bacnet-transport/src/bvll.rs::decode_length_shorter_than_header_errors",
         "crates/bacnet-transport/src/bvll.rs::decode_length_exceeds_data",
         "crates/bacnet-transport/src/bvll.rs::decode_preserves_unknown_bvlc_function_code",
-        "crates/bacnet-transport/src/bvll.rs::decode_slices_payload_to_declared_length"
+        "crates/bacnet-transport/src/bvll.rs::decode_slices_payload_to_declared_length",
+        "crates/bacnet-transport/src/bip/tests.rs::decode_bvlc_result_code_rejects_wrong_function",
+        "crates/bacnet-transport/src/bip/tests.rs::decode_bvlc_result_code_rejects_malformed_payload_lengths",
+        "crates/bacnet-transport/src/bip/tests.rs::expect_bvlc_function_rejects_unexpected_response_function"
       ],
       "benchmarks": ["benchmarks/benches/bip_latency.rs", "benchmarks/benches/bip_throughput.rs"],
       "public_claims": ["README BACnet/IP feature", "README transports table: BACnet/IP"],
-      "notes": "J-01 now covers Annex J.2 function constants through 0x0B, representative frames, wrong type, short/overlong declared lengths, unknown function passthrough, and the current decoder policy for bytes beyond the declared BVLC Length. SECURE_BVLL 0x0C is tested only as deleted-value passthrough. Function-specific management payload semantics remain for J-02/J-03."
+      "notes": "J-01 covers Annex J.2 function constants through 0x0B, representative frames, wrong type, short/overlong declared lengths, unknown function passthrough, and current decoder policy for bytes beyond the declared BVLC Length. J-02 adds exact two-byte BVLC-Result parsing, unknown result-code passthrough, malformed result rejection, and sender/expected-function correlation for pending management responses. SECURE_BVLL 0x0C is tested only as deleted-value passthrough. BBMD/FDT lifecycle semantics remain for later J-03 work."
     },
     {
       "id": "BACNET-J-ORIGINAL-UNICAST-NPDU",
@@ -286,11 +291,17 @@
       "requirement_summary": "BBMD Broadcast Distribution Table write/read/ACK behavior and peer broadcast fanout are validated.",
       "status": "implementation-present-needs-conformance-tests",
       "code_anchors": ["crates/bacnet-transport/src/bbmd.rs", "crates/bacnet-cli/src/shell/bbmd.rs"],
-      "positive_tests": [],
-      "negative_tests": [],
+      "positive_tests": [
+        "crates/bacnet-transport/src/bip/tests.rs::read_bdt_from_bbmd",
+        "crates/bacnet-transport/src/bip/tests.rs::write_bdt_to_bbmd"
+      ],
+      "negative_tests": [
+        "crates/bacnet-transport/src/bip/tests.rs::read_bdt_from_non_bbmd_surfaces_typed_nak",
+        "crates/bacnet-transport/src/bip/tests.rs::write_bdt_to_non_bbmd_surfaces_typed_nak"
+      ],
       "benchmarks": ["benchmarks/src/bin/bacnet_bbmd.rs", "benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["docs/CLI.md BBMD commands", "README CLI BBMD commands"],
-      "notes": "Needs BDT overwrite, read ACK, fanout, and loop prevention tests."
+      "notes": "J-02 covers read/write BDT caller paths and typed non-BBMD BVLC-Result NAK propagation. BDT overwrite, fanout, loop prevention, persistence, and ACL matrix tests remain for later lifecycle work."
     },
     {
       "id": "BACNET-J-FOREIGN-DEVICE-FDT",
@@ -299,11 +310,18 @@
       "requirement_summary": "Foreign-device registration, TTL bounds, re-registration, read/delete FDT, expiry, and DBTN authorization are validated.",
       "status": "implementation-present-needs-conformance-tests",
       "code_anchors": ["crates/bacnet-transport/src/bbmd.rs", "crates/bacnet-cli/src/shell/bbmd.rs"],
-      "positive_tests": [],
-      "negative_tests": [],
+      "positive_tests": [
+        "crates/bacnet-transport/src/bip/tests.rs::read_fdt_from_bbmd",
+        "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_via_bvlc"
+      ],
+      "negative_tests": [
+        "crates/bacnet-transport/src/bip/tests.rs::read_fdt_from_non_bbmd_surfaces_typed_nak",
+        "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_to_non_bbmd_surfaces_typed_nak",
+        "crates/bacnet-transport/src/bip/tests.rs::delete_fdt_entry_to_non_bbmd_surfaces_typed_nak"
+      ],
       "benchmarks": ["benchmarks/src/bin/bacnet_bbmd.rs", "benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["docs/CLI.md foreign device commands"],
-      "notes": "Needs unregistered/expired foreign device rejection evidence."
+      "notes": "J-02 covers FDT read/register/delete caller paths and typed non-BBMD BVLC-Result NAK propagation. TTL bounds, expiry, re-registration, DBTN authorization, and delete lifecycle semantics remain for later lifecycle work."
     },
     {
       "id": "BACNET-K-BIBBS",

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -3,15 +3,17 @@ use std::sync::Arc;
 
 use bytes::BytesMut;
 use tokio::net::UdpSocket;
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{mpsc, Mutex};
 use tracing::{debug, warn};
 
 use bacnet_types::enums::{BvlcFunction, BvlcResultCode};
 use bacnet_types::MacAddr;
 
 use crate::bbmd::BbmdState;
-use crate::bvll::{self, encode_bip_mac, encode_bvll, encode_bvll_forwarded, BvllMessage};
+use crate::bvll::{self, encode_bip_mac, encode_bvll, encode_bvll_forwarded};
 use crate::port::ReceivedNpdu;
+
+use super::{decode_bvlc_result_code, PendingBvlcResponse};
 
 /// Send a Register-Foreign-Device message to a BBMD.
 pub(super) async fn send_register_foreign_device(
@@ -41,8 +43,26 @@ pub(super) struct RecvContext {
     pub(super) bbmd: Option<Arc<Mutex<BbmdState>>>,
     pub(super) broadcast_addr: Ipv4Addr,
     pub(super) broadcast_port: u16,
-    pub(super) bvlc_response: Arc<Mutex<Option<oneshot::Sender<BvllMessage>>>>,
+    pub(super) pending_bvlc_response: Arc<Mutex<Option<PendingBvlcResponse>>>,
     pub(super) bdt_persist_path: Option<std::path::PathBuf>,
+}
+
+async fn complete_pending_bvlc_response(
+    msg: &bvll::BvllMessage,
+    sender: ([u8; 4], u16),
+    ctx: &RecvContext,
+) -> bool {
+    let mut slot = ctx.pending_bvlc_response.lock().await;
+    if slot
+        .as_ref()
+        .is_some_and(|pending| pending.matches(sender, msg.function))
+    {
+        let pending = slot.take().expect("pending response exists");
+        let _ = pending.tx.send(msg.clone());
+        true
+    } else {
+        false
+    }
 }
 
 /// Handle a decoded BVLL message in the recv loop.
@@ -464,57 +484,40 @@ pub(super) async fn handle_bvll_message(
         }
 
         f if f == BvlcFunction::BVLC_RESULT => {
-            let sender_opt = {
-                let mut slot = ctx.bvlc_response.lock().await;
-                slot.take()
-            };
-            if let Some(response_tx) = sender_opt {
-                let _ = response_tx.send(msg.clone());
-            } else if msg.payload.len() >= 2 {
-                let code =
-                    BvlcResultCode::from_raw(u16::from_be_bytes([msg.payload[0], msg.payload[1]]));
-                match code {
-                    BvlcResultCode::SUCCESSFUL_COMPLETION => {
+            if !complete_pending_bvlc_response(msg, sender, ctx).await {
+                match decode_bvlc_result_code(msg) {
+                    Ok(BvlcResultCode::SUCCESSFUL_COMPLETION) => {
                         debug!("Received BVLC-Result: successful");
                     }
-                    BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK => {
+                    Ok(BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK) => {
                         tracing::error!(
                             "BVLC-Result NAK: foreign device registration rejected by BBMD"
                         );
                     }
-                    BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK => {
+                    Ok(BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK) => {
                         tracing::error!(
-                            "BVLC-Result NAK: broadcast distribution rejected — \
+                            "BVLC-Result NAK: broadcast distribution rejected - \
                              foreign device registration may have failed or expired"
                         );
                     }
-                    _ => {
+                    Ok(code) => {
                         warn!(code = ?code, "Received BVLC-Result NAK");
+                    }
+                    Err(err) => {
+                        warn!(error = %err, "Received malformed BVLC-Result");
                     }
                 }
             }
         }
 
         f if f == BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK => {
-            let sender_opt = {
-                let mut slot = ctx.bvlc_response.lock().await;
-                slot.take()
-            };
-            if let Some(response_tx) = sender_opt {
-                let _ = response_tx.send(msg.clone());
-            } else {
+            if !complete_pending_bvlc_response(msg, sender, ctx).await {
                 debug!("Received Read-BDT-ACK with no pending request");
             }
         }
 
         f if f == BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK => {
-            let sender_opt = {
-                let mut slot = ctx.bvlc_response.lock().await;
-                slot.take()
-            };
-            if let Some(response_tx) = sender_opt {
-                let _ = response_tx.send(msg.clone());
-            } else {
+            if !complete_pending_bvlc_response(msg, sender, ctx).await {
                 debug!("Received Read-FDT-ACK with no pending request");
             }
         }

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -26,6 +26,74 @@ use io::{handle_bvll_message, resolve_local_ip, send_register_foreign_device, Re
 /// Default BACnet/IP port (0xBAC0 = 47808).
 pub const DEFAULT_BACNET_PORT: u16 = 0xBAC0;
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum BvlcResponseKind {
+    Result,
+    ReadBroadcastDistributionTableAck,
+    ReadForeignDeviceTableAck,
+}
+
+impl BvlcResponseKind {
+    pub(super) fn accepts(self, function: BvlcFunction) -> bool {
+        match self {
+            Self::Result => function == BvlcFunction::BVLC_RESULT,
+            Self::ReadBroadcastDistributionTableAck => {
+                function == BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK
+                    || function == BvlcFunction::BVLC_RESULT
+            }
+            Self::ReadForeignDeviceTableAck => {
+                function == BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK
+                    || function == BvlcFunction::BVLC_RESULT
+            }
+        }
+    }
+}
+
+pub(super) struct PendingBvlcResponse {
+    target: ([u8; 4], u16),
+    expected: BvlcResponseKind,
+    tx: oneshot::Sender<BvllMessage>,
+}
+
+impl PendingBvlcResponse {
+    pub(super) fn matches(&self, sender: ([u8; 4], u16), function: BvlcFunction) -> bool {
+        self.target == sender && self.expected.accepts(function)
+    }
+}
+
+pub(super) fn expect_bvlc_function(msg: &BvllMessage, expected: BvlcFunction) -> Result<(), Error> {
+    if msg.function == expected {
+        Ok(())
+    } else {
+        Err(Error::Encoding(format!(
+            "expected BVLC response {expected:?}, got {:?}",
+            msg.function
+        )))
+    }
+}
+
+pub(super) fn decode_bvlc_result_code(msg: &BvllMessage) -> Result<BvlcResultCode, Error> {
+    expect_bvlc_function(msg, BvlcFunction::BVLC_RESULT)?;
+    if msg.payload.len() != std::mem::size_of::<u16>() {
+        return Err(Error::Encoding(format!(
+            "BVLC-Result payload must be 2 bytes, got {}",
+            msg.payload.len()
+        )));
+    }
+
+    Ok(BvlcResultCode::from_raw(u16::from_be_bytes([
+        msg.payload[0],
+        msg.payload[1],
+    ])))
+}
+
+fn bvlc_result_error(msg: &BvllMessage) -> Error {
+    match decode_bvlc_result_code(msg) {
+        Ok(code) => Error::Encoding(format!("BVLC-Result: {code:?}")),
+        Err(err) => err,
+    }
+}
+
 /// Configuration for foreign device registration.
 #[derive(Debug, Clone)]
 pub struct ForeignDeviceConfig {
@@ -59,8 +127,8 @@ pub struct BipTransport {
     foreign_device: Option<ForeignDeviceConfig>,
     /// Re-registration timer task.
     registration_task: Option<JoinHandle<()>>,
-    /// Shared oneshot channel for routing BVLC management responses back to the caller.
-    bvlc_response_tx: Arc<Mutex<Option<oneshot::Sender<BvllMessage>>>>,
+    /// Pending BVLC management response, including the expected sender and response kind.
+    pending_bvlc_response: Arc<Mutex<Option<PendingBvlcResponse>>>,
     /// Optional path for persisting the BDT across restarts.
     bdt_persist_path: Option<std::path::PathBuf>,
 }
@@ -83,7 +151,7 @@ impl BipTransport {
             bbmd: None,
             foreign_device: None,
             registration_task: None,
-            bvlc_response_tx: Arc::new(Mutex::new(None)),
+            pending_bvlc_response: Arc::new(Mutex::new(None)),
             bdt_persist_path: None,
         }
     }
@@ -145,6 +213,7 @@ impl BipTransport {
         &self,
         target: &[u8],
         function: BvlcFunction,
+        expected_response: BvlcResponseKind,
         payload: &[u8],
     ) -> Result<BvllMessage, Error> {
         let socket = self.require_socket()?;
@@ -153,13 +222,17 @@ impl BipTransport {
 
         let (tx, rx) = oneshot::channel();
         {
-            let mut slot = self.bvlc_response_tx.lock().await;
+            let mut slot = self.pending_bvlc_response.lock().await;
             if slot.is_some() {
                 return Err(Error::Encoding(
                     "BVLC management request already in flight".into(),
                 ));
             }
-            *slot = Some(tx);
+            *slot = Some(PendingBvlcResponse {
+                target: (ip, port),
+                expected: expected_response,
+                tx,
+            });
         }
 
         let mut buf = BytesMut::with_capacity(4 + payload.len());
@@ -170,7 +243,7 @@ impl BipTransport {
             Ok(Ok(msg)) => Ok(msg),
             Ok(Err(_)) => Err(Error::Encoding("BVLC response channel dropped".to_string())),
             Err(_) => {
-                let mut slot = self.bvlc_response_tx.lock().await;
+                let mut slot = self.pending_bvlc_response.lock().await;
                 *slot = None;
                 Err(Error::Timeout(Self::BVLC_RESPONSE_TIMEOUT))
             }
@@ -180,16 +253,17 @@ impl BipTransport {
     /// Send Read-Broadcast-Distribution-Table and return the response entries.
     pub async fn read_bdt(&self, target: &[u8]) -> Result<Vec<BdtEntry>, Error> {
         let msg = self
-            .bvlc_request(target, BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE, &[])
+            .bvlc_request(
+                target,
+                BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE,
+                BvlcResponseKind::ReadBroadcastDistributionTableAck,
+                &[],
+            )
             .await?;
         if msg.function == BvlcFunction::BVLC_RESULT {
-            let code = if msg.payload.len() >= 2 {
-                BvlcResultCode::from_raw(u16::from_be_bytes([msg.payload[0], msg.payload[1]]))
-            } else {
-                BvlcResultCode::READ_BROADCAST_DISTRIBUTION_TABLE_NAK
-            };
-            return Err(Error::Encoding(format!("BVLC-Result: {code:?}")));
+            return Err(bvlc_result_error(&msg));
         }
+        expect_bvlc_function(&msg, BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK)?;
         BbmdState::decode_bdt(&msg.payload)
     }
 
@@ -205,32 +279,27 @@ impl BipTransport {
             .bvlc_request(
                 target,
                 BvlcFunction::WRITE_BROADCAST_DISTRIBUTION_TABLE,
+                BvlcResponseKind::Result,
                 &payload,
             )
             .await?;
-        if msg.payload.len() >= 2 {
-            Ok(BvlcResultCode::from_raw(u16::from_be_bytes([
-                msg.payload[0],
-                msg.payload[1],
-            ])))
-        } else {
-            Err(Error::Encoding("BVLC-Result too short".to_string()))
-        }
+        decode_bvlc_result_code(&msg)
     }
 
     /// Send Read-Foreign-Device-Table and return the response entries.
     pub async fn read_fdt(&self, target: &[u8]) -> Result<Vec<FdtEntryWire>, Error> {
         let msg = self
-            .bvlc_request(target, BvlcFunction::READ_FOREIGN_DEVICE_TABLE, &[])
+            .bvlc_request(
+                target,
+                BvlcFunction::READ_FOREIGN_DEVICE_TABLE,
+                BvlcResponseKind::ReadForeignDeviceTableAck,
+                &[],
+            )
             .await?;
         if msg.function == BvlcFunction::BVLC_RESULT {
-            let code = if msg.payload.len() >= 2 {
-                BvlcResultCode::from_raw(u16::from_be_bytes([msg.payload[0], msg.payload[1]]))
-            } else {
-                BvlcResultCode::READ_FOREIGN_DEVICE_TABLE_NAK
-            };
-            return Err(Error::Encoding(format!("BVLC-Result: {code:?}")));
+            return Err(bvlc_result_error(&msg));
         }
+        expect_bvlc_function(&msg, BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK)?;
         bbmd::decode_fdt(&msg.payload)
     }
 
@@ -248,17 +317,11 @@ impl BipTransport {
             .bvlc_request(
                 target,
                 BvlcFunction::DELETE_FOREIGN_DEVICE_TABLE_ENTRY,
+                BvlcResponseKind::Result,
                 &payload,
             )
             .await?;
-        if msg.payload.len() >= 2 {
-            Ok(BvlcResultCode::from_raw(u16::from_be_bytes([
-                msg.payload[0],
-                msg.payload[1],
-            ])))
-        } else {
-            Err(Error::Encoding("BVLC-Result too short".to_string()))
-        }
+        decode_bvlc_result_code(&msg)
     }
 
     /// Send a Register-Foreign-Device BVLC message to a BBMD and return the result code.
@@ -273,16 +336,14 @@ impl BipTransport {
     ) -> Result<BvlcResultCode, Error> {
         let payload = ttl.to_be_bytes();
         let msg = self
-            .bvlc_request(target, BvlcFunction::REGISTER_FOREIGN_DEVICE, &payload)
+            .bvlc_request(
+                target,
+                BvlcFunction::REGISTER_FOREIGN_DEVICE,
+                BvlcResponseKind::Result,
+                &payload,
+            )
             .await?;
-        if msg.payload.len() >= 2 {
-            Ok(BvlcResultCode::from_raw(u16::from_be_bytes([
-                msg.payload[0],
-                msg.payload[1],
-            ])))
-        } else {
-            Err(Error::Encoding("BVLC-Result too short".to_string()))
-        }
+        decode_bvlc_result_code(&msg)
     }
 }
 
@@ -389,7 +450,7 @@ impl TransportPort for BipTransport {
             bbmd: self.bbmd.clone(),
             broadcast_addr: self.broadcast_address,
             broadcast_port: self.port,
-            bvlc_response: self.bvlc_response_tx.clone(),
+            pending_bvlc_response: self.pending_bvlc_response.clone(),
             bdt_persist_path: self.bdt_persist_path.clone(),
         };
 

--- a/crates/bacnet-transport/src/bip/tests.rs
+++ b/crates/bacnet-transport/src/bip/tests.rs
@@ -1,5 +1,15 @@
 use super::*;
+use bytes::Bytes;
 use tokio::time::{timeout, Duration};
+
+fn test_bvll_message(function: BvlcFunction, payload: &[u8]) -> BvllMessage {
+    BvllMessage {
+        function,
+        payload: Bytes::copy_from_slice(payload),
+        originating_ip: None,
+        originating_port: None,
+    }
+}
 
 #[test]
 fn bip_max_apdu_length() {
@@ -9,6 +19,105 @@ fn bip_max_apdu_length() {
         std::net::Ipv4Addr::LOCALHOST,
     );
     assert_eq!(transport.max_apdu_length(), 1476);
+}
+
+#[test]
+fn decode_bvlc_result_code_accepts_named_and_unknown_codes() {
+    let named = test_bvll_message(BvlcFunction::BVLC_RESULT, &[0x00, 0x30]);
+    assert_eq!(
+        decode_bvlc_result_code(&named).unwrap(),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+
+    let unknown = test_bvll_message(BvlcFunction::BVLC_RESULT, &[0x12, 0x34]);
+    assert_eq!(decode_bvlc_result_code(&unknown).unwrap().to_raw(), 0x1234);
+}
+
+#[test]
+fn decode_bvlc_result_code_rejects_wrong_function() {
+    let msg = test_bvll_message(BvlcFunction::ORIGINAL_UNICAST_NPDU, &[0x00, 0x00]);
+    let err = decode_bvlc_result_code(&msg).unwrap_err();
+
+    assert!(
+        format!("{err}").contains("expected BVLC response BvlcFunction::BVLC_RESULT"),
+        "unexpected error: {err}"
+    );
+}
+
+#[test]
+fn decode_bvlc_result_code_rejects_malformed_payload_lengths() {
+    for payload in [&[][..], &[0x00][..], &[0x00, 0x00, 0x00][..]] {
+        let msg = test_bvll_message(BvlcFunction::BVLC_RESULT, payload);
+        let err = decode_bvlc_result_code(&msg).unwrap_err();
+
+        assert!(
+            format!("{err}").contains("BVLC-Result payload must be 2 bytes"),
+            "unexpected error: {err}"
+        );
+    }
+}
+
+#[test]
+fn expect_bvlc_function_rejects_unexpected_response_function() {
+    let msg = test_bvll_message(BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK, &[]);
+    let err = expect_bvlc_function(&msg, BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK)
+        .unwrap_err();
+
+    assert!(
+        format!("{err}")
+            .contains("expected BVLC response BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK"),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn pending_bvlc_response_requires_sender_and_expected_function() {
+    let socket = Arc::new(
+        UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap(),
+    );
+    let (npdu_tx, _npdu_rx) = mpsc::channel(1);
+    let pending_bvlc_response = Arc::new(Mutex::new(None));
+    let (tx, mut rx) = oneshot::channel();
+
+    {
+        let mut slot = pending_bvlc_response.lock().await;
+        *slot = Some(PendingBvlcResponse {
+            target: ([127, 0, 0, 1], 47808),
+            expected: BvlcResponseKind::ReadBroadcastDistributionTableAck,
+            tx,
+        });
+    }
+
+    let ctx = RecvContext {
+        local_mac: [0; 6],
+        socket,
+        npdu_tx,
+        bbmd: None,
+        broadcast_addr: Ipv4Addr::BROADCAST,
+        broadcast_port: 47808,
+        pending_bvlc_response: pending_bvlc_response.clone(),
+        bdt_persist_path: None,
+    };
+
+    let result = test_bvll_message(BvlcFunction::BVLC_RESULT, &[0x00, 0x00]);
+    handle_bvll_message(&result, ([127, 0, 0, 2], 47808), &ctx).await;
+    assert!(pending_bvlc_response.lock().await.is_some());
+    assert!(rx.try_recv().is_err());
+
+    let wrong_ack = test_bvll_message(BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK, &[]);
+    handle_bvll_message(&wrong_ack, ([127, 0, 0, 1], 47808), &ctx).await;
+    assert!(pending_bvlc_response.lock().await.is_some());
+    assert!(rx.try_recv().is_err());
+
+    let expected_ack = test_bvll_message(BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK, &[]);
+    handle_bvll_message(&expected_ack, ([127, 0, 0, 1], 47808), &ctx).await;
+    assert!(pending_bvlc_response.lock().await.is_none());
+    assert_eq!(
+        rx.await.unwrap().function,
+        BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK
+    );
 }
 
 #[tokio::test]
@@ -155,6 +264,44 @@ async fn read_fdt_from_bbmd() {
 }
 
 #[tokio::test]
+async fn read_bdt_from_non_bbmd_surfaces_typed_nak() {
+    let mut server_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _server_rx = server_transport.start().await.unwrap();
+    let server_mac = server_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let err = client_transport.read_bdt(&server_mac).await.unwrap_err();
+    assert!(
+        format!("{err}").contains("READ_BROADCAST_DISTRIBUTION_TABLE_NAK"),
+        "unexpected error: {err}"
+    );
+
+    client_transport.stop().await.unwrap();
+    server_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn read_fdt_from_non_bbmd_surfaces_typed_nak() {
+    let mut server_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _server_rx = server_transport.start().await.unwrap();
+    let server_mac = server_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let err = client_transport.read_fdt(&server_mac).await.unwrap_err();
+    assert!(
+        format!("{err}").contains("READ_FOREIGN_DEVICE_TABLE_NAK"),
+        "unexpected error: {err}"
+    );
+
+    client_transport.stop().await.unwrap();
+    server_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn write_bdt_to_bbmd() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
@@ -186,6 +333,25 @@ async fn write_bdt_to_bbmd() {
 }
 
 #[tokio::test]
+async fn write_bdt_to_non_bbmd_surfaces_typed_nak() {
+    let mut server_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _server_rx = server_transport.start().await.unwrap();
+    let server_mac = server_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let result = client_transport.write_bdt(&server_mac, &[]).await.unwrap();
+    assert_eq!(
+        result,
+        BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK
+    );
+
+    client_transport.stop().await.unwrap();
+    server_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn register_foreign_device_via_bvlc() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
@@ -203,6 +369,47 @@ async fn register_foreign_device_via_bvlc() {
 
     client_transport.stop().await.unwrap();
     bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn register_foreign_device_to_non_bbmd_surfaces_typed_nak() {
+    let mut server_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _server_rx = server_transport.start().await.unwrap();
+    let server_mac = server_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let result = client_transport
+        .register_foreign_device_bvlc(&server_mac, 60)
+        .await
+        .unwrap();
+    assert_eq!(result, BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK);
+
+    client_transport.stop().await.unwrap();
+    server_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_fdt_entry_to_non_bbmd_surfaces_typed_nak() {
+    let mut server_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _server_rx = server_transport.start().await.unwrap();
+    let server_mac = server_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let result = client_transport
+        .delete_fdt_entry(&server_mac, [127, 0, 0, 1], 47808)
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        BvlcResultCode::DELETE_FOREIGN_DEVICE_TABLE_ENTRY_NAK
+    );
+
+    client_transport.stop().await.unwrap();
+    server_transport.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -267,8 +474,13 @@ async fn bvlc_request_rejects_concurrent_calls() {
     // Manually install a pending sender to simulate an in-flight request
     {
         let (tx, _rx) = oneshot::channel();
-        let mut slot = transport.bvlc_response_tx.lock().await;
-        *slot = Some(tx);
+        let (ip, port) = decode_bip_mac(transport.local_mac()).unwrap();
+        let mut slot = transport.pending_bvlc_response.lock().await;
+        *slot = Some(PendingBvlcResponse {
+            target: (ip, port),
+            expected: BvlcResponseKind::ReadBroadcastDistributionTableAck,
+            tx,
+        });
     }
 
     // A second request should fail immediately

--- a/docs/conformance/pics-draft.md
+++ b/docs/conformance/pics-draft.md
@@ -10,7 +10,7 @@ This draft summarizes implementation evidence that may feed a future formal Prot
 |---|---|---|---|
 | `BACNET-7-ETHERNET-LLC` | Clause 7 | implementation-present-needs-platform-tests | `crates/bacnet-transport/src/ethernet*`, `crates/bacnet-transport/Cargo.toml` |
 | `BACNET-9-MSTP-FRAMES` | Clause 9.3 | implementation-present-needs-source-review | `crates/bacnet-transport/src/mstp_frame.rs`, `crates/bacnet-transport/src/mstp`, `crates/bacnet-transport/src/mstp/tests.rs` |
-| `BACNET-J-BVLC-FUNCTION-CODES` | Annex J.2 | implementation-present-needs-conformance-tests | `crates/bacnet-transport/src/bvll.rs`, `crates/bacnet-types/src/enums/bvll.rs` |
+| `BACNET-J-BVLC-FUNCTION-CODES` | Annex J.2 | implementation-present-needs-conformance-tests | `crates/bacnet-transport/src/bvll.rs`, `crates/bacnet-transport/src/bip/mod.rs`, `crates/bacnet-types/src/enums/bvll.rs` |
 | `BACNET-J-ORIGINAL-UNICAST-NPDU` | Annex J | implementation-present-needs-negative-tests | `crates/bacnet-transport/src/bvll.rs`, `crates/bacnet-transport/src/bip` |
 | `BACNET-J-ORIGINAL-BROADCAST-NPDU` | Annex J | implementation-present-needs-negative-tests | `crates/bacnet-transport/src/bvll.rs`, `crates/bacnet-transport/src/bip` |
 | `BACNET-J-FORWARDED-NPDU` | Annex J | implementation-present-needs-negative-tests | `crates/bacnet-transport/src/bvll.rs`, `crates/bacnet-transport/src/bbmd.rs` |

--- a/docs/conformance/standard-135-2020-ledger.md
+++ b/docs/conformance/standard-135-2020-ledger.md
@@ -6,10 +6,10 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020.
 - Reviewed at: 2026-06-28.
-- Repository SHA reviewed: `1308e4a7c6b67a1d225a112201f9381c6f9f006d`.
+- Repository SHA reviewed: `e8abd2d605bea2336dbb1016017eaf2d892343f8`.
 - Machine-readable source: `conformance/bacnet-135-2020.json`.
-- Current scope: Annex J J-01 BVLL codec evidence update; no runtime protocol behavior changes.
-- Addenda/errata status: local Standard 135-2020 Annex J.2 text checked for this tranche; current addenda and errata still require follow-up review before strengthening support claims.
+- Current scope: Annex J J-02 BVLC-Result typed handling evidence update; management response parsing and diagnostics hardened.
+- Addenda/errata status: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes found for this tranche.
 
 ## Status Taxonomy
 
@@ -83,12 +83,12 @@
 
 | Row ID | Anchor | Priority | Status | Evidence |
 |---|---|---|---|---|
-| `BACNET-J-BVLC-FUNCTION-CODES` | Annex J.2 | P0 | `implementation-present-needs-conformance-tests` | J-01 covers Annex J.2 constants through `0x0B`, representative frames, malformed type/length, unknown function passthrough, deleted-value passthrough, and current decoder policy for extra bytes beyond BVLC Length. |
+| `BACNET-J-BVLC-FUNCTION-CODES` | Annex J.2 | P0 | `implementation-present-needs-conformance-tests` | J-01 covers Annex J.2 constants through `0x0B`, representative frames, malformed type/length, unknown function passthrough, deleted-value passthrough, and current decoder policy for extra bytes beyond BVLC Length. J-02 adds exact two-byte BVLC-Result parsing, unknown result-code passthrough, malformed result rejection, and sender/expected-function correlation for pending management responses. |
 | `BACNET-J-ORIGINAL-UNICAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic BVLL envelope coverage exists; B/IP source/reply semantics need tests. |
 | `BACNET-J-ORIGINAL-BROADCAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic BVLL envelope coverage exists; broadcast semantics need tests. |
 | `BACNET-J-FORWARDED-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic originating-address parsing and truncated-address rejection are covered; BBMD source/loop behavior needs tests. |
-| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | P0 | `implementation-present-needs-conformance-tests` | BBMD/BDT paths exist; lifecycle tests remain open. |
-| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | P0 | `implementation-present-needs-conformance-tests` | FDT paths exist; TTL/delete/rejection tests remain open. |
+| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | P0 | `implementation-present-needs-conformance-tests` | J-02 covers read/write BDT caller paths and typed non-BBMD BVLC-Result NAK propagation; lifecycle tests remain open. |
+| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | P0 | `implementation-present-needs-conformance-tests` | J-02 covers FDT read/register/delete caller paths and typed non-BBMD BVLC-Result NAK propagation; TTL/expiry/lifecycle tests remain open. |
 
 ## Annex K BIBBs
 

--- a/docs/conformance/standard-135-2020-ledger.md
+++ b/docs/conformance/standard-135-2020-ledger.md
@@ -6,7 +6,7 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020.
 - Reviewed at: 2026-06-28.
-- Repository SHA reviewed: `e8abd2d605bea2336dbb1016017eaf2d892343f8`.
+- Repository SHA reviewed: `8961537a43f82dfa7675f2fd00c76f7de699f892`.
 - Machine-readable source: `conformance/bacnet-135-2020.json`.
 - Current scope: Annex J J-02 BVLC-Result typed handling evidence update; management response parsing and diagnostics hardened.
 - Addenda/errata status: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes found for this tranche.
@@ -125,4 +125,4 @@
 
 ## Follow-Up Backlog
 
-Rows not marked `supported-with-clause-evidence` are follow-up work. The next Annex J tranche should harden BVLC-Result and management-function typed result handling, then continue BBMD/BDT/FDT lifecycle evidence.
+Rows not marked `supported-with-clause-evidence` are follow-up work. The next Annex J tranche should continue BBMD/BDT/FDT lifecycle evidence, including TTL/expiry, delete semantics, DBTN authorization, BDT persistence, ACL behavior, and forwarding loop prevention.

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -4,9 +4,9 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020
 - Reviewed at: 2026-06-28
-- Repository SHA reviewed: `1308e4a7c6b67a1d225a112201f9381c6f9f006d`
-- Scope: Annex J J-01 BVLL codec evidence update; no runtime protocol behavior changes.
-- Addenda/errata: Local Standard 135-2020 Annex J.2 text checked for this tranche; current addenda/errata still require follow-up review before strengthening support claims.
+- Repository SHA reviewed: `e8abd2d605bea2336dbb1016017eaf2d892343f8`
+- Scope: Annex J J-02 BVLC-Result typed handling evidence update; management response parsing and diagnostics hardened.
+- Addenda/errata: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes found for this tranche.
 
 ## Counts
 

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -4,7 +4,7 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020
 - Reviewed at: 2026-06-28
-- Repository SHA reviewed: `e8abd2d605bea2336dbb1016017eaf2d892343f8`
+- Repository SHA reviewed: `8961537a43f82dfa7675f2fd00c76f7de699f892`
 - Scope: Annex J J-02 BVLC-Result typed handling evidence update; management response parsing and diagnostics hardened.
 - Addenda/errata: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes found for this tranche.
 


### PR DESCRIPTION
## Summary

- Harden BVLC-Result parsing to require exact two-byte payloads and preserve unknown result codes.
- Correlate pending B/IP management responses by sender and expected ACK/result function.
- Add J-02 transport tests and update conformance evidence/addenda status.

## Validation

- cargo fmt --all --check
- cargo test -p bacnet-transport --locked bip::tests --quiet
- cargo test -p bacnet-integration-tests --test conformance_ledger --locked --quiet
- python3 scripts/generate-conformance-docs.py --check
- cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
- git diff --check
- bash .github/scripts/check-file-size.sh
- bash .github/scripts/check-no-secrets.sh

## Notes

Official BACnet Committee Standard 135-2020 addenda through 135-2020cm were checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes were found for this tranche. This PR does not claim BBMD/FDT lifecycle completion.