### PR TITLE
fix(types): correct swapped AUDIT_LOG/AUDIT_REPORTER ObjectType codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ dist/
 
 # AI assistants
 codex-id.json
+codex-overnight-status.md
 .claude/
 CLAUDE.md
 .copilot/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct the `AUDIT_LOG` and `AUDIT_REPORTER` `ObjectType` constants to match ASHRAE 135-2020 Clause 21.6 (`audit-log = 61`, `audit-reporter = 62`). The constants were previously swapped (`AUDIT_REPORTER = 61`, `AUDIT_LOG = 62`), so `AuditLog` and `AuditReporter` objects encoded each other's object type on the wire and in the `OBJECT_TYPE` property. Downstream consumers that persisted, logged, or matched on the prior raw values should re-key AuditLog as type `61` and AuditReporter as type `62`.
+
 ## [0.10.1]
 
 ### Added

--- a/crates/bacnet-objects/src/audit.rs
+++ b/crates/bacnet-objects/src/audit.rs
@@ -1,4 +1,4 @@
-//! AuditLog (type 62) and AuditReporter (type 61) objects per Addendum 135-2016bj.
+//! AuditLog (type 61) and AuditReporter (type 62) objects per Addendum 135-2016bj.
 
 use std::borrow::Cow;
 use std::collections::VecDeque;
@@ -11,7 +11,7 @@ use crate::common::read_property_list_property;
 use crate::traits::BACnetObject;
 
 // ---------------------------------------------------------------------------
-// AuditLog (type 62)
+// AuditLog (type 61)
 // ---------------------------------------------------------------------------
 
 /// A single audit log record.
@@ -184,7 +184,7 @@ impl BACnetObject for AuditLogObject {
 }
 
 // ---------------------------------------------------------------------------
-// AuditReporter (type 61)
+// AuditReporter (type 62)
 // ---------------------------------------------------------------------------
 
 /// BACnet AuditReporter object — configures which audit notifications to send.

--- a/crates/bacnet-objects/src/device/mod.rs
+++ b/crates/bacnet-objects/src/device/mod.rs
@@ -282,8 +282,8 @@ impl DeviceObject {
             ObjectType::ESCALATOR.to_raw(),
             ObjectType::LIFT.to_raw(),
             ObjectType::STAGING.to_raw(),
-            ObjectType::AUDIT_REPORTER.to_raw(),
             ObjectType::AUDIT_LOG.to_raw(),
+            ObjectType::AUDIT_REPORTER.to_raw(),
             ObjectType::COLOR.to_raw(),
             ObjectType::COLOR_TEMPERATURE.to_raw(),
         ]);

