### PR TITLE
feat(client,server): use separate ports for broadcast vs unicast

### DIFF
--- a/benchmarks/src/bin/bacnet_device.rs
+++ b/benchmarks/src/bin/bacnet_device.rs
@@ -24,9 +24,13 @@ struct Args {
     #[arg(long, default_value = "0.0.0.0")]
     interface: String,
 
-    /// UDP port (BIP only)
+    /// UDP broadcast port (BIP only)
+    #[arg(long, default_value_t = 0)]
+    unicast_port: u16,
+
+    /// UDP broadcast port (BIP only)
     #[arg(long, default_value_t = 47808)]
-    port: u16,
+    broadcast_port: u16,
 
     /// Broadcast address (BIP only)
     #[arg(long, default_value = "255.255.255.255")]
@@ -108,7 +112,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let bbmd_ip: Ipv4Addr = parts[0].parse()?;
                 let bbmd_port: u16 = parts.get(1).unwrap_or(&"47808").parse()?;
 
-                let mut transport = BipTransport::new(interface, args.port, broadcast);
+                let mut transport = BipTransport::new(interface, args.broadcast_port, broadcast);
                 transport.register_as_foreign_device(ForeignDeviceConfig {
                     bbmd_ip,
                     bbmd_port,
@@ -123,7 +127,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             } else {
                 BACnetServer::bip_builder()
                     .interface(interface)
-                    .port(args.port)
+                    .broadcast_port(args.broadcast_port)
                     .broadcast_address(broadcast)
                     .database(db)
                     .build()

--- a/benchmarks/src/bin/stress_orchestrator.rs
+++ b/benchmarks/src/bin/stress_orchestrator.rs
@@ -71,7 +71,6 @@ async fn run_rp_scenario(
 ) -> DegradationPoint {
     let client = BACnetClient::bip_builder()
         .interface(interface)
-        .port(0)
         .broadcast_address(broadcast)
         .apdu_timeout_ms(5000)
         .build()
@@ -138,7 +137,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Probe server-a
     let probe_client = BACnetClient::bip_builder()
         .interface(Ipv4Addr::new(172, 20, 0, 100))
-        .port(0)
         .broadcast_address(Ipv4Addr::new(172, 20, 0, 255))
         .apdu_timeout_ms(5000)
         .build()

--- a/benchmarks/src/helpers.rs
+++ b/benchmarks/src/helpers.rs
@@ -48,7 +48,7 @@ pub async fn make_bip_server() -> Result<BACnetServer<BipTransport>, Error> {
 
     BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .broadcast_address(Ipv4Addr::LOCALHOST)
         .database(db)
         .build()
@@ -59,7 +59,6 @@ pub async fn make_bip_server() -> Result<BACnetServer<BipTransport>, Error> {
 pub async fn make_bip_client() -> Result<BACnetClient<BipTransport>, Error> {
     BACnetClient::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
         .broadcast_address(Ipv4Addr::LOCALHOST)
         .apdu_timeout_ms(2000)
         .build()

--- a/benchmarks/src/stress/harness.rs
+++ b/benchmarks/src/stress/harness.rs
@@ -47,7 +47,7 @@ pub async fn make_bip_server_with_db(
 ) -> Result<BACnetServer<BipTransport>, Error> {
     BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .broadcast_address(Ipv4Addr::LOCALHOST)
         .database(db)
         .build()
@@ -58,7 +58,6 @@ pub async fn make_bip_server_with_db(
 pub async fn make_stress_client() -> Result<BACnetClient<BipTransport>, Error> {
     BACnetClient::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
         .broadcast_address(Ipv4Addr::LOCALHOST)
         .apdu_timeout_ms(5000)
         .build()

--- a/crates/bacnet-cli/src/main.rs
+++ b/crates/bacnet-cli/src/main.rs
@@ -28,9 +28,13 @@ struct Cli {
     #[arg(short, long, global = true)]
     interface: Option<Ipv4Addr>,
 
-    /// BACnet UDP port.
+    /// BACnet UDP broadcast port.
+    #[arg(short, long, default_value_t = 0, global = true)]
+    unicast_port: u16,
+
+    /// BACnet UDP broadcast port.
     #[arg(short, long, default_value_t = 0xBAC0, global = true)]
-    port: u16,
+    broadcast_port: u16,
 
     /// Broadcast address for WhoIs.
     #[arg(short, long, default_value = "255.255.255.255", global = true)]
@@ -798,7 +802,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args = transport::TransportArgs {
         interface,
-        port: cli.port,
+        unicast_port: cli.unicast_port,
+        broadcast_port: cli.broadcast_port,
         broadcast,
         timeout_ms: cli.timeout,
         sc: cli.sc,

--- a/crates/bacnet-cli/src/transport.rs
+++ b/crates/bacnet-cli/src/transport.rs
@@ -10,7 +10,8 @@ use bacnet_types::error::Error;
 #[allow(dead_code)]
 pub struct TransportArgs {
     pub interface: Ipv4Addr,
-    pub port: u16,
+    pub unicast_port: u16,
+    pub broadcast_port: u16,
     pub broadcast: Ipv4Addr,
     pub timeout_ms: u64,
     pub sc: bool,
@@ -78,7 +79,8 @@ pub fn parse_sc_device_uuid_arg(value: &str) -> Result<[u8; 16], String> {
 pub async fn build_bip_client(args: &TransportArgs) -> Result<BACnetClient<BipTransport>, Error> {
     BACnetClient::bip_builder()
         .interface(args.interface)
-        .port(args.port)
+        .unicast_port(args.unicast_port)
+        .broadcast_port(args.broadcast_port)
         .broadcast_address(args.broadcast)
         .apdu_timeout_ms(args.timeout_ms)
         .build()
@@ -163,7 +165,8 @@ pub async fn build_bip6_client(args: &TransportArgs) -> Result<BACnetClient<Bip6
 
     let mut builder = BACnetClient::bip6_builder()
         .interface(ipv6_addr)
-        .port(args.port)
+        .unicast_port(args.unicast_port)
+        .broadcast_port(args.broadcast_port)
         .apdu_timeout_ms(args.timeout_ms);
 
     if let Some(instance) = args.device_instance {

--- a/crates/bacnet-client/src/client/builder_options_tests.rs
+++ b/crates/bacnet-client/src/client/builder_options_tests.rs
@@ -30,7 +30,7 @@ async fn generic_builder_sets_apdu_tuning_options() {
 async fn bip_builder_sets_apdu_tuning_options() {
     let mut client = BACnetClient::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .apdu_retries(7)
         .max_segments(Some(8))
         .segmented_response_accepted(false)

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -73,8 +73,10 @@ pub struct DeviceEvent {
 pub struct ClientConfig {
     /// Local interface to bind.
     pub interface: Ipv4Addr,
-    /// UDP port (0 for ephemeral).
-    pub port: u16,
+    /// UDP unicast port (0 for ephemeral).
+    pub unicast_port: u16,
+    /// UDP broadcast port.
+    pub broadcast_port: u16,
     /// Directed broadcast address.
     pub broadcast_address: Ipv4Addr,
     /// APDU timeout in milliseconds.
@@ -107,7 +109,8 @@ impl Default for ClientConfig {
     fn default() -> Self {
         Self {
             interface: Ipv4Addr::UNSPECIFIED,
-            port: 0xBAC0,
+            unicast_port: 0,
+            broadcast_port: 0xBAC0,
             broadcast_address: Ipv4Addr::BROADCAST,
             apdu_timeout_ms: 6000,
             apdu_retries: 3,
@@ -201,9 +204,15 @@ impl BipClientBuilder {
         self
     }
 
-    /// Set the UDP port (0 for ephemeral).
-    pub fn port(mut self, port: u16) -> Self {
-        self.config.port = port;
+    /// Set the UDP unicast port (0 for ephemeral).
+    pub fn unicast_port(mut self, port: u16) -> Self {
+        self.config.unicast_port = port;
+        self
+    }
+
+    /// Set the UDP broadcast port (0 for ephemeral).
+    pub fn broadcast_port(mut self, port: u16) -> Self {
+        self.config.broadcast_port = port;
         self
     }
 
@@ -235,7 +244,7 @@ impl BipClientBuilder {
     pub async fn build(self) -> Result<BACnetClient<BipTransport>, Error> {
         let transport = BipTransport::new(
             self.config.interface,
-            self.config.port,
+            self.config.broadcast_port,
             self.config.broadcast_address,
         );
         BACnetClient::start_with_options(self.config, transport, self.options).await
@@ -443,9 +452,15 @@ impl Bip6ClientBuilder {
         self
     }
 
-    /// Set the UDP port (0 for ephemeral).
-    pub fn port(mut self, port: u16) -> Self {
-        self.config.port = port;
+    /// Set the UDP unicast port (0 for ephemeral).
+    pub fn unicast_port(mut self, port: u16) -> Self {
+        self.config.unicast_port = port;
+        self
+    }
+
+    /// Set the UDP broadcast port.
+    pub fn broadcast_port(mut self, port: u16) -> Self {
+        self.config.broadcast_port = port;
         self
     }
 
@@ -475,7 +490,11 @@ impl Bip6ClientBuilder {
 
     /// Build and start the client, constructing a Bip6Transport from the config.
     pub async fn build(self) -> Result<BACnetClient<Bip6Transport>, Error> {
-        let transport = Bip6Transport::new(self.interface, self.config.port, self.device_instance);
+        let transport = Bip6Transport::new(
+            self.interface,
+            self.config.broadcast_port,
+            self.device_instance,
+        );
         BACnetClient::start_with_options(self.config, transport, self.options).await
     }
 }

--- a/crates/bacnet-client/src/client/tests.rs
+++ b/crates/bacnet-client/src/client/tests.rs
@@ -16,7 +16,7 @@ use tokio::time::Duration;
 async fn make_client() -> BACnetClient<BipTransport> {
     BACnetClient::builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .apdu_timeout_ms(2000)
         .build()
         .await
@@ -125,7 +125,7 @@ async fn client_stop_releases_bip_socket_before_drop() {
         loop {
             match BACnetClient::builder()
                 .interface(Ipv4Addr::LOCALHOST)
-                .port(port)
+                .broadcast_port(port)
                 .build()
                 .await
             {
@@ -174,7 +174,7 @@ async fn client_drop_releases_bip_socket() {
         loop {
             match BACnetClient::builder()
                 .interface(Ipv4Addr::LOCALHOST)
-                .port(port)
+                .broadcast_port(port)
                 .build()
                 .await
             {
@@ -246,7 +246,7 @@ async fn device_table_purge_runs_without_inbound_apdu() {
 async fn client_rejects_invalid_max_apdu_length() {
     let result = BACnetClient::builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .max_apdu_length(1000)
         .build()
         .await;
@@ -440,7 +440,7 @@ async fn segmented_complex_ack_reassembly() {
 async fn segmented_confirmed_request_sends_segments() {
     let mut client = BACnetClient::builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .apdu_timeout_ms(5000)
         .max_apdu_length(50)
         .build()
@@ -532,7 +532,7 @@ async fn segmented_confirmed_request_sends_segments() {
 async fn segmented_request_with_complex_ack_response() {
     let mut client = BACnetClient::builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .apdu_timeout_ms(5000)
         .max_apdu_length(50)
         .build()
@@ -715,7 +715,7 @@ async fn routed_segmented_request_uses_routed_tsm_key() {
 async fn segment_overflow_guard() {
     let mut client = BACnetClient::builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .apdu_timeout_ms(2000)
         .max_apdu_length(50)
         .build()

--- a/crates/bacnet-client/tests/integration.rs
+++ b/crates/bacnet-client/tests/integration.rs
@@ -26,7 +26,6 @@ async fn full_read_property_round_trip() {
     // Start the client
     let mut client = BACnetClient::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
         .apdu_timeout_ms(2000)
         .build()
         .await
@@ -124,7 +123,7 @@ async fn who_is_broadcast() {
     // Use LOCALHOST as broadcast address since 255.255.255.255 isn't routable in tests.
     let mut client = BACnetClient::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .broadcast_address(Ipv4Addr::LOCALHOST)
         .build()
         .await
@@ -142,7 +141,7 @@ async fn device_discovery_via_iam() {
     // Client that will discover devices
     let mut client = BACnetClient::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .apdu_timeout_ms(2000)
         .build()
         .await

--- a/crates/bacnet-integration-tests/tests/client.rs
+++ b/crates/bacnet-integration-tests/tests/client.rs
@@ -30,7 +30,7 @@ async fn cov_subscribe_and_notification() {
 
     let mut server = BACnetServer::builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .database(db)
         .build()
         .await
@@ -40,7 +40,7 @@ async fn cov_subscribe_and_notification() {
     // Start a client
     let mut client = BACnetClient::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .apdu_timeout_ms(2000)
         .build()
         .await

--- a/crates/bacnet-integration-tests/tests/server.rs
+++ b/crates/bacnet-integration-tests/tests/server.rs
@@ -54,7 +54,7 @@ async fn make_server() -> BACnetServer<BipTransport> {
 
     BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0) // ephemeral
+        .broadcast_port(0) // ephemeral
         .broadcast_address(Ipv4Addr::LOCALHOST)
         .database(db)
         .build()
@@ -65,7 +65,7 @@ async fn make_server() -> BACnetServer<BipTransport> {
 async fn make_client() -> BACnetClient<BipTransport> {
     BACnetClient::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .broadcast_address(Ipv4Addr::LOCALHOST)
         .apdu_timeout_ms(2000)
         .build()

--- a/crates/bacnet-integration-tests/tests/server/dcc.rs
+++ b/crates/bacnet-integration-tests/tests/server/dcc.rs
@@ -91,7 +91,7 @@ async fn dcc_disable_initiation_allows_rp_blocks_cov() {
 
     let mut server = BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .database(db)
         .build()
         .await
@@ -204,7 +204,7 @@ async fn dcc_enable_restores_normal_operation() {
 
     let mut server = BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .database(db)
         .build()
         .await

--- a/crates/bacnet-integration-tests/tests/server/error_cov.rs
+++ b/crates/bacnet-integration-tests/tests/server/error_cov.rs
@@ -221,7 +221,7 @@ async fn cov_subscribe_then_cancel() {
 
     let mut server = BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .database(db)
         .build()
         .await

--- a/crates/bacnet-integration-tests/tests/server/local_write_cov.rs
+++ b/crates/bacnet-integration-tests/tests/server/local_write_cov.rs
@@ -32,7 +32,7 @@ async fn local_write_fires_cov_notification() {
 
     let mut server = BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .database(db)
         .build()
         .await
@@ -125,7 +125,7 @@ async fn local_object_name_write_refreshes_name_index() {
 
     let mut server = BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .database(db)
         .build()
         .await

--- a/crates/bacnet-integration-tests/tests/server/segmentation_tx.rs
+++ b/crates/bacnet-integration-tests/tests/server/segmentation_tx.rs
@@ -48,7 +48,7 @@ async fn server_segments_large_rpm_response() {
 
     let mut server = BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .database(db)
         .build()
         .await
@@ -58,7 +58,7 @@ async fn server_segments_large_rpm_response() {
     // Create a client with max_apdu_length=128 so the response must be segmented.
     let mut client = BACnetClient::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
-        .port(0)
+        .broadcast_port(0)
         .broadcast_address(Ipv4Addr::LOCALHOST)
         .apdu_timeout_ms(5000)
         .max_apdu_length(128)

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -175,8 +175,10 @@ pub struct TimeSyncData {
 pub struct ServerConfig {
     /// Local interface to bind.
     pub interface: Ipv4Addr,
-    /// UDP port (default 0xBAC0 = 47808).
-    pub port: u16,
+    /// UDP unicast port.
+    pub unicast_port: u16,
+    /// UDP broadcast port (default 0xBAC0 = 47808).
+    pub broadcast_port: u16,
     /// Directed broadcast address.
     pub broadcast_address: Ipv4Addr,
     /// Maximum APDU length accepted.
@@ -246,7 +248,8 @@ impl std::fmt::Debug for ServerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ServerConfig")
             .field("interface", &self.interface)
-            .field("port", &self.port)
+            .field("unicast_port", &self.unicast_port)
+            .field("broadcast_port", &self.broadcast_port)
             .field("broadcast_address", &self.broadcast_address)
             .field("max_apdu_length", &self.max_apdu_length)
             .field("segmentation_supported", &self.segmentation_supported)
@@ -275,7 +278,8 @@ impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             interface: Ipv4Addr::UNSPECIFIED,
-            port: 0xBAC0,
+            unicast_port: 0,
+            broadcast_port: 0xBAC0,
             broadcast_address: Ipv4Addr::BROADCAST,
             max_apdu_length: 1476,
             segmentation_supported: Segmentation::NONE,
@@ -373,9 +377,15 @@ impl BipServerBuilder {
         self
     }
 
-    /// Set the UDP port.
-    pub fn port(mut self, port: u16) -> Self {
-        self.config.port = port;
+    /// Set the UDP unicast port.
+    pub fn unicast_port(mut self, port: u16) -> Self {
+        self.config.unicast_port = port;
+        self
+    }
+
+    /// Set the UDP broadcast port.
+    pub fn broadcast_port(mut self, port: u16) -> Self {
+        self.config.broadcast_port = port;
         self
     }
 
@@ -435,7 +445,7 @@ impl BipServerBuilder {
     pub async fn build(self) -> Result<BACnetServer<BipTransport>, Error> {
         let transport = BipTransport::new(
             self.config.interface,
-            self.config.port,
+            self.config.broadcast_port,
             self.config.broadcast_address,
         );
         BACnetServer::start(self.config, self.db, transport).await


### PR DESCRIPTION
broadcast port should default to 47808 so that every UDP endpoint knows in advance which port to listen to for broadcasts.

unicast port should default to 0 to assign ephemeral port so that only the intended recipients listen to the unicast instead of everybody getting spammed.

So far, a single port was used for both broadcast and unicast. This forced you to choose between broadcasts working and unicasts not (by setting port to 47808) or unicasts working and broadcasts not (by setting port to 0). This PR fixes it. Tested against Yabe simulator to confirm the fix.