### PR TITLE
Fix #73: add BACnet client device events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `BACnetClient::device_events()` with discovery/update/loss notifications while keeping `discovered_devices()` as the device-table snapshot API.
+
 ### Fixed
 
 - Abort `BACnetClient` dispatch on drop and cascade B/IP network cleanup so ungraceful teardown releases reader tasks and the UDP socket.

--- a/crates/bacnet-client/src/client/device_events.rs
+++ b/crates/bacnet-client/src/client/device_events.rs
@@ -1,0 +1,12 @@
+use super::*;
+
+impl<T: TransportPort + 'static> BACnetClient<T> {
+    /// Get a receiver for device discovery events. Each call returns a new
+    /// independent receiver.
+    ///
+    /// Events are notification-only; `discovered_devices()` remains the
+    /// authoritative snapshot of the current discovery table.
+    pub fn device_events(&self) -> broadcast::Receiver<DeviceEvent> {
+        self.device_tx.subscribe()
+    }
+}

--- a/crates/bacnet-client/src/client/device_events_tests.rs
+++ b/crates/bacnet-client/src/client/device_events_tests.rs
@@ -1,0 +1,115 @@
+use super::*;
+use bacnet_encoding::apdu::{encode_apdu, UnconfirmedRequest};
+use bacnet_encoding::npdu::{encode_npdu, Npdu};
+use bacnet_services::who_is::IAmRequest;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::enums::{ObjectType, Segmentation};
+use bacnet_types::primitives::ObjectIdentifier;
+
+fn i_am_npdu(instance: u32, vendor_id: u16) -> BytesMut {
+    let mut service_request = BytesMut::new();
+    IAmRequest {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, instance).unwrap(),
+        max_apdu_length: 1476,
+        segmentation_supported: Segmentation::NONE,
+        vendor_id,
+    }
+    .encode(&mut service_request);
+
+    let apdu = Apdu::UnconfirmedRequest(UnconfirmedRequest {
+        service_choice: UnconfirmedServiceChoice::I_AM,
+        service_request: service_request.freeze(),
+    });
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &apdu).unwrap();
+
+    let npdu = Npdu {
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu).unwrap();
+    npdu_buf
+}
+
+#[tokio::test]
+async fn device_events_emit_discovered_and_updated_for_i_am() {
+    let client_mac = vec![0x01];
+    let sender_mac = vec![0x02];
+    let (client_transport, sender_transport) =
+        LoopbackTransport::pair(client_mac, sender_mac.clone());
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+    let mut events = client.device_events();
+
+    sender_transport
+        .send_unicast(&i_am_npdu(1001, 42), client.local_mac())
+        .await
+        .unwrap();
+    let event = timeout(Duration::from_secs(1), events.recv())
+        .await
+        .expect("timed out waiting for discovered event")
+        .expect("device event channel closed");
+    assert_eq!(event.kind, DeviceEventKind::Discovered);
+    assert_eq!(event.device.object_identifier.instance_number(), 1001);
+    assert_eq!(event.device.mac_address.as_slice(), sender_mac.as_slice());
+    assert_eq!(event.device.vendor_id, 42);
+
+    sender_transport
+        .send_unicast(&i_am_npdu(1001, 84), client.local_mac())
+        .await
+        .unwrap();
+    let event = timeout(Duration::from_secs(1), events.recv())
+        .await
+        .expect("timed out waiting for updated event")
+        .expect("device event channel closed");
+    assert_eq!(event.kind, DeviceEventKind::Updated);
+    assert_eq!(event.device.object_identifier.instance_number(), 1001);
+    assert_eq!(event.device.vendor_id, 84);
+    assert_eq!(client.get_device(1001).await.unwrap().vendor_id, 84);
+
+    client.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn device_events_emit_lost_when_purge_removes_stale_device() {
+    let (client_transport, _peer_transport) = LoopbackTransport::pair(vec![0x10], vec![0x11]);
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+    let mut events = client.device_events();
+
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    client.device_table.lock().await.upsert(DiscoveredDevice {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 2001).unwrap(),
+        mac_address: MacAddr::from_slice(&[192, 168, 1, 42, 0xBA, 0xC0]),
+        max_apdu_length: 1476,
+        segmentation_supported: Segmentation::NONE,
+        max_segments_accepted: None,
+        vendor_id: 42,
+        last_seen: Instant::now()
+            .checked_sub(Duration::from_millis(1))
+            .unwrap_or_else(Instant::now),
+        source_network: None,
+        source_address: None,
+    });
+
+    tokio::time::advance(Duration::from_secs(300)).await;
+    tokio::task::yield_now().await;
+    tokio::task::yield_now().await;
+
+    let event = events.try_recv().expect("lost device event");
+    assert_eq!(event.kind, DeviceEventKind::Lost);
+    assert_eq!(event.device.object_identifier.instance_number(), 2001);
+    assert!(client.discovered_devices().await.is_empty());
+
+    client.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -8,6 +8,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         device_table: &Arc<Mutex<DeviceTable>>,
         network: &Arc<NetworkLayer<T>>,
         cov_tx: &broadcast::Sender<COVNotificationRequest>,
+        device_tx: &broadcast::Sender<DeviceEvent>,
         seg_state: &mut HashMap<SegKey, SegmentedReceiveState>,
         seg_ack_senders: &Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
         source_mac: &[u8],
@@ -143,7 +144,16 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                 source_network: src_net,
                                 source_address: src_addr,
                             };
