### PR TITLE
fix(client): abort BACnetClient tasks on drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Abort `BACnetClient` dispatch on drop and cascade B/IP network cleanup so ungraceful teardown releases reader tasks and the UDP socket.
+
 ## [0.10.0]
 
 ### BACnet/SC - Connection Resilience (ASHRAE 135-2020 Annex AB.6.2, AB.6.3)

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -1,5 +1,13 @@
 use super::*;
 
+impl<T: TransportPort> BACnetClient<T> {
+    fn abort_dispatch_task(&mut self) -> Option<JoinHandle<()>> {
+        let task = self.dispatch_task.take()?;
+        task.abort();
+        Some(task)
+    }
+}
+
 impl<T: TransportPort + 'static> BACnetClient<T> {
     /// Start the client: bind transport, start network layer, spawn dispatch.
     pub async fn start(mut config: ClientConfig, transport: T) -> Result<Self, Error> {
@@ -119,10 +127,19 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     }
     /// Stop the client, aborting the dispatch task.
     pub async fn stop(&mut self) -> Result<(), Error> {
-        if let Some(task) = self.dispatch_task.take() {
-            task.abort();
+        if let Some(task) = self.abort_dispatch_task() {
             let _ = task.await;
         }
+        let network = Arc::get_mut(&mut self.network).ok_or_else(|| {
+            Error::Encoding("cannot stop BACnetClient while network references remain".into())
+        })?;
+        network.stop().await?;
         Ok(())
+    }
+}
+
+impl<T: TransportPort> Drop for BACnetClient<T> {
+    fn drop(&mut self) {
+        let _ = self.abort_dispatch_task();
     }
 }

--- a/crates/bacnet-client/src/client/tests.rs
+++ b/crates/bacnet-client/src/client/tests.rs
@@ -46,6 +46,83 @@ async fn client_start_stop() {
 }
 
 #[tokio::test]
+async fn client_stop_releases_bip_socket_before_drop() {
+    let mut client = make_client().await;
+    let local_mac = client.local_mac().to_vec();
+    let port = u16::from_be_bytes([local_mac[4], local_mac[5]]);
+
+    client.stop().await.unwrap();
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            match BACnetClient::builder()
+                .interface(Ipv4Addr::LOCALHOST)
+                .port(port)
+                .build()
+                .await
+            {
+                Ok(mut replacement) => {
+                    replacement.stop().await.unwrap();
+                    break;
+                }
+                Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+            }
+        }
+    })
+    .await
+    .expect("stopping BACnetClient releases the B/IP socket");
+}
+
+#[tokio::test]
+async fn client_drop_aborts_dispatch_task() {
+    let client = make_client().await;
+    let abort_handle = client
+        .dispatch_task
+        .as_ref()
+        .expect("client starts a dispatch task")
+        .abort_handle();
+
+    assert!(!abort_handle.is_finished());
+    drop(client);
+
+    timeout(Duration::from_secs(1), async {
+        while !abort_handle.is_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("dropping BACnetClient aborts the dispatch task");
+}
+
+#[tokio::test]
+async fn client_drop_releases_bip_socket() {
+    let client = make_client().await;
+    let local_mac = client.local_mac().to_vec();
+    let port = u16::from_be_bytes([local_mac[4], local_mac[5]]);
+
+    drop(client);
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            match BACnetClient::builder()
+                .interface(Ipv4Addr::LOCALHOST)
+                .port(port)
+                .build()
+                .await
+            {
+                Ok(mut replacement) => {
+                    replacement.stop().await.unwrap();
+                    break;
+                }
+                Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+            }
+        }
+    })
+    .await
+    .expect("dropping BACnetClient releases the B/IP socket");
+}
+
+#[tokio::test]
 async fn client_rejects_invalid_max_apdu_length() {
     let result = BACnetClient::builder()
         .interface(Ipv4Addr::LOCALHOST)

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -381,11 +381,24 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
 
     /// Stop the network layer and underlying transport.
     pub async fn stop(&mut self) -> Result<(), Error> {
-        if let Some(task) = self.dispatch_task.take() {
-            task.abort();
+        if let Some(task) = self.abort_dispatch_task() {
             let _ = task.await;
         }
         self.transport.stop().await
+    }
+}
+
+impl<T: TransportPort> NetworkLayer<T> {
+    fn abort_dispatch_task(&mut self) -> Option<JoinHandle<()>> {
+        let task = self.dispatch_task.take()?;
+        task.abort();
+        Some(task)
+    }
+}
+
+impl<T: TransportPort> Drop for NetworkLayer<T> {
+    fn drop(&mut self) {
+        let _ = self.abort_dispatch_task();
     }
 }
 

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -233,6 +233,24 @@ impl BipTransport {
         })
     }
 
+    fn abort_background_tasks(&mut self) -> Vec<JoinHandle<()>> {
+        let mut tasks = Vec::new();
+        if let Some(task) = self.registration_task.take() {
+            task.abort();
+            tasks.push(task);
+        }
+        if let Some(task) = self.bbmd_fdt_purge_task.take() {
+            task.abort();
+            tasks.push(task);
+        }
+        if let Some(task) = self.recv_task.take() {
+            task.abort();
+            tasks.push(task);
+        }
+        self.socket = None;
+        tasks
+    }
+
     /// Send a raw BVLC management request and await the response.
     async fn bvlc_request(
         &self,
@@ -540,19 +558,9 @@ impl TransportPort for BipTransport {
     }
 
     async fn stop(&mut self) -> Result<(), Error> {
-        if let Some(task) = self.registration_task.take() {
-            task.abort();
+        for task in self.abort_background_tasks() {
             let _ = task.await;
         }
-        if let Some(task) = self.bbmd_fdt_purge_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
-        if let Some(task) = self.recv_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
-        self.socket = None;
         Ok(())
     }
 
@@ -600,6 +608,12 @@ impl TransportPort for BipTransport {
 
     fn local_mac(&self) -> &[u8] {
         &self.local_mac
+    }
+}
+
+impl Drop for BipTransport {
+    fn drop(&mut self) {
+        let _ = self.abort_background_tasks();
     }
 }
 


### PR DESCRIPTION
## Summary

- Add best-effort `Drop` cleanup for `BACnetClient` and `NetworkLayer` dispatch tasks.
- Cascade explicit `BACnetClient::stop()` through `NetworkLayer::stop()` and fail closed if network references remain.
- Abort B/IP background registration, BBMD purge, and receive tasks on stop/drop while clearing the UDP socket.
- Add regression coverage for explicit stop and ungraceful drop releasing the B/IP socket/task path.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked`
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked`
- `cargo audit` (passes with existing allowed `RUSTSEC-2026-0190` warning for `anyhow`)
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked`

## Notes

No version bumps, tags, release artifacts, `main` changes, or CI changes are included. The cleanup claim is scoped to the B/IP task and socket path covered by the new tests.

Fixes #74