### PR TITLE
fix(sc): require SC builder identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a managed finite `BACnetClient` COV subscription helper that renews before expiry and emits lifetime/renewal events.
 - Add `ScTransport::connection_state_changes()` returning a `tokio::sync::watch::Receiver<ScConnectionState>` so BACnet/SC consumers can await latest link-state changes without polling the inspection-only connection handle; rapid transitions may coalesce under watch semantics.
 - Add typed BACnet/SC connect-path errors via `bacnet_transport::sc::ScConnectError`, preserving BVLC-Result NAK class/code/details and distinguishing WebSocket dial, TLS, handshake, and subprotocol failures without string parsing.
+- Add `ScClientBuilder::device_uuid(...)` and BACnet/SC CLI `--sc-vmac` / `--sc-device-uuid` options so convenience clients can provision stable SC identity without hand-assembling `ScTransport`.
 
 ### Fixed
 
+- Fail fast in `ScClientBuilder` and the BACnet/SC CLI path when required SC identity is missing or uses reserved VMAC values, preventing all-zero Unknown VMAC connects from reaching the wire.
 - Propagate negotiated BACnet/SC hub Max-NPDU/BVLC limits into `ScTransport::max_apdu_length()` and `BACnetClient` request segmentation, with `BACnetClient::transport_max_apdu_length()` exposing the live post-connect transport budget.
 - Return BACnet/SC handshake timeouts as `Error::Timeout` and malformed BVLC-Result failures as typed `ScConnectError` values instead of collapsing them into `Error::Encoding`; downstream code should match `Error::Timeout` directly and use `ScConnectError::from_error` for SC transport details.
 - Re-dial BACnet/SC WebSocket connections during reconnect, failover, and primary restore instead of reusing a torn-down socket object.

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ bacnet --ipv6 discover
 bacnet --ipv6 read [fe80::1]:47808 ai:1 pv
 
 # BACnet/SC
-bacnet --sc --sc-url wss://hub:443 --sc-cert cert.pem --sc-key key.pem read 00:01:02:03:04:05 ai:1 pv
+bacnet --sc --sc-url wss://hub:443 --sc-cert cert.pem --sc-key key.pem --sc-vmac 22:01:02:03:04:05 --sc-device-uuid 00112233-4455-6677-8899-aabbccddeeff read 00:01:02:03:04:05 ai:1 pv
 
 # Output formats
 bacnet --json discover           # JSON output (default when piped)

--- a/crates/bacnet-cli/src/main.rs
+++ b/crates/bacnet-cli/src/main.rs
@@ -3,13 +3,10 @@
 //! Running `bacnet` with no arguments or with the `shell` subcommand launches
 //! an interactive REPL. Subcommands can also be used directly for scripting.
 
-use std::io::IsTerminal;
-use std::net::Ipv4Addr;
-use std::path::PathBuf;
+use std::{io::IsTerminal, net::Ipv4Addr, path::PathBuf};
 
 use bacnet_client::client::BACnetClient;
-use bacnet_transport::bip::BipTransport;
-use bacnet_transport::port::TransportPort;
+use bacnet_transport::{bip::BipTransport, port::TransportPort};
 use clap::{Parser, Subcommand};
 
 mod commands;
