### PR TITLE
chore(release): prepare v0.10.0 — version bump + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0]
+
+### BACnet/SC - Connection Resilience (ASHRAE 135-2020 Annex AB.6.2, AB.6.3)
+
+- Duplicate-VMAC recovery per AB.6.2: a `NODE_DUPLICATE_VMAC` NAK now triggers a Random-48 VMAC reseed and reconnect instead of failing the connection permanently; reseed fails closed on RNG errors, and retry eligibility is preserved across primary-restore probes.
+- SC hub duplicate Device-UUID replacement: a device reconnecting after an unclean drop now reclaims its stale session slot instead of being NAK'd until hub restart.
+- Failover hub is now used after mid-life reconnect exhaustion (previously only attempted on cold start; the reconnect path carried a TODO), and the primary hub is probed and restored after a failover.
+- Heartbeats are sent only when the link is idle (AB.6.3), and a `Heartbeat-ACK` must correlate to the outstanding request - stale, foreign, or malformed ACKs no longer keep a dead link alive; hub-side heartbeat-ACK timeouts are enforced.
+- Fatal `BVLC-Result` NAKs, receive errors, heartbeat send failures, and reconnect exhaustion now tear the transport down and set the connection state to `Disconnected` - no more phantom-`Connected` states on a dead link; pending-connect correlation state is cleared on handshake decode/IO errors.
+
+### BACnet/SC - Protocol Conformance (Annex AB.2, AB.3)
+
+- `BVLC-Result` payloads (Error Class / Error Code / Error Details) are parsed and surfaced instead of skipped.
+- Malformed SC frame option chains (bad length, truncated, unterminated) are rejected instead of accepted.
+- SC data options: outbound encoding, inbound exposure as `ReceivedNpdu::data_attributes` (new `DataAttribute` type + default-bodied `TransportPort::send_*_with_data_attributes` methods), rejection of unsupported must-understand options, and preservation of data attributes across router and hub forwarding.
+- Hub hardening: exact ConnectRequest payload-length validation, advertised `Max-BVLC-Length` enforced on inbound and relayed frames, and inbound frames carrying an Originating VMAC rejected (the hub stamps the registered VMAC).
+- TLS 1.3 is enforced for SC configurations.
+- New `ErrorCode` constants 139-151 (Clause 5.4.6 / Annex AB), including `NODE_DUPLICATE_VMAC` and `NOT_A_BACNET_SC_HUB`.
+
+### BACnet/IP - Annex J
+
+- The BIP UDP socket now binds `INADDR_ANY` (the configured interface IP is retained for the advertised MAC and I-Am source) so subnet and limited broadcasts reach the socket on Linux, with a startup probe of the interface IP.
+- Forwarded-NPDU rebroadcast loops are prevented and Original-Broadcast local echo is suppressed.
+- BBMD: Distribute-Broadcast-To-Network forwarding failures return a NAK, FDT entries are purged by a timer task with lifecycle-edge validation, BDT persistence survives restart, and management ACK wire format and ACLs are validated.
+
+### WASM (browser bindings)
+
+- BACnet/SC heartbeat keepalive scheduling after Connect-Accept, disconnect handling, and callback cleanup; SC data attributes are routed and preserved through the WASM layer.
+
+### Server
+
+- New `BACnetServer::i_am_broadcaster()` / `broadcast_i_am()` and `BipServerBuilder::vendor_id(u16)` for host-driven I-Am announcement.
+
+### Dependencies
+
+- `pyo3` upgraded to 0.29 (resolves audit advisories).
+
 ## [0.9.0]
 
 ### Spec Compliance - Codec Strictness (ASHRAE 135-2020 Clauses 20.1.2.7, 20.1.2.8, 20.1.6.x)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-network",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-encoding"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-types",
  "bytes",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-integration-tests"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-network"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-transport",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-objects"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-server"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-network",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-services"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-transport"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bitflags 2.11.1",
  "smallvec",
@@ -398,7 +398,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-wasm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-services",
@@ -2287,7 +2287,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-bacnet"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.93"
 license = "MIT"
@@ -53,14 +53,14 @@ keywords = ["bacnet", "building-automation", "ashrae", "iot", "protocol"]
 categories = ["network-programming", "embedded"]
 
 [workspace.dependencies]
-bacnet-types = { version = "0.9.0", path = "crates/bacnet-types" }
-bacnet-encoding = { version = "0.9.0", path = "crates/bacnet-encoding" }
-bacnet-services = { version = "0.9.0", path = "crates/bacnet-services" }
-bacnet-transport = { version = "0.9.0", path = "crates/bacnet-transport" }
-bacnet-network = { version = "0.9.0", path = "crates/bacnet-network" }
-bacnet-client = { version = "0.9.0", path = "crates/bacnet-client" }
-bacnet-objects = { version = "0.9.0", path = "crates/bacnet-objects" }
-bacnet-server = { version = "0.9.0", path = "crates/bacnet-server" }
+bacnet-types = { version = "0.10.0", path = "crates/bacnet-types" }
+bacnet-encoding = { version = "0.10.0", path = "crates/bacnet-encoding" }
+bacnet-services = { version = "0.10.0", path = "crates/bacnet-services" }
+bacnet-transport = { version = "0.10.0", path = "crates/bacnet-transport" }
+bacnet-network = { version = "0.10.0", path = "crates/bacnet-network" }
+bacnet-client = { version = "0.10.0", path = "crates/bacnet-client" }
+bacnet-objects = { version = "0.10.0", path = "crates/bacnet-objects" }
+bacnet-server = { version = "0.10.0", path = "crates/bacnet-server" }
 thiserror = "2"
 bitflags = "2"
 bytes = "1"


### PR DESCRIPTION
## Summary

Release preparation for **v0.10.0**: workspace version bump (0.9.0 → 0.10.0 across `[workspace.package]` and the 8 internal dependency pins), `Cargo.lock` refresh, and the `CHANGELOG.md` entry summarizing the 177 commits on `dev` since `v0.9.0`.

The changelog groups by area, matching the house style:
- **BACnet/SC — Connection Resilience** (AB.6.2/AB.6.3): duplicate-VMAC recovery, hub duplicate-UUID replacement, mid-life failover + primary restore, correlated idle-only heartbeats, elimination of phantom-`Connected` states
- **BACnet/SC — Protocol Conformance** (AB.2/AB.3): BVLC-Result payload parsing, malformed option-chain rejection, data options (encode/receive/must-understand/forwarding), hub Max-BVLC + Originating-VMAC enforcement, TLS 1.3 enforcement, `ErrorCode` 139–151
- **BACnet/IP — Annex J**: `INADDR_ANY` bind fix, forwarding loop/echo fixes, BBMD FDT purge + BDT persistence + management ACLs
- **WASM**, **Server**, **Dependencies** (pyo3 0.29)

## Verification

Local mirror of the CI gate: `fmt` ✓, `clippy` (same exclusions) 0 errors, file-size cap ✓, no-secrets ✓, `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked` → **2002 passed, 0 failed**.

The tag-push `validate` job's changelog check (`## [0.10.0]` present) is satisfied by this entry.

## Release sequence (after this merges)

1. `dev` → `main` release PR
2. Tag `v0.10.0` on `main` — this triggers the `publish-crates` job (crates.io, `release` environment)
3. Downstream: `verdant` re-pins from `v0.9.0` → `v0.10.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)