### PR TITLE
fix(annex-ab): align SC heartbeat liveness

### DIFF
--- a/conformance/bacnet-135-2020.json
+++ b/conformance/bacnet-135-2020.json
@@ -692,12 +692,31 @@
       "priority": "P0",
       "requirement_summary": "BACnet/SC heartbeat request/ack behavior, timeout range, disconnect, and retry behavior are validated.",
       "status": "implementation-present-needs-timeout-tests",
-      "code_anchors": ["crates/bacnet-transport/src/sc/mod.rs", "crates/bacnet-transport/src/sc_frame.rs"],
-      "positive_tests": [],
-      "negative_tests": [],
+      "code_anchors": [
+        "crates/bacnet-transport/src/sc/mod.rs",
+        "crates/bacnet-transport/src/sc_frame.rs",
+        "crates/bacnet-transport/src/sc_hub.rs",
+        "crates/bacnet-wasm/src/client.rs",
+        "crates/bacnet-wasm/src/sc_connection.rs"
+      ],
+      "positive_tests": [
+        "crates/bacnet-transport/src/sc/tests.rs::build_heartbeat",
+        "crates/bacnet-transport/src/sc/tests.rs::heartbeat_ack_has_no_vmacs",
+        "crates/bacnet-transport/src/sc/transport_lifecycle_tests.rs::sc_heartbeat_sent_periodically",
+        "crates/bacnet-transport/src/sc/transport_lifecycle_tests.rs::sc_inbound_bvlc_activity_defers_client_heartbeat",
+        "crates/bacnet-transport/src/sc/transport_lifecycle_tests.rs::sc_inbound_bvlc_activity_resets_heartbeat_timeout",
+        "crates/bacnet-wasm/src/sc_connection.rs::tests::heartbeat",
+        "crates/bacnet-wasm/src/sc_connection.rs::tests::heartbeat_ack"
+      ],
+      "negative_tests": [
+        "crates/bacnet-transport/src/sc/receive_state_tests.rs::sc_heartbeat_send_error_transitions_to_disconnected",
+        "crates/bacnet-transport/src/sc/transport_lifecycle_tests.rs::sc_heartbeat_ack_rejects_vmac_fields",
+        "crates/bacnet-transport/src/sc/transport_lifecycle_tests.rs::sc_heartbeat_ack_requires_matching_message_id",
+        "crates/bacnet-transport/src/sc/transport_lifecycle_tests.rs::sc_heartbeat_timeout_disconnects"
+      ],
       "benchmarks": ["benchmarks/benches/sc_latency.rs"],
-      "public_claims": ["docs/python-api.md sc_heartbeat_interval_ms"],
-      "notes": "Needs fast deterministic timeout tests."
+      "public_claims": ["docs/python-api.md sc_heartbeat_interval_ms", "docs/rust-api.md with_heartbeat_interval_ms"],
+      "notes": "AB.6.3 heartbeat evidence now covers no-VMAC Heartbeat-Request/Heartbeat-ACK construction, native Heartbeat-ACK message-id/no-VMAC validation, periodic heartbeat initiation after idle inbound BVLC activity, inbound BVLC activity resetting the liveness timer, timeout-driven native disconnect when no BVLC response arrives, and send-error disconnect behavior. The row remains open because hub-initiated heartbeat ACK timeout enforcement, WASM/browser keep-alive initiation, configurable timeout range validation or production-mode rejection/clamping, and fully deterministic timeout tests still need follow-up."
     }
   ]
 }

