### PR TITLE
fix(types): clarify object identifier wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Send the required initial COV notification after successful server-side COV subscription acceptance.
 - Encode `SubscribeCOVPropertyMultiple` lifetime/max-delay fields in standard order, validate their subscription/cancellation semantics, and expire server-side multiple-property COV subscriptions.
 - Correct `bacnet-client` property method rustdoc comments so read/write, auto-routing, and batch helpers describe the method they document.
+- Clarify `ObjectIdentifier` wildcard-instance semantics and add an addressable-object constructor that rejects the reserved wildcard value while preserving wire-level round trips.
 
 ## [0.10.0]
 

--- a/crates/bacnet-types/src/primitives.rs
+++ b/crates/bacnet-types/src/primitives.rs
@@ -17,6 +17,13 @@ use crate::error::Error;
 ///
 /// Uniquely identifies a BACnet object within a device. Encoded as a
 /// 4-byte big-endian value: `(object_type << 22) | instance_number`.
+///
+/// The all-ones instance value [`WILDCARD_INSTANCE`](Self::WILDCARD_INSTANCE)
+/// is still a valid 22-bit wire value, and some service contexts give it
+/// wildcard meaning. Use [`ObjectIdentifier::new`] or [`ObjectIdentifier::decode`]
+/// when preserving wire-level values. Use [`ObjectIdentifier::new_addressable`]
+/// when constructing identifiers for concrete objects that can be stored,
+/// addressed, or compared as actual object instances.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ObjectIdentifier {
     object_type: ObjectType,
