### PR TITLE
fix(server): harden segmented ComplexAck SegmentACK state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ mcp.json
 # Proprietary spec
 _spec/
 
+# Local conformance artifacts
+/conformance/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/crates/bacnet-integration-tests/tests/conformance_ledger.rs
+++ b/crates/bacnet-integration-tests/tests/conformance_ledger.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 use serde_json::{json, Value};
 
-const LEDGER_JSON: &str = include_str!("../../../conformance/bacnet-135-2020.json");
+const LEDGER_JSON: &str = include_str!("../../../docs/conformance/bacnet-135-2020.json");
 const SUPPORT_SUMMARY: &str = include_str!("../../../docs/conformance/support-summary.md");
 const PICS_DRAFT: &str = include_str!("../../../docs/conformance/pics-draft.md");
 const BIBBS_DRAFT: &str = include_str!("../../../docs/conformance/bibbs-draft.md");
@@ -183,7 +183,7 @@ fn read_repo_file(path: &str) -> String {
 fn ledger_schema_has_required_seed_rows_and_unique_ids() {
     let data = ledger();
     assert_eq!(data["standard"], "ANSI/ASHRAE Standard 135-2020");
-    assert_eq!(data["reviewed_at"], "2026-06-29");
+    assert_eq!(data["reviewed_at"], "2026-07-04");
     assert!(
         data["repo_sha"].as_str().is_some_and(|sha| sha.len() == 40),
         "repo_sha must be a full git SHA"
@@ -350,7 +350,7 @@ fn generated_support_docs_are_current_with_ledger() {
     let data = ledger();
     for doc in [SUPPORT_SUMMARY, PICS_DRAFT, BIBBS_DRAFT] {
         assert!(doc.contains("DRAFT internal support evidence"));
-        assert!(doc.contains("conformance/bacnet-135-2020.json"));
+        assert!(doc.contains("docs/conformance/bacnet-135-2020.json"));
     }
     assert!(STANDARD_LEDGER.contains("## Clause 4 Architecture"));
     assert!(STANDARD_LEDGER.contains("## Annex AB BACnet/SC"));

--- a/crates/bacnet-server/src/server/cov_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/cov_notifications_tests.rs
@@ -154,6 +154,7 @@ async fn routed_segmented_complex_ack_preserves_npdu_destination() {
         &sent,
     ))));
     let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
     let router_mac = MacAddr::from_slice(&[192, 168, 1, 1, 0xBA, 0xC0]);
     let remote = NpduAddress {
         network: 100,
@@ -164,12 +165,14 @@ async fn routed_segmented_complex_ack_preserves_npdu_destination() {
     let handle = {
         let network = Arc::clone(&network);
         let seg_ack_senders = Arc::clone(&seg_ack_senders);
+        let seg_send_permits = Arc::clone(&seg_send_permits);
         let remote = remote.clone();
         let router_mac = router_mac.clone();
         tokio::spawn(async move {
             BACnetServer::<RecordingTransport>::send_segmented_complex_ack(
                 &network,
                 &seg_ack_senders,
+                &seg_send_permits,
                 router_mac.as_slice(),
                 Some(&remote),
                 0x44,
@@ -201,6 +204,7 @@ async fn routed_segmented_complex_ack_preserves_npdu_destination() {
     assert_eq!(sent[0].1, router_mac);
     let npdu = decode_npdu(sent[0].0.clone()).unwrap();
     assert_eq!(npdu.destination, Some(remote));
+    assert!(npdu.expecting_reply);
     match decode_apdu(npdu.payload).unwrap() {
         Apdu::ComplexAck(ack) => {
             assert!(ack.segmented);

--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -1,6 +1,53 @@
 use super::*;
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
+    async fn route_segmented_send_event(
+        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+        key: SegKey,
+        event: SegmentedSendEvent,
+    ) -> bool {
+        let handle = {
+            let senders = seg_ack_senders.lock().await;
+            senders.get(&key).cloned()
+        };
+
+        let Some(handle) = handle else {
+            return false;
+        };
+
+        match event {
+            SegmentedSendEvent::Abort(abort) => {
+                handle.send_control(SegmentedSendControlEvent::Abort(abort));
+                true
+            }
+            SegmentedSendEvent::SegmentAck(ack) => {
+                let invoke_id = ack.invoke_id;
+                let seq = ack.sequence_number;
+                if !handle.accepts_segment_ack(&ack) {
+                    debug!(
+                        invoke_id,
+                        seq,
+                        negative = ack.negative_ack,
+                        "Ignoring SegmentAck outside current segmented-send window"
+                    );
+                    return true;
+                }
+
+                match handle.segment_ack_tx.try_send(ack) {
+                    Ok(()) => true,
+                    Err(mpsc::error::TrySendError::Full(_)) => {
+                        warn!(
+                            invoke_id,
+                            seq, "Dropping SegmentAck because segmented-send queue is full"
+                        );
+                        true
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_)) => false,
+                }
+            }
+        }
+    }
+
     /// Dispatch a received APDU.
     ///
     /// ConfirmedRequest and UnconfirmedRequest handlers are spawned as
@@ -16,7 +63,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         db: &Arc<RwLock<ObjectDatabase>>,
         network: &Arc<NetworkLayer<T>>,
         cov_table: &Arc<RwLock<CovSubscriptionTable>>,
-        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
+        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+        seg_send_permits: &Arc<Semaphore>,
         cov_in_flight: &Arc<Semaphore>,
         server_tsm: &Arc<Mutex<ServerTsm>>,
         comm_state: &Arc<AtomicU8>,
@@ -33,6 +81,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let network = Arc::clone(network);
                 let cov_table = Arc::clone(cov_table);
                 let seg_ack_senders = Arc::clone(seg_ack_senders);
+                let seg_send_permits = Arc::clone(seg_send_permits);
                 let cov_in_flight = Arc::clone(cov_in_flight);
                 let server_tsm = Arc::clone(server_tsm);
                 let comm_state = Arc::clone(comm_state);
@@ -46,6 +95,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         &network,
                         &cov_table,
                         &seg_ack_senders,
+                        &seg_send_permits,
                         &cov_in_flight,
                         &server_tsm,
                         &comm_state,
@@ -128,6 +178,18 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 );
             }
             Apdu::Abort(abort) if !abort.sent_by_server => {
+                let key = (
+                    MacAddr::from_slice(source_mac),
+                    received.source_network.clone(),
+                    abort.invoke_id,
+                );
+                let routed_segmented = Self::route_segmented_send_event(
+                    seg_ack_senders,
+                    key,
+                    SegmentedSendEvent::Abort(abort.clone()),
+                )
+                .await;
+
                 let mut tsm = server_tsm.lock().await;
                 let peer = MacAddr::from_slice(source_mac);
                 if !tsm.record_result(
@@ -140,21 +202,35 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 }
                 debug!(
                     invoke_id = abort.invoke_id,
-                    "Abort received for outgoing confirmed notification"
+                    routed_segmented,
+                    "Abort received for outgoing confirmed notification or segmented response"
                 );
             }
             Apdu::SegmentAck(sa) => {
+                let invoke_id = sa.invoke_id;
+                if sa.sent_by_server {
+                    debug!(
+                        invoke_id,
+                        seq = sa.sequence_number,
+                        "Server ignoring SegmentAck with server bit set"
+                    );
+                    return;
+                }
+
                 let key = (
                     MacAddr::from_slice(source_mac),
                     received.source_network.clone(),
-                    sa.invoke_id,
+                    invoke_id,
                 );
-                let senders = seg_ack_senders.lock().await;
-                if let Some(tx) = senders.get(&key) {
-                    let _ = tx.try_send(sa);
-                } else {
+                if !Self::route_segmented_send_event(
+                    seg_ack_senders,
+                    key,
+                    SegmentedSendEvent::SegmentAck(sa),
+                )
+                .await
+                {
                     debug!(
-                        invoke_id = sa.invoke_id,
+                        invoke_id,
                         "Server ignoring SegmentAck for unknown transaction"
                     );
                 }

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -27,8 +27,9 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let network = Arc::new(network);
         let db = Arc::new(RwLock::new(db));
         let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
-        let seg_ack_senders: Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>> =
+        let seg_ack_senders: Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>> =
             Arc::new(Mutex::new(HashMap::new()));
+        let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
 
         let cov_in_flight = Arc::new(Semaphore::new(255));
         let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
@@ -39,6 +40,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let db_dispatch = Arc::clone(&db);
         let cov_dispatch = Arc::clone(&cov_table);
         let seg_ack_dispatch = Arc::clone(&seg_ack_senders);
+        let seg_send_permits_dispatch = Arc::clone(&seg_send_permits);
         let cov_in_flight_dispatch = Arc::clone(&cov_in_flight);
         let server_tsm_dispatch = Arc::clone(&server_tsm);
         let comm_state_dispatch = Arc::clone(&comm_state);
@@ -268,10 +270,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                                 Self::dispatch(
 	                                                    &db_dispatch,
 	                                                    &network_dispatch,
-	                                                    &cov_dispatch,
-	                                                    &seg_ack_dispatch,
-	                                                    &cov_in_flight_dispatch,
-	                                                    &server_tsm_dispatch,
+                                    &cov_dispatch,
+                                    &seg_ack_dispatch,
+                                    &seg_send_permits_dispatch,
+                                    &cov_in_flight_dispatch,
+                                    &server_tsm_dispatch,
 	                                                    &comm_state_dispatch,
 	                                                    &dcc_timer_dispatch,
 	                                                    &config_dispatch,
@@ -314,6 +317,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 &network_dispatch,
                                 &cov_dispatch,
                                 &seg_ack_dispatch,
+                                &seg_send_permits_dispatch,
                                 &cov_in_flight_dispatch,
                                 &server_tsm_dispatch,
                                 &comm_state_dispatch,
@@ -429,6 +433,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             db,
             cov_table,
             seg_ack_senders,
+            seg_send_permits,
             cov_in_flight,
             server_tsm,
             comm_state,

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -6,12 +6,12 @@
 
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
 use bytes::{Bytes, BytesMut};
-use tokio::sync::{mpsc, oneshot, Mutex, RwLock, Semaphore};
+use tokio::sync::{mpsc, oneshot, watch, Mutex, RwLock, Semaphore};
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
 use tracing::{debug, warn};
@@ -52,11 +52,20 @@ use crate::handlers;
 /// Maximum number of concurrent segmented reassembly sessions.
 const MAX_SEG_RECEIVERS: usize = 128;
 
+/// Maximum number of concurrent segmented response send sessions.
+const MAX_SEG_SENDERS: usize = 128;
+
 /// Timeout for idle segmented reassembly sessions.
 const SEG_RECEIVER_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// Maximum negative SegmentAck retries during segmented response send.
 const MAX_NEG_SEGMENT_ACK_RETRIES: u8 = 3;
+
+/// Default timeout while waiting for SegmentACK during segmented response send.
+const DEFAULT_APDU_SEGMENT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Default retransmission budget for segmented response segments.
+const DEFAULT_APDU_SEGMENT_RETRIES: u8 = MAX_NEG_SEGMENT_ACK_RETRIES;
 
 /// Default number of APDU retries for confirmed COV notifications.
 const DEFAULT_APDU_RETRIES: u8 = 3;
@@ -352,6 +361,89 @@ impl BipServerBuilder {
 /// (source MAC/router MAC, optional routed source, invoke_id).
 type SegKey = (MacAddr, Option<NpduAddress>, u8);
 
+#[derive(Debug)]
+enum SegmentedSendEvent {
+    SegmentAck(SegmentAckPdu),
+    Abort(AbortPdu),
+}
+
+#[derive(Debug, Clone)]
+enum SegmentedSendControlEvent {
+    Abort(AbortPdu),
+    Cancel,
+}
+
+struct SegmentedSendHandle {
+    segment_ack_tx: mpsc::Sender<SegmentAckPdu>,
+    control_tx: watch::Sender<Option<SegmentedSendControlEvent>>,
+    closed: AtomicBool,
+    current_sequence: AtomicU16,
+    total_segments: usize,
+}
+
+impl SegmentedSendHandle {
+    fn new(
+        segment_ack_tx: mpsc::Sender<SegmentAckPdu>,
+        control_tx: watch::Sender<Option<SegmentedSendControlEvent>>,
+        total_segments: usize,
+    ) -> Self {
+        Self {
+            segment_ack_tx,
+            control_tx,
+            closed: AtomicBool::new(false),
+            current_sequence: AtomicU16::new(u16::MAX),
+            total_segments,
+        }
+    }
+
+    fn accepts_segment_ack(&self, ack: &SegmentAckPdu) -> bool {
+        if ack.sent_by_server || self.closed.load(Ordering::Acquire) {
+            return false;
+        }
+
+        let current = self.current_sequence.load(Ordering::Acquire) as usize;
+        if current >= self.total_segments {
+            return false;
+        }
+
+        if ack.negative_ack {
+            let ack_seq = ack.sequence_number as usize;
+            let requested = if ack_seq == 0 && current == 0 {
+                0
+            } else {
+                ack_seq.saturating_add(1)
+            };
+            requested < self.total_segments && requested == current
+        } else {
+            ack.sequence_number as usize == current
+        }
+    }
+
+    fn send_control(&self, event: SegmentedSendControlEvent) {
+        self.closed.store(true, Ordering::Release);
+        self.control_tx.send_replace(Some(event));
+    }
+
+    fn same_channel(&self, sender: &mpsc::Sender<SegmentAckPdu>) -> bool {
+        self.segment_ack_tx.same_channel(sender)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SegmentedSendOptions {
+    segment_timeout: Duration,
+    max_retries: u8,
+}
+
+impl Default for SegmentedSendOptions {
+    fn default() -> Self {
+        Self {
+            segment_timeout: DEFAULT_APDU_SEGMENT_TIMEOUT,
+            max_retries: DEFAULT_APDU_SEGMENT_RETRIES,
+        }
+    }
+}
+
 struct SegmentedRequestState {
     receiver: SegmentReceiver,
     first_req: bacnet_encoding::apdu::ConfirmedRequest,
@@ -374,9 +466,13 @@ pub struct BACnetServer<T: TransportPort> {
     /// COV subscription table (held to keep Arc alive for dispatch task).
     #[allow(dead_code)]
     cov_table: Arc<RwLock<CovSubscriptionTable>>,
-    /// Channels for routing SegmentAck PDUs to in-progress segmented sends.
+    /// Channels for routing segmented-send events to in-progress segmented sends.
     #[allow(dead_code)]
-    seg_ack_senders: Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
+    seg_ack_senders: Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+    /// Permits that cap live segmented response sender tasks, including
+    /// cancelled senders that have not yet exited a transport send.
+    #[allow(dead_code)]
+    seg_send_permits: Arc<Semaphore>,
     /// Semaphore that caps confirmed COV notifications at 255 in-flight
     /// to prevent invoke ID reuse (invoke IDs are u8 = 0..255).
     #[allow(dead_code)]
@@ -577,6 +673,8 @@ mod segmentation;
 
 #[cfg(test)]
 mod cov_notifications_tests;
+#[cfg(test)]
+mod segmentation_tests;
 #[cfg(test)]
 mod tests;
 

--- a/crates/bacnet-server/src/server/requests.rs
+++ b/crates/bacnet-server/src/server/requests.rs
@@ -7,7 +7,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         db: &Arc<RwLock<ObjectDatabase>>,
         network: &Arc<NetworkLayer<T>>,
         cov_table: &Arc<RwLock<CovSubscriptionTable>>,
-        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
+        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+        seg_send_permits: &Arc<Semaphore>,
         cov_in_flight: &Arc<Semaphore>,
         server_tsm: &Arc<Mutex<ServerTsm>>,
         comm_state: &Arc<AtomicU8>,
@@ -362,12 +363,14 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 } else {
                     let network = Arc::clone(network);
                     let seg_ack_senders = Arc::clone(seg_ack_senders);
+                    let seg_send_permits = Arc::clone(seg_send_permits);
                     let source_mac = MacAddr::from_slice(source_mac);
                     let service_ack_data = ack.service_ack.clone();
                     tokio::spawn(async move {
                         Self::send_segmented_complex_ack(
                             &network,
                             &seg_ack_senders,
+                            &seg_send_permits,
                             &source_mac,
                             source_network.as_ref(),
                             invoke_id,

--- a/crates/bacnet-server/src/server/responses.rs
+++ b/crates/bacnet-server/src/server/responses.rs
@@ -7,6 +7,23 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         source_mac: &[u8],
         source_network: Option<&NpduAddress>,
     ) -> Result<(), Error> {
+        Self::send_confirmed_response_apdu_expecting_reply(
+            network,
+            apdu,
+            source_mac,
+            source_network,
+            false,
+        )
+        .await
+    }
+
+    pub(super) async fn send_confirmed_response_apdu_expecting_reply(
+        network: &NetworkLayer<T>,
+        apdu: &[u8],
+        source_mac: &[u8],
+        source_network: Option<&NpduAddress>,
+        expecting_reply: bool,
+    ) -> Result<(), Error> {
         if let Some(destination) = source_network {
             network
                 .send_apdu_routed(
@@ -14,13 +31,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     destination.network,
                     &destination.mac_address,
                     source_mac,
-                    false,
+                    expecting_reply,
                     NetworkPriority::NORMAL,
                 )
                 .await
         } else {
             network
-                .send_apdu(apdu, source_mac, false, NetworkPriority::NORMAL)
+                .send_apdu(apdu, source_mac, expecting_reply, NetworkPriority::NORMAL)
                 .await
         }
     }

--- a/crates/bacnet-server/src/server/segmentation.rs
+++ b/crates/bacnet-server/src/server/segmentation.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+#[derive(Debug)]
+enum SegmentedSendWaitResult {
+    SegmentAck(SegmentAckPdu),
+    Abort(AbortPdu),
+    Cancel,
+    ChannelClosed,
+    Timeout,
+}
+
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Send a ComplexAck response using segmented transfer.
     ///
@@ -9,7 +18,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn send_segmented_complex_ack(
         network: &Arc<NetworkLayer<T>>,
-        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
+        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+        seg_send_permits: &Arc<Semaphore>,
         source_mac: &[u8],
         source_network: Option<&NpduAddress>,
         invoke_id: u8,
@@ -17,6 +27,36 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         service_ack_data: &[u8],
         client_max_apdu: u16,
         client_max_segments: Option<u8>,
+    ) {
+        Self::send_segmented_complex_ack_with_options(
+            network,
+            seg_ack_senders,
+            seg_send_permits,
+            source_mac,
+            source_network,
+            invoke_id,
+            service_choice,
+            service_ack_data,
+            client_max_apdu,
+            client_max_segments,
+            SegmentedSendOptions::default(),
+        )
+        .await;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn send_segmented_complex_ack_with_options(
+        network: &Arc<NetworkLayer<T>>,
+        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+        seg_send_permits: &Arc<Semaphore>,
+        source_mac: &[u8],
+        source_network: Option<&NpduAddress>,
+        invoke_id: u8,
+        service_choice: ConfirmedServiceChoice,
+        service_ack_data: &[u8],
+        client_max_apdu: u16,
+        client_max_segments: Option<u8>,
+        options: SegmentedSendOptions,
     ) {
         let max_seg_size = max_segment_payload(client_max_apdu, SegmentedPduType::ComplexAck);
         let segments = match split_payload(service_ack_data, max_seg_size) {
@@ -75,6 +115,28 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             return;
         }
 
+        let _sender_permit = match Arc::clone(seg_send_permits).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                warn!(
+                    invoke_id,
+                    limit = MAX_SEG_SENDERS,
+                    "Too many live segmented ComplexAck senders, aborting"
+                );
+                let abort = Apdu::Abort(AbortPdu {
+                    sent_by_server: true,
+                    invoke_id,
+                    abort_reason: AbortReason::BUFFER_OVERFLOW,
+                });
+                let mut buf = BytesMut::new();
+                encode_apdu(&mut buf, &abort).expect("valid APDU encoding");
+                let _ =
+                    Self::send_confirmed_response_apdu(network, &buf, source_mac, source_network)
+                        .await;
+                return;
+            }
+        };
+
         debug!(
             total_segments,
             max_seg_size,
@@ -82,21 +144,61 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             "Starting segmented ComplexAck send"
         );
 
-        let (seg_ack_tx, mut seg_ack_rx) = mpsc::channel(16);
+        let (seg_ack_tx, mut seg_ack_rx) = mpsc::channel::<SegmentAckPdu>(16);
+        let (control_tx, mut control_rx) =
+            watch::channel::<Option<SegmentedSendControlEvent>>(None);
+        let send_handle = Arc::new(SegmentedSendHandle::new(
+            seg_ack_tx.clone(),
+            control_tx,
+            total_segments,
+        ));
         let key = (
             MacAddr::from_slice(source_mac),
             source_network.cloned(),
             invoke_id,
         );
-        {
-            seg_ack_senders.lock().await.insert(key.clone(), seg_ack_tx);
+        let insert_result = {
+            let mut senders = seg_ack_senders.lock().await;
+            if !senders.contains_key(&key) && senders.len() >= MAX_SEG_SENDERS {
+                Err(())
+            } else {
+                Ok(senders.insert(key.clone(), Arc::clone(&send_handle)))
+            }
+        };
+        let replaced = match insert_result {
+            Ok(replaced) => replaced,
+            Err(()) => {
+                warn!(
+                    invoke_id,
+                    limit = MAX_SEG_SENDERS,
+                    "Too many active segmented ComplexAck senders, aborting"
+                );
+                let abort = Apdu::Abort(AbortPdu {
+                    sent_by_server: true,
+                    invoke_id,
+                    abort_reason: AbortReason::BUFFER_OVERFLOW,
+                });
+                let mut buf = BytesMut::new();
+                encode_apdu(&mut buf, &abort).expect("valid APDU encoding");
+                let _ =
+                    Self::send_confirmed_response_apdu(network, &buf, source_mac, source_network)
+                        .await;
+                return;
+            }
+        };
+        if let Some(replaced) = replaced {
+            warn!(
+                invoke_id,
+                "Replacing active segmented ComplexAck sender for peer/invoke-id"
+            );
+            replaced.send_control(SegmentedSendControlEvent::Cancel);
         }
 
-        let seg_timeout = Duration::from_secs(5);
+        let seg_timeout = options.segment_timeout;
         let mut seg_idx: usize = 0;
-        let mut neg_ack_retries: u8 = 0;
+        let mut retransmission_retries: u8 = 0;
 
-        while seg_idx < total_segments {
+        'send_segments: while seg_idx < total_segments {
             let is_last = seg_idx == total_segments - 1;
 
             let pdu = Apdu::ComplexAck(ComplexAck {
@@ -112,8 +214,18 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let mut buf = BytesMut::with_capacity(client_max_apdu as usize);
             encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
-            if let Err(e) =
-                Self::send_confirmed_response_apdu(network, &buf, source_mac, source_network).await
+            send_handle
+                .current_sequence
+                .store(seg_idx as u16, Ordering::Release);
+
+            if let Err(e) = Self::send_confirmed_response_apdu_expecting_reply(
+                network,
+                &buf,
+                source_mac,
+                source_network,
+                true,
+            )
+            .await
             {
                 warn!(error = %e, seq = seg_idx, "Failed to send segment");
                 break;
@@ -121,20 +233,99 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
             debug!(seq = seg_idx, is_last, "Sent ComplexAck segment");
 
-            if !is_last {
-                match tokio::time::timeout(seg_timeout, seg_ack_rx.recv()).await {
-                    Ok(Some(ack)) => {
+            let ack_deadline = tokio::time::Instant::now() + seg_timeout;
+            loop {
+                if send_handle.closed.load(Ordering::Acquire) {
+                    match control_rx.borrow_and_update().clone() {
+                        Some(SegmentedSendControlEvent::Abort(abort)) => {
+                            warn!(
+                                invoke_id = abort.invoke_id,
+                                reason = ?abort.abort_reason,
+                                "Client aborted segmented ComplexAck send"
+                            );
+                        }
+                        Some(SegmentedSendControlEvent::Cancel) | None => {
+                            warn!(
+                                invoke_id,
+                                "Segmented ComplexAck send cancelled by newer same-peer transaction"
+                            );
+                        }
+                    }
+                    break 'send_segments;
+                }
+
+                let wait_result = tokio::select! {
+                    biased;
+                    changed = control_rx.changed() => {
+                        if changed.is_err() {
+                            SegmentedSendWaitResult::ChannelClosed
+                        } else {
+                            match control_rx.borrow_and_update().clone() {
+                                Some(SegmentedSendControlEvent::Abort(abort)) => {
+                                    SegmentedSendWaitResult::Abort(abort)
+                                }
+                                Some(SegmentedSendControlEvent::Cancel) => {
+                                    SegmentedSendWaitResult::Cancel
+                                }
+                                None => continue,
+                            }
+                        }
+                    }
+                    ack = seg_ack_rx.recv() => {
+                        match ack {
+                            Some(ack) => SegmentedSendWaitResult::SegmentAck(ack),
+                            None => SegmentedSendWaitResult::ChannelClosed,
+                        }
+                    }
+                    _ = tokio::time::sleep_until(ack_deadline) => {
+                        SegmentedSendWaitResult::Timeout
+                    }
+                };
+
+                match wait_result {
+                    SegmentedSendWaitResult::SegmentAck(ack) => {
+                        if send_handle.closed.load(Ordering::Acquire) {
+                            continue;
+                        }
+
                         debug!(
                             seq = ack.sequence_number,
                             negative = ack.negative_ack,
+                            sent_by_server = ack.sent_by_server,
                             "Received SegmentAck for ComplexAck"
                         );
+
+                        if ack.sent_by_server {
+                            tracing::warn!(
+                                seq = ack.sequence_number,
+                                negative = ack.negative_ack,
+                                "Ignoring SegmentAck with server bit set for server ComplexAck send"
+                            );
+                            continue;
+                        }
+
                         if ack.negative_ack {
-                            neg_ack_retries += 1;
-                            if neg_ack_retries > MAX_NEG_SEGMENT_ACK_RETRIES {
+                            let ack_seq = ack.sequence_number as usize;
+                            let requested = if ack_seq == 0 && seg_idx == 0 {
+                                0
+                            } else {
+                                ack_seq.saturating_add(1)
+                            };
+                            if requested >= total_segments || requested != seg_idx {
+                                tracing::warn!(
+                                    seq = ack.sequence_number,
+                                    requested,
+                                    current = seg_idx,
+                                    total = total_segments,
+                                    "Ignoring negative SegmentAck outside current send window"
+                                );
+                                continue;
+                            }
+
+                            if retransmission_retries >= options.max_retries {
                                 warn!(
                                     invoke_id,
-                                    retries = neg_ack_retries,
+                                    retries = retransmission_retries,
                                     "Too many negative SegmentAck retries, aborting segmented send"
                                 );
                                 let abort = Apdu::Abort(AbortPdu {
@@ -151,66 +342,81 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                     source_network,
                                 )
                                 .await;
-                                break;
+                                break 'send_segments;
                             }
-                            let acknowledged = ack.sequence_number as usize;
-                            let requested = acknowledged + 1;
-                            if requested > total_segments {
-                                tracing::warn!(
-                                    seq = acknowledged,
-                                    total = total_segments,
-                                    "negative SegmentAck requests out-of-range sequence, aborting"
-                                );
-                                break;
-                            }
+                            retransmission_retries += 1;
+
                             debug!(
                                 seq = ack.sequence_number,
-                                "Negative SegmentAck — retransmitting from requested sequence"
+                                requested,
+                                "Negative SegmentAck retransmitting from requested sequence"
                             );
                             seg_idx = requested;
-                            continue;
+                            continue 'send_segments;
                         }
+
+                        let acknowledged = ack.sequence_number as usize;
+                        if acknowledged == seg_idx {
+                            retransmission_retries = 0;
+                            seg_idx += 1;
+                            continue 'send_segments;
+                        }
+
+                        tracing::warn!(
+                            seq = acknowledged,
+                            current = seg_idx,
+                            "Ignoring positive SegmentAck outside current send window"
+                        );
                     }
-                    Ok(None) => {
-                        warn!("SegmentAck channel closed during segmented send");
-                        break;
+                    SegmentedSendWaitResult::Abort(abort) => {
+                        warn!(
+                            invoke_id = abort.invoke_id,
+                            reason = ?abort.abort_reason,
+                            "Client aborted segmented ComplexAck send"
+                        );
+                        break 'send_segments;
                     }
-                    Err(_) => {
+                    SegmentedSendWaitResult::Cancel => {
+                        warn!(
+                            invoke_id,
+                            "Segmented ComplexAck send cancelled by newer same-peer transaction"
+                        );
+                        break 'send_segments;
+                    }
+                    SegmentedSendWaitResult::ChannelClosed => {
+                        warn!("Segmented send event channel closed during segmented send");
+                        break 'send_segments;
+                    }
+                    SegmentedSendWaitResult::Timeout => {
+                        if retransmission_retries < options.max_retries {
+                            retransmission_retries += 1;
+                            warn!(
+                                seq = seg_idx,
+                                retries = retransmission_retries,
+                                "Timeout waiting for SegmentAck, retransmitting segment"
+                            );
+                            continue 'send_segments;
+                        }
+
                         warn!(
                             seq = seg_idx,
-                            "Timeout waiting for SegmentAck, aborting segmented send"
+                            retries = retransmission_retries,
+                            "SegmentAck retry budget exhausted, ending segmented send"
                         );
-                        let abort = Apdu::Abort(AbortPdu {
-                            sent_by_server: true,
-                            invoke_id,
-                            abort_reason: AbortReason::TSM_TIMEOUT,
-                        });
-                        let mut abort_buf = BytesMut::new();
-                        encode_apdu(&mut abort_buf, &abort).expect("valid APDU encoding");
-                        let _ = Self::send_confirmed_response_apdu(
-                            network,
-                            &abort_buf,
-                            source_mac,
-                            source_network,
-                        )
-                        .await;
-                        break;
+                        break 'send_segments;
                     }
                 }
             }
-
-            seg_idx += 1;
         }
 
-        match tokio::time::timeout(seg_timeout, seg_ack_rx.recv()).await {
-            Ok(Some(_ack)) => {
-                debug!("Received final SegmentAck for ComplexAck");
-            }
-            _ => {
-                warn!("No final SegmentAck received for ComplexAck");
+        {
+            let mut senders = seg_ack_senders.lock().await;
+            if senders
+                .get(&key)
+                .is_some_and(|sender| sender.same_channel(&seg_ack_tx))
+            {
+                senders.remove(&key);
             }
         }
-
-        seg_ack_senders.lock().await.remove(&key);
     }
 }

--- a/crates/bacnet-server/src/server/segmentation_tests/ack_window.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/ack_window.rs
@@ -1,0 +1,326 @@
+use super::*;
+
+#[tokio::test]
+async fn segmented_complex_ack_retransmits_segment_zero_after_negative_ack_zero() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(1);
+    let invoke_id = 0x41;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = spawn_segmented_complex_ack(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0x55; 128],
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    assert_eq!(complex_ack_sequence(&sent, 0), 0);
+
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, true, 0)).await;
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(complex_ack_sequence(&sent, 1), 0);
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_ignores_future_positive_segment_ack() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(2);
+    let invoke_id = 0x42;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = spawn_segmented_complex_ack(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0x66; 128],
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    assert_eq!(complex_ack_sequence(&sent, 0), 0);
+
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, false, 1)).await;
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, true, 0)).await;
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(complex_ack_sequence(&sent, 1), 0);
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_retransmits_current_segment_after_negative_ack_previous_sequence() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(4);
+    let invoke_id = 0x44;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = spawn_segmented_complex_ack(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0x88; 192],
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    assert_eq!(complex_ack_sequence(&sent, 0), 0);
+
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, false, 0)).await;
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(complex_ack_sequence(&sent, 1), 1);
+
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, true, 0)).await;
+
+    wait_for_sent_len(&sent, 3).await;
+    assert_eq!(complex_ack_sequence(&sent, 2), 1);
+
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, false, 1)).await;
+
+    wait_for_sent_len(&sent, 4).await;
+    assert_eq!(complex_ack_sequence(&sent, 3), 2);
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_ignores_out_of_range_negative_segment_ack() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(5);
+    let invoke_id = 0x45;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = spawn_segmented_complex_ack(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0x99; 128],
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    assert_eq!(complex_ack_sequence(&sent, 0), 0);
+
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, true, 255)).await;
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, false, 0)).await;
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(complex_ack_sequence(&sent, 1), 1);
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_ignores_segment_ack_with_server_bit_set() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(6);
+    let invoke_id = 0x46;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = spawn_segmented_complex_ack(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0xAA; 128],
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    assert_eq!(complex_ack_sequence(&sent, 0), 0);
+
+    send_segment_ack(
+        &seg_ack_senders,
+        &key,
+        server_segment_ack(invoke_id, false, 0),
+    )
+    .await;
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, true, 0)).await;
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(complex_ack_sequence(&sent, 1), 0);
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_ignores_stale_positive_final_segment_ack() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(7);
+    let invoke_id = 0x47;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = spawn_segmented_complex_ack(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0xBB; 128],
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    assert_eq!(complex_ack_sequence(&sent, 0), 0);
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, false, 0)).await;
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(complex_ack_sequence(&sent, 1), 1);
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, false, 1)).await;
+
+    wait_for_sent_len(&sent, 3).await;
+    assert_eq!(complex_ack_sequence(&sent, 2), 2);
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, false, 1)).await;
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, true, 1)).await;
+
+    wait_for_sent_len(&sent, 4).await;
+    assert_eq!(complex_ack_sequence(&sent, 3), 2);
+    send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, false, 2)).await;
+
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("segmented response task should exit after final ACK")
+        .expect("segmented response task should not panic");
+    assert!(
+        !seg_ack_senders.lock().await.contains_key(&key),
+        "SegmentAck sender entry should be removed after final ACK"
+    );
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_aborts_after_repeated_negative_segment_ack() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(3);
+    let invoke_id = 0x43;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = spawn_segmented_complex_ack(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0x77; 128],
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+
+    for expected_len in 2..=(MAX_NEG_SEGMENT_ACK_RETRIES as usize + 2) {
+        send_segment_ack(&seg_ack_senders, &key, segment_ack(invoke_id, true, 0)).await;
+        wait_for_sent_len(&sent, expected_len).await;
+    }
+
+    assert_eq!(
+        abort_reason(&sent, sent_count(&sent) - 1),
+        AbortReason::TSM_TIMEOUT
+    );
+
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("segmented response task should exit after abort")
+        .expect("segmented response task should not panic");
+    assert!(
+        !seg_ack_senders.lock().await.contains_key(&key),
+        "SegmentAck sender entry should be removed after abort"
+    );
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_retransmits_after_segment_ack_timeout_then_goes_idle() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(8);
+    let invoke_id = 0x48;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = spawn_segmented_complex_ack_with_options(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0xCC; 128],
+        SegmentedSendOptions {
+            segment_timeout: Duration::from_millis(25),
+            max_retries: 1,
+        },
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    assert_eq!(complex_ack_sequence(&sent, 0), 0);
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(complex_ack_sequence(&sent, 1), 0);
+
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("segmented response task should exit after timeout retry exhaustion")
+        .expect("segmented response task should not panic");
+    assert_eq!(
+        sent_count(&sent),
+        2,
+        "server should go idle after final segment timeout without sending Abort"
+    );
+    assert!(
+        (0..sent_count(&sent))
+            .all(|index| !matches!(decoded_sent_apdu(&sent, index), Apdu::Abort(_))),
+        "server must not send Abort after final segment timeout"
+    );
+    assert!(
+        !seg_ack_senders.lock().await.contains_key(&key),
+        "SegmentAck sender entry should be removed after timeout retry exhaustion"
+    );
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_sets_npdu_expecting_reply_for_segments() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(9);
+    let invoke_id = 0x49;
+    let handle = spawn_segmented_complex_ack(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0xDD; 128],
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    assert!(sent_expecting_reply(&sent, 0));
+
+    handle.abort();
+    let _ = handle.await;
+}