@@ -70,6 +67,14 @@ struct Cli {
     /// SC TLS private key PEM file.
     #[arg(long, global = true)]
     sc_key: Option<PathBuf>,
+
+    /// BACnet/SC local VMAC as 12 hex digits or colon-separated bytes.
+    #[arg(long, global = true, value_parser = transport::parse_sc_vmac_arg)]
+    sc_vmac: Option<[u8; 6]>,
+
+    /// BACnet/SC device UUID as 32 hex digits or RFC 4122 hyphenated text.
+    #[arg(long, global = true, value_parser = transport::parse_sc_device_uuid_arg)]
+    sc_device_uuid: Option<[u8; 16]>,
 
     /// Output format (table, json).
     #[arg(long, global = true)]
@@ -800,6 +805,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         sc_url: cli.sc_url.clone(),
         sc_cert: cli.sc_cert.clone(),
         sc_key: cli.sc_key.clone(),
+        sc_vmac: cli.sc_vmac,
+        sc_device_uuid: cli.sc_device_uuid,
         ipv6: cli.ipv6,
         ipv6_interface,
         device_instance: cli.device_instance,

--- a/crates/bacnet-cli/src/transport.rs
+++ b/crates/bacnet-cli/src/transport.rs
@@ -17,9 +17,61 @@ pub struct TransportArgs {
     pub sc_url: Option<String>,
     pub sc_cert: Option<PathBuf>,
     pub sc_key: Option<PathBuf>,
+    pub sc_vmac: Option<[u8; 6]>,
+    pub sc_device_uuid: Option<[u8; 16]>,
     pub ipv6: bool,
     pub ipv6_interface: Option<Ipv6Addr>,
     pub device_instance: Option<u32>,
+}
+
+fn parse_fixed_hex_array<const N: usize>(
+    value: &str,
+    label: &str,
+    separators: &[char],
+) -> Result<[u8; N], String> {
+    let compact: String = value
+        .trim()
+        .chars()
+        .filter(|ch| !separators.contains(ch))
+        .collect();
+    let expected_len = N * 2;
+    if compact.len() != expected_len {
+        return Err(format!("{label} must contain exactly {N} hex bytes"));
+    }
+    if !compact.as_bytes().iter().all(u8::is_ascii_hexdigit) {
+        return Err(format!("{label} contains non-hex characters"));
+    }
+
+    let mut bytes = [0u8; N];
+    for (index, byte) in bytes.iter_mut().enumerate() {
+        let start = index * 2;
+        *byte = u8::from_str_radix(&compact[start..start + 2], 16)
+            .map_err(|e| format!("failed to parse {label}: {e}"))?;
+    }
+    Ok(bytes)
+}
+
+/// Parse a BACnet/SC VMAC CLI argument.
+pub fn parse_sc_vmac_arg(value: &str) -> Result<[u8; 6], String> {
+    let vmac = parse_fixed_hex_array::<6>(value, "SC VMAC", &[':', '-'])?;
+    match vmac {
+        bacnet_transport::sc_frame::UNKNOWN_VMAC => {
+            Err("--sc-vmac must not be the reserved unknown VMAC".into())
+        }
+        bacnet_transport::sc_frame::BROADCAST_VMAC => {
+            Err("--sc-vmac must not be the reserved broadcast VMAC".into())
+        }
+        _ => Ok(vmac),
+    }
+}
+
+/// Parse a BACnet/SC device UUID CLI argument.
+pub fn parse_sc_device_uuid_arg(value: &str) -> Result<[u8; 16], String> {
+    let uuid = parse_fixed_hex_array::<16>(value, "SC device UUID", &['-'])?;
+    if uuid == [0; 16] {
+        return Err("--sc-device-uuid must not be all zero".into());
+    }
+    Ok(uuid)
 }
 
 /// Build a BACnet/IP (BIP) client from CLI transport arguments.
@@ -62,6 +114,12 @@ pub async fn build_sc_client(
         .sc_url
         .as_deref()
         .ok_or_else(|| Error::Encoding("--sc-url is required for BACnet/SC".into()))?;
+    let sc_vmac = args
+        .sc_vmac
+        .ok_or_else(|| Error::Encoding("--sc-vmac is required for BACnet/SC".into()))?;
+    let sc_device_uuid = args
+        .sc_device_uuid
+        .ok_or_else(|| Error::Encoding("--sc-device-uuid is required for BACnet/SC".into()))?;
 
     let certs = CertificateDer::pem_file_iter(cert_path)
         .map_err(|e| Error::Encoding(format!("failed to read cert PEM: {e}")))?
@@ -92,6 +150,8 @@ pub async fn build_sc_client(
     BACnetClient::sc_builder()
         .hub_url(hub_url)
         .tls_config(Arc::new(tls_config))
+        .vmac(sc_vmac)
+        .device_uuid(sc_device_uuid)
         .apdu_timeout_ms(args.timeout_ms)
         .build()
         .await
@@ -111,4 +171,88 @@ pub async fn build_bip6_client(args: &TransportArgs) -> Result<BACnetClient<Bip6
     }
 
     builder.build().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "sc-tls")]