@@ -24,13 +31,34 @@ pub struct ObjectIdentifier {
 }
 
 impl ObjectIdentifier {
-    /// Maximum valid instance number (2^22 - 1 = 4,194,303).
+    /// Maximum encodable instance number (2^22 - 1 = 4,194,303).
+    ///
+    /// This is also [`WILDCARD_INSTANCE`](Self::WILDCARD_INSTANCE). It is
+    /// accepted by [`ObjectIdentifier::new`] and [`ObjectIdentifier::decode`]
+    /// for wire compatibility, but callers that need a concrete addressable
+    /// object should use [`MAX_ADDRESSABLE_INSTANCE`](Self::MAX_ADDRESSABLE_INSTANCE)
+    /// or [`ObjectIdentifier::new_addressable`].
     pub const MAX_INSTANCE: u32 = 0x3F_FFFF;
 
-    /// The "wildcard" instance number used in WhoIs/IAm (4,194,303).
+    /// The reserved wildcard instance number (4,194,303).
+    ///
+    /// BACnet service clauses assign this value special "any/local instance"
+    /// meaning in selected contexts, for example Who-Is/Who-Am-I discovery and
+    /// Device/Network Port object access. It is not a concrete object instance
+    /// for addressable-object storage.
     pub const WILDCARD_INSTANCE: u32 = Self::MAX_INSTANCE;
 
-    /// Create a new ObjectIdentifier.
+    /// Maximum instance number for a concrete addressable object (4,194,302).
+    ///
+    /// This excludes [`WILDCARD_INSTANCE`](Self::WILDCARD_INSTANCE).
+    pub const MAX_ADDRESSABLE_INSTANCE: u32 = Self::WILDCARD_INSTANCE - 1;
+
+    /// Create a new ObjectIdentifier from any valid 22-bit wire instance.
+    ///
+    /// This constructor preserves [`WILDCARD_INSTANCE`](Self::WILDCARD_INSTANCE)
+    /// because it is a valid encoded value in BACnet service payloads. Use
+    /// [`ObjectIdentifier::new_addressable`] when the identifier must name a
+    /// concrete object instance.
     ///
     /// # Errors
     /// Returns `Err` if `instance_number` exceeds [`MAX_INSTANCE`](Self::MAX_INSTANCE).
@@ -40,6 +68,37 @@ impl ObjectIdentifier {
                 "instance number {} exceeds max {}",
                 instance_number,
                 Self::MAX_INSTANCE
+            )));
+        }
+        Ok(Self {
+            object_type,
+            instance_number,
+        })
+    }
+
+    /// Create a new ObjectIdentifier for a concrete addressable object.
+    ///
+    /// This rejects [`WILDCARD_INSTANCE`](Self::WILDCARD_INSTANCE), while
+    /// [`ObjectIdentifier::new`] keeps accepting that value for wire-level
+    /// round trips and BACnet service contexts where it is meaningful.
+    ///
+    /// # Errors
+    /// Returns `Err` if `instance_number` exceeds
+    /// [`MAX_INSTANCE`](Self::MAX_INSTANCE) or equals
+    /// [`WILDCARD_INSTANCE`](Self::WILDCARD_INSTANCE).
+    pub fn new_addressable(object_type: ObjectType, instance_number: u32) -> Result<Self, Error> {
+        if instance_number > Self::MAX_INSTANCE {
+            return Err(Error::OutOfRange(alloc_or_std_format!(
+                "instance number {} exceeds max {}",
+                instance_number,
+                Self::MAX_INSTANCE
+            )));
+        }
+        if instance_number == Self::WILDCARD_INSTANCE {
+            return Err(Error::OutOfRange(alloc_or_std_format!(
+                "instance number {} is reserved as the wildcard value; maximum addressable instance is {}",
+                instance_number,
+                Self::MAX_ADDRESSABLE_INSTANCE
             )));
         }
         Ok(Self {
@@ -62,6 +121,11 @@ impl ObjectIdentifier {
     }
 
     /// The instance number (0 to 4,194,303).
+    ///
+    /// Values returned from wire decoding may equal
+    /// [`WILDCARD_INSTANCE`](Self::WILDCARD_INSTANCE). Treat that value as a
+    /// concrete addressable object only after the relevant service context has
+    /// resolved its wildcard semantics.
     pub const fn instance_number(&self) -> u32 {
         self.instance_number
     }
@@ -486,6 +550,56 @@ mod tests {
         let bytes = oid.encode();
         let decoded = ObjectIdentifier::decode(&bytes).unwrap();
         assert_eq!(decoded.instance_number(), ObjectIdentifier::MAX_INSTANCE);
+
+        let raw_wire_value = ((ObjectType::DEVICE.to_raw() << 22)
+            | ObjectIdentifier::WILDCARD_INSTANCE)
+            .to_be_bytes();
+        let decoded = ObjectIdentifier::decode(&raw_wire_value).unwrap();
+        assert_eq!(decoded.object_type(), ObjectType::DEVICE);
+        assert_eq!(
+            decoded.instance_number(),
+            ObjectIdentifier::WILDCARD_INSTANCE
+        );
+    }
+
+    #[test]
+    fn object_identifier_new_addressable_rejects_wildcard() {
+        assert_eq!(
+            ObjectIdentifier::MAX_ADDRESSABLE_INSTANCE,
+            ObjectIdentifier::WILDCARD_INSTANCE - 1
+        );
+
+        let oid = ObjectIdentifier::new_addressable(
+            ObjectType::DEVICE,
+            ObjectIdentifier::MAX_ADDRESSABLE_INSTANCE,
+        )
+        .unwrap();
+        assert_eq!(
+            oid.instance_number(),
+            ObjectIdentifier::MAX_ADDRESSABLE_INSTANCE
+        );
+
+        let analog_input = ObjectIdentifier::new_addressable(
+            ObjectType::ANALOG_INPUT,
+            ObjectIdentifier::MAX_ADDRESSABLE_INSTANCE,
+        )
+        .unwrap();
+        assert_eq!(analog_input.object_type(), ObjectType::ANALOG_INPUT);
+        assert_eq!(
+            analog_input.instance_number(),
+            ObjectIdentifier::MAX_ADDRESSABLE_INSTANCE
+        );
+
+        let wildcard =
+            ObjectIdentifier::new_addressable(ObjectType::DEVICE, ObjectIdentifier::MAX_INSTANCE)
+                .unwrap_err();
+        assert!(wildcard.to_string().contains("wildcard"));
+
+        let too_large = ObjectIdentifier::new_addressable(
+            ObjectType::DEVICE,
+            ObjectIdentifier::MAX_INSTANCE + 1,
+        );
+        assert!(too_large.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #85.

## Scope

This PR updates `bacnet-types` `ObjectIdentifier` semantics only:

- Documents the split between encodable 22-bit object identifier instances and concrete addressable object instances.
- Adds `ObjectIdentifier::MAX_ADDRESSABLE_INSTANCE` and `ObjectIdentifier::new_addressable(...)`.
- Keeps `ObjectIdentifier::new(...)` and `ObjectIdentifier::decode(...)` permissive for wire-level round trips.
- Adds unit coverage for wildcard preservation, literal wire-value wildcard decode, addressable construction, wildcard rejection, and overrange rejection.
- Adds an Unreleased changelog entry.

Changed files:

- `CHANGELOG.md`
- `crates/bacnet-types/src/primitives.rs`

## Standard anchors

- Clause/Annex:
  - Clause 12.1: actual object instances exclude `4194303`, while some `BACnetObjectIdentifier` property values may use that value for special non-concrete states.
  - Clause 15.5 and 15.7: selected ReadProperty / ReadPropertyMultiple Device and Network Port object identifiers use instance `4194303` with local-object semantics.
  - Clause 16.10: Who-Is/I-Am device instance range includes `0..=4194303`.
  - Clause 16.11: Who-Am-I / You-Are discovery uses Device instance `4194303` as a special discovery value.
  - Clause 20.2.14: Object Identifier encodes object type plus a 22-bit instance field.
- Tables/Figures: none.
- Addenda/errata checked: local Standard 135-2020 PDF only; the local reference states it incorporates addenda/errata through `bz`. No post-2020 addenda review in this PR.

## Current behavior

`ObjectIdentifier::MAX_INSTANCE` and `ObjectIdentifier::WILDCARD_INSTANCE` are both `0x3F_FFFF` / `4_194_303`. `ObjectIdentifier::new(...)` accepts that value because it is a valid 22-bit wire value. That is useful for decoding and service payload round trips, but the public API did not clearly separate those wire values from concrete addressable object identifiers.

## Change summary

- Clarifies rustdoc for `MAX_INSTANCE`, `WILDCARD_INSTANCE`, `new(...)`, and `instance_number(...)`.
- Adds `MAX_ADDRESSABLE_INSTANCE = WILDCARD_INSTANCE - 1`.
- Adds `new_addressable(...)`, which rejects `WILDCARD_INSTANCE` while still rejecting values above the 22-bit maximum.
- Keeps existing `new(...)`, `new_unchecked(...)`, `encode(...)`, and `decode(...)` behavior unchanged.
- Extends tests so wildcard wire behavior remains preserved while concrete-object construction gets a validating path.

## Unsupported/deferred variants

- Existing object-layer constructors and databases are not migrated to `new_addressable(...)` in this PR.
- Python and WASM bindings continue exposing the existing permissive constructor.
- Service-level wildcard interpretation stays in service/object code; primitive decode does not try to resolve context.

## Wire-format impact

- Byte-for-byte compatible: yes. Encode/decode logic is unchanged.
- Fixtures added/updated: none.
- Migration notes: Rust callers that need concrete addressable object identifiers can opt into `ObjectIdentifier::new_addressable(...)`; callers that need wire-level values should keep using `ObjectIdentifier::new(...)` or `ObjectIdentifier::decode(...)`.

## Conformance evidence

- Ledger rows: none; this is an API/rustdoc clarification with unit tests, not a conformance-claim expansion.
- Positive tests:
  - `object_identifier_wildcard_instance` verifies `new(...)`, encode/decode, and literal raw-wire decode preserve `WILDCARD_INSTANCE`.
  - `object_identifier_new_addressable_rejects_wildcard` verifies `MAX_ADDRESSABLE_INSTANCE` is constructible for Device and Analog Input object types.
- Negative tests:
  - `object_identifier_new_addressable_rejects_wildcard` verifies `new_addressable(...)` rejects `WILDCARD_INSTANCE` and `MAX_INSTANCE + 1`.
- BTL/interop evidence, if any: none.

## Benchmark evidence, if applicable

- Base SHA: `b91266f`
- Head SHA: `f169eb9`
- Commands: not applicable.
- Raw output directory: not applicable.
- Summary: not applicable; docs/additive constructor/unit-test change only.
- Regression budget: not applicable.
- Caveats: no runtime path or wire codec change.

## Python/WASM/CLI impact

No binding or CLI behavior change. Rust API gains an additive constructor. Python/WASM parity for addressable-object validation is deferred because the issue can be closed with documented primitive semantics and a Rust validating constructor.

## Security/safety/interop review

The change reduces API ambiguity for callers that persist or address concrete objects. Wire-level wildcard values remain representable for discovery and service contexts, so this should not break interop with peers that use `4194303` in valid service payloads. No secrets, network behavior, release workflow, or CI configuration changed.

## Subagent findings

- `bacnet-reference-researcher`: approved the scoped primitive diff. It confirmed the Standard split between a valid 22-bit wire value and a value excluded from actual object instances, and recommended keeping wildcard resolution at service context boundaries.
- `bacnet-ip-bvll-reviewer`: not used; no Annex J/BVLL/BACnet/IP behavior changed.
- `bacnet-sc-security-reviewer`: not used; no BACnet/SC behavior changed.
- `bacnet-tsm-network-reviewer`: not used; no APDU TSM, segmentation, NPDU, or routing behavior changed.
- `bacnet-services-objects-reviewer`: approved the scoped fix and noted non-blocking follow-ups for object-model enforcement and Python/WASM parity.
- `bacnet-data-link-reviewer`: not used; no data-link behavior changed.
- `bacnet-performance-reviewer`: not used; no measured hotspot or runtime behavior changed.
- `bacnet-safety-interop-reviewer`: not used; safety/interop risk was covered by the reference and services/object review for this primitive-only change.
- `bacnet-pr-packager`: requested packaging changes before publish because the review happened before commit/PR creation, and advised explicit Standard anchors and benchmark N/A wording. This PR body incorporates those items.

## Verification run

```bash
cargo fmt --all -- --check
# pass

cargo test -p bacnet-types object_identifier_ --locked --quiet
# pass: 12 passed, 59 filtered

git diff --check
# pass

cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
# pass; existing warning noise only

cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked
# pass; existing warning noise only

cargo audit
# pass with allowed warning RUSTSEC-2026-0190 for anyhow 1.0.102

bash .github/scripts/check-file-size.sh
# pass: all tracked .rs files within the 700 LOC cap

bash .github/scripts/check-no-secrets.sh
# pass: baseline no-secret scan clean

cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked
# pass: bacnet-transport 354 tests, bacnet-types 71 tests, doctests pass with existing ignored SC TLS doctest

cargo doc -p bacnet-types --no-deps --locked
# pass; existing missing-doc and constructed/mod.rs [0]/[1] rustdoc warnings only

cargo deny check advisories bans licenses sources
# pass; existing configured warnings only
```

## Known limitations and follow-ups

- Existing concrete object constructors and `ObjectDatabase::add(...)` can still accept wildcard instances unless callers opt into `new_addressable(...)`.
- Python/WASM surfaces still expose only the permissive wire-level constructor.
- No release, tag, version bump, or main-branch PR is included; this is intended for the later `0.10.1` rollup.
