### PR TITLE
fix(server): fire COV/event notifications on local property writes (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `BACnetObject::is_writable_property`, `BACnetObject::is_createable`, and `BACnetObject::is_deleteable` trait methods (with conservative defaults that preserve current behavior for unmigrated object types) so PICS generation and runtime dispatch share one truth source for property writability and object createability. The `bacnet-objects` crate is a public dependency; downstream implementors of `BACnetObject` now have these methods available to override (defaults preserve existing PICS output).
+- Add `BACnetServer::write_local` as the server-owned local-mutation entry point. It writes a property under the database lock (routing `OBJECT_NAME` through the name-uniqueness check and index refresh, like the network handler) and then fires the same post-write COV and event notifications as a network `WriteProperty`. The Python `write_property_local` binding now delegates to it.
 
 ### Fixed
 
@@ -18,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop over-reporting `Device` as deleteable via the static heuristic; `Device` and `NetworkPort` now override `is_deleteable` to `false` on the objects themselves.
 - Reconcile `handle_delete_object` with `is_deleteable`: the runtime DeleteObject handler now rejects `NetworkPort` (matching its `is_deleteable` override) in addition to `Device`, so PICS and runtime dispatch share one truth source for deleteability with no remaining drift.
 - Route `WriteProperty`, `WritePropertyMultiple`, `CreateObject` initial values, and the local `write_property_local` Python-binding writes of `OBJECT_NAME` through the `ObjectDatabase` name index. A duplicate name is now rejected up front with `DUPLICATE_NAME` (the database's `check_name_available` helper, previously dead code), and a successful rename refreshes the index via `update_name_index` so `find_by_name` resolves to the new name and the old name is freed for reuse. `WritePropertyMultiple` rollback re-syncs the index for any rolled-back `OBJECT_NAME` write, restoring the pre-transaction name mappings; `CreateObject` rolls back (removes the created object) when an `OBJECT_NAME` initial value collides. Previously, `write_property(OBJECT_NAME, …)` and `CreateObject` initial-value writes mutated the object's name field in place without touching the database secondary index, leaving stale lookups and allowing duplicates.
+- Fire COV (and event) notifications on local/internal property writes. The Python `write_property_local` path and direct object setters mutated objects without entering the server's post-write trigger path, so a subscription could observe a network mutation but not an equivalent local mutation. Local writes now go through `BACnetServer::write_local`, which applies the same post-write COV/event processing as the network dispatch loop (and respects DCC: notifications are skipped while communication is disabled). Low-level object setters (`set_present_value` and the like) remain notification-bypassing building blocks below the high-level server surface.
+
+### Changed
+
+- The Python `BACnetServer.write_property_local` now raises `BacnetProtocolError` (with `error_class`/`error_code`) for `UNKNOWN_OBJECT` and `DUPLICATE_NAME` instead of a generic `RuntimeError`, giving it structured parity with the network `WriteProperty` path. Python callers that caught `RuntimeError` specifically should catch `BacnetProtocolError` (or `Exception`) instead. The server lock is also held across the whole call (including post-write COV/event sends), so concurrent Python calls on the same `BACnetServer` serialize behind a local write; a confirmed-COV send to an unresponsive subscriber can stall other Python calls for up to the COV retry timeout. This prevents a `stop()` from racing the notification sends mid-flight.
 
 ## [0.10.1]
 

--- a/crates/bacnet-integration-tests/tests/server.rs
+++ b/crates/bacnet-integration-tests/tests/server.rs
@@ -79,6 +79,8 @@ mod basic;
 mod dcc;
 #[path = "server/error_cov.rs"]
 mod error_cov;
+#[path = "server/local_write_cov.rs"]
+mod local_write_cov;
 #[path = "server/routing_alarm.rs"]
 mod routing_alarm;
 #[path = "server/segmentation_rx.rs"]

--- a/crates/bacnet-integration-tests/tests/server/local_write_cov.rs
+++ b/crates/bacnet-integration-tests/tests/server/local_write_cov.rs
@@ -1,0 +1,184 @@
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Local-write COV/event integration tests (#117)
+//
+// `write_local` is the server-owned local-mutation entry point. These tests
+// prove it fires the same post-write COV notifications as a network
+// WriteProperty, and that OBJECT_NAME local writes still enforce uniqueness
+// and refresh the database name index.
+// ---------------------------------------------------------------------------
+
+/// A local `write_local` of PRESENT_VALUE fires a COV notification that a
+/// subscribed client receives — matching the network WriteProperty path.
+#[tokio::test]
+async fn local_write_fires_cov_notification() {
+    use bacnet_objects::analog::AnalogOutputObject;
+    use bacnet_types::primitives::PropertyValue;
+    use tokio::time::Duration;
+
+    // Server with a writable AnalogOutput + Device.
+    let mut db = ObjectDatabase::new();
+    let ao = AnalogOutputObject::new(1, "AO-1", 62).unwrap();
+    let ao_oid = ao.object_identifier();
+    db.add(Box::new(ao)).unwrap();
+    let dev = DeviceObject::new(DeviceConfig {
+        instance: 1234,
+        name: "Local-COV-Dev".into(),
+        ..DeviceConfig::default()
+    })
+    .unwrap();
+    db.add(Box::new(dev)).unwrap();
+
+    let mut server = BACnetServer::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .database(db)
+        .build()
+        .await
+        .unwrap();
+    let server_mac = server.local_mac().to_vec();
+
+    let mut client = make_client().await;
+    let mut cov_rx = client.cov_notifications();
+
+    // 1. Subscribe to COV on AO:1 (unconfirmed, 300s lifetime).
+    client
+        .subscribe_cov(&server_mac, 42, ao_oid, false, Some(300))
+        .await
+        .unwrap();
+
+    // Drain the initial COV notification emitted at subscription time.
+    let initial = tokio::time::timeout(Duration::from_secs(2), cov_rx.recv())
+        .await
+        .expect("timed out waiting for initial COV notification")
+        .expect("COV channel closed");
+    assert_eq!(initial.notification.monitored_object_identifier, ao_oid);
+
+    // 2. Mutate PRESENT_VALUE through the LOCAL write path — the path that
+    //    previously bypassed COV. A notification must now arrive.
+    server
+        .write_local(
+            &ao_oid,
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(50.0),
+            Some(16),
+        )
+        .await
+        .unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(2), cov_rx.recv())
+        .await
+        .expect("timed out waiting for COV notification after local write")
+        .expect("COV channel closed");
+    assert_eq!(received.notification.monitored_object_identifier, ao_oid);
+
+    // 3. Cancel the subscription; a further local write must NOT notify.
+    client
+        .unsubscribe_cov(&server_mac, 42, ao_oid)
+        .await
+        .unwrap();
+
+    server
+        .write_local(
+            &ao_oid,
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(99.0),
+            Some(16),
+        )
+        .await
+        .unwrap();
+
+    let timeout_result = tokio::time::timeout(Duration::from_millis(500), cov_rx.recv()).await;
+    assert!(
+        timeout_result.is_err(),
+        "should NOT receive a COV notification after unsubscribe, but got one"
+    );
+
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}
+
+/// A local `write_local` of OBJECT_NAME renames the object and refreshes the
+/// database name index, so a subsequent lookup by the new name resolves to the
+/// renamed object and a duplicate rename is rejected.
+#[tokio::test]
+async fn local_object_name_write_refreshes_name_index() {
+    use bacnet_objects::analog::AnalogOutputObject;
+    use bacnet_objects::database::ObjectDatabase;
+    use bacnet_types::primitives::PropertyValue;
+    use tokio::time::Duration;
+
+    let mut db = ObjectDatabase::new();
+    let ao = AnalogOutputObject::new(1, "AO-1", 62).unwrap();
+    let ao_oid = ao.object_identifier();
+    db.add(Box::new(ao)).unwrap();
+    let dev = DeviceObject::new(DeviceConfig {
+        instance: 1234,
+        name: "Local-Name-Dev".into(),
+        ..DeviceConfig::default()
+    })
+    .unwrap();
+    db.add(Box::new(dev)).unwrap();
+
+    let mut server = BACnetServer::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .database(db)
+        .build()
+        .await
+        .unwrap();
+
+    // Rename AO:1 to "AO-Renamed" via the local path.
+    server
+        .write_local(
+            &ao_oid,
+            PropertyIdentifier::OBJECT_NAME,
+            None,
+            PropertyValue::CharacterString("AO-Renamed".into()),
+            None,
+        )
+        .await
+        .unwrap();
+
+    // The name index must now resolve the new name to AO:1, and the old name
+    // must be freed.
+    {
+        let db = server.database().read().await;
+        assert_eq!(
+            db.find_by_name("AO-Renamed").map(|o| o.object_identifier()),
+            Some(ao_oid)
+        );
+        assert!(db.find_by_name("AO-1").is_none());
+    }
+
+    // "Local-Name-Dev" is owned by the Device object; renaming AO:1 to it via
+    // the local path must be rejected as a duplicate.
+    let dup = server
+        .write_local(
+            &ao_oid,
+            PropertyIdentifier::OBJECT_NAME,
+            None,
+            PropertyValue::CharacterString("Local-Name-Dev".into()),
+            None,
+        )
+        .await;
+    assert!(dup.is_err(), "duplicate object name must be rejected");
+
+    // The failed rename must not have corrupted the index: AO:1 is still
+    // reachable as "AO-Renamed" and the Device still owns its name.
+    {
+        let db = server.database().read().await;
+        assert_eq!(
+            db.find_by_name("AO-Renamed").map(|o| o.object_identifier()),
+            Some(ao_oid)
+        );
+        assert!(db.find_by_name("Local-Name-Dev").is_some());
+    }
+
+    // Let any background dispatch settle, then stop.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    server.stop().await.unwrap();
+}

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -474,6 +474,75 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         self.comm_state.load(Ordering::Acquire)
     }
 
+    /// Write a property on a local object and fire the same post-write COV
+    /// and event notifications that a network [`WriteProperty`] does.
+    ///
+    /// This is the server-owned local-mutation entry point: it performs the
+    /// write under the database lock — routing `OBJECT_NAME` through the name
+    /// uniqueness check and index refresh, exactly like the network handler —
+    /// then releases the lock and runs the COV/event trigger path so a
+    /// subscription observes a local mutation just as it would a network one.
+    ///
+    /// Low-level object setters (`set_present_value` and friends) deliberately
+    /// bypass this path; they are building blocks below the high-level server
+    /// surface and are not expected to emit notifications.
+    ///
+    /// [`WriteProperty`]: bacnet_services::write_property::WritePropertyRequest
+    pub async fn write_local(
+        &self,
+        oid: &ObjectIdentifier,
+        property: PropertyIdentifier,
+        array_index: Option<u32>,
+        value: PropertyValue,
+        priority: Option<u8>,
+    ) -> Result<(), Error> {
+        // Scoped write: mutate under the lock, then drop the guard before
+        // firing notifications — matching the network dispatch path, which
+        // releases the database lock before the post-write trigger loop.
+        {
+            let mut db = self.db.write().await;
+            if db.get(oid).is_none() {
+                return Err(Error::Protocol {
+                    class: ErrorClass::OBJECT.to_raw() as u32,
+                    code: ErrorCode::UNKNOWN_OBJECT.to_raw() as u32,
+                });
+            }
+            if property == PropertyIdentifier::OBJECT_NAME {
+                if let PropertyValue::CharacterString(ref new_name) = value {
+                    db.check_name_available(oid, new_name)?;
+                }
+            }
+            let object = db.get_mut(oid).expect("existence checked above");
+            object.write_property(property, array_index, value, priority)?;
+            if property == PropertyIdentifier::OBJECT_NAME {
+                db.update_name_index(oid);
+            }
+        }
+
+        // Post-write COV/event trigger, mirroring the network handler's loop.
+        Self::fire_event_notifications(
+            &self.db,
+            &self.network,
+            &self.comm_state,
+            &self.server_tsm,
+            oid,
+            self.config.cov_retry_timeout_ms,
+        )
+        .await;
+        Self::fire_cov_notifications(
+            &self.db,
+            &self.network,
+            &self.cov_table,
+            &self.cov_in_flight,
+            &self.server_tsm,
+            &self.comm_state,
+            &self.config,
+            oid,
+        )
+        .await;
+        Ok(())
+    }
+
     /// Generate a PICS document from the current object database and server configuration.
     ///
     /// The caller must supply a [`PicsConfig`] for fields not available from the server

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -456,15 +456,14 @@ struct SegmentedRequestState {
 
 /// BACnet server with APDU dispatch and service handling.
 pub struct BACnetServer<T: TransportPort> {
-    #[allow(dead_code)]
     config: ServerConfig,
-    /// Shared network layer (also held by dispatch task).
-    #[allow(dead_code)]
+    /// Shared network layer (also held by dispatch task; read by
+    /// [`write_local`](Self::write_local) for post-write COV/event sends).
     network: Arc<NetworkLayer<T>>,
     /// Shared object database.
     db: Arc<RwLock<ObjectDatabase>>,
-    /// COV subscription table (held to keep Arc alive for dispatch task).
-    #[allow(dead_code)]
+    /// COV subscription table (also held by dispatch task; read by
+    /// [`write_local`](Self::write_local) to fire post-write notifications).
     cov_table: Arc<RwLock<CovSubscriptionTable>>,
     /// Channels for routing segmented-send events to in-progress segmented sends.
     #[allow(dead_code)]
@@ -474,11 +473,11 @@ pub struct BACnetServer<T: TransportPort> {
     #[allow(dead_code)]
     seg_send_permits: Arc<Semaphore>,
     /// Semaphore that caps confirmed COV notifications at 255 in-flight
-    /// to prevent invoke ID reuse (invoke IDs are u8 = 0..255).
-    #[allow(dead_code)]
+    /// to prevent invoke ID reuse (invoke IDs are u8 = 0..255). Read by
+    /// [`write_local`](Self::write_local).
     cov_in_flight: Arc<Semaphore>,
-    /// Server-side TSM for outgoing confirmed COV notifications.
-    #[allow(dead_code)]
+    /// Server-side TSM for outgoing confirmed COV notifications. Read by
+    /// [`write_local`](Self::write_local).
     server_tsm: Arc<Mutex<ServerTsm>>,
     /// Communication state: 0 = Enable, 1 = Disable, 2 = DisableInitiation.
     comm_state: Arc<AtomicU8>,

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -52,7 +52,6 @@ use bacnet_transport::any::AnyTransport;
 use bacnet_transport::bip::BipTransport;
 use bacnet_transport::bip6::Bip6Transport;
 use bacnet_transport::mstp::NoSerial;
-use bacnet_types::enums::PropertyIdentifier;
 use bacnet_types::primitives::PropertyValue;
 
 use crate::errors::to_py_err;

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -237,10 +237,23 @@ impl BACnetServer {
 
     /// Write a property on a local object in the server's database.
     ///
-    /// `OBJECT_NAME` writes are routed through the database name index — a
-    /// duplicate name is rejected up front and a successful rename refreshes
-    /// the index — so local writes obey the same uniqueness and lookup
-    /// invariants as the network WriteProperty handlers.
+    /// Delegates to the server-owned [`write_local`](server::BACnetServer::write_local)
+    /// entry point so a local write fires the same post-write COV and event
+    /// notifications as a network `WriteProperty`. `OBJECT_NAME` writes are
+    /// routed through the database name index — a duplicate name is rejected
+    /// up front and a successful rename refreshes the index — so local writes
+    /// obey the same uniqueness and lookup invariants as the network handlers.
+    ///
+    /// Errors are surfaced as [`BacnetProtocolError`] (with `error_class`/
+    /// `error_code`) for parity with the network path — e.g. an unknown object
+    /// yields `UNKNOWN_OBJECT` rather than a generic `RuntimeError`.
+    ///
+    /// The server lock is held for the whole call (including the post-write
+    /// COV/event sends), so concurrent Python calls on the same `BACnetServer`
+    /// serialize behind a local write. This is deliberate: it prevents a
+    /// `stop()` racing the notification sends mid-flight. A confirmed-COV send
+    /// to an unresponsive subscriber can therefore stall other Python calls
+    /// for up to the COV retry timeout.
     #[pyo3(signature = (object_id, property_id, value, priority=None, array_index=None))]
     #[allow(clippy::too_many_arguments)]
     fn write_property_local<'py>(
@@ -258,34 +271,16 @@ impl BACnetServer {
         let prop_value = value.inner;
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let db_arc = {
-                let guard = inner.lock().await;
-                let srv = guard
-                    .as_ref()
-                    .ok_or_else(|| PyRuntimeError::new_err("server not started"))?;
-                srv.database().clone()
-            };
-            let mut db = db_arc.write().await;
-
-            // Enforce Object_Name uniqueness against the database index before
-            // mutating, matching the network WriteProperty handler.
-            if pid == PropertyIdentifier::OBJECT_NAME {
-                if let PropertyValue::CharacterString(ref new_name) = prop_value {
-                    db.check_name_available(&oid, new_name).map_err(to_py_err)?;
-                }
-            }
-
-            let obj = db
-                .get_mut(&oid)
-                .ok_or_else(|| PyRuntimeError::new_err(format!("object {oid} not found")))?;
-            obj.write_property(pid, array_index, prop_value, priority)
-                .map_err(to_py_err)?;
-
-            // Resync the database name index to the object's new name.
-            if pid == PropertyIdentifier::OBJECT_NAME {
-                db.update_name_index(&oid);
-            }
-            Ok(())
+            // Hold the server guard for the duration of the call: `write_local`
+            // borrows `srv` and runs the post-write COV/event trigger path,
+            // so the server must stay alive across the await.
+            let guard = inner.lock().await;
+            let srv = guard
+                .as_ref()
+                .ok_or_else(|| PyRuntimeError::new_err("server not started"))?;
+            srv.write_local(&oid, pid, array_index, prop_value, priority)
+                .await
+                .map_err(to_py_err)
         })
     }
 


### PR DESCRIPTION
## Summary

Fixes #117 — local/internal property writes bypassed the server's post-write COV/event trigger path, so a COV subscription could observe a network mutation but not an equivalent local mutation.

Adds `BACnetServer::write_local`: the server-owned local-mutation entry point that
1. writes the property under the database lock (routing `OBJECT_NAME` through the name-uniqueness check + index refresh, exactly like the network `WriteProperty` handler),
2. releases the lock, then
3. fires the same `fire_event_notifications` + `fire_cov_notifications` sequence the network dispatch loop uses (`requests.rs`).

Because COV-increment evaluation and `last_notified_value` bookkeeping live **inside** the shared `fire_*` code (not in the write handler), the local path inherits them for free and cannot drift from the network path. DCC gating is preserved (`fire_*` skip while `comm_state >= 1`); the local write itself applies regardless — local/management writes are not network comms.

The Python `write_property_local` binding now delegates to `write_local` instead of reaching into the database directly, so error parity (`UNKNOWN_OBJECT`, `DUPLICATE_NAME`) and lock discipline come from a single source. Low-level object setters (`set_present_value` etc.) remain notification-bypassing building blocks below the high-level server surface, as the issue explicitly allows.

## Root cause

`write_property_local` (Python) wrote directly to `ObjectDatabase` and never entered the post-write COV/event trigger path that network writes use.

## Changes
- `crates/bacnet-server/src/server/lifecycle.rs` — new `pub async fn write_local(...)`.
- `crates/bacnet-server/src/server/mod.rs` — removed stale `#[allow(dead_code)]` from the now-read `config`/`network`/`cov_table`/`cov_in_flight`/`server_tsm` fields; updated doc comments.
- `crates/rusty-bacnet/src/server/server_methods/lifecycle.rs` — `write_property_local` delegates to `srv.write_local(...)`.
- `crates/rusty-bacnet/src/server/mod.rs` — removed now-unused `PropertyIdentifier` import.
- `crates/bacnet-integration-tests/tests/server/local_write_cov.rs` — 2 new e2e tests (COV fires on local write; OBJECT_NAME local write refreshes index + rejects duplicates).
- `CHANGELOG.md` — Added + Fixed entries.

## Verification
- `cargo fmt --all --check` ✅
- `cargo clippy --workspace --exclude rusty-bacnet --exclude bacnet-wasm --all-targets --locked` ✅
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm` ✅ (all pass, incl. 2 new)
- `cargo check -p rusty-bacnet --tests` ✅
- `cargo check -p bacnet-wasm --target wasm32-unknown-unknown` ✅
- `bash .github/scripts/check-file-size.sh` ✅
- `cargo doc -p bacnet-server --no-deps` ✅ (no new broken links)

Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)