### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Clears the pre-existing **Cargo Audit** CI failure that was red on `dev` and every PR (including #139 and #140). `crossbeam-epoch 0.9.18` is flagged by [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) — invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared`. The fix is `>=0.9.20`.

A targeted `cargo update -p crossbeam-epoch` bumps only that one package (`0.9.18 → 0.9.20`), which is semver-compatible with `crossbeam-deque 0.8.6`'s `^0.9.17` requirement. **No source changes; `Cargo.lock` only.**

## Why it's a transitive/bench-only dependency

`crossbeam-epoch` enters via the benchmark toolchain:

```
bacnet-benchmarks → criterion 0.8.2 → rayon 1.12.0 → crossbeam-deque 0.8.6 → crossbeam-epoch 0.9.18
```

It does **not** appear in any production crate's dependency graph (`deny.toml` already excludes `bacnet-benchmarks` from its graph, which is why `cargo deny` passed while `cargo audit` failed — `cargo audit` scans the whole `Cargo.lock` with no exclusions).

## Out of scope

The separate `anyhow` advisory [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) (`Error::downcast_mut()` unsoundness, via the WASM/wit-bindgen toolchain) remains as an **allowed warning** and is not addressed by this bump.

## Validation

- `cargo audit` — **exit 0** (only the allowed `RUSTSEC-2026-0190` warning remains; no new advisories).
- `cargo deny check` — **advisories ok, bans ok, licenses ok, sources ok**.
- `RUSTUP_TOOLCHAIN=1.93 cargo check --workspace --locked` — **pass** (MSRV 1.93 preserved; `crossbeam-epoch 0.9.20` builds under 1.93).
- `cargo fmt --all --check` — pass.
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked --quiet` — pass.
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked` — pass.
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown --locked` — pass.
- `cargo check -p rusty-bacnet --tests --locked` — pass.
- `bash .github/scripts/check-file-size.sh` — pass.

## Diff

`Cargo.lock` only — one package, version + checksum, no dependency-edge changes:

```diff
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)