### PR TITLE
fix(client): purge device table on silent datalinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Abort `BACnetClient` dispatch on drop and cascade B/IP network cleanup so ungraceful teardown releases reader tasks and the UDP socket.
+- Run `BACnetClient` device-table stale-entry purging on an independent interval so fully silent datalinks can evict dead devices.
 
 ## [0.10.0]
 

--- a/crates/bacnet-client/Cargo.toml
+++ b/crates/bacnet-client/Cargo.toml
@@ -27,7 +27,7 @@ sc-tls = ["bacnet-transport/sc-tls", "tokio-rustls"]
 
 [dev-dependencies]
 bacnet-objects.workspace = true
-tokio = { workspace = true, features = ["net", "rt-multi-thread", "sync", "macros", "time"] }
+tokio = { workspace = true, features = ["net", "rt-multi-thread", "sync", "macros", "time", "test-util"] }
 
 [lints]
 workspace = true

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -46,65 +46,70 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 
         let dispatch_task = tokio::spawn(async move {
             let mut seg_state: HashMap<SegKey, SegmentedReceiveState> = HashMap::new();
-            let mut last_device_purge = Instant::now();
             const DEVICE_PURGE_INTERVAL: Duration = Duration::from_secs(300);
             const DEVICE_MAX_AGE: Duration = Duration::from_secs(600);
+            let mut device_purge_interval = tokio::time::interval(DEVICE_PURGE_INTERVAL);
 
-            while let Some(received) = apdu_rx.recv().await {
-                let now = Instant::now();
+            loop {
+                tokio::select! {
+                    _ = device_purge_interval.tick() => {
+                        device_table_dispatch
+                            .lock()
+                            .await
+                            .purge_stale(DEVICE_MAX_AGE);
+                    }
+                    received = apdu_rx.recv() => {
+                        let Some(received) = received else {
+                            break;
+                        };
+                        let now = Instant::now();
 
-                // Periodically purge stale device table entries
-                if now.duration_since(last_device_purge) >= DEVICE_PURGE_INTERVAL {
-                    device_table_dispatch
-                        .lock()
-                        .await
-                        .purge_stale(DEVICE_MAX_AGE);
-                    last_device_purge = now;
-                }
-                // Reap stale segmented sessions and send Abort to the server
-                let stale_keys: Vec<SegKey> = seg_state
-                    .iter()
-                    .filter(|(_, state)| {
-                        now.duration_since(state.last_activity) >= SEG_RECEIVER_TIMEOUT
-                    })
-                    .map(|(key, _)| key.clone())
-                    .collect();
-                for key in &stale_keys {
-                    if let Some(state) = seg_state.remove(key) {
-                        let abort = Apdu::Abort(AbortPdu {
-                            sent_by_server: false,
-                            invoke_id: key.1,
-                            abort_reason: bacnet_types::enums::AbortReason::TSM_TIMEOUT,
-                        });
-                        let mut buf = BytesMut::with_capacity(4);
-                        if let Err(e) = encode_apdu(&mut buf, &abort) {
-                            warn!(error = %e, "Failed to encode segmented receive timeout Abort");
-                            continue;
+                        // Reap stale segmented sessions and send Abort to the server
+                        let stale_keys: Vec<SegKey> = seg_state
+                            .iter()
+                            .filter(|(_, state)| {
+                                now.duration_since(state.last_activity) >= SEG_RECEIVER_TIMEOUT
+                            })
+                            .map(|(key, _)| key.clone())
+                            .collect();
+                        for key in &stale_keys {
+                            if let Some(state) = seg_state.remove(key) {
+                                let abort = Apdu::Abort(AbortPdu {
+                                    sent_by_server: false,
+                                    invoke_id: key.1,
+                                    abort_reason: bacnet_types::enums::AbortReason::TSM_TIMEOUT,
+                                });
+                                let mut buf = BytesMut::with_capacity(4);
+                                if let Err(e) = encode_apdu(&mut buf, &abort) {
+                                    warn!(error = %e, "Failed to encode segmented receive timeout Abort");
+                                    continue;
+                                }
+                                let _ = network_dispatch
+                                    .send_apdu(&buf, &state.reply_mac, false, NetworkPriority::NORMAL)
+                                    .await;
+                            }
                         }
-                        let _ = network_dispatch
-                            .send_apdu(&buf, &state.reply_mac, false, NetworkPriority::NORMAL)
-                            .await;
-                    }
-                }
 
-                match apdu::decode_apdu(received.apdu.clone()) {
-                    Ok(decoded) => {
-                        Self::dispatch_apdu(
-                            &tsm_dispatch,
-                            &device_table_dispatch,
-                            &network_dispatch,
-                            &cov_tx_dispatch,
-                            &mut seg_state,
-                            &seg_ack_senders_dispatch,
-                            &received.source_mac,
-                            &received.source_network,
-                            decoded,
-                            segmented_response_accepted,
-                        )
-                        .await;
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "Failed to decode received APDU");
+                        match apdu::decode_apdu(received.apdu.clone()) {
+                            Ok(decoded) => {
+                                Self::dispatch_apdu(
+                                    &tsm_dispatch,
+                                    &device_table_dispatch,
+                                    &network_dispatch,
+                                    &cov_tx_dispatch,
+                                    &mut seg_state,
+                                    &seg_ack_senders_dispatch,
+                                    &received.source_mac,
+                                    &received.source_network,
+                                    decoded,
+                                    segmented_response_accepted,
+                                )
+                                .await;
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "Failed to decode received APDU");
+                            }
+                        }
                     }
                 }
             }

--- a/crates/bacnet-client/src/client/tests.rs
+++ b/crates/bacnet-client/src/client/tests.rs
@@ -3,7 +3,10 @@ use bacnet_encoding::apdu::{ComplexAck, SimpleAck};
 use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
 use bacnet_transport::loopback::LoopbackTransport;
 use bacnet_transport::port::TransportPort;
+use bacnet_types::enums::{ObjectType, Segmentation};
+use bacnet_types::primitives::ObjectIdentifier;
 use std::net::Ipv4Addr;
+use std::time::Instant;
 use tokio::time::Duration;
 
 async fn make_client() -> BACnetClient<BipTransport> {
@@ -120,6 +123,34 @@ async fn client_drop_releases_bip_socket() {
     })
     .await
     .expect("dropping BACnetClient releases the B/IP socket");
+}
+
+#[tokio::test(start_paused = true)]
+async fn device_table_purge_runs_without_inbound_apdu() {
+    let mut client = make_client().await;
+
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    client.device_table.lock().await.upsert(DiscoveredDevice {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 2001).unwrap(),
+        mac_address: MacAddr::from_slice(&[192, 168, 1, 42, 0xBA, 0xC0]),
+        max_apdu_length: 1476,
+        segmentation_supported: Segmentation::NONE,
+        max_segments_accepted: None,
+        vendor_id: 42,
+        last_seen: Instant::now() - Duration::from_secs(601),
+        source_network: None,
+        source_address: None,
+    });
+    assert_eq!(client.discovered_devices().await.len(), 1);
+
+    tokio::time::advance(Duration::from_secs(300)).await;
+    tokio::task::yield_now().await;
+
+    assert!(client.discovered_devices().await.is_empty());
+
+    client.stop().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Move `BACnetClient` device-table stale-entry purging onto an independent `tokio::time::interval` branch in the APDU dispatch task.
- Keep APDU receive handling and segmented-session timeout reaping on the receive branch.
- Add a paused-time regression test proving stale devices are purged without inbound APDUs.
- Add the dev-only Tokio `test-util` feature needed by the paused-time test.

## Validation

- `cargo fmt --all --check`
- `cargo test -p bacnet-client device_table_purge_runs_without_inbound_apdu --locked`
- `cargo test -p bacnet-client --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked`
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked`
- `cargo audit` (passes with existing allowed `RUSTSEC-2026-0190` warning for `anyhow`)
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked`
- `cargo deny check` (warnings only; advisories, bans, licenses, and sources OK)

## Notes

No version bumps, tags, release artifacts, `main` changes, or CI changes are included.

Fixes #75