### PR TITLE
fix(sc): redial WebSocket reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Re-dial BACnet/SC WebSocket connections during reconnect, failover, and primary restore instead of reusing a torn-down socket object.
 - Abort `BACnetClient` dispatch on drop and cascade B/IP network cleanup so ungraceful teardown releases reader tasks and the UDP socket.
 - Run `BACnetClient` device-table stale-entry purging on an independent interval so fully silent datalinks can evict dead devices.
 - Avoid `Instant` underflow in `BACnetClient` device-table purging on fresh Windows runners.

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -575,15 +575,27 @@ impl ScClientBuilder {
             .ok_or_else(|| Error::Encoding("SC client builder: tls_config is required".into()))?;
         self.options.validate()?;
 
-        let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config).await?;
+        let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
+            .await?;
 
         let mut transport = bacnet_transport::sc::ScTransport::new(ws, self.vmac)
             .with_heartbeat_interval_ms(self.heartbeat_interval_ms)
             .with_heartbeat_timeout_ms(self.heartbeat_timeout_ms);
         if let Some(rc) = self.reconnect {
+            let hub_url = self.hub_url.clone();
+            let tls_config = tls_config.clone();
             #[allow(deprecated)]
             {
-                transport = transport.with_reconnect(rc);
+                transport = transport
+                    .with_connector(move || {
+                        let hub_url = hub_url.clone();
+                        let tls_config = tls_config.clone();
+                        async move {
+                            bacnet_transport::sc_tls::TlsWebSocket::connect(&hub_url, tls_config)
+                                .await
+                        }
+                    })
+                    .with_reconnect(rc);
             }
         }
 

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -539,15 +539,27 @@ impl ScServerBuilder {
             .tls_config
             .ok_or_else(|| Error::Encoding("SC server builder: tls_config is required".into()))?;
 
-        let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config).await?;
+        let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
+            .await?;
 
         let mut transport = bacnet_transport::sc::ScTransport::new(ws, self.vmac)
             .with_heartbeat_interval_ms(self.heartbeat_interval_ms)
             .with_heartbeat_timeout_ms(self.heartbeat_timeout_ms);
         if let Some(rc) = self.reconnect {
+            let hub_url = self.hub_url.clone();
+            let tls_config = tls_config.clone();
             #[allow(deprecated)]
             {
-                transport = transport.with_reconnect(rc);
+                transport = transport
+                    .with_connector(move || {
+                        let hub_url = hub_url.clone();
+                        let tls_config = tls_config.clone();
+                        async move {
+                            bacnet_transport::sc_tls::TlsWebSocket::connect(&hub_url, tls_config)
+                                .await
+                        }
+                    })
+                    .with_reconnect(rc);
             }
         }
 

