### PR TITLE
fix(encoding): encode BACnetPriorityValue choice tags

### DIFF
--- a/crates/bacnet-cli/src/output.rs
+++ b/crates/bacnet-cli/src/output.rs
@@ -206,6 +206,9 @@ pub fn format_property_value(value: &PropertyValue) -> String {
             let formatted: Vec<String> = items.iter().map(format_property_value).collect();
             format!("[{}]", formatted.join(", "))
         }
+        PropertyValue::ContextTagged { tag_number, value } => {
+            format!("context[{tag_number}]({})", format_property_value(value))
+        }
     }
 }
 

--- a/crates/bacnet-encoding/src/primitives/mod.rs
+++ b/crates/bacnet-encoding/src/primitives/mod.rs
@@ -599,7 +599,9 @@ pub fn encode_property_value(buf: &mut BytesMut, value: &PropertyValue) -> Resul
             }
         }
         PropertyValue::ContextTagged { tag_number, value } => {
-            encode_context_tagged_property_value(buf, *tag_number, value)?;
+            let mut encoded = BytesMut::new();
+            encode_context_tagged_property_value(&mut encoded, *tag_number, value)?;
+            buf.extend_from_slice(&encoded);
         }
     }
     Ok(())

--- a/crates/bacnet-encoding/src/primitives/mod.rs
+++ b/crates/bacnet-encoding/src/primitives/mod.rs
@@ -514,7 +514,68 @@ pub fn decode_application_value(
     Ok((value, content_end))
 }
 
