### PR TITLE
fix(client): avoid device purge instant underflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Abort `BACnetClient` dispatch on drop and cascade B/IP network cleanup so ungraceful teardown releases reader tasks and the UDP socket.
 - Run `BACnetClient` device-table stale-entry purging on an independent interval so fully silent datalinks can evict dead devices.
+- Avoid `Instant` underflow in `BACnetClient` device-table purging on fresh Windows runners.
 
 ## [0.10.0]
 

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+const DEVICE_PURGE_INTERVAL: Duration = Duration::from_secs(300);
+#[cfg(not(test))]
+const DEVICE_MAX_AGE: Duration = Duration::from_secs(600);
+// Unit tests use Tokio's paused clock, while DeviceTable timestamps use
+// std::time::Instant. Use an immediate threshold so the purge timer is
+// observable without constructing an unrepresentable old Instant on Windows.
+#[cfg(test)]
+const DEVICE_MAX_AGE: Duration = Duration::ZERO;
+
 impl<T: TransportPort> BACnetClient<T> {
     fn abort_dispatch_task(&mut self) -> Option<JoinHandle<()>> {
         let task = self.dispatch_task.take()?;
@@ -46,8 +55,6 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 
         let dispatch_task = tokio::spawn(async move {
             let mut seg_state: HashMap<SegKey, SegmentedReceiveState> = HashMap::new();
-            const DEVICE_PURGE_INTERVAL: Duration = Duration::from_secs(300);
-            const DEVICE_MAX_AGE: Duration = Duration::from_secs(600);
             let mut device_purge_interval = tokio::time::interval(DEVICE_PURGE_INTERVAL);
 
             loop {

--- a/crates/bacnet-client/src/client/tests.rs
+++ b/crates/bacnet-client/src/client/tests.rs
@@ -139,7 +139,9 @@ async fn device_table_purge_runs_without_inbound_apdu() {
         segmentation_supported: Segmentation::NONE,
         max_segments_accepted: None,
         vendor_id: 42,
-        last_seen: Instant::now() - Duration::from_secs(601),
+        last_seen: Instant::now()
+            .checked_sub(Duration::from_millis(1))
+            .unwrap_or_else(Instant::now),
         source_network: None,
         source_address: None,
     });

--- a/crates/bacnet-client/src/discovery.rs
+++ b/crates/bacnet-client/src/discovery.rs
@@ -93,8 +93,14 @@ impl DeviceTable {
 
     /// Remove entries whose `last_seen` is older than `max_age`.
     pub fn purge_stale(&mut self, max_age: Duration) {
-        let cutoff = Instant::now() - max_age;
-        self.devices.retain(|_, d| d.last_seen >= cutoff);
+        self.purge_stale_at(Instant::now(), max_age);
+    }
+
+    fn purge_stale_at(&mut self, now: Instant, max_age: Duration) {
+        self.devices.retain(|_, d| {
+            now.checked_duration_since(d.last_seen)
+                .is_none_or(|age| age <= max_age)
+        });
     }
 }
 
@@ -173,13 +179,16 @@ mod tests {
     #[test]
     fn purge_stale_removes_old_entries() {
         let mut table = DeviceTable::new();
+        let now = Instant::now();
         let mut old_device = make_device(1);
-        old_device.last_seen = Instant::now() - Duration::from_secs(120);
+        old_device.last_seen = now;
         table.upsert(old_device);
-        table.upsert(make_device(2));
+        let mut fresh_device = make_device(2);
+        fresh_device.last_seen = now + Duration::from_secs(120);
+        table.upsert(fresh_device);
         assert_eq!(table.len(), 2);
 
-        table.purge_stale(Duration::from_secs(60));
+        table.purge_stale_at(now + Duration::from_secs(120), Duration::from_secs(60));
         assert_eq!(table.len(), 1);
         assert!(table.get(1).is_none());
         assert!(table.get(2).is_some());
@@ -197,26 +206,40 @@ mod tests {
     #[test]
     fn purge_stale_removes_all_when_expired() {
         let mut table = DeviceTable::new();
+        let now = Instant::now();
         let mut d1 = make_device(1);
-        d1.last_seen = Instant::now() - Duration::from_secs(200);
+        d1.last_seen = now;
         let mut d2 = make_device(2);
-        d2.last_seen = Instant::now() - Duration::from_secs(200);
+        d2.last_seen = now;
         table.upsert(d1);
         table.upsert(d2);
-        table.purge_stale(Duration::from_secs(60));
+        table.purge_stale_at(now + Duration::from_secs(200), Duration::from_secs(60));
         assert!(table.is_empty());
     }
 
     #[test]
     fn upsert_refreshes_last_seen() {
         let mut table = DeviceTable::new();
+        let now = Instant::now();
         let mut old_device = make_device(1);
-        old_device.last_seen = Instant::now() - Duration::from_secs(120);
+        old_device.last_seen = now;
         table.upsert(old_device);
 
-        table.upsert(make_device(1));
-        table.purge_stale(Duration::from_secs(60));
+        let mut refreshed = make_device(1);
+        refreshed.last_seen = now + Duration::from_secs(120);
+        table.upsert(refreshed);
+        table.purge_stale_at(now + Duration::from_secs(120), Duration::from_secs(60));
         assert_eq!(table.len(), 1);
         assert!(table.get(1).is_some());
+    }
+
+    #[test]
+    fn purge_stale_handles_max_age_larger_than_instant_history() {
+        let mut table = DeviceTable::new();
+        table.upsert(make_device(1));
+
+        table.purge_stale(Duration::MAX);
+
+        assert_eq!(table.len(), 1);
     }
 }


### PR DESCRIPTION

## Summary
- avoid `Instant` underflow in `DeviceTable::purge_stale` by comparing checked elapsed age instead of subtracting `max_age` from `Instant::now()`
- make stale-device purge tests portable on fresh Windows runners
- add a regression test for very large purge ages and document the test-only paused-clock threshold

## Why
PR #88 for issue #82 is blocked by Windows CI failures from the earlier #75 device-table purge work. The failed job panicked with `overflow when subtracting duration from instant` in `bacnet-client` tests. This PR keeps the #82 COV fix separate and repairs the #75 portability regression first.

## Review
Deep multipanel review completed locally before push:
- correctness-reviewer: approve, no blocking findings
- security-reliability-reviewer: approve, one non-blocking caveat about test-only max-age threshold
- test-verifier: approve, local command coverage matches the failing CI command but Windows CI remains required
- release-risk-reviewer: approve, no API/version/release risk

## Validation
- cargo fmt --all
- cargo test -p bacnet-client purge_stale --lib
- cargo test -p bacnet-client device_table_purge_runs_without_inbound_apdu --lib
- cargo test -p bacnet-client --lib
- cargo fmt --all -- --check
- cargo audit (existing allowed RUSTSEC-2026-0190 warning)
- bash .github/scripts/check-file-size.sh
- bash .github/scripts/check-no-secrets.sh
- git diff --check
- cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
- cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked
- cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked
- cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls
- cargo deny check (existing warnings only; advisories/bans/licenses/sources OK)

Follow-up to #75; unblocks #88.

No release, tag, main-branch, or version-bump work in this PR.