--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -1,0 +1,295 @@
+//! BACnet/SC connection state machine.
+
+use bacnet_types::error::Error;
+use bytes::Bytes;
+use tracing::{debug, warn};
+
+use crate::port::DataAttribute;
+use crate::sc_frame::{
+    decode_sc_bvlc_result, is_broadcast_vmac, ScBvlcResult, ScFunction, ScMessage, Vmac,
+};
+
+use super::data_attributes;
+
+/// BACnet/SC connection state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScConnectionState {
+    /// Not connected.
+    Disconnected,
+    /// Connect-Request sent, waiting for Connect-Accept.
+    Connecting,
+    /// Connected and operational.
+    Connected,
+    /// Disconnect requested.
+    Disconnecting,
+}
+
+/// BACnet/SC hub connection manager.
+#[derive(Clone)]
+pub struct ScConnection {
+    pub state: ScConnectionState,
+    pub local_vmac: Vmac,
+    /// Device UUID (16 bytes, RFC 4122).
+    pub device_uuid: [u8; 16],
+    pub hub_vmac: Option<Vmac>,
+    /// Maximum encoded BACnet/SC BVLC message length this node can accept.
+    pub max_bvlc_length: u16,
+    /// Maximum NPDU length this node can accept (sent in ConnectRequest).
+    pub max_apdu_length: u16,
+    /// Maximum encoded BACnet/SC BVLC message length the hub can accept.
+    pub hub_max_bvlc_length: u16,
+    /// Maximum NPDU length the hub can accept (learned from ConnectAccept).
+    pub hub_max_apdu_length: u16,
+    pub(super) next_message_id: u16,
+    /// Pending Disconnect-ACK to send after receiving a Disconnect-Request.
+    pub disconnect_ack_to_send: Option<ScMessage>,
+    /// Message ID of the last ConnectRequest sent (for response verification).
+    pub(super) pending_connect_message_id: Option<u16>,
+    /// Device UUID of the connected hub.
+    pub hub_device_uuid: Option<[u8; 16]>,
+    /// Whether the last connect failure permits another connection attempt.
+    pub(super) connect_retry_allowed: bool,
+}
+
+impl ScConnection {
+    pub fn new(local_vmac: Vmac, device_uuid: [u8; 16]) -> Self {
+        Self {
+            state: ScConnectionState::Disconnected,
+            local_vmac,
+            device_uuid,
+            hub_vmac: None,
+            max_bvlc_length: 1476,
+            max_apdu_length: 1476,
+            hub_max_bvlc_length: 1476,
+            hub_max_apdu_length: 1476,
+            next_message_id: 1,
+            disconnect_ack_to_send: None,
+            pending_connect_message_id: None,
+            hub_device_uuid: None,
+            connect_retry_allowed: true,
+        }
+    }
+
+    pub(super) fn connect_probe(&self) -> Self {
+        let mut probe = Self::new(self.local_vmac, self.device_uuid);
+        probe.max_bvlc_length = self.max_bvlc_length;
+        probe.max_apdu_length = self.max_apdu_length;
+        probe
+    }
+
+    pub(super) fn absorb_failed_probe(&mut self, probe: &Self) {
+        self.local_vmac = probe.local_vmac;
+        if !probe.connect_retry_allowed {
+            self.connect_retry_allowed = false;
+        }
+    }
+
+    /// Generate the next message ID.
+    pub fn next_id(&mut self) -> u16 {
+        let id = self.next_message_id;
+        self.next_message_id = self.next_message_id.wrapping_add(1);
+        id
+    }
+
+    /// Build a Connect-Request message (26-byte payload, no VMACs).
+    pub fn build_connect_request(&mut self) -> ScMessage {
+        self.state = ScConnectionState::Connecting;
+        let mut payload_buf = Vec::with_capacity(26);
+        payload_buf.extend_from_slice(&self.local_vmac);
+        payload_buf.extend_from_slice(&self.device_uuid);
+        payload_buf.extend_from_slice(&self.max_bvlc_length.to_be_bytes());
+        payload_buf.extend_from_slice(&self.max_apdu_length.to_be_bytes());
+        let msg_id = self.next_id();
+        self.pending_connect_message_id = Some(msg_id);
+        ScMessage {
+            function: ScFunction::ConnectRequest,
+            message_id: msg_id,
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::from(payload_buf),
+        }
+    }
+
+    /// Handle a received Connect-Accept (26-byte payload).
+    pub fn handle_connect_accept(&mut self, msg: &ScMessage) -> bool {
+        if self.state != ScConnectionState::Connecting {
+            return false;
+        }
+        if msg.function != ScFunction::ConnectAccept {
+            return false;
+        }
+        if let Some(expected_id) = self.pending_connect_message_id {
+            if msg.message_id != expected_id {
+                warn!(
+                    "ConnectAccept message_id {:#x} does not match request {:#x}",
+                    msg.message_id, expected_id
+                );
+                return false;
+            }
+        }
+        if msg.payload.len() != 26 {
+            warn!(
+                "ConnectAccept payload has {} bytes, expected 26",
+                msg.payload.len()
+            );
+            return false;
+        }
+        self.pending_connect_message_id = None;
+        let mut hub_vmac = [0u8; 6];
+        hub_vmac.copy_from_slice(&msg.payload[0..6]);
+        self.hub_vmac = Some(hub_vmac);
+        let mut uuid = [0u8; 16];
+        uuid.copy_from_slice(&msg.payload[6..22]);
+        self.hub_device_uuid = Some(uuid);
+        self.hub_max_bvlc_length = u16::from_be_bytes([msg.payload[22], msg.payload[23]]);
+        self.hub_max_apdu_length = u16::from_be_bytes([msg.payload[24], msg.payload[25]]);
+        self.state = ScConnectionState::Connected;
+        true
+    }
+
+    /// Build a Disconnect-Request message (no VMACs).
+    ///
+    /// Returns an error if not yet connected (no hub VMAC available).
+    pub fn build_disconnect_request(&mut self) -> Result<ScMessage, Error> {
+        if self.hub_vmac.is_none() {
+            return Err(Error::Encoding(
+                "cannot build DisconnectRequest: no hub VMAC (not connected)".into(),
+            ));
+        }
+        self.state = ScConnectionState::Disconnecting;
+        Ok(ScMessage {
+            function: ScFunction::DisconnectRequest,
+            message_id: self.next_id(),
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::new(),
+        })
+    }
+
+    /// Build a Heartbeat-Request message (no VMACs).
+    pub fn build_heartbeat(&mut self) -> ScMessage {
+        ScMessage {
+            function: ScFunction::HeartbeatRequest,
+            message_id: self.next_id(),
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::new(),
+        }
+    }
+
+    /// Build a Heartbeat-ACK message. Per Annex AB.2.15, no VMACs.
+    pub fn build_heartbeat_ack(&self, request_message_id: u16) -> ScMessage {
+        ScMessage {
+            function: ScFunction::HeartbeatAck,
+            message_id: request_message_id,
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::new(),
+        }
+    }
+
+    /// Build an Encapsulated-NPDU message.
+    pub fn build_encapsulated_npdu(&mut self, dest_vmac: Vmac, npdu: &[u8]) -> ScMessage {
+        self.build_encapsulated_npdu_with_data_attributes(dest_vmac, npdu, &[])
+            .expect("empty data attributes are valid")
+    }
+
+    /// Build an Encapsulated-NPDU message with BACnet/SC Data Options.
+    pub fn build_encapsulated_npdu_with_data_attributes(
+        &mut self,
+        dest_vmac: Vmac,
+        npdu: &[u8],
+        data_attributes: &[DataAttribute],
+    ) -> Result<ScMessage, Error> {
+        Ok(ScMessage {
+            function: ScFunction::EncapsulatedNpdu,
+            message_id: self.next_id(),
+            originating_vmac: None,
+            destination_vmac: Some(dest_vmac),
+            dest_options: Vec::new(),
+            data_options: data_attributes::to_data_options(data_attributes)?,
+            payload: Bytes::copy_from_slice(npdu),
+        })
+    }
+
+    /// Handle a received message. Returns NPDU data if it's an Encapsulated-NPDU for us.
+    pub fn handle_received(&mut self, msg: &ScMessage) -> Option<(Bytes, Vmac)> {
+        match msg.function {
+            ScFunction::EncapsulatedNpdu => {
+                if self.state != ScConnectionState::Connected {
+                    debug!("Ignoring EncapsulatedNpdu in {:?} state", self.state);
+                    return None;
+                }
+                if let Some(dest) = msg.destination_vmac {
+                    if !is_broadcast_vmac(&dest) {
+                        return None;
+                    }
+                }
+                if msg.payload.len() > self.max_apdu_length as usize {
+                    warn!(
+                        "BACnet/SC NPDU ({} bytes) exceeds local Max-NPDU-Length ({}), dropping",
+                        msg.payload.len(),
+                        self.max_apdu_length
+                    );
+                    return None;
+                }
+                let source = msg.originating_vmac.unwrap_or([0; 6]);
+                Some((msg.payload.clone(), source))
+            }
+            ScFunction::HeartbeatRequest => None,
+            ScFunction::DisconnectRequest => {
+                self.state = ScConnectionState::Disconnected;
+                self.disconnect_ack_to_send = Some(ScMessage {
+                    function: ScFunction::DisconnectAck,
+                    message_id: msg.message_id,
+                    originating_vmac: None,
+                    destination_vmac: None,
+                    dest_options: Vec::new(),
+                    data_options: Vec::new(),
+                    payload: Bytes::new(),
+                });
+                None
+            }
+            ScFunction::DisconnectAck => {
+                if self.state == ScConnectionState::Disconnecting {
+                    self.state = ScConnectionState::Disconnected;
+                }
+                None
+            }
+            ScFunction::Result => {
+                match decode_sc_bvlc_result(msg) {
+                    Ok(ScBvlcResult::Ack { .. }) => {}
+                    Ok(ScBvlcResult::Nak {
+                        result_for,
+                        error_class,
+                        error_code,
+                        ..
+                    }) => {
+                        warn!(
+                            "BACnet/SC BVLC-Result NAK: function={:#x} \
+                             error_class={} error_code={}",
+                            result_for.to_raw(),
+                            error_class,
+                            error_code
+                        );
+                        self.state = ScConnectionState::Disconnected;
+                    }
+                    Err(e) => {
+                        warn!("Malformed BACnet/SC BVLC-Result: {e}");
+                        self.state = ScConnectionState::Disconnected;
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+}

--- a/crates/bacnet-transport/src/sc/connector.rs
+++ b/crates/bacnet-transport/src/sc/connector.rs
@@ -1,0 +1,91 @@
+//! BACnet/SC WebSocket redial connector helpers.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bacnet_types::error::Error;
+use tracing::warn;
+
+use super::failover::ActiveHub;
+use super::{ScTransport, WebSocketPort};
+
+type WebSocketConnectFuture<W> = Pin<Box<dyn Future<Output = Result<W, Error>> + Send>>;
+pub(super) type WebSocketConnector<W> = Arc<dyn Fn() -> WebSocketConnectFuture<W> + Send + Sync>;
+
+impl<W: WebSocketPort> ScTransport<W> {
+    /// Set a primary WebSocket connector used for reconnect and primary-restore dials.
+    ///
+    /// The initial connection still uses the WebSocket passed to [`ScTransport::new`].
+    /// When reconnecting after a socket-level failure, BACnet/SC needs a fresh
+    /// WebSocket/TCP/TLS connection before re-running the Annex AB.3 Connect-Request
+    /// handshake; this factory supplies that fresh connection without changing the
+    /// pure I/O [`WebSocketPort`] trait.
+    pub fn with_connector<F, Fut>(mut self, connector: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<W, Error>> + Send + 'static,
+    {
+        self.primary_connector = Some(Arc::new(move || Box::pin(connector())));
+        self
+    }
+
+    /// Set a failover WebSocket connector used when switching to the failover hub.
+    ///
+    /// This avoids holding a pre-dialed failover socket idle while the primary hub is
+    /// active. The connector is called at the failover decision point so the
+    /// Connect-Request handshake runs on a fresh WebSocket.
+    pub fn with_failover_connector<F, Fut>(mut self, connector: F) -> Self
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<W, Error>> + Send + 'static,
+    {
+        self.failover_connector = Some(Arc::new(move || Box::pin(connector())));
+        self
+    }
+}
+
+pub(super) async fn dial_reconnect_ws<W: WebSocketPort>(
+    active_hub: ActiveHub,
+    primary_connector: &Option<WebSocketConnector<W>>,
+    failover_connector: &Option<WebSocketConnector<W>>,
+    timeout_ms: u64,
+) -> Result<Option<Arc<W>>, Error> {
+    let connector = match active_hub {
+        ActiveHub::Primary => primary_connector.as_ref(),
+        ActiveHub::Failover => failover_connector.as_ref(),
+    };
+
+    match connector {
+        Some(connector) => Ok(Some(Arc::new(dial_connector(connector, timeout_ms).await?))),
+        None => Ok(None),
+    }
+}
+
+pub(super) async fn dial_failover_ws<W: WebSocketPort>(
+    failover_connector: &Option<WebSocketConnector<W>>,
+    failover_ws: &mut Option<Arc<W>>,
+    timeout_ms: u64,
+) -> Option<Arc<W>> {
+    if let Some(connector) = failover_connector {
+        match dial_connector(connector, timeout_ms).await {
+            Ok(ws) => return Some(Arc::new(ws)),
+            Err(e) => {
+                warn!(%e, "BACnet/SC failover WebSocket redial failed");
+            }
+        }
+    }
+
+    failover_ws.take()
+}
+
+pub(super) async fn dial_connector<W: WebSocketPort>(
+    connector: &WebSocketConnector<W>,
+    timeout_ms: u64,
+) -> Result<W, Error> {
+    match tokio::time::timeout(Duration::from_millis(timeout_ms), connector()).await {
+        Ok(result) => result,
+        Err(_) => Err(Error::Timeout(Duration::from_millis(timeout_ms))),
+    }
+}

--- a/crates/bacnet-transport/src/sc/failover.rs
+++ b/crates/bacnet-transport/src/sc/failover.rs
@@ -1,15 +1,19 @@
 //! BACnet/SC primary/failover hub switching helpers.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use bacnet_types::error::Error;
 use bytes::BytesMut;
 use tokio::sync::Mutex;
 use tracing::warn;
 
-use crate::sc_frame::encode_sc_message;
+use crate::sc_frame::{encode_sc_message, ScMessage};
 
-use super::{handshake::perform_handshake, ScConnection, WebSocketPort};
+use super::{
+    connector::dial_connector, handshake::perform_handshake, ScConnection, WebSocketConnector,
+    WebSocketPort,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum ActiveHub {
@@ -19,33 +23,42 @@ pub(super) enum ActiveHub {
 
 pub(super) async fn attempt_primary_restore<W: WebSocketPort>(
     primary_ws: &Arc<W>,
+    primary_connector: Option<&WebSocketConnector<W>>,
     current_ws: &Arc<W>,
     active_ws: &Arc<Mutex<Arc<W>>>,
     conn: &Arc<Mutex<ScConnection>>,
     connect_timeout_ms: u64,
-) -> Result<(), Error> {
+) -> Result<Arc<W>, Error> {
+    let restored_ws = if let Some(connector) = primary_connector {
+        Arc::new(dial_connector(connector, connect_timeout_ms).await?)
+    } else {
+        primary_ws.clone()
+    };
     let probe_conn = Arc::new(Mutex::new(primary_probe_connection(conn).await));
-    if let Err(e) = perform_handshake(&**primary_ws, &probe_conn, connect_timeout_ms).await {
+    if let Err(e) = perform_handshake(&*restored_ws, &probe_conn, connect_timeout_ms).await {
         absorb_failed_probe(conn, &probe_conn).await;
         return Err(e);
     }
 
-    send_disconnect_request(&**current_ws, conn).await;
-
+    let disconnect_msg = disconnect_request_from(conn).await;
     let restored = probe_conn.lock().await.clone();
     let mut current = active_ws.lock().await;
     let mut c = conn.lock().await;
     *c = restored;
-    *current = primary_ws.clone();
-    Ok(())
+    *current = restored_ws.clone();
+    drop(c);
+    drop(current);
+
+    let disconnect_ws = current_ws.clone();
+    let _ = tokio::spawn(async move {
+        send_disconnect_request(&*disconnect_ws, disconnect_msg, connect_timeout_ms).await;
+    });
+    Ok(restored_ws)
 }
 
 async fn primary_probe_connection(conn: &Arc<Mutex<ScConnection>>) -> ScConnection {
     let c = conn.lock().await;
-    let mut probe = ScConnection::new(c.local_vmac, c.device_uuid);
-    probe.max_bvlc_length = c.max_bvlc_length;
-    probe.max_apdu_length = c.max_apdu_length;
-    probe
+    c.connect_probe()
 }
 
 async fn absorb_failed_probe(
@@ -54,23 +67,31 @@ async fn absorb_failed_probe(
 ) {
     let probe = probe_conn.lock().await;
     let mut c = conn.lock().await;
-    c.local_vmac = probe.local_vmac;
-    if !probe.connect_retry_allowed {
-        c.connect_retry_allowed = false;
-    }
+    c.absorb_failed_probe(&probe);
 }
 
-async fn send_disconnect_request<W: WebSocketPort>(ws: &W, conn: &Arc<Mutex<ScConnection>>) {
-    let disconnect_msg = {
-        let c = conn.lock().await;
-        let mut snapshot = c.clone();
-        snapshot.build_disconnect_request().ok()
-    };
+async fn disconnect_request_from(conn: &Arc<Mutex<ScConnection>>) -> Option<ScMessage> {
+    let c = conn.lock().await;
+    let mut snapshot = c.clone();
+    snapshot.build_disconnect_request().ok()
+}
+
+async fn send_disconnect_request<W: WebSocketPort>(
+    ws: &W,
+    disconnect_msg: Option<ScMessage>,
+    timeout_ms: u64,
+) {
     if let Some(msg) = disconnect_msg {
         let mut buf = BytesMut::new();
         encode_sc_message(&mut buf, &msg);
-        if let Err(e) = ws.send(&buf).await {
-            warn!(%e, "BACnet/SC failover disconnect request failed during primary restore");
+        match tokio::time::timeout(Duration::from_millis(timeout_ms), ws.send(&buf)).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!(%e, "BACnet/SC failover disconnect request failed during primary restore");
+            }
+            Err(_) => {
+                warn!("BACnet/SC failover disconnect request timed out during primary restore");
+            }
         }
     }
 }

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -7,20 +7,23 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use bytes::{Bytes, BytesMut};
+#[cfg(test)]
+use bytes::Bytes;
+use bytes::BytesMut;
 use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
 use crate::port::{DataAttribute, ReceivedNpdu, TransportPort};
-use crate::sc_frame::{
-    decode_sc_bvlc_result, decode_sc_message, encode_sc_message, is_broadcast_vmac, ScBvlcResult,
-    ScFunction, ScMessage, Vmac, BROADCAST_VMAC,
-};
+#[cfg(test)]
+use crate::sc_frame::{decode_sc_bvlc_result, ScMessage};
+use crate::sc_frame::{decode_sc_message, encode_sc_message, ScFunction, Vmac, BROADCAST_VMAC};
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 
 mod connect_result;
+mod connection;
+mod connector;
 mod data_attributes;
 mod failover;
 mod handshake;
@@ -29,6 +32,8 @@ mod loopback;
 mod random48;
 mod reconnect;
 mod send;
+pub use connection::{ScConnection, ScConnectionState};
+use connector::{dial_failover_ws, dial_reconnect_ws, WebSocketConnector};
 use failover::{attempt_primary_restore, ActiveHub};
 use handshake::perform_handshake;
 pub use loopback::LoopbackWebSocket;
@@ -53,286 +58,6 @@ pub trait WebSocketPort: Send + Sync + 'static {
 }
 
 // ---------------------------------------------------------------------------
-// Connection state
-// ---------------------------------------------------------------------------
-
-/// BACnet/SC connection state.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ScConnectionState {
-    /// Not connected.
-    Disconnected,
-    /// Connect-Request sent, waiting for Connect-Accept.
-    Connecting,
-    /// Connected and operational.
-    Connected,
-    /// Disconnect requested.
-    Disconnecting,
-}
-
-/// BACnet/SC hub connection manager.
-#[derive(Clone)]
-pub struct ScConnection {
-    pub state: ScConnectionState,
-    pub local_vmac: Vmac,
-    /// Device UUID (16 bytes, RFC 4122).
-    pub device_uuid: [u8; 16],
-    pub hub_vmac: Option<Vmac>,
-    /// Maximum encoded BACnet/SC BVLC message length this node can accept.
-    pub max_bvlc_length: u16,
-    /// Maximum NPDU length this node can accept (sent in ConnectRequest).
-    pub max_apdu_length: u16,
-    /// Maximum encoded BACnet/SC BVLC message length the hub can accept.
-    pub hub_max_bvlc_length: u16,
-    /// Maximum NPDU length the hub can accept (learned from ConnectAccept).
-    pub hub_max_apdu_length: u16,
-    next_message_id: u16,
-    /// Pending Disconnect-ACK to send after receiving a Disconnect-Request.
-    pub disconnect_ack_to_send: Option<ScMessage>,
-    /// Message ID of the last ConnectRequest sent (for response verification).
-    pending_connect_message_id: Option<u16>,
-    /// Device UUID of the connected hub.
-    pub hub_device_uuid: Option<[u8; 16]>,
-    /// Whether the last connect failure permits another connection attempt.
-    connect_retry_allowed: bool,
-}
-
-impl ScConnection {
-    pub fn new(local_vmac: Vmac, device_uuid: [u8; 16]) -> Self {
-        Self {
-            state: ScConnectionState::Disconnected,
-            local_vmac,
-            device_uuid,
-            hub_vmac: None,
-            max_bvlc_length: 1476,
-            max_apdu_length: 1476,
-            hub_max_bvlc_length: 1476,
-            hub_max_apdu_length: 1476,
-            next_message_id: 1,
-            disconnect_ack_to_send: None,
-            pending_connect_message_id: None,
-            hub_device_uuid: None,
-            connect_retry_allowed: true,
-        }
-    }
-
-    /// Generate the next message ID.
-    pub fn next_id(&mut self) -> u16 {
-        let id = self.next_message_id;
-        self.next_message_id = self.next_message_id.wrapping_add(1);
-        id
-    }
-
-    /// Build a Connect-Request message (26-byte payload, no VMACs).
-    pub fn build_connect_request(&mut self) -> ScMessage {
-        self.state = ScConnectionState::Connecting;
-        let mut payload_buf = Vec::with_capacity(26);
-        payload_buf.extend_from_slice(&self.local_vmac);
-        payload_buf.extend_from_slice(&self.device_uuid);
-        payload_buf.extend_from_slice(&self.max_bvlc_length.to_be_bytes());
-        payload_buf.extend_from_slice(&self.max_apdu_length.to_be_bytes()); // Max-NPDU-Length
-        let msg_id = self.next_id();
-        self.pending_connect_message_id = Some(msg_id);
-        ScMessage {
-            function: ScFunction::ConnectRequest,
-            message_id: msg_id,
-            originating_vmac: None,
-            destination_vmac: None,
-            dest_options: Vec::new(),
-            data_options: Vec::new(),
-            payload: Bytes::from(payload_buf),
-        }
-    }
-
-    /// Handle a received Connect-Accept (26-byte payload).
-    pub fn handle_connect_accept(&mut self, msg: &ScMessage) -> bool {
-        if self.state != ScConnectionState::Connecting {
-            return false;
-        }
-        if msg.function != ScFunction::ConnectAccept {
-            return false;
-        }
-        // Verify message_id matches our ConnectRequest (spec AB.3.1.3)
-        if let Some(expected_id) = self.pending_connect_message_id {
-            if msg.message_id != expected_id {
-                tracing::warn!(
-                    "ConnectAccept message_id {:#x} does not match request {:#x}",
-                    msg.message_id,
-                    expected_id
-                );
-                return false;
-            }
-        }
-        if msg.payload.len() != 26 {
-            tracing::warn!(
-                "ConnectAccept payload has {} bytes, expected 26",
-                msg.payload.len()
-            );
-            return false;
-        }
-        self.pending_connect_message_id = None;
-        let mut hub_vmac = [0u8; 6];
-        hub_vmac.copy_from_slice(&msg.payload[0..6]);
-        self.hub_vmac = Some(hub_vmac);
-        let mut uuid = [0u8; 16];
-        uuid.copy_from_slice(&msg.payload[6..22]);
-        self.hub_device_uuid = Some(uuid);
-        self.hub_max_bvlc_length = u16::from_be_bytes([msg.payload[22], msg.payload[23]]);
-        self.hub_max_apdu_length = u16::from_be_bytes([msg.payload[24], msg.payload[25]]);
-        self.state = ScConnectionState::Connected;
-        true
-    }
-
-    /// Build a Disconnect-Request message (no VMACs).
-    ///
-    /// Returns an error if not yet connected (no hub VMAC available).
-    pub fn build_disconnect_request(&mut self) -> Result<ScMessage, Error> {
-        if self.hub_vmac.is_none() {
-            return Err(Error::Encoding(
-                "cannot build DisconnectRequest: no hub VMAC (not connected)".into(),
-            ));
-        }
-        self.state = ScConnectionState::Disconnecting;
-        Ok(ScMessage {
-            function: ScFunction::DisconnectRequest,
-            message_id: self.next_id(),
-            originating_vmac: None,
-            destination_vmac: None,
-            dest_options: Vec::new(),
-            data_options: Vec::new(),
-            payload: Bytes::new(),
-        })
-    }
-
-    /// Build a Heartbeat-Request message (no VMACs).
-    pub fn build_heartbeat(&mut self) -> ScMessage {
-        ScMessage {
-            function: ScFunction::HeartbeatRequest,
-            message_id: self.next_id(),
-            originating_vmac: None,
-            destination_vmac: None,
-            dest_options: Vec::new(),
-            data_options: Vec::new(),
-            payload: Bytes::new(),
-        }
-    }
-
-    /// Build a Heartbeat-ACK message. Per Annex AB.2.15, no VMACs.
-    pub fn build_heartbeat_ack(&self, request_message_id: u16) -> ScMessage {
-        ScMessage {
-            function: ScFunction::HeartbeatAck,
-            message_id: request_message_id,
-            originating_vmac: None,
-            destination_vmac: None,
-            dest_options: Vec::new(),
-            data_options: Vec::new(),
-            payload: Bytes::new(),
-        }
-    }
-
-    /// Build an Encapsulated-NPDU message.
-    pub fn build_encapsulated_npdu(&mut self, dest_vmac: Vmac, npdu: &[u8]) -> ScMessage {
-        self.build_encapsulated_npdu_with_data_attributes(dest_vmac, npdu, &[])
-            .expect("empty data attributes are valid")
-    }
-
-    /// Build an Encapsulated-NPDU message with BACnet/SC Data Options.
-    pub fn build_encapsulated_npdu_with_data_attributes(
-        &mut self,
-        dest_vmac: Vmac,
-        npdu: &[u8],
-        data_attributes: &[DataAttribute],
-    ) -> Result<ScMessage, Error> {
-        Ok(ScMessage {
-            function: ScFunction::EncapsulatedNpdu,
-            message_id: self.next_id(),
-            originating_vmac: None,
-            destination_vmac: Some(dest_vmac),
-            dest_options: Vec::new(),
-            data_options: data_attributes::to_data_options(data_attributes)?,
-            payload: Bytes::copy_from_slice(npdu),
-        })
-    }
-
-    /// Handle a received message. Returns NPDU data if it's an Encapsulated-NPDU for us.
-    pub fn handle_received(&mut self, msg: &ScMessage) -> Option<(Bytes, Vmac)> {
-        match msg.function {
-            ScFunction::EncapsulatedNpdu => {
-                if self.state != ScConnectionState::Connected {
-                    debug!("Ignoring EncapsulatedNpdu in {:?} state", self.state);
-                    return None;
-                }
-                // Hub-relayed unicast messages do not carry a Destination
-                // Virtual Address; broadcast relay keeps the broadcast VMAC.
-                if let Some(dest) = msg.destination_vmac {
-                    if !is_broadcast_vmac(&dest) {
-                        return None;
-                    }
-                }
-                if msg.payload.len() > self.max_apdu_length as usize {
-                    warn!(
-                        "BACnet/SC NPDU ({} bytes) exceeds local Max-NPDU-Length ({}), dropping",
-                        msg.payload.len(),
-                        self.max_apdu_length
-                    );
-                    return None;
-                }
-                let source = msg.originating_vmac.unwrap_or([0; 6]);
-                Some((msg.payload.clone(), source))
-            }
-            ScFunction::HeartbeatRequest => {
-                // Will be handled by transport layer (send HeartbeatAck)
-                None
-            }
-            ScFunction::DisconnectRequest => {
-                self.state = ScConnectionState::Disconnected;
-                self.disconnect_ack_to_send = Some(ScMessage {
-                    function: ScFunction::DisconnectAck,
-                    message_id: msg.message_id,
-                    originating_vmac: None,
-                    destination_vmac: None,
-                    dest_options: Vec::new(),
-                    data_options: Vec::new(),
-                    payload: Bytes::new(),
-                });
-                None
-            }
-            ScFunction::DisconnectAck => {
-                if self.state == ScConnectionState::Disconnecting {
-                    self.state = ScConnectionState::Disconnected;
-                }
-                None
-            }
-            ScFunction::Result => {
-                match decode_sc_bvlc_result(msg) {
-                    Ok(ScBvlcResult::Ack { .. }) => {}
-                    Ok(ScBvlcResult::Nak {
-                        result_for,
-                        error_class,
-                        error_code,
-                        ..
-                    }) => {
-                        warn!(
-                            "BACnet/SC BVLC-Result NAK: function={:#x} \
-                             error_class={} error_code={}",
-                            result_for.to_raw(),
-                            error_class,
-                            error_code
-                        );
-                        self.state = ScConnectionState::Disconnected;
-                    }
-                    Err(e) => {
-                        warn!("Malformed BACnet/SC BVLC-Result: {e}");
-                        self.state = ScConnectionState::Disconnected;
-                    }
-                }
-                None
-            }
-            _ => None,
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // BACnet/SC Transport
 // ---------------------------------------------------------------------------
 
@@ -349,6 +74,8 @@ pub struct ScTransport<W: WebSocketPort> {
     heartbeat_interval_ms: u64,
     heartbeat_timeout_ms: u64,
     failover_ws: Option<W>,
+    primary_connector: Option<WebSocketConnector<W>>,
+    failover_connector: Option<WebSocketConnector<W>>,
     reconnect_config: Option<ScReconnectConfig>,
     #[cfg(test)]
     allow_test_heartbeat_timing: bool,
@@ -367,6 +94,8 @@ impl<W: WebSocketPort> ScTransport<W> {
             heartbeat_interval_ms: heartbeat::DEFAULT_HEARTBEAT_INTERVAL_MS,
             heartbeat_timeout_ms: heartbeat::DEFAULT_HEARTBEAT_TIMEOUT_MS,
             failover_ws: None,
+            primary_connector: None,
+            failover_connector: None,
             reconnect_config: None,
             #[cfg(test)]
             allow_test_heartbeat_timing: false,
@@ -419,8 +148,10 @@ impl<W: WebSocketPort> ScTransport<W> {
 
     /// Enable reconnection with the given configuration.
     ///
-    /// When the WebSocket connection drops, the transport will attempt to
-    /// re-establish the connection using exponential backoff as configured.
+    /// When the BACnet/SC connection drops, the transport will attempt to reconnect
+    /// using exponential backoff as configured. Configure [`Self::with_connector`]
+    /// for true transport-level recovery from a dead WebSocket/TCP/TLS connection;
+    /// otherwise reconnect attempts can only reuse the current WebSocket object.
     /// The local VMAC is preserved across reconnections.
     pub fn with_reconnect(mut self, config: ScReconnectConfig) -> Self {
         self.reconnect_config = Some(config);
@@ -431,6 +162,32 @@ impl<W: WebSocketPort> ScTransport<W> {
     pub fn connection(&self) -> Option<&Arc<Mutex<ScConnection>>> {
         self.connection.as_ref()
     }
+}
+
+async fn connect_probe_from(conn: &Arc<Mutex<ScConnection>>) -> Arc<Mutex<ScConnection>> {
+    Arc::new(Mutex::new(conn.lock().await.connect_probe()))
+}
+
+async fn absorb_failed_connect_probe(
+    conn: &Arc<Mutex<ScConnection>>,
+    probe_conn: &Arc<Mutex<ScConnection>>,
+) {
+    let probe = probe_conn.lock().await;
+    let mut c = conn.lock().await;
+    c.absorb_failed_probe(&probe);
+}
+
+async fn publish_connected_ws<W: WebSocketPort>(
+    conn: &Arc<Mutex<ScConnection>>,
+    active_ws: &Arc<Mutex<Arc<W>>>,
+    ws: &Arc<W>,
+    probe_conn: &Arc<Mutex<ScConnection>>,
+) {
+    let restored = probe_conn.lock().await.clone();
+    let mut current = active_ws.lock().await;
+    let mut c = conn.lock().await;
+    *c = restored;
+    *current = ws.clone();
 }
 
 impl<W: WebSocketPort> TransportPort for ScTransport<W> {
@@ -464,6 +221,8 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
 
         let primary_ws = Arc::new(primary_ws);
         let mut failover_ws = self.failover_ws.take().map(Arc::new);
+        let primary_connector = self.primary_connector.clone();
+        let failover_connector = self.failover_connector.clone();
 
         // Attempt handshake on the primary WebSocket.
         let (ws, active_hub) =
@@ -474,7 +233,13 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                     if !conn.lock().await.connect_retry_allowed {
                         self.local_vmac = conn.lock().await.local_vmac;
                         return Err(primary_err);
-                    } else if let Some(failover) = failover_ws.take() {
+                    } else if let Some(failover) = dial_failover_ws(
+                        &failover_connector,
+                        &mut failover_ws,
+                        self.connect_timeout_ms,
+                    )
+                    .await
+                    {
                         debug!("BACnet/SC primary connect failed, attempting failover");
                         // Reset connection state for the retry.
                         {
@@ -639,6 +404,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                             }
                             match attempt_primary_restore(
                                 &primary_ws,
+                                primary_connector.as_ref(),
                                 &ws_clone,
                                 &active_ws,
                                 &conn,
@@ -646,8 +412,8 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                             )
                             .await
                             {
-                                Ok(()) => {
-                                    ws_clone = primary_ws.clone();
+                                Ok(restored_ws) => {
+                                    ws_clone = restored_ws;
                                     active_hub = ActiveHub::Primary;
                                     last_bvlc_received = Instant::now();
                                     pending_heartbeat_id = None;
@@ -713,13 +479,35 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                         c.reset_for_connect_retry();
                     }
 
-                    match perform_handshake(&*ws_clone, &conn, connect_timeout_ms).await {
+                    let reconnect_ws = match dial_reconnect_ws(
+                        active_hub,
+                        &primary_connector,
+                        &failover_connector,
+                        connect_timeout_ms,
+                    )
+                    .await
+                    {
+                        Ok(Some(ws)) => ws,
+                        Ok(None) => ws_clone.clone(),
+                        Err(e) => {
+                            warn!(%e, attempt, "SC reconnection redial failed");
+                            backoff = (backoff * 2).min(max_backoff);
+                            continue;
+                        }
+                    };
+
+                    let probe_conn = connect_probe_from(&conn).await;
+                    match perform_handshake(&*reconnect_ws, &probe_conn, connect_timeout_ms).await {
                         Ok(()) => {
+                            publish_connected_ws(&conn, &active_ws, &reconnect_ws, &probe_conn)
+                                .await;
+                            ws_clone = reconnect_ws;
                             info!(attempt, "SC reconnected after backoff");
                             reconnected = true;
                             break;
                         }
                         Err(e) => {
+                            absorb_failed_connect_probe(&conn, &probe_conn).await;
                             if !conn.lock().await.connect_retry_allowed {
                                 warn!(
                                     %e,
@@ -734,8 +522,14 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                     }
                 }
 
-                if !reconnected && conn.lock().await.connect_retry_allowed {
-                    if let Some(failover) = failover_ws.take() {
+                if !reconnected
+                    && active_hub == ActiveHub::Primary
+                    && conn.lock().await.connect_retry_allowed
+                {
+                    if let Some(failover) =
+                        dial_failover_ws(&failover_connector, &mut failover_ws, connect_timeout_ms)
+                            .await
+                    {
                         warn!("SC primary reconnection exhausted, attempting failover hub");
 
                         {
@@ -743,18 +537,18 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                             c.reset_for_connect_retry();
                         }
 
-                        match perform_handshake(&*failover, &conn, connect_timeout_ms).await {
+                        let probe_conn = connect_probe_from(&conn).await;
+                        match perform_handshake(&*failover, &probe_conn, connect_timeout_ms).await {
                             Ok(()) => {
-                                {
-                                    let mut current = active_ws.lock().await;
-                                    *current = failover.clone();
-                                }
+                                publish_connected_ws(&conn, &active_ws, &failover, &probe_conn)
+                                    .await;
                                 ws_clone = failover;
                                 active_hub = ActiveHub::Failover;
                                 info!("SC connected to failover hub after primary reconnect exhaustion");
                                 reconnected = true;
                             }
                             Err(e) => {
+                                absorb_failed_connect_probe(&conn, &probe_conn).await;
                                 warn!(%e, "SC failover connection failed");
                             }
                         }
@@ -780,10 +574,10 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
     async fn stop(&mut self) -> Result<(), Error> {
         // Attempt clean disconnect: send DisconnectRequest via the WebSocket
         if let (Some(ws), Some(conn)) = (&self.ws_shared, &self.connection) {
-            let ws = ws.lock().await.clone();
-            let disconnect_msg = {
+            let (ws, disconnect_msg) = {
+                let ws = ws.lock().await;
                 let mut c = conn.lock().await;
-                c.build_disconnect_request().ok()
+                (ws.clone(), c.build_disconnect_request().ok())
             };
             if let Some(msg) = disconnect_msg {
                 let mut buf = BytesMut::new();
@@ -855,6 +649,9 @@ mod result_tests;
 
 #[cfg(test)]
 mod primary_restore_tests;
+
+#[cfg(test)]
+mod redial_tests;
 
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-transport/src/sc/redial_tests.rs
+++ b/crates/bacnet-transport/src/sc/redial_tests.rs
@@ -1,0 +1,639 @@
+use super::*;
+use bacnet_types::error::Error;
+use std::future::{pending, Future};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+struct GateSendWebSocket {
+    inner: LoopbackWebSocket,
+    hang_send: Arc<AtomicBool>,
+}
+
+impl GateSendWebSocket {
+    fn pair(client_hang_send: Arc<AtomicBool>) -> (Self, Self) {
+        let (client, hub) = LoopbackWebSocket::pair();
+        (
+            Self {
+                inner: client,
+                hang_send: client_hang_send,
+            },
+            Self {
+                inner: hub,
+                hang_send: Arc::new(AtomicBool::new(false)),
+            },
+        )
+    }
+}
+
+impl WebSocketPort for GateSendWebSocket {
+    async fn send(&self, data: &[u8]) -> Result<(), Error> {
+        if self.hang_send.load(Ordering::SeqCst) {
+            pending::<Result<(), Error>>().await
+        } else {
+            self.inner.send(data).await
+        }
+    }
+
+    async fn recv(&self) -> Result<Vec<u8>, Error> {
+        self.inner.recv().await
+    }
+}
+
+fn loopback_redial_connector(
+    dial_count: Arc<AtomicUsize>,
+    hub_tx: tokio::sync::mpsc::UnboundedSender<LoopbackWebSocket>,
+) -> impl Fn() -> Pin<Box<dyn Future<Output = Result<LoopbackWebSocket, Error>> + Send>>
+       + Send
+       + Sync
+       + 'static {
+    move || {
+        let dial_count = dial_count.clone();
+        let hub_tx = hub_tx.clone();
+        Box::pin(async move {
+            dial_count.fetch_add(1, Ordering::SeqCst);
+            let (client, hub) = LoopbackWebSocket::pair();
+            hub_tx
+                .send(hub)
+                .map_err(|_| Error::Encoding("test connector hub receiver dropped".into()))?;
+            Ok(client)
+        })
+    }
+}
+
+fn hanging_redial_connector(
+    dial_count: Arc<AtomicUsize>,
+) -> impl Fn() -> Pin<Box<dyn Future<Output = Result<LoopbackWebSocket, Error>> + Send>>
+       + Send
+       + Sync
+       + 'static {
+    move || {
+        let dial_count = dial_count.clone();
+        Box::pin(async move {
+            dial_count.fetch_add(1, Ordering::SeqCst);
+            pending::<Result<LoopbackWebSocket, Error>>().await
+        })
+    }
+}
+
+fn loopback_first_success_then_error_connector(
+    dial_count: Arc<AtomicUsize>,
+    hub_tx: tokio::sync::mpsc::UnboundedSender<LoopbackWebSocket>,
+) -> impl Fn() -> Pin<Box<dyn Future<Output = Result<LoopbackWebSocket, Error>> + Send>>
+       + Send
+       + Sync
+       + 'static {
+    move || {
+        let dial_count = dial_count.clone();
+        let hub_tx = hub_tx.clone();
+        Box::pin(async move {
+            let attempt = dial_count.fetch_add(1, Ordering::SeqCst) + 1;
+            if attempt != 1 {
+                return Err(Error::Encoding(format!(
+                    "test connector rejects dial attempt {attempt}"
+                )));
+            }
+            let (client, hub) = LoopbackWebSocket::pair();
+            hub_tx
+                .send(hub)
+                .map_err(|_| Error::Encoding("test connector hub receiver dropped".into()))?;
+            Ok(client)
+        })
+    }
+}
+
+fn gate_send_redial_connector(
+    dial_count: Arc<AtomicUsize>,
+    hub_tx: tokio::sync::mpsc::UnboundedSender<GateSendWebSocket>,
+) -> impl Fn() -> Pin<Box<dyn Future<Output = Result<GateSendWebSocket, Error>> + Send>>
+       + Send
+       + Sync
+       + 'static {
+    move || {
+        let dial_count = dial_count.clone();
+        let hub_tx = hub_tx.clone();
+        Box::pin(async move {
+            dial_count.fetch_add(1, Ordering::SeqCst);
+            let (client, hub) = GateSendWebSocket::pair(Arc::new(AtomicBool::new(false)));
+            hub_tx
+                .send(hub)
+                .map_err(|_| Error::Encoding("test connector hub receiver dropped".into()))?;
+            Ok(client)
+        })
+    }
+}
+
+fn failing_loopback_connector(
+) -> impl Fn() -> Pin<Box<dyn Future<Output = Result<LoopbackWebSocket, Error>> + Send>>
+       + Send
+       + Sync
+       + 'static {
+    move || {
+        Box::pin(async {
+            Err(Error::Encoding(
+                "test primary connector intentionally fails".into(),
+            ))
+        })
+    }
+}
+
+async fn hub_accept<W: WebSocketPort>(ws_hub: &W, hub_vmac: Vmac) {
+    let data = ws_hub.recv().await.unwrap();
+    let req = decode_sc_message(&data).unwrap();
+    assert_eq!(req.function, ScFunction::ConnectRequest);
+
+    let mut accept_payload = Vec::with_capacity(26);
+    accept_payload.extend_from_slice(&hub_vmac);
+    accept_payload.extend_from_slice(&[0u8; 16]);
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+
+    let accept = ScMessage {
+        function: ScFunction::ConnectAccept,
+        message_id: req.message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(accept_payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &accept);
+    ws_hub.send(&buf).await.unwrap();
+}
+
+async fn wait_for_hub_vmac(conn: &Arc<Mutex<ScConnection>>, expected: Vmac, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if conn.lock().await.hub_vmac == Some(expected) {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for hub VMAC {expected:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn wait_for_dial_count(count: &AtomicUsize, expected: usize, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if count.load(Ordering::SeqCst) >= expected {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for dial count {expected}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+async fn wait_for_state(
+    conn: &Arc<Mutex<ScConnection>>,
+    expected: ScConnectionState,
+    timeout: Duration,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if conn.lock().await.state == expected {
+            return;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for SC state {expected:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn sc_reconnect_redials_fresh_websocket_after_socket_teardown() {
+    let (primary_client, primary_hub) = LoopbackWebSocket::pair();
+    let (redial_hub_tx, mut redial_hub_rx) =
+        tokio::sync::mpsc::unbounded_channel::<LoopbackWebSocket>();
+    let redial_count = Arc::new(AtomicUsize::new(0));
+
+    let client_vmac = [0x01; 6];
+    let primary_hub_vmac = [0x10; 6];
+    let redial_hub_vmac = [0x11; 6];
+
+    let mut transport = ScTransport::new(primary_client, client_vmac)
+        .with_connect_timeout_ms(100)
+        .with_test_heartbeat_timing_ms(5_000, 10_000)
+        .with_connector(loopback_redial_connector(
+            redial_count.clone(),
+            redial_hub_tx,
+        ))
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 10,
+            max_delay_ms: 10,
+            max_retries: 3,
+        });
+
+    let primary_task = tokio::spawn(async move {
+        hub_accept(&primary_hub, primary_hub_vmac).await;
+        primary_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let primary_hub = primary_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+    assert_eq!(conn.lock().await.hub_vmac, Some(primary_hub_vmac));
+
+    let redial_task = tokio::spawn(async move {
+        let redial_hub = tokio::time::timeout(Duration::from_secs(1), redial_hub_rx.recv())
+            .await
+            .expect("timed out waiting for redial connector")
+            .expect("redial connector channel closed");
+        hub_accept(&redial_hub, redial_hub_vmac).await;
+        redial_hub
+    });
+
+    drop(primary_hub);
+    let redial_hub = tokio::time::timeout(Duration::from_secs(2), redial_task)
+        .await
+        .expect("timed out waiting for redial handshake")
+        .unwrap();
+
+    wait_for_hub_vmac(&conn, redial_hub_vmac, Duration::from_secs(1)).await;
+    assert_eq!(redial_count.load(Ordering::SeqCst), 1);
+
+    let payload = [0x09, 0x08, 0x07];
+    let dest_vmac = [0x55; 6];
+    transport.send_unicast(&payload, &dest_vmac).await.unwrap();
+
+    let data = tokio::time::timeout(Duration::from_secs(1), redial_hub.recv())
+        .await
+        .expect("timed out waiting for unicast on redialed socket")
+        .unwrap();
+    let msg = decode_sc_message(&data).unwrap();
+    assert_eq!(msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(msg.destination_vmac, Some(dest_vmac));
+    assert_eq!(msg.payload.as_ref(), payload);
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_failover_connector_dials_when_failover_is_needed() {
+    let (primary_client, _primary_hub) = LoopbackWebSocket::pair();
+    let (failover_hub_tx, mut failover_hub_rx) =
+        tokio::sync::mpsc::unbounded_channel::<LoopbackWebSocket>();
+    let failover_dial_count = Arc::new(AtomicUsize::new(0));
+
+    let client_vmac = [0x01; 6];
+    let failover_hub_vmac = [0x20; 6];
+
+    let mut transport = ScTransport::new(primary_client, client_vmac)
+        .with_connect_timeout_ms(100)
+        .with_failover_connector(loopback_redial_connector(
+            failover_dial_count.clone(),
+            failover_hub_tx,
+        ));
+
+    let failover_task = tokio::spawn(async move {
+        let failover_hub = tokio::time::timeout(Duration::from_secs(1), failover_hub_rx.recv())
+            .await
+            .expect("timed out waiting for failover connector")
+            .expect("failover connector channel closed");
+        hub_accept(&failover_hub, failover_hub_vmac).await;
+        failover_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let failover_hub = failover_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+    assert_eq!(conn.lock().await.hub_vmac, Some(failover_hub_vmac));
+    assert_eq!(failover_dial_count.load(Ordering::SeqCst), 1);
+
+    let payload = [0x02, 0x04, 0x06];
+    let dest_vmac = [0x66; 6];
+    transport.send_unicast(&payload, &dest_vmac).await.unwrap();
+    let data = tokio::time::timeout(Duration::from_secs(1), failover_hub.recv())
+        .await
+        .expect("timed out waiting for failover unicast")
+        .unwrap();
+    let msg = decode_sc_message(&data).unwrap();
+    assert_eq!(msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(msg.destination_vmac, Some(dest_vmac));
+    assert_eq!(msg.payload.as_ref(), payload);
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_primary_restore_connector_redials_primary_socket() {
+    let (primary_client, _stale_primary_hub) = LoopbackWebSocket::pair();
+    let (failover_client, failover_hub) = LoopbackWebSocket::pair();
+    let (primary_hub_tx, mut primary_hub_rx) =
+        tokio::sync::mpsc::unbounded_channel::<LoopbackWebSocket>();
+    let primary_dial_count = Arc::new(AtomicUsize::new(0));
+
+    let client_vmac = [0x01; 6];
+    let primary_hub_vmac = [0x10; 6];
+    let failover_hub_vmac = [0x20; 6];
+
+    let mut transport = ScTransport::new(primary_client, client_vmac)
+        .with_connect_timeout_ms(100)
+        .with_heartbeat_interval_ms(5_000)
+        .with_connector(loopback_redial_connector(
+            primary_dial_count.clone(),
+            primary_hub_tx,
+        ))
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 25,
+            max_delay_ms: 25,
+            max_retries: 1,
+        })
+        .with_failover(failover_client);
+
+    let failover_task = tokio::spawn(async move {
+        hub_accept(&failover_hub, failover_hub_vmac).await;
+        failover_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let failover_hub = failover_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+    assert_eq!(conn.lock().await.hub_vmac, Some(failover_hub_vmac));
+
+    let primary_restore_task = tokio::spawn(async move {
+        let primary_hub = tokio::time::timeout(Duration::from_secs(1), primary_hub_rx.recv())
+            .await
+            .expect("timed out waiting for primary restore connector")
+            .expect("primary restore connector channel closed");
+        hub_accept(&primary_hub, primary_hub_vmac).await;
+        primary_hub
+    });
+
+    let primary_hub = tokio::time::timeout(Duration::from_secs(2), primary_restore_task)
+        .await
+        .expect("timed out waiting for primary restore handshake")
+        .unwrap();
+
+    wait_for_hub_vmac(&conn, primary_hub_vmac, Duration::from_secs(1)).await;
+    assert_eq!(primary_dial_count.load(Ordering::SeqCst), 1);
+
+    let failover_data = tokio::time::timeout(Duration::from_secs(1), failover_hub.recv())
+        .await
+        .expect("timed out waiting for failover disconnect")
+        .unwrap();
+    let failover_msg = decode_sc_message(&failover_data).unwrap();
+    assert_eq!(failover_msg.function, ScFunction::DisconnectRequest);
+
+    let payload = [0x03, 0x05, 0x07];
+    let dest_vmac = [0x77; 6];
+    transport.send_unicast(&payload, &dest_vmac).await.unwrap();
+    let data = tokio::time::timeout(Duration::from_secs(1), primary_hub.recv())
+        .await
+        .expect("timed out waiting for primary restore unicast")
+        .unwrap();
+    let msg = decode_sc_message(&data).unwrap();
+    assert_eq!(msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(msg.destination_vmac, Some(dest_vmac));
+    assert_eq!(msg.payload.as_ref(), payload);
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_failover_connector_timeout_does_not_hang_start() {
+    let (primary_client, _primary_hub) = LoopbackWebSocket::pair();
+    let failover_dial_count = Arc::new(AtomicUsize::new(0));
+
+    let mut transport = ScTransport::new(primary_client, [0x01; 6])
+        .with_connect_timeout_ms(20)
+        .with_failover_connector(hanging_redial_connector(failover_dial_count.clone()));
+
+    let result = tokio::time::timeout(Duration::from_secs(1), transport.start())
+        .await
+        .expect("start hung behind failover connector timeout");
+
+    assert!(result.is_err());
+    assert_eq!(failover_dial_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn sc_reconnect_connector_timeout_counts_as_failed_attempt() {
+    let (primary_client, primary_hub) = LoopbackWebSocket::pair();
+    let redial_count = Arc::new(AtomicUsize::new(0));
+
+    let client_vmac = [0x01; 6];
+    let primary_hub_vmac = [0x10; 6];
+
+    let mut transport = ScTransport::new(primary_client, client_vmac)
+        .with_connect_timeout_ms(20)
+        .with_test_heartbeat_timing_ms(5_000, 10_000)
+        .with_connector(hanging_redial_connector(redial_count.clone()))
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 10,
+            max_delay_ms: 10,
+            max_retries: 1,
+        });
+
+    let primary_task = tokio::spawn(async move {
+        hub_accept(&primary_hub, primary_hub_vmac).await;
+        primary_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let primary_hub = primary_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+    assert_eq!(conn.lock().await.hub_vmac, Some(primary_hub_vmac));
+
+    drop(primary_hub);
+    wait_for_dial_count(&redial_count, 1, Duration::from_secs(1)).await;
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if conn.lock().await.state == ScConnectionState::Disconnected {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("reconnect did not finish after connector timeout");
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_primary_restore_connector_timeout_leaves_failover_send_path_active() {
+    let (primary_client, _stale_primary_hub) = LoopbackWebSocket::pair();
+    let (failover_client, failover_hub) = LoopbackWebSocket::pair();
+    let primary_dial_count = Arc::new(AtomicUsize::new(0));
+
+    let client_vmac = [0x01; 6];
+    let failover_hub_vmac = [0x20; 6];
+
+    let mut transport = ScTransport::new(primary_client, client_vmac)
+        .with_connect_timeout_ms(50)
+        .with_heartbeat_interval_ms(5_000)
+        .with_connector(hanging_redial_connector(primary_dial_count.clone()))
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 10,
+            max_delay_ms: 10,
+            max_retries: 1,
+        })
+        .with_failover(failover_client);
+
+    let failover_task = tokio::spawn(async move {
+        hub_accept(&failover_hub, failover_hub_vmac).await;
+        failover_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let failover_hub = failover_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+    assert_eq!(conn.lock().await.hub_vmac, Some(failover_hub_vmac));
+
+    wait_for_dial_count(&primary_dial_count, 1, Duration::from_secs(1)).await;
+
+    let payload = [0x0a, 0x0b, 0x0c];
+    let dest_vmac = [0x88; 6];
+    transport.send_unicast(&payload, &dest_vmac).await.unwrap();
+    let data = tokio::time::timeout(Duration::from_secs(1), failover_hub.recv())
+        .await
+        .expect("timed out waiting for failover unicast while primary restore dial hung")
+        .unwrap();
+    let msg = decode_sc_message(&data).unwrap();
+    assert_eq!(msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(msg.destination_vmac, Some(dest_vmac));
+    assert_eq!(msg.payload.as_ref(), payload);
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_failover_reconnect_exhaustion_does_not_redial_failover_again() {
+    let (primary_client, primary_hub) = LoopbackWebSocket::pair();
+    drop(primary_hub);
+
+    let (failover_hub_tx, mut failover_hub_rx) =
+        tokio::sync::mpsc::unbounded_channel::<LoopbackWebSocket>();
+    let failover_dial_count = Arc::new(AtomicUsize::new(0));
+
+    let client_vmac = [0x01; 6];
+    let failover_hub_vmac = [0x20; 6];
+
+    let mut transport = ScTransport::new(primary_client, client_vmac)
+        .with_connect_timeout_ms(50)
+        .with_test_heartbeat_timing_ms(5_000, 10_000)
+        .with_connector(failing_loopback_connector())
+        .with_failover_connector(loopback_first_success_then_error_connector(
+            failover_dial_count.clone(),
+            failover_hub_tx,
+        ))
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 10,
+            max_delay_ms: 10,
+            max_retries: 1,
+        });
+
+    let failover_task = tokio::spawn(async move {
+        let failover_hub = tokio::time::timeout(Duration::from_secs(1), failover_hub_rx.recv())
+            .await
+            .expect("timed out waiting for initial failover connector")
+            .expect("failover connector channel closed");
+        hub_accept(&failover_hub, failover_hub_vmac).await;
+        failover_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let failover_hub = failover_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+    assert_eq!(conn.lock().await.hub_vmac, Some(failover_hub_vmac));
+    assert_eq!(failover_dial_count.load(Ordering::SeqCst), 1);
+
+    drop(failover_hub);
+    wait_for_dial_count(&failover_dial_count, 2, Duration::from_secs(1)).await;
+    wait_for_state(
+        &conn,
+        ScConnectionState::Disconnected,
+        Duration::from_secs(1),
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    assert_eq!(
+        failover_dial_count.load(Ordering::SeqCst),
+        2,
+        "failover connector should not be redialed again after failover reconnect budget is exhausted"
+    );
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_primary_restore_publishes_before_hung_failover_disconnect_send() {
+    let (primary_client, stale_primary_hub) =
+        GateSendWebSocket::pair(Arc::new(AtomicBool::new(false)));
+    drop(stale_primary_hub);
+    let failover_hang_send = Arc::new(AtomicBool::new(false));
+    let (failover_client, failover_hub) = GateSendWebSocket::pair(failover_hang_send.clone());
+    let (primary_hub_tx, mut primary_hub_rx) =
+        tokio::sync::mpsc::unbounded_channel::<GateSendWebSocket>();
+    let primary_dial_count = Arc::new(AtomicUsize::new(0));
+
+    let client_vmac = [0x01; 6];
+    let primary_hub_vmac = [0x10; 6];
+    let failover_hub_vmac = [0x20; 6];
+
+    let mut transport = ScTransport::new(primary_client, client_vmac)
+        .with_connect_timeout_ms(750)
+        .with_heartbeat_interval_ms(5_000)
+        .with_connector(gate_send_redial_connector(
+            primary_dial_count.clone(),
+            primary_hub_tx,
+        ))
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 10,
+            max_delay_ms: 10,
+            max_retries: 1,
+        })
+        .with_failover(failover_client);
+
+    let failover_task = tokio::spawn(async move {
+        hub_accept(&failover_hub, failover_hub_vmac).await;
+        failover_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let _failover_hub = failover_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+    assert_eq!(conn.lock().await.hub_vmac, Some(failover_hub_vmac));
+
+    failover_hang_send.store(true, Ordering::SeqCst);
+    let primary_restore_task = tokio::spawn(async move {
+        let primary_hub = tokio::time::timeout(Duration::from_secs(1), primary_hub_rx.recv())
+            .await
+            .expect("timed out waiting for primary restore connector")
+            .expect("primary restore connector channel closed");
+        hub_accept(&primary_hub, primary_hub_vmac).await;
+        primary_hub
+    });
+
+    let primary_hub = tokio::time::timeout(Duration::from_secs(2), primary_restore_task)
+        .await
+        .expect("timed out waiting for primary restore handshake")
+        .unwrap();
+
+    wait_for_hub_vmac(&conn, primary_hub_vmac, Duration::from_millis(250)).await;
+    assert_eq!(primary_dial_count.load(Ordering::SeqCst), 1);
+
+    let payload = [0x0d, 0x0e, 0x0f];
+    let dest_vmac = [0x99; 6];
+    transport.send_unicast(&payload, &dest_vmac).await.unwrap();
+    let data = tokio::time::timeout(Duration::from_secs(1), primary_hub.recv())
+        .await
+        .expect("timed out waiting for primary unicast while failover disconnect send hung")
+        .unwrap();
+    let msg = decode_sc_message(&data).unwrap();
+    assert_eq!(msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(msg.destination_vmac, Some(dest_vmac));
+    assert_eq!(msg.payload.as_ref(), payload);
+
+    transport.stop().await.unwrap();
+}

--- a/crates/bacnet-transport/src/sc/send.rs
+++ b/crates/bacnet-transport/src/sc/send.rs
@@ -20,13 +20,12 @@ impl<W: WebSocketPort> ScTransport<W> {
                 mac.len()
             )));
         }
-        let ws = self.ws_shared.as_ref().ok_or_else(|| {
+        let ws_shared = self.ws_shared.as_ref().ok_or_else(|| {
             Error::Transport(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
                 "BACnet/SC transport not started",
             ))
         })?;
-        let ws = ws.lock().await.clone();
         let conn = self.connection.as_ref().ok_or_else(|| {
             Error::Transport(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
@@ -37,23 +36,26 @@ impl<W: WebSocketPort> ScTransport<W> {
         let mut dest_vmac = [0u8; 6];
         dest_vmac.copy_from_slice(mac);
 
-        let mut c = conn.lock().await;
-        if c.state != ScConnectionState::Connected {
-            return Err(Error::Encoding(
-                "BACnet/SC transport not in Connected state".into(),
-            ));
-        }
-        if npdu.len() > c.hub_max_apdu_length as usize {
-            return Err(Error::Encoding(format!(
-                "BACnet/SC NPDU length {} exceeds peer Max-NPDU-Length {}",
-                npdu.len(),
-                c.hub_max_apdu_length
-            )));
-        }
-        let hub_max_bvlc_length = c.hub_max_bvlc_length;
-        let msg =
-            c.build_encapsulated_npdu_with_data_attributes(dest_vmac, npdu, data_attributes)?;
-        drop(c);
+        let (ws, hub_max_bvlc_length, msg) = {
+            let ws = ws_shared.lock().await;
+            let mut c = conn.lock().await;
+            if c.state != ScConnectionState::Connected {
+                return Err(Error::Encoding(
+                    "BACnet/SC transport not in Connected state".into(),
+                ));
+            }
+            if npdu.len() > c.hub_max_apdu_length as usize {
+                return Err(Error::Encoding(format!(
+                    "BACnet/SC NPDU length {} exceeds peer Max-NPDU-Length {}",
+                    npdu.len(),
+                    c.hub_max_apdu_length
+                )));
+            }
+            let hub_max_bvlc_length = c.hub_max_bvlc_length;
+            let msg =
+                c.build_encapsulated_npdu_with_data_attributes(dest_vmac, npdu, data_attributes)?;
+            (ws.clone(), hub_max_bvlc_length, msg)
+        };
 
         let mut buf = BytesMut::new();
         encode_sc_message(&mut buf, &msg);


### PR DESCRIPTION
Fixes #91.

## Summary

- Adds connector-backed BACnet/SC WebSocket redials so reconnect, failover, and primary restore use fresh sockets instead of reusing consumed streams.
- Wires the high-level client/server SC TLS builders to redial with cloned URL/TLS config.
- Publishes active socket and connection state together only after successful probe handshakes.
- Bounds connector and old-failover cleanup paths, and prevents an already-active failover path from consuming one extra failover redial after retry exhaustion.
- Adds regression coverage for reconnect, failover, primary restore, connector timeouts, retry exhaustion, and the publish-before-hung-cleanup race.

## Review

- Correctness, BACnet/SC security, security/reliability, and test-verifier subagent reviews found no remaining blockers after the follow-up fixes.
- Residual non-blocking risks remain outside this PR: default Device UUID plumbing in high-level SC builders and public `local_mac()` observability after duplicate-VMAC reseed.

## Verification

- `cargo fmt --all --check`
- `cargo test -p bacnet-transport --features sc-tls sc::redial_tests -- --nocapture`
- `cargo test -p bacnet-transport --features sc-tls sc::`
- `cargo check -p bacnet-client --features sc-tls`
- `cargo check -p bacnet-server --features sc-tls`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check --cached`
- `cargo package -p bacnet-transport --allow-dirty --no-verify --list`

## Notes

- CI does not automatically compile the package-local `bacnet-client` and `bacnet-server` `sc-tls` builder paths, so those checks are listed explicitly.
- `cargo clippy --workspace --all-targets -- -D warnings` still fails on existing missing-doc warnings; CI intentionally avoids `-D warnings`.
- Plain `cargo test --workspace` still fails locally on macOS in the excluded `rusty-bacnet` PyO3 target; the CI-equivalent command above excludes `rusty-bacnet` and `bacnet-wasm`.
- No live external BACnet/SC hub TLS interop run was performed for this redial-only fix.