--- a/crates/bacnet-transport/src/sc/heartbeat.rs
+++ b/crates/bacnet-transport/src/sc/heartbeat.rs
@@ -1,0 +1,15 @@
+use crate::sc_frame::{ScFunction, ScMessage};
+
+pub(super) fn is_bvlc_result_wire(data: &[u8]) -> bool {
+    data.first()
+        .is_some_and(|function| *function == ScFunction::Result.to_raw())
+}
+
+pub(super) fn ack_matches_outstanding(msg: &ScMessage, expected_message_id: Option<u16>) -> bool {
+    msg.function == ScFunction::HeartbeatAck
+        && expected_message_id.is_some_and(|message_id| msg.message_id == message_id)
+        && msg.originating_vmac.is_none()
+        && msg.destination_vmac.is_none()
+        && msg.data_options.is_empty()
+        && msg.payload.is_empty()
+}

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -20,13 +20,11 @@ use crate::sc_frame::{
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 
+mod heartbeat;
 mod loopback;
+mod reconnect;
 pub use loopback::LoopbackWebSocket;
-
-fn is_bvlc_result_wire(data: &[u8]) -> bool {
-    data.first()
-        .is_some_and(|function| *function == ScFunction::Result.to_raw())
-}
+pub use reconnect::ScReconnectConfig;
 
 // ---------------------------------------------------------------------------
 // WebSocket abstraction
@@ -203,7 +201,7 @@ impl ScConnection {
         }
     }
 