+    fn sc_args() -> TransportArgs {
+        TransportArgs {
+            interface: Ipv4Addr::UNSPECIFIED,
+            port: 0xBAC0,
+            broadcast: Ipv4Addr::BROADCAST,
+            timeout_ms: 6000,
+            sc: true,
+            sc_url: Some("wss://hub.example.com/bacnet".into()),
+            sc_cert: Some(PathBuf::from("cert.pem")),
+            sc_key: Some(PathBuf::from("key.pem")),
+            sc_vmac: Some([0x22, 0x01, 0x02, 0x03, 0x04, 0x05]),
+            sc_device_uuid: Some([0xAB; 16]),
+            ipv6: false,
+            ipv6_interface: None,
+            device_instance: None,
+        }
+    }
+
+    #[test]
+    fn parse_sc_vmac_arg_accepts_compact_and_separated_hex() {
+        assert_eq!(
+            parse_sc_vmac_arg("220102030405").unwrap(),
+            [0x22, 0x01, 0x02, 0x03, 0x04, 0x05]
+        );
+        assert_eq!(
+            parse_sc_vmac_arg("22:01:02:03:04:05").unwrap(),
+            [0x22, 0x01, 0x02, 0x03, 0x04, 0x05]
+        );
+    }
+
+    #[test]
+    fn parse_sc_vmac_arg_rejects_reserved_values() {
+        assert!(parse_sc_vmac_arg("00:00:00:00:00:00").is_err());
+        assert!(parse_sc_vmac_arg("ff:ff:ff:ff:ff:ff").is_err());
+    }
+
+    #[test]
+    fn parse_sc_device_uuid_arg_accepts_hyphenated_uuid() {
+        assert_eq!(
+            parse_sc_device_uuid_arg("00112233-4455-6677-8899-aabbccddeeff").unwrap(),
+            [
+                0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD,
+                0xEE, 0xFF,
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_sc_device_uuid_arg_rejects_zero_uuid() {
+        assert!(parse_sc_device_uuid_arg("00000000-0000-0000-0000-000000000000").is_err());
+    }
+
+    #[cfg(feature = "sc-tls")]
+    #[tokio::test]
+    async fn build_sc_client_requires_vmac_before_loading_tls_files() {
+        let mut args = sc_args();
+        args.sc_vmac = None;
+
+        let result = build_sc_client(&args).await;
+        assert!(matches!(
+            result,
+            Err(Error::Encoding(message)) if message.contains("--sc-vmac is required")
+        ));
+    }
+
+    #[cfg(feature = "sc-tls")]
+    #[tokio::test]
+    async fn build_sc_client_requires_device_uuid_before_loading_tls_files() {
+        let mut args = sc_args();
+        args.sc_device_uuid = None;
+
+        let result = build_sc_client(&args).await;
+        assert!(matches!(
+            result,
+            Err(Error::Encoding(message)) if message.contains("--sc-device-uuid is required")
+        ));
+    }
 }

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -490,6 +490,7 @@ impl BACnetClient<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::Tl
             hub_url: String::new(),
             tls_config: None,
             vmac: [0; 6],
+            device_uuid: [0; 16],
             heartbeat_interval_ms: 30_000,
             heartbeat_timeout_ms: 60_000,
             reconnect: None,
@@ -507,6 +508,7 @@ pub struct ScClientBuilder {
     hub_url: String,
     tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ClientConfig>>,
     vmac: bacnet_transport::sc_frame::Vmac,
+    device_uuid: [u8; 16],
     heartbeat_interval_ms: u64,
     heartbeat_timeout_ms: u64,
     reconnect: Option<bacnet_transport::sc::ScReconnectConfig>,
@@ -532,6 +534,12 @@ impl ScClientBuilder {
     /// Set the local VMAC address.
     pub fn vmac(mut self, vmac: [u8; 6]) -> Self {
         self.vmac = vmac;
+        self
+    }
+
+    /// Set the persistent BACnet/SC device UUID.
+    pub fn device_uuid(mut self, uuid: [u8; 16]) -> Self {
+        self.device_uuid = uuid;
         self
     }
 
@@ -565,6 +573,44 @@ impl ScClientBuilder {
         self
     }
 
+    fn validate_identity(&self) -> Result<(), Error> {
+        match self.vmac {
+            bacnet_transport::sc_frame::UNKNOWN_VMAC => Err(Error::Encoding(
+                "SC client builder: vmac must not be the reserved unknown VMAC".into(),
+            )),
+            bacnet_transport::sc_frame::BROADCAST_VMAC => Err(Error::Encoding(
+                "SC client builder: vmac must not be the reserved broadcast VMAC".into(),
+            )),
+            _ if self.device_uuid == [0; 16] => Err(Error::Encoding(
+                "SC client builder: device_uuid is required and must not be all zero".into(),
+            )),
+            _ => Ok(()),
+        }
+    }
+
+    fn sc_transport<W: bacnet_transport::sc::WebSocketPort>(
+        &self,
+        ws: W,
+    ) -> bacnet_transport::sc::ScTransport<W> {
+        bacnet_transport::sc::ScTransport::new(ws, self.vmac)
+            .with_device_uuid(self.device_uuid)
+            .with_heartbeat_interval_ms(self.heartbeat_interval_ms)
+            .with_heartbeat_timeout_ms(self.heartbeat_timeout_ms)
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn build_with_websocket_for_test<
+        W: bacnet_transport::sc::WebSocketPort + 'static,
+    >(
+        self,
+        ws: W,
+    ) -> Result<BACnetClient<bacnet_transport::sc::ScTransport<W>>, Error> {
+        self.validate_identity()?;
+        self.options.validate()?;
+        let transport = self.sc_transport(ws);
+        BACnetClient::start_with_options(self.config, transport, self.options).await
+    }
+
     /// Connect to the hub and start the client.
     pub async fn build(
         self,
@@ -572,17 +618,17 @@ impl ScClientBuilder {
         BACnetClient<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>>,
         Error,
     > {
-        let tls_config = self
-            .tls_config
-            .ok_or_else(|| Error::Encoding("SC client builder: tls_config is required".into()))?;
+        self.validate_identity()?;
         self.options.validate()?;
+        let tls_config =
+            self.tls_config.as_ref().cloned().ok_or_else(|| {
+                Error::Encoding("SC client builder: tls_config is required".into())
+            })?;
 
         let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
             .await?;
 
-        let mut transport = bacnet_transport::sc::ScTransport::new(ws, self.vmac)
-            .with_heartbeat_interval_ms(self.heartbeat_interval_ms)
-            .with_heartbeat_timeout_ms(self.heartbeat_timeout_ms);
+        let mut transport = self.sc_transport(ws);
         if let Some(rc) = self.reconnect {
             let hub_url = self.hub_url.clone();
             let tls_config = tls_config.clone();
@@ -709,6 +755,8 @@ mod cov_renewal_tests;
 mod cov_tests;
 #[cfg(test)]
 mod device_events_tests;
+#[cfg(all(test, feature = "sc-tls"))]
+mod sc_builder_tests;
 #[cfg(test)]
 mod sc_max_apdu_tests;
 #[cfg(test)]

--- a/crates/bacnet-client/src/client/sc_builder_tests.rs
+++ b/crates/bacnet-client/src/client/sc_builder_tests.rs
@@ -1,0 +1,104 @@
+use super::*;
+use bacnet_transport::sc::{LoopbackWebSocket, WebSocketPort};
+use bacnet_transport::sc_frame::{decode_sc_message, encode_sc_message, ScFunction, ScMessage};
+use bytes::{Bytes, BytesMut};
+use tokio::time::{timeout, Duration};
+
+#[tokio::test]
+async fn sc_client_builder_sends_configured_vmac_and_device_uuid() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let client_vmac = [0x22, 0x01, 0x02, 0x03, 0x04, 0x05];
+    let device_uuid = [0xAB; 16];
+    let hub_vmac = [0x10; 6];
+
+    let hub_task = tokio::spawn(async move {
+        let data = ws_hub.recv().await.unwrap();
+        let mut expected = vec![ScFunction::ConnectRequest.to_raw(), 0x00, 0x00, 0x01];
+        expected.extend_from_slice(&client_vmac);
+        expected.extend_from_slice(&device_uuid);
+        expected.extend_from_slice(&1476u16.to_be_bytes());
+        expected.extend_from_slice(&1476u16.to_be_bytes());
+        assert_eq!(data, expected);
+
+        let req = decode_sc_message(&data).unwrap();
+        assert_eq!(req.function, ScFunction::ConnectRequest);
+        assert_eq!(req.message_id, 1);
+        assert_eq!(req.originating_vmac, None);
+        assert_eq!(req.destination_vmac, None);
+        assert!(req.dest_options.is_empty());
+        assert!(req.data_options.is_empty());
+        assert_eq!(req.payload.len(), 26);
+        assert_eq!(&req.payload[0..6], &client_vmac);
+        assert_eq!(&req.payload[6..22], &device_uuid);
+
+        let mut accept_payload = Vec::with_capacity(26);
+        accept_payload.extend_from_slice(&hub_vmac);
+        accept_payload.extend_from_slice(&[0u8; 16]);
+        accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+        accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+
+        let accept = ScMessage {
+            function: ScFunction::ConnectAccept,
+            message_id: req.message_id,
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::from(accept_payload),
+        };
+        let mut buf = BytesMut::new();
+        encode_sc_message(&mut buf, &accept);
+        ws_hub.send(&buf).await.unwrap();
+        ws_hub
+    });
+
+    let mut client = BACnetClient::sc_builder()
+        .vmac(client_vmac)
+        .device_uuid(device_uuid)
+        .build_with_websocket_for_test(ws_client)
+        .await
+        .unwrap();
+    let ws_hub = hub_task.await.unwrap();
+
+    client.stop().await.unwrap();
+    drop(ws_hub);
+}
+
+#[tokio::test]
+async fn sc_client_builder_rejects_reserved_vmac_before_connect() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let result = BACnetClient::sc_builder()
+        .vmac(bacnet_transport::sc_frame::UNKNOWN_VMAC)
+        .device_uuid([0xAB; 16])
+        .build_with_websocket_for_test(ws_client)
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(Error::Encoding(message)) if message.contains("unknown VMAC")
+    ));
+
+    if let Ok(Ok(data)) = timeout(Duration::from_millis(50), ws_hub.recv()).await {
+        panic!("reserved VMAC reached wire: {data:?}");
+    }
+}
+
+#[test]
+fn sc_client_builder_rejects_broadcast_vmac_and_zero_device_uuid() {
+    let broadcast = BACnetClient::sc_builder()
+        .vmac(bacnet_transport::sc_frame::BROADCAST_VMAC)
+        .device_uuid([0xAB; 16])
+        .validate_identity();
+    assert!(matches!(
+        broadcast,
+        Err(Error::Encoding(message)) if message.contains("broadcast VMAC")
+    ));
+
+    let zero_uuid = BACnetClient::sc_builder()
+        .vmac([0x22, 0x01, 0x02, 0x03, 0x04, 0x05])
+        .validate_identity();
+    assert!(matches!(
+        zero_uuid,
+        Err(Error::Encoding(message)) if message.contains("device_uuid")
+    ));
+}

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -33,6 +33,8 @@ cargo install bacnet-cli --features sc-tls
 | `--sc-url <URL>` | | SC hub WebSocket URL |
 | `--sc-cert <FILE>` | | SC TLS certificate PEM |
 | `--sc-key <FILE>` | | SC TLS private key PEM |
+| `--sc-vmac <HEX>` | | SC local VMAC as 12 hex digits or separated bytes |
+| `--sc-device-uuid <UUID>` | | SC device UUID as 32 hex digits or hyphenated text |
 | `--format <FMT>` | auto | Output format: `table` or `json` |
 | `--json` | | JSON output shorthand |
 | `-v` | | Verbosity (`-v`, `-vv`, `-vvv`) |
@@ -375,7 +377,7 @@ bacnet --ipv6 discover
 bacnet --ipv6 read [fe80::1]:47808 ai:1 pv
 
 # BACnet/SC (requires sc-tls feature)
-bacnet --sc --sc-url wss://hub:443 --sc-cert cert.pem --sc-key key.pem read 00:01:02:03:04:05 ai:1 pv
+bacnet --sc --sc-url wss://hub:443 --sc-cert cert.pem --sc-key key.pem --sc-vmac 22:01:02:03:04:05 --sc-device-uuid 00112233-4455-6677-8899-aabbccddeeff read 00:01:02:03:04:05 ai:1 pv
 ```
 
 ## Object Type Shorthand


### PR DESCRIPTION
## Summary
- require `ScClientBuilder` callers to provide a non-reserved VMAC and non-zero device UUID before any BACnet/SC connect attempt
- add `--sc-vmac` and `--sc-device-uuid` CLI options, with parser validation before TLS files are loaded
- assert the raw Connect-Request bytes carry the configured VMAC and device UUID, and update SC CLI docs/changelog examples

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo test -p bacnet-client --locked --features sc-tls sc_client_builder --quiet`
- `cargo test -p bacnet-cli --locked transport::tests --quiet`
- `cargo test -p bacnet-cli --locked --features sc-tls transport::tests --quiet`
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls --quiet`
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked --quiet`

## Review Notes
- Read-only review covered correctness, test coverage, and BACnet/SC security scope. This PR intentionally fixes the convenience builder and CLI path for #92; the lower-level `ScTransport::new` API remains an explicit raw transport escape hatch.

Fixes #92