### PR TITLE
fix(annex-j): prevent Original-Broadcast local echo

### DIFF
--- a/conformance/bacnet-135-2020.json
+++ b/conformance/bacnet-135-2020.json
@@ -1,9 +1,9 @@
 {
   "standard": "ANSI/ASHRAE Standard 135-2020",
   "reviewed_at": "2026-06-28",
-  "repo_sha": "607255450009d3f5b470b7f361938886228abd70",
-  "review_scope": "Annex J J-04 BBMD Forwarded-NPDU source and loop-prevention evidence update; directed-broadcast peer forwarding hardened.",
-  "addenda_errata_status": "Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP Forwarded-NPDU forwarding changes found for this tranche.",
+  "repo_sha": "ccece409211cdcc85d5736e1701db928b66cfaf8",
+  "review_scope": "Annex J J-04 Original-Unicast/Original-Broadcast B/IP source and BBMD fanout evidence update; Original-Broadcast local Forwarded-NPDU echo removed.",
+  "addenda_errata_status": "Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP Original-NPDU broadcast forwarding changes found for this tranche.",
   "status_taxonomy": [
     "in-progress",
     "implementation-present-needs-conformance-tests",
@@ -249,11 +249,17 @@
       "requirement_summary": "Original-Unicast-NPDU frames preserve exact BVLC length, payload validation, and source/reply semantics.",
       "status": "implementation-present-needs-negative-tests",
       "code_anchors": ["crates/bacnet-transport/src/bvll.rs", "crates/bacnet-transport/src/bip"],
-      "positive_tests": ["crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough"],
-      "negative_tests": ["crates/bacnet-transport/src/bvll.rs::decode_slices_payload_to_declared_length"],
+      "positive_tests": [
+        "crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough",
+        "crates/bacnet-transport/src/bip/original_tests.rs::original_unicast_npdu_uses_udp_sender_source_mac_and_ignores_self"
+      ],
+      "negative_tests": [
+        "crates/bacnet-transport/src/bvll.rs::decode_slices_payload_to_declared_length",
+        "crates/bacnet-transport/src/bip/original_tests.rs::original_unicast_npdu_uses_udp_sender_source_mac_and_ignores_self"
+      ],
       "benchmarks": ["benchmarks/benches/bip_latency.rs"],
       "public_claims": ["README BACnet/IP feature"],
-      "notes": "Generic BVLL envelope coverage exists; source/reply path and NPDU semantic tests remain."
+      "notes": "Generic BVLL envelope coverage exists. J-04 Original-NPDU evidence covers UDP sender B/IP MAC delivery to the upper layer and self-originated frame suppression. Directed reply-path integration remains open."
     },
     {
       "id": "BACNET-J-ORIGINAL-BROADCAST-NPDU",
@@ -262,11 +268,17 @@
       "requirement_summary": "Original-Broadcast-NPDU frames are encoded, decoded, and routed according to BACnet/IP broadcast semantics.",
       "status": "implementation-present-needs-negative-tests",
       "code_anchors": ["crates/bacnet-transport/src/bvll.rs", "crates/bacnet-transport/src/bip"],
-      "positive_tests": ["crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough"],
-      "negative_tests": ["crates/bacnet-transport/src/bvll.rs::decode_slices_payload_to_declared_length"],
+      "positive_tests": [
+        "crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough",
+        "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo"
+      ],
+      "negative_tests": [
+        "crates/bacnet-transport/src/bvll.rs::decode_slices_payload_to_declared_length",
+        "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo"
+      ],
       "benchmarks": ["benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["README BACnet/IP feature"],
-      "notes": "Generic BVLL envelope coverage exists; local, remote, and global broadcast behavior tests remain."
+      "notes": "Generic BVLL envelope coverage exists. J-04 Original-NPDU evidence covers BBMD handling of Original-Broadcast-NPDU: local delivery uses sender B/IP MAC, remote BDT peer and registered FDT targets receive Forwarded-NPDU with the original sender encoded, and the BBMD does not echo the already-local broadcast back onto the local subnet as Forwarded-NPDU. Remote/global NPDU DNET/DADR broadcast addressing remains open."
     },
     {
       "id": "BACNET-J-FORWARDED-NPDU",
@@ -278,15 +290,17 @@
       "positive_tests": [
         "crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough",
         "crates/bacnet-transport/src/bvll.rs::encode_decode_forwarded_npdu",
-        "crates/bacnet-transport/src/bip/forwarded_tests.rs::forwarded_npdu_from_bdt_peer_uses_originating_source_mac"
+        "crates/bacnet-transport/src/bip/forwarded_tests.rs::forwarded_npdu_from_bdt_peer_uses_originating_source_mac",
+        "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo"
       ],
       "negative_tests": [
         "crates/bacnet-transport/src/bvll.rs::decode_forwarded_too_short_for_address",
-        "crates/bacnet-transport/src/bip/forwarded_tests.rs::forwarded_npdu_from_directed_broadcast_peer_skips_local_rebroadcast"
+        "crates/bacnet-transport/src/bip/forwarded_tests.rs::forwarded_npdu_from_directed_broadcast_peer_skips_local_rebroadcast",
+        "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo"
       ],
       "benchmarks": ["benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["README BACnet/IP feature", "docs/CLI.md BBMD commands"],
-      "notes": "J-04 covers generic originating-address parsing, truncated-address rejection, BBMD delivery with originating B/IP source MAC, FDT fanout preserving the origin, local rebroadcast for unicast peer arrivals, directed-broadcast peer local-rebroadcast suppression, and no onward forwarding to other BDT peers. Non-BDT source rejection and Original-Broadcast/DBTN multi-target fanout remain open."
+      "notes": "J-04 covers generic originating-address parsing, truncated-address rejection, BBMD delivery with originating B/IP source MAC, FDT fanout preserving the origin, local rebroadcast for unicast peer arrivals, directed-broadcast peer local-rebroadcast suppression, and no onward forwarding to other BDT peers. Original-Broadcast fanout now covers BDT/FDT Forwarded-NPDU emission with original sender preservation and no local echoed Forwarded-NPDU. Non-BDT source rejection and DBTN multi-target fanout remain open."
     },
     {
       "id": "BACNET-J-BBMD-BDT",
@@ -303,7 +317,8 @@
         "crates/bacnet-transport/src/bbmd.rs::forwarding_targets_excludes_source",
         "crates/bacnet-transport/src/bbmd.rs::forwarding_targets_uses_broadcast_mask",
         "crates/bacnet-transport/src/bbmd.rs::forwarding_targets_unicast_with_full_mask",
-        "crates/bacnet-transport/src/bbmd.rs::forwarded_npdu_needs_local_broadcast_for_unicast_peer"
+        "crates/bacnet-transport/src/bbmd.rs::forwarded_npdu_needs_local_broadcast_for_unicast_peer",
+        "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo"
       ],
       "negative_tests": [
         "crates/bacnet-transport/src/bip/tests.rs::read_bdt_from_non_bbmd_surfaces_typed_nak",
@@ -311,11 +326,12 @@
         "crates/bacnet-transport/src/bip/tests.rs::write_bdt_rejects_malformed_payload_and_preserves_table",
         "crates/bacnet-transport/src/bbmd.rs::set_bdt_rejects_max_entries_when_self_insert_would_exceed_limit",
         "crates/bacnet-transport/src/bbmd.rs::forwarded_npdu_skips_local_broadcast_for_directed_broadcast_peer",
-        "crates/bacnet-transport/src/bbmd.rs::forwarded_npdu_skips_local_broadcast_for_unknown_peer"
+        "crates/bacnet-transport/src/bbmd.rs::forwarded_npdu_skips_local_broadcast_for_unknown_peer",
+        "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo"
       ],
       "benchmarks": ["benchmarks/src/bin/bacnet_bbmd.rs", "benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["docs/CLI.md BBMD commands", "README CLI BBMD commands"],
-      "notes": "J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. J-04 adds Forwarded-NPDU BDT mask behavior: full-mask peers require local rebroadcast, directed-broadcast and unknown peers skip it, and Forwarded-NPDUs are not forwarded onward to other BDT peers. Persistence, ACL matrix, Original-Broadcast fanout, and DBTN multi-target fanout remain open."
+      "notes": "J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. J-04 adds Forwarded-NPDU BDT mask behavior: full-mask peers require local rebroadcast, directed-broadcast and unknown peers skip it, and Forwarded-NPDUs are not forwarded onward to other BDT peers. Original-Broadcast fanout now covers one remote BDT target and verifies no local Forwarded-NPDU echo. Persistence, ACL matrix, and DBTN multi-target fanout remain open."
     },
     {
       "id": "BACNET-J-FOREIGN-DEVICE-FDT",
@@ -330,6 +346,7 @@
         "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_accepts_max_ttl_and_caps_remaining",
         "crates/bacnet-transport/src/bip/tests.rs::delete_fdt_entry_removes_registered_foreign_device",
         "crates/bacnet-transport/src/bip/tests.rs::foreign_device_broadcast_via_bbmd",
+        "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo",
         "crates/bacnet-transport/src/bbmd.rs::register_and_lookup_foreign_device",
         "crates/bacnet-transport/src/bbmd.rs::re_register_updates_existing",
         "crates/bacnet-transport/src/bbmd.rs::delete_foreign_device",
@@ -352,7 +369,7 @@
       ],
       "benchmarks": ["benchmarks/src/bin/bacnet_bbmd.rs", "benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["docs/CLI.md foreign device commands"],
-      "notes": "J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. Multi-device forwarded fanout and timer-driven expiry integration remain for later lifecycle work."
+      "notes": "J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. J-04 Original-Broadcast evidence covers fanout to one registered foreign device while preserving the original sender in the Forwarded-NPDU. Multi-device forwarded fanout and timer-driven expiry integration remain for later lifecycle work."
     },
     {
       "id": "BACNET-K-BIBBS",

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -115,16 +115,6 @@ pub(super) async fn handle_bvll_message(
                     state.forwarding_targets(sender.0, sender.1)
                 };
                 forward_npdu(&ctx.socket, &msg.payload, sender.0, sender.1, &targets).await;
-
-                // Re-broadcast on local subnet as Forwarded-NPDU.
-                let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
-                let mut buf = BytesMut::with_capacity(10 + msg.payload.len());
-                match encode_bvll_forwarded(&mut buf, sender.0, sender.1, &msg.payload) {
-                    Ok(()) => {
-                        let _ = ctx.socket.send_to(&buf, dest).await;
-                    }
-                    Err(e) => warn!(error = %e, "Failed to encode Forwarded-NPDU rebroadcast"),
-                }
             }
         }
 

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -571,4 +571,6 @@ impl TransportPort for BipTransport {
 #[cfg(test)]
 mod forwarded_tests;
 #[cfg(test)]
+mod original_tests;
+#[cfg(test)]
 mod tests;

--- a/crates/bacnet-transport/src/bip/original_tests.rs
+++ b/crates/bacnet-transport/src/bip/original_tests.rs
@@ -1,0 +1,147 @@
+use super::*;
+use bytes::Bytes;
+use tokio::time::{timeout, Duration};
+
+async fn recv_bvll(socket: &UdpSocket) -> BvllMessage {
+    let mut recv_buf = [0u8; 2048];
+    let (len, _addr) = timeout(Duration::from_secs(2), socket.recv_from(&mut recv_buf))
+        .await
+        .expect("timed out waiting for BVLL frame")
+        .unwrap();
+    decode_bvll(&recv_buf[..len]).unwrap()
+}
+
+#[tokio::test]
+async fn original_unicast_npdu_uses_udp_sender_source_mac_and_ignores_self() {
+    let socket = Arc::new(
+        UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap(),
+    );
+    let local_port = socket.local_addr().unwrap().port();
+    let (npdu_tx, mut npdu_rx) = mpsc::channel(1);
+    let ctx = RecvContext {
+        local_mac: encode_bip_mac(Ipv4Addr::LOCALHOST.octets(), local_port),
+        socket,
+        npdu_tx,
+        bbmd: None,
+        broadcast_addr: Ipv4Addr::LOCALHOST,
+        broadcast_port: local_port,
+        pending_bvlc_response: Arc::new(Mutex::new(None)),
+        bdt_persist_path: None,
+    };
+    let sender = ([192, 0, 2, 30], 0xBAC0);
+    let msg = BvllMessage {
+        function: BvlcFunction::ORIGINAL_UNICAST_NPDU,
+        payload: Bytes::from_static(&[0x01, 0x04, 0xAA, 0xBB]),
+        originating_ip: None,
+        originating_port: None,
+    };
+
+    handle_bvll_message(&msg, sender, &ctx).await;
+
+    let received = timeout(Duration::from_secs(2), npdu_rx.recv())
+        .await
+        .expect("timed out waiting for received NPDU")
+        .expect("NPDU channel closed");
+    assert_eq!(received.npdu.as_ref(), msg.payload.as_ref());
+    assert_eq!(
+        received.source_mac.as_slice(),
+        &encode_bip_mac(sender.0, sender.1)
+    );
+
+    handle_bvll_message(&msg, (Ipv4Addr::LOCALHOST.octets(), local_port), &ctx).await;
+    assert!(
+        timeout(Duration::from_millis(100), npdu_rx.recv())
+            .await
+            .is_err(),
+        "Original-Unicast-NPDU from this transport's B/IP MAC must be ignored"
+    );
+}
+
+#[tokio::test]
+async fn original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo() {
+    let bbmd_socket = Arc::new(
+        UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap(),
+    );
+    let local_port = bbmd_socket.local_addr().unwrap().port();
+    let local_broadcast_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let local_broadcast_port = local_broadcast_sink.local_addr().unwrap().port();
+    let bdt_peer_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let bdt_peer_port = bdt_peer_sink.local_addr().unwrap().port();
+    let fdt_socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let fdt_port = fdt_socket.local_addr().unwrap().port();
+    let (npdu_tx, mut npdu_rx) = mpsc::channel(1);
+    let sender = ([192, 0, 2, 40], 0xBAC1);
+    let mut state = BbmdState::new(Ipv4Addr::LOCALHOST.octets(), local_port);
+    state
+        .set_bdt(vec![BdtEntry {
+            ip: Ipv4Addr::LOCALHOST.octets(),
+            port: bdt_peer_port,
+            broadcast_mask: [255, 255, 255, 255],
+        }])
+        .unwrap();
+    assert_eq!(
+        state.register_foreign_device(Ipv4Addr::LOCALHOST.octets(), fdt_port, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+
+    let ctx = RecvContext {
+        local_mac: encode_bip_mac(Ipv4Addr::LOCALHOST.octets(), local_port),
+        socket: bbmd_socket,
+        npdu_tx,
+        bbmd: Some(Arc::new(Mutex::new(state))),
+        broadcast_addr: Ipv4Addr::LOCALHOST,
+        broadcast_port: local_broadcast_port,
+        pending_bvlc_response: Arc::new(Mutex::new(None)),
+        bdt_persist_path: None,
+    };
+    let msg = BvllMessage {
+        function: BvlcFunction::ORIGINAL_BROADCAST_NPDU,
+        payload: Bytes::from_static(&[0x01, 0x20, 0xDE, 0xAD, 0xBE, 0xEF]),
+        originating_ip: None,
+        originating_port: None,
+    };
+
+    handle_bvll_message(&msg, sender, &ctx).await;
+
+    let received = timeout(Duration::from_secs(2), npdu_rx.recv())
+        .await
+        .expect("timed out waiting for received NPDU")
+        .expect("NPDU channel closed");
+    assert_eq!(received.npdu.as_ref(), msg.payload.as_ref());
+    assert_eq!(
+        received.source_mac.as_slice(),
+        &encode_bip_mac(sender.0, sender.1)
+    );
+
+    for (label, socket) in [
+        ("BDT peer", &bdt_peer_sink),
+        ("foreign device", &fdt_socket),
+    ] {
+        let frame = recv_bvll(socket).await;
+        assert_eq!(frame.function, BvlcFunction::FORWARDED_NPDU, "{label}");
+        assert_eq!(frame.originating_ip, Some(sender.0), "{label}");
+        assert_eq!(frame.originating_port, Some(sender.1), "{label}");
+        assert_eq!(frame.payload.as_ref(), msg.payload.as_ref(), "{label}");
+    }
+
+    let mut local_broadcast_buf = [0u8; 2048];
+    assert!(
+        timeout(
+            Duration::from_millis(100),
+            local_broadcast_sink.recv_from(&mut local_broadcast_buf)
+        )
+        .await
+        .is_err(),
+        "Original-Broadcast-NPDU was already visible on the local subnet and must not be echoed locally as Forwarded-NPDU"
+    );
+}

--- a/docs/conformance/standard-135-2020-ledger.md
+++ b/docs/conformance/standard-135-2020-ledger.md
@@ -6,10 +6,10 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020.
 - Reviewed at: 2026-06-28.
-- Repository SHA reviewed: `ed21fc339c5aa73b82fee2176ba40ad7a1010ece`.
+- Repository SHA reviewed: `ccece409211cdcc85d5736e1701db928b66cfaf8`.
 - Machine-readable source: `conformance/bacnet-135-2020.json`.
-- Current scope: Annex J J-03 BBMD BDT/FDT lifecycle validation evidence update; malformed management payloads, TTL bounds, table limits, delete semantics, and DBTN authorization hardened.
-- Addenda/errata status: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP BBMD/FDT lifecycle changes found for this tranche.
+- Current scope: Annex J J-04 Original-Unicast/Original-Broadcast B/IP source and BBMD fanout evidence update; Original-Broadcast local Forwarded-NPDU echo removed.
+- Addenda/errata status: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP Original-NPDU broadcast forwarding changes found for this tranche.
 
 ## Status Taxonomy
 
@@ -84,11 +84,11 @@
 | Row ID | Anchor | Priority | Status | Evidence |
 |---|---|---|---|---|
 | `BACNET-J-BVLC-FUNCTION-CODES` | Annex J.2 | P0 | `implementation-present-needs-conformance-tests` | J-01 covers Annex J.2 constants through `0x0B`, representative frames, malformed type/length, unknown function passthrough, deleted-value passthrough, and current decoder policy for extra bytes beyond BVLC Length. J-02 adds exact two-byte BVLC-Result parsing, unknown result-code passthrough, malformed result rejection, and sender/expected-function correlation for pending management responses. |
-| `BACNET-J-ORIGINAL-UNICAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic BVLL envelope coverage exists; B/IP source/reply semantics need tests. |
-| `BACNET-J-ORIGINAL-BROADCAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | Generic BVLL envelope coverage exists; broadcast semantics need tests. |
-| `BACNET-J-FORWARDED-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | J-04 covers originating-address parsing, truncated-address rejection, BBMD delivery with originating B/IP source MAC, FDT fanout preserving the origin, local rebroadcast for unicast peer arrivals, directed-broadcast peer local-rebroadcast suppression, and no onward forwarding to other BDT peers. Non-BDT source rejection and Original-Broadcast/DBTN multi-target fanout remain open. |
-| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. J-04 adds Forwarded-NPDU BDT mask behavior for local rebroadcast decisions and no onward forwarding to other BDT peers. Persistence, ACL matrix, Original-Broadcast fanout, and DBTN multi-target fanout remain open. |
-| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. Multi-device forwarded fanout and timer-driven expiry integration remain open. |
+| `BACNET-J-ORIGINAL-UNICAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | J-04 Original-NPDU evidence covers UDP sender B/IP MAC delivery and self-originated frame suppression; directed reply-path integration remains open. |
+| `BACNET-J-ORIGINAL-BROADCAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | J-04 Original-NPDU evidence covers BBMD Original-Broadcast local delivery, BDT/FDT Forwarded-NPDU fanout with original sender preservation, and no local Forwarded-NPDU echo. Remote/global NPDU broadcast addressing remains open. |
+| `BACNET-J-FORWARDED-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | J-04 covers originating-address parsing, truncated-address rejection, BBMD delivery with originating B/IP source MAC, FDT fanout preserving the origin, local rebroadcast for unicast peer arrivals, directed-broadcast peer local-rebroadcast suppression, no onward forwarding to other BDT peers, and Original-Broadcast BDT/FDT Forwarded-NPDU emission. Non-BDT source rejection and DBTN multi-target fanout remain open. |
+| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. J-04 adds Forwarded-NPDU BDT mask behavior, no onward forwarding to other BDT peers, and Original-Broadcast one-peer fanout without local echo. Persistence, ACL matrix, and DBTN multi-target fanout remain open. |
+| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. J-04 Original-Broadcast evidence covers one registered FDT target; multi-device forwarded fanout and timer-driven expiry integration remain open. |
 
 ## Annex K BIBBs
 

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -4,9 +4,9 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020
 - Reviewed at: 2026-06-28
-- Repository SHA reviewed: `607255450009d3f5b470b7f361938886228abd70`
-- Scope: Annex J J-04 BBMD Forwarded-NPDU source and loop-prevention evidence update; directed-broadcast peer forwarding hardened.
-- Addenda/errata: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP Forwarded-NPDU forwarding changes found for this tranche.
+- Repository SHA reviewed: `ccece409211cdcc85d5736e1701db928b66cfaf8`
+- Scope: Annex J J-04 Original-Unicast/Original-Broadcast B/IP source and BBMD fanout evidence update; Original-Broadcast local Forwarded-NPDU echo removed.
+- Addenda/errata: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP Original-NPDU broadcast forwarding changes found for this tranche.
 
 ## Counts
 


### PR DESCRIPTION
## Scope

Annex J J-04 Original-NPDU semantics for BACnet/IP:

- prevent BBMDs from echoing an already-local `Original-Broadcast-NPDU` back onto the local subnet as `Forwarded-NPDU`
- add focused loopback evidence for `Original-Unicast-NPDU` source MAC/self-drop behavior
- add focused BBMD evidence for `Original-Broadcast-NPDU` fanout to one BDT peer and one registered FDT entry
- update the conformance ledger and generated support summary conservatively

## Standard anchors

- Clause/Annex: Annex J.2.11, J.2.12, J.4.5
- Tables/Figures: BVLC function semantics for `Original-Unicast-NPDU`, `Original-Broadcast-NPDU`, `Forwarded-NPDU`, and `Distribute-Broadcast-To-Network`
- Addenda/errata checked: official Standard 135-2020 addenda through 135-2020cm were checked previously on 2026-06-28; no Annex J/BACnet/IP Original-NPDU broadcast forwarding changes found for this tranche

## Current behavior

Before this change, the BBMD receive path for `Original-Broadcast-NPDU` delivered the NPDU locally, forwarded it to BDT/FDT targets, and also transmitted a local-subnet `Forwarded-NPDU`. Annex J.4.5 only calls for BDT/FDT forwarding for an `Original-Broadcast-NPDU`; the local-subnet `Forwarded-NPDU` requirement belongs to registered foreign-device DBTN handling.

## Change summary

- Removed the local `Forwarded-NPDU` echo from the `Original-Broadcast-NPDU` BBMD path.
- Kept DBTN local `Forwarded-NPDU` broadcast behavior unchanged.
- Added `bip/original_tests.rs` coverage for:
  - `Original-Unicast-NPDU` delivers sender B/IP MAC and ignores self-originated frames.
  - BBMD `Original-Broadcast-NPDU` forwards to BDT/FDT as `Forwarded-NPDU` with original sender preserved and does not local-echo.
- Updated `conformance/bacnet-135-2020.json`, `docs/conformance/standard-135-2020-ledger.md`, and generated `support-summary.md`.

## Unsupported/deferred variants

- Directed reply-path integration remains open.
- Remote/global NPDU broadcast DNET/DADR semantics remain open.
- DBTN multi-target fanout remains open.
- Multi-device FDT fanout and timer-driven expiry integration remain open.
- Real subnet directed-broadcast interop remains outside this small PR.

## Wire-format impact

- Byte-for-byte compatible: BVLL frame encoding stays unchanged.
- Packet routing change: BBMD no longer emits a local-subnet `Forwarded-NPDU` when processing local `Original-Broadcast-NPDU`.
- Fixtures added/updated: focused B/IP loopback unit tests only.
- Migration notes: no API or persisted data changes.

## Conformance evidence

- Ledger rows:
  - `BACNET-J-ORIGINAL-UNICAST-NPDU`
  - `BACNET-J-ORIGINAL-BROADCAST-NPDU`
  - `BACNET-J-FORWARDED-NPDU`
  - `BACNET-J-BBMD-BDT`
  - `BACNET-J-FOREIGN-DEVICE-FDT`
- Positive tests:
  - `crates/bacnet-transport/src/bip/original_tests.rs::original_unicast_npdu_uses_udp_sender_source_mac_and_ignores_self`
  - `crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo`
- Negative tests:
  - self-originated `Original-Unicast-NPDU` suppression
  - no local `Forwarded-NPDU` echo for BBMD `Original-Broadcast-NPDU`
- BTL/interop evidence: none; this is local conformance evidence only.

## Benchmark evidence, if applicable

Not applicable. This change removes one outbound send from one receive path and adds tests/docs only.

## Python/WASM/CLI impact

No Python, WASM, or CLI API changes.

## Security/safety/interop review

- Avoids duplicate local forwarded broadcasts for BBMDs processing local original broadcasts.
- Keeps DBTN local broadcast behavior intact for registered foreign devices.
- Does not add CI, secrets, dependencies, or public support claims.

## Subagent findings

- `bacnet-reference-researcher`: requested changes for stale human ledger header; fixed by updating `standard-135-2020-ledger.md` scope/SHA/addenda metadata to match JSON/support summary. Confirmed Original-Broadcast local echo removal is Annex J.4.5 aligned and DBTN local broadcast remains preserved.
- `bacnet-ip-bvll-reviewer`: approved transport behavior; no functional regression found. Noted missing DBTN multi-target and directed broadcast mask/FDT exclusion tests as non-blocking follow-ups, consistent with ledger.
- `bacnet-pr-packager`: requested changes for the same stale ledger header; fixed and verified with metadata search plus conformance checks.

## Verification run

```bash
cargo fmt --all --check
bash .github/scripts/check-file-size.sh
bash .github/scripts/check-no-secrets.sh
python3 scripts/generate-conformance-docs.py --check
rg -n "Repository SHA reviewed|Current scope|Addenda|Scope:" conformance/bacnet-135-2020.json docs/conformance/standard-135-2020-ledger.md docs/conformance/support-summary.md
cargo test -p bacnet-transport --locked --quiet
cargo test -p bacnet-integration-tests --test conformance_ledger --locked --quiet
cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
```

All commands passed locally. Clippy completed with existing warnings.

## Known limitations and follow-ups

- Add DBTN multi-target fanout evidence.
- Add directed-broadcast BDT mask coverage for Original-Broadcast paths.
- Add explicit FDT/BDT source-exclusion cases for Original-Broadcast.
- Add real subnet directed-broadcast interop evidence when Docker/network test scope is expanded.
