### PR TITLE
fix(ci): make PR event triggers explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main, dev]
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +26,7 @@ permissions:
   id-token: write
 
 # =============================================================================
-# Tier 1 — CI (runs on PRs to main/dev, pushes to main, and v* tags)
+# Tier 1 — CI (runs on PR updates to main/dev, pushes to main, and v* tags)
 # =============================================================================
 
 jobs:


### PR DESCRIPTION
## Summary
- restrict CI pull_request events to opened, synchronize, and reopened
- keep push CI limited to main and v* tags
- clarify the workflow comment so PR merges to dev are not described as CI trigger points

## Verification
- actionlint .github/workflows/ci.yml
- git diff --check
- gh run list --workflow CI --branch dev --status in_progress --limit 20 --json ... returned []
- audited all visible PR titles; none violated type(scope): subject style