### PR TITLE
Fix #78: add routed COV client helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `BACnetClient::device_events()` with discovery/update/loss notifications while keeping `discovered_devices()` as the device-table snapshot API.
 - Add BACnet client builder setters for APDU retries, accepted segment count, segmented-response acceptance, and proposed window size.
+- Add `BACnetClient` COV subscribe/unsubscribe helpers that resolve discovered-device routing.
 
 ### Fixed
 

--- a/crates/bacnet-client/src/client/cov.rs
+++ b/crates/bacnet-client/src/client/cov.rs
@@ -1,30 +1,93 @@
 use super::*;
+use bacnet_services::cov::SubscribeCOVRequest;
+use bacnet_types::primitives::ObjectIdentifier;
 
 impl<T: TransportPort + 'static> BACnetClient<T> {
-    pub async fn subscribe_cov(
-        &self,
-        destination_mac: &[u8],
+    fn subscribe_cov_request(
         subscriber_process_identifier: u32,
-        monitored_object_identifier: bacnet_types::primitives::ObjectIdentifier,
-        confirmed: bool,
+        monitored_object_identifier: ObjectIdentifier,
+        confirmed: Option<bool>,
         lifetime: Option<u32>,
-    ) -> Result<(), Error> {
-        use bacnet_services::cov::SubscribeCOVRequest;
-
-        let request = SubscribeCOVRequest {
+    ) -> SubscribeCOVRequest {
+        SubscribeCOVRequest {
             subscriber_process_identifier,
             monitored_object_identifier,
-            issue_confirmed_notifications: Some(confirmed),
+            issue_confirmed_notifications: confirmed,
             lifetime,
-        };
+        }
+    }
+
+    async fn send_subscribe_cov_request(
+        &self,
+        target: ConfirmedTarget<'_>,
+        request: SubscribeCOVRequest,
+    ) -> Result<(), Error> {
         let mut buf = BytesMut::new();
         request.encode(&mut buf);
 
         let _ = self
-            .confirmed_request(destination_mac, ConfirmedServiceChoice::SUBSCRIBE_COV, &buf)
+            .confirmed_request_inner(target, ConfirmedServiceChoice::SUBSCRIBE_COV, &buf)
             .await?;
 
         Ok(())
+    }
+
+    /// Subscribe to COV notifications for an object at a directly reachable MAC address.
+    pub async fn subscribe_cov(
+        &self,
+        destination_mac: &[u8],
+        subscriber_process_identifier: u32,
+        monitored_object_identifier: ObjectIdentifier,
+        confirmed: bool,
+        lifetime: Option<u32>,
+    ) -> Result<(), Error> {
+        let request = Self::subscribe_cov_request(
+            subscriber_process_identifier,
+            monitored_object_identifier,
+            Some(confirmed),
+            lifetime,
+        );
+
+        self.send_subscribe_cov_request(
+            ConfirmedTarget::Local {
+                mac: destination_mac,
+            },
+            request,
+        )
+        .await
+    }
+
+    /// Subscribe to COV notifications for a discovered device, auto-routing if needed.
+    pub async fn subscribe_cov_to_device(
+        &self,
+        device_instance: u32,
+        subscriber_process_identifier: u32,
+        monitored_object_identifier: ObjectIdentifier,
+        confirmed: bool,
+        lifetime: Option<u32>,
+    ) -> Result<(), Error> {
+        let (mac, routing) = self.resolve_device(device_instance).await?;
+        let request = Self::subscribe_cov_request(
+            subscriber_process_identifier,
+            monitored_object_identifier,
+            Some(confirmed),
+            lifetime,
+        );
+
+        if let Some((dnet, dadr)) = routing {
+            self.send_subscribe_cov_request(
+                ConfirmedTarget::Routed {
+                    router_mac: &mac,
+                    dest_network: dnet,
+                    dest_mac: &dadr,
+                },
+                request,
+            )
+            .await
+        } else {
+            self.send_subscribe_cov_request(ConfirmedTarget::Local { mac: &mac }, request)
+                .await
+        }
     }
 
     /// Cancel a COV subscription on a remote device.
@@ -32,27 +95,55 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         &self,
         destination_mac: &[u8],
         subscriber_process_identifier: u32,
-        monitored_object_identifier: bacnet_types::primitives::ObjectIdentifier,
+        monitored_object_identifier: ObjectIdentifier,
     ) -> Result<(), Error> {
-        use bacnet_services::cov::SubscribeCOVRequest;
-
-        let request = SubscribeCOVRequest {
+        let request = Self::subscribe_cov_request(
             subscriber_process_identifier,
             monitored_object_identifier,
-            issue_confirmed_notifications: None,
-            lifetime: None,
-        };
-        let mut buf = BytesMut::new();
-        request.encode(&mut buf);
+            None,
+            None,
+        );
 
-        let _ = self
-            .confirmed_request(destination_mac, ConfirmedServiceChoice::SUBSCRIBE_COV, &buf)
-            .await?;
-
-        Ok(())
+        self.send_subscribe_cov_request(
+            ConfirmedTarget::Local {
+                mac: destination_mac,
+            },
+            request,
+        )
+        .await
     }
 