--- a/crates/bacnet-server/src/server/segmentation_tests/control_limits.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/control_limits.rs
@@ -1,0 +1,533 @@
+use super::*;
+
+#[tokio::test]
+async fn client_abort_routed_by_dispatch_terminates_segmented_complex_ack() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(10);
+    let invoke_id = 0x4A;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = spawn_segmented_complex_ack_with_options(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac.clone(),
+        invoke_id,
+        vec![0xEE; 128],
+        SegmentedSendOptions {
+            segment_timeout: Duration::from_millis(50),
+            max_retries: 0,
+        },
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    dispatch_test_apdu(
+        &network,
+        &seg_ack_senders,
+        &source_mac,
+        Apdu::Abort(AbortPdu {
+            sent_by_server: false,
+            invoke_id,
+            abort_reason: AbortReason::OTHER,
+        }),
+    )
+    .await;
+
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("client Abort should terminate segmented response task")
+        .expect("segmented response task should not panic");
+    assert_eq!(
+        sent_count(&sent),
+        1,
+        "server must not send a timeout Abort after client Abort"
+    );
+    assert!(
+        !seg_ack_senders.lock().await.contains_key(&key),
+        "SegmentAck sender entry should be removed after client Abort"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_accepts_segment_ack_before_send_future_returns() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let first_send_started = Arc::new(Notify::new());
+    let release_first_send = Arc::new(Notify::new());
+    let network = Arc::new(NetworkLayer::new(BlockingSendTransport::new(
+        StdArc::clone(&sent),
+        Arc::clone(&first_send_started),
+        Arc::clone(&release_first_send),
+    )));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let source_mac = test_mac(13);
+    let invoke_id = 0x4D;
+    let handle = {
+        let network = Arc::clone(&network);
+        let seg_ack_senders = Arc::clone(&seg_ack_senders);
+        let seg_send_permits = Arc::clone(&seg_send_permits);
+        let source_mac = source_mac.clone();
+        tokio::spawn(async move {
+            BACnetServer::<BlockingSendTransport>::send_segmented_complex_ack_with_options(
+                &network,
+                &seg_ack_senders,
+                &seg_send_permits,
+                source_mac.as_slice(),
+                None,
+                invoke_id,
+                ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+                &[0xF2; 128],
+                50,
+                None,
+                SegmentedSendOptions {
+                    segment_timeout: Duration::from_millis(500),
+                    max_retries: 0,
+                },
+            )
+            .await;
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(1), first_send_started.notified())
+        .await
+        .expect("first segment send should start");
+    dispatch_test_apdu(
+        &network,
+        &seg_ack_senders,
+        &source_mac,
+        Apdu::SegmentAck(segment_ack(invoke_id, false, 0)),
+    )
+    .await;
+    release_first_send.notify_waiters();
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(complex_ack_sequence(&sent, 1), 1);
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn client_abort_is_prioritized_over_queued_segment_ack() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let first_send_started = Arc::new(Notify::new());
+    let release_first_send = Arc::new(Notify::new());
+    let network = Arc::new(NetworkLayer::new(BlockingSendTransport::new(
+        StdArc::clone(&sent),
+        Arc::clone(&first_send_started),
+        Arc::clone(&release_first_send),
+    )));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let source_mac = test_mac(14);
+    let invoke_id = 0x4E;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let handle = {
+        let network = Arc::clone(&network);
+        let seg_ack_senders = Arc::clone(&seg_ack_senders);
+        let seg_send_permits = Arc::clone(&seg_send_permits);
+        let source_mac = source_mac.clone();
+        tokio::spawn(async move {
+            BACnetServer::<BlockingSendTransport>::send_segmented_complex_ack_with_options(
+                &network,
+                &seg_ack_senders,
+                &seg_send_permits,
+                source_mac.as_slice(),
+                None,
+                invoke_id,
+                ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+                &[0xF3; 128],
+                50,
+                None,
+                SegmentedSendOptions {
+                    segment_timeout: Duration::from_millis(500),
+                    max_retries: 0,
+                },
+            )
+            .await;
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(1), first_send_started.notified())
+        .await
+        .expect("first segment send should start");
+    dispatch_test_apdu(
+        &network,
+        &seg_ack_senders,
+        &source_mac,
+        Apdu::SegmentAck(segment_ack(invoke_id, false, 0)),
+    )
+    .await;
+    dispatch_test_apdu(
+        &network,
+        &seg_ack_senders,
+        &source_mac,
+        Apdu::Abort(AbortPdu {
+            sent_by_server: false,
+            invoke_id,
+            abort_reason: AbortReason::OTHER,
+        }),
+    )
+    .await;
+    release_first_send.notify_waiters();
+
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("client Abort should terminate segmented response task")
+        .expect("segmented response task should not panic");
+    assert_eq!(
+        sent_count(&sent),
+        1,
+        "queued SegmentACK must not advance after client Abort"
+    );
+    assert!(
+        !seg_ack_senders.lock().await.contains_key(&key),
+        "SegmentAck sender entry should be removed after prioritized client Abort"
+    );
+}
+
+#[tokio::test]
+async fn same_key_cancel_is_prioritized_over_queued_segment_ack() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let first_send_started = Arc::new(Notify::new());
+    let release_first_send = Arc::new(Notify::new());
+    let network = Arc::new(NetworkLayer::new(BlockingSendTransport::new(
+        StdArc::clone(&sent),
+        Arc::clone(&first_send_started),
+        Arc::clone(&release_first_send),
+    )));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let source_mac = test_mac(15);
+    let invoke_id = 0x4F;
+    let first = {
+        let network = Arc::clone(&network);
+        let seg_ack_senders = Arc::clone(&seg_ack_senders);
+        let seg_send_permits = Arc::clone(&seg_send_permits);
+        let source_mac = source_mac.clone();
+        tokio::spawn(async move {
+            BACnetServer::<BlockingSendTransport>::send_segmented_complex_ack_with_options(
+                &network,
+                &seg_ack_senders,
+                &seg_send_permits,
+                source_mac.as_slice(),
+                None,
+                invoke_id,
+                ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+                &[0xF4; 128],
+                50,
+                None,
+                SegmentedSendOptions {
+                    segment_timeout: Duration::from_millis(500),
+                    max_retries: 0,
+                },
+            )
+            .await;
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(1), first_send_started.notified())
+        .await
+        .expect("first segment send should start");
+    dispatch_test_apdu(
+        &network,
+        &seg_ack_senders,
+        &source_mac,
+        Apdu::SegmentAck(segment_ack(invoke_id, false, 0)),
+    )
+    .await;
+
+    let second = {
+        let network = Arc::clone(&network);
+        let seg_ack_senders = Arc::clone(&seg_ack_senders);
+        let seg_send_permits = Arc::clone(&seg_send_permits);
+        let source_mac = source_mac.clone();
+        tokio::spawn(async move {
+            BACnetServer::<BlockingSendTransport>::send_segmented_complex_ack_with_options(
+                &network,
+                &seg_ack_senders,
+                &seg_send_permits,
+                source_mac.as_slice(),
+                None,
+                invoke_id,
+                ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+                &[0xF5; 128],
+                50,
+                None,
+                SegmentedSendOptions {
+                    segment_timeout: Duration::from_millis(500),
+                    max_retries: 0,
+                },
+            )
+            .await;
+        })
+    };
+
+    wait_for_sent_len(&sent, 2).await;
+    release_first_send.notify_waiters();
+    tokio::time::timeout(Duration::from_secs(1), first)
+        .await
+        .expect("older segmented sender should be cancelled")
+        .expect("older segmented sender should not panic");
+    assert_eq!(
+        sent_count(&sent),
+        2,
+        "queued SegmentACK must not advance after same-key Cancel"
+    );
+
+    second.abort();
+    let _ = second.await;
+}
+
+#[tokio::test]
+async fn same_key_replacement_is_rejected_when_live_sender_permits_are_exhausted() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let first_send_started = Arc::new(Notify::new());
+    let release_first_send = Arc::new(Notify::new());
+    let network = Arc::new(NetworkLayer::new(BlockingSendTransport::new(
+        StdArc::clone(&sent),
+        Arc::clone(&first_send_started),
+        Arc::clone(&release_first_send),
+    )));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(1));
+    let source_mac = test_mac(16);
+    let invoke_id = 0x50;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+
+    let first = {
+        let network = Arc::clone(&network);
+        let seg_ack_senders = Arc::clone(&seg_ack_senders);
+        let seg_send_permits = Arc::clone(&seg_send_permits);
+        let source_mac = source_mac.clone();
+        tokio::spawn(async move {
+            BACnetServer::<BlockingSendTransport>::send_segmented_complex_ack_with_options(
+                &network,
+                &seg_ack_senders,
+                &seg_send_permits,
+                source_mac.as_slice(),
+                None,
+                invoke_id,
+                ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+                &[0xF8; 128],
+                50,
+                None,
+                SegmentedSendOptions {
+                    segment_timeout: Duration::from_millis(500),
+                    max_retries: 0,
+                },
+            )
+            .await;
+        })
+    };
+
+    tokio::time::timeout(Duration::from_secs(1), first_send_started.notified())
+        .await
+        .expect("first segment send should start");
+
+    BACnetServer::<BlockingSendTransport>::send_segmented_complex_ack_with_options(
+        &network,
+        &seg_ack_senders,
+        &seg_send_permits,
+        source_mac.as_slice(),
+        None,
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+        &[0xF9; 128],
+        50,
+        None,
+        SegmentedSendOptions {
+            segment_timeout: Duration::from_millis(500),
+            max_retries: 0,
+        },
+    )
+    .await;
+
+    assert_eq!(sent_count(&sent), 2);
+    assert_eq!(abort_reason(&sent, 1), AbortReason::BUFFER_OVERFLOW);
+    assert!(
+        seg_ack_senders.lock().await.contains_key(&key),
+        "rejected replacement must leave the original sender registered"
+    );
+
+    dispatch_test_apdu(
+        &network,
+        &seg_ack_senders,
+        &source_mac,
+        Apdu::Abort(AbortPdu {
+            sent_by_server: false,
+            invoke_id,
+            abort_reason: AbortReason::OTHER,
+        }),
+    )
+    .await;
+    release_first_send.notify_waiters();
+    tokio::time::timeout(Duration::from_secs(1), first)
+        .await
+        .expect("original sender should terminate after client Abort")
+        .expect("original sender should not panic");
+    assert!(
+        !seg_ack_senders.lock().await.contains_key(&key),
+        "original sender should clean up after client Abort"
+    );
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_rejects_new_sender_when_active_sender_limit_reached() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+
+    {
+        let mut senders = seg_ack_senders.lock().await;
+        for idx in 0..MAX_SEG_SENDERS {
+            let (handle, _segment_rx, _control_rx) = fake_segmented_send_handle(1, 2, 0);
+            senders.insert((test_mac(idx as u8), None, idx as u8), handle);
+        }
+    }
+
+    let source_mac = test_mac(200);
+    let invoke_id = 0x60;
+    BACnetServer::<RecordingTransport>::send_segmented_complex_ack(
+        &network,
+        &seg_ack_senders,
+        &seg_send_permits,
+        source_mac.as_slice(),
+        None,
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+        &[0xF6; 128],
+        50,
+        None,
+    )
+    .await;
+
+    assert_eq!(sent_count(&sent), 1);
+    assert_eq!(abort_reason(&sent, 0), AbortReason::BUFFER_OVERFLOW);
+    assert_eq!(seg_ack_senders.lock().await.len(), MAX_SEG_SENDERS);
+}
+
+#[tokio::test]
+async fn dispatch_returns_when_segment_ack_queue_is_full() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(13);
+    let invoke_id = 0x4D;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let (handle, _rx, _control_rx) = fake_segmented_send_handle(1, 2, 0);
+    handle
+        .segment_ack_tx
+        .try_send(segment_ack(invoke_id, false, 0))
+        .expect("test queue should accept one SegmentACK");
+    seg_ack_senders.lock().await.insert(key, handle);
+
+    tokio::time::timeout(
+        Duration::from_millis(50),
+        dispatch_test_apdu(
+            &network,
+            &seg_ack_senders,
+            &source_mac,
+            Apdu::SegmentAck(segment_ack(invoke_id, false, 0)),
+        ),
+    )
+    .await
+    .expect("dispatch must not wait for capacity on a full SegmentACK queue");
+}
+
+#[tokio::test]
+async fn dispatch_client_abort_not_blocked_by_full_segment_ack_queue() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(14);
+    let invoke_id = 0x4E;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let (handle, _rx, mut control_rx) = fake_segmented_send_handle(1, 2, 0);
+    handle
+        .segment_ack_tx
+        .try_send(segment_ack(invoke_id, false, 0))
+        .expect("test queue should accept one SegmentACK");
+    seg_ack_senders.lock().await.insert(key, handle);
+
+    tokio::time::timeout(
+        Duration::from_millis(50),
+        dispatch_test_apdu(
+            &network,
+            &seg_ack_senders,
+            &source_mac,
+            Apdu::Abort(AbortPdu {
+                sent_by_server: false,
+                invoke_id,
+                abort_reason: AbortReason::OTHER,
+            }),
+        ),
+    )
+    .await
+    .expect("client Abort dispatch must not wait for SegmentACK queue capacity");
+
+    tokio::time::timeout(Duration::from_millis(50), control_rx.changed())
+        .await
+        .expect("Abort control event should be delivered")
+        .expect("Abort control channel should remain open");
+    let control_event = control_rx.borrow_and_update().clone();
+    match control_event {
+        Some(SegmentedSendControlEvent::Abort(abort)) => {
+            assert_eq!(abort.invoke_id, invoke_id);
+            assert_eq!(abort.abort_reason, AbortReason::OTHER);
+        }
+        other => panic!("expected Abort control event, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn same_key_replacement_does_not_wait_for_full_old_queue() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(15);
+    let invoke_id = 0x4F;
+    let key: SegKey = (source_mac.clone(), None, invoke_id);
+    let (old_handle, _old_rx, mut old_control_rx) = fake_segmented_send_handle(1, 2, 0);
+    old_handle
+        .segment_ack_tx
+        .try_send(segment_ack(invoke_id, false, 0))
+        .expect("test queue should accept one SegmentACK");
+    seg_ack_senders.lock().await.insert(key, old_handle);
+
+    let replacement = spawn_segmented_complex_ack_with_options(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0xF2; 128],
+        SegmentedSendOptions {
+            segment_timeout: Duration::from_millis(500),
+            max_retries: 0,
+        },
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    tokio::time::timeout(Duration::from_millis(50), old_control_rx.changed())
+        .await
+        .expect("replacement should deliver a nonblocking Cancel")
+        .expect("old control channel should remain open");
+    assert!(matches!(
+        old_control_rx.borrow_and_update().clone(),
+        Some(SegmentedSendControlEvent::Cancel)
+    ));
+
+    replacement.abort();
+    let _ = replacement.await;
+}

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -1,0 +1,398 @@
+use super::*;
+use bacnet_encoding::apdu::decode_apdu;
+use bacnet_encoding::npdu::decode_npdu;
+use bytes::Bytes;
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
+use tokio::sync::{mpsc, watch, Notify};
+
+type SentFrames = StdArc<StdMutex<Vec<(Bytes, MacAddr)>>>;
+
+#[derive(Clone, Default)]
+struct RecordingTransport {
+    sent_unicast: SentFrames,
+    local_mac: Vec<u8>,
+}
+
+impl RecordingTransport {
+    fn new(sent_unicast: SentFrames) -> Self {
+        Self {
+            sent_unicast,
+            local_mac: vec![127, 0, 0, 1, 0xBA, 0xC0],
+        }
+    }
+}
+
+impl TransportPort for RecordingTransport {
+    async fn start(
+        &mut self,
+    ) -> Result<mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+        let (_tx, rx) = mpsc::channel(1);
+        Ok(rx)
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
+        self.sent_unicast
+            .lock()
+            .unwrap()
+            .push((Bytes::copy_from_slice(npdu), MacAddr::from_slice(mac)));
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &self.local_mac
+    }
+}
+
+#[derive(Clone)]
+struct BlockingSendTransport {
+    sent_unicast: SentFrames,
+    local_mac: Vec<u8>,
+    first_send_started: Arc<Notify>,
+    release_first_send: Arc<Notify>,
+    block_first_send: Arc<AtomicBool>,
+}
+
+impl BlockingSendTransport {
+    fn new(
+        sent_unicast: SentFrames,
+        first_send_started: Arc<Notify>,
+        release_first_send: Arc<Notify>,
+    ) -> Self {
+        Self {
+            sent_unicast,
+            local_mac: vec![127, 0, 0, 1, 0xBA, 0xC0],
+            first_send_started,
+            release_first_send,
+            block_first_send: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+impl TransportPort for BlockingSendTransport {
+    async fn start(
+        &mut self,
+    ) -> Result<mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+        let (_tx, rx) = mpsc::channel(1);
+        Ok(rx)
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
+        self.sent_unicast
+            .lock()
+            .unwrap()
+            .push((Bytes::copy_from_slice(npdu), MacAddr::from_slice(mac)));
+
+        if self.block_first_send.swap(false, Ordering::AcqRel) {
+            self.first_send_started.notify_waiters();
+            self.release_first_send.notified().await;
+        }
+
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &self.local_mac
+    }
+}
+
+fn test_mac(byte: u8) -> MacAddr {
+    MacAddr::from_slice(&[127, 0, 0, byte, 0xBA, 0xC0])
+}
+
+fn spawn_segmented_complex_ack(
+    network: Arc<NetworkLayer<RecordingTransport>>,
+    seg_ack_senders: Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+    source_mac: MacAddr,
+    invoke_id: u8,
+    service_ack_data: Vec<u8>,
+) -> JoinHandle<()> {
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    spawn_segmented_complex_ack_from_network(
+        network,
+        seg_ack_senders,
+        seg_send_permits,
+        source_mac,
+        None,
+        invoke_id,
+        service_ack_data,
+    )
+}
+
+fn spawn_segmented_complex_ack_from_network(
+    network: Arc<NetworkLayer<RecordingTransport>>,
+    seg_ack_senders: Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+    seg_send_permits: Arc<Semaphore>,
+    source_mac: MacAddr,
+    source_network: Option<NpduAddress>,
+    invoke_id: u8,
+    service_ack_data: Vec<u8>,
+) -> JoinHandle<()> {
+    spawn_segmented_complex_ack_from_network_with_options(
+        network,
+        seg_ack_senders,
+        seg_send_permits,
+        SegmentedSendTestRequest {
+            source_mac,
+            source_network,
+            invoke_id,
+            service_ack_data,
+            options: SegmentedSendOptions::default(),
+        },
+    )
+}
+
+struct SegmentedSendTestRequest {
+    source_mac: MacAddr,
+    source_network: Option<NpduAddress>,
+    invoke_id: u8,
+    service_ack_data: Vec<u8>,
+    options: SegmentedSendOptions,
+}
+
+fn spawn_segmented_complex_ack_from_network_with_options(
+    network: Arc<NetworkLayer<RecordingTransport>>,
+    seg_ack_senders: Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+    seg_send_permits: Arc<Semaphore>,
+    request: SegmentedSendTestRequest,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        BACnetServer::<RecordingTransport>::send_segmented_complex_ack_with_options(
+            &network,
+            &seg_ack_senders,
+            &seg_send_permits,
+            request.source_mac.as_slice(),
+            request.source_network.as_ref(),
+            request.invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+            &request.service_ack_data,
+            50,
+            None,
+            request.options,
+        )
+        .await;
+    })
+}
+
+fn spawn_segmented_complex_ack_with_options(
+    network: Arc<NetworkLayer<RecordingTransport>>,
+    seg_ack_senders: Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+    source_mac: MacAddr,
+    invoke_id: u8,
+    service_ack_data: Vec<u8>,
+    options: SegmentedSendOptions,
+) -> JoinHandle<()> {
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    spawn_segmented_complex_ack_from_network_with_options(
+        network,
+        seg_ack_senders,
+        seg_send_permits,
+        SegmentedSendTestRequest {
+            source_mac,
+            source_network: None,
+            invoke_id,
+            service_ack_data,
+            options,
+        },
+    )
+}
+
+async fn wait_until_sent_len(sent: &SentFrames, expected: usize) {
+    loop {
+        if sent.lock().unwrap().len() >= expected {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+async fn wait_for_sent_len(sent: &SentFrames, expected: usize) {
+    tokio::time::timeout(Duration::from_secs(1), wait_until_sent_len(sent, expected))
+        .await
+        .expect("timed out waiting for segmented response frame");
+}
+
+async fn send_segment_ack(
+    seg_ack_senders: &Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+    key: &SegKey,
+    ack: SegmentAckPdu,
+) {
+    let handle = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if let Some(handle) = seg_ack_senders.lock().await.get(key).cloned() {
+                return handle;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for SegmentAck sender");
+
+    handle
+        .segment_ack_tx
+        .send(ack)
+        .await
+        .expect("segmented response task should still be waiting for SegmentAck");
+}
+
+async fn dispatch_test_apdu<T: TransportPort + 'static>(
+    network: &Arc<NetworkLayer<T>>,
+    seg_ack_senders: &Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+    source_mac: &MacAddr,
+    apdu: Apdu,
+) {
+    dispatch_test_apdu_from_network(network, seg_ack_senders, source_mac, None, apdu).await;
+}
+
+async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
+    network: &Arc<NetworkLayer<T>>,
+    seg_ack_senders: &Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+    source_mac: &MacAddr,
+    source_network: Option<NpduAddress>,
+    apdu: Apdu,
+) {
+    let db = Arc::new(RwLock::new(ObjectDatabase::new()));
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
+    let cov_in_flight = Arc::new(Semaphore::new(255));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+    let comm_state = Arc::new(AtomicU8::new(0));
+    let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
+    let config = Arc::new(ServerConfig::default());
+
+    BACnetServer::<T>::dispatch(
+        &db,
+        network,
+        &cov_table,
+        seg_ack_senders,
+        &seg_send_permits,
+        &cov_in_flight,
+        &server_tsm,
+        &comm_state,
+        &dcc_timer,
+        &config,
+        source_mac.as_slice(),
+        apdu,
+        bacnet_network::layer::ReceivedApdu {
+            apdu: Bytes::new(),
+            source_mac: source_mac.clone(),
+            source_network,
+            data_attributes: Vec::new(),
+            reply_tx: None,
+        },
+    )
+    .await;
+}
+
+fn decoded_sent_apdu(sent: &SentFrames, index: usize) -> Apdu {
+    let npdu_bytes = {
+        let sent = sent.lock().unwrap();
+        sent[index].0.clone()
+    };
+    let npdu = decode_npdu(npdu_bytes).expect("sent frame should decode as NPDU");
+    decode_apdu(npdu.payload).expect("sent NPDU payload should decode as APDU")
+}
+
+fn sent_expecting_reply(sent: &SentFrames, index: usize) -> bool {
+    let npdu_bytes = {
+        let sent = sent.lock().unwrap();
+        sent[index].0.clone()
+    };
+    decode_npdu(npdu_bytes)
+        .expect("sent frame should decode as NPDU")
+        .expecting_reply
+}
+
+fn complex_ack_sequence(sent: &SentFrames, index: usize) -> u8 {
+    match decoded_sent_apdu(sent, index) {
+        Apdu::ComplexAck(ack) => {
+            assert!(ack.segmented);
+            assert_eq!(
+                ack.service_choice,
+                ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE
+            );
+            ack.sequence_number
+                .expect("segmented ComplexAck should carry a sequence number")
+        }
+        other => panic!("expected segmented ComplexAck, got {other:?}"),
+    }
+}
+
+fn abort_reason(sent: &SentFrames, index: usize) -> AbortReason {
+    match decoded_sent_apdu(sent, index) {
+        Apdu::Abort(abort) => abort.abort_reason,
+        other => panic!("expected Abort, got {other:?}"),
+    }
+}
+
+fn sent_count(sent: &SentFrames) -> usize {
+    sent.lock().unwrap().len()
+}
+
+fn segment_ack(invoke_id: u8, negative_ack: bool, sequence_number: u8) -> SegmentAckPdu {
+    SegmentAckPdu {
+        negative_ack,
+        sent_by_server: false,
+        invoke_id,
+        sequence_number,
+        actual_window_size: 1,
+    }
+}
+
+fn server_segment_ack(invoke_id: u8, negative_ack: bool, sequence_number: u8) -> SegmentAckPdu {
+    SegmentAckPdu {
+        negative_ack,
+        sent_by_server: true,
+        invoke_id,
+        sequence_number,
+        actual_window_size: 1,
+    }
+}
+
+fn routed_address(network: u16, byte: u8) -> NpduAddress {
+    NpduAddress {
+        network,
+        mac_address: MacAddr::from_slice(&[byte, byte.wrapping_add(1), byte.wrapping_add(2)]),
+    }
+}
+
+fn fake_segmented_send_handle(
+    capacity: usize,
+    total_segments: usize,
+    current_sequence: u16,
+) -> (
+    Arc<SegmentedSendHandle>,
+    mpsc::Receiver<SegmentAckPdu>,
+    watch::Receiver<Option<SegmentedSendControlEvent>>,
+) {
+    let (segment_ack_tx, segment_ack_rx) = mpsc::channel(capacity);
+    let (control_tx, control_rx) = watch::channel(None);
+    let handle = Arc::new(SegmentedSendHandle::new(
+        segment_ack_tx,
+        control_tx,
+        total_segments,
+    ));
+    handle
+        .current_sequence
+        .store(current_sequence, Ordering::Release);
+    (handle, segment_ack_rx, control_rx)
+}
+
+mod ack_window;
+mod control_limits;
+mod routing_overlap;

--- a/crates/bacnet-server/src/server/segmentation_tests/routing_overlap.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/routing_overlap.rs
@@ -1,0 +1,205 @@
+use super::*;
+
+#[tokio::test]
+async fn routed_source_segment_ack_and_abort_match_npdu_source() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let router_mac = test_mac(16);
+    let remote = routed_address(100, 0x10);
+    let other_remote = routed_address(101, 0x20);
+    let invoke_id = 0x50;
+    let key: SegKey = (router_mac.clone(), Some(remote.clone()), invoke_id);
+    let handle = spawn_segmented_complex_ack_from_network_with_options(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        Arc::clone(&seg_send_permits),
+        SegmentedSendTestRequest {
+            source_mac: router_mac.clone(),
+            source_network: Some(remote.clone()),
+            invoke_id,
+            service_ack_data: vec![0xF3; 128],
+            options: SegmentedSendOptions {
+                segment_timeout: Duration::from_millis(500),
+                max_retries: 1,
+            },
+        },
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    assert_eq!(complex_ack_sequence(&sent, 0), 0);
+
+    dispatch_test_apdu_from_network(
+        &network,
+        &seg_ack_senders,
+        &router_mac,
+        Some(other_remote.clone()),
+        Apdu::SegmentAck(segment_ack(invoke_id, true, 0)),
+    )
+    .await;
+    dispatch_test_apdu_from_network(
+        &network,
+        &seg_ack_senders,
+        &router_mac,
+        Some(remote.clone()),
+        Apdu::SegmentAck(segment_ack(invoke_id, false, 0)),
+    )
+    .await;
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(
+        complex_ack_sequence(&sent, 1),
+        1,
+        "SegmentACK from a different NPDU source must not retransmit segment 0"
+    );
+
+    dispatch_test_apdu_from_network(
+        &network,
+        &seg_ack_senders,
+        &router_mac,
+        Some(other_remote),
+        Apdu::Abort(AbortPdu {
+            sent_by_server: false,
+            invoke_id,
+            abort_reason: AbortReason::OTHER,
+        }),
+    )
+    .await;
+    dispatch_test_apdu_from_network(
+        &network,
+        &seg_ack_senders,
+        &router_mac,
+        Some(remote.clone()),
+        Apdu::SegmentAck(segment_ack(invoke_id, true, 0)),
+    )
+    .await;
+
+    wait_for_sent_len(&sent, 3).await;
+    assert_eq!(
+        complex_ack_sequence(&sent, 2),
+        1,
+        "matching routed negative SegmentACK should retransmit the current segment"
+    );
+
+    dispatch_test_apdu_from_network(
+        &network,
+        &seg_ack_senders,
+        &router_mac,
+        Some(remote),
+        Apdu::Abort(AbortPdu {
+            sent_by_server: false,
+            invoke_id,
+            abort_reason: AbortReason::OTHER,
+        }),
+    )
+    .await;
+
+    tokio::time::timeout(Duration::from_secs(1), handle)
+        .await
+        .expect("matching routed client Abort should terminate segmented response task")
+        .expect("segmented response task should not panic");
+    assert_eq!(
+        sent_count(&sent),
+        3,
+        "server must not send a timeout Abort after matching routed client Abort"
+    );
+    assert!(
+        !seg_ack_senders.lock().await.contains_key(&key),
+        "SegmentAck sender entry should be removed after routed client Abort"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_ack_flood_does_not_drop_valid_segment_ack() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(11);
+    let invoke_id = 0x4B;
+    let handle = spawn_segmented_complex_ack(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac.clone(),
+        invoke_id,
+        vec![0xEF; 128],
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    for _ in 0..32 {
+        dispatch_test_apdu(
+            &network,
+            &seg_ack_senders,
+            &source_mac,
+            Apdu::SegmentAck(segment_ack(invoke_id, false, 1)),
+        )
+        .await;
+    }
+    dispatch_test_apdu(
+        &network,
+        &seg_ack_senders,
+        &source_mac,
+        Apdu::SegmentAck(segment_ack(invoke_id, true, 0)),
+    )
+    .await;
+
+    wait_for_sent_len(&sent, 2).await;
+    assert_eq!(complex_ack_sequence(&sent, 1), 0);
+
+    handle.abort();
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn overlapping_same_peer_invoke_id_cancels_old_segmented_sender() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let source_mac = test_mac(12);
+    let invoke_id = 0x4C;
+    let first = spawn_segmented_complex_ack_with_options(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac.clone(),
+        invoke_id,
+        vec![0xF0; 128],
+        SegmentedSendOptions {
+            segment_timeout: Duration::from_millis(50),
+            max_retries: 0,
+        },
+    );
+
+    wait_for_sent_len(&sent, 1).await;
+    let second = spawn_segmented_complex_ack_with_options(
+        Arc::clone(&network),
+        Arc::clone(&seg_ack_senders),
+        source_mac,
+        invoke_id,
+        vec![0xF1; 128],
+        SegmentedSendOptions {
+            segment_timeout: Duration::from_millis(500),
+            max_retries: 0,
+        },
+    );
+
+    wait_for_sent_len(&sent, 2).await;
+    tokio::time::timeout(Duration::from_secs(1), first)
+        .await
+        .expect("older segmented sender should be cancelled")
+        .expect("older segmented sender should not panic");
+    tokio::time::sleep(Duration::from_millis(90)).await;
+    assert!(
+        (0..sent_count(&sent))
+            .all(|index| !matches!(decoded_sent_apdu(&sent, index), Apdu::Abort(_))),
+        "older segmented sender should not send timeout Abort after replacement"
+    );
+
+    second.abort();
+    let _ = second.await;
+}

--- a/crates/bacnet-server/src/server/tests.rs
+++ b/crates/bacnet-server/src/server/tests.rs
@@ -207,6 +207,7 @@ async fn reply_tx_response_preserves_routed_npdu_destination() {
     let db = Arc::new(RwLock::new(ObjectDatabase::new()));
     let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
     let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
     let cov_in_flight = Arc::new(Semaphore::new(1));
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
     let comm_state = Arc::new(AtomicU8::new(0));
@@ -236,6 +237,7 @@ async fn reply_tx_response_preserves_routed_npdu_destination() {
         &network,
         &cov_table,
         &seg_ack_senders,
+        &seg_send_permits,
         &cov_in_flight,
         &server_tsm,
         &comm_state,

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -1,7 +1,7 @@
 {
   "standard": "ANSI/ASHRAE Standard 135-2020",
   "reviewed_at": "2026-07-04",
-  "repo_sha": "8b8c0cba3e92caa30e145c91abedfa003c64f2c9",
+  "repo_sha": "e6be3eacfd2b780f11812de3931fb7f8e8dec584",
   "review_scope": "Clause 5 server segmented ComplexAck send-side SegmentACK behavior, covering client-direction SegmentACK validation, current-window positive and negative SegmentACK handling, final SegmentACK validation, timeout retransmission before idle cleanup, client Abort routing, routed NPDU source matching, segmented-response NPDU expecting-reply, nonblocking full-queue dispatch, same-peer sender replacement cleanup, and root conformance artifact relocation from `conformance/` to `docs/conformance/`.",
   "addenda_errata_status": "Local source `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` was reviewed for Clause 5 segmented APDU transfer and SegmentACK behavior. No external addenda/errata check was performed for this tranche, so the affected Clause 5 rows remain in gap statuses rather than `supported-with-clause-evidence`.",
   "status_taxonomy": [

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -1,9 +1,9 @@
 {
   "standard": "ANSI/ASHRAE Standard 135-2020",
-  "reviewed_at": "2026-06-29",
-  "repo_sha": "a889b76331bfcb4e2dd998b8a78e544ad37397b2",
-  "review_scope": "Annex AB.6.3 BACnet/SC heartbeat initiation and liveness behavior for browser/WASM clients, covering post-Connect-Accept heartbeat tracking, monotonic Performance-clock scheduling, no-VMAC Heartbeat-ACK correlation, timeout/send-failure fail-closed disconnect, receive-loop/timer cleanup, and pending confirmed-service Promise rejection on terminal disconnect paths.",
-  "addenda_errata_status": "Local source `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` was reviewed for Annex AB.2.14 Heartbeat-Request, AB.2.15 Heartbeat-ACK, Annex AB.6.3 heartbeat interval/timeout behavior, and Table AB-1 BVLC-SC function constraints. The BACnet Committee Addenda page and ASHRAE Errata page were checked on 2026-06-29 for Standard 135-2020 addenda/errata through addenda bv, bx, ca, cc, cd, ce, cf, ch, ci, cj, ck, cn, cm, co, cp, cq, and cs, plus the 135-2020 base errata summary and listed addendum errata through addendum cp. No checked addendum or erratum changes the AB.6.3 browser heartbeat behavior covered by this tranche.",
+  "reviewed_at": "2026-07-04",
+  "repo_sha": "8b8c0cba3e92caa30e145c91abedfa003c64f2c9",
+  "review_scope": "Clause 5 server segmented ComplexAck send-side SegmentACK behavior, covering client-direction SegmentACK validation, current-window positive and negative SegmentACK handling, final SegmentACK validation, timeout retransmission before idle cleanup, client Abort routing, routed NPDU source matching, segmented-response NPDU expecting-reply, nonblocking full-queue dispatch, same-peer sender replacement cleanup, and root conformance artifact relocation from `conformance/` to `docs/conformance/`.",
+  "addenda_errata_status": "Local source `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` was reviewed for Clause 5 segmented APDU transfer and SegmentACK behavior. No external addenda/errata check was performed for this tranche, so the affected Clause 5 rows remain in gap statuses rather than `supported-with-clause-evidence`.",
   "status_taxonomy": [
     "in-progress",
     "implementation-present-needs-conformance-tests",
@@ -52,12 +52,33 @@
       "priority": "P1",
       "requirement_summary": "Server transaction state machine behavior, segmented request handling, SegmentACK behavior, and abort/reject mapping.",
       "status": "implementation-present-needs-state-machine-audit",
-      "code_anchors": ["crates/bacnet-server/src", "crates/bacnet-integration-tests/tests/server/segmentation_rx.rs"],
-      "positive_tests": ["crates/bacnet-integration-tests/tests/server/segmentation_rx.rs"],
-      "negative_tests": [],
+      "code_anchors": ["crates/bacnet-server/src", "crates/bacnet-server/src/server/dispatch.rs", "crates/bacnet-server/src/server/responses.rs", "crates/bacnet-server/src/server/segmentation.rs", "crates/bacnet-server/src/server/segmentation_tests.rs", "crates/bacnet-integration-tests/tests/server/segmentation_rx.rs"],
+      "positive_tests": [
+        "crates/bacnet-integration-tests/tests/server/segmentation_rx.rs",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_retransmits_segment_zero_after_negative_ack_zero",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_retransmits_current_segment_after_negative_ack_previous_sequence",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_ignores_stale_positive_final_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_retransmits_after_segment_ack_timeout_then_goes_idle",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_sets_npdu_expecting_reply_for_segments"
+      ],
+      "negative_tests": [
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_ignores_future_positive_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_ignores_out_of_range_negative_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_ignores_segment_ack_with_server_bit_set",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_aborts_after_repeated_negative_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::client_abort_routed_by_dispatch_terminates_segmented_complex_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::dispatch_ack_flood_does_not_drop_valid_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::dispatch_returns_when_segment_ack_queue_is_full",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::dispatch_client_abort_not_blocked_by_full_segment_ack_queue",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::same_key_replacement_does_not_wait_for_full_old_queue",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::same_key_replacement_is_rejected_when_live_sender_permits_are_exhausted",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_rejects_new_sender_when_active_sender_limit_reached",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::routed_source_segment_ack_and_abort_match_npdu_source",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::overlapping_same_peer_invoke_id_cancels_old_segmented_sender"
+      ],
       "benchmarks": [],
       "public_claims": ["README supported services"],
-      "notes": "Requires independent audit of server TSM states and failure mapping."
+      "notes": "This slice adds server segmented ComplexAck send-side SegmentACK validation: SegmentACKs with the server bit set are ignored, positive ACKs advance only for the current segment, negative ACKs retransmit only the current requested segment, out-of-range negative ACKs are ignored, stale final ACKs do not complete the transfer, timeout retries retransmit before idle cleanup without a final timeout Abort, client Abort is routed to terminate the active segmented response without a spurious timeout Abort, routed SegmentACK/Abort events match the NPDU source-network key, segmented response frames set NPDU expecting_reply while waiting for SegmentACK, dispatch filters stale/future ACKs before queue insertion and does not block on a full SegmentACK queue, client Abort and same-peer/invoke-id replacement use nonblocking control events, live segmented sender tasks are capped by permits until each task exits, and replacement cancels the older sender so it cannot later emit a timeout Abort. The row remains below supported status pending a fuller server TSM transition audit, configured APDU segment timeout/retry exposure, and broader Reject/Error failure mapping coverage."
     },
     {
       "id": "BACNET-5-SEGMENTATION-WINDOW",
@@ -65,12 +86,27 @@
       "priority": "P1",
       "requirement_summary": "Only Confirmed-Request and ComplexACK may be segmented; SegmentACK windows and modulo-256 sequence handling are enforced.",
       "status": "implementation-present-needs-window-tests",
-      "code_anchors": ["crates/bacnet-encoding/src/segmentation.rs", "crates/bacnet-client/src/client/segmentation.rs"],
-      "positive_tests": ["crates/bacnet-integration-tests/tests/server/segmentation_rx.rs", "crates/bacnet-integration-tests/tests/server/segmentation_tx.rs"],
-      "negative_tests": [],
+      "code_anchors": ["crates/bacnet-encoding/src/segmentation.rs", "crates/bacnet-client/src/client/segmentation.rs", "crates/bacnet-server/src/server/dispatch.rs", "crates/bacnet-server/src/server/segmentation.rs", "crates/bacnet-server/src/server/segmentation_tests.rs"],
+      "positive_tests": [
+        "crates/bacnet-integration-tests/tests/server/segmentation_rx.rs",
+        "crates/bacnet-integration-tests/tests/server/segmentation_tx.rs",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_retransmits_segment_zero_after_negative_ack_zero",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_retransmits_current_segment_after_negative_ack_previous_sequence",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_ignores_stale_positive_final_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_retransmits_after_segment_ack_timeout_then_goes_idle"
+      ],
+      "negative_tests": [
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_ignores_future_positive_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_ignores_out_of_range_negative_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_ignores_segment_ack_with_server_bit_set",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::segmented_complex_ack_aborts_after_repeated_negative_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::dispatch_ack_flood_does_not_drop_valid_segment_ack",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::dispatch_returns_when_segment_ack_queue_is_full",
+        "crates/bacnet-server/src/server/segmentation_tests.rs::routed_source_segment_ack_and_abort_match_npdu_source"
+      ],
       "benchmarks": ["benchmarks/src/stress/segmentation.rs"],
       "public_claims": ["docs/wasm-api.md segmentation limitation", "docs/python-api.md segmentation support"],
-      "notes": "Needs duplicate, gap, out-of-order, final segment, max APDU, and max segment tests."
+      "notes": "This slice adds server ComplexAck send-side window evidence for current-sequence positive ACK advancement, first-window NAK0 retransmission, NAK of the previous sequence retransmitting the current segment, stale/future positive ACK ignore, wrong-direction ACK ignore, routed source-network matching, out-of-range NAK ignore, final ACK validation, timeout retransmission, repeated valid NAK abort, ACK flood/current-window filtering, and nonblocking full-queue SegmentACK dispatch. Remaining segmentation/window gaps include multi-segment window sizes beyond the current window-one send behavior, modulo-256 wrap, duplicate segment receive behavior, max APDU/max segment boundaries, and broader client/server receive-side out-of-order coverage."
     },
     {
       "id": "BACNET-6-NPDU-CONTROL",

--- a/docs/conformance/bibbs-draft.md
+++ b/docs/conformance/bibbs-draft.md
@@ -1,6 +1,6 @@
 # Draft BACnet BIBB Support Evidence
 
-> DRAFT internal support evidence. Generated from `conformance/bacnet-135-2020.json`; this is not a BTL certification claim or formal PICS/BIBB declaration.
+> DRAFT internal support evidence. Generated from `docs/conformance/bacnet-135-2020.json`; this is not a BTL certification claim or formal PICS/BIBB declaration.
 
 This draft is a ledger-derived starting point for future Annex K BIBB mapping. Detailed BIBB claims require service-specific positive and negative tests.
 

--- a/docs/conformance/pics-draft.md
+++ b/docs/conformance/pics-draft.md
@@ -1,6 +1,6 @@
 # Draft BACnet PICS Support Evidence
 
-> DRAFT internal support evidence. Generated from `conformance/bacnet-135-2020.json`; this is not a BTL certification claim or formal PICS/BIBB declaration.
+> DRAFT internal support evidence. Generated from `docs/conformance/bacnet-135-2020.json`; this is not a BTL certification claim or formal PICS/BIBB declaration.
 
 This draft summarizes implementation evidence that may feed a future formal Protocol Implementation Conformance Statement. It intentionally stays below a certification claim.
 

--- a/docs/conformance/standard-135-2020-ledger.md
+++ b/docs/conformance/standard-135-2020-ledger.md
@@ -6,7 +6,7 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020.
 - Reviewed at: 2026-07-04.
-- Implementation evidence SHA reviewed: `8b8c0cba3e92caa30e145c91abedfa003c64f2c9`.
+- Implementation evidence SHA reviewed: `e6be3eacfd2b780f11812de3931fb7f8e8dec584`.
 - Machine-readable source: `docs/conformance/bacnet-135-2020.json`.
 - Current scope: Clause 5 server segmented ComplexAck send-side SegmentACK behavior, covering client-direction SegmentACK validation, current-window positive and negative SegmentACK handling, final SegmentACK validation, timeout retransmission before idle cleanup, client Abort routing, routed NPDU source matching, segmented-response NPDU expecting-reply, nonblocking full-queue dispatch, same-peer sender replacement cleanup, and root conformance artifact relocation from `conformance/` to `docs/conformance/`.
 - Addenda/errata status: Local source `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` was reviewed for Clause 5 segmented APDU transfer and SegmentACK behavior. No external addenda/errata check was performed for this tranche, so the affected Clause 5 rows remain in gap statuses rather than `supported-with-clause-evidence`.

--- a/docs/conformance/standard-135-2020-ledger.md
+++ b/docs/conformance/standard-135-2020-ledger.md
@@ -5,11 +5,11 @@
 ## Scope
 
 - Standard: ANSI/ASHRAE Standard 135-2020.
-- Reviewed at: 2026-06-29.
-- Implementation evidence SHA reviewed: `a889b76331bfcb4e2dd998b8a78e544ad37397b2`.
-- Machine-readable source: `conformance/bacnet-135-2020.json`.
-- Current scope: Annex AB.6.3 BACnet/SC heartbeat initiation and liveness behavior for browser/WASM clients, covering post-Connect-Accept heartbeat tracking, monotonic Performance-clock scheduling, no-VMAC Heartbeat-ACK correlation, timeout/send-failure fail-closed disconnect, receive-loop/timer cleanup, and pending confirmed-service Promise rejection on terminal disconnect paths.
-- Addenda/errata status: Local source `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` was reviewed for Annex AB.2.14 Heartbeat-Request, AB.2.15 Heartbeat-ACK, Annex AB.6.3 heartbeat interval/timeout behavior, and Table AB-1 BVLC-SC function constraints. The BACnet Committee Addenda page and ASHRAE Errata page were checked on 2026-06-29 for Standard 135-2020 addenda/errata through addenda bv, bx, ca, cc, cd, ce, cf, ch, ci, cj, ck, cn, cm, co, cp, cq, and cs, plus the 135-2020 base errata summary and listed addendum errata through addendum cp. No checked addendum or erratum changes the AB.6.3 browser heartbeat behavior covered by this tranche.
+- Reviewed at: 2026-07-04.
+- Implementation evidence SHA reviewed: `8b8c0cba3e92caa30e145c91abedfa003c64f2c9`.
+- Machine-readable source: `docs/conformance/bacnet-135-2020.json`.
+- Current scope: Clause 5 server segmented ComplexAck send-side SegmentACK behavior, covering client-direction SegmentACK validation, current-window positive and negative SegmentACK handling, final SegmentACK validation, timeout retransmission before idle cleanup, client Abort routing, routed NPDU source matching, segmented-response NPDU expecting-reply, nonblocking full-queue dispatch, same-peer sender replacement cleanup, and root conformance artifact relocation from `conformance/` to `docs/conformance/`.
+- Addenda/errata status: Local source `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` was reviewed for Clause 5 segmented APDU transfer and SegmentACK behavior. No external addenda/errata check was performed for this tranche, so the affected Clause 5 rows remain in gap statuses rather than `supported-with-clause-evidence`.
 
 ## Status Taxonomy
 
@@ -40,8 +40,8 @@
 | Row ID | Anchor | Priority | Status | Evidence |
 |---|---|---|---|---|
 | `BACNET-5-TSM-CLIENT` | Clause 5.4.4 | P1 | `implementation-present-needs-state-machine-audit` | Client TSM paths exist under `crates/bacnet-client/src/client`. |
-| `BACNET-5-TSM-SERVER` | Clause 5.4.5 | P1 | `implementation-present-needs-state-machine-audit` | Server segmentation and handler paths exist under `crates/bacnet-server/src`. |
-| `BACNET-5-SEGMENTATION-WINDOW` | Clauses 5.2-5.4 | P1 | `implementation-present-needs-window-tests` | Segmentation code and integration tests exist; window edge cases remain open. |
+| `BACNET-5-TSM-SERVER` | Clause 5.4.5 | P1 | `implementation-present-needs-state-machine-audit` | This slice adds server segmented ComplexAck send-side SegmentACK validation in `crates/bacnet-server/src/server/segmentation.rs` with focused tests in `crates/bacnet-server/src/server/segmentation_tests.rs`: SegmentACKs with the server bit set are ignored; positive ACKs advance only for the current segment; NAK0 and previous-sequence NAKs retransmit the expected current segment; out-of-range NAKs are ignored; stale final ACKs do not complete the transfer; timeout retries retransmit before idle cleanup without a final timeout Abort; client Abort terminates the active segmented response without a spurious timeout Abort; routed SegmentACK/Abort events match the NPDU source-network key; segmented response frames set NPDU expecting-reply while waiting for SegmentACK; dispatch filters stale/future ACKs before queue insertion and does not block on a full SegmentACK queue; client Abort and same-peer/invoke-id replacement use nonblocking control events; active segmented senders are capped; and overlapping same-peer/invoke-id senders cancel the older sender. Remaining gaps include full server TSM transition audit, configured APDU segment timeout/retry exposure, and broader Reject/Error mapping coverage. |
+| `BACNET-5-SEGMENTATION-WINDOW` | Clauses 5.2-5.4 | P1 | `implementation-present-needs-window-tests` | This slice adds window-one server ComplexAck send evidence for current-sequence ACK advancement, first-window NAK0 retransmission, previous-sequence NAK retransmission of the current segment, stale/future ACK ignore, wrong-direction ACK ignore, routed source-network matching, out-of-range NAK ignore, final ACK validation, timeout retransmission, repeated valid NAK abort, ACK flood/current-window filtering, and nonblocking full-queue SegmentACK dispatch. Remaining gaps include multi-segment window sizes beyond current window-one behavior, modulo-256 wrap, duplicate receive behavior, max APDU/max segment boundaries, and broader client/server receive-side out-of-order coverage. |
 
 ## Clause 6 Network Layer
 

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -1,12 +1,12 @@
 # BACnet Standard 135-2020 Support Summary
 
-> DRAFT internal support evidence. Generated from `conformance/bacnet-135-2020.json`; this is not a BTL certification claim or formal PICS/BIBB declaration.
+> DRAFT internal support evidence. Generated from `docs/conformance/bacnet-135-2020.json`; this is not a BTL certification claim or formal PICS/BIBB declaration.
 
 - Standard: ANSI/ASHRAE Standard 135-2020
-- Reviewed at: 2026-06-29
-- Implementation evidence SHA reviewed: `a889b76331bfcb4e2dd998b8a78e544ad37397b2`
-- Scope: Annex AB.6.3 BACnet/SC heartbeat initiation and liveness behavior for browser/WASM clients, covering post-Connect-Accept heartbeat tracking, monotonic Performance-clock scheduling, no-VMAC Heartbeat-ACK correlation, timeout/send-failure fail-closed disconnect, receive-loop/timer cleanup, and pending confirmed-service Promise rejection on terminal disconnect paths.
-- Addenda/errata: Local source `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` was reviewed for Annex AB.2.14 Heartbeat-Request, AB.2.15 Heartbeat-ACK, Annex AB.6.3 heartbeat interval/timeout behavior, and Table AB-1 BVLC-SC function constraints. The BACnet Committee Addenda page and ASHRAE Errata page were checked on 2026-06-29 for Standard 135-2020 addenda/errata through addenda bv, bx, ca, cc, cd, ce, cf, ch, ci, cj, ck, cn, cm, co, cp, cq, and cs, plus the 135-2020 base errata summary and listed addendum errata through addendum cp. No checked addendum or erratum changes the AB.6.3 browser heartbeat behavior covered by this tranche.
+- Reviewed at: 2026-07-04
+- Implementation evidence SHA reviewed: `8b8c0cba3e92caa30e145c91abedfa003c64f2c9`
+- Scope: Clause 5 server segmented ComplexAck send-side SegmentACK behavior, covering client-direction SegmentACK validation, current-window positive and negative SegmentACK handling, final SegmentACK validation, timeout retransmission before idle cleanup, client Abort routing, routed NPDU source matching, segmented-response NPDU expecting-reply, nonblocking full-queue dispatch, same-peer sender replacement cleanup, and root conformance artifact relocation from `conformance/` to `docs/conformance/`.
+- Addenda/errata: Local source `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` was reviewed for Clause 5 segmented APDU transfer and SegmentACK behavior. No external addenda/errata check was performed for this tranche, so the affected Clause 5 rows remain in gap statuses rather than `supported-with-clause-evidence`.
 
 ## Counts
 

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -4,7 +4,7 @@
 
 - Standard: ANSI/ASHRAE Standard 135-2020
 - Reviewed at: 2026-07-04
-- Implementation evidence SHA reviewed: `8b8c0cba3e92caa30e145c91abedfa003c64f2c9`
+- Implementation evidence SHA reviewed: `e6be3eacfd2b780f11812de3931fb7f8e8dec584`
 - Scope: Clause 5 server segmented ComplexAck send-side SegmentACK behavior, covering client-direction SegmentACK validation, current-window positive and negative SegmentACK handling, final SegmentACK validation, timeout retransmission before idle cleanup, client Abort routing, routed NPDU source matching, segmented-response NPDU expecting-reply, nonblocking full-queue dispatch, same-peer sender replacement cleanup, and root conformance artifact relocation from `conformance/` to `docs/conformance/`.
 - Addenda/errata: Local source `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` was reviewed for Clause 5 segmented APDU transfer and SegmentACK behavior. No external addenda/errata check was performed for this tranche, so the affected Clause 5 rows remain in gap statuses rather than `supported-with-clause-evidence`.
 

--- a/scripts/generate-conformance-docs.py
+++ b/scripts/generate-conformance-docs.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-LEDGER = ROOT / "conformance" / "bacnet-135-2020.json"
+LEDGER = ROOT / "docs" / "conformance" / "bacnet-135-2020.json"
 OUTPUTS = {
     "support": ROOT / "docs" / "conformance" / "support-summary.md",
     "pics": ROOT / "docs" / "conformance" / "pics-draft.md",
@@ -27,7 +27,7 @@ def header(title: str) -> list[str]:
     return [
         f"# {title}",
         "",
-        "> DRAFT internal support evidence. Generated from `conformance/bacnet-135-2020.json`; this is not a BTL certification claim or formal PICS/BIBB declaration.",
+        "> DRAFT internal support evidence. Generated from `docs/conformance/bacnet-135-2020.json`; this is not a BTL certification claim or formal PICS/BIBB declaration.",
         "",
     ]
 


### PR DESCRIPTION
## Summary

Hardens the server segmented ComplexAck send path for Clause 5 SegmentACK handling and records conservative conformance evidence for the tranche.

Implementation commit: `e6be3eacfd2b780f11812de3931fb7f8e8dec584`.
Evidence-SHA commit: `2c04dc1` updates `repo_sha`, the manual ledger evidence SHA, and generated support docs.

## Changes

- Tracks segmented ComplexAck senders with control state, current sequence, and a server-owned live sender permit pool.
- Caps live segmented sender tasks with `seg_send_permits` until each sender exits; exhaustion fails closed with server Abort `BUFFER_OVERFLOW`.
- Keeps the active sender map cap as a second guard and makes same-peer/invoke-id replacement cancel the older sender without blocking on SegmentACK queue capacity.
- Publishes `current_sequence` before awaiting the transport send, allowing early valid SegmentACKs to be accepted.
- Routes SegmentACK/Abort by source MAC plus routed NPDU source and filters server-bit, wrong-direction, stale/future, and out-of-window SegmentACKs before queue insertion.
- Sets NPDU `expecting_reply` for segmented ComplexAck response segments.
- Moves the conformance JSON to `docs/conformance/bacnet-135-2020.json` and ignores root `/conformance/` for local artifacts.

## Wire Impact

- APDU layout is unchanged.
- Segmented ComplexAck response NPDUs now carry DER/`expecting_reply` while waiting for SegmentACK.
- SegmentACK timeout retry exhaustion now idles and cleans up without a final timeout Abort.
- Repeated valid negative SegmentACK exhaustion still sends server Abort `TSM_TIMEOUT`.
- Sender-cap exhaustion sends server Abort `BUFFER_OVERFLOW`.

## Validation

- `cargo fmt --all`
- `cargo test -p bacnet-server segmentation_tests --locked --quiet` passed, 21 tests.
- `bash .github/scripts/check-file-size.sh`
- `python3 scripts/generate-conformance-docs.py --check`
- `cargo fmt --all --check`
- `cargo test -p bacnet-integration-tests generated_support_docs_are_current_with_ledger --locked --quiet`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked --quiet` passed with existing repository warning noise only.
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --quiet` passed outside the sandbox after the sandboxed run failed only because SC/mTLS local hub bind returned `Operation not permitted`.
- `git diff --check`

No benchmarks were run, and this PR makes no performance claim.

## Review

- Security/reliability: APPROVE. Previous live sender cap finding closed by the permit pool and regression coverage.
- Correctness: APPROVE.
- Clause 5 / NPDU routing: APPROVE.
- Safety/interop: APPROVE.
- Packaging: APPROVE. Confirmed JSON move, `/conformance/` ignore, generated docs, and two-commit evidence-SHA flow.

## Remaining Gaps

This remains conservative evidence, not a broad support claim or certification claim. Follow-up coverage still needed for a full server TSM transition audit, configurable APDU segment timeout/retry exposure, broader Reject/Error mapping, window sizes greater than one, modulo-256 behavior, max APDU/segment boundaries, and receive-side duplicate/out-of-order cases.
