### PR TITLE
fix(sc): tear down transport on drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Re-dial BACnet/SC WebSocket connections during reconnect, failover, and primary restore instead of reusing a torn-down socket object.
+- Abort BACnet/SC receive tasks and close WebSocket ownership on ungraceful `Drop`, including the `BACnetClient`/`NetworkLayer` drop cascade, while preserving graceful Disconnect-Request shutdown.
 - Abort `BACnetClient` dispatch on drop and cascade B/IP network cleanup so ungraceful teardown releases reader tasks and the UDP socket.
 - Run `BACnetClient` device-table stale-entry purging on an independent interval so fully silent datalinks can evict dead devices.
 - Avoid `Instant` underflow in `BACnetClient` device-table purging on fresh Windows runners.

--- a/crates/bacnet-client/src/client/tests.rs
+++ b/crates/bacnet-client/src/client/tests.rs
@@ -3,6 +3,10 @@ use bacnet_encoding::apdu::{ComplexAck, SimpleAck};
 use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
 use bacnet_transport::loopback::LoopbackTransport;
 use bacnet_transport::port::TransportPort;
+use bacnet_transport::sc::{LoopbackWebSocket, ScTransport, WebSocketPort};
+use bacnet_transport::sc_frame::{
+    decode_sc_message, encode_sc_message, ScFunction, ScMessage, Vmac,
+};
 use bacnet_types::enums::{ObjectType, Segmentation};
 use bacnet_types::primitives::ObjectIdentifier;
 use std::net::Ipv4Addr;