-    /// Build a Heartbeat-ACK message. Per spec AB.2.11, no VMACs.
+    /// Build a Heartbeat-ACK message. Per Annex AB.2.15, no VMACs.
     pub fn build_heartbeat_ack(&self, request_message_id: u16) -> ScMessage {
         ScMessage {
             function: ScFunction::HeartbeatAck,
@@ -303,31 +301,6 @@ impl ScConnection {
                 None
             }
             _ => None,
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Reconnection configuration
-// ---------------------------------------------------------------------------
-
-/// Configuration for SC transport reconnection with exponential backoff.
-#[derive(Debug, Clone)]
-pub struct ScReconnectConfig {
-    /// Initial delay before first reconnect attempt (ms).
-    pub initial_delay_ms: u64,
-    /// Maximum delay between reconnect attempts (ms).
-    pub max_delay_ms: u64,
-    /// Maximum number of reconnect attempts before giving up.
-    pub max_retries: u32,
-}
-
-impl Default for ScReconnectConfig {
-    fn default() -> Self {
-        Self {
-            initial_delay_ms: 10_000,
-            max_delay_ms: 600_000,
-            max_retries: 10,
         }
     }
 }
@@ -445,7 +418,7 @@ async fn perform_handshake<W: WebSocketPort>(
             }
             let msg = match decode_sc_message(&data) {
                 Ok(msg) => msg,
-                Err(e) if is_bvlc_result_wire(&data) => {
+                Err(e) if heartbeat::is_bvlc_result_wire(&data) => {
                     let mut c = conn.lock().await;
                     c.state = ScConnectionState::Disconnected;
                     return Err(Error::Encoding(format!(
@@ -580,7 +553,8 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                 let mut hb_interval =
                     tokio::time::interval(Duration::from_millis(heartbeat_interval_ms));
                 hb_interval.tick().await; // consume the first immediate tick
-                let mut last_heartbeat_ack = Instant::now();
+                let mut last_bvlc_received = Instant::now();
+                let mut pending_heartbeat_id = None;
 
                 loop {
                     tokio::select! {
@@ -593,7 +567,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                     }
                                     let msg = match decode_sc_message(&data) {
                                         Ok(m) => m,
-                                        Err(e) if is_bvlc_result_wire(&data) => {
+                                        Err(e) if heartbeat::is_bvlc_result_wire(&data) => {
                                             warn!("Malformed wire-level BACnet/SC BVLC-Result: {e}");
                                             let mut c = conn.lock().await;
                                             c.state = ScConnectionState::Disconnected;
@@ -605,11 +579,18 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                         }
                                     };
 
-                                    // Handle HeartbeatAck — update last_heartbeat_ack timestamp
                                     if msg.function == ScFunction::HeartbeatAck {
-                                        last_heartbeat_ack = Instant::now();
+                                        if heartbeat::ack_matches_outstanding(&msg, pending_heartbeat_id) {
+                                            last_bvlc_received = Instant::now();
+                                            pending_heartbeat_id = None;
+                                        } else {
+                                            warn!("BACnet/SC ignored unexpected Heartbeat-ACK");
+                                        }
                                         continue;
                                     }
+
+                                    last_bvlc_received = Instant::now();
+                                    pending_heartbeat_id = None;
 
                                     // Handle Heartbeat-Request with Heartbeat-ACK
                                     if msg.function == ScFunction::HeartbeatRequest {
@@ -674,24 +655,26 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                             }
                         }
                         _ = hb_interval.tick() => {
-                            // Send heartbeat request first
-                            let mut c = conn.lock().await;
-                            let hb_msg = c.build_heartbeat();
-                            let mut buf = BytesMut::new();
-                            encode_sc_message(&mut buf, &hb_msg);
-                            drop(c);
-                            if let Err(e) = ws_clone.send(&buf).await {
-                                warn!("BACnet/SC heartbeat send error: {}", e);
-                                let mut c = conn.lock().await;
-                                c.state = ScConnectionState::Disconnected;
-                                break;
-                            }
-                            // Check heartbeat timeout: has the hub acked within
-                            // the timeout window? Checking after send ensures the
-                            // first heartbeat gets a full timeout period for a reply.
-                            if last_heartbeat_ack.elapsed()
-                                > Duration::from_millis(heartbeat_timeout_ms)
+                            let idle_for = last_bvlc_received.elapsed();
+                            if idle_for >= Duration::from_millis(heartbeat_interval_ms)
+                                && pending_heartbeat_id.is_none()
                             {
+                                let mut c = conn.lock().await;
+                                let hb_msg = c.build_heartbeat();
+                                let mut buf = BytesMut::new();
+                                encode_sc_message(&mut buf, &hb_msg);
+                                let heartbeat_message_id = hb_msg.message_id;
+                                drop(c);
+                                if let Err(e) = ws_clone.send(&buf).await {
+                                    warn!("BACnet/SC heartbeat send error: {}", e);
+                                    let mut c = conn.lock().await;
+                                    c.state = ScConnectionState::Disconnected;
+                                    break;
+                                }
+                                pending_heartbeat_id = Some(heartbeat_message_id);
+                            }
+
+                            if idle_for > Duration::from_millis(heartbeat_timeout_ms) {
                                 warn!("BACnet/SC heartbeat timeout — disconnecting");
                                 let mut c = conn.lock().await;
                                 c.state = ScConnectionState::Disconnected;

--- a/crates/bacnet-transport/src/sc/reconnect.rs
+++ b/crates/bacnet-transport/src/sc/reconnect.rs
@@ -1,0 +1,20 @@
+/// Configuration for SC transport reconnection with exponential backoff.
+#[derive(Debug, Clone)]
+pub struct ScReconnectConfig {
+    /// Initial delay before first reconnect attempt (ms).
+    pub initial_delay_ms: u64,
+    /// Maximum delay between reconnect attempts (ms).
+    pub max_delay_ms: u64,
+    /// Maximum number of reconnect attempts before giving up.
+    pub max_retries: u32,
+}
+
+impl Default for ScReconnectConfig {
+    fn default() -> Self {
+        Self {
+            initial_delay_ms: 10_000,
+            max_delay_ms: 600_000,
+            max_retries: 10,
+        }
+    }
+}

--- a/crates/bacnet-transport/src/sc/transport_lifecycle_tests.rs
+++ b/crates/bacnet-transport/src/sc/transport_lifecycle_tests.rs
@@ -25,6 +25,21 @@ async fn hub_accept(ws_hub: &LoopbackWebSocket, hub_vmac: Vmac) {
     ws_hub.send(&buf).await.unwrap();
 }
 
+async fn wait_for_connection_state(
+    conn: &Arc<Mutex<ScConnection>>,
+    expected: ScConnectionState,
+    timeout: Duration,
+) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if conn.lock().await.state == expected {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    false
+}
+
 #[tokio::test]
 async fn sc_connect_timeout() {
     let (ws_client, _ws_server) = LoopbackWebSocket::pair();
@@ -119,6 +134,98 @@ async fn sc_heartbeat_sent_periodically() {
     let ack = ScMessage {
         function: ScFunction::HeartbeatAck,
         message_id: msg.message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::new(),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &ack);
+    ws_hub.send(&buf).await.unwrap();
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_heartbeat_ack_requires_matching_message_id() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let client_vmac = [0x01; 6];
+    let hub_vmac = [0x10; 6];
+
+    let mut transport = ScTransport::new(ws_client, client_vmac)
+        .with_heartbeat_interval_ms(100)
+        .with_heartbeat_timeout_ms(300);
+
+    let hub_task = tokio::spawn(async move {
+        hub_accept(&ws_hub, hub_vmac).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let ws_hub = hub_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+
+    let data = tokio::time::timeout(Duration::from_millis(300), ws_hub.recv())
+        .await
+        .expect("timed out waiting for heartbeat")
+        .unwrap();
+    let msg = decode_sc_message(&data).unwrap();
+    assert_eq!(msg.function, ScFunction::HeartbeatRequest);
+
+    let ack = ScMessage {
+        function: ScFunction::HeartbeatAck,
+        message_id: msg.message_id.wrapping_add(1),
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::new(),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &ack);
+    ws_hub.send(&buf).await.unwrap();
+
+    assert!(
+        wait_for_connection_state(
+            &conn,
+            ScConnectionState::Disconnected,
+            Duration::from_millis(500)
+        )
+        .await
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_heartbeat_ack_rejects_vmac_fields() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let client_vmac = [0x01; 6];
+    let hub_vmac = [0x10; 6];
+
+    let mut transport = ScTransport::new(ws_client, client_vmac)
+        .with_heartbeat_interval_ms(100)
+        .with_heartbeat_timeout_ms(300);
+
+    let hub_task = tokio::spawn(async move {
+        hub_accept(&ws_hub, hub_vmac).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let ws_hub = hub_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+
+    let data = tokio::time::timeout(Duration::from_millis(300), ws_hub.recv())
+        .await
+        .expect("timed out waiting for heartbeat")
+        .unwrap();
+    let msg = decode_sc_message(&data).unwrap();
+    assert_eq!(msg.function, ScFunction::HeartbeatRequest);
+
+    let ack = ScMessage {
+        function: ScFunction::HeartbeatAck,
+        message_id: msg.message_id,
         originating_vmac: Some(hub_vmac),
         destination_vmac: Some(client_vmac),
         dest_options: Vec::new(),
@@ -128,6 +235,122 @@ async fn sc_heartbeat_sent_periodically() {
     let mut buf = BytesMut::new();
     encode_sc_message(&mut buf, &ack);
     ws_hub.send(&buf).await.unwrap();
+
+    assert!(
+        wait_for_connection_state(
+            &conn,
+            ScConnectionState::Disconnected,
+            Duration::from_millis(500)
+        )
+        .await
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_inbound_bvlc_activity_defers_client_heartbeat() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let client_vmac = [0x01; 6];
+    let hub_vmac = [0x10; 6];
+
+    let mut transport = ScTransport::new(ws_client, client_vmac)
+        .with_heartbeat_interval_ms(100)
+        .with_heartbeat_timeout_ms(1000);
+
+    let hub_task = tokio::spawn(async move {
+        hub_accept(&ws_hub, hub_vmac).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let ws_hub = hub_task.await.unwrap();
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let hb = ScMessage {
+        function: ScFunction::HeartbeatRequest,
+        message_id: 0x55,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::new(),
+    };
+    let mut hb_buf = BytesMut::new();
+    encode_sc_message(&mut hb_buf, &hb);
+    ws_hub.send(&hb_buf).await.unwrap();
+
+    let data = tokio::time::timeout(Duration::from_millis(100), ws_hub.recv())
+        .await
+        .expect("timed out waiting for heartbeat ack")
+        .unwrap();
+    let ack = decode_sc_message(&data).unwrap();
+    assert_eq!(ack.function, ScFunction::HeartbeatAck);
+    assert_eq!(ack.message_id, 0x55);
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(80), ws_hub.recv())
+            .await
+            .is_err(),
+        "client heartbeat was sent before the connection was idle"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_inbound_bvlc_activity_resets_heartbeat_timeout() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let client_vmac = [0x01; 6];
+    let hub_vmac = [0x10; 6];
+
+    let mut transport = ScTransport::new(ws_client, client_vmac)
+        .with_heartbeat_interval_ms(100)
+        .with_heartbeat_timeout_ms(300);
+
+    let hub_task = tokio::spawn(async move {
+        hub_accept(&ws_hub, hub_vmac).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let ws_hub = hub_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    let hb = ScMessage {
+        function: ScFunction::HeartbeatRequest,
+        message_id: 0x66,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::new(),
+    };
+    let mut hb_buf = BytesMut::new();
+    encode_sc_message(&mut hb_buf, &hb);
+    ws_hub.send(&hb_buf).await.unwrap();
+
+    let mut received_ack = false;
+    let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        let data = tokio::time::timeout(remaining, ws_hub.recv())
+            .await
+            .expect("timed out waiting for heartbeat ack")
+            .unwrap();
+        let msg = decode_sc_message(&data).unwrap();
+        if msg.function == ScFunction::HeartbeatAck && msg.message_id == 0x66 {
+            received_ack = true;
+            break;
+        }
+    }
+    assert!(
+        received_ack,
+        "transport did not acknowledge inbound heartbeat"
+    );
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    assert_eq!(conn.lock().await.state, ScConnectionState::Connected);
 
     transport.stop().await.unwrap();
 }

--- a/crates/bacnet-transport/src/sc_hub.rs
+++ b/crates/bacnet-transport/src/sc_hub.rs
@@ -164,7 +164,7 @@ async fn accept_loop(
     const MAX_ACTIVE_CONNECTIONS: usize = 512;
 
     // Heartbeat sweep: periodically check for idle clients and send HeartbeatRequest.
-    // Per spec AB.6.2, the hub shall initiate heartbeats to detect dead connections.
+    // Per Annex AB.6.3, peers initiate heartbeats to detect idle/dead connections.
     const HEARTBEAT_CHECK_INTERVAL_SECS: u64 = 30;
     const HEARTBEAT_IDLE_THRESHOLD_SECS: u64 = 60;
     {

--- a/crates/bacnet-wasm/src/client.rs
+++ b/crates/bacnet-wasm/src/client.rs
@@ -327,15 +327,7 @@ impl BACnetScClient {
 
                 // Handle heartbeat
                 if sc_msg.function == ScFunction::HeartbeatRequest {
-                    let ack = crate::sc_frame::ScMessage {
-                        function: ScFunction::HeartbeatAck,
-                        message_id: sc_msg.message_id,
-                        originating_vmac: sc_msg.destination_vmac,
-                        destination_vmac: sc_msg.originating_vmac,
-                        dest_options: Vec::new(),
-                        data_options: Vec::new(),
-                        payload: bytes::Bytes::new(),
-                    };
+                    let ack = connection.borrow().build_heartbeat_ack(sc_msg.message_id);
                     let mut buf = BytesMut::new();
                     encode_sc_message(&mut buf, &ack);
                     if let Some(ws) = ws.borrow().as_ref() {

--- a/crates/bacnet-wasm/src/sc_connection.rs
+++ b/crates/bacnet-wasm/src/sc_connection.rs
@@ -150,6 +150,20 @@ impl ScConnection {
         }
     }
 
+    /// Build a Heartbeat-ACK message.
+    /// AB.2.15.1: No Originating/Destination Virtual Address.
+    pub fn build_heartbeat_ack(&self, request_message_id: u16) -> ScMessage {
+        ScMessage {
+            function: ScFunction::HeartbeatAck,
+            message_id: request_message_id,
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::new(),
+        }
+    }
+
     /// Build an Encapsulated-NPDU message.
     pub fn build_encapsulated_npdu(&mut self, dest_vmac: Vmac, npdu: &[u8]) -> ScMessage {
         ScMessage {
@@ -553,6 +567,19 @@ mod tests {
         assert!(hb.originating_vmac.is_none());
         assert!(hb.destination_vmac.is_none());
         assert!(hb.payload.is_empty());
+    }
+
+    #[test]
+    fn heartbeat_ack() {
+        let conn = ScConnection::new([1; 6]);
+        let ack = conn.build_heartbeat_ack(42);
+        assert_eq!(ack.function, ScFunction::HeartbeatAck);
+        assert_eq!(ack.message_id, 42);
+        // AB.2.15.1: no VMACs on HeartbeatAck
+        assert!(ack.originating_vmac.is_none());
+        assert!(ack.destination_vmac.is_none());
+        assert!(ack.data_options.is_empty());
+        assert!(ack.payload.is_empty());
     }
 
     #[test]

--- a/docs/conformance/pics-draft.md
+++ b/docs/conformance/pics-draft.md
@@ -24,7 +24,7 @@ This draft summarizes implementation evidence that may feed a future formal Prot
 | `BACNET-AB-SC-CONNECTION-STATE` | Annex AB.6.2 | implementation-present-needs-state-machine-audit | `crates/bacnet-transport/src/sc/mod.rs`, `crates/bacnet-transport/src/sc/receive_state_tests.rs`, `crates/bacnet-transport/src/sc/tests.rs`, `crates/bacnet-transport/src/sc_hub.rs`, `crates/bacnet-transport/src/sc_hub/tests.rs`, `crates/bacnet-wasm/src/client.rs`, `crates/bacnet-wasm/src/sc_connection.rs`, `crates/bacnet-types/src/enums/protocol.rs` |
 | `BACNET-AB-SC-HUB-CONNECTOR` | Annex AB.5 | implementation-present-needs-conformance-tests | `crates/bacnet-transport/src/sc/mod.rs`, `crates/bacnet-transport/src/sc_hub.rs` |
 | `BACNET-AB-SC-WEBSOCKET-TLS` | Annex AB.7 | implementation-present-needs-security-tests | `crates/bacnet-transport/src/sc_frame.rs`, `crates/bacnet-transport/src/sc_hub.rs`, `crates/bacnet-transport/src/sc_tls.rs`, `crates/bacnet-wasm/src/sc_websocket.rs`, `crates/bacnet-wasm/src/ws_transport.rs`, `crates/rusty-bacnet/src/tls.rs` |
-| `BACNET-AB-SC-HEARTBEAT` | Annex AB.6.3 | implementation-present-needs-timeout-tests | `crates/bacnet-transport/src/sc/mod.rs`, `crates/bacnet-transport/src/sc_frame.rs` |
+| `BACNET-AB-SC-HEARTBEAT` | Annex AB.6.3 | implementation-present-needs-timeout-tests | `crates/bacnet-transport/src/sc/mod.rs`, `crates/bacnet-transport/src/sc_frame.rs`, `crates/bacnet-transport/src/sc_hub.rs`, `crates/bacnet-wasm/src/client.rs`, `crates/bacnet-wasm/src/sc_connection.rs` |
 
 ## PICS/Profile Rows
 

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -64,7 +64,7 @@
 | `BACNET-AB-SC-CONNECTION-STATE` | Annex AB.6.2 | P0 | implementation-present-needs-state-machine-audit | 2 |
 | `BACNET-AB-SC-HUB-CONNECTOR` | Annex AB.5 | P0 | implementation-present-needs-conformance-tests | 2 |
 | `BACNET-AB-SC-WEBSOCKET-TLS` | Annex AB.7 | P0 | implementation-present-needs-security-tests | 2 |
-| `BACNET-AB-SC-HEARTBEAT` | Annex AB.6.3 | P0 | implementation-present-needs-timeout-tests | 1 |
+| `BACNET-AB-SC-HEARTBEAT` | Annex AB.6.3 | P0 | implementation-present-needs-timeout-tests | 2 |
 
 ## Follow-Up Source
 


### PR DESCRIPTION
Summary:
- Track native BACnet/SC liveness from any valid inbound BVLC message instead of only HeartbeatAck.
- Correlate HeartbeatAck by outstanding message id and reject ACKs with VMAC fields, data options, or payload as liveness evidence.
- Add WASM HeartbeatAck helper and update conformance ledger evidence while keeping BACNET-AB-SC-HEARTBEAT open for hub ACK timeout, WASM keep-alive initiation, timeout range validation, and deterministic timeout follow-up.

Validation:
- cargo fmt --all --check
- python3 scripts/generate-conformance-docs.py --check
- git diff --check
- python3 -m json.tool conformance/bacnet-135-2020.json
- cargo test -p bacnet-transport --features sc-tls --locked
- cargo test -p bacnet-wasm --lib --locked
- cargo test -p bacnet-integration-tests --test conformance_ledger --locked

Review:
- Standard/source review checked Annex AB.2.14, AB.2.15, and AB.6.3 against the local Standard PDF.
- SC security review identified follow-up gaps retained in the ledger notes.