-    /// Delete an object on a remote device.
+    /// Cancel a COV subscription for a discovered device, auto-routing if needed.
+    pub async fn unsubscribe_cov_to_device(
+        &self,
+        device_instance: u32,
+        subscriber_process_identifier: u32,
+        monitored_object_identifier: ObjectIdentifier,
+    ) -> Result<(), Error> {
+        let (mac, routing) = self.resolve_device(device_instance).await?;
+        let request = Self::subscribe_cov_request(
+            subscriber_process_identifier,
+            monitored_object_identifier,
+            None,
+            None,
+        );
+
+        if let Some((dnet, dadr)) = routing {
+            self.send_subscribe_cov_request(
+                ConfirmedTarget::Routed {
+                    router_mac: &mac,
+                    dest_network: dnet,
+                    dest_mac: &dadr,
+                },
+                request,
+            )
+            .await
+        } else {
+            self.send_subscribe_cov_request(ConfirmedTarget::Local { mac: &mac }, request)
+                .await
+        }
+    }
+
     /// Get a receiver for incoming COV notifications. Each call returns a new
     /// independent receiver.
     pub fn cov_notifications(&self) -> broadcast::Receiver<COVNotificationRequest> {

--- a/crates/bacnet-client/src/client/cov_tests.rs
+++ b/crates/bacnet-client/src/client/cov_tests.rs
@@ -1,0 +1,200 @@
+use super::*;
+use bacnet_encoding::apdu::{decode_apdu, encode_apdu};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_services::cov::SubscribeCOVRequest;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::enums::{ObjectType, Segmentation};
+use bacnet_types::primitives::ObjectIdentifier;
+use std::time::Instant;
+
+fn device_object(instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::DEVICE, instance).unwrap()
+}
+
+fn analog_object(instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap()
+}
+
+fn routed_device(
+    instance: u32,
+    router_mac: &[u8],
+    remote_network: u16,
+    remote_mac: &[u8],
+) -> DiscoveredDevice {
+    DiscoveredDevice {
+        object_identifier: device_object(instance),
+        mac_address: MacAddr::from_slice(router_mac),
+        max_apdu_length: 1476,
+        segmentation_supported: Segmentation::NONE,
+        max_segments_accepted: None,
+        vendor_id: 42,
+        last_seen: Instant::now(),
+        source_network: Some(remote_network),
+        source_address: Some(MacAddr::from_slice(remote_mac)),
+    }
+}
+
+async fn send_routed_simple_ack<T: TransportPort>(
+    transport: &T,
+    client_mac: &[u8],
+    source_network: u16,
+    source_mac: &[u8],
+    invoke_id: u8,
+) {
+    let ack = Apdu::SimpleAck(SimpleAck {
+        invoke_id,
+        service_choice: ConfirmedServiceChoice::SUBSCRIBE_COV,
+    });
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &ack).unwrap();
+
+    let npdu = Npdu {
+        source: Some(NpduAddress {
+            network: source_network,
+            mac_address: MacAddr::from_slice(source_mac),
+        }),
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu).unwrap();
+    transport.send_unicast(&npdu_buf, client_mac).await.unwrap();
+}
+
+async fn receive_routed_subscribe_cov(
+    router_rx: &mut tokio::sync::mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>,
+    client_mac: &[u8],
+    remote_network: u16,
+    remote_mac: &[u8],
+) -> (u8, SubscribeCOVRequest) {
+    let received = timeout(Duration::from_secs(2), router_rx.recv())
+        .await
+        .expect("router timed out waiting for SubscribeCOV")
+        .expect("router channel closed");
+    assert_eq!(&received.source_mac[..], client_mac);
+
+    let npdu = decode_npdu(received.npdu).unwrap();
+    let destination = npdu.destination.expect("routed NPDU destination");
+    assert_eq!(destination.network, remote_network);
+    assert_eq!(&destination.mac_address[..], remote_mac);
+
+    let decoded = decode_apdu(npdu.payload).unwrap();
+    let Apdu::ConfirmedRequest(request) = decoded else {
+        panic!("expected SubscribeCOV confirmed request, got {decoded:?}");
+    };
+    assert_eq!(
+        request.service_choice,
+        ConfirmedServiceChoice::SUBSCRIBE_COV
+    );
+    assert!(!request.segmented);
+
+    let cov_request = SubscribeCOVRequest::decode(&request.service_request).unwrap();
+    (request.invoke_id, cov_request)
+}
+
+#[tokio::test]
+async fn subscribe_cov_to_device_uses_routed_addressing() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03, 0x04];
+    let monitored_object = analog_object(10);
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+    let mut router_rx = router_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(routed_device(
+        2001,
+        &router_mac,
+        remote_network,
+        &remote_mac,
+    ));
+
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .subscribe_cov_to_device(2001, 77, monitored_object, true, Some(120))
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let (invoke_id, request) =
+        receive_routed_subscribe_cov(&mut router_rx, &client_mac, remote_network, &remote_mac)
+            .await;
+    assert_eq!(request.subscriber_process_identifier, 77);
+    assert_eq!(request.monitored_object_identifier, monitored_object);
+    assert_eq!(request.issue_confirmed_notifications, Some(true));
+    assert_eq!(request.lifetime, Some(120));
+
+    send_routed_simple_ack(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        invoke_id,
+    )
+    .await;
+
+    assert!(request_task.await.unwrap().is_ok());
+    router_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn unsubscribe_cov_to_device_uses_routed_addressing() {
+    let client_mac = vec![0x11];
+    let router_mac = vec![0x12];
+    let remote_network = 101;
+    let remote_mac = vec![0x13, 0x14];
+    let monitored_object = analog_object(11);
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+    let mut router_rx = router_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(routed_device(
+        2002,
+        &router_mac,
+        remote_network,
+        &remote_mac,
+    ));
+
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .unsubscribe_cov_to_device(2002, 78, monitored_object)
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let (invoke_id, request) =
+        receive_routed_subscribe_cov(&mut router_rx, &client_mac, remote_network, &remote_mac)
+            .await;
+    assert_eq!(request.subscriber_process_identifier, 78);
+    assert_eq!(request.monitored_object_identifier, monitored_object);
+    assert_eq!(request.issue_confirmed_notifications, None);
+    assert_eq!(request.lifetime, None);
+
+    send_routed_simple_ack(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        invoke_id,
+    )
+    .await;
+
+    assert!(request_task.await.unwrap().is_ok());
+    router_transport.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -647,6 +647,8 @@ mod segmentation;
 #[cfg(test)]
 mod builder_options_tests;
 #[cfg(test)]
+mod cov_tests;
+#[cfg(test)]
 mod device_events_tests;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
- Add `subscribe_cov_to_device` and `unsubscribe_cov_to_device` helpers that resolve discovered-device MAC and NPDU routing.
- Reuse the existing confirmed request routing path for SubscribeCOV when a device has `source_network`/`source_address`.
- Add routed SubscribeCOV regression tests that decode DNET/DADR and complete with a routed SimpleAck.
- Document the unreleased client API addition in the changelog.

## Validation
- cargo test -p bacnet-client cov_tests --locked
- cargo test -p bacnet-client --locked
- cargo check -p bacnet-client --features ipv6,sc-tls --locked
- cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked
- cargo fmt --all --check
- cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked
- git diff --check
- git diff --cached --check
- bash .github/scripts/check-file-size.sh
- bash .github/scripts/check-no-secrets.sh

Closes #78