### PR TITLE
fix(pics): derive writability/createability from object capability methods (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `BACnetObject::is_writable_property`, `BACnetObject::is_createable`, and `BACnetObject::is_deleteable` trait methods (with conservative defaults that preserve current behavior for unmigrated object types) so PICS generation and runtime dispatch share one truth source for property writability and object createability. The `bacnet-objects` crate is a public dependency; downstream implementors of `BACnetObject` now have these methods available to override (defaults preserve existing PICS output).
+
 ### Fixed
 
-- Correct the `AUDIT_LOG` and `AUDIT_REPORTER` `ObjectType` constants to match ASHRAE 135-2020 Clause 21.6 (`audit-log = 61`, `audit-reporter = 62`). The constants were previously swapped (`AUDIT_REPORTER = 61`, `AUDIT_LOG = 62`), so `AuditLog` and `AuditReporter` objects encoded each other's object type on the wire and in the `OBJECT_TYPE` property. Downstream consumers that persisted, logged, or matched on the prior raw values should re-key AuditLog as type `61` and AuditReporter as type `62`.
+- Correct PICS writable-property flags for the 9 core I/O/V object types (AnalogInput/Output/Value, BinaryInput/Output/Value, MultiStateInput/Output/Value) so they mirror the objects' real `write_property` arms. The previous static heuristic omitted 33 writable routes that the objects actually accept — `LIMIT_ENABLE`, `EVENT_ENABLE`, `NOTIFY_TYPE`, `TIME_DELAY`, `NOTIFICATION_CLASS`, `HIGH_LIMIT`, `LOW_LIMIT`, `DEADBAND` (event-capable analog types), `PRIORITY_ARRAY` (commandable types), `STATE_TEXT` (multistate types), and `PRESENT_VALUE` on input types (writable when out-of-service) — producing false-negatives in PICS. Writability is now derived from the object's own `is_writable_property` capability method, so PICS and runtime dispatch cannot drift apart.
+- Stop over-reporting `AnalogValue` as createable in PICS. The static heuristic declared all types createable except Device and NetworkPort, but `handle_create_object` has no branch for `AnalogValue` (it falls through to `UNSUPPORTED_OBJECT_TYPE`). `is_createable` now returns `true` only for the 8 types the runtime factory actually constructs (AI, AO, BI, BO, BV, MSI, MSO, MSV); `AnalogValue` is `false` until/unless a later PR adds the factory branch.
+- Stop over-reporting `Device` as deleteable via the static heuristic; `Device` and `NetworkPort` now override `is_deleteable` to `false` on the objects themselves.
+- Reconcile `handle_delete_object` with `is_deleteable`: the runtime DeleteObject handler now rejects `NetworkPort` (matching its `is_deleteable` override) in addition to `Device`, so PICS and runtime dispatch share one truth source for deleteability with no remaining drift.
 
 ## [0.10.1]
 

--- a/crates/bacnet-objects/src/analog/mod.rs
+++ b/crates/bacnet-objects/src/analog/mod.rs
@@ -237,6 +237,19 @@ impl BACnetObject for AnalogInputObject {
         self.event_detector.acked_transitions |= transition_bit & 0x07;
         Ok(())
     }
+
+    fn is_createable(&self) -> bool {
+        true
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        // Mirrors the AnalogInput `write_property` arms.
+        common::is_common_writable(property)
+            || property == PropertyIdentifier::PRESENT_VALUE
+            || property == PropertyIdentifier::RELIABILITY
+            || property == PropertyIdentifier::COV_INCREMENT
+            || common::is_event_property_writable(property)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -491,6 +504,20 @@ impl BACnetObject for AnalogOutputObject {
     fn acknowledge_alarm(&mut self, transition_bit: u8) -> Result<(), bacnet_types::error::Error> {
         self.event_detector.acked_transitions |= transition_bit & 0x07;
         Ok(())
+    }
+
+    fn is_createable(&self) -> bool {
+        true
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        // Mirrors the AnalogOutput `write_property` arms: commandable
+        // (PRIORITY_ARRAY + PRESENT_VALUE) + common + event properties.
+        common::is_commandable_property_writable(property)
+            || common::is_common_writable(property)
+            || property == PropertyIdentifier::RELIABILITY
+            || property == PropertyIdentifier::COV_INCREMENT
+            || common::is_event_property_writable(property)
     }
 }
 
@@ -758,6 +785,22 @@ impl BACnetObject for AnalogValueObject {
     fn acknowledge_alarm(&mut self, transition_bit: u8) -> Result<(), bacnet_types::error::Error> {
         self.event_detector.acked_transitions |= transition_bit & 0x07;
         Ok(())
+    }
+
+    /// AnalogValue is NOT createable: `handle_create_object` has no branch for
+    /// it, so PICS must not advertise createability the runtime rejects.
+    fn is_createable(&self) -> bool {
+        false
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        // Mirrors the AnalogValue `write_property` arms. Same set as
+        // AnalogOutput (commandable + common + event properties).
+        common::is_commandable_property_writable(property)
+            || common::is_common_writable(property)
+            || property == PropertyIdentifier::RELIABILITY
+            || property == PropertyIdentifier::COV_INCREMENT
+            || common::is_event_property_writable(property)
     }
 }
 

--- a/crates/bacnet-objects/src/analog/tests/input_output.rs
+++ b/crates/bacnet-objects/src/analog/tests/input_output.rs
@@ -700,3 +700,64 @@ fn ao_direct_priority_array_index_17_error() {
     );
     assert!(result.is_err());
 }
+
+// ── Trait capability method tests (issue #115 shared truth source) ──────────
+
+#[test]
+fn ai_is_createable_matches_factory() {
+    use crate::traits::BACnetObject;
+    let ai = AnalogInputObject::new(1, "ai-1", 95).unwrap();
+    assert!(ai.is_createable(), "AnalogInput is factory-constructable");
+}
+
+#[test]
+fn ai_is_writable_property_mirrors_write_property() {
+    use crate::traits::BACnetObject;
+    let ai = AnalogInputObject::new(1, "ai-1", 95).unwrap();
+    // Event properties accepted via write_event_properties! — the old
+    // heuristic omitted these (false-negatives).
+    assert!(ai.is_writable_property(PropertyIdentifier::LIMIT_ENABLE));
+    assert!(ai.is_writable_property(PropertyIdentifier::NOTIFY_TYPE));
+    assert!(ai.is_writable_property(PropertyIdentifier::TIME_DELAY));
+    assert!(ai.is_writable_property(PropertyIdentifier::EVENT_ENABLE));
+    assert!(ai.is_writable_property(PropertyIdentifier::NOTIFICATION_CLASS));
+    // Common + RELIABILITY + COV_INCREMENT.
+    assert!(ai.is_writable_property(PropertyIdentifier::OUT_OF_SERVICE));
+    assert!(ai.is_writable_property(PropertyIdentifier::OBJECT_NAME));
+    assert!(ai.is_writable_property(PropertyIdentifier::DESCRIPTION));
+    assert!(ai.is_writable_property(PropertyIdentifier::RELIABILITY));
+    assert!(ai.is_writable_property(PropertyIdentifier::COV_INCREMENT));
+    // PRESENT_VALUE accepted when out-of-service.
+    assert!(ai.is_writable_property(PropertyIdentifier::PRESENT_VALUE));
+    // Universal read-only.
+    assert!(!ai.is_writable_property(PropertyIdentifier::OBJECT_IDENTIFIER));
+    assert!(!ai.is_writable_property(PropertyIdentifier::OBJECT_TYPE));
+    assert!(!ai.is_writable_property(PropertyIdentifier::PROPERTY_LIST));
+    assert!(!ai.is_writable_property(PropertyIdentifier::STATUS_FLAGS));
+    // Not accepted by AI write_property.
+    assert!(!ai.is_writable_property(PropertyIdentifier::PRIORITY_ARRAY));
+    assert!(!ai.is_writable_property(PropertyIdentifier::RELINQUISH_DEFAULT));
+}
+
+#[test]
+fn ao_is_createable_matches_factory() {
+    use crate::traits::BACnetObject;
+    let ao = AnalogOutputObject::new(1, "ao-1", 95).unwrap();
+    assert!(ao.is_createable(), "AnalogOutput is factory-constructable");
+}
+
+#[test]
+fn ao_is_writable_property_mirrors_write_property() {
+    use crate::traits::BACnetObject;
+    let ao = AnalogOutputObject::new(1, "ao-1", 95).unwrap();
+    // Commandable.
+    assert!(ao.is_writable_property(PropertyIdentifier::PRIORITY_ARRAY));
+    assert!(ao.is_writable_property(PropertyIdentifier::PRESENT_VALUE));
+    // Event + common.
+    assert!(ao.is_writable_property(PropertyIdentifier::LIMIT_ENABLE));
+    assert!(ao.is_writable_property(PropertyIdentifier::NOTIFY_TYPE));
+    assert!(ao.is_writable_property(PropertyIdentifier::TIME_DELAY));
+    assert!(ao.is_writable_property(PropertyIdentifier::OUT_OF_SERVICE));
+    // RELINQUISH_DEFAULT has no write arm.
+    assert!(!ao.is_writable_property(PropertyIdentifier::RELINQUISH_DEFAULT));
+}

--- a/crates/bacnet-objects/src/analog/tests/value.rs
+++ b/crates/bacnet-objects/src/analog/tests/value.rs
@@ -599,3 +599,31 @@ fn ai_property_list_invalid_index_returns_error() {
     let result = ai.read_property(PropertyIdentifier::PROPERTY_LIST, Some(count + 1));
     assert!(result.is_err());
 }
+
+// ── Trait capability method tests (issue #115 shared truth source) ──────────
+
+#[test]
+fn av_is_not_createable_matches_factory() {
+    use crate::traits::BACnetObject;
+    let av = AnalogValueObject::new(1, "av-1", 95).unwrap();
+    // handle_create_object has NO branch for ANALOG_VALUE — it falls through
+    // to UNSUPPORTED_OBJECT_TYPE. PICS must not advertise createability.
+    assert!(!av.is_createable(), "AnalogValue must NOT be createable");
+}
+
+#[test]
+fn av_is_writable_property_mirrors_write_property() {
+    use crate::traits::BACnetObject;
+    let av = AnalogValueObject::new(1, "av-1", 95).unwrap();
+    // Commandable (same as AO).
+    assert!(av.is_writable_property(PropertyIdentifier::PRIORITY_ARRAY));
+    assert!(av.is_writable_property(PropertyIdentifier::PRESENT_VALUE));
+    // Event properties.
+    assert!(av.is_writable_property(PropertyIdentifier::LIMIT_ENABLE));
+    assert!(av.is_writable_property(PropertyIdentifier::NOTIFY_TYPE));
+    assert!(av.is_writable_property(PropertyIdentifier::TIME_DELAY));
+    // RELINQUISH_DEFAULT has no write arm.
+    assert!(!av.is_writable_property(PropertyIdentifier::RELINQUISH_DEFAULT));
+    // Universal read-only.
+    assert!(!av.is_writable_property(PropertyIdentifier::STATUS_FLAGS));
+}

--- a/crates/bacnet-objects/src/binary/mod.rs
+++ b/crates/bacnet-objects/src/binary/mod.rs
@@ -206,6 +206,20 @@ impl BACnetObject for BinaryInputObject {
         ];
         Cow::Borrowed(PROPS)
     }