@@ -17,6 +21,67 @@ async fn make_client() -> BACnetClient<BipTransport> {
         .build()
         .await
         .unwrap()
+}
+
+async fn sc_hub_accept(ws_hub: &LoopbackWebSocket, hub_vmac: Vmac) {
+    let data = ws_hub.recv().await.unwrap();
+    let req = decode_sc_message(&data).unwrap();
+    assert_eq!(req.function, ScFunction::ConnectRequest);
+
+    let mut accept_payload = Vec::with_capacity(26);
+    accept_payload.extend_from_slice(&hub_vmac);
+    accept_payload.extend_from_slice(&[0u8; 16]);
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+
+    let accept = ScMessage {
+        function: ScFunction::ConnectAccept,
+        message_id: req.message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(accept_payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &accept);
+    ws_hub.send(&buf).await.unwrap();
+}
+
+async fn assert_sc_socket_closed_after_drop(ws_hub: &LoopbackWebSocket, context: &str) {
+    timeout(Duration::from_secs(1), async {
+        loop {
+            match ws_hub.recv().await {
+                Ok(data) => {
+                    let msg = decode_sc_message(&data).unwrap();
+                    assert_ne!(
+                        msg.function,
+                        ScFunction::HeartbeatAck,
+                        "{context} must not leave SC answering heartbeats"
+                    );
+                }
+                Err(_) => break,
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("{context} did not close the SC WebSocket"));
+
+    let heartbeat = ScMessage {
+        function: ScFunction::HeartbeatRequest,
+        message_id: 0x66,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::new(),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &heartbeat);
+    assert!(
+        ws_hub.send(&buf).await.is_err(),
+        "{context} must reject post-drop Heartbeat-Request on the closed socket"
+    );
 }
 
 async fn send_routed_response<T: TransportPort>(
@@ -123,6 +188,28 @@ async fn client_drop_releases_bip_socket() {
     })
     .await
     .expect("dropping BACnetClient releases the B/IP socket");
+}
+
+#[tokio::test]
+async fn client_drop_releases_sc_transport_socket() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let client_vmac = [0x01; 6];
+    let hub_vmac = [0x10; 6];
+    let transport = ScTransport::new(ws_client, client_vmac);
+
+    let hub_task = tokio::spawn(async move {
+        sc_hub_accept(&ws_hub, hub_vmac).await;
+        ws_hub
+    });
+
+    let client = BACnetClient::start(ClientConfig::default(), transport)
+        .await
+        .unwrap();
+    let ws_hub = hub_task.await.unwrap();
+
+    drop(client);
+
+    assert_sc_socket_closed_after_drop(&ws_hub, "dropped BACnetClient").await;
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -399,6 +399,7 @@ impl<T: TransportPort> NetworkLayer<T> {
 impl<T: TransportPort> Drop for NetworkLayer<T> {
     fn drop(&mut self) {
         let _ = self.abort_dispatch_task();
+        self.transport.abort();
     }
 }
 
@@ -436,6 +437,42 @@ mod tests {
         let mut buf = BytesMut::new();
         encode_sc_message(&mut buf, &accept);
         ws_hub.send(&buf).await.unwrap();
+    }
+
+    async fn assert_sc_socket_closed_after_drop(ws_hub: &LoopbackWebSocket, context: &str) {
+        timeout(Duration::from_secs(1), async {
+            loop {
+                match ws_hub.recv().await {
+                    Ok(data) => {
+                        let msg = decode_sc_message(&data).unwrap();
+                        assert_ne!(
+                            msg.function,
+                            ScFunction::HeartbeatAck,
+                            "{context} must not leave SC answering heartbeats"
+                        );
+                    }
+                    Err(_) => break,
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("{context} did not close the SC WebSocket"));
+
+        let heartbeat = ScMessage {
+            function: ScFunction::HeartbeatRequest,
+            message_id: 0x66,
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::new(),
+        };
+        let mut buf = BytesMut::new();
+        encode_sc_message(&mut buf, &heartbeat);
+        assert!(
+            ws_hub.send(&buf).await.is_err(),
+            "{context} must reject post-drop Heartbeat-Request on the closed socket"
+        );
     }
 
     #[tokio::test]
@@ -542,6 +579,25 @@ mod tests {
         assert_eq!(received.data_attributes[1].data, vec![0x12, 0x34, 0x56]);
 
         net.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn network_layer_drop_releases_sc_transport_socket() {
+        let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+        let hub_vmac = [0x10; 6];
+        let mut net = NetworkLayer::new(ScTransport::new(ws_client, [0x01; 6]));
+
+        let hub_accept_task = tokio::spawn(async move {
+            sc_hub_accept(&ws_hub, hub_vmac).await;
+            ws_hub
+        });
+
+        let _rx = net.start().await.unwrap();
+        let ws_hub = hub_accept_task.await.unwrap();
+
+        drop(net);
+
+        assert_sc_socket_closed_after_drop(&ws_hub, "dropped NetworkLayer").await;
     }
 
     #[tokio::test]

--- a/crates/bacnet-transport/src/any.rs
+++ b/crates/bacnet-transport/src/any.rs
@@ -71,6 +71,20 @@ impl<S: SerialPort + 'static> TransportPort for AnyTransport<S> {
         }
     }
 
+    fn abort(&mut self) {
+        match self {
+            Self::Bip(t) => t.abort(),
+            Self::Mstp(t) => t.abort(),
+            #[cfg(feature = "ipv6")]
+            Self::Bip6(t) => t.abort(),
+            #[cfg(all(feature = "ethernet", target_os = "linux"))]
+            Self::Ethernet(t) => t.abort(),
+            #[cfg(feature = "sc-tls")]
+            Self::Sc(t) => t.abort(),
+            Self::Loopback(t) => t.abort(),
+        }
+    }
+
     async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
         match self {
             Self::Bip(t) => t.send_unicast(npdu, mac).await,

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -564,6 +564,10 @@ impl TransportPort for BipTransport {
         Ok(())
     }
 
+    fn abort(&mut self) {
+        let _ = self.abort_background_tasks();
+    }
+
     async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
         let socket = self.require_socket()?;
 
@@ -613,7 +617,7 @@ impl TransportPort for BipTransport {
 
 impl Drop for BipTransport {
     fn drop(&mut self) {
-        let _ = self.abort_background_tasks();
+        self.abort();
     }
 }
 

--- a/crates/bacnet-transport/src/port.rs
+++ b/crates/bacnet-transport/src/port.rs
@@ -77,6 +77,13 @@ pub trait TransportPort: Send + Sync {
     /// Stop the transport and clean up resources.
     fn stop(&mut self) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 
+    /// Synchronously abort background work and release owned transport resources.
+    ///
+    /// This hook is intended for `Drop` paths where async [`Self::stop`] cannot
+    /// be awaited. Implementations should not attempt graceful protocol shutdown
+    /// here; graceful disconnects remain the responsibility of [`Self::stop`].
+    fn abort(&mut self) {}
+
     /// Send NPDU bytes to a specific MAC address (unicast).
     fn send_unicast(
         &self,

--- a/crates/bacnet-transport/src/sc/drop_tests.rs
+++ b/crates/bacnet-transport/src/sc/drop_tests.rs
@@ -1,0 +1,131 @@
+use super::*;
+use tokio::time::timeout;
+
+async fn hub_accept(ws_hub: &LoopbackWebSocket, hub_vmac: Vmac) {
+    let data = ws_hub.recv().await.unwrap();
+    let req = decode_sc_message(&data).unwrap();
+    assert_eq!(req.function, ScFunction::ConnectRequest);
+
+    let mut accept_payload = Vec::with_capacity(26);
+    accept_payload.extend_from_slice(&hub_vmac);
+    accept_payload.extend_from_slice(&[0u8; 16]);
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+
+    let accept = ScMessage {
+        function: ScFunction::ConnectAccept,
+        message_id: req.message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(accept_payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &accept);
+    ws_hub.send(&buf).await.unwrap();
+}
+
+async fn assert_closed_without_post_drop_heartbeat(ws_hub: &LoopbackWebSocket, context: &str) {
+    timeout(Duration::from_secs(1), async {
+        loop {
+            match ws_hub.recv().await {
+                Ok(data) => {
+                    let msg = decode_sc_message(&data).unwrap();
+                    assert_ne!(
+                        msg.function,
+                        ScFunction::HeartbeatAck,
+                        "{context} must not leave SC answering heartbeats"
+                    );
+                }
+                Err(_) => break,
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("{context} did not close the loopback WebSocket"));
+
+    let heartbeat = ScMessage {
+        function: ScFunction::HeartbeatRequest,
+        message_id: 0x66,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::new(),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &heartbeat);
+    assert!(
+        ws_hub.send(&buf).await.is_err(),
+        "{context} must reject post-drop Heartbeat-Request on the closed socket"
+    );
+}
+
+async fn start_loopback_sc(
+    client_vmac: Vmac,
+    hub_vmac: Vmac,
+) -> (ScTransport<LoopbackWebSocket>, LoopbackWebSocket) {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(ws_client, client_vmac);
+    let hub_task = tokio::spawn(async move {
+        hub_accept(&ws_hub, hub_vmac).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    (transport, hub_task.await.unwrap())
+}
+
+#[tokio::test]
+async fn sc_drop_aborts_recv_task_and_closes_loopback_socket() {
+    let client_vmac = [0x01; 6];
+    let hub_vmac = [0x10; 6];
+    let (transport, ws_hub) = start_loopback_sc(client_vmac, hub_vmac).await;
+    let conn = transport.connection().unwrap().clone();
+    let abort_handle = transport
+        .recv_task
+        .as_ref()
+        .expect("SC start spawns recv task")
+        .abort_handle();
+
+    assert!(!abort_handle.is_finished());
+    drop(transport);
+
+    timeout(Duration::from_secs(1), async {
+        while !abort_handle.is_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("dropping SC transport aborts recv task");
+
+    assert_eq!(conn.lock().await.state, ScConnectionState::Disconnected);
+
+    assert_closed_without_post_drop_heartbeat(&ws_hub, "dropped SC transport").await;
+
+    let (mut replacement, _replacement_hub) = start_loopback_sc(client_vmac, hub_vmac).await;
+    replacement.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_stop_sends_disconnect_and_drop_after_stop_is_idempotent() {
+    let (mut transport, ws_hub) = start_loopback_sc([0x01; 6], [0x10; 6]).await;
+    let abort_handle = transport
+        .recv_task
+        .as_ref()
+        .expect("SC start spawns recv task")
+        .abort_handle();
+
+    transport.stop().await.unwrap();
+
+    let data = timeout(Duration::from_secs(1), ws_hub.recv())
+        .await
+        .expect("SC stop sends Disconnect-Request before closing socket")
+        .expect("hub socket receives Disconnect-Request");
+    let msg = decode_sc_message(&data).unwrap();
+    assert_eq!(msg.function, ScFunction::DisconnectRequest);
+    assert!(abort_handle.is_finished());
+
+    drop(transport);
+}

--- a/crates/bacnet-transport/src/sc/failover.rs
+++ b/crates/bacnet-transport/src/sc/failover.rs
@@ -1,11 +1,12 @@
 //! BACnet/SC primary/failover hub switching helpers.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use bacnet_types::error::Error;
 use bytes::BytesMut;
 use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::sc_frame::{encode_sc_message, ScMessage};
@@ -27,6 +28,7 @@ pub(super) async fn attempt_primary_restore<W: WebSocketPort>(
     current_ws: &Arc<W>,
     active_ws: &Arc<Mutex<Arc<W>>>,
     conn: &Arc<Mutex<ScConnection>>,
+    restore_disconnect_task: &Arc<StdMutex<Option<JoinHandle<()>>>>,
     connect_timeout_ms: u64,
 ) -> Result<Arc<W>, Error> {
     let restored_ws = if let Some(connector) = primary_connector {
@@ -50,9 +52,17 @@ pub(super) async fn attempt_primary_restore<W: WebSocketPort>(
     drop(current);
 
     let disconnect_ws = current_ws.clone();
-    let _ = tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         send_disconnect_request(&*disconnect_ws, disconnect_msg, connect_timeout_ms).await;
     });
+    match restore_disconnect_task.lock() {
+        Ok(mut slot) => {
+            if let Some(previous) = slot.replace(task) {
+                previous.abort();
+            }
+        }
+        Err(_) => task.abort(),
+    }
     Ok(restored_ws)
 }
 

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -4,7 +4,7 @@
 //! The actual WebSocket I/O is abstracted behind the [`WebSocketPort`] trait
 //! so the connection state machine can be tested without a TLS stack.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
 #[cfg(test)]
@@ -77,6 +77,7 @@ pub struct ScTransport<W: WebSocketPort> {
     primary_connector: Option<WebSocketConnector<W>>,
     failover_connector: Option<WebSocketConnector<W>>,
     reconnect_config: Option<ScReconnectConfig>,
+    restore_disconnect_task: Arc<StdMutex<Option<JoinHandle<()>>>>,
     #[cfg(test)]
     allow_test_heartbeat_timing: bool,
 }
@@ -97,6 +98,7 @@ impl<W: WebSocketPort> ScTransport<W> {
             primary_connector: None,
             failover_connector: None,
             reconnect_config: None,
+            restore_disconnect_task: Arc::new(StdMutex::new(None)),
             #[cfg(test)]
             allow_test_heartbeat_timing: false,
         }
@@ -161,6 +163,33 @@ impl<W: WebSocketPort> ScTransport<W> {
     /// Get the connection state (for testing/inspection).
     pub fn connection(&self) -> Option<&Arc<Mutex<ScConnection>>> {
         self.connection.as_ref()
+    }
+
+    fn abort_background_task_and_drop_sockets(
+        &mut self,
+    ) -> (Option<JoinHandle<()>>, Option<JoinHandle<()>>) {
+        let task = self.recv_task.take();
+        if let Some(task) = &task {
+            task.abort();
+        }
+        let restore_task = self
+            .restore_disconnect_task
+            .lock()
+            .ok()
+            .and_then(|mut task| task.take());
+        if let Some(task) = &restore_task {
+            task.abort();
+        }
+        if let Some(conn) = &self.connection {
+            if let Ok(mut c) = conn.try_lock() {
+                c.state = ScConnectionState::Disconnected;
+            }
+        }
+        self.ws_shared = None;
+        self.connection = None;
+        self.ws = None;
+        self.failover_ws = None;
+        (task, restore_task)
     }
 }
 
@@ -266,6 +295,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
         let heartbeat_interval_ms = self.heartbeat_interval_ms;
         let heartbeat_timeout_ms = self.heartbeat_timeout_ms;
         let reconnect_config = self.reconnect_config.clone();
+        let restore_disconnect_task = self.restore_disconnect_task.clone();
         let connect_timeout_ms = self.connect_timeout_ms;
         let restore_enabled = reconnect_config.is_some();
         let restore_interval_ms = reconnect_config
@@ -408,6 +438,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                 &ws_clone,
                                 &active_ws,
                                 &conn,
+                                &restore_disconnect_task,
                                 connect_timeout_ms,
                             )
                             .await
@@ -588,19 +619,24 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
             }
         }
 
-        if let Some(task) = self.recv_task.take() {
-            task.abort();
+        let conn_for_state = self.connection.clone();
+        let (recv_task, restore_task) = self.abort_background_task_and_drop_sockets();
+        if let Some(task) = recv_task {
+            let _ = task.await;
+        }
+        if let Some(task) = restore_task {
             let _ = task.await;
         }
 
-        // Clear shared state to prevent stale sends
-        if let Some(conn) = &self.connection {
+        if let Some(conn) = conn_for_state {
             let mut c = conn.lock().await;
             c.state = ScConnectionState::Disconnected;
         }
-        self.ws_shared = None;
-        self.connection = None;
         Ok(())
+    }
+
+    fn abort(&mut self) {
+        let _ = self.abort_background_task_and_drop_sockets();
     }
 
     async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
@@ -638,8 +674,17 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
     }
 }
 
+impl<W: WebSocketPort> Drop for ScTransport<W> {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}
+
 #[cfg(test)]
 mod data_attribute_tests;
+
+#[cfg(test)]
+mod drop_tests;
 
 #[cfg(test)]
 mod receive_state_tests;

--- a/crates/bacnet-transport/src/sc/redial_tests.rs
+++ b/crates/bacnet-transport/src/sc/redial_tests.rs
@@ -637,3 +637,82 @@ async fn sc_primary_restore_publishes_before_hung_failover_disconnect_send() {
 
     transport.stop().await.unwrap();
 }
+
+#[tokio::test]
+async fn sc_drop_aborts_hung_primary_restore_failover_disconnect() {
+    let (primary_client, stale_primary_hub) =
+        GateSendWebSocket::pair(Arc::new(AtomicBool::new(false)));
+    drop(stale_primary_hub);
+    let failover_hang_send = Arc::new(AtomicBool::new(false));
+    let (failover_client, failover_hub) = GateSendWebSocket::pair(failover_hang_send.clone());
+    let (primary_hub_tx, mut primary_hub_rx) =
+        tokio::sync::mpsc::unbounded_channel::<GateSendWebSocket>();
+    let primary_dial_count = Arc::new(AtomicUsize::new(0));
+
+    let primary_hub_vmac = [0x10; 6];
+    let failover_hub_vmac = [0x20; 6];
+    let mut transport = ScTransport::new(primary_client, [0x01; 6])
+        .with_connect_timeout_ms(750)
+        .with_heartbeat_interval_ms(5_000)
+        .with_connector(gate_send_redial_connector(
+            primary_dial_count,
+            primary_hub_tx,
+        ))
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 10,
+            max_delay_ms: 10,
+            max_retries: 1,
+        })
+        .with_failover(failover_client);
+
+    let failover_task = tokio::spawn(async move {
+        hub_accept(&failover_hub, failover_hub_vmac).await;
+        failover_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let failover_hub = failover_task.await.unwrap();
+    let conn = transport.connection().unwrap().clone();
+    assert_eq!(conn.lock().await.hub_vmac, Some(failover_hub_vmac));
+
+    failover_hang_send.store(true, Ordering::SeqCst);
+    let primary_restore_task = tokio::spawn(async move {
+        let primary_hub = primary_hub_rx.recv().await.unwrap();
+        hub_accept(&primary_hub, primary_hub_vmac).await;
+        primary_hub
+    });
+    let _primary_hub = tokio::time::timeout(Duration::from_secs(2), primary_restore_task)
+        .await
+        .expect("timed out waiting for primary restore handshake")
+        .unwrap();
+    wait_for_hub_vmac(&conn, primary_hub_vmac, Duration::from_millis(250)).await;
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if transport.restore_disconnect_task.lock().unwrap().is_some() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for failover disconnect task");
+
+    let abort_handle = transport.recv_task.as_ref().unwrap().abort_handle();
+    drop(transport);
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while !abort_handle.is_finished() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("dropping SC transport aborts recv task");
+
+    let failover_recv = tokio::time::timeout(Duration::from_secs(1), failover_hub.recv())
+        .await
+        .expect("old failover socket stayed open after Drop");
+    assert!(
+        failover_recv.is_err(),
+        "old failover socket must close after Drop aborts restore disconnect task"
+    );
+}


### PR DESCRIPTION
Fixes #90.

## Summary
- Add a `TransportPort::abort` hook for synchronous ungraceful teardown from `Drop`, route `NetworkLayer`, `AnyTransport`, B/IP, and BACnet/SC through it.
- Abort BACnet/SC receive task ownership and close retained WebSocket handles on `Drop`, while keeping `stop()` as the graceful path that sends `DisconnectRequest`.
- Track and abort the primary-restore failover disconnect task so it cannot retain an old failover socket after transport drop.
- Add direct SC, NetworkLayer, and BACnetClient drop regressions that verify socket closure and reject post-drop heartbeat traffic.

## Validation
- `cargo fmt --all --check`
- `git diff --cached --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `cargo test -p bacnet-transport sc::drop_tests`
- `cargo test -p bacnet-transport sc_drop_aborts_hung_primary_restore_failover_disconnect`
- `cargo test -p bacnet-transport sc_primary_restore_publishes_before_hung_failover_disconnect_send`
- `cargo test -p bacnet-network network_layer_drop_releases_sc_transport_socket`
- `cargo test -p bacnet-client client_drop_releases_sc_transport_socket`
- `cargo test -p bacnet-transport sc::`
- `cargo test -p bacnet-client client::tests`
- `cargo test -p bacnet-network layer::tests`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked`

## Scope notes
- `Drop` is intentionally ungraceful: it aborts local tasks/sockets and does not perform the full Annex AB close sequence. `stop()` remains the path that sends `DisconnectRequest`.
- `TransportPort::abort` is source-compatible via a default no-op; this PR proves cleanup for B/IP and BACnet/SC, not arbitrary downstream custom transports.
- The SC connection-state update during `Drop` is best-effort under lock contention; the resource-release guarantee is the task/socket teardown.