--- a/crates/bacnet-types/src/enums/object_type.rs
+++ b/crates/bacnet-types/src/enums/object_type.rs
@@ -73,9 +73,9 @@ bacnet_enum! {
     /// New in 135-2020.
     const STAGING = 60;
     /// New in 135-2020.
-    const AUDIT_REPORTER = 61;
+    const AUDIT_LOG = 61;
     /// New in 135-2020.
-    const AUDIT_LOG = 62;
+    const AUDIT_REPORTER = 62;
     /// New in 135-2020.
     const COLOR = 63;
     /// New in 135-2020.

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -20,6 +20,30 @@ fn object_type_display_known() {
     assert_eq!(format!("{:?}", ObjectType::DEVICE), "ObjectType::DEVICE");
 }
 
+/// Standard 135-2020 Clause 21.6 (`BACnetObjectType ::= ENUMERATED`) assigns
+/// `audit-log (61)` and `audit-reporter (62)`. Guard against a swap regression:
+/// the constants were previously reversed (`AUDIT_REPORTER = 61`, `AUDIT_LOG
+/// = 62`), which encoded the wrong object type on the wire.
+#[test]
+fn object_type_audit_codes_match_clause_21_6() {
+    assert_eq!(ObjectType::AUDIT_LOG.to_raw(), 61);
+    assert_eq!(ObjectType::AUDIT_REPORTER.to_raw(), 62);
+    assert_eq!(ObjectType::from_raw(61), ObjectType::AUDIT_LOG);
+    assert_eq!(ObjectType::from_raw(62), ObjectType::AUDIT_REPORTER);
+
+    // Lock the on-wire ObjectIdentifier encoding, not just the enum value:
+    // the high 10 bits of a 4-byte OID carry the object type, so an AuditLog
+    // (type 61) instance 1 must encode as `(61 << 22) | 1` big-endian.
+    let audit_log = crate::primitives::ObjectIdentifier::new(ObjectType::AUDIT_LOG, 1).unwrap();
+    assert_eq!(audit_log.encode(), ((61u32 << 22) | 1u32).to_be_bytes());
+    let audit_reporter =
+        crate::primitives::ObjectIdentifier::new(ObjectType::AUDIT_REPORTER, 1).unwrap();
+    assert_eq!(
+        audit_reporter.encode(),
+        ((62u32 << 22) | 1u32).to_be_bytes()
+    );
+}
+
 #[test]
 fn property_identifier_round_trip() {
     assert_eq!(PropertyIdentifier::PRESENT_VALUE.to_raw(), 85);


### PR DESCRIPTION
## Summary

Corrects the `AUDIT_LOG` and `AUDIT_REPORTER` `ObjectType` constants, which were swapped relative to ASHRAE Standard 135-2020 Clause 21.6 (`BACnetObjectType ::= ENUMERATED`): the Standard assigns `audit-log = 61` and `audit-reporter = 62`, but the code had `AUDIT_REPORTER = 61` and `AUDIT_LOG = 62`. As a result, `AuditLog` and `AuditReporter` objects encoded each other's object type on the wire and in the `OBJECT_TYPE` property.

Closes the open conformance work item _"Fix swapped BACnet Audit Log/Reporter ObjectType codes"_. Research and adversarial review ran as Opus-agent workflows (4 research agents → 3 independent reviewers + verify).

## Standard anchor

ASHRAE 135-2020 Clause 21.6 (`BACnetObjectType ::= ENUMERATED`, printed p.919 / PDF p.921) assigns `audit-log (61)` and `audit-reporter (62)`. This is corroborated twice more in the same clause: the `BACnetPropertyIdentifier` cross-reference comments (PDF p.921) and the `BACnetObjectTypesSupported ::= BIT STRING` (PDF p.922-923). A full-text search of the Standard found zero occurrences of the swapped pattern (`audit-log (62)` / `audit-reporter (61)`) — no addenda or contradicting clause. The authoritative source is Clause 21.6, not Clause 12 or an annex.

## Changes

- `crates/bacnet-types/src/enums/object_type.rs`: swap the constants to `AUDIT_LOG = 61`, `AUDIT_REPORTER = 62`.
- `crates/bacnet-objects/src/audit.rs`: correct three module/section header comments that hardcoded the old (wrong) values.
- `crates/bacnet-objects/src/device/mod.rs`: reorder the `Protocol_Object_Types_Supported` input list to numeric order (`AUDIT_LOG` before `AUDIT_REPORTER`). Functionally a no-op — `compute_object_types_supported` ORs bits and is order-insensitive — but removes a readability hazard for future reviewers auditing the list against the Standard.
- `crates/bacnet-types/src/enums/tests.rs`: add `object_type_audit_codes_match_clause_21_6`, a regression test asserting both the enum mapping (`to_raw`/`from_raw`) and the 4-byte `ObjectIdentifier` wire encoding (`(61 << 22) | 1` for AuditLog, `(62 << 22) | 1` for AuditReporter). No existing test bound these constants to the Standard.
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`.
- `.gitignore`: ignore `codex-overnight-status.md` (local Codex handoff artifact; was already untracked, now ignored so it cannot be committed by accident).

## Wire impact (behavior change)

This is a wire-value change. An `AuditLog` object that previously encoded its object type as `62` now encodes `61`; `AuditReporter` flips `61` → `62`. This affects the 4-byte `ObjectIdentifier` and the `OBJECT_TYPE` property. Downstream consumers that persisted, logged, or matched on the prior raw values should re-key AuditLog as type `61` and AuditReporter as type `62`. The `CHANGELOG` entry documents this.

No call-site edits were required: every one of the 11+ usages references the constants by symbolic name (`ObjectType::AUDIT_LOG` / `AUDIT_REPORTER` via `to_raw()` / `ObjectIdentifier::new`), so the swap propagates at compile time. Verified no golden-byte/serialization fixtures, `.pyi` stubs, CLI numeric-parse paths, or PICS output hardcode the wrong numeric. `ObjectIdentifier` packs the type into 10 high bits; `61` and `62` are distinct with no collision risk.

## Validation

- `cargo fmt --all --check`
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --quiet` — pass
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked --quiet` — pass (existing `missing_docs` warn-level noise only)
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked` — pass
- `cargo check -p rusty-bacnet --tests --locked` — pass (Python bindings)
- `cargo test -p bacnet-integration-tests generated_support_docs_are_current_with_ledger --locked --quiet` — pass (ledger guard)
- `bash .github/scripts/check-file-size.sh` — pass (700 LOC cap)
- `git diff --check` — pass
- New regression test `object_type_audit_codes_match_clause_21_6` — pass; existing `audit_log_read_object_type` / `audit_reporter_read_object_type` and `read_protocol_object_types_supported` self-adjust and pass.

No benchmarks were run; this is a constant-value correctness fix with no performance-sensitive path change, so no performance claim is made.

## Review

Three independent Opus reviewers (spec-adherence, correctness/blast-radius, completeness-critic) plus an adversarial verify pass on each major/major+ finding:

- **Spec adherence: APPROVE.** Re-verified the Clause 21.6 codes from the PDF; enum declaration order and doc-comment citation confirmed accurate.
- **Correctness / blast radius: APPROVE.** Exhaustive grep across all crates, tests, examples, `.pyi`, and fixtures found no site that encodes a wrong numeric; OID bit-packing and `bacnet_enum!` Debug/Display match arms confirmed non-colliding and exhaustive.
- **Completeness: APPROVE-WITH-NITS.** One major (confirmed on verify): no CHANGELOG entry for the wire-value change — addressed by adding the `[Unreleased] → Fixed` entry. Two minors addressed (strengthened the regression test to assert the wire encoding; reordered the device PICS list to numeric). Remaining nits (auto-generated `.pyi` stub order; adding a clause cite directly on the const) deliberately not addressed — no functional impact, out of scope for a two-constant fix.

## Remaining gaps / out of scope

- The conformance ledger (`docs/conformance/bacnet-135-2020.json`) is clause/annex-oriented and has no audit object-type rows; nothing to correct there. Adding object-type-oriented ledger rows would be a structural scope expansion and was intentionally not done. A future reviewer auditing "which object types does this stack claim to support and at what code?" should treat `object_type.rs` as the source of truth (now pinned by the new test).
- No release-note write-up beyond the `CHANGELOG` entry (per the chosen tranche scope); a tagged release would carry the `[Unreleased]` entry forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)