### PR TITLE
fix(client): make COV channel capacity configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Encode `SubscribeCOVPropertyMultiple` lifetime/max-delay fields in standard order, validate their subscription/cancellation semantics, and expire server-side multiple-property COV subscriptions.
 - Correct `bacnet-client` property method rustdoc comments so read/write, auto-routing, and batch helpers describe the method they document.
 - Clarify `ObjectIdentifier` wildcard-instance semantics and add an addressable-object constructor that rejects the reserved wildcard value while preserving wire-level round trips.
+- Make the `bacnet-client` COV notification broadcast channel capacity configurable while preserving the default capacity of 64.
 
 ## [0.10.0]
 

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -19,7 +19,16 @@ impl<T: TransportPort> BACnetClient<T> {
 
 impl<T: TransportPort + 'static> BACnetClient<T> {
     /// Start the client: bind transport, start network layer, spawn dispatch.
-    pub async fn start(mut config: ClientConfig, transport: T) -> Result<Self, Error> {
+    pub async fn start(config: ClientConfig, transport: T) -> Result<Self, Error> {
+        Self::start_with_options(config, transport, ClientOptions::default()).await
+    }
+
+    /// Start the client with additional startup options.
+    pub async fn start_with_options(
+        mut config: ClientConfig,
+        transport: T,
+        options: ClientOptions,
+    ) -> Result<Self, Error> {
         let transport_max = transport.max_apdu_length();
         config.max_apdu_length = config.max_apdu_length.min(transport_max);
         validate_max_apdu_length(config.max_apdu_length)?;
@@ -29,6 +38,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 config.proposed_window_size
             )));
         }
+        options.validate()?;
 
         let mut network = NetworkLayer::new(transport);
         let mut apdu_rx = network.start().await?;
@@ -46,7 +56,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let device_table = Arc::new(Mutex::new(DeviceTable::new()));
         let device_table_dispatch = Arc::clone(&device_table);
         let network_dispatch = Arc::clone(&network);
-        let (cov_tx, _) = broadcast::channel::<COVNotificationRequest>(64);
+        let (cov_tx, _) =
+            broadcast::channel::<COVNotificationRequest>(options.cov_channel_capacity);
         let cov_tx_dispatch = cov_tx.clone();
         let seg_ack_senders: Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>> =
             Arc::new(Mutex::new(HashMap::new()));

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -35,6 +35,12 @@ use crate::discovery::{DeviceTable, DiscoveredDevice};
 use crate::segmentation::{max_segment_payload, split_payload, SegmentReceiver, SegmentedPduType};
 use crate::tsm::{Tsm, TsmConfig, TsmResponse};
 
+/// Default COV notification broadcast channel capacity.
+pub const DEFAULT_COV_CHANNEL_CAPACITY: usize = 64;
+
+/// Maximum COV notification broadcast channel capacity accepted at startup.
+pub const MAX_COV_CHANNEL_CAPACITY: usize = 65_536;
+
 /// Client configuration.
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
@@ -58,6 +64,17 @@ pub struct ClientConfig {
     pub proposed_window_size: u8,
 }
 
