### PR TITLE
ci: lean feature→dev checks; heavy checks on dev→main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,19 @@ permissions:
   id-token: write
 
 # =============================================================================
-# Tier 1 — CI (runs on PR updates to main/dev, pushes to main, and v* tags)
+# Tier 1 — CI
+#
+# Two tiers of jobs share the triggers (PRs to main/dev, push to main, v* tags):
+#   Lean  — every PR (incl. feature→dev), push to main, v* tags.
+#           Fast gate: fmt, clippy, file-size, no-secret, Linux test.
+#   Heavy — skips feature→dev PRs; runs on dev→main PRs, push to main, v* tags.
+#           Cross-OS tests, MSRV, WASM, cargo-audit, cargo-deny.
+# This keeps the high-throughput feature→dev loop fast while the dev→main
+# gate (and the tag/push-main release gate) run the full matrix before merge.
+#
+# Guard cheat-sheet (the `if:` on each job is one of these two):
+#   lean : github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+#   heavy: github.event_name == 'push' || github.base_ref == 'main'
 # =============================================================================
 
 jobs:
@@ -59,7 +71,7 @@ jobs:
 
   wasm-check:
     name: WASM Check
-    if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.event_name == 'push' || github.base_ref == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +84,7 @@ jobs:
 
   audit:
     name: Cargo Audit
-    if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.event_name == 'push' || github.base_ref == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -104,7 +116,7 @@ jobs:
 
   msrv:
     name: MSRV (1.93)
-    if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.event_name == 'push' || github.base_ref == 'main' }}
     runs-on: ubuntu-latest
     env:
       # Override `rust-toolchain.toml` (which pins the dev/CI channel to
@@ -129,15 +141,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux: full feature set (serial + ethernet are Linux-only deps)
+          # Linux only in the lean tier: the full-feature suite (serial +
+          # ethernet are Linux-only deps). macOS/Windows run in `test-cross`
+          # below, gated to dev→main PRs / push-main / tags so the
+          # feature→dev loop isn't held up by cross-OS runners.
           - os: ubuntu-latest
             features: "--features bacnet-transport/ipv6,bacnet-transport/sc-tls,bacnet-transport/serial,bacnet-transport/ethernet"
-          # macOS: ipv6 + sc-tls only
-          - os: macos-latest
-            features: "--features bacnet-transport/ipv6,bacnet-transport/sc-tls"
-          # Windows: ipv6 + sc-tls only
-          - os: windows-latest
-            features: "--features bacnet-transport/ipv6,bacnet-transport/sc-tls"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -153,9 +162,35 @@ jobs:
           cache-bin: false
       - run: cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked ${{ matrix.features }}
 
+  test-cross:
+    name: Test (${{ matrix.os }})
+    if: ${{ github.event_name == 'push' || github.base_ref == 'main' }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Cross-OS legs (macOS/Windows) — heavy tier, only on dev→main PRs,
+          # push to main, and v* tags. Linux is already covered by `test`
+          # above in the lean tier.
+          - os: macos-latest
+            features: "--features bacnet-transport/ipv6,bacnet-transport/sc-tls"
+          - os: windows-latest
+            features: "--features bacnet-transport/ipv6,bacnet-transport/sc-tls"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.95.0"
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.os }}
+          cache-bin: false
+      - run: cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm --locked ${{ matrix.features }}
+
   deny:
     name: Cargo Deny
-    if: ${{ github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.event_name == 'push' || github.base_ref == 'main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -168,7 +203,7 @@ jobs:
   validate:
     name: Validate Release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [fmt, clippy, test, deny, wasm-check, audit, no-secret-scan]
+    needs: [fmt, clippy, test, test-cross, deny, wasm-check, audit, no-secret-scan]
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Split CI into a lean and a heavy tier so feature→dev PRs run only the fast gate (`rustfmt`, `clippy`, file-size cap, no-secret scan, and the Linux test matrix) while the cross-OS test matrix (macOS, Windows), MSRV, `cargo audit`, `cargo deny`, and the WASM check run on dev→main PRs, pushes to `main`, and `v*` tags. The feature→dev loop is no longer held up by macOS/Windows runners or the advisory/license/MSRV/WASM jobs; the full matrix still gates every merge into `main` and every release (the `validate` job waits on `test-cross` as well as `test`).
 - The Python `BACnetServer.write_property_local` now raises `BacnetProtocolError` (with `error_class`/`error_code`) for `UNKNOWN_OBJECT` and `DUPLICATE_NAME` instead of a generic `RuntimeError`, giving it structured parity with the network `WriteProperty` path. Python callers that caught `RuntimeError` specifically should catch `BacnetProtocolError` (or `Exception`) instead. The server lock is also held across the whole call (including post-write COV/event sends), so concurrent Python calls on the same `BACnetServer` serialize behind a local write; a confirmed-COV send to an unresponsive subscriber can stall other Python calls for up to the COV retry timeout. This prevents a `stop()` from racing the notification sends mid-flight.
 
 ## [0.10.1]


### PR DESCRIPTION
## What

Split the single-tier CI into a **lean** and a **heavy** tier so the high-throughput feature→dev loop runs only the fast gate, while the full matrix still gates every merge into `main` and every release.

### Lean (every PR, incl. feature→dev — plus push-main & tags)
`fmt`, `clippy`, `file-size-cap`, `no-secret-scan`, **`test` (Linux only)**

### Heavy (skips feature→dev — runs on dev→main PRs, push to main, v* tags)
`test-cross` (macOS + Windows), `msrv`, `wasm-check`, `audit`, `deny`

## How

Two `if:` guards (documented at the top of `ci.yml`):
- **lean** — `github.event_name != 'push' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')`
- **heavy** — `github.event_name == 'push' || github.base_ref == 'main'`

The `test` job keeps the lean guard but is narrowed to the Linux matrix; macOS/Windows move to a new `test-cross` job with the heavy guard (no Linux duplication). The `validate` release gate now `needs: [..., test, test-cross, ...]` so a broken cross-OS release still cannot ship.

## Event matrix (verified by parsing the workflow)

| Event | Lean | Heavy |
|---|---|---|
| feature→dev PR (`pull_request`, `base_ref=dev`) | run | **skip** |
| dev→main PR (`pull_request`, `base_ref=main`) | run | run |
| push to main (`push`, `ref=main`) | run | run |
| `v*` tag (`push`, `ref=tags/v*`) | run | run (release gate intact) |

## Safety

- `dev` has **no branch-protection required checks** (`gh api …/branches/dev/protection` → 404), so a skipped heavy job cannot block a feature→dev merge.
- No `run:` step interpolates any author-controllable GitHub context (`base_ref`, `ref`, `event_name` are GitHub-controlled and used only in `if:` expressions) — no workflow-injection surface.
- Release coverage unchanged: on a `v*` tag every job still runs and `validate` waits on all of them including `test-cross`.

## Why

17 more PRs to land on this issue-cleanup pass. The macOS + Windows test legs are the bulk of per-PR CI wall-clock; deferring them (plus audit/deny/MSRV/WASM) to the dev→main gate keeps feature work moving while the full matrix still runs before anything reaches `main` or a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)