### PR TITLE
test(objects): lock Priority_Array application tags

### DIFF
--- a/crates/bacnet-objects/src/analog/tests/input_output.rs
+++ b/crates/bacnet-objects/src/analog/tests/input_output.rs
@@ -1,6 +1,8 @@
 use super::super::*;
 use crate::event::LimitEnable;
+use bacnet_encoding::primitives::encode_property_value;
 use bacnet_types::enums::EventState;
+use bytes::BytesMut;
 
 // --- AnalogInput ---
 
@@ -94,6 +96,26 @@ fn ao_write_with_priority() {
         .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(1))
         .unwrap();
     assert_eq!(slot, PropertyValue::Null);
+}
+
+#[test]
+fn ashrae_135_2020_clause_21_bacnet_priority_value_real_uses_application_tag() {
+    let mut ao = AnalogOutputObject::new(1, "AO-1", 62).unwrap();
+    ao.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Real(50.0),
+        Some(8),
+    )
+    .unwrap();
+
+    let priority_value = ao
+        .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
+        .unwrap();
+    let mut encoded = BytesMut::new();
+    encode_property_value(&mut encoded, &priority_value).unwrap();
+
+    assert_eq!(encoded.as_ref(), &[0x44, 0x42, 0x48, 0x00, 0x00]);
 }
 
 #[test]

--- a/crates/bacnet-objects/src/analog/tests/input_output.rs
+++ b/crates/bacnet-objects/src/analog/tests/input_output.rs
@@ -99,7 +99,7 @@ fn ao_write_with_priority() {
 }
 
 #[test]
-fn ashrae_135_2020_clause_21_bacnet_priority_value_real_uses_application_tag() {
+fn ao_priority_array_real_encodes_as_application_value() {
     let mut ao = AnalogOutputObject::new(1, "AO-1", 62).unwrap();
     ao.write_property(
         PropertyIdentifier::PRESENT_VALUE,


### PR DESCRIPTION
## Summary

Add one regression test that locks the standards-correct wire encoding of a primitive `BACnetPriorityValue` read from `Priority_Array`.

The test exercises the real object path:

1. write `Real(50.0)` to an `AnalogOutputObject` at priority 8;
2. read indexed `Priority_Array[8]`;
3. encode the returned property value;
4. require the complete BACnet REAL application encoding `44 42 48 00 00`.

## Why a test-only change is necessary

The production implementation on `dev` is already correct. The missing coverage is at the boundary between the commandable object model and the wire encoder:

- `ao_write_with_priority` verifies that an occupied indexed slot returns `PropertyValue::Real(50.0)` and an empty slot returns `PropertyValue::Null`;
- the generic encoding tests independently verify application-value encoding;
- no existing test passes a value returned by `Priority_Array` through `encode_property_value` and asserts the exact tag class and bytes.

That gap matters because an object-layer change can preserve the apparent value while wrapping it in a context tag. The object tests and generic encoder tests can each remain internally consistent, while the resulting `Priority_Array` wire representation violates the standard. This regression joins those two layers and locks the observable protocol boundary.

## Standards basis

ANSI/ASHRAE Standard 135-2020 Clause 21 defines primitive `BACnetPriorityValue` alternatives as application values. Explicit context tagging is used for the constructed-value alternative, so primitive REAL uses application tag 4 rather than context tag 1.

Official standard landing page: https://www.ashrae.org/technical-resources/bookstore/bacnet

ASHRAE interpretation confirming the application-type alternatives and context-tagged constructed-value option: https://bacnet.org/wp-content/uploads/sites/4/2022/08/IC-135-2004-24.pdf

## Regression proof

The same test was applied in a disposable worktree to faulty branch state `bdcfd270524ac89ed38844106a7097a1814bb529`, which contains the non-standard object wrapping introduced by its ancestor `9b2d967c8c360244f22a3ae1a01b537758e691b3`.

- Faulty bytes: `1c 42 48 00 00`
- Required bytes: `44 42 48 00 00`
- Focused test exit: 101, expected assertion failure

## Verification

- renamed focused regression: 1 passed
- `bacnet-objects`: 739 passed
- workspace excluding binding crates: 2,119 passed on the original test commit
- `cargo fmt --all --check`: passed
- clippy: passed with existing warning-level diagnostics only on the original test commit
- file-size and no-secret guards: passed on the original test commit
- `git diff --check`: passed

## Scope

One test file. No production implementation, API, documentation, CI, dependency, or generated-artifact changes.