-                            device_table.lock().await.upsert(device);
+                            let status =
+                                device_table.lock().await.upsert_with_result(device.clone());
+                            let kind = match status {
+                                DeviceUpsertResult::Inserted => Some(DeviceEventKind::Discovered),
+                                DeviceUpsertResult::Updated => Some(DeviceEventKind::Updated),
+                                DeviceUpsertResult::Dropped => None,
+                            };
+                            if let Some(kind) = kind {
+                                let _ = device_tx.send(DeviceEvent { kind, device });
+                            }
                         }
                         Err(e) => {
                             warn!(error = %e, "Failed to decode IAm");

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -59,6 +59,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let (cov_tx, _) =
             broadcast::channel::<COVNotificationRequest>(options.cov_channel_capacity);
         let cov_tx_dispatch = cov_tx.clone();
+        let (device_tx, _) = broadcast::channel::<DeviceEvent>(DEVICE_EVENT_CHANNEL_CAPACITY);
+        let device_tx_dispatch = device_tx.clone();
         let seg_ack_senders: Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let seg_ack_senders_dispatch = Arc::clone(&seg_ack_senders);
@@ -71,10 +73,16 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             loop {
                 tokio::select! {
                     _ = device_purge_interval.tick() => {
-                        device_table_dispatch
+                        let lost_devices = device_table_dispatch
                             .lock()
                             .await
-                            .purge_stale(DEVICE_MAX_AGE);
+                            .purge_stale_collect(DEVICE_MAX_AGE);
+                        for device in lost_devices {
+                            let _ = device_tx_dispatch.send(DeviceEvent {
+                                kind: DeviceEventKind::Lost,
+                                device,
+                            });
+                        }
                     }
                     received = apdu_rx.recv() => {
                         let Some(received) = received else {
@@ -115,6 +123,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     &device_table_dispatch,
                                     &network_dispatch,
                                     &cov_tx_dispatch,
+                                    &device_tx_dispatch,
                                     &mut seg_state,
                                     &seg_ack_senders_dispatch,
                                     &received.source_mac,
@@ -139,6 +148,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             tsm,
             device_table,
             cov_tx,
+            device_tx,
             dispatch_task: Some(dispatch_task),
             seg_ack_senders,
             local_mac,

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -31,7 +31,7 @@ use bacnet_types::enums::{ConfirmedServiceChoice, NetworkPriority, UnconfirmedSe
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 
-use crate::discovery::{DeviceTable, DiscoveredDevice};
+use crate::discovery::{DeviceTable, DeviceUpsertResult, DiscoveredDevice};
 use crate::segmentation::{max_segment_payload, split_payload, SegmentReceiver, SegmentedPduType};
 use crate::tsm::{Tsm, TsmConfig, TsmResponse};
 
@@ -40,6 +40,29 @@ pub const DEFAULT_COV_CHANNEL_CAPACITY: usize = 64;
 
 /// Maximum COV notification broadcast channel capacity accepted at startup.
 pub const MAX_COV_CHANNEL_CAPACITY: usize = 65_536;
+
+/// Device discovery event broadcast channel capacity.
+pub const DEVICE_EVENT_CHANNEL_CAPACITY: usize = 64;
+
+/// Type of change observed in the device discovery table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceEventKind {
+    /// A new device instance was inserted into the discovery table.
+    Discovered,
+    /// An existing device instance was refreshed by a later I-Am.
+    Updated,
+    /// A previously discovered device was purged as stale.
+    Lost,
+}
+
+/// Notification emitted when the client observes a device discovery change.
+#[derive(Debug, Clone)]
+pub struct DeviceEvent {
+    /// The kind of discovery-table change.
+    pub kind: DeviceEventKind,
+    /// Snapshot of the device entry after discovery/update or before removal.
+    pub device: DiscoveredDevice,
+}
 
 /// Client configuration.
 #[derive(Debug, Clone)]
@@ -313,6 +336,7 @@ pub struct BACnetClient<T: TransportPort> {
     tsm: Arc<Mutex<Tsm>>,
     device_table: Arc<Mutex<DeviceTable>>,
     cov_tx: broadcast::Sender<COVNotificationRequest>,
+    device_tx: broadcast::Sender<DeviceEvent>,
     dispatch_task: Option<JoinHandle<()>>,
     seg_ack_senders: Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
     local_mac: MacAddr,
@@ -608,6 +632,7 @@ fn response_tsm_mac(source_mac: &[u8], source_network: &Option<NpduAddress>) -> 
 }
 
 mod cov;
+mod device_events;
 mod device_mgmt;
 mod discovery;
 mod dispatch;
@@ -618,6 +643,8 @@ mod property;
 mod requests;
 mod segmentation;
 
+#[cfg(test)]
+mod device_events_tests;
 #[cfg(test)]
 mod tests;
 

--- a/crates/bacnet-client/src/discovery.rs
+++ b/crates/bacnet-client/src/discovery.rs
@@ -39,6 +39,13 @@ pub struct DeviceTable {
     devices: HashMap<u32, DiscoveredDevice>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DeviceUpsertResult {
+    Inserted,
+    Updated,
+    Dropped,
+}
+
 impl DeviceTable {
     pub fn new() -> Self {
         Self {
@@ -51,12 +58,22 @@ impl DeviceTable {
     /// The table is capped at 4096 entries. If the table is full and the
     /// device is not already present, the new entry is silently dropped.
     pub fn upsert(&mut self, device: DiscoveredDevice) {
+        let _ = self.upsert_with_result(device);
+    }
+
+    pub(crate) fn upsert_with_result(&mut self, device: DiscoveredDevice) -> DeviceUpsertResult {
         const MAX_DEVICE_TABLE_ENTRIES: usize = 4096;
         let key = device.object_identifier.instance_number();
-        if !self.devices.contains_key(&key) && self.devices.len() >= MAX_DEVICE_TABLE_ENTRIES {
-            return;
+        let is_existing = self.devices.contains_key(&key);
+        if !is_existing && self.devices.len() >= MAX_DEVICE_TABLE_ENTRIES {
+            return DeviceUpsertResult::Dropped;
         }
         self.devices.insert(key, device);
+        if is_existing {
+            DeviceUpsertResult::Updated
+        } else {
+            DeviceUpsertResult::Inserted
+        }
     }
 
     /// Get all discovered devices as a snapshot.
@@ -93,14 +110,29 @@ impl DeviceTable {
 
     /// Remove entries whose `last_seen` is older than `max_age`.
     pub fn purge_stale(&mut self, max_age: Duration) {
-        self.purge_stale_at(Instant::now(), max_age);
+        let _ = self.purge_stale_at(Instant::now(), max_age);
     }
 
-    fn purge_stale_at(&mut self, now: Instant, max_age: Duration) {
-        self.devices.retain(|_, d| {
-            now.checked_duration_since(d.last_seen)
-                .is_none_or(|age| age <= max_age)
-        });
+    pub(crate) fn purge_stale_collect(&mut self, max_age: Duration) -> Vec<DiscoveredDevice> {
+        self.purge_stale_at(Instant::now(), max_age)
+    }
+
+    fn purge_stale_at(&mut self, now: Instant, max_age: Duration) -> Vec<DiscoveredDevice> {
+        let stale_keys: Vec<u32> = self
+            .devices
+            .iter()
+            .filter_map(|(key, device)| {
+                let is_stale = now
+                    .checked_duration_since(device.last_seen)
+                    .is_some_and(|age| age > max_age);
+                is_stale.then_some(*key)
+            })
+            .collect();
+
+        stale_keys
+            .into_iter()
+            .filter_map(|key| self.devices.remove(&key))
+            .collect()
     }
 }
 
@@ -141,6 +173,19 @@ mod tests {
         table.upsert(updated);
         assert_eq!(table.len(), 1);
         assert_eq!(table.get(1234).unwrap().vendor_id, 99);
+    }
+
+    #[test]
+    fn upsert_with_result_reports_insert_and_update() {
+        let mut table = DeviceTable::new();
+        assert_eq!(
+            table.upsert_with_result(make_device(1234)),
+            DeviceUpsertResult::Inserted
+        );
+        assert_eq!(
+            table.upsert_with_result(make_device(1234)),
+            DeviceUpsertResult::Updated
+        );
     }
 
     #[test]
@@ -188,8 +233,10 @@ mod tests {
         table.upsert(fresh_device);
         assert_eq!(table.len(), 2);
 
-        table.purge_stale_at(now + Duration::from_secs(120), Duration::from_secs(60));
+        let removed = table.purge_stale_at(now + Duration::from_secs(120), Duration::from_secs(60));
         assert_eq!(table.len(), 1);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].object_identifier.instance_number(), 1);
         assert!(table.get(1).is_none());
         assert!(table.get(2).is_some());
     }
@@ -213,8 +260,9 @@ mod tests {
         d2.last_seen = now;
         table.upsert(d1);
         table.upsert(d2);
-        table.purge_stale_at(now + Duration::from_secs(200), Duration::from_secs(60));
+        let removed = table.purge_stale_at(now + Duration::from_secs(200), Duration::from_secs(60));
         assert!(table.is_empty());
+        assert_eq!(removed.len(), 2);
     }
 
     #[test]
@@ -228,8 +276,9 @@ mod tests {
         let mut refreshed = make_device(1);
         refreshed.last_seen = now + Duration::from_secs(120);
         table.upsert(refreshed);
-        table.purge_stale_at(now + Duration::from_secs(120), Duration::from_secs(60));
+        let removed = table.purge_stale_at(now + Duration::from_secs(120), Duration::from_secs(60));
         assert_eq!(table.len(), 1);
+        assert!(removed.is_empty());
         assert!(table.get(1).is_some());
     }
 


### PR DESCRIPTION
## Summary
- Add BACnetClient::device_events() with DeviceEvent/DeviceEventKind for Discovered, Updated, and Lost notifications.
- Emit device events from inbound I-Am dispatch after successful DeviceTable upsert and from the stale-device purge path before removal is discarded.
- Keep discovered_devices() and DeviceTable as the pull/snapshot source of truth, preserving existing upsert/purge APIs via crate-private helpers.
- Add focused loopback tests for I-Am discovered/updated events and purge-driven lost events.

## Validation
- cargo fmt --all --check
- cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
- cargo test -p bacnet-client
- cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked
- bash .github/scripts/check-file-size.sh
- bash .github/scripts/check-no-secrets.sh

Closes #73