+
+    fn is_createable(&self) -> bool {
+        true
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        // Mirrors the BinaryInput `write_property` arms. EVENT_ENABLE,
+        // NOTIFICATION_CLASS, and ACKED_TRANSITIONS are read-only on BI
+        // (no write arms), so they are intentionally excluded.
+        common::is_common_writable(property)
+            || property == PropertyIdentifier::PRESENT_VALUE
+            || property == PropertyIdentifier::ACTIVE_TEXT
+            || property == PropertyIdentifier::INACTIVE_TEXT
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -436,6 +450,19 @@ impl BACnetObject for BinaryOutputObject {
         ];
         Cow::Borrowed(PROPS)
     }
+
+    fn is_createable(&self) -> bool {
+        true
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        // Mirrors the BinaryOutput `write_property` arms: commandable
+        // (PRIORITY_ARRAY + PRESENT_VALUE) + common + text properties.
+        common::is_commandable_property_writable(property)
+            || common::is_common_writable(property)
+            || property == PropertyIdentifier::ACTIVE_TEXT
+            || property == PropertyIdentifier::INACTIVE_TEXT
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -661,6 +688,19 @@ impl BACnetObject for BinaryValueObject {
             PropertyIdentifier::INACTIVE_TEXT,
         ];
         Cow::Borrowed(PROPS)
+    }
+
+    fn is_createable(&self) -> bool {
+        true
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        // Mirrors the BinaryValue `write_property` arms. Same set as
+        // BinaryOutput (commandable + common + text properties).
+        common::is_commandable_property_writable(property)
+            || common::is_common_writable(property)
+            || property == PropertyIdentifier::ACTIVE_TEXT
+            || property == PropertyIdentifier::INACTIVE_TEXT
     }
 }
 

--- a/crates/bacnet-objects/src/binary/tests/input_output.rs
+++ b/crates/bacnet-objects/src/binary/tests/input_output.rs
@@ -452,3 +452,53 @@ fn bo_direct_priority_array_index_17_error() {
     );
     assert!(result.is_err());
 }
+
+// ── Trait capability method tests (issue #115 shared truth source) ──────────
+
+#[test]
+fn bi_is_createable_matches_factory() {
+    use crate::traits::BACnetObject;
+    let bi = BinaryInputObject::new(1, "bi-1").unwrap();
+    assert!(bi.is_createable(), "BinaryInput is factory-constructable");
+}
+
+#[test]
+fn bi_is_writable_property_mirrors_write_property() {
+    use crate::traits::BACnetObject;
+    let bi = BinaryInputObject::new(1, "bi-1").unwrap();
+    // BI accepts PRESENT_VALUE (when OOS), ACTIVE/INACTIVE_TEXT, common set.
+    assert!(bi.is_writable_property(PropertyIdentifier::PRESENT_VALUE));
+    assert!(bi.is_writable_property(PropertyIdentifier::ACTIVE_TEXT));
+    assert!(bi.is_writable_property(PropertyIdentifier::INACTIVE_TEXT));
+    assert!(bi.is_writable_property(PropertyIdentifier::OUT_OF_SERVICE));
+    assert!(bi.is_writable_property(PropertyIdentifier::OBJECT_NAME));
+    assert!(bi.is_writable_property(PropertyIdentifier::DESCRIPTION));
+    // EVENT_ENABLE/NOTIFICATION_CLASS/ACKED_TRANSITIONS are read-only on BI.
+    assert!(!bi.is_writable_property(PropertyIdentifier::EVENT_ENABLE));
+    assert!(!bi.is_writable_property(PropertyIdentifier::NOTIFICATION_CLASS));
+    assert!(!bi.is_writable_property(PropertyIdentifier::ACKED_TRANSITIONS));
+    // Not commandable.
+    assert!(!bi.is_writable_property(PropertyIdentifier::PRIORITY_ARRAY));
+}
+
+#[test]
+fn bo_is_createable_matches_factory() {
+    use crate::traits::BACnetObject;
+    let bo = BinaryOutputObject::new(1, "bo-1").unwrap();
+    assert!(bo.is_createable(), "BinaryOutput is factory-constructable");
+}
+
+#[test]
+fn bo_is_writable_property_mirrors_write_property() {
+    use crate::traits::BACnetObject;
+    let bo = BinaryOutputObject::new(1, "bo-1").unwrap();
+    // Commandable.
+    assert!(bo.is_writable_property(PropertyIdentifier::PRIORITY_ARRAY));
+    assert!(bo.is_writable_property(PropertyIdentifier::PRESENT_VALUE));
+    // Text + common.
+    assert!(bo.is_writable_property(PropertyIdentifier::ACTIVE_TEXT));
+    assert!(bo.is_writable_property(PropertyIdentifier::INACTIVE_TEXT));
+    assert!(bo.is_writable_property(PropertyIdentifier::OUT_OF_SERVICE));
+    // Not event-writable (read-only on BO).
+    assert!(!bo.is_writable_property(PropertyIdentifier::EVENT_ENABLE));
+}

