### PR TITLE
fix(annex-j): harden BBMD/FDT lifecycle validation

### DIFF
--- a/conformance/bacnet-135-2020.json
+++ b/conformance/bacnet-135-2020.json
@@ -1,9 +1,9 @@
 {
   "standard": "ANSI/ASHRAE Standard 135-2020",
   "reviewed_at": "2026-06-28",
-  "repo_sha": "8961537a43f82dfa7675f2fd00c76f7de699f892",
-  "review_scope": "Annex J J-02 BVLC-Result typed handling evidence update; management response parsing and diagnostics hardened.",
-  "addenda_errata_status": "Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes found for this tranche.",
+  "repo_sha": "ed21fc339c5aa73b82fee2176ba40ad7a1010ece",
+  "review_scope": "Annex J J-03 BBMD BDT/FDT lifecycle validation evidence update; malformed management payloads, TTL bounds, table limits, delete semantics, and DBTN authorization hardened.",
+  "addenda_errata_status": "Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BBMD/FDT lifecycle changes found for this tranche.",
   "status_taxonomy": [
     "in-progress",
     "implementation-present-needs-conformance-tests",
@@ -290,18 +290,25 @@
       "priority": "P0",
       "requirement_summary": "BBMD Broadcast Distribution Table write/read/ACK behavior and peer broadcast fanout are validated.",
       "status": "implementation-present-needs-conformance-tests",
-      "code_anchors": ["crates/bacnet-transport/src/bbmd.rs", "crates/bacnet-cli/src/shell/bbmd.rs"],
+      "code_anchors": ["crates/bacnet-transport/src/bbmd.rs", "crates/bacnet-transport/src/bip/io.rs", "crates/bacnet-cli/src/shell/bbmd.rs"],
       "positive_tests": [
         "crates/bacnet-transport/src/bip/tests.rs::read_bdt_from_bbmd",
-        "crates/bacnet-transport/src/bip/tests.rs::write_bdt_to_bbmd"
+        "crates/bacnet-transport/src/bip/tests.rs::write_bdt_to_bbmd",
+        "crates/bacnet-transport/src/bbmd.rs::set_bdt_auto_inserts_self",
+        "crates/bacnet-transport/src/bbmd.rs::set_bdt_does_not_duplicate_self",
+        "crates/bacnet-transport/src/bbmd.rs::forwarding_targets_excludes_source",
+        "crates/bacnet-transport/src/bbmd.rs::forwarding_targets_uses_broadcast_mask",
+        "crates/bacnet-transport/src/bbmd.rs::forwarding_targets_unicast_with_full_mask"
       ],
       "negative_tests": [
         "crates/bacnet-transport/src/bip/tests.rs::read_bdt_from_non_bbmd_surfaces_typed_nak",
-        "crates/bacnet-transport/src/bip/tests.rs::write_bdt_to_non_bbmd_surfaces_typed_nak"
+        "crates/bacnet-transport/src/bip/tests.rs::write_bdt_to_non_bbmd_surfaces_typed_nak",
+        "crates/bacnet-transport/src/bip/tests.rs::write_bdt_rejects_malformed_payload_and_preserves_table",
+        "crates/bacnet-transport/src/bbmd.rs::set_bdt_rejects_max_entries_when_self_insert_would_exceed_limit"
       ],
       "benchmarks": ["benchmarks/src/bin/bacnet_bbmd.rs", "benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["docs/CLI.md BBMD commands", "README CLI BBMD commands"],
-      "notes": "J-02 covers read/write BDT caller paths and typed non-BBMD BVLC-Result NAK propagation. BDT overwrite, fanout, loop prevention, persistence, and ACL matrix tests remain for later lifecycle work."
+      "notes": "J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. Persistence, ACL matrix, and multi-BBMD fanout/loop behavior remain for later lifecycle work."
     },
     {
       "id": "BACNET-J-FOREIGN-DEVICE-FDT",
@@ -309,19 +316,36 @@
       "priority": "P0",
       "requirement_summary": "Foreign-device registration, TTL bounds, re-registration, read/delete FDT, expiry, and DBTN authorization are validated.",
       "status": "implementation-present-needs-conformance-tests",
-      "code_anchors": ["crates/bacnet-transport/src/bbmd.rs", "crates/bacnet-cli/src/shell/bbmd.rs"],
+      "code_anchors": ["crates/bacnet-transport/src/bbmd.rs", "crates/bacnet-transport/src/bip/io.rs", "crates/bacnet-cli/src/shell/bbmd.rs"],
       "positive_tests": [
         "crates/bacnet-transport/src/bip/tests.rs::read_fdt_from_bbmd",
-        "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_via_bvlc"
+        "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_via_bvlc",
+        "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_accepts_max_ttl_and_caps_remaining",
+        "crates/bacnet-transport/src/bip/tests.rs::delete_fdt_entry_removes_registered_foreign_device",
+        "crates/bacnet-transport/src/bip/tests.rs::foreign_device_broadcast_via_bbmd",
+        "crates/bacnet-transport/src/bbmd.rs::register_and_lookup_foreign_device",
+        "crates/bacnet-transport/src/bbmd.rs::re_register_updates_existing",
+        "crates/bacnet-transport/src/bbmd.rs::delete_foreign_device",
+        "crates/bacnet-transport/src/bbmd.rs::fdt_encode",
+        "crates/bacnet-transport/src/bbmd.rs::fdt_encode_caps_max_ttl_remaining_time",
+        "crates/bacnet-transport/src/bbmd.rs::seconds_remaining_includes_grace_period"
       ],
       "negative_tests": [
         "crates/bacnet-transport/src/bip/tests.rs::read_fdt_from_non_bbmd_surfaces_typed_nak",
         "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_to_non_bbmd_surfaces_typed_nak",
-        "crates/bacnet-transport/src/bip/tests.rs::delete_fdt_entry_to_non_bbmd_surfaces_typed_nak"
+        "crates/bacnet-transport/src/bip/tests.rs::delete_fdt_entry_to_non_bbmd_surfaces_typed_nak",
+        "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_rejects_zero_ttl",
+        "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_rejects_malformed_ttl_payload_lengths",
+        "crates/bacnet-transport/src/bip/tests.rs::delete_fdt_entry_rejects_malformed_payload_and_preserves_entry",
+        "crates/bacnet-transport/src/bip/tests.rs::distribute_broadcast_from_unregistered_foreign_device_naks_without_delivery",
+        "crates/bacnet-transport/src/bbmd.rs::register_foreign_device_zero_ttl_naks",
+        "crates/bacnet-transport/src/bbmd.rs::delete_nonexistent_foreign_device_naks",
+        "crates/bacnet-transport/src/bbmd.rs::expired_entries_purged",
+        "crates/bacnet-transport/src/bbmd.rs::forwarding_targets_excludes_originating_foreign_device_and_expired_entries"
       ],
       "benchmarks": ["benchmarks/src/bin/bacnet_bbmd.rs", "benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["docs/CLI.md foreign device commands"],
-      "notes": "J-02 covers FDT read/register/delete caller paths and typed non-BBMD BVLC-Result NAK propagation. TTL bounds, expiry, re-registration, DBTN authorization, and delete lifecycle semantics remain for later lifecycle work."
+      "notes": "J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. Multi-device forwarded fanout and timer-driven expiry integration remain for later lifecycle work."
     },
     {
       "id": "BACNET-K-BIBBS",

--- a/crates/bacnet-transport/src/bbmd.rs
+++ b/crates/bacnet-transport/src/bbmd.rs
@@ -134,10 +134,15 @@ impl BbmdState {
     ///
     /// Returns an error if the number of entries exceeds `MAX_BDT_ENTRIES`.
     pub fn set_bdt(&mut self, entries: Vec<BdtEntry>) -> Result<(), Error> {
-        if entries.len() > Self::MAX_BDT_ENTRIES {
+        let needs_self = !entries
+            .iter()
+            .any(|e| e.ip == self.local_ip && e.port == self.local_port);
+        let effective_len = entries.len() + usize::from(needs_self);
+
+        if effective_len > Self::MAX_BDT_ENTRIES {
             return Err(Error::Encoding(format!(
-                "BDT size {} exceeds maximum of {}",
-                entries.len(),
+                "BDT size {} exceeds maximum of {} after self-entry insertion",
+                effective_len,
                 Self::MAX_BDT_ENTRIES
             )));
         }
@@ -219,6 +224,10 @@ impl BbmdState {
 
     /// Register or re-register a foreign device.
     pub fn register_foreign_device(&mut self, ip: [u8; 4], port: u16, ttl: u16) -> BvlcResultCode {
+        if ttl == 0 {
+            return BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK;
+        }
+
         // Update existing or insert new
         if let Some(entry) = self.fdt.iter_mut().find(|e| e.ip == ip && e.port == port) {
             entry.ttl = ttl;
@@ -410,6 +419,21 @@ mod tests {
     }
 
     #[test]
+    fn set_bdt_rejects_max_entries_when_self_insert_would_exceed_limit() {
+        let mut bbmd = make_bbmd();
+        let entries = (0..BbmdState::MAX_BDT_ENTRIES)
+            .map(|i| BdtEntry {
+                ip: [10, 0, (i / 256) as u8, i as u8],
+                port: 0xBAC0,
+                broadcast_mask: [255, 255, 255, 255],
+            })
+            .collect();
+
+        assert!(bbmd.set_bdt(entries).is_err());
+        assert!(bbmd.bdt().is_empty());
+    }
+
+    #[test]
     fn register_and_lookup_foreign_device() {
         let mut bbmd = make_bbmd();
         let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
@@ -417,6 +441,14 @@ mod tests {
         assert_eq!(bbmd.fdt().len(), 1);
         assert_eq!(bbmd.fdt()[0].ip, [10, 0, 0, 5]);
         assert_eq!(bbmd.fdt()[0].ttl, 60);
+    }
+
+    #[test]
+    fn register_foreign_device_zero_ttl_naks() {
+        let mut bbmd = make_bbmd();
+        let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 0);
+        assert_eq!(result, BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK);
+        assert!(bbmd.fdt().is_empty());
     }
 
     #[test]
@@ -473,6 +505,20 @@ mod tests {
         assert_eq!(u16::from_be_bytes([buf[4], buf[5]]), 0xBAC0);
         // TTL
         assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 60);
+    }
+
+    #[test]
+    fn fdt_encode_caps_max_ttl_remaining_time() {
+        let mut bbmd = make_bbmd();
+        let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, u16::MAX);
+        assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+
+        let mut buf = BytesMut::new();
+        bbmd.encode_fdt(&mut buf);
+
+        assert_eq!(buf.len(), FDT_ENTRY_SIZE);
+        assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), u16::MAX);
+        assert_eq!(u16::from_be_bytes([buf[8], buf[9]]), u16::MAX);
     }
 
     #[test]
@@ -543,6 +589,29 @@ mod tests {
         let targets = bbmd.forwarding_targets([192, 168, 1, 100], 0xBAC0);
         assert_eq!(targets.len(), 1);
         assert!(targets.contains(&([10, 0, 0, 1], 0xBAC0)));
+    }
+
+    #[test]
+    fn forwarding_targets_excludes_originating_foreign_device_and_expired_entries() {
+        let mut bbmd = BbmdState::new([192, 168, 1, 1], 0xBAC0);
+        bbmd.set_bdt(vec![BdtEntry {
+            ip: [192, 168, 2, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        }])
+        .unwrap();
+        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+        bbmd.fdt.push(FdtEntry {
+            ip: [10, 0, 0, 6],
+            port: 0xBAC0,
+            ttl: 60,
+            registered_at: Instant::now() - Duration::from_secs(91),
+        });
+
+        let targets = bbmd.forwarding_targets([10, 0, 0, 5], 0xBAC0);
+
+        assert_eq!(targets, vec![([192, 168, 2, 1], 0xBAC0)]);
+        assert_eq!(bbmd.fdt().len(), 1);
     }
 
     #[test]

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -273,7 +273,7 @@ pub(super) async fn handle_bvll_message(
 
         f if f == BvlcFunction::REGISTER_FOREIGN_DEVICE => {
             if let Some(bbmd) = &ctx.bbmd {
-                if msg.payload.len() < 2 {
+                if msg.payload.len() != 2 {
                     send_bvlc_result(
                         &ctx.socket,
                         sender,
@@ -452,7 +452,7 @@ pub(super) async fn handle_bvll_message(
                         BvlcResultCode::DELETE_FOREIGN_DEVICE_TABLE_ENTRY_NAK,
                     )
                     .await;
-                } else if msg.payload.len() >= 6 {
+                } else if msg.payload.len() == 6 {
                     let ip = [
                         msg.payload[0],
                         msg.payload[1],

--- a/crates/bacnet-transport/src/bip/tests.rs
+++ b/crates/bacnet-transport/src/bip/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use tokio::time::{timeout, Duration};
 
 fn test_bvll_message(function: BvlcFunction, payload: &[u8]) -> BvllMessage {
@@ -9,6 +9,25 @@ fn test_bvll_message(function: BvlcFunction, payload: &[u8]) -> BvllMessage {
         originating_ip: None,
         originating_port: None,
     }
+}
+
+async fn raw_bvlc_request(target: &[u8], function: BvlcFunction, payload: &[u8]) -> BvllMessage {
+    let socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let (ip, port) = decode_bip_mac(target).unwrap();
+    let dest = SocketAddrV4::new(Ipv4Addr::from(ip), port);
+
+    let mut buf = BytesMut::new();
+    encode_bvll(&mut buf, function, payload).unwrap();
+    socket.send_to(&buf, dest).await.unwrap();
+
+    let mut recv_buf = [0u8; 2048];
+    let (len, _addr) = timeout(Duration::from_secs(2), socket.recv_from(&mut recv_buf))
+        .await
+        .expect("timed out waiting for BVLC response")
+        .unwrap();
+    decode_bvll(&recv_buf[..len]).unwrap()
 }
 
 #[test]
@@ -304,7 +323,12 @@ async fn read_fdt_from_non_bbmd_surfaces_typed_nak() {
 #[tokio::test]
 async fn write_bdt_to_bbmd() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
-    bbmd_transport.enable_bbmd(vec![]);
+    let old_bdt_entry = BdtEntry {
+        ip: [10, 0, 0, 1],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 0],
+    };
+    bbmd_transport.enable_bbmd(vec![old_bdt_entry.clone()]);
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -327,6 +351,45 @@ async fn write_bdt_to_bbmd() {
     assert!(bdt
         .iter()
         .any(|e| e.ip == [192, 168, 1, 1] && e.port == 0xBAC0));
+    assert!(
+        !bdt.iter().any(|e| e == &old_bdt_entry),
+        "Write-BDT must replace the prior configured BDT entries"
+    );
+
+    client_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn write_bdt_rejects_malformed_payload_and_preserves_table() {
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let initial_entry = BdtEntry {
+        ip: [10, 0, 0, 1],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 0],
+    };
+    bbmd_transport.enable_bbmd(vec![initial_entry.clone()]);
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let response = raw_bvlc_request(
+        &bbmd_mac,
+        BvlcFunction::WRITE_BROADCAST_DISTRIBUTION_TABLE,
+        &[0; bbmd::BDT_ENTRY_SIZE - 1],
+    )
+    .await;
+    assert_eq!(
+        decode_bvlc_result_code(&response).unwrap(),
+        BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK
+    );
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+    let bdt = client_transport.read_bdt(&bbmd_mac).await.unwrap();
+    assert!(
+        bdt.iter().any(|e| e == &initial_entry),
+        "malformed Write-BDT must leave the existing BDT intact"
+    );
 
     client_transport.stop().await.unwrap();
     bbmd_transport.stop().await.unwrap();
@@ -366,6 +429,82 @@ async fn register_foreign_device_via_bvlc() {
         .await
         .unwrap();
     assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+
+    client_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn register_foreign_device_rejects_zero_ttl() {
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![]);
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let result = client_transport
+        .register_foreign_device_bvlc(&bbmd_mac, 0)
+        .await
+        .unwrap();
+    assert_eq!(result, BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK);
+
+    {
+        let state = bbmd_transport.bbmd_state().unwrap();
+        let mut state = state.lock().await;
+        assert!(state.fdt().is_empty());
+    }
+
+    client_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn register_foreign_device_rejects_malformed_ttl_payload_lengths() {
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![]);
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    for payload in [&[0x00][..], &[0x00, 0x3c, 0x00][..]] {
+        let response =
+            raw_bvlc_request(&bbmd_mac, BvlcFunction::REGISTER_FOREIGN_DEVICE, payload).await;
+        assert_eq!(
+            decode_bvlc_result_code(&response).unwrap(),
+            BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+        );
+    }
+
+    {
+        let state = bbmd_transport.bbmd_state().unwrap();
+        let mut state = state.lock().await;
+        assert!(state.fdt().is_empty());
+    }
+
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn register_foreign_device_accepts_max_ttl_and_caps_remaining() {
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![]);
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let result = client_transport
+        .register_foreign_device_bvlc(&bbmd_mac, u16::MAX)
+        .await
+        .unwrap();
+    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+
+    let fdt = client_transport.read_fdt(&bbmd_mac).await.unwrap();
+    assert_eq!(fdt.len(), 1);
+    assert_eq!(fdt[0].ttl, u16::MAX);
+    assert_eq!(fdt[0].seconds_remaining, u16::MAX);
 
     client_transport.stop().await.unwrap();
     bbmd_transport.stop().await.unwrap();
@@ -413,6 +552,79 @@ async fn delete_fdt_entry_to_non_bbmd_surfaces_typed_nak() {
 }
 
 #[tokio::test]
+async fn delete_fdt_entry_removes_registered_foreign_device() {
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![]);
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let result = client_transport
+        .register_foreign_device_bvlc(&bbmd_mac, 60)
+        .await
+        .unwrap();
+    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+
+    let (fd_ip, fd_port) = decode_bip_mac(client_transport.local_mac()).unwrap();
+    let result = client_transport
+        .delete_fdt_entry(&bbmd_mac, fd_ip, fd_port)
+        .await
+        .unwrap();
+    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+
+    let fdt = client_transport.read_fdt(&bbmd_mac).await.unwrap();
+    assert!(fdt.is_empty());
+
+    client_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn delete_fdt_entry_rejects_malformed_payload_and_preserves_entry() {
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![]);
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let result = client_transport
+        .register_foreign_device_bvlc(&bbmd_mac, 60)
+        .await
+        .unwrap();
+    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+
+    let (fd_ip, fd_port) = decode_bip_mac(client_transport.local_mac()).unwrap();
+    let mut payload_with_trailing_byte = Vec::from(fd_ip);
+    payload_with_trailing_byte.extend_from_slice(&fd_port.to_be_bytes());
+    payload_with_trailing_byte.push(0);
+
+    for payload in [&[0; 5][..], payload_with_trailing_byte.as_slice()] {
+        let response = raw_bvlc_request(
+            &bbmd_mac,
+            BvlcFunction::DELETE_FOREIGN_DEVICE_TABLE_ENTRY,
+            payload,
+        )
+        .await;
+        assert_eq!(
+            decode_bvlc_result_code(&response).unwrap(),
+            BvlcResultCode::DELETE_FOREIGN_DEVICE_TABLE_ENTRY_NAK
+        );
+    }
+
+    let fdt = client_transport.read_fdt(&bbmd_mac).await.unwrap();
+    assert_eq!(fdt.len(), 1);
+    assert_eq!(fdt[0].ip, fd_ip);
+    assert_eq!(fdt[0].port, fd_port);
+
+    client_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn foreign_device_broadcast_via_bbmd() {
     // BBMD
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
@@ -446,6 +658,34 @@ async fn foreign_device_broadcast_via_bbmd() {
     assert_eq!(received.npdu, test_npdu);
 
     fd_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn distribute_broadcast_from_unregistered_foreign_device_naks_without_delivery() {
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![]);
+    let mut bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let response = raw_bvlc_request(
+        &bbmd_mac,
+        BvlcFunction::DISTRIBUTE_BROADCAST_TO_NETWORK,
+        &[0x01, 0x00, 0xAA, 0xBB],
+    )
+    .await;
+    assert_eq!(
+        decode_bvlc_result_code(&response).unwrap(),
+        BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK
+    );
+
+    assert!(
+        timeout(Duration::from_millis(100), bbmd_rx.recv())
+            .await
+            .is_err(),
+        "unregistered DBTN must not deliver an NPDU to the BBMD"
+    );
+
     bbmd_transport.stop().await.unwrap();
 }
 

--- a/docs/conformance/pics-draft.md
+++ b/docs/conformance/pics-draft.md
@@ -14,8 +14,8 @@ This draft summarizes implementation evidence that may feed a future formal Prot
 | `BACNET-J-ORIGINAL-UNICAST-NPDU` | Annex J | implementation-present-needs-negative-tests | `crates/bacnet-transport/src/bvll.rs`, `crates/bacnet-transport/src/bip` |
 | `BACNET-J-ORIGINAL-BROADCAST-NPDU` | Annex J | implementation-present-needs-negative-tests | `crates/bacnet-transport/src/bvll.rs`, `crates/bacnet-transport/src/bip` |
 | `BACNET-J-FORWARDED-NPDU` | Annex J | implementation-present-needs-negative-tests | `crates/bacnet-transport/src/bvll.rs`, `crates/bacnet-transport/src/bbmd.rs` |
-| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | implementation-present-needs-conformance-tests | `crates/bacnet-transport/src/bbmd.rs`, `crates/bacnet-cli/src/shell/bbmd.rs` |
-| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | implementation-present-needs-conformance-tests | `crates/bacnet-transport/src/bbmd.rs`, `crates/bacnet-cli/src/shell/bbmd.rs` |
+| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | implementation-present-needs-conformance-tests | `crates/bacnet-transport/src/bbmd.rs`, `crates/bacnet-transport/src/bip/io.rs`, `crates/bacnet-cli/src/shell/bbmd.rs` |
+| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | implementation-present-needs-conformance-tests | `crates/bacnet-transport/src/bbmd.rs`, `crates/bacnet-transport/src/bip/io.rs`, `crates/bacnet-cli/src/shell/bbmd.rs` |
 | `BACNET-U-IPV6-BVLL` | Annex U | implementation-present-needs-conformance-tests | `crates/bacnet-transport/src/bip6`, `crates/bacnet-types/src/enums/bvll.rs` |
 | `BACNET-AB-SC-FRAME` | Annex AB.2 | implementation-present-needs-negative-tests | `crates/bacnet-transport/src/sc_frame.rs`, `crates/bacnet-wasm/src/sc_frame.rs` |
 | `BACNET-AB-SC-HUB-CONNECTOR` | Annex AB.5 | implementation-present-needs-conformance-tests | `crates/bacnet-transport/src/sc/mod.rs`, `crates/bacnet-transport/src/sc_hub.rs` |

--- a/docs/conformance/standard-135-2020-ledger.md
+++ b/docs/conformance/standard-135-2020-ledger.md
@@ -6,10 +6,10 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020.
 - Reviewed at: 2026-06-28.
-- Repository SHA reviewed: `8961537a43f82dfa7675f2fd00c76f7de699f892`.
+- Repository SHA reviewed: `ed21fc339c5aa73b82fee2176ba40ad7a1010ece`.
 - Machine-readable source: `conformance/bacnet-135-2020.json`.
-- Current scope: Annex J J-02 BVLC-Result typed handling evidence update; management response parsing and diagnostics hardened.
-- Addenda/errata status: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes found for this tranche.
+- Current scope: Annex J J-03 BBMD BDT/FDT lifecycle validation evidence update; malformed management payloads, TTL bounds, table limits, delete semantics, and DBTN authorization hardened.
+- Addenda/errata status: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BBMD/FDT lifecycle changes found for this tranche.
 
 ## Status Taxonomy
 
@@ -87,8 +87,8 @@
 | `BACNET-J-ORIGINAL-UNICAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic BVLL envelope coverage exists; B/IP source/reply semantics need tests. |
 | `BACNET-J-ORIGINAL-BROADCAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic BVLL envelope coverage exists; broadcast semantics need tests. |
 | `BACNET-J-FORWARDED-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic originating-address parsing and truncated-address rejection are covered; BBMD source/loop behavior needs tests. |
-| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | P0 | `implementation-present-needs-conformance-tests` | J-02 covers read/write BDT caller paths and typed non-BBMD BVLC-Result NAK propagation; lifecycle tests remain open. |
-| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | P0 | `implementation-present-needs-conformance-tests` | J-02 covers FDT read/register/delete caller paths and typed non-BBMD BVLC-Result NAK propagation; TTL/expiry/lifecycle tests remain open. |
+| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. Persistence, ACL matrix, and multi-BBMD fanout/loop behavior remain open. |
+| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. Multi-device forwarded fanout and timer-driven expiry integration remain open. |
 
 ## Annex K BIBBs
 
@@ -125,4 +125,4 @@
 
 ## Follow-Up Backlog
 
-Rows not marked `supported-with-clause-evidence` are follow-up work. The next Annex J tranche should continue BBMD/BDT/FDT lifecycle evidence, including TTL/expiry, delete semantics, DBTN authorization, BDT persistence, ACL behavior, and forwarding loop prevention.
+Rows not marked `supported-with-clause-evidence` are follow-up work. The next Annex J tranche should continue BBMD/BDT/FDT lifecycle evidence, including timer-driven expiry integration, multi-device forwarded fanout, BDT persistence, ACL behavior, and forwarding loop prevention.

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -4,9 +4,9 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020
 - Reviewed at: 2026-06-28
-- Repository SHA reviewed: `8961537a43f82dfa7675f2fd00c76f7de699f892`
-- Scope: Annex J J-02 BVLC-Result typed handling evidence update; management response parsing and diagnostics hardened.
-- Addenda/errata: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BVLC-Result changes found for this tranche.
+- Repository SHA reviewed: `ed21fc339c5aa73b82fee2176ba40ad7a1010ece`
+- Scope: Annex J J-03 BBMD BDT/FDT lifecycle validation evidence update; malformed management payloads, TTL bounds, table limits, delete semantics, and DBTN authorization hardened.
+- Addenda/errata: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BBMD/FDT lifecycle changes found for this tranche.
 
 ## Counts
 


### PR DESCRIPTION
## Summary
- enforce exact BVLC payload lengths for Register-Foreign-Device and Delete-FDT-Entry
- reject zero TTL foreign-device registrations and prevent BDT overflow after required self-entry insertion
- add BBMD/FDT lifecycle regressions for BDT replacement, malformed management payloads, max TTL capping, delete semantics, expired entry exclusion, and unregistered DBTN rejection
- update Annex J J-03 conformance ledger evidence and generated summaries

## Validation
- cargo test -p bacnet-transport --locked bbmd --quiet
- cargo test -p bacnet-transport --locked bip::tests --quiet
- python3 scripts/generate-conformance-docs.py --check
- cargo fmt --all --check
- cargo test -p bacnet-integration-tests --test conformance_ledger --locked --quiet
- bash .github/scripts/check-file-size.sh
- bash .github/scripts/check-no-secrets.sh
- cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
- cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls --quiet

Note: cargo output still includes the repository existing missing_docs/print warnings, but all commands completed successfully.