### PR TITLE
fix(sc): propagate negotiated max APDU limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Propagate negotiated BACnet/SC hub Max-NPDU/BVLC limits into `ScTransport::max_apdu_length()` and `BACnetClient` request segmentation, with `BACnetClient::transport_max_apdu_length()` exposing the live post-connect transport budget.
 - Return BACnet/SC handshake timeouts as `Error::Timeout` and malformed BVLC-Result failures as typed `ScConnectError` values instead of collapsing them into `Error::Encoding`; downstream code should match `Error::Timeout` directly and use `ScConnectError::from_error` for SC transport details.
 - Re-dial BACnet/SC WebSocket connections during reconnect, failover, and primary restore instead of reusing a torn-down socket object.
 - Abort BACnet/SC receive tasks and close WebSocket ownership on ungraceful `Drop`, including the `BACnetClient`/`NetworkLayer` drop cascade, while preserving graceful Disconnect-Request shutdown.

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -29,9 +29,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         transport: T,
         options: ClientOptions,
     ) -> Result<Self, Error> {
-        let transport_max = transport.max_apdu_length();
-        config.max_apdu_length = config.max_apdu_length.min(transport_max);
         validate_max_apdu_length(config.max_apdu_length)?;
+        config.max_apdu_length =
+            cap_max_apdu_to_transport(config.max_apdu_length, transport.max_apdu_length())?;
         if !(1..=127).contains(&config.proposed_window_size) {
             return Err(Error::Encoding(format!(
                 "invalid proposed-window-size {}; expected 1..=127",
@@ -42,6 +42,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 
         let mut network = NetworkLayer::new(transport);
         let mut apdu_rx = network.start().await?;
+        config.max_apdu_length = cap_max_apdu_to_transport(
+            config.max_apdu_length,
+            network.transport().max_apdu_length(),
+        )?;
         let local_mac = MacAddr::from_slice(network.local_mac());
 
         let network = Arc::new(network);
@@ -163,6 +167,30 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     pub fn local_mac(&self) -> &[u8] {
         &self.local_mac
     }
+
+    /// Current BACnet max-APDU bucket advertised by this client.
+    ///
+    /// Returns `0` if the live transport budget is below the smallest BACnet
+    /// max-APDU bucket and a confirmed request would currently fail before
+    /// encoding.
+    pub fn max_apdu_length(&self) -> u16 {
+        max_apdu_bucket_at_or_below(
+            self.config
+                .max_apdu_length
+                .min(self.network.transport().max_apdu_length()),
+        )
+        .unwrap_or(0)
+    }
+
+    /// Current APDU payload budget reported by the underlying transport.
+    ///
+    /// For BACnet/SC this reflects the negotiated hub envelope after connect
+    /// and may be lower than the encoded BACnet max-APDU bucket advertised by
+    /// the client.
+    pub fn transport_max_apdu_length(&self) -> u16 {
+        self.network.transport().max_apdu_length()
+    }
+
     /// Stop the client, aborting the dispatch task.
     pub async fn stop(&mut self) -> Result<(), Error> {
         if let Some(task) = self.abort_dispatch_task() {

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -46,6 +46,8 @@ pub const MAX_COV_CHANNEL_CAPACITY: usize = 65_536;
 /// Device discovery event broadcast channel capacity.
 pub const DEVICE_EVENT_CHANNEL_CAPACITY: usize = 64;
 
+const VALID_MAX_APDU_LENGTHS: [u16; 6] = [50, 128, 206, 480, 1024, 1476];
+
 /// Type of change observed in the device discovery table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeviceEventKind {
@@ -628,6 +630,32 @@ impl<'a> ConfirmedTarget<'a> {
             } => routed_tsm_mac(*dest_network, dest_mac),
         }
     }
+
+    fn additional_npdu_header_len(&self) -> u16 {
+        match self {
+            Self::Local { .. } => 0,
+            Self::Routed { dest_mac, .. } => u16::try_from(dest_mac.len())
+                .unwrap_or(u16::MAX)
+                .saturating_add(4),
+        }
+    }
+}
+
+fn max_apdu_bucket_at_or_below(limit: u16) -> Option<u16> {
+    VALID_MAX_APDU_LENGTHS
+        .iter()
+        .rev()
+        .copied()
+        .find(|bucket| *bucket <= limit)
+}
+
+fn cap_max_apdu_to_transport(configured: u16, transport_limit: u16) -> Result<u16, Error> {
+    let limit = configured.min(transport_limit);
+    max_apdu_bucket_at_or_below(limit).ok_or_else(|| {
+        Error::Encoding(format!(
+            "transport max-APDU-length {transport_limit} leaves no valid BACnet APDU bucket"
+        ))
+    })
 }
 
 fn routed_tsm_mac(network: u16, mac: &[u8]) -> MacAddr {
@@ -681,6 +709,10 @@ mod cov_renewal_tests;
 mod cov_tests;
 #[cfg(test)]
 mod device_events_tests;
+#[cfg(test)]
+mod sc_max_apdu_tests;
+#[cfg(test)]
+mod segmentation_retransmit_tests;
 #[cfg(test)]
 mod tests;
 

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -54,6 +54,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     ) -> Result<Bytes, Error> {
         let tsm_mac = target.tsm_mac();
         let unsegmented_apdu_size = 4 + service_data.len();
+        let target_transport_max_apdu = self.target_transport_max_apdu_length(target);
 
         match target {
             ConfirmedTarget::Local { mac } => {
@@ -64,7 +65,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         .map(|d| d.max_apdu_length as u16)
                         .unwrap_or(self.config.max_apdu_length);
                     let max_seg = device.and_then(|d| d.max_segments_accepted);
-                    (max_apdu, max_seg)
+                    (max_apdu.min(target_transport_max_apdu), max_seg)
                 };
                 if unsegmented_apdu_size > remote_max_apdu as usize {
                     return self
@@ -79,7 +80,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 }
             }
             ConfirmedTarget::Routed { .. } => {
-                let remote_max_apdu = self.config.max_apdu_length;
+                let remote_max_apdu = self.config.max_apdu_length.min(target_transport_max_apdu);
                 if unsegmented_apdu_size > remote_max_apdu as usize {
                     return self
                         .segmented_confirmed_request(
@@ -94,6 +95,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             }
         }
 
+        let advertised_max_apdu = self.advertised_max_apdu_length_for_target(target)?;
         let (invoke_id, rx) = {
             let mut tsm = self.tsm.lock().await;
             let invoke_id = tsm.allocate_invoke_id(&tsm_mac).ok_or_else(|| {
@@ -112,7 +114,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             more_follows: false,
             segmented_response_accepted: self.config.segmented_response_accepted,
             max_segments: self.config.max_segments,
-            max_apdu_length: self.config.max_apdu_length,
+            max_apdu_length: advertised_max_apdu,
             invoke_id,
             sequence_number: None,
             proposed_window_size: None,
@@ -222,6 +224,24 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             }
         }
     }
+
+    pub(super) fn target_transport_max_apdu_length(&self, target: ConfirmedTarget<'_>) -> u16 {
+        self.network
+            .transport()
+            .max_apdu_length()
+            .saturating_sub(target.additional_npdu_header_len())
+    }
+
+    pub(super) fn advertised_max_apdu_length_for_target(
+        &self,
+        target: ConfirmedTarget<'_>,
+    ) -> Result<u16, Error> {
+        cap_max_apdu_to_transport(
+            self.config.max_apdu_length,
+            self.target_transport_max_apdu_length(target),
+        )
+    }
+
     /// Send an unconfirmed request (fire-and-forget) to a specific destination.
     pub async fn unconfirmed_request(
         &self,

--- a/crates/bacnet-client/src/client/sc_max_apdu_tests.rs
+++ b/crates/bacnet-client/src/client/sc_max_apdu_tests.rs
@@ -1,0 +1,370 @@
+use std::time::Instant;
+
+use bacnet_encoding::apdu::{self, encode_apdu, Apdu, SegmentAck, SimpleAck};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu, NpduAddress};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_transport::sc::{LoopbackWebSocket, ScReconnectConfig, ScTransport, WebSocketPort};
+use bacnet_transport::sc_frame::{
+    decode_sc_message, encode_sc_message, ScFunction, ScMessage, Vmac,
+};
+use bacnet_types::enums::{ConfirmedServiceChoice, ObjectType, Segmentation};
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+use bytes::{Bytes, BytesMut};
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+use crate::discovery::DiscoveredDevice;
+
+use super::BACnetClient;
+
+struct LimitedTransport {
+    inner: LoopbackTransport,
+    max_apdu_length: u16,
+}
+
+impl TransportPort for LimitedTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, bacnet_types::error::Error> {
+        self.inner.start().await
+    }
+
+    async fn stop(&mut self) -> Result<(), bacnet_types::error::Error> {
+        self.inner.stop().await
+    }
+
+    async fn send_unicast(
+        &self,
+        npdu: &[u8],
+        mac: &[u8],
+    ) -> Result<(), bacnet_types::error::Error> {
+        self.inner.send_unicast(npdu, mac).await
+    }
+
+    async fn send_broadcast(&self, npdu: &[u8]) -> Result<(), bacnet_types::error::Error> {
+        self.inner.send_broadcast(npdu).await
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        self.inner.local_mac()
+    }
+
+    fn max_apdu_length(&self) -> u16 {
+        self.max_apdu_length
+    }
+}
+
+async fn send_peer_apdu(
+    transport: &LoopbackTransport,
+    client_mac: &[u8],
+    apdu: Apdu,
+) -> Result<(), bacnet_types::error::Error> {
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &apdu)?;
+    let npdu = Npdu {
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu)?;
+    transport.send_unicast(&npdu_buf, client_mac).await
+}
+
+async fn send_peer_routed_apdu(
+    transport: &LoopbackTransport,
+    client_mac: &[u8],
+    source_network: u16,
+    source_mac: &[u8],
+    apdu: Apdu,
+) -> Result<(), bacnet_types::error::Error> {
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &apdu)?;
+    let npdu = Npdu {
+        source: Some(NpduAddress {
+            network: source_network,
+            mac_address: MacAddr::from_slice(source_mac),
+        }),
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu)?;
+    transport.send_unicast(&npdu_buf, client_mac).await
+}
+
+async fn accept_sc_with_limits(
+    ws_hub: &LoopbackWebSocket,
+    hub_vmac: Vmac,
+    hub_max_bvlc_length: u16,
+    hub_max_npdu_length: u16,
+) {
+    let data = ws_hub.recv().await.unwrap();
+    let req = decode_sc_message(&data).unwrap();
+    assert_eq!(req.function, ScFunction::ConnectRequest);
+
+    let mut payload = Vec::with_capacity(26);
+    payload.extend_from_slice(&hub_vmac);
+    payload.extend_from_slice(&[0u8; 16]);
+    payload.extend_from_slice(&hub_max_bvlc_length.to_be_bytes());
+    payload.extend_from_slice(&hub_max_npdu_length.to_be_bytes());
+
+    let accept = ScMessage {
+        function: ScFunction::ConnectAccept,
+        message_id: req.message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &accept);
+    ws_hub.send(&buf).await.unwrap();
+}
+
+async fn wait_for_client_transport_max_apdu_length<T: TransportPort + 'static>(
+    client: &BACnetClient<T>,
+    expected: u16,
+    timeout_duration: Duration,
+) {
+    let deadline = Instant::now() + timeout_duration;
+    loop {
+        if client.transport_max_apdu_length() == expected {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for client transport max APDU {expected}, got {}",
+            client.transport_max_apdu_length()
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn client_segments_known_device_requests_to_live_transport_limit() {
+    let client_mac = vec![0x01];
+    let peer_mac = vec![0x02];
+    let (client_inner, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let client_transport = LimitedTransport {
+        inner: client_inner,
+        max_apdu_length: 478,
+    };
+    let mut peer_rx = peer_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(5000)
+        .build()
+        .await
+        .unwrap();
+    assert_eq!(client.transport_max_apdu_length(), 478);
+    assert_eq!(client.max_apdu_length(), 206);
+
+    client.device_table.lock().await.upsert(DiscoveredDevice {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 42).unwrap(),
+        mac_address: MacAddr::from_slice(&peer_mac),
+        max_apdu_length: 1476,
+        segmentation_supported: Segmentation::BOTH,
+        max_segments_accepted: None,
+        vendor_id: 42,
+        last_seen: Instant::now(),
+        source_network: None,
+        source_address: None,
+    });
+
+    let service_data: Vec<u8> = (0..900).map(|i| (i % 251) as u8).collect();
+    let expected_service_data = service_data.clone();
+    let request_future = client.confirmed_request(
+        &peer_mac,
+        ConfirmedServiceChoice::WRITE_PROPERTY,
+        &service_data,
+    );
+    let peer_future = async {
+        let mut received_service_data = Vec::new();
+        let invoke_id = loop {
+            let received = timeout(Duration::from_secs(3), peer_rx.recv())
+                .await
+                .expect("timed out waiting for segmented NPDU")
+                .expect("peer channel closed");
+            assert!(
+                received.npdu.len() <= 480,
+                "NPDU exceeded simulated SC hub Max-NPDU-Length"
+            );
+
+            let npdu = decode_npdu(Bytes::copy_from_slice(&received.npdu)).unwrap();
+            let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+            let Apdu::ConfirmedRequest(req) = decoded else {
+                panic!("expected segmented ConfirmedRequest");
+            };
+            assert!(req.segmented);
+            assert_eq!(req.max_apdu_length, 206);
+            let seq = req.sequence_number.unwrap();
+            received_service_data.extend_from_slice(&req.service_request);
+
+            send_peer_apdu(
+                &peer_transport,
+                &client_mac,
+                Apdu::SegmentAck(SegmentAck {
+                    negative_ack: false,
+                    sent_by_server: true,
+                    invoke_id: req.invoke_id,
+                    sequence_number: seq,
+                    actual_window_size: 1,
+                }),
+            )
+            .await
+            .unwrap();
+
+            if !req.more_follows {
+                break req.invoke_id;
+            }
+        };
+
+        send_peer_apdu(
+            &peer_transport,
+            &client_mac,
+            Apdu::SimpleAck(SimpleAck {
+                invoke_id,
+                service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+            }),
+        )
+        .await
+        .unwrap();
+        received_service_data
+    };
+
+    let (result, received_service_data) = tokio::join!(request_future, peer_future);
+
+    assert!(result.unwrap().is_empty());
+    assert_eq!(received_service_data, expected_service_data);
+
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn client_routed_unsegmented_request_accounts_for_npdu_overhead_bucket() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+    let (client_inner, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+    let client_transport = LimitedTransport {
+        inner: client_inner,
+        max_apdu_length: 1024,
+    };
+    let mut router_rx = router_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(5000)
+        .build()
+        .await
+        .unwrap();
+    assert_eq!(client.transport_max_apdu_length(), 1024);
+    assert_eq!(client.max_apdu_length(), 1024);
+
+    let service_data: Vec<u8> = (0..900).map(|i| (i % 251) as u8).collect();
+    let request_future = client.confirmed_request_routed(
+        &router_mac,
+        remote_network,
+        &remote_mac,
+        ConfirmedServiceChoice::WRITE_PROPERTY,
+        &service_data,
+    );
+    let router_future = async {
+        let received = timeout(Duration::from_secs(3), router_rx.recv())
+            .await
+            .expect("timed out waiting for routed NPDU")
+            .expect("router channel closed");
+        assert!(
+            received.npdu.len() <= 1026,
+            "routed NPDU exceeded simulated SC local Max-NPDU budget"
+        );
+
+        let npdu = decode_npdu(Bytes::copy_from_slice(&received.npdu)).unwrap();
+        let destination = npdu.destination.expect("routed NPDU destination");
+        assert_eq!(destination.network, remote_network);
+        assert_eq!(&destination.mac_address[..], &remote_mac[..]);
+
+        let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+        let Apdu::ConfirmedRequest(req) = decoded else {
+            panic!("expected ConfirmedRequest");
+        };
+        assert!(!req.segmented);
+        assert_eq!(req.max_apdu_length, 480);
+        assert_eq!(&req.service_request[..], &service_data[..]);
+
+        send_peer_routed_apdu(
+            &router_transport,
+            &client_mac,
+            remote_network,
+            &remote_mac,
+            Apdu::SimpleAck(SimpleAck {
+                invoke_id: req.invoke_id,
+                service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+            }),
+        )
+        .await
+        .unwrap();
+    };
+
+    let (result, ()) = tokio::join!(request_future, router_future);
+
+    assert!(result.unwrap().is_empty());
+
+    client.stop().await.unwrap();
+    router_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn client_max_apdu_length_reflects_sc_failover_transport_limit() {
+    let (primary_client, primary_hub) = LoopbackWebSocket::pair();
+    let (failover_client, failover_hub) = LoopbackWebSocket::pair();
+    let primary_hub_vmac = [0x10; 6];
+    let failover_hub_vmac = [0x20; 6];
+    let sc_transport = ScTransport::new(primary_client, [0x01; 6])
+        .with_connect_timeout_ms(100)
+        .with_heartbeat_interval_ms(5_000)
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 25,
+            max_delay_ms: 25,
+            max_retries: 1,
+        })
+        .with_failover(failover_client);
+
+    let primary_task = tokio::spawn(async move {
+        accept_sc_with_limits(&primary_hub, primary_hub_vmac, 1476, 1026).await;
+        primary_hub
+    });
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(sc_transport)
+        .apdu_timeout_ms(5000)
+        .build()
+        .await
+        .unwrap();
+    let primary_hub = primary_task.await.unwrap();
+    assert_eq!(client.transport_max_apdu_length(), 1024);
+    assert_eq!(client.max_apdu_length(), 1024);
+
+    let failover_task = tokio::spawn(async move {
+        accept_sc_with_limits(&failover_hub, failover_hub_vmac, 1200, 480).await;
+        failover_hub
+    });
+
+    drop(primary_hub);
+    let failover_hub = timeout(Duration::from_secs(2), failover_task)
+        .await
+        .expect("timed out waiting for failover handshake")
+        .unwrap();
+
+    wait_for_client_transport_max_apdu_length(&client, 478, Duration::from_secs(1)).await;
+    assert_eq!(client.max_apdu_length(), 206);
+
+    client.stop().await.unwrap();
+    drop(failover_hub);
+}

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -176,6 +176,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         remote_max_segments: Option<u32>,
     ) -> Result<Bytes, Error> {
         let tsm_mac = target.tsm_mac();
+        let advertised_max_apdu = self.advertised_max_apdu_length_for_target(target)?;
         let max_seg_size = max_segment_payload(remote_max_apdu, SegmentedPduType::ConfirmedRequest);
         let segments = split_payload(service_data, max_seg_size)?;
         let total_segments = segments.len();
@@ -221,12 +222,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 
         let result = async {
             while next_seq < total_segments {
-                let window_end = (next_seq + window_size).min(total_segments);
+                let window_start = next_seq;
+                let window_end = (window_start + window_size).min(total_segments);
 
-                for (seq, segment_data) in segments[next_seq..window_end]
+                for (seq, segment_data) in segments[window_start..window_end]
                     .iter()
                     .enumerate()
-                    .map(|(i, s)| (next_seq + i, s))
+                    .map(|(i, s)| (window_start + i, s))
                 {
                     let is_last = seq == total_segments - 1;
                     let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
@@ -234,7 +236,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         more_follows: !is_last,
                         segmented_response_accepted: self.config.segmented_response_accepted,
                         max_segments: self.config.max_segments,
-                        max_apdu_length: self.config.max_apdu_length,
+                        max_apdu_length: advertised_max_apdu,
                         invoke_id,
                         sequence_number: Some(seq as u8),
                         proposed_window_size: Some(self.config.proposed_window_size.max(1)),
@@ -254,7 +256,39 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     let mut ack_retries: u8 = 0;
                     loop {
                         match timeout(timeout_duration, seg_ack_rx.recv()).await {
-                            Ok(Some(ack)) => break ack,
+                            Ok(Some(ack)) => {
+                                let ack_seq = ack.sequence_number as usize;
+                                if ack_seq >= total_segments {
+                                    return Err(Error::Segmentation(format!(
+                                        "SegmentAck sequence {} out of range (total {})",
+                                        ack_seq, total_segments
+                                    )));
+                                }
+
+                                let ack_in_current_window = if ack.negative_ack {
+                                    let resend_seq = if ack_seq == 0 && window_start == 0 {
+                                        0
+                                    } else {
+                                        ack_seq + 1
+                                    };
+                                    resend_seq >= window_start && resend_seq < window_end
+                                } else {
+                                    ack_seq >= window_start && ack_seq < window_end
+                                };
+
+                                if !ack_in_current_window {
+                                    debug!(
+                                        seq = ack.sequence_number,
+                                        negative = ack.negative_ack,
+                                        window_start,
+                                        window_end,
+                                        "Ignoring SegmentAck outside current send window"
+                                    );
+                                    continue;
+                                }
+
+                                break ack;
+                            }
                             Ok(None) => {
                                 return Err(Error::Encoding("SegmentAck channel closed".into()));
                             }
@@ -267,10 +301,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     attempt = ack_retries,
                                     "Retransmitting segmented request window"
                                 );
-                                for (seq, segment_data) in segments[next_seq..window_end]
+                                for (seq, segment_data) in segments[window_start..window_end]
                                     .iter()
                                     .enumerate()
-                                    .map(|(i, s)| (next_seq + i, s))
+                                    .map(|(i, s)| (window_start + i, s))
                                 {
                                     let is_last = seq == total_segments - 1;
                                     let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
@@ -280,7 +314,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                             .config
                                             .segmented_response_accepted,
                                         max_segments: self.config.max_segments,
-                                        max_apdu_length: self.config.max_apdu_length,
+                                        max_apdu_length: advertised_max_apdu,
                                         invoke_id,
                                         sequence_number: Some(seq as u8),
                                         proposed_window_size: Some(
@@ -310,13 +344,6 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 window_size = ack.actual_window_size.max(1) as usize;
 
                 let ack_seq = ack.sequence_number as usize;
-                if ack_seq >= total_segments {
-                    return Err(Error::Segmentation(format!(
-                        "SegmentAck sequence {} out of range (total {})",
-                        ack_seq, total_segments
-                    )));
-                }
-
                 if ack.negative_ack {
                     neg_ack_retries += 1;
                     if neg_ack_retries > MAX_NEG_ACK_RETRIES {
@@ -324,7 +351,16 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                             "too many negative SegmentAck retransmissions".into(),
                         ));
                     }
-                    next_seq = ack_seq + 1;
+                    // A first-window negative SegmentACK with sequence 0 is
+                    // ambiguous: it can mean segment 0 was the last accepted
+                    // segment, or that no segment has been accepted yet. Later
+                    // NAK 0 frames are stale for this window and are ignored
+                    // before reaching this branch.
+                    next_seq = if ack_seq == 0 && window_start == 0 {
+                        0
+                    } else {
+                        ack_seq + 1
+                    };
                 } else {
                     neg_ack_retries = 0;
                     next_seq = ack_seq + 1;

--- a/crates/bacnet-client/src/client/segmentation_retransmit_tests.rs
+++ b/crates/bacnet-client/src/client/segmentation_retransmit_tests.rs
@@ -1,0 +1,301 @@
+use bacnet_encoding::apdu::{self, encode_apdu, Apdu, ConfirmedRequest, SegmentAck, SimpleAck};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_types::enums::ConfirmedServiceChoice;
+use bytes::BytesMut;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+use super::{BACnetClient, ClientConfig};
+
+async fn send_local_response<T: TransportPort>(transport: &T, client_mac: &[u8], apdu: Apdu) {
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &apdu).expect("valid APDU encoding");
+    let npdu = Npdu {
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu).unwrap();
+    transport.send_unicast(&npdu_buf, client_mac).await.unwrap();
+}
+
+async fn recv_confirmed_segment(
+    rx: &mut mpsc::Receiver<ReceivedNpdu>,
+    context: &str,
+) -> ConfirmedRequest {
+    let received = timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{context}: timed out waiting for segment"))
+        .unwrap_or_else(|| panic!("{context}: server channel closed"));
+    let npdu = decode_npdu(received.npdu).unwrap();
+    let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+    let Apdu::ConfirmedRequest(req) = decoded else {
+        panic!("{context}: expected ConfirmedRequest, got {:?}", decoded);
+    };
+    assert!(req.segmented, "{context}: request must be segmented");
+    req
+}
+
+#[tokio::test]
+async fn segmented_request_retransmits_segment_zero_after_negative_ack_zero() {
+    let client_mac = vec![0x01];
+    let server_mac = vec![0x02];
+    let (client_transport, mut server_transport) =
+        LoopbackTransport::pair(client_mac.clone(), server_mac.clone());
+    let mut server_rx = server_transport.start().await.unwrap();
+
+    let mut config = ClientConfig {
+        apdu_timeout_ms: 2000,
+        max_apdu_length: 50,
+        proposed_window_size: 2,
+        ..ClientConfig::default()
+    };
+    config.apdu_retries = 2;
+    let mut client = BACnetClient::start(config, client_transport).await.unwrap();
+
+    let request_server_mac = server_mac.clone();
+    let service_data: Vec<u8> = (0u8..100).collect();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request(
+                &request_server_mac,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let mut invoke_id = None;
+    for expected_seq in [0, 1] {
+        let received = timeout(Duration::from_secs(2), server_rx.recv())
+            .await
+            .expect("server timed out waiting for initial window segment")
+            .expect("server channel closed");
+        let npdu = decode_npdu(received.npdu).unwrap();
+        let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+        let Apdu::ConfirmedRequest(req) = decoded else {
+            panic!("Expected ConfirmedRequest, got {:?}", decoded);
+        };
+        assert!(req.segmented);
+        assert_eq!(req.sequence_number, Some(expected_seq));
+        invoke_id = Some(req.invoke_id);
+    }
+
+    let invoke_id = invoke_id.unwrap();
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: true,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 0,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+
+    for expected_seq in [0, 1] {
+        let received = timeout(Duration::from_secs(2), server_rx.recv())
+            .await
+            .expect("server timed out waiting for retransmitted window segment")
+            .expect("server channel closed");
+        let npdu = decode_npdu(received.npdu).unwrap();
+        let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+        let Apdu::ConfirmedRequest(req) = decoded else {
+            panic!("Expected ConfirmedRequest, got {:?}", decoded);
+        };
+        assert_eq!(req.invoke_id, invoke_id);
+        assert_eq!(req.sequence_number, Some(expected_seq));
+    }
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 1,
+            actual_window_size: 1,
+        }),
+    )
+    .await;
+
+    loop {
+        let received = timeout(Duration::from_secs(2), server_rx.recv())
+            .await
+            .expect("server timed out waiting for remaining segment")
+            .expect("server channel closed");
+        let npdu = decode_npdu(received.npdu).unwrap();
+        let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+        let Apdu::ConfirmedRequest(req) = decoded else {
+            panic!("Expected ConfirmedRequest, got {:?}", decoded);
+        };
+        assert_eq!(req.invoke_id, invoke_id);
+        let seq = req.sequence_number.unwrap();
+        assert!(seq >= 2);
+        let more_follows = req.more_follows;
+
+        send_local_response(
+            &server_transport,
+            &client_mac,
+            Apdu::SegmentAck(SegmentAck {
+                negative_ack: false,
+                sent_by_server: true,
+                invoke_id,
+                sequence_number: seq,
+                actual_window_size: 1,
+            }),
+        )
+        .await;
+
+        if !more_follows {
+            break;
+        }
+    }
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+
+    let result = request_task.await.unwrap();
+    assert!(result.unwrap().is_empty());
+    server_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn segmented_request_ignores_stale_negative_ack_zero_after_progress() {
+    let client_mac = vec![0x01];
+    let server_mac = vec![0x02];
+    let (client_transport, mut server_transport) =
+        LoopbackTransport::pair(client_mac.clone(), server_mac.clone());
+    let mut server_rx = server_transport.start().await.unwrap();
+
+    let mut config = ClientConfig {
+        apdu_timeout_ms: 2000,
+        max_apdu_length: 50,
+        proposed_window_size: 2,
+        ..ClientConfig::default()
+    };
+    config.apdu_retries = 2;
+    let mut client = BACnetClient::start(config, client_transport).await.unwrap();
+
+    let request_server_mac = server_mac.clone();
+    let service_data: Vec<u8> = (0..260).map(|i| (i % 251) as u8).collect();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request(
+                &request_server_mac,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let mut invoke_id = None;
+    for expected_seq in [0, 1] {
+        let req = recv_confirmed_segment(&mut server_rx, "initial window").await;
+        assert_eq!(req.sequence_number, Some(expected_seq));
+        invoke_id = Some(req.invoke_id);
+    }
+
+    let invoke_id = invoke_id.unwrap();
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 1,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+
+    for expected_seq in [2, 3] {
+        let req = recv_confirmed_segment(&mut server_rx, "second window").await;
+        assert_eq!(req.invoke_id, invoke_id);
+        assert_eq!(req.sequence_number, Some(expected_seq));
+    }
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: true,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 0,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 3,
+            actual_window_size: 1,
+        }),
+    )
+    .await;
+
+    loop {
+        let req = recv_confirmed_segment(&mut server_rx, "post-stale-ack window").await;
+        assert_eq!(req.invoke_id, invoke_id);
+        let seq = req.sequence_number.unwrap();
+        assert!(
+            seq >= 4,
+            "stale negative SegmentACK 0 rewound transfer to segment {seq}"
+        );
+        let more_follows = req.more_follows;
+
+        send_local_response(
+            &server_transport,
+            &client_mac,
+            Apdu::SegmentAck(SegmentAck {
+                negative_ack: false,
+                sent_by_server: true,
+                invoke_id,
+                sequence_number: seq,
+                actual_window_size: 1,
+            }),
+        )
+        .await;
+
+        if !more_follows {
+            break;
+        }
+    }
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+
+    let result = request_task.await.unwrap();
+    assert!(result.unwrap().is_empty());
+    server_transport.stop().await.unwrap();
+}

--- a/crates/bacnet-transport/src/sc/failover.rs
+++ b/crates/bacnet-transport/src/sc/failover.rs
@@ -1,6 +1,6 @@
 //! BACnet/SC primary/failover hub switching helpers.
 
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{atomic::AtomicU16, Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use bacnet_types::error::Error;
@@ -12,8 +12,8 @@ use tracing::warn;
 use crate::sc_frame::{encode_sc_message, ScMessage};
 
 use super::{
-    connector::dial_connector, handshake::perform_handshake, ScConnection, ScConnectionState,
-    WebSocketConnector, WebSocketPort,
+    connector::dial_connector, handshake::perform_handshake, publish_effective_max_apdu_length,
+    ScConnection, ScConnectionState, WebSocketConnector, WebSocketPort,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -31,6 +31,7 @@ pub(super) async fn attempt_primary_restore<W: WebSocketPort>(
     restore_disconnect_task: &Arc<StdMutex<Option<JoinHandle<()>>>>,
     state_tx: &watch::Sender<ScConnectionState>,
     connect_timeout_ms: u64,
+    effective_max_apdu_length: &AtomicU16,
 ) -> Result<Arc<W>, Error> {
     let restored_ws = if let Some(connector) = primary_connector {
         Arc::new(dial_connector(connector, connect_timeout_ms).await?)
@@ -49,6 +50,7 @@ pub(super) async fn attempt_primary_restore<W: WebSocketPort>(
     let mut c = conn.lock().await;
     *c = restored;
     *current = restored_ws.clone();
+    publish_effective_max_apdu_length(effective_max_apdu_length, &c);
     state_tx.send_replace(c.state);
     drop(c);
     drop(current);

--- a/crates/bacnet-transport/src/sc/max_apdu_tests.rs
+++ b/crates/bacnet-transport/src/sc/max_apdu_tests.rs
@@ -1,0 +1,159 @@
+use bytes::{Bytes, BytesMut};
+use tokio::time::{Duration, Instant};
+
+use crate::port::TransportPort;
+use crate::sc_frame::{decode_sc_message, encode_sc_message, ScFunction, ScMessage, Vmac};
+
+use super::{LoopbackWebSocket, ScReconnectConfig, ScTransport, WebSocketPort};
+
+async fn accept_with_limits(
+    ws_hub: &LoopbackWebSocket,
+    hub_vmac: Vmac,
+    hub_max_bvlc_length: u16,
+    hub_max_npdu_length: u16,
+) {
+    let data = ws_hub.recv().await.unwrap();
+    let req = decode_sc_message(&data).unwrap();
+    assert_eq!(req.function, ScFunction::ConnectRequest);
+
+    let mut payload = Vec::with_capacity(26);
+    payload.extend_from_slice(&hub_vmac);
+    payload.extend_from_slice(&[0u8; 16]);
+    payload.extend_from_slice(&hub_max_bvlc_length.to_be_bytes());
+    payload.extend_from_slice(&hub_max_npdu_length.to_be_bytes());
+
+    let accept = ScMessage {
+        function: ScFunction::ConnectAccept,
+        message_id: req.message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &accept);
+    ws_hub.send(&buf).await.unwrap();
+}
+
+async fn wait_for_transport_max_apdu_length(
+    transport: &ScTransport<LoopbackWebSocket>,
+    expected: u16,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if transport.max_apdu_length() == expected {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for max APDU {expected}, got {}",
+            transport.max_apdu_length()
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test]
+async fn sc_max_apdu_length_accounts_for_sc_and_npdu_headers() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let hub_vmac = [0x10; 6];
+    let mut transport = ScTransport::new(ws_client, [0x01; 6]);
+
+    let hub_task = tokio::spawn(async move {
+        accept_with_limits(&ws_hub, hub_vmac, 1476, 1476).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let ws_hub = hub_task.await.unwrap();
+
+    assert_eq!(transport.max_apdu_length(), 1464);
+
+    transport.stop().await.unwrap();
+    drop(ws_hub);
+}
+
+#[tokio::test]
+async fn sc_max_apdu_length_reflects_negotiated_hub_npdu_limit() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let hub_vmac = [0x10; 6];
+    let mut transport = ScTransport::new(ws_client, [0x01; 6]);
+    assert_eq!(transport.max_apdu_length(), 1476);
+
+    let hub_task = tokio::spawn(async move {
+        accept_with_limits(&ws_hub, hub_vmac, 1200, 480).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let ws_hub = hub_task.await.unwrap();
+
+    assert_eq!(transport.max_apdu_length(), 478);
+
+    transport.stop().await.unwrap();
+    drop(ws_hub);
+}
+
+#[tokio::test]
+async fn sc_max_apdu_length_updates_after_failover_handshake() {
+    let (primary_client, primary_hub) = LoopbackWebSocket::pair();
+    let (failover_client, failover_hub) = LoopbackWebSocket::pair();
+    let primary_hub_vmac = [0x10; 6];
+    let failover_hub_vmac = [0x20; 6];
+    let mut transport = ScTransport::new(primary_client, [0x01; 6])
+        .with_connect_timeout_ms(100)
+        .with_heartbeat_interval_ms(5_000)
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 25,
+            max_delay_ms: 25,
+            max_retries: 1,
+        })
+        .with_failover(failover_client);
+
+    let primary_task = tokio::spawn(async move {
+        accept_with_limits(&primary_hub, primary_hub_vmac, 1200, 480).await;
+        primary_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let primary_hub = primary_task.await.unwrap();
+    assert_eq!(transport.max_apdu_length(), 478);
+
+    let failover_task = tokio::spawn(async move {
+        accept_with_limits(&failover_hub, failover_hub_vmac, 300, 1476).await;
+        failover_hub
+    });
+
+    drop(primary_hub);
+    let failover_hub = tokio::time::timeout(Duration::from_secs(2), failover_task)
+        .await
+        .expect("timed out waiting for failover handshake")
+        .unwrap();
+
+    wait_for_transport_max_apdu_length(&transport, 288, Duration::from_secs(1)).await;
+
+    transport.stop().await.unwrap();
+    drop(failover_hub);
+}
+
+#[tokio::test]
+async fn sc_max_apdu_length_reflects_negotiated_hub_bvlc_limit() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let hub_vmac = [0x10; 6];
+    let mut transport = ScTransport::new(ws_client, [0x01; 6]);
+
+    let hub_task = tokio::spawn(async move {
+        accept_with_limits(&ws_hub, hub_vmac, 300, 1476).await;
+        ws_hub
+    });
+
+    let _rx = transport.start().await.unwrap();
+    let ws_hub = hub_task.await.unwrap();
+
+    assert_eq!(transport.max_apdu_length(), 288);
+
+    transport.stop().await.unwrap();
+    drop(ws_hub);
+}

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -4,7 +4,10 @@
 //! The actual WebSocket I/O is abstracted behind the [`WebSocketPort`] trait
 //! so the connection state machine can be tested without a TLS stack.
 
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{
+    atomic::{AtomicU16, Ordering},
+    Arc, Mutex as StdMutex,
+};
 use std::time::{Duration, Instant};
 
 #[cfg(test)]
@@ -44,6 +47,10 @@ pub(crate) use random48::generate_random48_vmac;
 pub(crate) use random48::set_test_random48_vmac_generator;
 pub use reconnect::ScReconnectConfig;
 
+const DEFAULT_MAX_APDU_LENGTH: u16 = 1476;
+const BACNET_NPDU_BASE_HEADER_LEN: u16 = 2;
+const SC_ENCAPSULATED_NPDU_BASE_HEADER_LEN: u16 = 10;
+
 // ---------------------------------------------------------------------------
 // WebSocket abstraction
 // ---------------------------------------------------------------------------
@@ -71,6 +78,7 @@ pub struct ScTransport<W: WebSocketPort> {
     /// Device UUID (16 bytes, RFC 4122).
     device_uuid: [u8; 16],
     connection: Option<Arc<Mutex<ScConnection>>>,
+    effective_max_apdu_length: Arc<AtomicU16>,
     state_tx: watch::Sender<ScConnectionState>,
     recv_task: Option<JoinHandle<()>>,
     connect_timeout_ms: u64,
@@ -94,6 +102,7 @@ impl<W: WebSocketPort> ScTransport<W> {
             local_vmac,
             device_uuid: [0u8; 16],
             connection: None,
+            effective_max_apdu_length: Arc::new(AtomicU16::new(DEFAULT_MAX_APDU_LENGTH)),
             state_tx,
             recv_task: None,
             connect_timeout_ms: 10_000,
@@ -200,6 +209,8 @@ impl<W: WebSocketPort> ScTransport<W> {
                 c.state = ScConnectionState::Disconnected;
             }
         }
+        self.effective_max_apdu_length
+            .store(DEFAULT_MAX_APDU_LENGTH, Ordering::Relaxed);
         self.state_tx.send_replace(ScConnectionState::Disconnected);
         self.ws_shared = None;
         self.connection = None;
@@ -207,6 +218,18 @@ impl<W: WebSocketPort> ScTransport<W> {
         self.failover_ws = None;
         (task, restore_task)
     }
+}
+
+fn effective_max_apdu_length(conn: &ScConnection) -> u16 {
+    let bvlc_npdu_budget = conn
+        .hub_max_bvlc_length
+        .saturating_sub(SC_ENCAPSULATED_NPDU_BASE_HEADER_LEN);
+    let effective_npdu = conn.hub_max_apdu_length.min(bvlc_npdu_budget);
+    effective_npdu.saturating_sub(BACNET_NPDU_BASE_HEADER_LEN)
+}
+
+fn publish_effective_max_apdu_length(store: &AtomicU16, conn: &ScConnection) {
+    store.store(effective_max_apdu_length(conn), Ordering::Relaxed);
 }
 
 async fn connect_probe_from(conn: &Arc<Mutex<ScConnection>>) -> Arc<Mutex<ScConnection>> {
@@ -228,12 +251,14 @@ async fn publish_connected_ws<W: WebSocketPort>(
     ws: &Arc<W>,
     probe_conn: &Arc<Mutex<ScConnection>>,
     state_tx: &watch::Sender<ScConnectionState>,
+    effective_max_apdu_length: &AtomicU16,
 ) {
     let restored = probe_conn.lock().await.clone();
     let mut current = active_ws.lock().await;
     let mut c = conn.lock().await;
     *c = restored;
     *current = ws.clone();
+    publish_effective_max_apdu_length(effective_max_apdu_length, &c);
     state_tx.send_replace(c.state);
 }
 
@@ -312,7 +337,11 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
             }
         };
 
-        self.local_vmac = conn.lock().await.local_vmac;
+        {
+            let c = conn.lock().await;
+            self.local_vmac = c.local_vmac;
+            publish_effective_max_apdu_length(&self.effective_max_apdu_length, &c);
+        }
 
         let active_ws = Arc::new(Mutex::new(ws.clone()));
         self.ws_shared = Some(active_ws.clone());
@@ -332,6 +361,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
         let primary_ws = primary_ws.clone();
         let mut ws_clone = ws.clone();
         let mut active_hub = active_hub;
+        let effective_max_apdu_length = self.effective_max_apdu_length.clone();
         let task = tokio::spawn(async move {
             let mut primary_restore_interval =
                 tokio::time::interval(Duration::from_millis(restore_interval_ms));
@@ -475,6 +505,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                 &restore_disconnect_task,
                                 &state_tx,
                                 connect_timeout_ms,
+                                &effective_max_apdu_length,
                             )
                             .await
                             {
@@ -576,6 +607,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                 &reconnect_ws,
                                 &probe_conn,
                                 &state_tx,
+                                &effective_max_apdu_length,
                             )
                             .await;
                             ws_clone = reconnect_ws;
@@ -626,6 +658,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                     &failover,
                                     &probe_conn,
                                     &state_tx,
+                                    &effective_max_apdu_length,
                                 )
                                 .await;
                                 ws_clone = failover;
@@ -733,6 +766,10 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
         // Use a trick: reference the stored array.
         &self.local_vmac
     }
+
+    fn max_apdu_length(&self) -> u16 {
+        self.effective_max_apdu_length.load(Ordering::Relaxed)
+    }
 }
 
 impl<W: WebSocketPort> Drop for ScTransport<W> {
@@ -746,6 +783,9 @@ mod data_attribute_tests;
 
 #[cfg(test)]
 mod drop_tests;
+
+#[cfg(test)]
+mod max_apdu_tests;
 
 #[cfg(test)]
 mod receive_state_tests;


### PR DESCRIPTION
Summary
- publish BACnet/SC negotiated Max-NPDU/Max-BVLC as the live ScTransport APDU budget across connect, reconnect, failover, and primary restore
- cap BACnetClient startup/request/segmentation APDU buckets against the live transport budget, including routed NPDU overhead, and expose live transport/client APDU accessors
- tighten segmented-request SegmentACK handling so first-window NAK 0 can recover segment 0 while stale out-of-window ACK/NAK frames cannot rewind progress

Validation
- cargo fmt --all --check
- git diff --check
- git diff --cached --check
- bash .github/scripts/check-file-size.sh
- bash .github/scripts/check-no-secrets.sh
- cargo test -p bacnet-client --locked sc_max_apdu_tests --quiet
- cargo test -p bacnet-client --locked segmentation_retransmit_tests --quiet
- cargo test -p bacnet-transport --locked sc::max_apdu_tests --quiet
- cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls
- cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls
- cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked

Fixes #93