### PR TITLE
fix(sc): export Random-48 VMAC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ScTransport::connection_state_changes()` returning a `tokio::sync::watch::Receiver<ScConnectionState>` so BACnet/SC consumers can await latest link-state changes without polling the inspection-only connection handle; rapid transitions may coalesce under watch semantics.
 - Add typed BACnet/SC connect-path errors via `bacnet_transport::sc::ScConnectError`, preserving BVLC-Result NAK class/code/details and distinguishing WebSocket dial, TLS, handshake, and subprotocol failures without string parsing.
 - Add `ScClientBuilder::device_uuid(...)` and BACnet/SC CLI `--sc-vmac` / `--sc-device-uuid` options so convenience clients can provision stable SC identity without hand-assembling `ScTransport`.
+- Export `bacnet_transport::sc::generate_random48_vmac()` and add `bacnet_transport::sc_frame::is_valid_random48_vmac()` so downstream composition roots can mint and validate Clause H.7.3 Random-48 VMACs without duplicating bit-shape logic.
 
 ### Fixed
 

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -42,7 +42,7 @@ pub use errors::{ScConnectError, ScWebSocketErrorKind};
 use failover::{attempt_primary_restore, ActiveHub};
 use handshake::perform_handshake;
 pub use loopback::LoopbackWebSocket;
-pub(crate) use random48::generate_random48_vmac;
+pub use random48::generate_random48_vmac;
 #[cfg(test)]
 pub(crate) use random48::set_test_random48_vmac_generator;
 pub use reconnect::ScReconnectConfig;

--- a/crates/bacnet-transport/src/sc/random48.rs
+++ b/crates/bacnet-transport/src/sc/random48.rs
@@ -4,11 +4,11 @@ use bacnet_types::error::Error;
 
 use crate::sc_frame::Vmac;
 
-/// Generate an Annex H.7.3 Random-48 VMAC.
+/// Generate a Clause H.7.3 Random-48 VMAC.
 ///
 /// The low nibble of the first octet is fixed at X'2'; the high nibble and
 /// remaining five octets carry 44 bits of OS randomness.
-pub(crate) fn generate_random48_vmac() -> Result<Vmac, Error> {
+pub fn generate_random48_vmac() -> Result<Vmac, Error> {
     #[cfg(test)]
     if let Some(generator) = test_random48_vmac_generator() {
         return generator();

--- a/crates/bacnet-transport/src/sc_frame.rs
+++ b/crates/bacnet-transport/src/sc_frame.rs
@@ -158,6 +158,14 @@ pub fn is_broadcast_vmac(vmac: &Vmac) -> bool {
     *vmac == BROADCAST_VMAC
 }
 
+/// Check if a VMAC has the Clause H.7.3 Random-48 shape.
+///
+/// A Random-48 VMAC is six octets with the least significant four bits of the
+/// first octet fixed at B'0010' (X'2'); the remaining 44 bits are random.
+pub fn is_valid_random48_vmac(vmac: &Vmac) -> bool {
+    vmac[0] & 0x0F == 0x02
+}
+
 /// A single BACnet/SC header option.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ScOption {

--- a/crates/bacnet-transport/tests/random48_public_api.rs
+++ b/crates/bacnet-transport/tests/random48_public_api.rs
@@ -1,0 +1,40 @@
+//! Public Random-48 VMAC API tests.
+
+use bacnet_transport::sc::generate_random48_vmac;
+use bacnet_transport::sc_frame::{is_valid_random48_vmac, BROADCAST_VMAC, UNKNOWN_VMAC};
+
+#[test]
+fn public_random48_generator_is_callable_and_shape_valid() {
+    let vmac = generate_random48_vmac().unwrap();
+
+    assert!(is_valid_random48_vmac(&vmac));
+    assert_eq!(vmac[0] & 0x0F, 0x02);
+    assert_ne!(vmac, UNKNOWN_VMAC);
+    assert_ne!(vmac, BROADCAST_VMAC);
+}
+
+#[test]
+fn public_random48_shape_predicate_checks_marker_nibble() {
+    assert!(is_valid_random48_vmac(&[
+        0xF2, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE
+    ]));
+
+    for marker in 0x00..=0x0F {
+        let mut vmac = [0xF0 | marker, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE];
+        assert_eq!(
+            is_valid_random48_vmac(&vmac),
+            marker == 0x02,
+            "low nibble {marker:#04x} should be the only Random-48 marker"
+        );
+
+        vmac[0] = marker;
+        assert_eq!(
+            is_valid_random48_vmac(&vmac),
+            marker == 0x02,
+            "high nibble must not affect Random-48 marker validation"
+        );
+    }
+
+    assert!(!is_valid_random48_vmac(&UNKNOWN_VMAC));
+    assert!(!is_valid_random48_vmac(&BROADCAST_VMAC));
+}


### PR DESCRIPTION
## Summary

- Export `bacnet_transport::sc::generate_random48_vmac()` as an additive public BACnet/SC API.
- Add `bacnet_transport::sc_frame::is_valid_random48_vmac()` with Clause H.7.3 docs for the six-octet Random-48 marker shape: first-octet low nibble fixed at `X'2'`.
- Add an integration test that imports the generator and predicate through public crate paths and exhaustively checks the Random-48 marker nibble.

Fixes #96

## Review Evidence

- `bacnet-reference-researcher`: no findings; verified Standard 135-2020 H.7.3 defines Random-48 by first-octet low nibble `X'2'`.
- `correctness-reviewer`: no API compatibility findings; export is additive and internal duplicate-VMAC recovery callers remain unchanged.
- `test-verifier`: requested exhaustive predicate coverage for all low-nibble values; addressed in `random48_public_api.rs`.

## Validation

- `cargo fmt --all --check`
- `cargo test -p bacnet-transport --test random48_public_api --locked --quiet`
- `cargo test -p bacnet-transport --locked random48 --quiet`
- `cargo clippy -p bacnet-transport --all-targets --locked --message-format=short`
- `git diff --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked --quiet`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked --message-format=short`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls --message-format=short`
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --features bacnet-transport/ipv6,bacnet-transport/sc-tls --quiet`
- `cargo +1.93 check --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked`
- `cargo audit --color never`
- `cargo deny check`

Notes: local lint/audit/deny output includes the existing warning baseline, including the allowed `anyhow` advisory warning and deny duplicate/license warnings; commands exited successfully.