--- a/crates/bacnet-objects/src/common.rs
+++ b/crates/bacnet-objects/src/common.rs
@@ -685,3 +685,97 @@ pub(crate) fn write_cov_increment(
         None
     }
 }
+
+// ──────────────────────────────────────────────────────────────────────────
+// PICS writability helpers
+// ──────────────────────────────────────────────────────────────────────────
+//
+// Shared property-set predicates used by the `is_writable_property` overrides
+// on the core object types. Each predicate mirrors the arms of the matching
+// `write_property` implementation (via the `write_event_properties!` macro and
+// the `write_priority_array!` / `write_priority_array_direct!` macros) so PICS
+// and runtime dispatch share one truth source. Keep these in lock-step with
+// the macros below.
+
+/// Writable event-detection properties exposed by objects that use the
+/// `write_event_properties!` macro (AnalogInput/Output/Value).
+///
+/// Mirrors the macro arms at `common.rs:459-565`: HIGH_LIMIT, LOW_LIMIT,
+/// DEADBAND, LIMIT_ENABLE, EVENT_ENABLE, NOTIFICATION_CLASS, NOTIFY_TYPE,
+/// TIME_DELAY. ACKED_TRANSITIONS is read-only (write-access-denied) and is
+/// intentionally excluded.
+#[inline]
+pub(crate) fn is_event_property_writable(
+    property: bacnet_types::enums::PropertyIdentifier,
+) -> bool {
+    matches!(
+        property,
+        bacnet_types::enums::PropertyIdentifier::HIGH_LIMIT
+            | bacnet_types::enums::PropertyIdentifier::LOW_LIMIT
+            | bacnet_types::enums::PropertyIdentifier::DEADBAND
+            | bacnet_types::enums::PropertyIdentifier::LIMIT_ENABLE
+            | bacnet_types::enums::PropertyIdentifier::EVENT_ENABLE
+            | bacnet_types::enums::PropertyIdentifier::NOTIFICATION_CLASS
+            | bacnet_types::enums::PropertyIdentifier::NOTIFY_TYPE
+            | bacnet_types::enums::PropertyIdentifier::TIME_DELAY
+    )
+}
+
+/// Writable commandable-object properties shared by all commandable types
+/// (AnalogOutput, AnalogValue, BinaryOutput, BinaryValue, MultiStateOutput,
+/// MultiStateValue): `PRIORITY_ARRAY` direct writes and commandable
+/// `PRESENT_VALUE` writes.
+///
+/// Returns `true` for `PRIORITY_ARRAY` and `PRESENT_VALUE` only.
+/// `RELINQUISH_DEFAULT` and `CURRENT_COMMAND_PRIORITY` are read-only in every
+/// current implementation (no `write_property` arm accepts either) and are
+/// intentionally not included here; if a future type grows a write arm for
+/// either, add it in that type's `is_writable_property` override.
+#[inline]
+pub(crate) fn is_commandable_property_writable(
+    property: bacnet_types::enums::PropertyIdentifier,
+) -> bool {
+    matches!(
+        property,
+        bacnet_types::enums::PropertyIdentifier::PRIORITY_ARRAY
+            | bacnet_types::enums::PropertyIdentifier::PRESENT_VALUE
+    )
+}
+
+/// Writable common properties shared by all core I/O/V object types
+/// (accepted via the `write_out_of_service`, `write_object_name`, and
+/// `write_description` helpers in `common.rs`).
+#[inline]
+pub(crate) fn is_common_writable(property: bacnet_types::enums::PropertyIdentifier) -> bool {
+    matches!(
+        property,
+        bacnet_types::enums::PropertyIdentifier::OUT_OF_SERVICE
+            | bacnet_types::enums::PropertyIdentifier::OBJECT_NAME
+            | bacnet_types::enums::PropertyIdentifier::DESCRIPTION
+    )
+}
+
+/// Writable properties for commandable Multi-State objects (MSO, MSV):
+/// commandable (PRIORITY_ARRAY + PRESENT_VALUE) + common + STATE_TEXT.
+/// Mirrors the `write_property` arms of MultiStateOutput/Value.
+#[inline]
+pub(crate) fn is_multistate_commandable_writable(
+    property: bacnet_types::enums::PropertyIdentifier,
+) -> bool {
+    is_commandable_property_writable(property)
+        || is_common_writable(property)
+        || property == bacnet_types::enums::PropertyIdentifier::STATE_TEXT
+}
+
+/// Writable properties for Multi-State Input (MSI): PRESENT_VALUE (when out
+/// of service) + common + STATE_TEXT. Mirrors the `write_property` arms of
+/// MultiStateInput (commandable `PRESENT_VALUE` is not accepted — inputs are
+/// not commandable — so this excludes `is_commandable_property_writable`).
+#[inline]
+pub(crate) fn is_multistate_input_writable(
+    property: bacnet_types::enums::PropertyIdentifier,
+) -> bool {
+    is_common_writable(property)
+        || property == bacnet_types::enums::PropertyIdentifier::PRESENT_VALUE
+        || property == bacnet_types::enums::PropertyIdentifier::STATE_TEXT
+}

--- a/crates/bacnet-objects/src/device/mod.rs
+++ b/crates/bacnet-objects/src/device/mod.rs
@@ -483,6 +483,14 @@ impl BACnetObject for DeviceObject {
         props.sort_by_key(|p| p.to_raw());
         Cow::Owned(props)
     }
+
+    /// Device is not createable or deleteable at runtime.
+    fn is_createable(&self) -> bool {
+        false
+    }
+    fn is_deleteable(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/bacnet-objects/src/multistate/mod.rs
+++ b/crates/bacnet-objects/src/multistate/mod.rs
@@ -235,6 +235,14 @@ impl BACnetObject for MultiStateInputObject {
         ];
         Cow::Borrowed(PROPS)
     }
+
+    fn is_createable(&self) -> bool {
+        true
+    }
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        // Mirrors the MultiStateInput `write_property` arms.
+        common::is_multistate_input_writable(property)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -494,6 +502,14 @@ impl BACnetObject for MultiStateOutputObject {
         ];
         Cow::Borrowed(PROPS)
     }
+
+    fn is_createable(&self) -> bool {
+        true
+    }
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        // Mirrors the MultiStateOutput `write_property` arms.
+        common::is_multistate_commandable_writable(property)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -750,6 +766,14 @@ impl BACnetObject for MultiStateValueObject {
             PropertyIdentifier::STATE_TEXT,
         ];
         Cow::Borrowed(PROPS)
+    }
+
+    fn is_createable(&self) -> bool {
+        true
+    }
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        // Mirrors the MultiStateValue `write_property` arms.
+        common::is_multistate_commandable_writable(property)
     }
 }
 

--- a/crates/bacnet-objects/src/multistate/tests/objects.rs
+++ b/crates/bacnet-objects/src/multistate/tests/objects.rs
@@ -511,3 +511,56 @@ fn mso_direct_priority_array_index_17_error() {
     );
     assert!(result.is_err());
 }
