### PR TITLE
Fix bacnet-client property method docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Avoid `Instant` underflow in `BACnetClient` device-table purging on fresh Windows runners.
 - Send the required initial COV notification after successful server-side COV subscription acceptance.
 - Encode `SubscribeCOVPropertyMultiple` lifetime/max-delay fields in standard order, validate their subscription/cancellation semantics, and expire server-side multiple-property COV subscriptions.
+- Correct `bacnet-client` property method rustdoc comments so read/write, auto-routing, and batch helpers describe the method they document.
 
 ## [0.10.0]
 

--- a/crates/bacnet-client/src/client/property.rs
+++ b/crates/bacnet-client/src/client/property.rs
@@ -100,7 +100,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         bacnet_services::read_property::ReadPropertyACK::decode(&response_data)
     }
 
-    /// Write a property on a remote device.
+    /// Read multiple properties from one or more objects on a remote device.
     pub async fn read_property_multiple(
         &self,
         destination_mac: &[u8],
@@ -125,7 +125,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         ReadPropertyMultipleACK::decode(&response_data)
     }
 
-    /// Write multiple properties on one or more objects on a remote device.
+    /// Read multiple properties from a discovered device, auto-routing if needed.
     pub async fn read_property_multiple_from_device(
         &self,
         device_instance: u32,
@@ -158,7 +158,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         }
     }
 
-    /// Write a property on a discovered device, auto-routing if needed.
+    /// Read one property from multiple discovered devices concurrently.
+    ///
+    /// All reads are dispatched concurrently (up to `max_concurrent`,
+    /// default 32). Results are returned in completion order.
     pub async fn read_property_from_devices(
         &self,
         requests: Vec<DeviceReadRequest>,
@@ -217,10 +220,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             .await
     }
 
-    /// Write a property on multiple devices concurrently.
-    ///
-    /// All writes are dispatched concurrently (up to `max_concurrent`,
-    /// default 32). Results are returned in completion order.
+    /// Write a property on a remote device.
     pub async fn write_property(
         &self,
         destination_mac: &[u8],
@@ -253,7 +253,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         Ok(())
     }
 
-    /// Read multiple properties from one or more objects on a remote device.
+    /// Write multiple properties on one or more objects on a remote device.
     pub async fn write_property_multiple(
         &self,
         destination_mac: &[u8],
@@ -282,7 +282,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     // Auto-routing _from_device variants (RPM, WP, WPM)
     // -----------------------------------------------------------------------
 
-    /// Read multiple properties from a discovered device, auto-routing if needed.
+    /// Write a property on a discovered device, auto-routing if needed.
     pub async fn write_property_to_device(
         &self,
         device_instance: u32,
@@ -361,6 +361,11 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             self.write_property_multiple(&mac, specs).await
         }
     }
