### PR TITLE
test(annex-j): add DBTN fanout evidence

### DIFF
--- a/conformance/bacnet-135-2020.json
+++ b/conformance/bacnet-135-2020.json
@@ -1,9 +1,9 @@
 {
   "standard": "ANSI/ASHRAE Standard 135-2020",
   "reviewed_at": "2026-06-28",
-  "repo_sha": "ccece409211cdcc85d5736e1701db928b66cfaf8",
-  "review_scope": "Annex J J-04 Original-Unicast/Original-Broadcast B/IP source and BBMD fanout evidence update; Original-Broadcast local Forwarded-NPDU echo removed.",
-  "addenda_errata_status": "Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP Original-NPDU broadcast forwarding changes found for this tranche.",
+  "repo_sha": "a0ab55d9a4803704712a740be469c9edaf2cce71",
+  "review_scope": "Annex J J.4.5 Distribute-Broadcast-To-Network fanout evidence for registered foreign devices.",
+  "addenda_errata_status": "Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP DBTN broadcast distribution changes found for this tranche.",
   "status_taxonomy": [
     "in-progress",
     "implementation-present-needs-conformance-tests",
@@ -291,16 +291,18 @@
         "crates/bacnet-transport/src/bvll.rs::decode_annex_j_bvlc_functions_and_deleted_secure_passthrough",
         "crates/bacnet-transport/src/bvll.rs::encode_decode_forwarded_npdu",
         "crates/bacnet-transport/src/bip/forwarded_tests.rs::forwarded_npdu_from_bdt_peer_uses_originating_source_mac",
+        "crates/bacnet-transport/src/bip/dbtn_tests.rs::dbtn_registered_foreign_device_fans_out_without_origin_echo",
         "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo"
       ],
       "negative_tests": [
         "crates/bacnet-transport/src/bvll.rs::decode_forwarded_too_short_for_address",
         "crates/bacnet-transport/src/bip/forwarded_tests.rs::forwarded_npdu_from_directed_broadcast_peer_skips_local_rebroadcast",
+        "crates/bacnet-transport/src/bip/dbtn_tests.rs::dbtn_registered_foreign_device_fans_out_without_origin_echo",
         "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo"
       ],
       "benchmarks": ["benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["README BACnet/IP feature", "docs/CLI.md BBMD commands"],
-      "notes": "J-04 covers generic originating-address parsing, truncated-address rejection, BBMD delivery with originating B/IP source MAC, FDT fanout preserving the origin, local rebroadcast for unicast peer arrivals, directed-broadcast peer local-rebroadcast suppression, and no onward forwarding to other BDT peers. Original-Broadcast fanout now covers BDT/FDT Forwarded-NPDU emission with original sender preservation and no local echoed Forwarded-NPDU. Non-BDT source rejection and DBTN multi-target fanout remain open."
+      "notes": "J-04 covers generic originating-address parsing, truncated-address rejection, BBMD delivery with originating B/IP source MAC, FDT fanout preserving the origin, local rebroadcast for unicast peer arrivals, directed-broadcast peer local-rebroadcast suppression, and no onward forwarding to other BDT peers. Original-Broadcast fanout covers BDT/FDT Forwarded-NPDU emission with original sender preservation and no local echoed Forwarded-NPDU. DBTN evidence now covers registered foreign-device fanout to local broadcast, BDT peer, and non-origin FDT peer while preserving the origin and excluding origin echo. Non-BDT source rejection remains open."
     },
     {
       "id": "BACNET-J-BBMD-BDT",
@@ -318,6 +320,7 @@
         "crates/bacnet-transport/src/bbmd.rs::forwarding_targets_uses_broadcast_mask",
         "crates/bacnet-transport/src/bbmd.rs::forwarding_targets_unicast_with_full_mask",
         "crates/bacnet-transport/src/bbmd.rs::forwarded_npdu_needs_local_broadcast_for_unicast_peer",
+        "crates/bacnet-transport/src/bip/dbtn_tests.rs::dbtn_registered_foreign_device_fans_out_without_origin_echo",
         "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo"
       ],
       "negative_tests": [
@@ -331,7 +334,7 @@
       ],
       "benchmarks": ["benchmarks/src/bin/bacnet_bbmd.rs", "benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["docs/CLI.md BBMD commands", "README CLI BBMD commands"],
-      "notes": "J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. J-04 adds Forwarded-NPDU BDT mask behavior: full-mask peers require local rebroadcast, directed-broadcast and unknown peers skip it, and Forwarded-NPDUs are not forwarded onward to other BDT peers. Original-Broadcast fanout now covers one remote BDT target and verifies no local Forwarded-NPDU echo. Persistence, ACL matrix, and DBTN multi-target fanout remain open."
+      "notes": "J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. J-04 adds Forwarded-NPDU BDT mask behavior: full-mask peers require local rebroadcast, directed-broadcast and unknown peers skip it, and Forwarded-NPDUs are not forwarded onward to other BDT peers. Original-Broadcast fanout covers one remote BDT target and verifies no local Forwarded-NPDU echo. DBTN fanout now covers a registered foreign-device request forwarded to a BDT peer plus local broadcast and FDT targets. Persistence and ACL matrix remain open."
     },
     {
       "id": "BACNET-J-FOREIGN-DEVICE-FDT",
@@ -346,6 +349,7 @@
         "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_accepts_max_ttl_and_caps_remaining",
         "crates/bacnet-transport/src/bip/tests.rs::delete_fdt_entry_removes_registered_foreign_device",
         "crates/bacnet-transport/src/bip/tests.rs::foreign_device_broadcast_via_bbmd",
+        "crates/bacnet-transport/src/bip/dbtn_tests.rs::dbtn_registered_foreign_device_fans_out_without_origin_echo",
         "crates/bacnet-transport/src/bip/original_tests.rs::original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo",
         "crates/bacnet-transport/src/bbmd.rs::register_and_lookup_foreign_device",
         "crates/bacnet-transport/src/bbmd.rs::re_register_updates_existing",
@@ -362,6 +366,7 @@
         "crates/bacnet-transport/src/bip/tests.rs::register_foreign_device_rejects_malformed_ttl_payload_lengths",
         "crates/bacnet-transport/src/bip/tests.rs::delete_fdt_entry_rejects_malformed_payload_and_preserves_entry",
         "crates/bacnet-transport/src/bip/tests.rs::distribute_broadcast_from_unregistered_foreign_device_naks_without_delivery",
+        "crates/bacnet-transport/src/bip/dbtn_tests.rs::dbtn_registered_foreign_device_fans_out_without_origin_echo",
         "crates/bacnet-transport/src/bbmd.rs::register_foreign_device_zero_ttl_naks",
         "crates/bacnet-transport/src/bbmd.rs::delete_nonexistent_foreign_device_naks",
         "crates/bacnet-transport/src/bbmd.rs::expired_entries_purged",
@@ -369,7 +374,7 @@
       ],
       "benchmarks": ["benchmarks/src/bin/bacnet_bbmd.rs", "benchmarks/src/stress/bbmd.rs"],
       "public_claims": ["docs/CLI.md foreign device commands"],
-      "notes": "J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. J-04 Original-Broadcast evidence covers fanout to one registered foreign device while preserving the original sender in the Forwarded-NPDU. Multi-device forwarded fanout and timer-driven expiry integration remain for later lifecycle work."
+      "notes": "J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. J-04 Original-Broadcast evidence covers fanout to one registered foreign device while preserving the original sender in the Forwarded-NPDU. DBTN evidence covers registered origin plus peer FDT fanout, preserves the original foreign-device B/IP source, and verifies no echo to the originating foreign device. Timer-driven expiry integration remains open."
     },
     {
       "id": "BACNET-K-BIBBS",

--- a/crates/bacnet-transport/src/bip/dbtn_tests.rs
+++ b/crates/bacnet-transport/src/bip/dbtn_tests.rs
@@ -1,0 +1,109 @@
+use super::*;
+use bytes::Bytes;
+use tokio::time::{timeout, Duration};
+
+async fn recv_bvll(socket: &UdpSocket) -> BvllMessage {
+    let mut recv_buf = [0u8; 2048];
+    let (len, _addr) = timeout(Duration::from_secs(2), socket.recv_from(&mut recv_buf))
+        .await
+        .expect("timed out waiting for BVLL frame")
+        .unwrap();
+    decode_bvll(&recv_buf[..len]).unwrap()
+}
+
+#[tokio::test]
+async fn dbtn_registered_foreign_device_fans_out_without_origin_echo() {
+    let bbmd_socket = Arc::new(
+        UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap(),
+    );
+    let local_port = bbmd_socket.local_addr().unwrap().port();
+    let local_broadcast_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let local_broadcast_port = local_broadcast_sink.local_addr().unwrap().port();
+    let bdt_peer_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let bdt_peer_port = bdt_peer_sink.local_addr().unwrap().port();
+    let origin_fd_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let origin_fd_port = origin_fd_sink.local_addr().unwrap().port();
+    let peer_fd_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let peer_fd_port = peer_fd_sink.local_addr().unwrap().port();
+    let (npdu_tx, mut npdu_rx) = mpsc::channel(1);
+
+    let mut state = BbmdState::new(Ipv4Addr::LOCALHOST.octets(), local_port);
+    state
+        .set_bdt(vec![BdtEntry {
+            ip: Ipv4Addr::LOCALHOST.octets(),
+            port: bdt_peer_port,
+            broadcast_mask: [255, 255, 255, 255],
+        }])
+        .unwrap();
+    assert_eq!(
+        state.register_foreign_device(Ipv4Addr::LOCALHOST.octets(), origin_fd_port, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(
+        state.register_foreign_device(Ipv4Addr::LOCALHOST.octets(), peer_fd_port, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+
+    let ctx = RecvContext {
+        local_mac: encode_bip_mac(Ipv4Addr::LOCALHOST.octets(), local_port),
+        socket: bbmd_socket,
+        npdu_tx,
+        bbmd: Some(Arc::new(Mutex::new(state))),
+        broadcast_addr: Ipv4Addr::LOCALHOST,
+        broadcast_port: local_broadcast_port,
+        pending_bvlc_response: Arc::new(Mutex::new(None)),
+        bdt_persist_path: None,
+    };
+    let sender = (Ipv4Addr::LOCALHOST.octets(), origin_fd_port);
+    let msg = BvllMessage {
+        function: BvlcFunction::DISTRIBUTE_BROADCAST_TO_NETWORK,
+        payload: Bytes::from_static(&[0x01, 0x20, 0xBA, 0xC0, 0xDB, 0x10]),
+        originating_ip: None,
+        originating_port: None,
+    };
+
+    handle_bvll_message(&msg, sender, &ctx).await;
+
+    let received = timeout(Duration::from_secs(2), npdu_rx.recv())
+        .await
+        .expect("timed out waiting for received DBTN NPDU")
+        .expect("NPDU channel closed");
+    assert_eq!(received.npdu.as_ref(), msg.payload.as_ref());
+    assert_eq!(
+        received.source_mac.as_slice(),
+        &encode_bip_mac(sender.0, sender.1)
+    );
+
+    for (label, socket) in [
+        ("local broadcast", &local_broadcast_sink),
+        ("BDT peer", &bdt_peer_sink),
+        ("foreign device peer", &peer_fd_sink),
+    ] {
+        let frame = recv_bvll(socket).await;
+        assert_eq!(frame.function, BvlcFunction::FORWARDED_NPDU, "{label}");
+        assert_eq!(frame.originating_ip, Some(sender.0), "{label}");
+        assert_eq!(frame.originating_port, Some(sender.1), "{label}");
+        assert_eq!(frame.payload.as_ref(), msg.payload.as_ref(), "{label}");
+    }
+
+    let mut origin_echo_buf = [0u8; 2048];
+    assert!(
+        timeout(
+            Duration::from_millis(100),
+            origin_fd_sink.recv_from(&mut origin_echo_buf)
+        )
+        .await
+        .is_err(),
+        "DBTN fanout must exclude the originating foreign device"
+    );
+}

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -569,6 +569,8 @@ impl TransportPort for BipTransport {
 }
 
 #[cfg(test)]
+mod dbtn_tests;
+#[cfg(test)]
 mod forwarded_tests;
 #[cfg(test)]
 mod original_tests;

--- a/docs/conformance/standard-135-2020-ledger.md
+++ b/docs/conformance/standard-135-2020-ledger.md
@@ -6,10 +6,10 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020.
 - Reviewed at: 2026-06-28.
-- Repository SHA reviewed: `ccece409211cdcc85d5736e1701db928b66cfaf8`.
+- Repository SHA reviewed: `a0ab55d9a4803704712a740be469c9edaf2cce71`.
 - Machine-readable source: `conformance/bacnet-135-2020.json`.
-- Current scope: Annex J J-04 Original-Unicast/Original-Broadcast B/IP source and BBMD fanout evidence update; Original-Broadcast local Forwarded-NPDU echo removed.
-- Addenda/errata status: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP Original-NPDU broadcast forwarding changes found for this tranche.
+- Current scope: Annex J J.4.5 Distribute-Broadcast-To-Network fanout evidence for registered foreign devices.
+- Addenda/errata status: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP DBTN broadcast distribution changes found for this tranche.
 
 ## Status Taxonomy
 
@@ -86,9 +86,9 @@
 | `BACNET-J-BVLC-FUNCTION-CODES` | Annex J.2 | P0 | `implementation-present-needs-conformance-tests` | J-01 covers Annex J.2 constants through `0x0B`, representative frames, malformed type/length, unknown function passthrough, deleted-value passthrough, and current decoder policy for extra bytes beyond BVLC Length. J-02 adds exact two-byte BVLC-Result parsing, unknown result-code passthrough, malformed result rejection, and sender/expected-function correlation for pending management responses. |
 | `BACNET-J-ORIGINAL-UNICAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | J-04 Original-NPDU evidence covers UDP sender B/IP MAC delivery and self-originated frame suppression; directed reply-path integration remains open. |
 | `BACNET-J-ORIGINAL-BROADCAST-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | J-04 Original-NPDU evidence covers BBMD Original-Broadcast local delivery, BDT/FDT Forwarded-NPDU fanout with original sender preservation, and no local Forwarded-NPDU echo. Remote/global NPDU broadcast addressing remains open. |
-| `BACNET-J-FORWARDED-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | J-04 covers originating-address parsing, truncated-address rejection, BBMD delivery with originating B/IP source MAC, FDT fanout preserving the origin, local rebroadcast for unicast peer arrivals, directed-broadcast peer local-rebroadcast suppression, no onward forwarding to other BDT peers, and Original-Broadcast BDT/FDT Forwarded-NPDU emission. Non-BDT source rejection and DBTN multi-target fanout remain open. |
-| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. J-04 adds Forwarded-NPDU BDT mask behavior, no onward forwarding to other BDT peers, and Original-Broadcast one-peer fanout without local echo. Persistence, ACL matrix, and DBTN multi-target fanout remain open. |
-| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. J-04 Original-Broadcast evidence covers one registered FDT target; multi-device forwarded fanout and timer-driven expiry integration remain open. |
+| `BACNET-J-FORWARDED-NPDU` | Annex J | P0 | `implementation-present-needs-negative-tests` | J-04 covers originating-address parsing, truncated-address rejection, BBMD delivery with originating B/IP source MAC, FDT fanout preserving the origin, local rebroadcast for unicast peer arrivals, directed-broadcast peer local-rebroadcast suppression, no onward forwarding to other BDT peers, and Original-Broadcast BDT/FDT Forwarded-NPDU emission. DBTN evidence now covers registered foreign-device fanout to local broadcast, BDT peer, and non-origin FDT peer while preserving the origin and excluding origin echo. Non-BDT source rejection remains open. |
+| `BACNET-J-BBMD-BDT` | Annex J.4/J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers read/write BDT caller paths, replacement semantics, malformed Write-BDT NAK without table mutation, self-entry insertion without overflow, and directed-broadcast forwarding target calculation. J-04 adds Forwarded-NPDU BDT mask behavior, no onward forwarding to other BDT peers, and Original-Broadcast one-peer fanout without local echo. DBTN fanout now covers a registered foreign-device request forwarded to a BDT peer plus local broadcast and FDT targets. Persistence and ACL matrix remain open. |
+| `BACNET-J-FOREIGN-DEVICE-FDT` | Annex J.5 | P0 | `implementation-present-needs-conformance-tests` | J-03 covers FDT read/register/delete caller paths, re-registration, zero-TTL and malformed TTL NAKs, exact Delete-FDT payload length, max TTL remaining-time capping, expiry purge, source exclusion, and unregistered DBTN NAK without local delivery. J-04 Original-Broadcast evidence covers one registered FDT target; DBTN evidence covers registered origin plus peer FDT fanout, source preservation, and no echo to the originating foreign device. Timer-driven expiry integration remains open. |
 
 ## Annex K BIBBs
 
@@ -125,4 +125,4 @@
 
 ## Follow-Up Backlog
 
-Rows not marked `supported-with-clause-evidence` are follow-up work. The next Annex J tranche should continue BBMD/BDT/FDT lifecycle evidence, including timer-driven expiry integration, multi-device forwarded fanout, BDT persistence, ACL behavior, and forwarding loop prevention.
+Rows not marked `supported-with-clause-evidence` are follow-up work. The next Annex J tranche should continue BBMD/BDT/FDT lifecycle evidence, including timer-driven expiry integration, BDT persistence, ACL behavior, non-BDT source rejection, NAT/multicast decisions, and forwarding loop prevention.

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -4,9 +4,9 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020
 - Reviewed at: 2026-06-28
-- Repository SHA reviewed: `ccece409211cdcc85d5736e1701db928b66cfaf8`
-- Scope: Annex J J-04 Original-Unicast/Original-Broadcast B/IP source and BBMD fanout evidence update; Original-Broadcast local Forwarded-NPDU echo removed.
-- Addenda/errata: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP Original-NPDU broadcast forwarding changes found for this tranche.
+- Repository SHA reviewed: `a0ab55d9a4803704712a740be469c9edaf2cce71`
+- Scope: Annex J J.4.5 Distribute-Broadcast-To-Network fanout evidence for registered foreign devices.
+- Addenda/errata: Official BACnet Committee Standard 135-2020 addenda through 135-2020cm checked on 2026-06-28; no Annex J/BACnet/IP DBTN broadcast distribution changes found for this tranche.
 
 ## Counts
 


### PR DESCRIPTION
## Summary
- add loopback evidence for Annex J J.4.5 Distribute-Broadcast-To-Network from a registered foreign device
- verify local configured-broadcast Forwarded-NPDU, full-mask BDT peer fanout, peer FDT fanout, original B/IP source preservation, and no echo to the originating foreign device
- update the conformance ledger and generated support summary without broadening public support or certification claims

## Standard anchors
- ANSI/ASHRAE 135-2020 Annex J.2.10 / J.2.10.1: DBTN purpose and format
- Annex J.4.5: registered foreign-device DBTN fanout to local Forwarded-NPDU broadcast, BDT entries, and FDT entries except the originating node

## Wire behavior
- Runtime behavior unchanged; this PR adds tests and evidence docs only.
- The BDT peer target in this test uses a full-mask/two-hop target, so this proves BDT peer fanout, not non-full-mask directed broadcast traversal.
- The local broadcast assertion uses a loopback configured broadcast sink for deterministic CI evidence.

## Validation
- cargo fmt --all --check
- bash .github/scripts/check-file-size.sh
- bash .github/scripts/check-no-secrets.sh
- python3 scripts/generate-conformance-docs.py --check
- cargo test -p bacnet-transport --locked --quiet
- cargo test -p bacnet-integration-tests --test conformance_ledger --locked --quiet
- cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked

## Subagent review
- bacnet-reference-researcher: approved; residual gaps are unable-to-forward NAK, real platform broadcast behavior, and directed-mask DBTN evidence.
- bacnet-ip-bvll-reviewer: approved; confirmed source preservation, local configured broadcast, BDT peer fanout, FDT peer fanout, and origin exclusion.
- bacnet-safety-interop-reviewer: approved; no findings, ledger remains conservative.
- bacnet-pr-packager: approved; no new CI, generated docs consistent, performance reviewer omitted because no hot-path or benchmark claim.

## Follow-up left open
- BDT persistence and ACL matrix
- non-BDT source rejection
- NAT/multicast decisions
- timer-driven FDT expiry integration
- unable-to-forward DBTN NAK behavior
- non-full-mask directed-broadcast DBTN fanout