+/// Additional client startup options.
+#[derive(Debug, Clone)]
+pub struct ClientOptions {
+    /// Capacity of the COV notification broadcast channel.
+    ///
+    /// Slow receivers lag once more than this many notifications arrive before
+    /// they call `recv()`. The default preserves the historical fixed capacity
+    /// of 64.
+    pub cov_channel_capacity: usize,
+}
+
 impl Default for ClientConfig {
     fn default() -> Self {
         Self {
@@ -74,9 +91,36 @@ impl Default for ClientConfig {
     }
 }
 
+impl Default for ClientOptions {
+    fn default() -> Self {
+        Self {
+            cov_channel_capacity: DEFAULT_COV_CHANNEL_CAPACITY,
+        }
+    }
+}
+
+impl ClientOptions {
+    /// Set the COV notification broadcast channel capacity.
+    pub fn with_cov_channel_capacity(mut self, capacity: usize) -> Self {
+        self.cov_channel_capacity = capacity;
+        self
+    }
+
+    fn validate(&self) -> Result<(), Error> {
+        if !(1..=MAX_COV_CHANNEL_CAPACITY).contains(&self.cov_channel_capacity) {
+            return Err(Error::Encoding(format!(
+                "invalid cov-channel-capacity {}; expected 1..={}",
+                self.cov_channel_capacity, MAX_COV_CHANNEL_CAPACITY
+            )));
+        }
+        Ok(())
+    }
+}
+
 /// Generic builder for BACnetClient with a pre-built transport.
 pub struct ClientBuilder<T: TransportPort> {
     config: ClientConfig,
+    options: ClientOptions,
     transport: Option<T>,
 }
 
@@ -99,18 +143,25 @@ impl<T: TransportPort + 'static> ClientBuilder<T> {
         self
     }
 
+    /// Set the COV notification broadcast channel capacity.
+    pub fn cov_channel_capacity(mut self, capacity: usize) -> Self {
+        self.options.cov_channel_capacity = capacity;
+        self
+    }
+
     /// Build and start the client.
     pub async fn build(self) -> Result<BACnetClient<T>, Error> {
         let transport = self
             .transport
             .ok_or_else(|| Error::Encoding("transport not set on ClientBuilder".into()))?;
-        BACnetClient::start(self.config, transport).await
+        BACnetClient::start_with_options(self.config, transport, self.options).await
     }
 }
 
 /// BIP-specific builder that constructs `BipTransport` from interface/port/broadcast fields.
 pub struct BipClientBuilder {
     config: ClientConfig,
+    options: ClientOptions,
 }
 
 impl BipClientBuilder {
@@ -144,6 +195,12 @@ impl BipClientBuilder {
         self
     }
 
+    /// Set the COV notification broadcast channel capacity.
+    pub fn cov_channel_capacity(mut self, capacity: usize) -> Self {
+        self.options.cov_channel_capacity = capacity;
+        self
+    }
+
     /// Build and start the client, constructing a BipTransport from the config.
     pub async fn build(self) -> Result<BACnetClient<BipTransport>, Error> {
         let transport = BipTransport::new(
@@ -151,7 +208,7 @@ impl BipClientBuilder {
             self.config.port,
             self.config.broadcast_address,
         );
-        BACnetClient::start(self.config, transport).await
+        BACnetClient::start_with_options(self.config, transport, self.options).await
     }
 }
 
@@ -266,6 +323,7 @@ impl BACnetClient<BipTransport> {
     pub fn bip_builder() -> BipClientBuilder {
         BipClientBuilder {
             config: ClientConfig::default(),
+            options: ClientOptions::default(),
         }
     }
 
@@ -330,6 +388,7 @@ impl BACnetClient<Bip6Transport> {
     pub fn bip6_builder() -> Bip6ClientBuilder {
         Bip6ClientBuilder {
             config: ClientConfig::default(),
+            options: ClientOptions::default(),
             interface: Ipv6Addr::UNSPECIFIED,
             device_instance: None,
         }
@@ -340,6 +399,7 @@ impl BACnetClient<Bip6Transport> {
 #[cfg(feature = "ipv6")]
 pub struct Bip6ClientBuilder {
     config: ClientConfig,
+    options: ClientOptions,
     interface: Ipv6Addr,
     device_instance: Option<u32>,
 }
@@ -376,10 +436,16 @@ impl Bip6ClientBuilder {
         self
     }
 
+    /// Set the COV notification broadcast channel capacity.
+    pub fn cov_channel_capacity(mut self, capacity: usize) -> Self {
+        self.options.cov_channel_capacity = capacity;
+        self
+    }
+
     /// Build and start the client, constructing a Bip6Transport from the config.
     pub async fn build(self) -> Result<BACnetClient<Bip6Transport>, Error> {
         let transport = Bip6Transport::new(self.interface, self.config.port, self.device_instance);
-        BACnetClient::start(self.config, transport).await
+        BACnetClient::start_with_options(self.config, transport, self.options).await
     }
 }
 
@@ -389,6 +455,7 @@ impl BACnetClient<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::Tl
     pub fn sc_builder() -> ScClientBuilder {
         ScClientBuilder {
             config: ClientConfig::default(),
+            options: ClientOptions::default(),
             hub_url: String::new(),
             tls_config: None,
             vmac: [0; 6],
@@ -405,6 +472,7 @@ impl BACnetClient<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::Tl
 #[cfg(feature = "sc-tls")]
 pub struct ScClientBuilder {
     config: ClientConfig,
+    options: ClientOptions,
     hub_url: String,
     tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ClientConfig>>,
     vmac: bacnet_transport::sc_frame::Vmac,
@@ -442,6 +510,12 @@ impl ScClientBuilder {
         self
     }
 
+    /// Set the COV notification broadcast channel capacity.
+    pub fn cov_channel_capacity(mut self, capacity: usize) -> Self {
+        self.options.cov_channel_capacity = capacity;
+        self
+    }
+
     /// Set the heartbeat interval in milliseconds (default 30 000).
     pub fn heartbeat_interval_ms(mut self, ms: u64) -> Self {
         self.heartbeat_interval_ms = ms;
@@ -470,6 +544,7 @@ impl ScClientBuilder {
         let tls_config = self
             .tls_config
             .ok_or_else(|| Error::Encoding("SC client builder: tls_config is required".into()))?;
+        self.options.validate()?;
 
         let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config).await?;
 
@@ -483,7 +558,7 @@ impl ScClientBuilder {
             }
         }
 
-        BACnetClient::start(self.config, transport).await
+        BACnetClient::start_with_options(self.config, transport, self.options).await
     }
 }
 
@@ -551,6 +626,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     pub fn generic_builder() -> ClientBuilder<T> {
         ClientBuilder {
             config: ClientConfig::default(),
+            options: ClientOptions::default(),
             transport: None,
         }
     }

--- a/crates/bacnet-client/src/client/tests.rs
+++ b/crates/bacnet-client/src/client/tests.rs
@@ -7,6 +7,7 @@ use bacnet_types::enums::{ObjectType, Segmentation};
 use bacnet_types::primitives::ObjectIdentifier;
 use std::net::Ipv4Addr;
 use std::time::Instant;
+use tokio::sync::broadcast::error::RecvError;
 use tokio::time::Duration;
 
 async fn make_client() -> BACnetClient<BipTransport> {
@@ -165,6 +166,45 @@ async fn client_rejects_invalid_max_apdu_length() {
         .await;
 
     assert!(result.is_err());
+}
+
+fn cov_notification(process_id: u32) -> COVNotificationRequest {
+    COVNotificationRequest {
+        subscriber_process_identifier: process_id,
+        initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 100).unwrap(),
+        monitored_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+        time_remaining: 60,
+        list_of_values: Vec::new(),
+    }
+}
+
+#[tokio::test]
+async fn cov_notification_channel_uses_configured_capacity() {
+    assert_eq!(ClientOptions::default().cov_channel_capacity, 64);
+    let max_options = ClientOptions::default().with_cov_channel_capacity(MAX_COV_CHANNEL_CAPACITY);
+    assert!(max_options.validate().is_ok());
+    for capacity in [0, MAX_COV_CHANNEL_CAPACITY + 1] {
+        let (bad_transport, _) = LoopbackTransport::pair(vec![0x10], vec![0x11]);
+        assert!(BACnetClient::generic_builder()
+            .transport(bad_transport)
+            .cov_channel_capacity(capacity)
+            .build()
+            .await
+            .is_err());
+    }
+    let (transport, _) = LoopbackTransport::pair(vec![0x20], vec![0x21]);
+    let mut client = BACnetClient::generic_builder()
+        .transport(transport)
+        .cov_channel_capacity(1)
+        .build()
+        .await
+        .unwrap();
+    let mut rx = client.cov_notifications();
+    client.cov_tx.send(cov_notification(1)).unwrap();
+    client.cov_tx.send(cov_notification(2)).unwrap();
+    assert!(matches!(rx.recv().await, Err(RecvError::Lagged(1))));
+    assert_eq!(rx.recv().await.unwrap().subscriber_process_identifier, 2);
+    client.stop().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Scope

Fixes #77.

This is a `bacnet-client` runtime-buffering change for decoded COV notifications. It adds an additive capacity option for the client-side Tokio broadcast channel while preserving the historical default of 64.

Changed files:

- `CHANGELOG.md`
- `crates/bacnet-client/src/client/mod.rs`
- `crates/bacnet-client/src/client/lifecycle.rs`
- `crates/bacnet-client/src/client/tests.rs`

## Standard anchors

- Clause/Annex: N/A. This is local client buffering after COV notification decode, not ASHRAE 135 wire behavior.
- Tables/Figures: N/A.
- Addenda/errata checked: N/A.

## Current behavior

`BACnetClient::start` created `broadcast::channel::<COVNotificationRequest>(64)` directly. Slow COV notification receivers therefore lagged according to Tokio broadcast semantics once they fell behind the fixed capacity, and callers could not tune that local buffer size.

## Change summary

- Add `DEFAULT_COV_CHANNEL_CAPACITY = 64` and `MAX_COV_CHANNEL_CAPACITY = 65_536`.
- Add additive `ClientOptions` with `cov_channel_capacity`.
- Keep `ClientConfig` fields unchanged and preserve the existing `BACnetClient::start(config, transport)` signature.
- Add `BACnetClient::start_with_options(config, transport, options)` for direct callers that need options.
- Add `.cov_channel_capacity(...)` setters to the generic, B/IP, B/IP6, and BACnet/SC builders.
- Validate accepted capacity range `1..=65_536` before network startup; the SC builder validates before `TlsWebSocket::connect`.
- Thread the validated option into `broadcast::channel`.
- Add regression coverage for default capacity, max accepted, invalid bounds, and capacity-1 lag behavior.

## Unsupported/deferred variants

Python, WASM, and CLI wrappers are not extended in this PR. They continue using the default COV notification buffer capacity unless a future PR exposes this Rust client option there.

## Wire-format impact

- Byte-for-byte compatible: Yes. No APDU, NPDU, BVLL, service encode/decode, transport wire bytes, or COV acknowledgement semantics changed.
- Fixtures added/updated: None.
- Migration notes: No migration required. `ClientConfig` remains source-compatible; new tuning is available through `.cov_channel_capacity(n)` or `BACnetClient::start_with_options(..., ClientOptions::default().with_cov_channel_capacity(n))`.

## Conformance evidence

- Ledger rows: N/A.
- Positive tests: `cov_notification_channel_uses_configured_capacity`.
- Negative tests: invalid `0` and `MAX_COV_CHANNEL_CAPACITY + 1` capacity values reject before startup.
- BTL/interop evidence, if any: N/A.

## Benchmark evidence, if applicable

- Base SHA: N/A.
- Head SHA: `b693516`.
- Commands: N/A.
- Raw output directory: N/A.
- Summary: No benchmark claim.
- Regression budget: N/A.
- Caveats: Larger capacities allocate larger local broadcast buffers; slow receivers can still lag if they fall behind the configured capacity.

## Python/WASM/CLI impact

No Python, WASM, or CLI API changes. Existing wrapper behavior remains on the default capacity of 64.

## Security/safety/interop review

Invalid capacities now fail closed with `Error::Encoding` instead of relying on Tokio broadcast panics. Validation runs before `NetworkLayer::new/start`, and the BACnet/SC builder validates before outbound TLS/WebSocket connection attempts. This is local configuration only and is not remotely triggerable through BACnet packets.

## Subagent findings

- `bacnet-services-objects-reviewer`: Approved. No BACnet wire behavior change; Rust `bacnet-client` scope matches issue #77.
- `bacnet-safety-interop-reviewer`: Requested oversized-capacity and SC fail-closed fixes; approved after `MAX_COV_CHANNEL_CAPACITY` validation and pre-connect SC validation.
- `release-risk-reviewer`: Requested removal of source-breaking `ClientConfig` field; approved after moving capacity into additive `ClientOptions` / `start_with_options`.
- `test-verifier`: Approved. Regression proves configured capacity is used and invalid bounds are rejected.
- `bacnet-pr-packager`: Approved for packaging. PR body should mark Standard/wire/ledger sections N/A and avoid conformance overclaiming.

## Verification run

```bash
cargo fmt --all -- --check
git diff --check
bash .github/scripts/check-file-size.sh
bash .github/scripts/check-no-secrets.sh
cargo test -p bacnet-client cov_notification_channel_uses_configured_capacity --locked --quiet
cargo check -p bacnet-client --tests --all-features --locked
cargo test -p bacnet-client --locked --quiet
cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked
cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked
cargo audit
cargo deny check advisories bans licenses sources
```

All commands passed. Existing warning noise remains: missing-docs/clippy print warnings, the allowed `RUSTSEC-2026-0190` `anyhow` audit warning, and configured `cargo deny` warnings for unmatched license allowances/exceptions and duplicate Windows crates.

## Known limitations and follow-ups

- Slow receivers can still receive `RecvError::Lagged(n)` after falling behind the configured capacity.
- Python/WASM/CLI exposure is intentionally deferred.
- No release, tag, version bump, or main-branch action in this PR; this change is intended to roll into the later 0.10.1 release bundle.