+
+    /// Write one property on multiple discovered devices concurrently.
+    ///
+    /// All writes are dispatched concurrently (up to `max_concurrent`,
+    /// default 32). Results are returned in completion order.
     pub async fn write_property_to_devices(
         &self,
         requests: Vec<DeviceWriteRequest>,
@@ -390,5 +395,85 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             .buffer_unordered(concurrency)
             .collect()
             .await
+    }
+}
+
+#[cfg(test)]
+mod doc_tests {
+    const SOURCE: &str = include_str!("property.rs");
+
+    fn doc_block_for(fn_name: &str) -> String {
+        let needle = format!("pub async fn {fn_name}(");
+        let lines: Vec<_> = SOURCE.lines().collect();
+        let signature_index = lines
+            .iter()
+            .position(|line| line.trim_start().starts_with(&needle))
+            .unwrap_or_else(|| panic!("missing function {fn_name}"));
+        let mut docs = Vec::new();
+        let mut index = signature_index;
+        while index > 0 {
+            index -= 1;
+            let line = lines[index].trim_start();
+            if let Some(doc) = line.strip_prefix("///") {
+                docs.push(doc.trim());
+            } else {
+                break;
+            }
+        }
+        docs.reverse();
+        docs.join(" ")
+    }
+
+    #[test]
+    fn property_method_docblocks_match_their_methods() {
+        let cases = [
+            (
+                "read_property_multiple",
+                "Read multiple properties from one or more objects on a remote device.",
+                "Write",
+            ),
+            (
+                "read_property_multiple_from_device",
+                "Read multiple properties from a discovered device, auto-routing if needed.",
+                "Write",
+            ),
+            (
+                "read_property_from_devices",
+                "Read one property from multiple discovered devices concurrently.",
+                "Write",
+            ),
+            (
+                "write_property",
+                "Write a property on a remote device.",
+                "multiple devices concurrently",
+            ),
+            (
+                "write_property_multiple",
+                "Write multiple properties on one or more objects on a remote device.",
+                "Read",
+            ),
+            (
+                "write_property_to_device",
+                "Write a property on a discovered device, auto-routing if needed.",
+                "Read",
+            ),
+            (
+                "write_property_to_devices",
+                "Write one property on multiple discovered devices concurrently.",
+                "Read",
+            ),
+        ];
+
+        for (fn_name, expected, forbidden) in cases {
+            let docs = doc_block_for(fn_name);
+            assert!(
+                docs.contains(expected),
+                "{fn_name} docs did not contain expected text: {docs}"
+            );
+            assert!(
+                !docs.contains(forbidden),
+                "{fn_name} docs still contain misattributed text: {docs}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Scope

Fixes #84.

This PR corrects misattributed rustdoc comments in `crates/bacnet-client/src/client/property.rs` for the `BACnetClient` property read/write helpers and adds a narrow regression test so the affected docblocks stay attached to the intended functions.

Changed files:
- `crates/bacnet-client/src/client/property.rs`
- `CHANGELOG.md`

## Standard anchors

- Clause/Annex: N/A - rustdoc-only client API documentation fix.
- Tables/Figures: N/A.
- Addenda/errata checked: N/A.

## Current behavior

Several `BACnetClient` property helper doc comments were shifted from nearby methods, causing read helpers to describe write operations and write helpers to describe read or batch operations.

## Change summary

- Corrected rustdoc for `read_property_multiple`, `read_property_multiple_from_device`, and `read_property_from_devices`.
- Corrected rustdoc for `write_property`, `write_property_multiple`, `write_property_to_device`, and `write_property_to_devices`.
- Added `property_method_docblocks_match_their_methods` to guard the affected docblocks against future shifts.
- Added an `[Unreleased]` changelog entry.

## Unsupported/deferred variants

N/A - no protocol behavior or support matrix changed.

## Wire-format impact

- Byte-for-byte compatible: Yes. Comments, test code, and changelog only; no runtime encode/decode behavior changed.
- Fixtures added/updated: N/A.
- Migration notes: N/A.

## Conformance evidence

- Ledger rows: N/A - no conformance claim changed.
- Positive tests: `property_method_docblocks_match_their_methods`.
- Negative tests: The regression test rejects the old misattributed read/write text on each affected method.
- BTL/interop evidence, if any: N/A.

## Benchmark evidence, if applicable

- Base SHA: N/A.
- Head SHA: 7a5eafd.
- Commands: N/A.
- Raw output directory: N/A.
- Summary: N/A - docs/test-only change.
- Regression budget: N/A.
- Caveats: N/A.

## Python/WASM/CLI impact

N/A - no Python, WASM, or CLI code changed.

## Security/safety/interop review

No security, packet validation, routing, timeout, resource-cap, or interop behavior changed. Wire bytes are unchanged.

## Subagent findings

- `bacnet-reference-researcher`: Omitted; protocol semantics and Standard conformance are unchanged.
- `bacnet-ip-bvll-reviewer`: Omitted; no BVLL/BACnet/IP behavior changed.
- `bacnet-sc-security-reviewer`: Omitted; no BACnet/SC behavior changed.
- `bacnet-tsm-network-reviewer`: Omitted; no APDU/NPDU/TSM behavior changed.
- `bacnet-services-objects-reviewer`: Approved; corrected docs match the actual read/write, auto-routing, and concurrent multi-device behavior in `property.rs`.
- `bacnet-data-link-reviewer`: Omitted; no data-link behavior changed.
- `bacnet-performance-reviewer`: Omitted; no performance-sensitive code or benchmark claims changed.
- `bacnet-safety-interop-reviewer`: Omitted; no malformed packet, safety, routing, broadcast, or resource behavior changed.
- `bacnet-pr-packager`: Confirmed one-issue scope and no release/version/main boundary violation; requested packaging completion via commit, push, and full PR body.
- `test-verifier`: Approved; targeted regression and rendered rustdoc checks cover the affected doc comments.

## Verification run

```bash
cargo fmt --all -- --check
# passed

cargo test -p bacnet-client property_method_docblocks_match_their_methods --locked --quiet
# passed: 1 test passed

cargo check -p bacnet-client --tests --locked
# passed

git diff --check
# passed

bash .github/scripts/check-file-size.sh
# passed

bash .github/scripts/check-no-secrets.sh
# passed

cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
# passed with existing warnings

cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked
# passed with existing warnings

cargo audit
# passed with one allowed warning: RUSTSEC-2026-0190

cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked
# passed
```

## Known limitations and follow-ups

The regression test intentionally covers the seven issue #84 docblocks and is not a general semantic rustdoc verifier for every future helper in `property.rs`.
