### PR TITLE
fix(client): add managed COV renewal helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `BACnetClient` COV subscribe/unsubscribe helpers that resolve discovered-device routing.
 - Add `BACnetClient` SubscribeCOVProperty subscribe/unsubscribe helpers for property-level COV subscriptions.
 - Add source metadata, delivery kind, and configurable confirmed-notification ACK policy to `BACnetClient` COV notification delivery.
+- Add a managed finite `BACnetClient` COV subscription helper that renews before expiry and emits lifetime/renewal events.
 
 ### Fixed
 

--- a/crates/bacnet-client/src/client/cov_renewal.rs
+++ b/crates/bacnet-client/src/client/cov_renewal.rs
@@ -1,0 +1,310 @@
+use super::*;
+use std::sync::Mutex as StdMutex;
+use tokio::sync::oneshot;
+use tokio::time::{sleep_until, Instant as TokioInstant};
+
+const DEFAULT_COV_RENEWAL_MARGIN: Duration = Duration::from_secs(30);
+const DEFAULT_COV_RENEWAL_EVENT_CAPACITY: usize = 16;
+
+/// Options for a managed finite COV subscription.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct ManagedCOVSubscriptionOptions {
+    /// How long before the known remaining lifetime the helper should renew.
+    ///
+    /// The helper schedules renewal at `time_remaining - renewal_margin`, using
+    /// the requested lifetime until inbound notifications provide a fresher
+    /// `time_remaining` value.
+    pub renewal_margin: Duration,
+    /// Capacity of the renewal event broadcast channel.
+    ///
+    /// Accepted range is `1..=MAX_COV_CHANNEL_CAPACITY`.
+    pub event_channel_capacity: usize,
+}
+
+impl Default for ManagedCOVSubscriptionOptions {
+    fn default() -> Self {
+        Self {
+            renewal_margin: DEFAULT_COV_RENEWAL_MARGIN,
+            event_channel_capacity: DEFAULT_COV_RENEWAL_EVENT_CAPACITY,
+        }
+    }
+}
+
+impl ManagedCOVSubscriptionOptions {
+    /// Set the renewal margin.
+    pub fn with_renewal_margin(mut self, margin: Duration) -> Self {
+        self.renewal_margin = margin;
+        self
+    }
+
+    /// Set the renewal event broadcast channel capacity.
+    pub fn with_event_channel_capacity(mut self, capacity: usize) -> Self {
+        self.event_channel_capacity = capacity;
+        self
+    }
+
+    fn validate(&self, lifetime: u32) -> Result<(), Error> {
+        if !(1..=MAX_COV_CHANNEL_CAPACITY).contains(&self.event_channel_capacity) {
+            return Err(Error::Encoding(format!(
+                "invalid managed COV subscription event channel capacity {}; expected 1..={}",
+                self.event_channel_capacity, MAX_COV_CHANNEL_CAPACITY
+            )));
+        }
+        if self.renewal_margin >= Duration::from_secs(u64::from(lifetime)) {
+            return Err(Error::Encoding(
+                "managed COV subscription renewal margin must be shorter than lifetime".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn renewal_delay(&self, time_remaining: u32) -> Duration {
+        Duration::from_secs(u64::from(time_remaining)).saturating_sub(self.renewal_margin)
+    }
+}
+
+/// Events emitted by a managed finite COV subscription.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ManagedCOVSubscriptionEvent {
+    /// A matching COV notification supplied a new lifetime observation.
+    NotificationObserved {
+        /// The `time_remaining` field from the inbound notification.
+        time_remaining: u32,
+        /// Delay until the next renewal after applying the configured margin.
+        renew_after: Duration,
+    },
+    /// The observed lifetime is inside the configured renewal margin.
+    ImpendingExpiry {
+        /// The `time_remaining` field from the inbound notification.
+        time_remaining: u32,
+    },
+    /// The helper successfully renewed the subscription.
+    Renewed {
+        /// Lifetime requested on the renewed SubscribeCOV request.
+        requested_lifetime: u32,
+        /// Delay until the next scheduled renewal after applying the margin.
+        renew_after: Duration,
+    },
+    /// A renewal SubscribeCOV request failed and the helper stopped.
+    RenewalFailed {
+        /// Display form of the protocol, reject, abort, transport, or timeout error.
+        error: String,
+    },
+}
+
+/// Handle for a managed finite COV subscription renewal task.
+pub struct ManagedCOVSubscription {
+    events_tx: broadcast::Sender<ManagedCOVSubscriptionEvent>,
+    last_event: Arc<StdMutex<Option<ManagedCOVSubscriptionEvent>>>,
+    stop_tx: Option<oneshot::Sender<()>>,
+    task: Option<JoinHandle<()>>,
+}
+
+impl ManagedCOVSubscription {
+    /// Subscribe to lifetime observations and renewal outcomes.
+    pub fn events(&self) -> broadcast::Receiver<ManagedCOVSubscriptionEvent> {
+        self.events_tx.subscribe()
+    }
+
+    /// Return the latest observed renewal event, if any.
+    pub fn last_event(&self) -> Option<ManagedCOVSubscriptionEvent> {
+        self.last_event.lock().ok().and_then(|event| event.clone())
+    }
+
+    /// Stop renewing and wait for the renewal task to exit.
+    pub async fn stop(mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
+    }
+
+    /// Return whether the renewal task has already finished.
+    pub fn is_finished(&self) -> bool {
+        match &self.task {
+            Some(task) => task.is_finished(),
+            None => true,
+        }
+    }
+}
+
+impl Drop for ManagedCOVSubscription {
+    fn drop(&mut self) {
+        if let Some(stop_tx) = self.stop_tx.take() {
+            let _ = stop_tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+impl<T: TransportPort + 'static> BACnetClient<T> {
+    /// Start a managed finite SubscribeCOV renewal task for a directly reachable device.
+    ///
+    /// The helper sends the initial SubscribeCOV request, then renews the same
+    /// subscription before expiry. It also listens to [`Self::cov_notifications`]
+    /// and moves the renewal earlier when matching notifications report a lower
+    /// `time_remaining` than the requested lifetime-based schedule.
+    ///
+    /// This method takes `Arc<Self>` so the renewal task can keep the client alive.
+    /// Call it as `Arc::clone(&client).manage_cov_subscription(...)`.
+    pub async fn manage_cov_subscription(
+        self: Arc<Self>,
+        destination_mac: &[u8],
+        subscriber_process_identifier: u32,
+        monitored_object_identifier: bacnet_types::primitives::ObjectIdentifier,
+        confirmed: bool,
+        lifetime: u32,
+        options: ManagedCOVSubscriptionOptions,
+    ) -> Result<ManagedCOVSubscription, Error> {
+        if lifetime == 0 {
+            return Err(Error::Encoding(
+                "managed COV subscriptions require a finite non-zero lifetime".into(),
+            ));
+        }
+        options.validate(lifetime)?;
+
+        let destination_mac = MacAddr::from_slice(destination_mac);
+        let mut notifications = self.cov_notifications();
+
+        self.subscribe_cov(
+            &destination_mac,
+            subscriber_process_identifier,
+            monitored_object_identifier,
+            confirmed,
+            Some(lifetime),
+        )
+        .await?;
+
+        let (events_tx, _) = broadcast::channel(options.event_channel_capacity);
+        let events_tx_for_task = events_tx.clone();
+        let last_event = Arc::new(StdMutex::new(None));
+        let last_event_for_task = Arc::clone(&last_event);
+        let (stop_tx, mut stop_rx) = oneshot::channel();
+        let client = Arc::clone(&self);
+        let mut renew_at = TokioInstant::now() + options.renewal_delay(lifetime);
+
+        let task = tokio::spawn(async move {
+            loop {
+                let renew_sleep = sleep_until(renew_at);
+                tokio::pin!(renew_sleep);
+                tokio::select! {
+                    _ = &mut stop_rx => break,
+                    _ = &mut renew_sleep => {
+                        let renewal = client.subscribe_cov(
+                            &destination_mac,
+                            subscriber_process_identifier,
+                            monitored_object_identifier,
+                            confirmed,
+                            Some(lifetime),
+                        );
+                        tokio::pin!(renewal);
+                        tokio::select! {
+                            _ = &mut stop_rx => break,
+                            result = &mut renewal => match result {
+                                Ok(()) => {
+                                    let renew_after = options.renewal_delay(lifetime);
+                                    publish_managed_cov_event(
+                                        &events_tx_for_task,
+                                        &last_event_for_task,
+                                        ManagedCOVSubscriptionEvent::Renewed {
+                                            requested_lifetime: lifetime,
+                                            renew_after,
+                                        },
+                                    );
+                                    renew_at = TokioInstant::now() + renew_after;
+                                }
+                                Err(error) => {
+                                    publish_managed_cov_event(
+                                        &events_tx_for_task,
+                                        &last_event_for_task,
+                                        ManagedCOVSubscriptionEvent::RenewalFailed {
+                                            error: error.to_string(),
+                                        },
+                                    );
+                                    break;
+                                }
+                            },
+                        }
+                    }
+                    received = notifications.recv() => {
+                        let received = match received {
+                            Ok(received) => received,
+                            Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                            Err(broadcast::error::RecvError::Closed) => break,
+                        };
+                        if !matches_managed_cov_notification(
+                            &received,
+                            &destination_mac,
+                            subscriber_process_identifier,
+                            monitored_object_identifier,
+                        ) {
+                            continue;
+                        }
+
+                        let time_remaining = received.notification.time_remaining;
+                        let renew_after = options.renewal_delay(time_remaining);
+                        publish_managed_cov_event(
+                            &events_tx_for_task,
+                            &last_event_for_task,
+                            ManagedCOVSubscriptionEvent::NotificationObserved {
+                                time_remaining,
+                                renew_after,
+                            },
+                        );
+
+                        let observed_renew_at = TokioInstant::now() + renew_after;
+                        if renew_after.is_zero() {
+                            publish_managed_cov_event(
+                                &events_tx_for_task,
+                                &last_event_for_task,
+                                ManagedCOVSubscriptionEvent::ImpendingExpiry {
+                                    time_remaining,
+                                },
+                            );
+                            renew_at = observed_renew_at;
+                        } else if observed_renew_at < renew_at {
+                            renew_at = observed_renew_at;
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(ManagedCOVSubscription {
+            events_tx,
+            last_event,
+            stop_tx: Some(stop_tx),
+            task: Some(task),
+        })
+    }
+}
+
+fn publish_managed_cov_event(
+    events_tx: &broadcast::Sender<ManagedCOVSubscriptionEvent>,
+    last_event: &StdMutex<Option<ManagedCOVSubscriptionEvent>>,
+    event: ManagedCOVSubscriptionEvent,
+) {
+    if let Ok(mut last_event) = last_event.lock() {
+        *last_event = Some(event.clone());
+    }
+    let _ = events_tx.send(event);
+}
+
+fn matches_managed_cov_notification(
+    received: &ReceivedCOVNotification,
+    destination_mac: &[u8],
+    subscriber_process_identifier: u32,
+    monitored_object_identifier: bacnet_types::primitives::ObjectIdentifier,
+) -> bool {
+    received.notification.subscriber_process_identifier == subscriber_process_identifier
+        && received.notification.monitored_object_identifier == monitored_object_identifier
+        && received.source_network.is_none()
+        && received.source_address.is_none()
+        && &received.source_mac[..] == destination_mac
+}

--- a/crates/bacnet-client/src/client/cov_renewal_tests.rs
+++ b/crates/bacnet-client/src/client/cov_renewal_tests.rs
@@ -1,0 +1,640 @@
+use super::*;
+use bacnet_encoding::apdu::{decode_apdu, encode_apdu, UnconfirmedRequest};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_services::common::BACnetPropertyValue;
+use bacnet_services::cov::SubscribeCOVRequest;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_types::primitives::ObjectIdentifier;
+
+fn analog_object(instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap()
+}
+
+fn cov_notification(
+    subscriber_process_identifier: u32,
+    monitored_object_identifier: ObjectIdentifier,
+    time_remaining: u32,
+) -> COVNotificationRequest {
+    COVNotificationRequest {
+        subscriber_process_identifier,
+        initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 100).unwrap(),
+        monitored_object_identifier,
+        time_remaining,
+        list_of_values: vec![BACnetPropertyValue {
+            property_identifier: PropertyIdentifier::PRESENT_VALUE,
+            property_array_index: None,
+            value: vec![0x44, 0x42, 0x48, 0x00, 0x00],
+            priority: None,
+        }],
+    }
+}
+
+fn received_cov_notification(
+    subscriber_process_identifier: u32,
+    monitored_object_identifier: ObjectIdentifier,
+    time_remaining: u32,
+    source_mac: &[u8],
+) -> ReceivedCOVNotification {
+    ReceivedCOVNotification::new(
+        cov_notification(
+            subscriber_process_identifier,
+            monitored_object_identifier,
+            time_remaining,
+        ),
+        source_mac,
+        &None,
+        COVNotificationDelivery::Unconfirmed,
+    )
+}
+
+async fn send_local_simple_ack<T: TransportPort>(
+    transport: &T,
+    client_mac: &[u8],
+    invoke_id: u8,
+    service_choice: ConfirmedServiceChoice,
+) {
+    let ack = Apdu::SimpleAck(SimpleAck {
+        invoke_id,
+        service_choice,
+    });
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &ack).unwrap();
+
+    let npdu = Npdu {
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu).unwrap();
+    transport.send_unicast(&npdu_buf, client_mac).await.unwrap();
+}
+
+async fn receive_local_subscribe_cov(
+    peer_rx: &mut tokio::sync::mpsc::Receiver<ReceivedNpdu>,
+    client_mac: &[u8],
+) -> (u8, SubscribeCOVRequest) {
+    let received = timeout(Duration::from_secs(2), peer_rx.recv())
+        .await
+        .expect("peer timed out waiting for SubscribeCOV")
+        .expect("peer channel closed");
+    assert_eq!(&received.source_mac[..], client_mac);
+
+    let npdu = decode_npdu(received.npdu).unwrap();
+    assert!(
+        npdu.destination.is_none(),
+        "managed direct COV renewal must use local addressing"
+    );
+    let decoded = decode_apdu(npdu.payload).unwrap();
+    let Apdu::ConfirmedRequest(request) = decoded else {
+        panic!("expected confirmed request, got {decoded:?}");
+    };
+    assert_eq!(
+        request.service_choice,
+        ConfirmedServiceChoice::SUBSCRIBE_COV
+    );
+    assert!(!request.segmented);
+
+    (
+        request.invoke_id,
+        SubscribeCOVRequest::decode(&request.service_request).unwrap(),
+    )
+}
+
+async fn send_unconfirmed_cov_notification<T: TransportPort>(
+    transport: &T,
+    client_mac: &[u8],
+    subscriber_process_identifier: u32,
+    monitored_object_identifier: ObjectIdentifier,
+    time_remaining: u32,
+) {
+    let notification = cov_notification(
+        subscriber_process_identifier,
+        monitored_object_identifier,
+        time_remaining,
+    );
+    let mut service_request = BytesMut::new();
+    notification.encode(&mut service_request);
+    let apdu = Apdu::UnconfirmedRequest(UnconfirmedRequest {
+        service_choice: UnconfirmedServiceChoice::UNCONFIRMED_COV_NOTIFICATION,
+        service_request: service_request.freeze(),
+    });
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &apdu).unwrap();
+
+    let npdu = Npdu {
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu).unwrap();
+    transport.send_unicast(&npdu_buf, client_mac).await.unwrap();
+}
+
+#[tokio::test]
+async fn managed_cov_subscription_uses_notification_observed_during_initial_subscribe() {
+    let client_mac = vec![0x41];
+    let peer_mac = vec![0x42];
+    let monitored_object = analog_object(4);
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::generic_builder()
+            .transport(client_transport)
+            .apdu_timeout_ms(1000)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    let subscriber_process_identifier = 4004;
+    let client_for_task = Arc::clone(&client);
+    let peer_mac_for_task = peer_mac.clone();
+    let start = tokio::spawn(async move {
+        client_for_task
+            .manage_cov_subscription(
+                &peer_mac_for_task,
+                subscriber_process_identifier,
+                monitored_object,
+                false,
+                20,
+                ManagedCOVSubscriptionOptions::default()
+                    .with_renewal_margin(Duration::from_secs(5)),
+            )
+            .await
+    });
+
+    let (invoke_id, _) = receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    assert_eq!(
+        client
+            .cov_tx
+            .send(received_cov_notification(
+                subscriber_process_identifier,
+                monitored_object,
+                3,
+                &peer_mac,
+            ))
+            .unwrap(),
+        1
+    );
+    send_local_simple_ack(
+        &peer_transport,
+        &client_mac,
+        invoke_id,
+        ConfirmedServiceChoice::SUBSCRIBE_COV,
+    )
+    .await;
+
+    let managed = start.await.unwrap().unwrap();
+    let (renew_invoke_id, renewed_request) =
+        receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    assert_eq!(
+        renewed_request.subscriber_process_identifier,
+        subscriber_process_identifier
+    );
+    assert_eq!(
+        managed.last_event(),
+        Some(ManagedCOVSubscriptionEvent::ImpendingExpiry { time_remaining: 3 })
+    );
+    send_local_simple_ack(
+        &peer_transport,
+        &client_mac,
+        renew_invoke_id,
+        ConfirmedServiceChoice::SUBSCRIBE_COV,
+    )
+    .await;
+
+    managed.stop().await;
+    let mut client = match Arc::try_unwrap(client) {
+        Ok(client) => client,
+        Err(_) => panic!("managed subscription kept a client reference after stop"),
+    };
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn managed_cov_subscription_renews_before_requested_lifetime() {
+    let client_mac = vec![0x51];
+    let peer_mac = vec![0x52];
+    let monitored_object = analog_object(1);
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::generic_builder()
+            .transport(client_transport)
+            .apdu_timeout_ms(1000)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    let subscriber_process_identifier = 4001;
+    let client_for_task = Arc::clone(&client);
+    let peer_mac_for_task = peer_mac.clone();
+    let start = tokio::spawn(async move {
+        client_for_task
+            .manage_cov_subscription(
+                &peer_mac_for_task,
+                subscriber_process_identifier,
+                monitored_object,
+                false,
+                2,
+                ManagedCOVSubscriptionOptions::default()
+                    .with_renewal_margin(Duration::from_millis(1500)),
+            )
+            .await
+    });
+
+    let (invoke_id, request) = receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    assert_eq!(
+        request.subscriber_process_identifier,
+        subscriber_process_identifier
+    );
+    assert_eq!(request.monitored_object_identifier, monitored_object);
+    assert_eq!(request.issue_confirmed_notifications, Some(false));
+    assert_eq!(request.lifetime, Some(2));
+    send_local_simple_ack(
+        &peer_transport,
+        &client_mac,
+        invoke_id,
+        ConfirmedServiceChoice::SUBSCRIBE_COV,
+    )
+    .await;
+
+    let managed = start.await.unwrap().unwrap();
+    let mut events = managed.events();
+    let (renew_invoke_id, renewed_request) =
+        receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    assert_eq!(
+        renewed_request.subscriber_process_identifier,
+        subscriber_process_identifier
+    );
+    assert_eq!(
+        renewed_request.monitored_object_identifier,
+        monitored_object
+    );
+    assert_eq!(renewed_request.lifetime, Some(2));
+    send_local_simple_ack(
+        &peer_transport,
+        &client_mac,
+        renew_invoke_id,
+        ConfirmedServiceChoice::SUBSCRIBE_COV,
+    )
+    .await;
+
+    let event = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("timed out waiting for renewal event")
+        .expect("renewal events closed");
+    assert_eq!(
+        event,
+        ManagedCOVSubscriptionEvent::Renewed {
+            requested_lifetime: 2,
+            renew_after: Duration::from_millis(500),
+        }
+    );
+
+    managed.stop().await;
+    let mut client = match Arc::try_unwrap(client) {
+        Ok(client) => client,
+        Err(_) => panic!("managed subscription kept a client reference after stop"),
+    };
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn managed_cov_subscription_uses_observed_time_remaining() {
+    let client_mac = vec![0x61];
+    let peer_mac = vec![0x62];
+    let monitored_object = analog_object(2);
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::generic_builder()
+            .transport(client_transport)
+            .apdu_timeout_ms(1000)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    let subscriber_process_identifier = 4002;
+    let client_for_task = Arc::clone(&client);
+    let peer_mac_for_task = peer_mac.clone();
+    let start = tokio::spawn(async move {
+        client_for_task
+            .manage_cov_subscription(
+                &peer_mac_for_task,
+                subscriber_process_identifier,
+                monitored_object,
+                false,
+                20,
+                ManagedCOVSubscriptionOptions::default()
+                    .with_renewal_margin(Duration::from_secs(5)),
+            )
+            .await
+    });
+
+    let (invoke_id, _) = receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    send_local_simple_ack(
+        &peer_transport,
+        &client_mac,
+        invoke_id,
+        ConfirmedServiceChoice::SUBSCRIBE_COV,
+    )
+    .await;
+    let managed = start.await.unwrap().unwrap();
+    let mut events = managed.events();
+
+    send_unconfirmed_cov_notification(
+        &peer_transport,
+        &client_mac,
+        subscriber_process_identifier,
+        monitored_object,
+        3,
+    )
+    .await;
+
+    let observed = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("timed out waiting for observation")
+        .expect("renewal events closed");
+    assert_eq!(
+        observed,
+        ManagedCOVSubscriptionEvent::NotificationObserved {
+            time_remaining: 3,
+            renew_after: Duration::from_secs(0),
+        }
+    );
+    let expiry = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("timed out waiting for expiry warning")
+        .expect("renewal events closed");
+    assert_eq!(
+        expiry,
+        ManagedCOVSubscriptionEvent::ImpendingExpiry { time_remaining: 3 }
+    );
+
+    let (renew_invoke_id, renewed_request) =
+        receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    assert_eq!(
+        renewed_request.subscriber_process_identifier,
+        subscriber_process_identifier
+    );
+    assert_eq!(
+        renewed_request.monitored_object_identifier,
+        monitored_object
+    );
+    assert_eq!(renewed_request.lifetime, Some(20));
+    send_local_simple_ack(
+        &peer_transport,
+        &client_mac,
+        renew_invoke_id,
+        ConfirmedServiceChoice::SUBSCRIBE_COV,
+    )
+    .await;
+    let renewed = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("timed out waiting for renewal")
+        .expect("renewal events closed");
+    assert_eq!(
+        renewed,
+        ManagedCOVSubscriptionEvent::Renewed {
+            requested_lifetime: 20,
+            renew_after: Duration::from_secs(15),
+        }
+    );
+
+    managed.stop().await;
+    let mut client = match Arc::try_unwrap(client) {
+        Ok(client) => client,
+        Err(_) => panic!("managed subscription kept a client reference after stop"),
+    };
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn managed_cov_subscription_stop_cancels_in_flight_renewal() {
+    let client_mac = vec![0x81];
+    let peer_mac = vec![0x82];
+    let monitored_object = analog_object(5);
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::generic_builder()
+            .transport(client_transport)
+            .apdu_timeout_ms(1000)
+            .apdu_retries(3)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    let subscriber_process_identifier = 4005;
+    let client_for_task = Arc::clone(&client);
+    let peer_mac_for_task = peer_mac.clone();
+    let start = tokio::spawn(async move {
+        client_for_task
+            .manage_cov_subscription(
+                &peer_mac_for_task,
+                subscriber_process_identifier,
+                monitored_object,
+                false,
+                2,
+                ManagedCOVSubscriptionOptions::default()
+                    .with_renewal_margin(Duration::from_millis(1500)),
+            )
+            .await
+    });
+
+    let (invoke_id, _) = receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    send_local_simple_ack(
+        &peer_transport,
+        &client_mac,
+        invoke_id,
+        ConfirmedServiceChoice::SUBSCRIBE_COV,
+    )
+    .await;
+    let managed = start.await.unwrap().unwrap();
+
+    let (_renew_invoke_id, renewed_request) =
+        receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    assert_eq!(
+        renewed_request.subscriber_process_identifier,
+        subscriber_process_identifier
+    );
+
+    timeout(Duration::from_millis(500), managed.stop())
+        .await
+        .expect("managed stop should cancel in-flight renewal promptly");
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+
+    let mut client = match Arc::try_unwrap(client) {
+        Ok(client) => client,
+        Err(_) => panic!("managed subscription kept a client reference after stop"),
+    };
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn managed_cov_subscription_records_failure_without_event_receiver() {
+    let client_mac = vec![0x91];
+    let peer_mac = vec![0x92];
+    let monitored_object = analog_object(6);
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::generic_builder()
+            .transport(client_transport)
+            .apdu_timeout_ms(100)
+            .apdu_retries(0)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    let subscriber_process_identifier = 4006;
+    let client_for_task = Arc::clone(&client);
+    let peer_mac_for_task = peer_mac.clone();
+    let start = tokio::spawn(async move {
+        client_for_task
+            .manage_cov_subscription(
+                &peer_mac_for_task,
+                subscriber_process_identifier,
+                monitored_object,
+                false,
+                2,
+                ManagedCOVSubscriptionOptions::default()
+                    .with_renewal_margin(Duration::from_millis(1500)),
+            )
+            .await
+    });
+
+    let (invoke_id, _) = receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    send_local_simple_ack(
+        &peer_transport,
+        &client_mac,
+        invoke_id,
+        ConfirmedServiceChoice::SUBSCRIBE_COV,
+    )
+    .await;
+    let managed = start.await.unwrap().unwrap();
+
+    let (_renew_invoke_id, renewed_request) =
+        receive_local_subscribe_cov(&mut peer_rx, &client_mac).await;
+    assert_eq!(
+        renewed_request.subscriber_process_identifier,
+        subscriber_process_identifier
+    );
+
+    timeout(Duration::from_secs(2), async {
+        while !managed.is_finished() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("renewal should fail after the configured timeout");
+    let Some(ManagedCOVSubscriptionEvent::RenewalFailed { error }) = managed.last_event() else {
+        panic!("expected durable RenewalFailed event");
+    };
+    assert!(error.contains("request timed out"));
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+
+    managed.stop().await;
+    let mut client = match Arc::try_unwrap(client) {
+        Ok(client) => client,
+        Err(_) => panic!("managed subscription kept a client reference after stop"),
+    };
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn managed_cov_subscription_validates_finite_lifetime_options() {
+    let client_mac = vec![0x71];
+    let peer_mac = vec![0x72];
+    let monitored_object = analog_object(3);
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let _peer_rx = peer_transport.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::generic_builder()
+            .transport(client_transport)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    let zero_lifetime = match Arc::clone(&client)
+        .manage_cov_subscription(
+            &peer_mac,
+            4003,
+            monitored_object,
+            false,
+            0,
+            ManagedCOVSubscriptionOptions::default(),
+        )
+        .await
+    {
+        Ok(_) => panic!("zero lifetime should be rejected before subscribing"),
+        Err(error) => error,
+    };
+    assert!(zero_lifetime
+        .to_string()
+        .contains("finite non-zero lifetime"));
+
+    let oversized_margin = match Arc::clone(&client)
+        .manage_cov_subscription(
+            &peer_mac,
+            4003,
+            monitored_object,
+            false,
+            5,
+            ManagedCOVSubscriptionOptions::default().with_renewal_margin(Duration::from_secs(5)),
+        )
+        .await
+    {
+        Ok(_) => panic!("oversized renewal margin should be rejected before subscribing"),
+        Err(error) => error,
+    };
+    assert!(oversized_margin
+        .to_string()
+        .contains("renewal margin must be shorter than lifetime"));
+
+    for capacity in [0, MAX_COV_CHANNEL_CAPACITY + 1] {
+        let invalid_capacity = match Arc::clone(&client)
+            .manage_cov_subscription(
+                &peer_mac,
+                4003,
+                monitored_object,
+                false,
+                60,
+                ManagedCOVSubscriptionOptions::default().with_event_channel_capacity(capacity),
+            )
+            .await
+        {
+            Ok(_) => panic!("invalid event channel capacity should be rejected before subscribing"),
+            Err(error) => error,
+        };
+        assert!(invalid_capacity
+            .to_string()
+            .contains("event channel capacity"));
+    }
+
+    let mut client = match Arc::try_unwrap(client) {
+        Ok(client) => client,
+        Err(_) => panic!("validation kept a client reference"),
+    };
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -639,6 +639,7 @@ fn response_tsm_mac(source_mac: &[u8], source_network: &Option<NpduAddress>) -> 
 mod builder_options;
 mod cov;
 mod cov_notifications;
+mod cov_renewal;
 mod device_events;
 mod device_mgmt;
 mod discovery;
@@ -654,11 +655,16 @@ pub use cov_notifications::{
     COVNotificationDelivery, ConfirmedCOVNotificationAckPolicy, ConfirmedCOVNotificationResponse,
     ReceivedCOVNotification,
 };
+pub use cov_renewal::{
+    ManagedCOVSubscription, ManagedCOVSubscriptionEvent, ManagedCOVSubscriptionOptions,
+};
 
 #[cfg(test)]
 mod builder_options_tests;
 #[cfg(test)]
 mod cov_notification_tests;
+#[cfg(test)]
+mod cov_renewal_tests;
 #[cfg(test)]
 mod cov_tests;
 #[cfg(test)]


### PR DESCRIPTION
Closes #81

## Scope

Adds a managed finite direct-MAC `BACnetClient::manage_cov_subscription(...)` helper for object-level SubscribeCOV renewal. It sends the initial SubscribeCOV request, renews before expiry using a configurable margin, observes matching inbound COV notifications for fresher `time_remaining`, emits renewal/lifetime events, and stops cleanly.

Files changed:
- `CHANGELOG.md`
- `crates/bacnet-client/src/client/mod.rs`
- `crates/bacnet-client/src/client/cov_renewal.rs`
- `crates/bacnet-client/src/client/cov_renewal_tests.rs`

## Standard anchors

- ASHRAE 135-2020 Clause 13.1: Change of Value reporting.
- Clause 13.14 / Table 13-18: SubscribeCOV service and lifetime/resubscription behavior.
- Clauses 13.6 and 13.7: COV notification `Time Remaining` field observed by the helper.
- Annex K DS-COV-A/B relevance only; this PR does not make a new formal BIBB/PICS claim.

## Wire-format impact

No new BACnet wire encoding, decoder, tag order, service choice, or fixture changes. The helper reuses the existing `SubscribeCOVRequest::encode` and `BACnetClient::subscribe_cov` path. Runtime impact is additional scheduled confirmed SubscribeCOV requests for renewal; service request fields are the same requested process id/object/confirmed flag/lifetime, while invoke id remains dynamically allocated by the existing TSM path.

## Tests / commands

Passed after final patch:
- `cargo fmt --all --check`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked`
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked`
- `cargo audit` with one existing allowed `anyhow` warning
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked`

## Ledger / PICS / BIBB

No conformance ledger, PICS, or BIBB draft files changed. Existing COV ledger status remains below formal support claim.

## Benchmarks

Not applicable. No benchmark docs, raw logs, or machine-readable benchmark output were added, and this PR makes no performance claim.

## Limitations

- Directly reachable MAC only; no routed `*_to_device` managed helper.
- Object-level SubscribeCOV only; no managed SubscribeCOVProperty or SubscribeCOVPropertyMultiple renewal helper.
- Finite non-zero lifetime only; indefinite lifetime (`0`) is intentionally rejected.
- Matching notification observations require direct source metadata: no source network/address and source MAC equal to the destination MAC.
- `stop()`/drop stops local renewal; callers should use `unsubscribe_cov` if they need immediate remote cancellation.
- Repeated matching low-`time_remaining` notifications can move renewal earlier; bounded by one in-flight renewal, but future hardening can add a debounce/coalescing window if field devices need more protection.

## Release status

Unreleased changelog only. Workspace version remains `0.10.0`; HEAD is untagged and not merged to `dev`/`main`.

## Reviewer findings

- `correctness-reviewer`: found in-flight `stop()` cancellation gap; fixed by racing renewal `subscribe_cov` against the stop signal and adding coverage.
- `test-verifier`: found initial notification receiver timing and option-bound coverage gaps; fixed by subscribing before initial SubscribeCOV and adding tests.
- `security-reliability-reviewer`: found durable failure-observability and cancellation gaps; fixed with `last_event()` and cancellation-aware renewal.
- `release-risk-reviewer`: suggested non-exhaustive public API; added `#[non_exhaustive]` to options/events.
- `bacnet-services-objects-reviewer`: ready; noted direct-MAC whole-object finite helper only.
- `bacnet-tsm-network-reviewer`: ready; noted helper reuses existing confirmed SubscribeCOV/TSM path.
- `bacnet-safety-interop-reviewer`: ready; noted non-blocking debounce/coalescing hardening follow-up.
- `bacnet-pr-packager`: ready; scope/evidence/release status are clean.