+
+// ── Trait capability method tests (issue #115 shared truth source) ──────────
+
+#[test]
+fn msi_is_createable_and_writable_match_factory() {
+    use crate::traits::BACnetObject;
+    let msi = MultiStateInputObject::new(1, "msi-1", 2).unwrap();
+    assert!(
+        msi.is_createable(),
+        "MultiStateInput is factory-constructable"
+    );
+    // PRESENT_VALUE (when OOS) + STATE_TEXT + common.
+    assert!(msi.is_writable_property(PropertyIdentifier::PRESENT_VALUE));
+    assert!(msi.is_writable_property(PropertyIdentifier::STATE_TEXT));
+    assert!(msi.is_writable_property(PropertyIdentifier::OUT_OF_SERVICE));
+    assert!(msi.is_writable_property(PropertyIdentifier::OBJECT_NAME));
+    // Not commandable.
+    assert!(!msi.is_writable_property(PropertyIdentifier::PRIORITY_ARRAY));
+    // EVENT_ENABLE read-only on MSI.
+    assert!(!msi.is_writable_property(PropertyIdentifier::EVENT_ENABLE));
+}
+
+#[test]
+fn mso_is_createable_and_writable_match_factory() {
+    use crate::traits::BACnetObject;
+    let mso = MultiStateOutputObject::new(1, "mso-1", 2).unwrap();
+    assert!(
+        mso.is_createable(),
+        "MultiStateOutput is factory-constructable"
+    );
+    // Commandable + STATE_TEXT + common.
+    assert!(mso.is_writable_property(PropertyIdentifier::PRIORITY_ARRAY));
+    assert!(mso.is_writable_property(PropertyIdentifier::PRESENT_VALUE));
+    assert!(mso.is_writable_property(PropertyIdentifier::STATE_TEXT));
+    assert!(mso.is_writable_property(PropertyIdentifier::OUT_OF_SERVICE));
+    // EVENT_ENABLE read-only on MSO.
+    assert!(!mso.is_writable_property(PropertyIdentifier::EVENT_ENABLE));
+}
+
+#[test]
+fn msv_is_createable_and_writable_match_factory() {
+    use crate::traits::BACnetObject;
+    let msv = MultiStateValueObject::new(1, "msv-1", 2).unwrap();
+    assert!(
+        msv.is_createable(),
+        "MultiStateValue is factory-constructable"
+    );
+    // Commandable + STATE_TEXT + common.
+    assert!(msv.is_writable_property(PropertyIdentifier::PRIORITY_ARRAY));
+    assert!(msv.is_writable_property(PropertyIdentifier::PRESENT_VALUE));
+    assert!(msv.is_writable_property(PropertyIdentifier::STATE_TEXT));
+    assert!(msv.is_writable_property(PropertyIdentifier::OUT_OF_SERVICE));
+}

--- a/crates/bacnet-objects/src/network_port.rs
+++ b/crates/bacnet-objects/src/network_port.rs
@@ -268,6 +268,14 @@ impl BACnetObject for NetworkPortObject {
         ];
         Cow::Borrowed(PROPS)
     }