-/// Encode a `PropertyValue` as an application-tagged value.
+fn checked_context_tag_number(tag_number: u32) -> Result<u8, Error> {
+    let tag = u8::try_from(tag_number).map_err(|_| {
+        Error::Encoding(format!(
+            "context tag number {tag_number} exceeds the maximum encodable value 254"
+        ))
+    })?;
+    if tag == u8::MAX {
+        return Err(Error::Encoding(format!(
+            "context tag number {tag_number} exceeds the maximum encodable value 254"
+        )));
+    }
+    Ok(tag)
+}
+
+fn encode_context_tagged_property_value(
+    buf: &mut BytesMut,
+    tag_number: u32,
+    value: &PropertyValue,
+) -> Result<(), Error> {
+    let tag = checked_context_tag_number(tag_number)?;
+    match value {
+        PropertyValue::Null => tags::encode_tag(buf, tag, TagClass::Context, 0),
+        PropertyValue::Boolean(v) => encode_ctx_boolean(buf, tag, *v),
+        PropertyValue::Unsigned(v) => encode_ctx_unsigned(buf, tag, *v),
+        PropertyValue::Signed(v) => encode_ctx_signed(buf, tag, *v),
+        PropertyValue::Real(v) => encode_ctx_real(buf, tag, *v),
+        PropertyValue::Double(v) => encode_ctx_double(buf, tag, *v),
+        PropertyValue::OctetString(v) => encode_ctx_octet_string(buf, tag, v),
+        PropertyValue::CharacterString(v) => encode_ctx_character_string(buf, tag, v)?,
+        PropertyValue::BitString { unused_bits, data } => {
+            encode_ctx_bit_string(buf, tag, *unused_bits, data)
+        }
+        PropertyValue::Enumerated(v) => encode_ctx_enumerated(buf, tag, *v),
+        PropertyValue::Date(v) => encode_ctx_date(buf, tag, v),
+        PropertyValue::Time(v) => {
+            tags::encode_tag(buf, tag, TagClass::Context, 4);
+            buf.put_slice(&v.encode());
+        }
+        PropertyValue::ObjectIdentifier(v) => encode_ctx_object_id(buf, tag, v),
+        PropertyValue::List(values) => {
+            tags::encode_opening_tag(buf, tag);
+            for value in values {
+                encode_property_value(buf, value)?;
+            }
+            tags::encode_closing_tag(buf, tag);
+        }
+        PropertyValue::ContextTagged { .. } => {
+            return Err(Error::Encoding(
+                "nested context-tagged PropertyValue is ambiguous".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Encode a `PropertyValue` using its application or explicit context tag.
+///
+/// Existing primitive variants and [`PropertyValue::List`] retain their
+/// application-tagged behavior. [`PropertyValue::ContextTagged`] encodes the
+/// wrapped primitive as raw context-tagged content, or wraps a list in a
+/// context opening/closing tag pair. Nested context-tagged wrappers are
+/// rejected because their construction semantics are ambiguous.
 pub fn encode_property_value(buf: &mut BytesMut, value: &PropertyValue) -> Result<(), Error> {
     match value {
         PropertyValue::Null => encode_app_null(buf),
@@ -536,6 +597,9 @@ pub fn encode_property_value(buf: &mut BytesMut, value: &PropertyValue) -> Resul
             for v in values {
                 encode_property_value(buf, v)?;
             }
+        }
+        PropertyValue::ContextTagged { tag_number, value } => {
+            encode_context_tagged_property_value(buf, *tag_number, value)?;
         }
     }
     Ok(())

--- a/crates/bacnet-encoding/src/primitives/tests.rs
+++ b/crates/bacnet-encoding/src/primitives/tests.rs
@@ -357,6 +357,146 @@ fn property_value_encode_decode_all_types() {
 
 // --- Context-tagged encode ---
 
+fn context_tagged(tag_number: u32, value: PropertyValue) -> PropertyValue {
+    PropertyValue::ContextTagged {
+        tag_number,
+        value: Box::new(value),
+    }
+}
+
+#[test]
+fn property_value_context_tagged_encodes_all_primitive_contents() {
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let cases = vec![
+        (context_tagged(0, PropertyValue::Null), vec![0x08]),
+        (
+            context_tagged(1, PropertyValue::Boolean(true)),
+            vec![0x19, 0x01],
+        ),
+        (
+            context_tagged(2, PropertyValue::Unsigned(42)),
+            vec![0x29, 0x2a],
+        ),
+        (
+            context_tagged(3, PropertyValue::Signed(-1)),
+            vec![0x39, 0xff],
+        ),
+        (
+            context_tagged(4, PropertyValue::Real(1.0)),
+            vec![0x4c, 0x3f, 0x80, 0x00, 0x00],
+        ),
+        (
+            context_tagged(5, PropertyValue::Double(1.0)),
+            vec![0x5d, 0x08, 0x3f, 0xf0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        ),
+        (
+            context_tagged(6, PropertyValue::OctetString(vec![0xaa])),
+            vec![0x69, 0xaa],
+        ),
+        (
+            context_tagged(7, PropertyValue::CharacterString("A".into())),
+            vec![0x7a, 0x00, 0x41],
+        ),
+        (
+            context_tagged(
+                8,
+                PropertyValue::BitString {
+                    unused_bits: 0,
+                    data: vec![0xff],
+                },
+            ),
+            vec![0x8a, 0x00, 0xff],
+        ),
+        (
+            context_tagged(9, PropertyValue::Enumerated(1)),
+            vec![0x99, 0x01],
+        ),
+        (
+            context_tagged(
+                10,
+                PropertyValue::Date(Date {
+                    year: 124,
+                    month: 1,
+                    day: 2,
+                    day_of_week: 2,
+                }),
+            ),
+            vec![0xac, 124, 1, 2, 2],
+        ),
+        (
+            context_tagged(
+                11,
+                PropertyValue::Time(Time {
+                    hour: 12,
+                    minute: 34,
+                    second: 56,
+                    hundredths: 78,
+                }),
+            ),
+            vec![0xbc, 12, 34, 56, 78],
+        ),
+        (
+            context_tagged(12, PropertyValue::ObjectIdentifier(oid)),
+            vec![0xcc, 0x00, 0x00, 0x00, 0x01],
+        ),
+    ];
+
+    for (value, expected) in cases {
+        let bytes = encode_to_vec(|buf| encode_property_value(buf, &value).unwrap());
+        assert_eq!(bytes, expected, "wrong encoding for {value:?}");
+    }
+}
+
+#[test]
+fn property_value_context_tagged_list_uses_opening_and_closing_tags() {
+    let value = context_tagged(
+        20,
+        PropertyValue::List(vec![
+            PropertyValue::Unsigned(1),
+            context_tagged(2, PropertyValue::Enumerated(3)),
+        ]),
+    );
+
+    let bytes = encode_to_vec(|buf| encode_property_value(buf, &value).unwrap());
+    assert_eq!(bytes, vec![0xfe, 20, 0x21, 0x01, 0x29, 0x03, 0xff, 20]);
+}
+
+#[test]
+fn property_value_context_tagged_rejects_nested_context_tagged_values() {
+    let value = context_tagged(20, context_tagged(2, PropertyValue::Unsigned(1)));
+    let mut bytes = BytesMut::new();
+
+    let error = encode_property_value(&mut bytes, &value).unwrap_err();
+
+    assert!(
+        matches!(error, Error::Encoding(_)),
+        "unexpected error: {error}"
+    );
+    assert!(error.to_string().contains("nested context-tagged"));
+    assert!(bytes.is_empty());
+}
+
+#[test]
+fn property_value_context_tagged_supports_extended_tag_numbers() {
+    let value = context_tagged(254, PropertyValue::Real(1.0));
+    let bytes = encode_to_vec(|buf| encode_property_value(buf, &value).unwrap());
+    assert_eq!(bytes, vec![0xfc, 254, 0x3f, 0x80, 0x00, 0x00]);
+}
+
+#[test]
+fn property_value_context_tagged_rejects_unrepresentable_tag_numbers() {
+    for tag_number in [255, 256, u32::MAX] {
+        let value = context_tagged(tag_number, PropertyValue::Null);
+        let mut bytes = BytesMut::new();
+        let error = encode_property_value(&mut bytes, &value).unwrap_err();
+        assert!(
+            error.to_string().contains("context tag number"),
+            "unexpected error for tag {tag_number}: {error}"
+        );
+        assert!(bytes.is_empty());
+    }
+}
+
 #[test]
 fn ctx_unsigned_encoding() {
     let bytes = encode_to_vec(|buf| encode_ctx_unsigned(buf, 1, 42));

--- a/crates/bacnet-encoding/src/primitives/tests.rs
+++ b/crates/bacnet-encoding/src/primitives/tests.rs
@@ -498,6 +498,24 @@ fn property_value_context_tagged_rejects_unrepresentable_tag_numbers() {
 }
 
 #[test]
+fn property_value_context_tagged_list_error_preserves_existing_buffer() {
+    let value = context_tagged(
+        20,
+        PropertyValue::List(vec![
+            PropertyValue::Unsigned(1),
+            context_tagged(255, PropertyValue::Null),
+        ]),
+    );
+    let sentinel = [0xDE, 0xAD, 0xBE, 0xEF];
+    let mut bytes = BytesMut::from(&sentinel[..]);
+
+    let error = encode_property_value(&mut bytes, &value).unwrap_err();
+
+    assert!(error.to_string().contains("context tag number 255"));
+    assert_eq!(&bytes[..], sentinel);
+}
+
+#[test]
 fn ctx_unsigned_encoding() {
     let bytes = encode_to_vec(|buf| encode_ctx_unsigned(buf, 1, 42));
     // Context tag 1, length 1, value 42

--- a/crates/bacnet-objects/src/analog/tests/input_output.rs
+++ b/crates/bacnet-objects/src/analog/tests/input_output.rs
@@ -2,6 +2,13 @@ use super::super::*;
 use crate::event::LimitEnable;
 use bacnet_types::enums::EventState;
 
+fn context(tag_number: u32, value: PropertyValue) -> PropertyValue {
+    PropertyValue::ContextTagged {
+        tag_number,
+        value: Box::new(value),
+    }
+}
+
 // --- AnalogInput ---
 
 #[test]
@@ -87,13 +94,13 @@ fn ao_write_with_priority() {
     let slot = ao
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Real(50.0));
+    assert_eq!(slot, context(1, PropertyValue::Real(50.0)));
 
     // Priority array at index 1 should be Null
     let slot = ao
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(1))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Null);
+    assert_eq!(slot, context(0, PropertyValue::Null));
 }
 
 #[test]
@@ -576,7 +583,7 @@ fn ao_priority_array_read_all_slots_none_by_default() {
     if let PropertyValue::List(elements) = val {
         assert_eq!(elements.len(), 16);
         for elem in &elements {
-            assert_eq!(elem, &PropertyValue::Null);
+            assert_eq!(elem, &context(0, PropertyValue::Null));
         }
     } else {
         panic!("Expected List for priority array without index");
@@ -606,7 +613,7 @@ fn ao_direct_priority_array_write_value() {
     assert_eq!(
         ao.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
             .unwrap(),
-        PropertyValue::Real(42.0)
+        context(1, PropertyValue::Real(42.0))
     );
 }
 
@@ -638,7 +645,7 @@ fn ao_direct_priority_array_relinquish() {
     assert_eq!(
         ao.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
             .unwrap(),
-        PropertyValue::Null
+        context(0, PropertyValue::Null)
     );
 }
 

--- a/crates/bacnet-objects/src/analog/tests/value.rs
+++ b/crates/bacnet-objects/src/analog/tests/value.rs
@@ -1,6 +1,21 @@
 use super::super::*;
 use crate::event::LimitEnable;
+use bacnet_encoding::primitives::encode_property_value;
 use bacnet_types::enums::EventState;
+use bytes::BytesMut;
+
+fn encode_value(value: &PropertyValue) -> Vec<u8> {
+    let mut bytes = BytesMut::new();
+    encode_property_value(&mut bytes, value).unwrap();
+    bytes.to_vec()
+}
+
+fn context(tag_number: u32, value: PropertyValue) -> PropertyValue {
+    PropertyValue::ContextTagged {
+        tag_number,
+        value: Box::new(value),
+    }
+}
 
 // --- AnalogValue ---
 
@@ -64,13 +79,38 @@ fn av_write_with_priority() {
     let slot = av
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Real(55.0));
+    assert_eq!(slot, context(1, PropertyValue::Real(55.0)));
 
     // Priority array at index 1 should be Null
     let slot = av
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(1))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Null);
+    assert_eq!(slot, context(0, PropertyValue::Null));
+}
+
+#[test]
+fn av_priority_array_slots_encode_as_bacnet_priority_value_choices() {
+    let mut av = AnalogValueObject::new(1, "AV-1", 62).unwrap();
+    av.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Real(55.0),
+        Some(8),
+    )
+    .unwrap();
+
+    let null_slot = av
+        .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(1))
+        .unwrap();
+    assert_eq!(encode_value(&null_slot), vec![0x08]);
+
+    let real_slot = av
+        .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
+        .unwrap();
+    assert_eq!(
+        encode_value(&real_slot),
+        [vec![0x1c], 55.0_f32.to_be_bytes().to_vec()].concat()
+    );
 }
 
 #[test]
@@ -144,7 +184,7 @@ fn av_priority_array_read_all_slots_none_by_default() {
     if let PropertyValue::List(elements) = val {
         assert_eq!(elements.len(), 16);
         for elem in &elements {
-            assert_eq!(elem, &PropertyValue::Null);
+            assert_eq!(elem, &context(0, PropertyValue::Null));
         }
     } else {
         panic!("Expected List for priority array without index");
@@ -235,7 +275,7 @@ fn av_direct_priority_array_write_value() {
     assert_eq!(
         av.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
             .unwrap(),
-        PropertyValue::Real(42.0)
+        context(1, PropertyValue::Real(42.0))
     );
 }
 
@@ -264,7 +304,7 @@ fn av_direct_priority_array_relinquish() {
     assert_eq!(
         av.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
             .unwrap(),
-        PropertyValue::Null
+        context(0, PropertyValue::Null)
     );
 }
 

--- a/crates/bacnet-objects/src/binary/tests/input_output.rs
+++ b/crates/bacnet-objects/src/binary/tests/input_output.rs
@@ -1,5 +1,12 @@
 use super::super::*;
 
+fn context(tag_number: u32, value: PropertyValue) -> PropertyValue {
+    PropertyValue::ContextTagged {
+        tag_number,
+        value: Box::new(value),
+    }
+}
+
 #[test]
 fn bv_read_present_value_default() {
     let bv = BinaryValueObject::new(1, "BV-1").unwrap();
@@ -163,7 +170,7 @@ fn bo_write_with_priority() {
     let slot = bo
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Enumerated(1));
+    assert_eq!(slot, context(2, PropertyValue::Enumerated(1)));
 }
 
 #[test]
@@ -361,7 +368,7 @@ fn bo_priority_array_read_all_slots_none_by_default() {
     if let PropertyValue::List(elements) = val {
         assert_eq!(elements.len(), 16);
         for elem in &elements {
-            assert_eq!(elem, &PropertyValue::Null);
+            assert_eq!(elem, &context(0, PropertyValue::Null));
         }
     } else {
         panic!("Expected List for priority array without index");
@@ -388,7 +395,7 @@ fn bo_direct_priority_array_write_value() {
     assert_eq!(
         bo.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
             .unwrap(),
-        PropertyValue::Enumerated(1)
+        context(2, PropertyValue::Enumerated(1))
     );
 }
 

--- a/crates/bacnet-objects/src/binary/tests/value.rs
+++ b/crates/bacnet-objects/src/binary/tests/value.rs
@@ -1,4 +1,19 @@
 use super::super::*;
+use bacnet_encoding::primitives::encode_property_value;
+use bytes::BytesMut;
+
+fn encode_value(value: &PropertyValue) -> Vec<u8> {
+    let mut bytes = BytesMut::new();
+    encode_property_value(&mut bytes, value).unwrap();
+    bytes.to_vec()
+}
+
+fn context(tag_number: u32, value: PropertyValue) -> PropertyValue {
+    PropertyValue::ContextTagged {
+        tag_number,
+        value: Box::new(value),
+    }
+}
 
 #[test]
 fn bv_read_present_value_default() {
@@ -89,7 +104,24 @@ fn bv_write_with_priority() {
     let slot = bv
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Enumerated(1));
+    assert_eq!(slot, context(2, PropertyValue::Enumerated(1)));
+}
+
+#[test]
+fn bv_priority_array_slot_encodes_as_binary_bacnet_priority_value_choice() {
+    let mut bv = BinaryValueObject::new(1, "BV-1").unwrap();
+    bv.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Enumerated(1),
+        Some(8),
+    )
+    .unwrap();
+
+    let slot = bv
+        .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
+        .unwrap();
+    assert_eq!(encode_value(&slot), vec![0x29, 0x01]);
 }
 
 #[test]
@@ -130,7 +162,7 @@ fn bv_read_priority_array_all_none() {
     if let PropertyValue::List(elements) = val {
         assert_eq!(elements.len(), 16);
         for elem in &elements {
-            assert_eq!(elem, &PropertyValue::Null);
+            assert_eq!(elem, &context(0, PropertyValue::Null));
         }
     } else {
         panic!("Expected List for priority array without index");
@@ -172,7 +204,7 @@ fn bv_direct_priority_array_write() {
     assert_eq!(
         bv.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
             .unwrap(),
-        PropertyValue::Enumerated(1)
+        context(2, PropertyValue::Enumerated(1))
     );
 }
 

--- a/crates/bacnet-objects/src/common.rs
+++ b/crates/bacnet-objects/src/common.rs
@@ -564,6 +564,29 @@ macro_rules! write_event_properties {
 }
 pub(crate) use write_event_properties;
 
+/// Wrap one of the four standard `BACnetPriorityValue` CHOICE alternatives.
+///
+/// Other property-value kinds cannot be represented by this standard CHOICE
+/// and return an invalid-data-type protocol error.
+pub(crate) fn bacnet_priority_value(
+    value: bacnet_types::primitives::PropertyValue,
+) -> Result<bacnet_types::primitives::PropertyValue, bacnet_types::error::Error> {
+    use bacnet_types::primitives::PropertyValue;
+
+    let tag_number = match &value {
+        PropertyValue::Null => 0,
+        PropertyValue::Real(_) => 1,
+        PropertyValue::Enumerated(_) => 2,
+        PropertyValue::Unsigned(_) => 3,
+        _ => return Err(invalid_data_type_error()),
+    };
+
+    Ok(PropertyValue::ContextTagged {
+        tag_number,
+        value: Box::new(value),
+    })
+}
+
 /// Read a priority array property (handles array_index=None, Some(0), Some(1..=16)).
 ///
 /// `$wrap` is a closure/function that converts `T` into a `PropertyValue`.
@@ -576,17 +599,21 @@ macro_rules! read_priority_array {
                     .priority_array
                     .iter()
                     .map(|slot| match slot {
-                        Some(v) => wrap_fn(*v),
-                        None => bacnet_types::primitives::PropertyValue::Null,
+                        Some(v) => $crate::common::bacnet_priority_value(wrap_fn(*v)),
+                        None => $crate::common::bacnet_priority_value(
+                            bacnet_types::primitives::PropertyValue::Null,
+                        ),
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>, bacnet_types::error::Error>>()?;
                 Ok(bacnet_types::primitives::PropertyValue::List(elements))
             }
             Some(0) => Ok(bacnet_types::primitives::PropertyValue::Unsigned(16)),
             Some(idx) if (1..=16).contains(&idx) => {
                 match $self.priority_array[(idx - 1) as usize] {
-                    Some(v) => Ok(wrap_fn(v)),
-                    None => Ok(bacnet_types::primitives::PropertyValue::Null),
+                    Some(v) => $crate::common::bacnet_priority_value(wrap_fn(v)),
+                    None => $crate::common::bacnet_priority_value(
+                        bacnet_types::primitives::PropertyValue::Null,
+                    ),
                 }
             }
             _ => Err($crate::common::invalid_array_index_error()),

--- a/crates/bacnet-objects/src/lighting/tests.rs
+++ b/crates/bacnet-objects/src/lighting/tests.rs
@@ -1,5 +1,12 @@
 use super::*;
 
+fn context(tag_number: u32, value: PropertyValue) -> PropertyValue {
+    PropertyValue::ContextTagged {
+        tag_number,
+        value: Box::new(value),
+    }
+}
+
 // --- LightingOutputObject ---
 
 #[test]
@@ -116,13 +123,13 @@ fn lighting_output_priority_array_read() {
     let slot = obj
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Real(50.0));
+    assert_eq!(slot, context(1, PropertyValue::Real(50.0)));
 
     // Read empty slot 1
     let slot = obj
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(1))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Null);
+    assert_eq!(slot, context(0, PropertyValue::Null));
 }
 
 #[test]
@@ -347,13 +354,13 @@ fn binary_lighting_output_priority_array() {
     let slot = obj
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Enumerated(1));
+    assert_eq!(slot, context(2, PropertyValue::Enumerated(1)));
 
     // Read empty slot 1
     let slot = obj
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(1))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Null);
+    assert_eq!(slot, context(0, PropertyValue::Null));
 }
 
 #[test]

--- a/crates/bacnet-objects/src/multistate/tests/objects.rs
+++ b/crates/bacnet-objects/src/multistate/tests/objects.rs
@@ -1,4 +1,19 @@
 use super::super::*;
+use bacnet_encoding::primitives::encode_property_value;
+use bytes::BytesMut;
+
+fn encode_value(value: &PropertyValue) -> Vec<u8> {
+    let mut bytes = BytesMut::new();
+    encode_property_value(&mut bytes, value).unwrap();
+    bytes.to_vec()
+}
+
+fn context(tag_number: u32, value: PropertyValue) -> PropertyValue {
+    PropertyValue::ContextTagged {
+        tag_number,
+        value: Box::new(value),
+    }
+}
 
 // --- MultiStateInput ---
 
@@ -111,7 +126,7 @@ fn mso_write_with_priority() {
     let slot = mso
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Unsigned(3));
+    assert_eq!(slot, context(3, PropertyValue::Unsigned(3)));
 }
 
 #[test]
@@ -201,7 +216,24 @@ fn msv_write_with_priority() {
     let slot = msv
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
         .unwrap();
-    assert_eq!(slot, PropertyValue::Unsigned(2));
+    assert_eq!(slot, context(3, PropertyValue::Unsigned(2)));
+}
+
+#[test]
+fn msv_priority_array_slot_encodes_as_multistate_bacnet_priority_value_choice() {
+    let mut msv = MultiStateValueObject::new(1, "MSV-1", 3).unwrap();
+    msv.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Unsigned(2),
+        Some(8),
+    )
+    .unwrap();
+
+    let slot = msv
+        .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
+        .unwrap();
+    assert_eq!(encode_value(&slot), vec![0x39, 0x02]);
 }
 
 #[test]
@@ -242,7 +274,7 @@ fn msv_read_priority_array_all_none() {
     if let PropertyValue::List(elements) = val {
         assert_eq!(elements.len(), 16);
         for elem in &elements {
-            assert_eq!(elem, &PropertyValue::Null);
+            assert_eq!(elem, &context(0, PropertyValue::Null));
         }
     } else {
         panic!("Expected List for priority array without index");
@@ -332,7 +364,7 @@ fn msv_direct_priority_array_write_value() {
     assert_eq!(
         msv.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
             .unwrap(),
-        PropertyValue::Unsigned(3)
+        context(3, PropertyValue::Unsigned(3))
     );
 }
 
@@ -447,7 +479,7 @@ fn mso_direct_priority_array_write_value() {
     assert_eq!(
         mso.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
             .unwrap(),
-        PropertyValue::Unsigned(3)
+        context(3, PropertyValue::Unsigned(3))
     );
 }
 

--- a/crates/bacnet-objects/src/value_types/mod.rs
+++ b/crates/bacnet-objects/src/value_types/mod.rs
@@ -227,17 +227,17 @@ macro_rules! define_value_object_commandable {
                     .priority_array
                     .iter()
                     .map(|slot| match slot {
-                        Some(v) => wrap_fn(v),
-                        None => PropertyValue::Null,
+                        Some(v) => common::bacnet_priority_value(wrap_fn(v)),
+                        None => common::bacnet_priority_value(PropertyValue::Null),
                     })
-                    .collect();
+                    .collect::<Result<Vec<_>, Error>>()?;
                 Ok(PropertyValue::List(elements))
             }
             Some(0) => Ok(PropertyValue::Unsigned(16)),
             Some(idx) if (1..=16).contains(&idx) => {
                 match &$self.priority_array[(idx - 1) as usize] {
-                    Some(v) => Ok(wrap_fn(v)),
-                    None => Ok(PropertyValue::Null),
+                    Some(v) => common::bacnet_priority_value(wrap_fn(v)),
+                    None => common::bacnet_priority_value(PropertyValue::Null),
                 }
             }
             _ => Err(common::invalid_array_index_error()),

--- a/crates/bacnet-objects/src/value_types/tests.rs
+++ b/crates/bacnet-objects/src/value_types/tests.rs
@@ -1,5 +1,14 @@
 use super::*;
-use bacnet_types::enums::ObjectType;
+use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType};
+
+fn assert_invalid_data_type(error: Error) {
+    assert!(matches!(
+        error,
+        Error::Protocol { class, code }
+            if class == ErrorClass::PROPERTY.to_raw() as u32
+                && code == ErrorCode::INVALID_DATA_TYPE.to_raw() as u32
+    ));
+}
 
 // -----------------------------------------------------------------------
 // IntegerValueObject
@@ -731,10 +740,10 @@ fn value_object_priority_array_direct_write() {
     .unwrap();
 
     // Read back slot 5
-    let slot = obj
+    let error = obj
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
-        .unwrap();
-    assert_eq!(slot, PropertyValue::Signed(77));
+        .unwrap_err();
+    assert_invalid_data_type(error);
 
     // PV should reflect it
     let pv = obj
@@ -756,6 +765,24 @@ fn value_object_priority_array_direct_write() {
         .read_property(PropertyIdentifier::PRESENT_VALUE, None)
         .unwrap();
     assert_eq!(pv, PropertyValue::Signed(0));
+}
+
+#[test]
+fn integer_value_priority_array_rejects_non_standard_choice() {
+    let mut obj = IntegerValueObject::new(1, "IV-1").unwrap();
+    obj.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Signed(77),
+        Some(5),
+    )
+    .unwrap();
+
+    let error = obj
+        .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(5))
+        .unwrap_err();
+
+    assert_invalid_data_type(error);
 }
 
 #[test]

--- a/crates/bacnet-types/src/primitives.rs
+++ b/crates/bacnet-types/src/primitives.rs
@@ -4,7 +4,9 @@
 //! [`Time`], and the [`PropertyValue`] sum type.
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
+use alloc::{boxed::Box, string::String, vec::Vec};
+#[cfg(feature = "std")]
+use std::boxed::Box;
 
 use crate::enums::ObjectType;
 use crate::error::Error;
@@ -381,6 +383,18 @@ pub enum PropertyValue {
     /// (Clause 15.5.1). Each element is encoded as its own application-tagged
     /// value, concatenated in order.
     List(Vec<PropertyValue>),
+    /// A value encoded with a BACnet context tag rather than an application tag.
+    ///
+    /// Primitive values use a context tag header followed by their raw content.
+    /// A [`PropertyValue::List`] uses an opening/closing tag pair and preserves
+    /// the normal encoding of each contained value. Nested context-tagged
+    /// wrappers are rejected by the encoder.
+    ContextTagged {
+        /// Context tag number. Values greater than 254 are rejected by the encoder.
+        tag_number: u32,
+        /// Primitive or list value carried by the context tag.
+        value: Box<PropertyValue>,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -639,12 +639,16 @@ class PropertyValue:
     def list(items: list[PropertyValue]) -> PropertyValue:
         """Create a List (array) value from a list of PropertyValue items."""
         ...
+    @staticmethod
+    def context_tagged(tag_number: int, value: PropertyValue) -> PropertyValue:
+        """Wrap a primitive or list value in an explicit BACnet context tag."""
+        ...
 
     @property
     def tag(self) -> str:
         """Type tag: 'null', 'boolean', 'unsigned', 'signed', 'real', 'double',
         'octet_string', 'character_string', 'bit_string', 'enumerated',
-        'date', 'time', 'object_identifier'."""
+        'date', 'time', 'object_identifier', 'list', or 'context_tagged'."""
         ...
 
     @property

--- a/crates/rusty-bacnet/src/types/property_value.rs
+++ b/crates/rusty-bacnet/src/types/property_value.rs
@@ -75,6 +75,12 @@ fn property_value_to_py(py: Python<'_>, value: &primitives::PropertyValue) -> Py
             }
             list.into_any().unbind()
         }
+        primitives::PropertyValue::ContextTagged { tag_number, value } => {
+            let dict = pyo3::types::PyDict::new(py);
+            dict.set_item("tag_number", tag_number)?;
+            dict.set_item("value", property_value_to_py(py, value)?)?;
+            dict.into_any().unbind()
+        }
     })
 }
 
@@ -207,6 +213,20 @@ impl PyPropertyValue {
         }
     }
 
+    /// Wrap a primitive or list value in an explicit BACnet context tag.
+    ///
+    /// Tag numbers 0-254 are encodable. Larger values are retained here so
+    /// encoding can return a typed error instead of truncating the number.
+    #[staticmethod]
+    fn context_tagged(tag_number: u32, value: &PyPropertyValue) -> Self {
+        Self {
+            inner: primitives::PropertyValue::ContextTagged {
+                tag_number,
+                value: Box::new(value.inner.clone()),
+            },
+        }
+    }
+
     // -- Accessors -----------------------------------------------------------
 
     /// The BACnet type tag (e.g. "real", "unsigned", "boolean").
@@ -227,6 +247,7 @@ impl PyPropertyValue {
             primitives::PropertyValue::Time(_) => "time",
             primitives::PropertyValue::ObjectIdentifier(_) => "object_identifier",
             primitives::PropertyValue::List(_) => "list",
+            primitives::PropertyValue::ContextTagged { .. } => "context_tagged",
         }
     }
 
@@ -270,6 +291,10 @@ impl PyPropertyValue {
             primitives::PropertyValue::List(elements) => {
                 format!("PropertyValue.list(<{} elements>)", elements.len())
             }
+            primitives::PropertyValue::ContextTagged { tag_number, value } => {
+                let inner = Self::from_rust((**value).clone()).__repr__();
+                format!("PropertyValue.context_tagged({tag_number}, {inner})")
+            }
         }
     }
 
@@ -283,5 +308,50 @@ impl PyPropertyValue {
         std::mem::discriminant(&self.inner).hash(&mut h);
         format!("{:?}", self.inner).hash(&mut h);
         h.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn context_tagged_has_coherent_python_surface() {
+        let inner = PyPropertyValue::real(1.5);
+        let value = PyPropertyValue::context_tagged(1, &inner);
+
+        assert_eq!(value.tag(), "context_tagged");
+        assert_eq!(
+            value.__repr__(),
+            "PropertyValue.context_tagged(1, PropertyValue.real(1.5))"
+        );
+        assert_eq!(
+            value.inner,
+            primitives::PropertyValue::ContextTagged {
+                tag_number: 1,
+                value: Box::new(primitives::PropertyValue::Real(1.5)),
+            }
+        );
+
+        Python::attach(|py| {
+            let native = value.value(py).unwrap();
+            let dict = native.bind(py).cast::<pyo3::types::PyDict>().unwrap();
+            assert_eq!(
+                dict.get_item("tag_number")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<u32>()
+                    .unwrap(),
+                1
+            );
+            assert_eq!(
+                dict.get_item("value")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<f64>()
+                    .unwrap(),
+                1.5
+            );
+        });
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,6 +149,25 @@ pub trait BACnetObject: Send + Sync {
 
 `ObjectDatabase` stores `Box<dyn BACnetObject>` keyed by `ObjectIdentifier`, with secondary indexes by name (for WhoHas) and by type (for efficient enumeration).
 
+### Property value wire representation
+
+`PropertyValue` separates value structure from the tag class used on the wire.
+Primitive variants and an unwrapped `List` retain the existing application-tag
+encoding; `List` concatenates each element in order. `ContextTagged` pairs a
+tag number with a primitive or `List` `PropertyValue`. Primitives emit the
+context header plus raw content, while a `List` emits an opening/closing context
+tag pair around its normally encoded elements. The encoder accepts the
+repository tag range 0-254 and returns an encoding error for larger numbers or
+ambiguous nested `ContextTagged` wrappers.
+
+Commandable object `Priority_Array` reads use this representation for
+BACnetPriorityValue choices: Null is context [0], Real is context [1], binary
+Enumerated is context [2], and multi-state Unsigned is context [3]. This applies
+to whole-array elements and indexed slots. Array index 0 remains an application
+Unsigned array length. Priority arrays whose element type is outside these four
+standard CHOICE alternatives return an invalid-data-type protocol error instead
+of inventing additional context tags.
+
 ## Concurrency Model
 
 The stack runs on a Tokio multi-threaded runtime.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -162,6 +162,7 @@ PropertyValue.date(2026, 3, 21, 6)    # year, month, day, day_of_week (1=Mon)
 PropertyValue.time(14, 30, 0, 0)      # hour, minute, second, hundredths
 PropertyValue.bit_string(0, b"\xff")  # unused_bits, data
 PropertyValue.list([PropertyValue.unsigned(1), PropertyValue.unsigned(2)])
+PropertyValue.context_tagged(1, PropertyValue.real(72.5))
 ```
 
 ### Accessors
@@ -170,6 +171,11 @@ PropertyValue.list([PropertyValue.unsigned(1), PropertyValue.unsigned(2)])
 v = PropertyValue.real(72.5)
 v.tag     # "real"
 v.value   # 72.5 (native Python float)
+
+choice = PropertyValue.context_tagged(1, v)
+choice.tag    # "context_tagged"
+choice.value  # {"tag_number": 1, "value": 72.5}
+# repr(choice) == "PropertyValue.context_tagged(1, PropertyValue.real(72.5))"
 ```
 
 | Tag | Python `.value` type |
@@ -188,6 +194,14 @@ v.value   # 72.5 (native Python float)
 | `"date"` | `tuple(year, month, day, day_of_week)` |
 | `"time"` | `tuple(hour, minute, second, hundredths)` |
 | `"list"` | `list` of native Python values |
+| `"context_tagged"` | `dict` with `"tag_number"` and native `"value"` |
+
+Context tag numbers 0-254 are encodable. The constructor retains the supplied
+integer so an out-of-range tag fails during BACnet encoding instead of being
+silently truncated. A context-tagged `list` is encoded as a constructed value
+with an opening/closing tag pair; an unwrapped `list` retains concatenated
+application-tagged element encoding. Nested context-tagged wrappers are rejected
+with an encoding error because their construction semantics are ambiguous.
 
 ---
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -50,6 +50,12 @@ let val = PropertyValue::Real(72.5);
 let val = PropertyValue::Boolean(true);
 let val = PropertyValue::CharacterString("hello".into());
 let val = PropertyValue::Null;
+
+// Explicit context tag; tag numbers 0-254 are encodable.
+let val = PropertyValue::ContextTagged {
+    tag_number: 1,
+    value: Box::new(PropertyValue::Real(72.5)),
+};
 ```
 
 ### Error
@@ -78,13 +84,28 @@ use bytes::BytesMut;
 
 // Encode
 let mut buf = BytesMut::new();
-encode_property_value(&mut buf, &PropertyValue::Real(72.5));
+encode_property_value(&mut buf, &PropertyValue::Real(72.5))?;
 let bytes = buf.to_vec();
 
 // Decode
 let (value, bytes_consumed) = decode_application_value(&bytes, 0)?;
 assert_eq!(value, PropertyValue::Real(72.5));
+
+// Context-tagged primitive: context [1], four Real content octets.
+let context_value = PropertyValue::ContextTagged {
+    tag_number: 1,
+    value: Box::new(PropertyValue::Real(72.5)),
+};
+let mut context_buf = BytesMut::new();
+encode_property_value(&mut context_buf, &context_value)?;
+assert_eq!(context_buf[0], 0x1c);
 ```
+
+`PropertyValue::List` keeps its existing behavior: its elements are encoded as
+concatenated application-tagged values. Wrapping a `List` in
+`ContextTagged` emits an opening/closing context tag pair around those elements.
+Tag numbers above 254 and nested `ContextTagged` wrappers return
+`Error::Encoding`; tag numbers are never truncated.
 
 ### APDU Types
 


### PR DESCRIPTION
## Summary

- Encode server-side BACnetPriorityValue values with the standard Null `[0]`, Real `[1]`, Enumerated `[2]`, and Unsigned `[3]` context choice tags.
- Preserve the choice tag explicitly in `PropertyValue::ContextTagged` instead of inferring it from payload bytes.
- Reject unsupported, oversized, or nested context values with typed errors.
- Keep context-value encoding atomic so an error does not leave partial bytes in the destination buffer.

## Root cause and current scope

Priority-array object values were represented as ordinary application values. Server responses therefore emitted application tags where BACnetPriorityValue requires a context-tagged CHOICE, so the value type could not be represented correctly on the wire.

This Draft establishes the encoding-side representation and propagates it through priority-array object implementations. It also includes CLI and Python surface plumbing for the new representation.

The generic client decoder still rejects context-tagged values. Property-aware decoding from a Priority_Array read response into Rust, Python, and CLI values is not yet implemented, so this Draft does not claim end-to-end client round trips.

## API and compatibility

`PropertyValue` gains a public `ContextTagged` variant and Python values expose the context tag. Because the Rust enum is public and not `#[non_exhaustive]`, this can break downstream exhaustive matches even though existing constructors and application-tag encodings are unchanged. Maintainer guidance on the preferred compatibility treatment is welcome before this PR is marked Ready.

Unsupported context tags, tag numbers above 254, and nested context values are rejected rather than silently emitted with ambiguous wire semantics.

## Validation

Local validation on `e8ab7fbd66606667be617e8e2c4d1fa85fafd486`:

- `cargo fmt --all --check`
- `git diff --check origin/dev...HEAD`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `cargo test -p bacnet-types -p bacnet-encoding -p bacnet-objects --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked`

The existing missing-docs warning baseline remains unchanged. Upstream PR CI is waiting for maintainer approval to run because this is a first-time external fork contribution.

## Draft gates before Ready

- Decide whether this PR remains an encoding-side fix or adds property-aware Priority_Array client decoding and end-to-end tests.
- Resolve the public enum compatibility approach with maintainer input.
- Add the accepted behavior and API impact to `CHANGELOG.md`.
- Run the upstream Tier-1 CI after workflow approval; add a Python wheel/import smoke if the Python surface remains in scope.

## Review focus

- Context-tag encoding and rejection boundaries in `bacnet-encoding`.
- Priority-array encoding across analog, binary, multistate, lighting, and value objects.
- Preferred public API shape for representing context-tagged BACnet CHOICE values.