### PR TITLE
Fix #76: add BACnet client builder APDU options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `BACnetClient::device_events()` with discovery/update/loss notifications while keeping `discovered_devices()` as the device-table snapshot API.
+- Add BACnet client builder setters for APDU retries, accepted segment count, segmented-response acceptance, and proposed window size.
 
 ### Fixed
 

--- a/crates/bacnet-client/src/client/builder_options.rs
+++ b/crates/bacnet-client/src/client/builder_options.rs
@@ -1,0 +1,107 @@
+use super::*;
+
+impl<T: TransportPort + 'static> ClientBuilder<T> {
+    /// Set the number of APDU retries before a confirmed request times out.
+    pub fn apdu_retries(mut self, retries: u8) -> Self {
+        self.config.apdu_retries = retries;
+        self
+    }
+
+    /// Set the maximum number of APDU segments this client accepts.
+    pub fn max_segments(mut self, max_segments: Option<u8>) -> Self {
+        self.config.max_segments = max_segments;
+        self
+    }
+
+    /// Set whether this client accepts segmented responses.
+    pub fn segmented_response_accepted(mut self, accepted: bool) -> Self {
+        self.config.segmented_response_accepted = accepted;
+        self
+    }
+
+    /// Set the proposed segmented-transfer window size.
+    pub fn proposed_window_size(mut self, window_size: u8) -> Self {
+        self.config.proposed_window_size = window_size;
+        self
+    }
+}
+
+impl BipClientBuilder {
+    /// Set the number of APDU retries before a confirmed request times out.
+    pub fn apdu_retries(mut self, retries: u8) -> Self {
+        self.config.apdu_retries = retries;
+        self
+    }
+
+    /// Set the maximum number of APDU segments this client accepts.
+    pub fn max_segments(mut self, max_segments: Option<u8>) -> Self {
+        self.config.max_segments = max_segments;
+        self
+    }
+
+    /// Set whether this client accepts segmented responses.
+    pub fn segmented_response_accepted(mut self, accepted: bool) -> Self {
+        self.config.segmented_response_accepted = accepted;
+        self
+    }
+
+    /// Set the proposed segmented-transfer window size.
+    pub fn proposed_window_size(mut self, window_size: u8) -> Self {
+        self.config.proposed_window_size = window_size;
+        self
+    }
+}
+
+#[cfg(feature = "ipv6")]
+impl Bip6ClientBuilder {
+    /// Set the number of APDU retries before a confirmed request times out.
+    pub fn apdu_retries(mut self, retries: u8) -> Self {
+        self.config.apdu_retries = retries;
+        self
+    }
+
+    /// Set the maximum number of APDU segments this client accepts.
+    pub fn max_segments(mut self, max_segments: Option<u8>) -> Self {
+        self.config.max_segments = max_segments;
+        self
+    }
+
+    /// Set whether this client accepts segmented responses.
+    pub fn segmented_response_accepted(mut self, accepted: bool) -> Self {
+        self.config.segmented_response_accepted = accepted;
+        self
+    }
+
+    /// Set the proposed segmented-transfer window size.
+    pub fn proposed_window_size(mut self, window_size: u8) -> Self {
+        self.config.proposed_window_size = window_size;
+        self
+    }
+}
+
+#[cfg(feature = "sc-tls")]
+impl ScClientBuilder {
+    /// Set the number of APDU retries before a confirmed request times out.
+    pub fn apdu_retries(mut self, retries: u8) -> Self {
+        self.config.apdu_retries = retries;
+        self
+    }
+
+    /// Set the maximum number of APDU segments this client accepts.
+    pub fn max_segments(mut self, max_segments: Option<u8>) -> Self {
+        self.config.max_segments = max_segments;
+        self
+    }
+
+    /// Set whether this client accepts segmented responses.
+    pub fn segmented_response_accepted(mut self, accepted: bool) -> Self {
+        self.config.segmented_response_accepted = accepted;
+        self
+    }
+
+    /// Set the proposed segmented-transfer window size.
+    pub fn proposed_window_size(mut self, window_size: u8) -> Self {
+        self.config.proposed_window_size = window_size;
+        self
+    }
+}

--- a/crates/bacnet-client/src/client/builder_options_tests.rs
+++ b/crates/bacnet-client/src/client/builder_options_tests.rs
@@ -1,0 +1,56 @@
+use super::*;
+use bacnet_transport::loopback::LoopbackTransport;
+use std::net::Ipv4Addr;
+
+fn assert_apdu_tuning(config: &ClientConfig) {
+    assert_eq!(config.apdu_retries, 7);
+    assert_eq!(config.max_segments, Some(8));
+    assert!(!config.segmented_response_accepted);
+    assert_eq!(config.proposed_window_size, 4);
+}
+
+#[tokio::test]
+async fn generic_builder_sets_apdu_tuning_options() {
+    let (transport, _peer_transport) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let mut client = BACnetClient::generic_builder()
+        .transport(transport)
+        .apdu_retries(7)
+        .max_segments(Some(8))
+        .segmented_response_accepted(false)
+        .proposed_window_size(4)
+        .build()
+        .await
+        .unwrap();
+
+    assert_apdu_tuning(&client.config);
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn bip_builder_sets_apdu_tuning_options() {
+    let mut client = BACnetClient::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .apdu_retries(7)
+        .max_segments(Some(8))
+        .segmented_response_accepted(false)
+        .proposed_window_size(4)
+        .build()
+        .await
+        .unwrap();
+
+    assert_apdu_tuning(&client.config);
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn builder_rejects_invalid_proposed_window_size() {
+    let (transport, _peer_transport) = LoopbackTransport::pair(vec![0x10], vec![0x11]);
+    let result = BACnetClient::generic_builder()
+        .transport(transport)
+        .proposed_window_size(0)
+        .build()
+        .await;
+
+    assert!(result.is_err());
+}

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -69,6 +69,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let dispatch_task = tokio::spawn(async move {
             let mut seg_state: HashMap<SegKey, SegmentedReceiveState> = HashMap::new();
             let mut device_purge_interval = tokio::time::interval(DEVICE_PURGE_INTERVAL);
+            // Tokio intervals tick immediately; consume that tick so discovery purges
+            // run on the configured cadence instead of racing the first APDU.
+            device_purge_interval.tick().await;
 
             loop {
                 tokio::select! {

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -631,6 +631,7 @@ fn response_tsm_mac(source_mac: &[u8], source_network: &Option<NpduAddress>) -> 
     }
 }
 
+mod builder_options;
 mod cov;
 mod device_events;
 mod device_mgmt;
@@ -643,6 +644,8 @@ mod property;
 mod requests;
 mod segmentation;
 
+#[cfg(test)]
+mod builder_options_tests;
 #[cfg(test)]
 mod device_events_tests;
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add APDU tuning setters to generic, B/IP, B/IP6, and BACnet/SC client builders.
- Cover generic and B/IP builder config propagation plus invalid proposed window size rejection.
- Stabilize the device purge timer startup so its immediate first tick cannot race the first received APDU/device event.
- Document the unreleased client API addition in the changelog.

## Validation
- cargo fmt
- cargo test -p bacnet-client builder_options
- cargo check -p bacnet-client --features ipv6,sc-tls --locked
- cargo test -p bacnet-client
- cargo test -p bacnet-client device_events --locked
- cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked
- cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls
- cargo fmt --all --check
- cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
- git diff --cached --check
- git diff --check
- bash .github/scripts/check-file-size.sh
- bash .github/scripts/check-no-secrets.sh

Closes #76