+
+    /// NetworkPort is not createable or deleteable at runtime.
+    fn is_createable(&self) -> bool {
+        false
+    }
+    fn is_deleteable(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -3,7 +3,7 @@
 use std::borrow::Cow;
 
 use bacnet_types::constructed::BACnetLogRecord;
-use bacnet_types::enums::PropertyIdentifier;
+use bacnet_types::enums::{ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
@@ -38,6 +38,40 @@ pub trait BACnetObject: Send + Sync {
 
     /// List all properties this object supports.
     fn property_list(&self) -> Cow<'static, [PropertyIdentifier]>;
+
+    /// Whether `write_property` accepts `property` for this object.
+    ///
+    /// PICS generation and runtime dispatch MUST consult this (or
+    /// `write_property` itself) rather than a separate heuristic, so the PICS
+    /// writable flags cannot drift from the actual write routes. The default
+    /// reproduces the historical PICS heuristic (see
+    /// [`historical_writable_default`]) so unmigrated object types keep their
+    /// current PICS output. Object implementations override to mirror their
+    /// real `write_property` arms exactly.
+    ///
+    /// Universal read-only properties (`OBJECT_IDENTIFIER`, `OBJECT_TYPE`,
+    /// `PROPERTY_LIST`, `STATUS_FLAGS`) are always non-writable and are
+    /// excluded by the default; overrides should preserve that invariant.
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        historical_writable_default(self.object_identifier().object_type(), property)
+    }
+
+    /// Whether this object type can be created at runtime via CreateObject.
+    ///
+    /// Default `false`; override `true` only for types the network factory
+    /// (`handle_create_object`) actually constructs, so PICS createability
+    /// matches the runtime factory with no separate list to drift.
+    fn is_createable(&self) -> bool {
+        false
+    }
+
+    /// Whether this object type can be deleted at runtime via DeleteObject.
+    ///
+    /// Default `true`; override `false` on object types that are not
+    /// deleteable (e.g. `Device`, `NetworkPort`).
+    fn is_deleteable(&self) -> bool {
+        true
+    }
 
     /// List the REQUIRED properties for this object type.
     ///
@@ -115,4 +149,46 @@ pub trait BACnetObject: Send + Sync {
     ///
     /// Default is a no-op. TrendLog objects override to append to their buffer.
     fn add_trend_record(&mut self, _record: BACnetLogRecord) {}
+}
+
+/// The historical PICS writable-property heuristic, used by the default
+/// [`BACnetObject::is_writable_property`] so unmigrated object types keep
+/// their current PICS output.
+///
+/// This is a free function (not a per-object override) so the default trait
+/// method can delegate to it without requiring `Self: Sized` (which would
+/// break `dyn BACnetObject` dispatch). Object implementations should override
+/// [`BACnetObject::is_writable_property`] to mirror their real `write_property`
+/// arms exactly rather than calling this.
+#[inline]
+pub(crate) fn historical_writable_default(
+    object_type: ObjectType,
+    property: PropertyIdentifier,
+) -> bool {
+    // Universal read-only properties.
+    if property == PropertyIdentifier::OBJECT_IDENTIFIER
+        || property == PropertyIdentifier::OBJECT_TYPE
+        || property == PropertyIdentifier::PROPERTY_LIST
+        || property == PropertyIdentifier::STATUS_FLAGS
+    {
+        return false;
+    }
+
+    if property == PropertyIdentifier::OBJECT_NAME {
+        return true;
+    }
+
+    if property == PropertyIdentifier::PRESENT_VALUE {
+        return object_type != ObjectType::ANALOG_INPUT
+            && object_type != ObjectType::BINARY_INPUT
+            && object_type != ObjectType::MULTI_STATE_INPUT;
+    }
+
+    property == PropertyIdentifier::DESCRIPTION
+        || property == PropertyIdentifier::OUT_OF_SERVICE
+        || property == PropertyIdentifier::COV_INCREMENT
+        || property == PropertyIdentifier::HIGH_LIMIT
+        || property == PropertyIdentifier::LOW_LIMIT
+        || property == PropertyIdentifier::DEADBAND
+        || property == PropertyIdentifier::NOTIFICATION_CLASS
 }

--- a/crates/bacnet-server/src/handlers/object_mgmt.rs
+++ b/crates/bacnet-server/src/handlers/object_mgmt.rs
@@ -162,15 +162,21 @@ pub fn handle_create_object(
 /// Handle a DeleteObject request.
 ///
 /// Removes the object from the database. Returns an error if the object
-/// doesn't exist or is the Device object (which cannot be deleted).
+/// doesn't exist or is an object type that cannot be deleted at runtime
+/// (Device and NetworkPort, which model the running node itself). The set
+/// of non-deleteable types is kept in sync with `BACnetObject::is_deleteable`
+/// so PICS and runtime dispatch share one truth source.
 pub fn handle_delete_object(db: &mut ObjectDatabase, service_data: &[u8]) -> Result<(), Error> {
     let request = DeleteObjectRequest::decode(service_data)?;
 
-    if request.object_identifier.object_type() == ObjectType::DEVICE {
-        return Err(Error::Protocol {
-            class: ErrorClass::OBJECT.to_raw() as u32,
-            code: ErrorCode::OBJECT_DELETION_NOT_PERMITTED.to_raw() as u32,
-        });
+    match request.object_identifier.object_type() {
+        ObjectType::DEVICE | ObjectType::NETWORK_PORT => {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::OBJECT_DELETION_NOT_PERMITTED.to_raw() as u32,
+            });
+        }
+        _ => {}
     }
 
     db.remove(&request.object_identifier)

--- a/crates/bacnet-server/src/handlers/tests/write_cov_who.rs
+++ b/crates/bacnet-server/src/handlers/tests/write_cov_who.rs
@@ -712,3 +712,29 @@ fn delete_device_object_fails() {
 
     assert!(handle_delete_object(&mut db, &buf).is_err());
 }
+
+#[test]
+fn delete_network_port_object_fails() {
+    // NetworkPort models a running node's port and is not deleteable at
+    // runtime, mirroring `NetworkPortObject::is_deleteable` so PICS and the
+    // runtime DeleteObject handler share one truth source.
+    let mut db = ObjectDatabase::new();
+    let np = bacnet_objects::network_port::NetworkPortObject::new(1, "NP-1", 0).unwrap();
+    db.add(Box::new(np)).unwrap();
+
+    let oid = ObjectIdentifier::new(ObjectType::NETWORK_PORT, 1).unwrap();
+    let request = bacnet_services::object_mgmt::DeleteObjectRequest {
+        object_identifier: oid,
+    };
+    let mut buf = BytesMut::new();
+    request.encode(&mut buf);
+
+    assert!(
+        handle_delete_object(&mut db, &buf).is_err(),
+        "DeleteObject must reject NETWORK_PORT (non-deleteable)"
+    );
+    assert!(
+        db.get(&oid).is_some(),
+        "NetworkPort must still be present after a rejected delete"
+    );
+}

--- a/crates/bacnet-server/src/pics/mod.rs
+++ b/crates/bacnet-server/src/pics/mod.rs
@@ -281,7 +281,7 @@ impl<'a> PicsGenerator<'a> {
                 .iter()
                 .map(|&pid| {
                     let is_required = required.contains(&pid);
-                    let writable = Self::is_writable_property(object_type, pid);
+                    let writable = representative.is_writable_property(pid);
                     PropertySupport {
                         property_id: pid,
                         access: PropertyAccess {
@@ -293,8 +293,8 @@ impl<'a> PicsGenerator<'a> {
                 })
                 .collect();
 
-            let createable = Self::is_createable(object_type);
-            let deleteable = Self::is_deleteable(object_type);
+            let createable = representative.is_createable();
+            let deleteable = representative.is_deleteable();
 
             result.push(ObjectTypeSupport {
                 object_type,
@@ -304,43 +304,6 @@ impl<'a> PicsGenerator<'a> {
             });
         }
         result
-    }
-
-    /// Heuristic for commonly writable properties.
-    fn is_writable_property(object_type: ObjectType, pid: PropertyIdentifier) -> bool {
-        if pid == PropertyIdentifier::OBJECT_IDENTIFIER
-            || pid == PropertyIdentifier::OBJECT_TYPE
-            || pid == PropertyIdentifier::PROPERTY_LIST
-            || pid == PropertyIdentifier::STATUS_FLAGS
-        {
-            return false;
-        }
-
-        if pid == PropertyIdentifier::OBJECT_NAME {
-            return true;
-        }
-
-        if pid == PropertyIdentifier::PRESENT_VALUE {
-            return object_type != ObjectType::ANALOG_INPUT
-                && object_type != ObjectType::BINARY_INPUT
-                && object_type != ObjectType::MULTI_STATE_INPUT;
-        }
-
-        pid == PropertyIdentifier::DESCRIPTION
-            || pid == PropertyIdentifier::OUT_OF_SERVICE
-            || pid == PropertyIdentifier::COV_INCREMENT
-            || pid == PropertyIdentifier::HIGH_LIMIT
-            || pid == PropertyIdentifier::LOW_LIMIT
-            || pid == PropertyIdentifier::DEADBAND
-            || pid == PropertyIdentifier::NOTIFICATION_CLASS
-    }
-
-    fn is_createable(object_type: ObjectType) -> bool {
-        object_type != ObjectType::DEVICE && object_type != ObjectType::NETWORK_PORT
-    }
-
-    fn is_deleteable(object_type: ObjectType) -> bool {
-        object_type != ObjectType::DEVICE && object_type != ObjectType::NETWORK_PORT
     }
 
     /// Build the service support list based on what the server actually handles.
@@ -633,3 +596,6 @@ pub fn generate_pics(
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod truth_source_tests;

--- a/crates/bacnet-server/src/pics/tests.rs
+++ b/crates/bacnet-server/src/pics/tests.rs
@@ -138,6 +138,13 @@ impl BACnetObject for TestDevice {
         ];
         Cow::Borrowed(&PROPS)
     }
+    /// Device is not createable or deleteable; mirrors the real DeviceObject.
+    fn is_createable(&self) -> bool {
+        false
+    }
+    fn is_deleteable(&self) -> bool {
+        false
+    }
 }
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -241,7 +248,11 @@ fn object_type_properties_populated() {
     // AI has 8 properties in our test fixture
     assert_eq!(ai.supported_properties.len(), 8);
 
-    // PRESENT_VALUE should be read-only for input objects
+    // The TestAnalogInput stub does not override is_writable_property, so it
+    // inherits the default historical_writable_default heuristic, which reports
+    // PRESENT_VALUE read-only for ANALOG_INPUT. The real AnalogInputObject
+    // overrides this to writable-when-out-of-service — see
+    // pics_input_present_value_writable_only_when_out_of_service.
     let pv = ai
         .supported_properties
         .iter()
@@ -265,6 +276,28 @@ fn device_not_createable_or_deleteable() {
         .expect("DEVICE should be in PICS");
     assert!(!dev.createable);
     assert!(!dev.deleteable);
+}
+
+#[test]
+fn real_device_and_network_port_overrides_not_createable_or_deleteable() {
+    // Directly exercise the real DeviceObject and NetworkPortObject trait
+    // overrides (not the TestDevice stub) so a regression flipping either
+    // override to true fails here rather than silently changing PICS output.
+    use bacnet_objects::device::{DeviceConfig, DeviceObject};
+    use bacnet_objects::network_port::NetworkPortObject;
+
+    let device = DeviceObject::new(DeviceConfig {
+        instance: 1,
+        name: "Dev".into(),
+        ..Default::default()
+    })
+    .unwrap();
+    assert!(!device.is_createable(), "Device must not be createable");
+    assert!(!device.is_deleteable(), "Device must not be deleteable");
+
+    let np = NetworkPortObject::new(1, "NP-1", 0).unwrap();
+    assert!(!np.is_createable(), "NetworkPort must not be createable");
+    assert!(!np.is_deleteable(), "NetworkPort must not be deleteable");
 }
 
 #[test]
@@ -428,5 +461,271 @@ fn binary_value_present_value_is_writable() {
     assert!(
         pv.access.writable,
         "BinaryValue PRESENT_VALUE should be writable"
+    );
+}
+
+// ── Real-object PICS writability/createability tests ───────────────────────
+//
+// The tests above use minimal stub objects. The tests below use the real
+// bacnet-objects implementations to verify that PICS writable flags and
+// createability match the objects' own `write_property` arms and the runtime
+// `handle_create_object` factory. This is the core regression guard for the
+// shared-truth-source fix (issue #115): PICS and runtime dispatch must agree.
+
+use bacnet_objects::analog::{AnalogInputObject, AnalogOutputObject, AnalogValueObject};
+use bacnet_objects::binary::{BinaryInputObject, BinaryOutputObject, BinaryValueObject};
+use bacnet_objects::multistate::{
+    MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject,
+};
+
+/// Build a database with one of each of the 9 core I/O/V object types.
+fn make_real_objects_db() -> ObjectDatabase {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(AnalogInputObject::new(1, "ai-1", 95).unwrap()))
+        .unwrap();
+    db.add(Box::new(AnalogOutputObject::new(1, "ao-1", 95).unwrap()))
+        .unwrap();
+    db.add(Box::new(AnalogValueObject::new(1, "av-1", 95).unwrap()))
+        .unwrap();
+    db.add(Box::new(BinaryInputObject::new(1, "bi-1").unwrap()))
+        .unwrap();
+    db.add(Box::new(BinaryOutputObject::new(1, "bo-1").unwrap()))
+        .unwrap();
+    db.add(Box::new(BinaryValueObject::new(1, "bv-1").unwrap()))
+        .unwrap();
+    db.add(Box::new(MultiStateInputObject::new(1, "msi-1", 2).unwrap()))
+        .unwrap();
+    db.add(Box::new(
+        MultiStateOutputObject::new(1, "mso-1", 2).unwrap(),
+    ))
+    .unwrap();
+    db.add(Box::new(MultiStateValueObject::new(1, "msv-1", 2).unwrap()))
+        .unwrap();
+    db
+}
+
+/// Helper: look up a property's writable flag in a PICS ObjectTypeSupport.
+fn pics_writable<'a>(pics: &'a Pics, object_type: ObjectType, pid: PropertyIdentifier) -> bool {
+    pics.supported_object_types
+        .iter()
+        .find(|ot| ot.object_type == object_type)
+        .and_then(|ot| {
+            ot.supported_properties
+                .iter()
+                .find(|p| p.property_id == pid)
+        })
+        .map(|p| p.access.writable)
+        .expect("property should be in the PICS list")
+}
+
+#[test]
+fn pics_event_properties_writable_on_analog_types() {
+    // The old heuristic omitted LIMIT_ENABLE, NOTIFY_TYPE, TIME_DELAY,
+    // EVENT_ENABLE — which the objects actually accept via write_event_properties!.
+    let db = make_real_objects_db();
+    let pics = generate_pics(&db, &ServerConfig::default(), &make_pics_config());
+
+    for ot in [
+        ObjectType::ANALOG_INPUT,
+        ObjectType::ANALOG_OUTPUT,
+        ObjectType::ANALOG_VALUE,
+    ] {
+        for pid in [
+            PropertyIdentifier::LIMIT_ENABLE,
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyIdentifier::TIME_DELAY,
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyIdentifier::HIGH_LIMIT,
+            PropertyIdentifier::LOW_LIMIT,
+            PropertyIdentifier::DEADBAND,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+        ] {
+            assert!(
+                pics_writable(&pics, ot, pid),
+                "{ot:?}: {pid:?} should be writable (accepted by write_event_properties!)"
+            );
+        }
+    }
+}
+
+#[test]
+fn pics_priority_array_writable_on_commandable_types() {
+    let db = make_real_objects_db();
+    let pics = generate_pics(&db, &ServerConfig::default(), &make_pics_config());
+
+    // Commandable types accept PRIORITY_ARRAY (direct) and PRESENT_VALUE
+    // (via the priority array). RELINQUISH_DEFAULT is read-only on these
+    // implementations (no write arm), so it must NOT be writable.
+    for ot in [
+        ObjectType::ANALOG_OUTPUT,
+        ObjectType::ANALOG_VALUE,
+        ObjectType::BINARY_OUTPUT,
+        ObjectType::BINARY_VALUE,
+        ObjectType::MULTI_STATE_OUTPUT,
+        ObjectType::MULTI_STATE_VALUE,
+    ] {
+        assert!(
+            pics_writable(&pics, ot, PropertyIdentifier::PRIORITY_ARRAY),
+            "{ot:?}: PRIORITY_ARRAY should be writable"
+        );
+        assert!(
+            pics_writable(&pics, ot, PropertyIdentifier::PRESENT_VALUE),
+            "{ot:?}: PRESENT_VALUE should be writable"
+        );
+        // RELINQUISH_DEFAULT has no write arm in these implementations.
+        assert!(
+            !pics_writable(&pics, ot, PropertyIdentifier::RELINQUISH_DEFAULT),
+            "{ot:?}: RELINQUISH_DEFAULT should NOT be writable (no write arm)"
+        );
+    }
+}
+
+#[test]
+fn pics_input_present_value_writable_only_when_out_of_service() {
+    let db = make_real_objects_db();
+    let pics = generate_pics(&db, &ServerConfig::default(), &make_pics_config());
+
+    // Input types (AI, BI, MSI) accept PRESENT_VALUE writes when
+    // out-of-service. PICS reports the type-level writability (the runtime
+    // enforces the out-of-service guard), so PRESENT_VALUE is writable.
+    // This was a false-negative in the old heuristic for AI (AI was excluded);
+    // the trait override now mirrors the real write_property arm.
+    for ot in [
+        ObjectType::ANALOG_INPUT,
+        ObjectType::BINARY_INPUT,
+        ObjectType::MULTI_STATE_INPUT,
+    ] {
+        assert!(
+            pics_writable(&pics, ot, PropertyIdentifier::PRESENT_VALUE),
+            "{ot:?}: PRESENT_VALUE should be writable (accepted when out-of-service)"
+        );
+    }
+}
+
+#[test]
+fn pics_state_text_writable_on_multistate_types() {
+    let db = make_real_objects_db();
+    let pics = generate_pics(&db, &ServerConfig::default(), &make_pics_config());
+
+    // All three multistate types accept STATE_TEXT writes (array-indexed).
+    for ot in [
+        ObjectType::MULTI_STATE_INPUT,
+        ObjectType::MULTI_STATE_OUTPUT,
+        ObjectType::MULTI_STATE_VALUE,
+    ] {
+        assert!(
+            pics_writable(&pics, ot, PropertyIdentifier::STATE_TEXT),
+            "{ot:?}: STATE_TEXT should be writable"
+        );
+    }
+}
+
+#[test]
+fn pics_universal_readonly_properties_never_writable() {
+    let db = make_real_objects_db();
+    let pics = generate_pics(&db, &ServerConfig::default(), &make_pics_config());
+
+    // OBJECT_IDENTIFIER, OBJECT_TYPE, PROPERTY_LIST, STATUS_FLAGS are never
+    // writable on any object type.
+    for ot in pics.supported_object_types.iter() {
+        for pid in [
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::PROPERTY_LIST,
+            PropertyIdentifier::STATUS_FLAGS,
+        ] {
+            if ot.supported_properties.iter().any(|p| p.property_id == pid) {
+                assert!(
+                    !pics_writable(&pics, ot.object_type, pid),
+                    "{ot:?}: {pid:?} must never be writable"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn pics_createability_matches_runtime_factory() {
+    let db = make_real_objects_db();
+    let pics = generate_pics(&db, &ServerConfig::default(), &make_pics_config());
+
+    // The 8 types handle_create_object actually constructs must be createable.
+    for ot in [
+        ObjectType::ANALOG_INPUT,
+        ObjectType::ANALOG_OUTPUT,
+        ObjectType::BINARY_INPUT,
+        ObjectType::BINARY_OUTPUT,
+        ObjectType::BINARY_VALUE,
+        ObjectType::MULTI_STATE_INPUT,
+        ObjectType::MULTI_STATE_OUTPUT,
+        ObjectType::MULTI_STATE_VALUE,
+    ] {
+        let entry = pics
+            .supported_object_types
+            .iter()
+            .find(|e| e.object_type == ot)
+            .expect("type should be in PICS");
+        assert!(
+            entry.createable,
+            "{ot:?} should be createable (factory constructs it)"
+        );
+    }
+
+    // AnalogValue is NOT in the factory — PICS must not advertise createability.
+    let av = pics
+        .supported_object_types
+        .iter()
+        .find(|e| e.object_type == ObjectType::ANALOG_VALUE)
+        .expect("ANALOG_VALUE should be in PICS");
+    assert!(
+        !av.createable,
+        "AnalogValue must NOT be createable (factory rejects it with UNSUPPORTED_OBJECT_TYPE)"
+    );
+}
+
+#[test]
+fn pics_writability_matches_runtime_write_property() {
+    // Cross-check: PICS reports LIMIT_ENABLE writable on AnalogInput AND
+    // write_property actually accepts it. The old heuristic reported it
+    // non-writable (false-negative); the trait override fixes both.
+    use bacnet_objects::event::LimitEnable;
+    use bacnet_objects::traits::BACnetObject;
+
+    let mut ai = AnalogInputObject::new(1, "ai-1", 95).unwrap();
+    // PICS (via the trait method) must report it writable.
+    assert!(
+        ai.is_writable_property(PropertyIdentifier::LIMIT_ENABLE),
+        "is_writable_property must report LIMIT_ENABLE writable on AnalogInput"
+    );
+    // And the runtime write_property must accept it.
+    let bits = LimitEnable::BOTH.to_bits();
+    let result = ai.write_property(
+        PropertyIdentifier::LIMIT_ENABLE,
+        None,
+        PropertyValue::BitString {
+            unused_bits: 6,
+            data: vec![bits],
+        },
+        None,
+    );
+    assert!(
+        result.is_ok(),
+        "write_property must accept LIMIT_ENABLE, got: {result:?}"
+    );
+
+    // Cross-check a property PICS reports non-writable: STATUS_FLAGS.
+    assert!(
+        !ai.is_writable_property(PropertyIdentifier::STATUS_FLAGS),
+        "STATUS_FLAGS must not be writable on AnalogInput"
+    );
+    let result = ai.write_property(
+        PropertyIdentifier::STATUS_FLAGS,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    );
+    assert!(
+        result.is_err(),
+        "write_property must reject STATUS_FLAGS, got: {result:?}"
     );
 }

--- a/crates/bacnet-server/src/pics/truth_source_tests.rs
+++ b/crates/bacnet-server/src/pics/truth_source_tests.rs
@@ -1,0 +1,361 @@
+//! Truth-source cross-check tests for the PICS writability fix (issue #115).
+//!
+//! These tests live in a sibling module to `tests.rs` to keep `tests.rs` under
+//! the workspace's 700-LOC file cap. They verify the central invariant of the
+//! shared-truth-source design: for every core I/O/V object type, the
+//! `BACnetObject::is_writable_property` override and the runtime
+//! `write_property` match arms must agree — if the override reports a property
+//! writable, `write_property` must accept it, and if it reports it read-only,
+//! `write_property` must reject it. This is the regression guard that prevents
+//! an override and its `write_property` arms from drifting apart (the exact
+//! false-negative class issue #115 eliminates).
+
+use bacnet_objects::analog::{AnalogInputObject, AnalogOutputObject, AnalogValueObject};
+use bacnet_objects::binary::{BinaryInputObject, BinaryOutputObject, BinaryValueObject};
+use bacnet_objects::multistate::{
+    MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject,
+};
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::enums::PropertyIdentifier;
+use bacnet_types::primitives::PropertyValue;
+
+/// Cross-check the central truth-source invariant: for every core I/O/V type,
+/// `is_writable_property` and `write_property` must agree. If the override
+/// reports a property writable, `write_property` must accept it; if it reports
+/// it read-only, `write_property` must reject it. This guards against the
+/// override and the `write_property` match arms drifting apart — the exact
+/// false-negative class issue #115 is meant to eliminate.
+///
+/// Sample values are chosen to satisfy `write_property`'s validation so a true
+/// agreement is tested (not a rejection on bad input). Input types (AI, BI,
+/// MSI) require `out_of_service` before PRESENT_VALUE is accepted, so those
+/// objects are pre-flipped where needed.
+#[test]
+fn is_writable_property_matches_write_property_on_all_core_types() {
+    use bacnet_objects::event::LimitEnable;
+
+    // A read-only property every type rejects — used as a universal negative.
+    const READ_ONLY: PropertyIdentifier = PropertyIdentifier::STATUS_FLAGS;
+
+    // Helper: assert the override says writable AND write_property accepts it.
+    fn assert_accepts(
+        obj: &mut dyn BACnetObject,
+        pid: PropertyIdentifier,
+        value: PropertyValue,
+        label: &str,
+    ) {
+        assert!(
+            obj.is_writable_property(pid),
+            "{label}: is_writable_property must report {pid:?} writable"
+        );
+        let result = obj.write_property(pid, None, value, None);
+        assert!(
+            result.is_ok(),
+            "{label}: write_property must accept {pid:?}, got: {result:?}"
+        );
+    }
+
+    // Helper: assert the override says read-only AND write_property rejects it.
+    fn assert_rejects(obj: &mut dyn BACnetObject, pid: PropertyIdentifier, label: &str) {
+        assert!(
+            !obj.is_writable_property(pid),
+            "{label}: is_writable_property must report {pid:?} NOT writable"
+        );
+        let result = obj.write_property(pid, None, PropertyValue::Null, None);
+        assert!(
+            result.is_err(),
+            "{label}: write_property must reject {pid:?}, got: {result:?}"
+        );
+    }
+
+    // Helper: like assert_accepts but supplies an array_index (PRIORITY_ARRAY
+    // requires Some(1..=16); STATE_TEXT similarly takes an element index).
+    fn assert_accepts_indexed(
+        obj: &mut dyn BACnetObject,
+        pid: PropertyIdentifier,
+        index: u32,
+        value: PropertyValue,
+        label: &str,
+    ) {
+        assert!(
+            obj.is_writable_property(pid),
+            "{label}: is_writable_property must report {pid:?} writable"
+        );
+        let result = obj.write_property(pid, Some(index), value, None);
+        assert!(
+            result.is_ok(),
+            "{label}: write_property must accept {pid:?}[{index}], got: {result:?}"
+        );
+    }
+
+    // AnalogInput — PRESENT_VALUE needs out-of-service.
+    let mut ai = AnalogInputObject::new(1, "ai", 95).unwrap();
+    ai.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    assert_accepts(
+        &mut ai,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Real(50.0),
+        "AI",
+    );
+    assert_accepts(
+        &mut ai,
+        PropertyIdentifier::COV_INCREMENT,
+        PropertyValue::Real(1.0),
+        "AI",
+    );
+    assert_accepts(
+        &mut ai,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(0),
+        "AI",
+    );
+    assert_accepts(
+        &mut ai,
+        PropertyIdentifier::LIMIT_ENABLE,
+        PropertyValue::BitString {
+            unused_bits: 6,
+            data: vec![LimitEnable::BOTH.to_bits()],
+        },
+        "AI",
+    );
+    assert_rejects(&mut ai, READ_ONLY, "AI");
+
+    // AnalogOutput — commandable: PRIORITY_ARRAY + PRESENT_VALUE + event set.
+    let mut ao = AnalogOutputObject::new(1, "ao", 95).unwrap();
+    assert_accepts(
+        &mut ao,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Real(50.0),
+        "AO",
+    );
+    assert_accepts_indexed(
+        &mut ao,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        PropertyValue::Null,
+        "AO",
+    );
+    assert_accepts(
+        &mut ao,
+        PropertyIdentifier::COV_INCREMENT,
+        PropertyValue::Real(1.0),
+        "AO",
+    );
+    assert_accepts(
+        &mut ao,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(0),
+        "AO",
+    );
+    assert_accepts(
+        &mut ao,
+        PropertyIdentifier::NOTIFY_TYPE,
+        PropertyValue::Enumerated(0),
+        "AO",
+    );
+    assert_rejects(&mut ao, READ_ONLY, "AO");
+
+    // AnalogValue — same writable set as AnalogOutput.
+    let mut av = AnalogValueObject::new(1, "av", 95).unwrap();
+    assert_accepts(
+        &mut av,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Real(50.0),
+        "AV",
+    );
+    assert_accepts_indexed(
+        &mut av,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        PropertyValue::Null,
+        "AV",
+    );
+    assert_accepts(
+        &mut av,
+        PropertyIdentifier::COV_INCREMENT,
+        PropertyValue::Real(1.0),
+        "AV",
+    );
+    assert_accepts(
+        &mut av,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(0),
+        "AV",
+    );
+    assert_accepts(
+        &mut av,
+        PropertyIdentifier::EVENT_ENABLE,
+        PropertyValue::BitString {
+            unused_bits: 6,
+            data: vec![LimitEnable::BOTH.to_bits()],
+        },
+        "AV",
+    );
+    assert_rejects(&mut av, READ_ONLY, "AV");
+
+    // BinaryInput — PRESENT_VALUE needs out-of-service; ACTIVE/INACTIVE_TEXT.
+    let mut bi = BinaryInputObject::new(1, "bi").unwrap();
+    bi.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    assert_accepts(
+        &mut bi,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Enumerated(1),
+        "BI",
+    );
+    assert_accepts(
+        &mut bi,
+        PropertyIdentifier::ACTIVE_TEXT,
+        PropertyValue::CharacterString("on".into()),
+        "BI",
+    );
+    assert_accepts(
+        &mut bi,
+        PropertyIdentifier::INACTIVE_TEXT,
+        PropertyValue::CharacterString("off".into()),
+        "BI",
+    );
+    assert_rejects(&mut bi, READ_ONLY, "BI");
+
+    // BinaryOutput — commandable + ACTIVE/INACTIVE_TEXT.
+    let mut bo = BinaryOutputObject::new(1, "bo").unwrap();
+    assert_accepts(
+        &mut bo,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Enumerated(1),
+        "BO",
+    );
+    assert_accepts_indexed(
+        &mut bo,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        PropertyValue::Null,
+        "BO",
+    );
+    assert_accepts(
+        &mut bo,
+        PropertyIdentifier::ACTIVE_TEXT,
+        PropertyValue::CharacterString("on".into()),
+        "BO",
+    );
+    assert_accepts(
+        &mut bo,
+        PropertyIdentifier::INACTIVE_TEXT,
+        PropertyValue::CharacterString("off".into()),
+        "BO",
+    );
+    assert_rejects(&mut bo, READ_ONLY, "BO");
+
+    // BinaryValue — same writable set as BinaryOutput (no dedicated mirror
+    // test exists, so this is the BV override's regression guard).
+    let mut bv = BinaryValueObject::new(1, "bv").unwrap();
+    assert_accepts(
+        &mut bv,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Enumerated(1),
+        "BV",
+    );
+    assert_accepts_indexed(
+        &mut bv,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        PropertyValue::Null,
+        "BV",
+    );
+    assert_accepts(
+        &mut bv,
+        PropertyIdentifier::ACTIVE_TEXT,
+        PropertyValue::CharacterString("on".into()),
+        "BV",
+    );
+    assert_accepts(
+        &mut bv,
+        PropertyIdentifier::INACTIVE_TEXT,
+        PropertyValue::CharacterString("off".into()),
+        "BV",
+    );
+    assert_rejects(&mut bv, READ_ONLY, "BV");
+
+    // MultiStateInput — PRESENT_VALUE needs out-of-service; STATE_TEXT (array).
+    let mut msi = MultiStateInputObject::new(1, "msi", 2).unwrap();
+    msi.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    assert_accepts(
+        &mut msi,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Unsigned(1),
+        "MSI",
+    );
+    assert_accepts_indexed(
+        &mut msi,
+        PropertyIdentifier::STATE_TEXT,
+        1,
+        PropertyValue::CharacterString("s1".into()),
+        "MSI",
+    );
+    assert_rejects(&mut msi, READ_ONLY, "MSI");
+
+    // MultiStateOutput — commandable + STATE_TEXT (array).
+    let mut mso = MultiStateOutputObject::new(1, "mso", 2).unwrap();
+    assert_accepts(
+        &mut mso,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Unsigned(1),
+        "MSO",
+    );
+    assert_accepts_indexed(
+        &mut mso,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        PropertyValue::Null,
+        "MSO",
+    );
+    assert_accepts_indexed(
+        &mut mso,
+        PropertyIdentifier::STATE_TEXT,
+        1,
+        PropertyValue::CharacterString("s1".into()),
+        "MSO",
+    );
+    assert_rejects(&mut mso, READ_ONLY, "MSO");
+
+    // MultiStateValue — commandable + STATE_TEXT (array).
+    let mut msv = MultiStateValueObject::new(1, "msv", 2).unwrap();
+    assert_accepts(
+        &mut msv,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Unsigned(1),
+        "MSV",
+    );
+    assert_accepts_indexed(
+        &mut msv,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        PropertyValue::Null,
+        "MSV",
+    );
+    assert_accepts_indexed(
+        &mut msv,
+        PropertyIdentifier::STATE_TEXT,
+        1,
+        PropertyValue::CharacterString("s1".into()),
+        "MSV",
+    );
+    assert_rejects(&mut msv, READ_ONLY, "MSV");
+}


### PR DESCRIPTION
## Summary

Closes #115. PICS writable-property flags and createability/deleteability were produced by a static heuristic in `pics/mod.rs` that drifted from the objects' real `write_property` arms and the runtime `handle_create_object`/`handle_delete_object` factory. The issue measured **33 writable false-negatives** (LIMIT_ENABLE, EVENT_ENABLE, NOTIFY_TYPE, TIME_DELAY, NOTIFICATION_CLASS, HIGH/LOW_LIMIT, DEADBAND, PRIORITY_ARRAY, STATE_TEXT, PRESENT_VALUE-on-inputs) and **AnalogValue over-reported as createable** (the factory has no branch for it and returns `UNSUPPORTED_OBJECT_TYPE`).

This PR makes the object the single truth source and reconciles the runtime handler to match.

## Changes

**Trait API (`bacnet-objects/src/traits.rs`)**
- Add `BACnetObject::is_writable_property`, `is_createable`, `is_deleteable` with conservative, dyn-compatible defaults.
  - `is_writable_property` default delegates to `historical_writable_default` (a `pub(crate)` free fn, not `Self: Sized`, so the trait stays dyn-compatible) that reproduces the old heuristic exactly.
  - `is_createable` defaults `false` so unmigrated types cannot re-introduce over-reporting.
  - `is_deleteable` defaults `true`.

**Per-type overrides (mirror each `write_property`)**
- 9 core I/O/V types override `is_writable_property` to match their write arms; AnalogValue `is_createable=false` (no factory branch); Device/NetworkPort `is_createable=false, is_deleteable=false`.
- Shared helpers in `common.rs` (`is_event_property_writable`, `is_commandable_property_writable`, `is_common_writable`, `is_multistate_commandable_writable`, `is_multistate_input_writable`) so overrides mirror the `write_event_properties!` / `write_priority_array!` macro arms from one place.

**PICS (`bacnet-server/src/pics/mod.rs`)**
- `build_object_types` now calls `representative.is_writable_property()`, `is_createable()`, `is_deleteable()`. The 3 static heuristics are deleted (net −30 LOC).

**Runtime reconciliation (`handlers/object_mgmt.rs`)**
- `handle_delete_object` now rejects `NetworkPort` in addition to `Device`, matching `NetworkPortObject::is_deleteable=false` so PICS and runtime dispatch share one truth source with no remaining drift.

**Tests**
- `pics/truth_source_tests.rs`: `is_writable_property_matches_write_property_on_all_core_types` — for every core type, asserts the override and `write_property` agree (writable ⇒ accepted, read-only ⇒ rejected), closing the drift window that issue #115 is about.
- `pics/tests.rs`: direct coverage of the real `DeviceObject`/`NetworkPortObject` `is_createable`/`is_deleteable` overrides (not the stub).
- `handlers/tests/write_cov_who.rs`: `delete_network_port_object_fails` verifies the runtime rejection.
- Per-type override mirror tests in the objects crates.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked` — clean (only pre-existing missing-doc/print-stderr warnings in benchmarks)
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm` — **2143 passed, 0 failed, 2 ignored**
- `cargo check -p rusty-bacnet --tests` (Python bindings) and `cargo check -p bacnet-wasm --target wasm32-unknown-unknown` (WASM) — compile
- `.github/scripts/check-file-size.sh` — all tracked `.rs` within the 700-LOC cap (`multistate/mod.rs` proactively slimmed to 695 via the new `is_multistate_input_writable` helper, leaving headroom for future work)

## Adversarial review

An Opus 2-reviewer adversarial pass (correctness/spec/coverage + compat/API/maintainability lenses, per-finding verification) ran against this diff. 9 findings, all CONFIRMED/PLAUSIBLE, 0 refuted, 0 CRITICAL — the shipped code was correct. All actionable findings are folded into this commit:
- **MAJOR test-coverage gap** in the central truth-source invariant (cross-checked on 1 property/1 type) → addressed by the new `is_writable_property_matches_write_property_on_all_core_types` cross-check covering all 9 types.
- **PICS/runtime deleteability drift** for NetworkPort (trait said non-deleteable, runtime would delete) → addressed by the `handle_delete_object` NetworkPort rejection.
- Missing direct coverage of real Device/NetworkPort overrides, BinaryValue override, AO/AV RELIABILITY/COV_INCREMENT → addressed by added/expanded tests.
- Misleading doc comments → corrected.
- `multistate/mod.rs` headroom squeeze → addressed by the proactive slim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)