### PR TITLE
fix(sc): expose connection state watch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `BACnetClient` SubscribeCOVProperty subscribe/unsubscribe helpers for property-level COV subscriptions.
 - Add source metadata, delivery kind, and configurable confirmed-notification ACK policy to `BACnetClient` COV notification delivery.
 - Add a managed finite `BACnetClient` COV subscription helper that renews before expiry and emits lifetime/renewal events.
+- Add `ScTransport::connection_state_changes()` returning a `tokio::sync::watch::Receiver<ScConnectionState>` so BACnet/SC consumers can await latest link-state changes without polling the inspection-only connection handle; rapid transitions may coalesce under watch semantics.
 
 ### Fixed
 

--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -151,8 +151,13 @@ impl ScConnection {
 
     /// Build a Disconnect-Request message (no VMACs).
     ///
-    /// Returns an error if not yet connected (no hub VMAC available).
+    /// Returns an error if not connected.
     pub fn build_disconnect_request(&mut self) -> Result<ScMessage, Error> {
+        if self.state != ScConnectionState::Connected {
+            return Err(Error::Encoding(
+                "cannot build DisconnectRequest: connection is not connected".into(),
+            ));
+        }
         if self.hub_vmac.is_none() {
             return Err(Error::Encoding(
                 "cannot build DisconnectRequest: no hub VMAC (not connected)".into(),

--- a/crates/bacnet-transport/src/sc/failover.rs
+++ b/crates/bacnet-transport/src/sc/failover.rs
@@ -5,15 +5,15 @@ use std::time::Duration;
 
 use bacnet_types::error::Error;
 use bytes::BytesMut;
-use tokio::sync::Mutex;
+use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
 use tracing::warn;
 
 use crate::sc_frame::{encode_sc_message, ScMessage};
 
 use super::{
-    connector::dial_connector, handshake::perform_handshake, ScConnection, WebSocketConnector,
-    WebSocketPort,
+    connector::dial_connector, handshake::perform_handshake, ScConnection, ScConnectionState,
+    WebSocketConnector, WebSocketPort,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -29,6 +29,7 @@ pub(super) async fn attempt_primary_restore<W: WebSocketPort>(
     active_ws: &Arc<Mutex<Arc<W>>>,
     conn: &Arc<Mutex<ScConnection>>,
     restore_disconnect_task: &Arc<StdMutex<Option<JoinHandle<()>>>>,
+    state_tx: &watch::Sender<ScConnectionState>,
     connect_timeout_ms: u64,
 ) -> Result<Arc<W>, Error> {
     let restored_ws = if let Some(connector) = primary_connector {
@@ -37,7 +38,7 @@ pub(super) async fn attempt_primary_restore<W: WebSocketPort>(
         primary_ws.clone()
     };
     let probe_conn = Arc::new(Mutex::new(primary_probe_connection(conn).await));
-    if let Err(e) = perform_handshake(&*restored_ws, &probe_conn, connect_timeout_ms).await {
+    if let Err(e) = perform_handshake(&*restored_ws, &probe_conn, None, connect_timeout_ms).await {
         absorb_failed_probe(conn, &probe_conn).await;
         return Err(e);
     }
@@ -48,6 +49,7 @@ pub(super) async fn attempt_primary_restore<W: WebSocketPort>(
     let mut c = conn.lock().await;
     *c = restored;
     *current = restored_ws.clone();
+    state_tx.send_replace(c.state);
     drop(c);
     drop(current);
 

--- a/crates/bacnet-transport/src/sc/handshake.rs
+++ b/crates/bacnet-transport/src/sc/handshake.rs
@@ -5,14 +5,20 @@ use std::time::Duration;
 
 use bacnet_types::error::Error;
 use bytes::BytesMut;
-use tokio::sync::Mutex;
+use tokio::sync::{watch, Mutex};
 use tracing::{debug, warn};
 
 use crate::sc_frame::{
     decode_sc_bvlc_result, decode_sc_message, encode_sc_message, ScBvlcResult, ScFunction,
 };
 
-use super::{heartbeat, ScConnection, WebSocketPort};
+use super::{heartbeat, ScConnection, ScConnectionState, WebSocketPort};
+
+fn notify_state(state_tx: Option<&watch::Sender<ScConnectionState>>, state: ScConnectionState) {
+    if let Some(state_tx) = state_tx {
+        state_tx.send_replace(state);
+    }
+}
 
 /// Perform the Connect-Request / Connect-Accept handshake on a WebSocket.
 ///
@@ -20,15 +26,18 @@ use super::{heartbeat, ScConnection, WebSocketPort};
 pub(super) async fn perform_handshake<W: WebSocketPort>(
     ws: &W,
     conn: &Arc<Mutex<ScConnection>>,
+    state_tx: Option<&watch::Sender<ScConnectionState>>,
     timeout_ms: u64,
 ) -> Result<(), Error> {
     {
         let mut c = conn.lock().await;
         let msg = c.build_connect_request();
+        notify_state(state_tx, c.state);
         let mut buf = BytesMut::new();
         encode_sc_message(&mut buf, &msg);
         if let Err(e) = ws.send(&buf).await {
             c.abort_connect();
+            notify_state(state_tx, c.state);
             return Err(e);
         }
     }
@@ -41,6 +50,7 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
                 Err(e) => {
                     let mut c = conn.lock().await;
                     c.abort_connect();
+                    notify_state(state_tx, c.state);
                     return Err(e);
                 }
             };
@@ -53,6 +63,7 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
                 Err(e) if heartbeat::is_bvlc_result_wire(&data) => {
                     let mut c = conn.lock().await;
                     c.abort_connect();
+                    notify_state(state_tx, c.state);
                     return Err(Error::Encoding(format!(
                         "malformed BACnet/SC BVLC-Result during connect: {e}"
                     )));
@@ -60,6 +71,7 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
                 Err(e) => {
                     let mut c = conn.lock().await;
                     c.abort_connect();
+                    notify_state(state_tx, c.state);
                     return Err(e);
                 }
             };
@@ -80,6 +92,7 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
                         } => {
                             let duplicate_vmac =
                                 c.handle_connect_result(msg.message_id, &result)?;
+                            notify_state(state_tx, c.state);
                             let duplicate_note = if duplicate_vmac {
                                 "; selected new Random-48 local VMAC"
                             } else {
@@ -97,6 +110,7 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
                         }
                         ScBvlcResult::Ack { result_for } => {
                             let _ = c.handle_connect_result(msg.message_id, &result);
+                            notify_state(state_tx, c.state);
                             Err(Error::Encoding(format!(
                                 "unexpected BACnet/SC BVLC-Result ACK during connect: function={:#x}",
                                 result_for.to_raw()
@@ -105,6 +119,7 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
                     },
                     Err(e) => {
                         c.abort_connect();
+                        notify_state(state_tx, c.state);
                         Err(Error::Encoding(format!(
                             "malformed BACnet/SC BVLC-Result during connect: {e}"
                         )))
@@ -119,10 +134,12 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
         Ok(Ok(msg)) => {
             let mut c = conn.lock().await;
             if c.handle_connect_accept(&msg) {
+                notify_state(state_tx, c.state);
                 debug!("BACnet/SC connected");
                 Ok(())
             } else {
                 c.abort_connect();
+                notify_state(state_tx, c.state);
                 Err(Error::Encoding(
                     "BACnet/SC Connect-Accept did not match pending Connect-Request".into(),
                 ))
@@ -131,11 +148,13 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
         Ok(Err(e)) => {
             let mut c = conn.lock().await;
             c.abort_connect();
+            notify_state(state_tx, c.state);
             Err(e)
         }
         Err(_) => {
             let mut c = conn.lock().await;
             c.abort_connect();
+            notify_state(state_tx, c.state);
             Err(Error::Encoding("BACnet/SC connect timeout".into()))
         }
     }

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 #[cfg(test)]
 use bytes::Bytes;
 use bytes::BytesMut;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, watch, Mutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
@@ -69,6 +69,7 @@ pub struct ScTransport<W: WebSocketPort> {
     /// Device UUID (16 bytes, RFC 4122).
     device_uuid: [u8; 16],
     connection: Option<Arc<Mutex<ScConnection>>>,
+    state_tx: watch::Sender<ScConnectionState>,
     recv_task: Option<JoinHandle<()>>,
     connect_timeout_ms: u64,
     heartbeat_interval_ms: u64,
@@ -84,12 +85,14 @@ pub struct ScTransport<W: WebSocketPort> {
 
 impl<W: WebSocketPort> ScTransport<W> {
     pub fn new(ws: W, local_vmac: Vmac) -> Self {
+        let (state_tx, _) = watch::channel(ScConnectionState::Disconnected);
         Self {
             ws: Some(ws),
             ws_shared: None,
             local_vmac,
             device_uuid: [0u8; 16],
             connection: None,
+            state_tx,
             recv_task: None,
             connect_timeout_ms: 10_000,
             heartbeat_interval_ms: heartbeat::DEFAULT_HEARTBEAT_INTERVAL_MS,
@@ -165,6 +168,16 @@ impl<W: WebSocketPort> ScTransport<W> {
         self.connection.as_ref()
     }
 
+    /// Subscribe to BACnet/SC connection state changes.
+    ///
+    /// The returned watch receiver yields the latest known state immediately and
+    /// change notifications for subsequent state updates observed by the
+    /// transport. Rapid updates can coalesce under Tokio watch semantics, so use
+    /// this as a current-state signal rather than a durable transition log.
+    pub fn connection_state_changes(&self) -> watch::Receiver<ScConnectionState> {
+        self.state_tx.subscribe()
+    }
+
     fn abort_background_task_and_drop_sockets(
         &mut self,
     ) -> (Option<JoinHandle<()>>, Option<JoinHandle<()>>) {
@@ -185,6 +198,7 @@ impl<W: WebSocketPort> ScTransport<W> {
                 c.state = ScConnectionState::Disconnected;
             }
         }
+        self.state_tx.send_replace(ScConnectionState::Disconnected);
         self.ws_shared = None;
         self.connection = None;
         self.ws = None;
@@ -211,12 +225,14 @@ async fn publish_connected_ws<W: WebSocketPort>(
     active_ws: &Arc<Mutex<Arc<W>>>,
     ws: &Arc<W>,
     probe_conn: &Arc<Mutex<ScConnection>>,
+    state_tx: &watch::Sender<ScConnectionState>,
 ) {
     let restored = probe_conn.lock().await.clone();
     let mut current = active_ws.lock().await;
     let mut c = conn.lock().await;
     *c = restored;
     *current = ws.clone();
+    state_tx.send_replace(c.state);
 }
 
 impl<W: WebSocketPort> TransportPort for ScTransport<W> {
@@ -252,39 +268,47 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
         let mut failover_ws = self.failover_ws.take().map(Arc::new);
         let primary_connector = self.primary_connector.clone();
         let failover_connector = self.failover_connector.clone();
+        let state_tx = self.state_tx.clone();
 
         // Attempt handshake on the primary WebSocket.
-        let (ws, active_hub) =
-            match perform_handshake(&*primary_ws, &conn, self.connect_timeout_ms).await {
-                Ok(()) => (primary_ws.clone(), ActiveHub::Primary),
-                Err(primary_err) => {
-                    // Primary failed — try failover if configured.
-                    if !conn.lock().await.connect_retry_allowed {
-                        self.local_vmac = conn.lock().await.local_vmac;
-                        return Err(primary_err);
-                    } else if let Some(failover) = dial_failover_ws(
-                        &failover_connector,
-                        &mut failover_ws,
-                        self.connect_timeout_ms,
-                    )
-                    .await
+        let (ws, active_hub) = match perform_handshake(
+            &*primary_ws,
+            &conn,
+            Some(&state_tx),
+            self.connect_timeout_ms,
+        )
+        .await
+        {
+            Ok(()) => (primary_ws.clone(), ActiveHub::Primary),
+            Err(primary_err) => {
+                // Primary failed — try failover if configured.
+                if !conn.lock().await.connect_retry_allowed {
+                    self.local_vmac = conn.lock().await.local_vmac;
+                    return Err(primary_err);
+                } else if let Some(failover) = dial_failover_ws(
+                    &failover_connector,
+                    &mut failover_ws,
+                    self.connect_timeout_ms,
+                )
+                .await
+                {
+                    debug!("BACnet/SC primary connect failed, attempting failover");
+                    // Reset connection state for the retry.
                     {
-                        debug!("BACnet/SC primary connect failed, attempting failover");
-                        // Reset connection state for the retry.
-                        {
-                            let mut c = conn.lock().await;
-                            c.reset_for_connect_retry();
-                        }
-                        perform_handshake(&*failover, &conn, self.connect_timeout_ms)
-                            .await
-                            .map(|()| (failover, ActiveHub::Failover))
-                            .map_err(|_| primary_err)?
-                    } else {
-                        self.local_vmac = conn.lock().await.local_vmac;
-                        return Err(primary_err);
+                        let mut c = conn.lock().await;
+                        c.reset_for_connect_retry();
+                        state_tx.send_replace(c.state);
                     }
+                    perform_handshake(&*failover, &conn, Some(&state_tx), self.connect_timeout_ms)
+                        .await
+                        .map(|()| (failover, ActiveHub::Failover))
+                        .map_err(|_| primary_err)?
+                } else {
+                    self.local_vmac = conn.lock().await.local_vmac;
+                    return Err(primary_err);
                 }
-            };
+            }
+        };
 
         self.local_vmac = conn.lock().await.local_vmac;
 
@@ -334,6 +358,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                             warn!("Malformed wire-level BACnet/SC BVLC-Result: {e}");
                                             let mut c = conn.lock().await;
                                             c.state = ScConnectionState::Disconnected;
+                                            state_tx.send_replace(c.state);
                                             break;
                                         }
                                         Err(e) => {
@@ -379,17 +404,23 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                     }
 
                                     // Handle NPDU — lock, extract results, drop before awaiting
-                                    let (npdu_result, disconnect_ack) = {
+                                    let (npdu_result, disconnect_ack, fatal_result, state_change) = {
                                         let mut c = conn.lock().await;
+                                        let before_state = c.state;
                                         let npdu = c.handle_received(&msg);
                                         let ack = c.disconnect_ack_to_send.take();
-                                        (npdu, ack)
+                                        let after_state = c.state;
+                                        (
+                                            npdu,
+                                            ack,
+                                            msg.function == ScFunction::Result
+                                                && after_state == ScConnectionState::Disconnected,
+                                            (after_state != before_state).then_some(after_state),
+                                        )
                                     };
-                                    let fatal_result = {
-                                        let c = conn.lock().await;
-                                        msg.function == ScFunction::Result
-                                            && c.state == ScConnectionState::Disconnected
-                                    };
+                                    if let Some(state) = state_change {
+                                        state_tx.send_replace(state);
+                                    }
 
                                     if let Some((npdu, source_vmac)) = npdu_result {
                                         if npdu_tx
@@ -423,6 +454,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                     warn!("BACnet/SC recv error: {}", e);
                                     let mut c = conn.lock().await;
                                     c.state = ScConnectionState::Disconnected;
+                                    state_tx.send_replace(c.state);
                                     break;
                                 }
                             }
@@ -439,6 +471,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                 &active_ws,
                                 &conn,
                                 &restore_disconnect_task,
+                                &state_tx,
                                 connect_timeout_ms,
                             )
                             .await
@@ -470,6 +503,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                     warn!("BACnet/SC heartbeat send error: {}", e);
                                     let mut c = conn.lock().await;
                                     c.state = ScConnectionState::Disconnected;
+                                    state_tx.send_replace(c.state);
                                     break;
                                 }
                                 pending_heartbeat_id = Some(heartbeat_message_id);
@@ -479,6 +513,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                 warn!("BACnet/SC heartbeat timeout — disconnecting");
                                 let mut c = conn.lock().await;
                                 c.state = ScConnectionState::Disconnected;
+                                state_tx.send_replace(c.state);
                                 break;
                             }
                         }
@@ -508,6 +543,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                     {
                         let mut c = conn.lock().await;
                         c.reset_for_connect_retry();
+                        state_tx.send_replace(c.state);
                     }
 
                     let reconnect_ws = match dial_reconnect_ws(
@@ -528,10 +564,18 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                     };
 
                     let probe_conn = connect_probe_from(&conn).await;
-                    match perform_handshake(&*reconnect_ws, &probe_conn, connect_timeout_ms).await {
+                    match perform_handshake(&*reconnect_ws, &probe_conn, None, connect_timeout_ms)
+                        .await
+                    {
                         Ok(()) => {
-                            publish_connected_ws(&conn, &active_ws, &reconnect_ws, &probe_conn)
-                                .await;
+                            publish_connected_ws(
+                                &conn,
+                                &active_ws,
+                                &reconnect_ws,
+                                &probe_conn,
+                                &state_tx,
+                            )
+                            .await;
                             ws_clone = reconnect_ws;
                             info!(attempt, "SC reconnected after backoff");
                             reconnected = true;
@@ -566,13 +610,22 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                         {
                             let mut c = conn.lock().await;
                             c.reset_for_connect_retry();
+                            state_tx.send_replace(c.state);
                         }
 
                         let probe_conn = connect_probe_from(&conn).await;
-                        match perform_handshake(&*failover, &probe_conn, connect_timeout_ms).await {
+                        match perform_handshake(&*failover, &probe_conn, None, connect_timeout_ms)
+                            .await
+                        {
                             Ok(()) => {
-                                publish_connected_ws(&conn, &active_ws, &failover, &probe_conn)
-                                    .await;
+                                publish_connected_ws(
+                                    &conn,
+                                    &active_ws,
+                                    &failover,
+                                    &probe_conn,
+                                    &state_tx,
+                                )
+                                .await;
                                 ws_clone = failover;
                                 active_hub = ActiveHub::Failover;
                                 info!("SC connected to failover hub after primary reconnect exhaustion");
@@ -593,6 +646,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                     );
                     let mut c = conn.lock().await;
                     c.state = ScConnectionState::Disconnected;
+                    state_tx.send_replace(c.state);
                     break 'transport;
                 }
             }
@@ -608,7 +662,11 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
             let (ws, disconnect_msg) = {
                 let ws = ws.lock().await;
                 let mut c = conn.lock().await;
-                (ws.clone(), c.build_disconnect_request().ok())
+                let disconnect_msg = c.build_disconnect_request().ok();
+                if disconnect_msg.is_some() {
+                    self.state_tx.send_replace(c.state);
+                }
+                (ws.clone(), disconnect_msg)
             };
             if let Some(msg) = disconnect_msg {
                 let mut buf = BytesMut::new();
@@ -631,6 +689,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
         if let Some(conn) = conn_for_state {
             let mut c = conn.lock().await;
             c.state = ScConnectionState::Disconnected;
+            self.state_tx.send_replace(c.state);
         }
         Ok(())
     }
@@ -691,6 +750,9 @@ mod receive_state_tests;
 
 #[cfg(test)]
 mod result_tests;
+
+#[cfg(test)]
+mod state_watch_tests;
 
 #[cfg(test)]
 mod primary_restore_tests;

--- a/crates/bacnet-transport/src/sc/state_watch_tests.rs
+++ b/crates/bacnet-transport/src/sc/state_watch_tests.rs
@@ -1,0 +1,141 @@
+use super::*;
+
+async fn hub_accept(ws_hub: &LoopbackWebSocket, hub_vmac: Vmac) {
+    let data = ws_hub.recv().await.unwrap();
+    let req = decode_sc_message(&data).unwrap();
+    assert_eq!(req.function, ScFunction::ConnectRequest);
+
+    let mut accept_payload = Vec::with_capacity(26);
+    accept_payload.extend_from_slice(&hub_vmac);
+    accept_payload.extend_from_slice(&[0u8; 16]);
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+
+    let accept = ScMessage {
+        function: ScFunction::ConnectAccept,
+        message_id: req.message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(accept_payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &accept);
+    ws_hub.send(&buf).await.unwrap();
+}
+
+async fn wait_for_state_notification(
+    states: &mut tokio::sync::watch::Receiver<ScConnectionState>,
+    expected: ScConnectionState,
+    timeout: Duration,
+) {
+    tokio::time::timeout(timeout, async {
+        loop {
+            if *states.borrow_and_update() == expected {
+                return;
+            }
+            states.changed().await.expect("state watch closed");
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {expected:?} notification"));
+}
+
+async fn send_message(ws: &LoopbackWebSocket, msg: &ScMessage) {
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, msg);
+    ws.send(&buf).await.unwrap();
+}
+
+fn bvlc_result_nak(message_id: u16) -> ScMessage {
+    ScMessage {
+        function: ScFunction::Result,
+        message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from_static(&[0x06, 0x01, 0x00, 0x00, 0x07, 0x01, 0x17]),
+    }
+}
+
+#[tokio::test]
+async fn sc_connection_state_changes_reports_connected_then_disconnected() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let client_vmac = [0x01; 6];
+    let hub_vmac = [0x10; 6];
+
+    let mut transport =
+        ScTransport::new(ws_client, client_vmac).with_test_heartbeat_timing_ms(100, 300);
+    let mut states = transport.connection_state_changes();
+
+    let hub_task = tokio::spawn(async move {
+        hub_accept(&ws_hub, hub_vmac).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let _ws_hub = hub_task.await.unwrap();
+
+    wait_for_state_notification(
+        &mut states,
+        ScConnectionState::Connected,
+        Duration::from_secs(1),
+    )
+    .await;
+    wait_for_state_notification(
+        &mut states,
+        ScConnectionState::Disconnected,
+        Duration::from_secs(1),
+    )
+    .await;
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_connection_state_changes_reports_bvlc_result_disconnect_without_stale_stop() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let client_vmac = [0x01; 6];
+    let hub_vmac = [0x10; 6];
+
+    let mut transport = ScTransport::new(ws_client, client_vmac);
+    let mut states = transport.connection_state_changes();
+
+    let hub_task = tokio::spawn(async move {
+        hub_accept(&ws_hub, hub_vmac).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let ws_hub = hub_task.await.unwrap();
+
+    wait_for_state_notification(
+        &mut states,
+        ScConnectionState::Connected,
+        Duration::from_secs(1),
+    )
+    .await;
+    send_message(&ws_hub, &bvlc_result_nak(0x66)).await;
+    wait_for_state_notification(
+        &mut states,
+        ScConnectionState::Disconnected,
+        Duration::from_secs(1),
+    )
+    .await;
+
+    transport.stop().await.unwrap();
+
+    match tokio::time::timeout(Duration::from_millis(100), ws_hub.recv()).await {
+        Ok(Ok(data)) => {
+            let msg = decode_sc_message(&data).unwrap();
+            assert_ne!(
+                msg.function,
+                ScFunction::DisconnectRequest,
+                "stop sent a stale Disconnect-Request after fatal disconnect"
+            );
+        }
+        Ok(Err(_)) | Err(_) => {}
+    }
+}

--- a/crates/bacnet-transport/src/sc/tests.rs
+++ b/crates/bacnet-transport/src/sc/tests.rs
@@ -226,6 +226,16 @@ fn build_disconnect_before_connect_returns_error() {
 }
 
 #[test]
+fn build_disconnect_after_disconnect_returns_error() {
+    let mut conn = ScConnection::new([0x01; 6], [0u8; 16]);
+    conn.hub_vmac = Some([0x10; 6]);
+
+    let result = conn.build_disconnect_request();
+    assert!(result.is_err());
+    assert_eq!(conn.state, ScConnectionState::Disconnected);
+}
+
+#[test]
 fn connect_request_has_payload() {
     let mut conn = ScConnection::new([0x01; 6], [0u8; 16]);
     conn.max_bvlc_length = 1200;


### PR DESCRIPTION
## Summary
- add `ScTransport::connection_state_changes(&self) -> tokio::sync::watch::Receiver<ScConnectionState>` for BACnet/SC latest-state notifications
- publish active connection state changes from handshake, fatal receive paths, heartbeat timeout/send errors, reconnect/failover replacement, primary restore, stop, and drop
- keep probe handshakes private until their websocket becomes the active transport, and guard Disconnect-Request creation so stale `Disconnected` connections cannot publish `Disconnecting`
- document Tokio watch semantics: this is a latest-state signal, not a durable transition log; rapid updates may coalesce

## Tests
- `cargo fmt --all --check`
- `git diff --check`
- `git diff --cached --check`
- `cargo test -p bacnet-transport sc::state_watch_tests --quiet`
- `cargo test -p bacnet-transport build_disconnect --quiet`
- `cargo test -p bacnet-transport sc:: --quiet`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

## Review
- correctness reviewer: approved
- test verifier: approved
- release/API reviewer: requested docs wording for watch coalescing; fixed and approved
- BACnet/SC security reviewer: requested stale-stop fix; fixed and follow-up approved

Fixes #95