### PR TITLE
fix(objects,server)!: gate Reliability writability on Out_Of_Service across all nine intrinsic-reporting types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `FaultDetector` gained a private field for warning suppression and is therefore
+  no longer constructible with struct-literal syntax. `FaultDetector { comm_timeout }`
+  becomes a compile error; use `FaultDetector::new(comm_timeout)`, which has been
+  available all along. `comm_timeout` remains `pub` and readable and writable as
+  before. This is a source break in a published crate and is called out separately
+  from the trait addition below, because the compiler error it produces names a
+  private field rather than the change that caused it.
+- Add `BACnetObject::set_reliability_internal` as the trusted lifecycle route for
+  object reliability evaluation, distinct from the network `WriteProperty`
+  route. Ownership is symmetric: clients may write `Reliability` only while
+  `Out_Of_Service` is TRUE, and internal evaluation may write it only while
+  `Out_Of_Service` is FALSE. Entering simulation saves the evaluated value and
+  leaving restores it, avoiding a transient NO_FAULT_DETECTED window on analog
+  objects while still discarding a client simulation; an object restored
+  already out of service falls back to NO_FAULT_DETECTED when no saved value
+  exists. The `bacnet-objects` crate is a public dependency;
+  downstream `BACnetObject` implementors registered as Analog Input, Analog
+  Output, or Analog Value must override this method to keep server fault
+  detection working. The `OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED` default leaves
+  their fault-detection update unapplied and emits a warning. Both public and
+  internal routes enforce the same BACnetReliability value set; repeated
+  identical internal-route failures are warned once per object until the error
+  changes or a write succeeds.
 - Add `Event_Detection_Enable` to Analog Input, Analog Output, Analog Value, Binary Input, Binary Value, Multi-state Input and Multi-state Value (ASHRAE 135-2020 Clauses 12.2, 12.3, 12.4, 12.6, 12.8, 12.18 and 12.20). It carries conformance code **O** on all seven with a bidirectional footnote pair — "These properties are required if the object supports intrinsic reporting" and "These properties shall be present only if the object supports intrinsic reporting" — so on types that do support intrinsic reporting, as these seven do, its presence is required rather than optional. With Binary Output and Multi-state Output already covered, all nine intrinsically-reporting types now model the property. The property gates both intrinsic-reporting entry points, and a write of FALSE establishes the Clause 13.2.2.1 initial conditions for the state each type actually carries: `Event_State` NORMAL, `Acked_Transitions` all-set, no pending Time_Delay countdown, and on the analog types `Event_Time_Stamps` and `Event_Message_Texts` restored as well. The reset runs on any write of FALSE rather than on the TRUE→FALSE edge, because an edge-only reset never fires for an object constructed or restored with the property already FALSE.
 
   **On Binary Input, Binary Value, Multi-state Input and Multi-state Value the invariant is established only partially, and not because those types are exempt.** Clause 13.2.2.1 names `Event_Time_Stamps` and `Event_Message_Texts` alongside `Acked_Transitions`, and the same conformance footnote pair that makes `Event_Detection_Enable` required on an intrinsically-reporting object makes those two required as well — they sit in the same footnote group in every one of these tables. Those four types do not model either property, so there is nothing for the reset to restore. That gap predates this change: all four already called `impl_intrinsic_reporting!` and therefore already supported intrinsic reporting without the properties their footnotes require. This change closes one of the three for them and leaves the other two, which are tracked as #235, alongside #230 (the identical omission on Multi-state Output). It does not make the gap worse, and the reset is complete for every property these types actually have.
@@ -58,6 +81,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserve WritePropertyMultiple atomicity when rolling back an
+  `Out_Of_Service` write. The rollback now restores the client-simulated
+  `Reliability` and reconstructs the saved evaluated value as well as restoring
+  `Out_Of_Service`.
 - Re-enter FAULT when `Reliability` changes to a *different* fault value (ASHRAE 135-2020 Clause 13.2.2.1). The Fault state defines a ToFault transition — "If reliability-evaluation indicates a different Reliability value and the new Reliability value is not NO_FAULT_DETECTED ... then perform the corresponding transition actions and re-enter the Fault state" — and the same clause makes the transition actions apply "even if the transition does not change the event state". `fault_precedence` reduced reliability to a boolean on its first line and no detector retained the previous value, so a change from `OVER_RANGE` to `NO_SENSOR` while already in FAULT held silently and no `CHANGE_OF_RELIABILITY` notification was produced.
 
   `FaultPrecedence` gains a `ReenterFault` variant, and each of the three detectors gains a `fault_reliability: Option<u32>` holding the value in force at the last entry to FAULT.

--- a/crates/bacnet-objects/src/analog/input.rs
+++ b/crates/bacnet-objects/src/analog/input.rs
@@ -27,6 +27,7 @@ pub struct AnalogInputObject {
     event_detection_enable: bool,
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
+    reliability_before_out_of_service: Option<u32>,
     /// Optional minimum present value for fault detection.
     min_pres_value: Option<f32>,
     /// Optional maximum present value for fault detection.
@@ -53,6 +54,7 @@ impl AnalogInputObject {
             event_detector: OutOfRangeDetector::default(),
             event_detection_enable: true,
             reliability: 0,
+            reliability_before_out_of_service: None,
             min_pres_value: None,
             max_pres_value: None,
             event_time_stamps: [
@@ -168,9 +170,13 @@ impl BACnetObject for AnalogInputObject {
             }
             return Err(common::invalid_data_type_error());
         }
-        if let Some(result) =
-            common::write_out_of_service(&mut self.out_of_service, property, &value)
-        {
+        if let Some(result) = common::write_out_of_service_with_reliability_restore(
+            &mut self.out_of_service,
+            &mut self.reliability,
+            &mut self.reliability_before_out_of_service,
+            property,
+            &value,
+        ) {
             return result;
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
@@ -180,7 +186,13 @@ impl BACnetObject for AnalogInputObject {
             return result;
         }
         if property == PropertyIdentifier::RELIABILITY {
+            if !self.out_of_service {
+                return Err(common::write_access_denied_error());
+            }
             if let PropertyValue::Enumerated(v) = value {
+                if !common::is_reliability_value_valid(v) {
+                    return Err(common::value_out_of_range_error());
+                }
                 self.reliability = v;
                 return Ok(());
             }
@@ -264,6 +276,17 @@ impl BACnetObject for AnalogInputObject {
 
     fn acknowledge_alarm(&mut self, transition_bit: u8) -> Result<(), bacnet_types::error::Error> {
         self.event_detector.acked_transitions |= transition_bit & 0x07;
+        Ok(())
+    }
+
+    fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        if !common::is_reliability_value_valid(reliability) {
+            return Err(common::value_out_of_range_error());
+        }
+        self.reliability = reliability;
         Ok(())
     }
 

--- a/crates/bacnet-objects/src/analog/output.rs
+++ b/crates/bacnet-objects/src/analog/output.rs
@@ -28,6 +28,7 @@ pub struct AnalogOutputObject {
     /// Event_Detection_Enable property is FALSE, then this state machine is not evaluated."
     event_detection_enable: bool,
     reliability: u32,
+    reliability_before_out_of_service: Option<u32>,
     min_pres_value: Option<f32>,
     max_pres_value: Option<f32>,
     event_time_stamps: [BACnetTimeStamp; 3],
@@ -54,6 +55,7 @@ impl AnalogOutputObject {
             event_detector: OutOfRangeDetector::default(),
             event_detection_enable: true,
             reliability: 0,
+            reliability_before_out_of_service: None,
             min_pres_value: None,
             max_pres_value: None,
             event_time_stamps: [
@@ -192,9 +194,13 @@ impl BACnetObject for AnalogOutputObject {
                 }
             });
         }
-        if let Some(result) =
-            common::write_out_of_service(&mut self.out_of_service, property, &value)
-        {
+        if let Some(result) = common::write_out_of_service_with_reliability_restore(
+            &mut self.out_of_service,
+            &mut self.reliability,
+            &mut self.reliability_before_out_of_service,
+            property,
+            &value,
+        ) {
             return result;
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
@@ -203,8 +209,19 @@ impl BACnetObject for AnalogOutputObject {
         if let Some(result) = common::write_description(&mut self.description, property, &value) {
             return result;
         }
+        // Clause 12.3, while Out_Of_Service is TRUE: "the Present_Value property and
+        // the Reliability property, if present and capable of taking on values other
+        // than NO_FAULT_DETECTED, shall be writable to allow simulating specific
+        // conditions or for testing purposes".
+        // `is_writable_property` stays statically true because it describes capability.
         if property == PropertyIdentifier::RELIABILITY {
+            if !self.out_of_service {
+                return Err(common::write_access_denied_error());
+            }
             if let PropertyValue::Enumerated(v) = value {
+                if !common::is_reliability_value_valid(v) {
+                    return Err(common::value_out_of_range_error());
+                }
                 self.reliability = v;
                 return Ok(());
             }
@@ -291,6 +308,17 @@ impl BACnetObject for AnalogOutputObject {
 
     fn acknowledge_alarm(&mut self, transition_bit: u8) -> Result<(), bacnet_types::error::Error> {
         self.event_detector.acked_transitions |= transition_bit & 0x07;
+        Ok(())
+    }
+
+    fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        if !common::is_reliability_value_valid(reliability) {
+            return Err(common::value_out_of_range_error());
+        }
+        self.reliability = reliability;
         Ok(())
     }
 

--- a/crates/bacnet-objects/src/analog/value.rs
+++ b/crates/bacnet-objects/src/analog/value.rs
@@ -30,6 +30,7 @@ pub struct AnalogValueObject {
     event_detection_enable: bool,
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
+    reliability_before_out_of_service: Option<u32>,
     min_pres_value: Option<f32>,
     max_pres_value: Option<f32>,
     event_time_stamps: [BACnetTimeStamp; 3],
@@ -56,6 +57,7 @@ impl AnalogValueObject {
             event_detector: OutOfRangeDetector::default(),
             event_detection_enable: true,
             reliability: 0,
+            reliability_before_out_of_service: None,
             min_pres_value: None,
             max_pres_value: None,
             event_time_stamps: [
@@ -204,9 +206,13 @@ impl BACnetObject for AnalogValueObject {
                 }
             });
         }
-        if let Some(result) =
-            common::write_out_of_service(&mut self.out_of_service, property, &value)
-        {
+        if let Some(result) = common::write_out_of_service_with_reliability_restore(
+            &mut self.out_of_service,
+            &mut self.reliability,
+            &mut self.reliability_before_out_of_service,
+            property,
+            &value,
+        ) {
             return result;
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
@@ -215,8 +221,19 @@ impl BACnetObject for AnalogValueObject {
         if let Some(result) = common::write_description(&mut self.description, property, &value) {
             return result;
         }
+        // Clause 12.4, while Out_Of_Service is TRUE: "the Present_Value property and
+        // the Reliability property, if present and capable of taking on values other
+        // than NO_FAULT_DETECTED, shall be writable to allow simulating specific
+        // conditions or for testing purposes".
+        // `is_writable_property` stays statically true because it describes capability.
         if property == PropertyIdentifier::RELIABILITY {
+            if !self.out_of_service {
+                return Err(common::write_access_denied_error());
+            }
             if let PropertyValue::Enumerated(v) = value {
+                if !common::is_reliability_value_valid(v) {
+                    return Err(common::value_out_of_range_error());
+                }
                 self.reliability = v;
                 return Ok(());
             }
@@ -303,6 +320,17 @@ impl BACnetObject for AnalogValueObject {
 
     fn acknowledge_alarm(&mut self, transition_bit: u8) -> Result<(), bacnet_types::error::Error> {
         self.event_detector.acked_transitions |= transition_bit & 0x07;
+        Ok(())
+    }
+
+    fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        if !common::is_reliability_value_valid(reliability) {
+            return Err(common::value_out_of_range_error());
+        }
+        self.reliability = reliability;
         Ok(())
     }
 

--- a/crates/bacnet-objects/src/binary/input.rs
+++ b/crates/bacnet-objects/src/binary/input.rs
@@ -19,6 +19,7 @@ pub struct BinaryInputObject {
     polarity: u32,
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
+    reliability_before_out_of_service: Option<u32>,
     active_text: String,
     inactive_text: String,
     /// CHANGE_OF_STATE event detector.
@@ -45,6 +46,7 @@ impl BinaryInputObject {
             status_flags: StatusFlags::empty(),
             polarity: 0,
             reliability: 0,
+            reliability_before_out_of_service: None,
             active_text: "Active".into(),
             inactive_text: "Inactive".into(),
             event_detector: ChangeOfStateDetector::default(),
@@ -193,9 +195,13 @@ impl BACnetObject for BinaryInputObject {
             }
             return Err(common::invalid_data_type_error());
         }
-        if let Some(result) =
-            common::write_out_of_service(&mut self.out_of_service, property, &value)
-        {
+        if let Some(result) = common::write_out_of_service_with_reliability_restore(
+            &mut self.out_of_service,
+            &mut self.reliability,
+            &mut self.reliability_before_out_of_service,
+            property,
+            &value,
+        ) {
             return result;
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
@@ -203,6 +209,19 @@ impl BACnetObject for BinaryInputObject {
         }
         if let Some(result) = common::write_description(&mut self.description, property, &value) {
             return result;
+        }
+        if property == PropertyIdentifier::RELIABILITY {
+            if !self.out_of_service {
+                return Err(common::write_access_denied_error());
+            }
+            if let PropertyValue::Enumerated(v) = value {
+                if !common::is_reliability_value_valid(v) {
+                    return Err(common::value_out_of_range_error());
+                }
+                self.reliability = v;
+                return Ok(());
+            }
+            return Err(common::invalid_data_type_error());
         }
         Err(common::write_access_denied_error())
     }
@@ -230,6 +249,17 @@ impl BACnetObject for BinaryInputObject {
         true
     }
 
+    fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        if !common::is_reliability_value_valid(reliability) {
+            return Err(common::value_out_of_range_error());
+        }
+        self.reliability = reliability;
+        Ok(())
+    }
+
     fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
         // Mirrors the BinaryInput `write_property` arms. EVENT_ENABLE,
         // NOTIFICATION_CLASS, and ACKED_TRANSITIONS are read-only on BI
@@ -239,6 +269,7 @@ impl BACnetObject for BinaryInputObject {
             || property == PropertyIdentifier::ACTIVE_TEXT
             || property == PropertyIdentifier::INACTIVE_TEXT
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE
+            || property == PropertyIdentifier::RELIABILITY
     }
 }
 

--- a/crates/bacnet-objects/src/binary/output.rs
+++ b/crates/bacnet-objects/src/binary/output.rs
@@ -22,6 +22,7 @@ pub struct BinaryOutputObject {
     polarity: u32,
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
+    reliability_before_out_of_service: Option<u32>,
     event_detection_enable: bool,
     active_text: String,
     inactive_text: String,
@@ -46,6 +47,7 @@ impl BinaryOutputObject {
             relinquish_default: 0,
             polarity: 0,
             reliability: 0,
+            reliability_before_out_of_service: None,
             event_detection_enable: false,
             active_text: "Active".into(),
             inactive_text: "Inactive".into(),
@@ -223,9 +225,13 @@ impl BACnetObject for BinaryOutputObject {
         if let Some(result) = write_generic_event_properties!(self, property, value) {
             return result;
         }
-        if let Some(result) =
-            common::write_out_of_service(&mut self.out_of_service, property, &value)
-        {
+        if let Some(result) = common::write_out_of_service_with_reliability_restore(
+            &mut self.out_of_service,
+            &mut self.reliability,
+            &mut self.reliability_before_out_of_service,
+            property,
+            &value,
+        ) {
             return result;
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
@@ -233,6 +239,24 @@ impl BACnetObject for BinaryOutputObject {
         }
         if let Some(result) = common::write_description(&mut self.description, property, &value) {
             return result;
+        }
+        // Clause 12.7, while Out_Of_Service is TRUE: "the Present_Value property and
+        // the Reliability property, if present and capable of taking on values other
+        // than NO_FAULT_DETECTED, shall be writable to allow simulating specific
+        // conditions or for testing purposes".
+        // `is_writable_property` stays statically true because it describes capability.
+        if property == PropertyIdentifier::RELIABILITY {
+            if !self.out_of_service {
+                return Err(common::write_access_denied_error());
+            }
+            if let PropertyValue::Enumerated(v) = value {
+                if !common::is_reliability_value_valid(v) {
+                    return Err(common::value_out_of_range_error());
+                }
+                self.reliability = v;
+                return Ok(());
+            }
+            return Err(common::invalid_data_type_error());
         }
         Err(common::write_access_denied_error())
     }
@@ -269,6 +293,17 @@ impl BACnetObject for BinaryOutputObject {
         true
     }
 
+    fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        if !common::is_reliability_value_valid(reliability) {
+            return Err(common::value_out_of_range_error());
+        }
+        self.reliability = reliability;
+        Ok(())
+    }
+
     fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
         // Mirrors the BinaryOutput `write_property` arms: commandable
         // (PRIORITY_ARRAY + PRESENT_VALUE) + common + text properties.
@@ -278,6 +313,7 @@ impl BACnetObject for BinaryOutputObject {
             || property == PropertyIdentifier::FEEDBACK_VALUE
             || property == PropertyIdentifier::ACTIVE_TEXT
             || property == PropertyIdentifier::INACTIVE_TEXT
+            || property == PropertyIdentifier::RELIABILITY
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE
     }
 }

--- a/crates/bacnet-objects/src/binary/value.rs
+++ b/crates/bacnet-objects/src/binary/value.rs
@@ -19,6 +19,7 @@ pub struct BinaryValueObject {
     relinquish_default: u32,
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
+    reliability_before_out_of_service: Option<u32>,
     active_text: String,
     inactive_text: String,
     /// CHANGE_OF_STATE event detector.
@@ -49,6 +50,7 @@ impl BinaryValueObject {
             priority_array: [None; 16],
             relinquish_default: 0,
             reliability: 0,
+            reliability_before_out_of_service: None,
             active_text: "Active".into(),
             inactive_text: "Inactive".into(),
             event_detector: ChangeOfStateDetector::default(),
@@ -219,9 +221,13 @@ impl BACnetObject for BinaryValueObject {
             }
             return Err(common::invalid_data_type_error());
         }
-        if let Some(result) =
-            common::write_out_of_service(&mut self.out_of_service, property, &value)
-        {
+        if let Some(result) = common::write_out_of_service_with_reliability_restore(
+            &mut self.out_of_service,
+            &mut self.reliability,
+            &mut self.reliability_before_out_of_service,
+            property,
+            &value,
+        ) {
             return result;
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
@@ -229,6 +235,24 @@ impl BACnetObject for BinaryValueObject {
         }
         if let Some(result) = common::write_description(&mut self.description, property, &value) {
             return result;
+        }
+        // Clause 12.8, while Out_Of_Service is TRUE: "the Present_Value property and
+        // the Reliability property, if present and capable of taking on values other
+        // than NO_FAULT_DETECTED, shall be writable to allow simulating specific
+        // conditions or for testing purposes".
+        // `is_writable_property` stays statically true because it describes capability.
+        if property == PropertyIdentifier::RELIABILITY {
+            if !self.out_of_service {
+                return Err(common::write_access_denied_error());
+            }
+            if let PropertyValue::Enumerated(v) = value {
+                if !common::is_reliability_value_valid(v) {
+                    return Err(common::value_out_of_range_error());
+                }
+                self.reliability = v;
+                return Ok(());
+            }
+            return Err(common::invalid_data_type_error());
         }
         Err(common::write_access_denied_error())
     }
@@ -258,6 +282,17 @@ impl BACnetObject for BinaryValueObject {
         true
     }
 
+    fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        if !common::is_reliability_value_valid(reliability) {
+            return Err(common::value_out_of_range_error());
+        }
+        self.reliability = reliability;
+        Ok(())
+    }
+
     fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
         // Mirrors the BinaryValue `write_property` arms. Same set as
         // BinaryOutput (commandable + common + text properties).
@@ -265,6 +300,7 @@ impl BACnetObject for BinaryValueObject {
             || common::is_common_writable(property)
             || property == PropertyIdentifier::ACTIVE_TEXT
             || property == PropertyIdentifier::INACTIVE_TEXT
+            || property == PropertyIdentifier::RELIABILITY
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE
     }
 }

--- a/crates/bacnet-objects/src/common.rs
+++ b/crates/bacnet-objects/src/common.rs
@@ -180,6 +180,42 @@ pub(crate) fn write_out_of_service(
     }
 }
 
+/// Handle writing OUT_OF_SERVICE for objects that temporarily transfer
+/// Reliability ownership to a client simulation.
+///
+/// The evaluated value is saved on the FALSE-to-TRUE edge and restored directly
+/// on the TRUE-to-FALSE edge. If the entry edge was not observed, the restore
+/// falls back to NO_FAULT_DETECTED.
+#[inline]
+pub(crate) fn write_out_of_service_with_reliability_restore(
+    out_of_service: &mut bool,
+    reliability: &mut u32,
+    saved_reliability: &mut Option<u32>,
+    property: bacnet_types::enums::PropertyIdentifier,
+    value: &bacnet_types::primitives::PropertyValue,
+) -> Option<Result<(), bacnet_types::error::Error>> {
+    if property == bacnet_types::enums::PropertyIdentifier::OUT_OF_SERVICE {
+        if let bacnet_types::primitives::PropertyValue::Boolean(v) = value {
+            if !*out_of_service && *v {
+                *saved_reliability = Some(*reliability);
+            } else if *out_of_service && !*v {
+                *reliability = saved_reliability
+                    .take()
+                    .unwrap_or(bacnet_types::enums::Reliability::NO_FAULT_DETECTED.to_raw());
+            }
+            *out_of_service = *v;
+            Some(Ok(()))
+        } else {
+            Some(Err(protocol_error(
+                bacnet_types::enums::ErrorClass::PROPERTY,
+                bacnet_types::enums::ErrorCode::INVALID_DATA_TYPE,
+            )))
+        }
+    } else {
+        None
+    }
+}
+
 /// Handle writing the DESCRIPTION property.
 ///
 /// Returns `Some(Ok(()))` if the property was DESCRIPTION and successfully handled,
@@ -253,6 +289,13 @@ pub(crate) fn value_out_of_range_error() -> bacnet_types::error::Error {
         bacnet_types::enums::ErrorClass::PROPERTY,
         bacnet_types::enums::ErrorCode::VALUE_OUT_OF_RANGE,
     )
+}
+
+/// Return whether a raw BACnetReliability value is defined by ASHRAE or lies
+/// in the vendor-proprietary range.
+#[inline]
+pub(crate) fn is_reliability_value_valid(value: u32) -> bool {
+    matches!(value, 0..=10 | 12..=25 | 64..=65_535)
 }
 
 /// Return the invalid-array-index protocol error.
@@ -786,9 +829,10 @@ pub(crate) fn is_commandable_property_writable(
     )
 }
 
-/// Writable common properties shared by all core I/O/V object types
-/// (accepted via the `write_out_of_service`, `write_object_name`, and
-/// `write_description` helpers in `common.rs`).
+/// Writable common properties shared by all core I/O/V object types (accepted
+/// via `write_out_of_service` or
+/// `write_out_of_service_with_reliability_restore`, plus `write_object_name`
+/// and `write_description`).
 #[inline]
 pub(crate) fn is_common_writable(property: bacnet_types::enums::PropertyIdentifier) -> bool {
     matches!(

--- a/crates/bacnet-objects/src/event/fault_tests.rs
+++ b/crates/bacnet-objects/src/event/fault_tests.rs
@@ -726,6 +726,13 @@ fn writing_reliability_on_an_object_drives_event_state_to_fault() {
     );
 
     ai.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .expect("Out_Of_Service is writable");
+    ai.write_property(
         PropertyIdentifier::RELIABILITY,
         None,
         PropertyValue::Enumerated(OVER_RANGE),
@@ -752,6 +759,13 @@ fn ticking_an_object_uses_reliability_for_fault_and_recovery() {
     use bacnet_types::primitives::PropertyValue;
 
     let mut ai = AnalogInputObject::new(3, "ai-3", 62).expect("construct");
+    ai.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .expect("Out_Of_Service is writable");
     ai.write_property(
         PropertyIdentifier::RELIABILITY,
         None,
@@ -793,13 +807,8 @@ fn faulted_object_reports_both_fault_and_in_alarm_status_flags() {
     use bacnet_types::primitives::{PropertyValue, StatusFlags};
 
     let mut ai = AnalogInputObject::new(2, "ai-2", 62).expect("construct");
-    ai.write_property(
-        PropertyIdentifier::RELIABILITY,
-        None,
-        PropertyValue::Enumerated(OVER_RANGE),
-        None,
-    )
-    .expect("reliability is writable");
+    ai.set_reliability_internal(OVER_RANGE)
+        .expect("in-service reliability evaluation is supported");
     ai.evaluate_intrinsic_reporting();
 
     let flags = ai

--- a/crates/bacnet-objects/src/lib.rs
+++ b/crates/bacnet-objects/src/lib.rs
@@ -32,3 +32,6 @@ pub mod timer;
 pub mod traits;
 pub mod trend;
 pub mod value_types;
+
+#[cfg(test)]
+mod reliability_writability_tests;

--- a/crates/bacnet-objects/src/multistate/input.rs
+++ b/crates/bacnet-objects/src/multistate/input.rs
@@ -18,6 +18,7 @@ pub struct MultiStateInputObject {
     status_flags: StatusFlags,
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
+    reliability_before_out_of_service: Option<u32>,
     state_text: Vec<String>,
     /// Alarm_Values — state values that trigger OFFNORMAL.
     alarm_values: Vec<u32>,
@@ -52,6 +53,7 @@ impl MultiStateInputObject {
             out_of_service: false,
             status_flags: StatusFlags::empty(),
             reliability: 0,
+            reliability_before_out_of_service: None,
             state_text: (1..=number_of_states)
                 .map(|i| format!("State {i}"))
                 .collect(),
@@ -222,9 +224,13 @@ impl BACnetObject for MultiStateInputObject {
             }
             return Err(common::invalid_data_type_error());
         }
-        if let Some(result) =
-            common::write_out_of_service(&mut self.out_of_service, property, &value)
-        {
+        if let Some(result) = common::write_out_of_service_with_reliability_restore(
+            &mut self.out_of_service,
+            &mut self.reliability,
+            &mut self.reliability_before_out_of_service,
+            property,
+            &value,
+        ) {
             return result;
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
@@ -232,6 +238,24 @@ impl BACnetObject for MultiStateInputObject {
         }
         if let Some(result) = common::write_description(&mut self.description, property, &value) {
             return result;
+        }
+        // Clause 12.18, while Out_Of_Service is TRUE: "the Present_Value property and
+        // the Reliability property, if present and capable of taking on values other
+        // than NO_FAULT_DETECTED, shall be writable to allow simulating specific
+        // conditions or for testing purposes".
+        // `is_writable_property` stays statically true because it describes capability.
+        if property == PropertyIdentifier::RELIABILITY {
+            if !self.out_of_service {
+                return Err(common::write_access_denied_error());
+            }
+            if let PropertyValue::Enumerated(v) = value {
+                if !common::is_reliability_value_valid(v) {
+                    return Err(common::value_out_of_range_error());
+                }
+                self.reliability = v;
+                return Ok(());
+            }
+            return Err(common::invalid_data_type_error());
         }
         Err(common::write_access_denied_error())
     }
@@ -259,9 +283,21 @@ impl BACnetObject for MultiStateInputObject {
     fn is_createable(&self) -> bool {
         true
     }
+    fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        if !common::is_reliability_value_valid(reliability) {
+            return Err(common::value_out_of_range_error());
+        }
+        self.reliability = reliability;
+        Ok(())
+    }
+
     fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
         // Mirrors the MultiStateInput `write_property` arms.
         common::is_multistate_input_writable(property)
+            || property == PropertyIdentifier::RELIABILITY
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE
     }
 }

--- a/crates/bacnet-objects/src/multistate/output.rs
+++ b/crates/bacnet-objects/src/multistate/output.rs
@@ -23,6 +23,7 @@ pub struct MultiStateOutputObject {
     relinquish_default: u32,
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
+    reliability_before_out_of_service: Option<u32>,
     event_detection_enable: bool,
     state_text: Vec<String>,
     alarm_values: Vec<u32>,
@@ -53,6 +54,7 @@ impl MultiStateOutputObject {
             priority_array: [None; 16],
             relinquish_default: 1,
             reliability: 0,
+            reliability_before_out_of_service: None,
             event_detection_enable: false,
             state_text: (1..=number_of_states)
                 .map(|i| format!("State {i}"))
@@ -267,9 +269,13 @@ impl BACnetObject for MultiStateOutputObject {
         if let Some(result) = write_generic_event_properties!(self, property, value) {
             return result;
         }
-        if let Some(result) =
-            common::write_out_of_service(&mut self.out_of_service, property, &value)
-        {
+        if let Some(result) = common::write_out_of_service_with_reliability_restore(
+            &mut self.out_of_service,
+            &mut self.reliability,
+            &mut self.reliability_before_out_of_service,
+            property,
+            &value,
+        ) {
             return result;
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
@@ -277,6 +283,24 @@ impl BACnetObject for MultiStateOutputObject {
         }
         if let Some(result) = common::write_description(&mut self.description, property, &value) {
             return result;
+        }
+        // Clause 12.19, while Out_Of_Service is TRUE: "the Present_Value property and
+        // the Reliability property, if present and capable of taking on values other
+        // than NO_FAULT_DETECTED, shall be writable to allow simulating specific
+        // conditions or for testing purposes".
+        // `is_writable_property` stays statically true because it describes capability.
+        if property == PropertyIdentifier::RELIABILITY {
+            if !self.out_of_service {
+                return Err(common::write_access_denied_error());
+            }
+            if let PropertyValue::Enumerated(v) = value {
+                if !common::is_reliability_value_valid(v) {
+                    return Err(common::value_out_of_range_error());
+                }
+                self.reliability = v;
+                return Ok(());
+            }
+            return Err(common::invalid_data_type_error());
         }
         Err(common::write_access_denied_error())
     }
@@ -313,9 +337,21 @@ impl BACnetObject for MultiStateOutputObject {
     fn is_createable(&self) -> bool {
         true
     }
+    fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        if !common::is_reliability_value_valid(reliability) {
+            return Err(common::value_out_of_range_error());
+        }
+        self.reliability = reliability;
+        Ok(())
+    }
+
     fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
         // Mirrors the MultiStateOutput `write_property` arms.
         common::is_multistate_commandable_writable(property)
+            || property == PropertyIdentifier::RELIABILITY
             || common::is_generic_event_property_writable(property)
             || property == PropertyIdentifier::FEEDBACK_VALUE
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE

--- a/crates/bacnet-objects/src/multistate/value.rs
+++ b/crates/bacnet-objects/src/multistate/value.rs
@@ -20,6 +20,7 @@ pub struct MultiStateValueObject {
     relinquish_default: u32,
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
+    reliability_before_out_of_service: Option<u32>,
     state_text: Vec<String>,
     alarm_values: Vec<u32>,
     fault_values: Vec<u32>,
@@ -56,6 +57,7 @@ impl MultiStateValueObject {
             priority_array: [None; 16],
             relinquish_default: 1,
             reliability: 0,
+            reliability_before_out_of_service: None,
             state_text: (1..=number_of_states)
                 .map(|i| format!("State {i}"))
                 .collect(),
@@ -251,9 +253,13 @@ impl BACnetObject for MultiStateValueObject {
             }
             return Err(common::invalid_data_type_error());
         }
-        if let Some(result) =
-            common::write_out_of_service(&mut self.out_of_service, property, &value)
-        {
+        if let Some(result) = common::write_out_of_service_with_reliability_restore(
+            &mut self.out_of_service,
+            &mut self.reliability,
+            &mut self.reliability_before_out_of_service,
+            property,
+            &value,
+        ) {
             return result;
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
@@ -261,6 +267,24 @@ impl BACnetObject for MultiStateValueObject {
         }
         if let Some(result) = common::write_description(&mut self.description, property, &value) {
             return result;
+        }
+        // Clause 12.20, while Out_Of_Service is TRUE: "the Present_Value property and
+        // the Reliability property, if present and capable of taking on values other
+        // than NO_FAULT_DETECTED, shall be writable to allow simulating specific
+        // conditions or for testing purposes".
+        // `is_writable_property` stays statically true because it describes capability.
+        if property == PropertyIdentifier::RELIABILITY {
+            if !self.out_of_service {
+                return Err(common::write_access_denied_error());
+            }
+            if let PropertyValue::Enumerated(v) = value {
+                if !common::is_reliability_value_valid(v) {
+                    return Err(common::value_out_of_range_error());
+                }
+                self.reliability = v;
+                return Ok(());
+            }
+            return Err(common::invalid_data_type_error());
         }
         Err(common::write_access_denied_error())
     }
@@ -289,9 +313,21 @@ impl BACnetObject for MultiStateValueObject {
     fn is_createable(&self) -> bool {
         true
     }
+    fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        if !common::is_reliability_value_valid(reliability) {
+            return Err(common::value_out_of_range_error());
+        }
+        self.reliability = reliability;
+        Ok(())
+    }
+
     fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
         // Mirrors the MultiStateValue `write_property` arms.
         common::is_multistate_commandable_writable(property)
+            || property == PropertyIdentifier::RELIABILITY
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE
     }
 }

--- a/crates/bacnet-objects/src/reliability_writability_tests.rs
+++ b/crates/bacnet-objects/src/reliability_writability_tests.rs
@@ -1,0 +1,303 @@
+use crate::analog::{AnalogInputObject, AnalogOutputObject, AnalogValueObject};
+use crate::binary::{BinaryInputObject, BinaryOutputObject, BinaryValueObject};
+use crate::multistate::{MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject};
+use crate::traits::BACnetObject;
+use bacnet_types::enums::{ErrorClass, ErrorCode, PropertyIdentifier, Reliability};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::PropertyValue;
+
+fn assert_reliability_gate(object: &mut dyn BACnetObject) {
+    assert!(
+        object.is_writable_property(PropertyIdentifier::RELIABILITY),
+        "static capability must advertise Reliability as writable"
+    );
+
+    let denied = object
+        .write_property(
+            PropertyIdentifier::RELIABILITY,
+            None,
+            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+            None,
+        )
+        .expect_err("in-service Reliability write must be refused");
+    match denied {
+        Error::Protocol { class, code } => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(code, ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32);
+        }
+        other => panic!("expected PROPERTY / WRITE_ACCESS_DENIED, got {other:?}"),
+    }
+
+    object
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .expect("Out_Of_Service must be writable");
+
+    for invalid in [11, 26, 63, 65_536] {
+        let invalid_value = object
+            .write_property(
+                PropertyIdentifier::RELIABILITY,
+                None,
+                PropertyValue::Enumerated(invalid),
+                None,
+            )
+            .expect_err("reserved or out-of-range Reliability must be refused");
+        match invalid_value {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+                assert_eq!(code, ErrorCode::VALUE_OUT_OF_RANGE.to_raw() as u32);
+            }
+            other => panic!("expected PROPERTY / VALUE_OUT_OF_RANGE, got {other:?}"),
+        }
+    }
+    for valid in [25, 64, 65_535] {
+        object
+            .write_property(
+                PropertyIdentifier::RELIABILITY,
+                None,
+                PropertyValue::Enumerated(valid),
+                None,
+            )
+            .expect("defined or vendor Reliability boundary must be accepted");
+    }
+
+    object
+        .write_property(
+            PropertyIdentifier::RELIABILITY,
+            None,
+            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+            None,
+        )
+        .expect("out-of-service Reliability write must succeed");
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .expect("Reliability must read back"),
+        PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw())
+    );
+
+    let internal_denied = object
+        .set_reliability_internal(Reliability::NO_FAULT_DETECTED.to_raw())
+        .expect_err("internal Reliability write must not overwrite client simulation");
+    match internal_denied {
+        Error::Protocol { class, code } => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(code, ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32);
+        }
+        other => panic!("expected PROPERTY / WRITE_ACCESS_DENIED, got {other:?}"),
+    }
+
+    object
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .expect("returning to service must succeed");
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .expect("restored Reliability must read back"),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+        "returning to service must discard the simulated Reliability"
+    );
+
+    let invalid_internal = object
+        .set_reliability_internal(65_536)
+        .expect_err("internal route must enforce the Reliability datatype");
+    match invalid_internal {
+        Error::Protocol { class, code } => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(code, ErrorCode::VALUE_OUT_OF_RANGE.to_raw() as u32);
+        }
+        other => panic!("expected PROPERTY / VALUE_OUT_OF_RANGE, got {other:?}"),
+    }
+    object
+        .set_reliability_internal(Reliability::NO_SENSOR.to_raw())
+        .expect("internal Reliability write must succeed in service");
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .expect("internally written Reliability must read back"),
+        PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw())
+    );
+    object
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .expect("redundant in-service write must succeed");
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .expect("Reliability must survive redundant FALSE"),
+        PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+        "a redundant FALSE write must not replay restore logic"
+    );
+
+    object
+        .set_reliability_internal(Reliability::OVER_RANGE.to_raw())
+        .expect("internal evaluator must establish a non-default saved value");
+    object
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .expect("entering a second simulation must succeed");
+    object
+        .write_property(
+            PropertyIdentifier::RELIABILITY,
+            None,
+            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+            None,
+        )
+        .expect("second client simulation must succeed");
+    object
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .expect("leaving a second simulation must succeed");
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .expect("saved non-default Reliability must read back"),
+        PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
+        "save and restore must preserve a non-default evaluated value"
+    );
+}
+
+#[test]
+fn reliability_value_boundaries_match_asn1() {
+    let boundaries = [11, 25, 26, 63, 64, 65_535, 65_536];
+    let actual: Vec<bool> = boundaries
+        .into_iter()
+        .map(crate::common::is_reliability_value_valid)
+        .collect();
+    assert_eq!(
+        actual,
+        vec![false, true, false, false, true, true, false],
+        "boundary order is 11, 25, 26, 63, 64, 65535, 65536"
+    );
+}
+
+#[test]
+fn entering_out_of_service_saves_evaluated_reliability() {
+    let mut out_of_service = false;
+    let mut reliability = Reliability::OVER_RANGE.to_raw();
+    let mut saved = None;
+
+    crate::common::write_out_of_service_with_reliability_restore(
+        &mut out_of_service,
+        &mut reliability,
+        &mut saved,
+        PropertyIdentifier::OUT_OF_SERVICE,
+        &PropertyValue::Boolean(true),
+    )
+    .expect("Out_Of_Service must be handled")
+    .expect("entry must succeed");
+
+    assert!(out_of_service);
+    assert_eq!(saved, Some(Reliability::OVER_RANGE.to_raw()));
+    assert_eq!(reliability, Reliability::OVER_RANGE.to_raw());
+}
+
+#[test]
+fn leaving_out_of_service_restores_saved_reliability() {
+    let mut out_of_service = true;
+    let mut reliability = Reliability::NO_SENSOR.to_raw();
+    let mut saved = Some(Reliability::OVER_RANGE.to_raw());
+
+    crate::common::write_out_of_service_with_reliability_restore(
+        &mut out_of_service,
+        &mut reliability,
+        &mut saved,
+        PropertyIdentifier::OUT_OF_SERVICE,
+        &PropertyValue::Boolean(false),
+    )
+    .expect("Out_Of_Service must be handled")
+    .expect("exit must succeed");
+
+    assert!(!out_of_service);
+    assert_eq!(saved, None);
+    assert_eq!(reliability, Reliability::OVER_RANGE.to_raw());
+}
+
+#[test]
+fn leaving_out_of_service_without_saved_value_falls_back_to_no_fault() {
+    let mut out_of_service = true;
+    let mut reliability = Reliability::NO_SENSOR.to_raw();
+    let mut saved = None;
+
+    crate::common::write_out_of_service_with_reliability_restore(
+        &mut out_of_service,
+        &mut reliability,
+        &mut saved,
+        PropertyIdentifier::OUT_OF_SERVICE,
+        &PropertyValue::Boolean(false),
+    )
+    .expect("Out_Of_Service must be handled")
+    .expect("fallback exit must succeed");
+
+    assert!(!out_of_service);
+    assert_eq!(saved, None);
+    assert_eq!(reliability, Reliability::NO_FAULT_DETECTED.to_raw());
+}
+
+macro_rules! reliability_gate_test {
+    ($name:ident, $object:expr) => {
+        #[test]
+        fn $name() {
+            let mut object = $object;
+            assert_reliability_gate(&mut object);
+        }
+    };
+}
+
+reliability_gate_test!(
+    analog_input_reliability_requires_out_of_service,
+    AnalogInputObject::new(1, "AI-1", 62).unwrap()
+);
+reliability_gate_test!(
+    analog_output_reliability_requires_out_of_service,
+    AnalogOutputObject::new(1, "AO-1", 62).unwrap()
+);
+reliability_gate_test!(
+    analog_value_reliability_requires_out_of_service,
+    AnalogValueObject::new(1, "AV-1", 62).unwrap()
+);
+reliability_gate_test!(
+    binary_input_reliability_requires_out_of_service,
+    BinaryInputObject::new(1, "BI-1").unwrap()
+);
+reliability_gate_test!(
+    binary_output_reliability_requires_out_of_service,
+    BinaryOutputObject::new(1, "BO-1").unwrap()
+);
+reliability_gate_test!(
+    binary_value_reliability_requires_out_of_service,
+    BinaryValueObject::new(1, "BV-1").unwrap()
+);
+reliability_gate_test!(
+    multistate_input_reliability_requires_out_of_service,
+    MultiStateInputObject::new(1, "MSI-1", 3).unwrap()
+);
+reliability_gate_test!(
+    multistate_output_reliability_requires_out_of_service,
+    MultiStateOutputObject::new(1, "MSO-1", 3).unwrap()
+);
+reliability_gate_test!(
+    multistate_value_reliability_requires_out_of_service,
+    MultiStateValueObject::new(1, "MSV-1", 3).unwrap()
+);

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -196,6 +196,25 @@ pub trait BACnetObject: Send + Sync {
         })
     }
 
+    /// Apply an internally-derived `Reliability` value.
+    ///
+    /// This is the **internal** reliability-evaluation path, distinct from the
+    /// network [`write_property`](Self::write_property) route. Implementations
+    /// enforce symmetric ownership: clients may write while `Out_Of_Service`
+    /// is TRUE, and internal evaluation may write while it is FALSE. ASHRAE
+    /// 135-2020 Clause 3.2 defines reliability evaluation as "the process by
+    /// which an object determines its reliability and thus the value to set
+    /// into its Reliability property."
+    ///
+    /// The default rejects the operation, so object types without an internal
+    /// reliability-evaluation process remain unaffected.
+    fn set_reliability_internal(&mut self, _reliability: u32) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::OBJECT.to_raw() as u32,
+            code: ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw() as u32,
+        })
+    }
+
     /// Add a trend log record (only meaningful for TrendLog / TrendLogMultiple).
     ///
     /// Default is a no-op. TrendLog objects override to append to their buffer.

--- a/crates/bacnet-server/src/fault_detection.rs
+++ b/crates/bacnet-server/src/fault_detection.rs
@@ -7,6 +7,8 @@
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_types::enums::{ObjectType, PropertyIdentifier, Reliability};
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+use std::collections::HashMap;
+use std::sync::Mutex;
 
 /// A reliability change detected by the fault detector.
 #[derive(Debug, Clone, PartialEq)]
@@ -28,12 +30,14 @@ pub struct FaultDetector {
     /// Timeout after which an object is considered to have a communication
     /// failure.  Set to `None` to disable communication-failure detection.
     pub comm_timeout: Option<std::time::Duration>,
+    warned_internal_failures: Mutex<HashMap<ObjectIdentifier, String>>,
 }
 
 impl Default for FaultDetector {
     fn default() -> Self {
         Self {
             comm_timeout: Some(std::time::Duration::from_secs(60)),
+            warned_internal_failures: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -41,7 +45,30 @@ impl Default for FaultDetector {
 impl FaultDetector {
     /// Create a new fault detector with the given communication timeout.
     pub fn new(comm_timeout: Option<std::time::Duration>) -> Self {
-        Self { comm_timeout }
+        Self {
+            comm_timeout,
+            warned_internal_failures: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn should_warn_internal_failure(&self, oid: ObjectIdentifier, error: &str) -> bool {
+        let mut warned = self
+            .warned_internal_failures
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if warned.get(&oid).is_some_and(|previous| previous == error) {
+            false
+        } else {
+            warned.insert(oid, error.to_owned());
+            true
+        }
+    }
+
+    fn clear_internal_failure(&self, oid: &ObjectIdentifier) {
+        self.warned_internal_failures
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(oid);
     }
 
     /// Evaluate reliability for all objects in the database.
@@ -163,20 +190,25 @@ impl FaultDetector {
         let mut changes = Vec::new();
         for (oid, old_rel, new_rel) in updates {
             if let Some(obj) = db.get_mut(&oid) {
-                if obj
-                    .write_property(
-                        PropertyIdentifier::RELIABILITY,
-                        None,
-                        PropertyValue::Enumerated(new_rel),
-                        None,
-                    )
-                    .is_ok()
-                {
-                    changes.push(ReliabilityChange {
-                        object_id: oid,
-                        old_reliability: old_rel,
-                        new_reliability: new_rel,
-                    });
+                match obj.set_reliability_internal(new_rel) {
+                    Ok(()) => {
+                        self.clear_internal_failure(&oid);
+                        changes.push(ReliabilityChange {
+                            object_id: oid,
+                            old_reliability: old_rel,
+                            new_reliability: new_rel,
+                        });
+                    }
+                    Err(error) => {
+                        let error_text = error.to_string();
+                        if self.should_warn_internal_failure(oid, &error_text) {
+                            tracing::warn!(
+                                object = %oid,
+                                error = %error,
+                                "Fault detection could not apply Reliability through BACnetObject::set_reliability_internal"
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -189,6 +221,8 @@ impl FaultDetector {
 mod tests {
     use super::*;
     use bacnet_objects::analog::{AnalogInputObject, AnalogOutputObject, AnalogValueObject};
+    use bacnet_types::enums::{ErrorClass, ErrorCode, EventState};
+    use bacnet_types::error::Error;
 
     /// Helper: build an ObjectDatabase with a single AI that has min/max limits.
     fn db_with_analog_input(
@@ -207,6 +241,20 @@ mod tests {
         let mut db = ObjectDatabase::new();
         db.add(Box::new(ai)).unwrap();
         db
+    }
+
+    #[test]
+    fn identical_internal_failure_warning_is_suppressed_until_state_changes() {
+        let detector = FaultDetector::default();
+        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+
+        assert!(detector.should_warn_internal_failure(oid, "first error"));
+        assert!(!detector.should_warn_internal_failure(oid, "first error"));
+        assert!(detector.should_warn_internal_failure(oid, "different error"));
+        assert!(!detector.should_warn_internal_failure(oid, "different error"));
+
+        detector.clear_internal_failure(&oid);
+        assert!(detector.should_warn_internal_failure(oid, "first error"));
     }
 
     #[test]
@@ -239,6 +287,68 @@ mod tests {
         assert_eq!(
             changes[0].new_reliability,
             Reliability::UNDER_RANGE.to_raw()
+        );
+    }
+
+    #[test]
+    fn analog_simulation_restores_derived_fault_without_normal_churn() {
+        let mut db = db_with_analog_input(150.0, Some(0.0), Some(100.0));
+        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+        let changes = FaultDetector::default().evaluate(&mut db);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].new_reliability, Reliability::OVER_RANGE.to_raw());
+
+        let obj = db.get_mut(&oid).unwrap();
+        let real_fault = obj
+            .evaluate_intrinsic_reporting()
+            .expect("derived Reliability must enter FAULT");
+        assert_eq!(real_fault.change.to, EventState::FAULT);
+
+        obj.write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+        obj.write_property(
+            PropertyIdentifier::RELIABILITY,
+            None,
+            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+            None,
+        )
+        .unwrap();
+        let simulated_fault = obj
+            .evaluate_intrinsic_reporting()
+            .expect("different simulated fault must re-enter FAULT");
+        assert_eq!(simulated_fault.change.to, EventState::FAULT);
+
+        obj.write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            obj.read_property(PropertyIdentifier::RELIABILITY, None)
+                .unwrap(),
+            PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw())
+        );
+        assert_eq!(
+            obj.read_property(PropertyIdentifier::EVENT_STATE, None)
+                .unwrap(),
+            PropertyValue::Enumerated(EventState::FAULT.to_raw())
+        );
+
+        let restored_fault = obj
+            .evaluate_intrinsic_reporting()
+            .expect("restored real fault must re-enter FAULT");
+        assert_eq!(restored_fault.change.to, EventState::FAULT);
+        assert_eq!(
+            obj.read_property(PropertyIdentifier::EVENT_STATE, None)
+                .unwrap(),
+            PropertyValue::Enumerated(EventState::FAULT.to_raw())
         );
     }
 
@@ -286,7 +396,14 @@ mod tests {
         )
         .unwrap();
 
-        // Second evaluation: back to no-fault
+        assert_eq!(
+            obj.read_property(PropertyIdentifier::RELIABILITY, None)
+                .unwrap(),
+            PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw())
+        );
+
+        // Returning to service restores the pre-simulation fault. The detector
+        // then converges it to the corrected physical condition.
         let changes = detector.evaluate(&mut db);
         assert_eq!(changes.len(), 1);
         assert_eq!(
@@ -395,21 +512,30 @@ mod tests {
     }
 
     #[test]
-    fn in_service_still_recomputes_client_written_reliability() {
+    fn in_service_refuses_client_write_and_recomputes_reliability() {
         let mut db = db_with_analog_input(50.0, Some(0.0), Some(100.0));
         let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-        db.get_mut(&oid)
-            .unwrap()
+        let obj = db.get_mut(&oid).unwrap();
+        obj.set_reliability_internal(Reliability::NO_SENSOR.to_raw())
+            .unwrap();
+        let error = obj
             .write_property(
                 PropertyIdentifier::RELIABILITY,
                 None,
-                PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+                PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
                 None,
             )
-            .unwrap();
+            .expect_err("in-service Reliability write must be refused");
 
         let changes = FaultDetector::default().evaluate(&mut db);
 
+        match error {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+                assert_eq!(code, ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32);
+            }
+            other => panic!("expected PROPERTY / WRITE_ACCESS_DENIED, got {other:?}"),
+        }
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].object_id, oid);
         assert_eq!(

--- a/crates/bacnet-server/src/handlers/tests/wpm_create_alarm.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_create_alarm.rs
@@ -90,6 +90,87 @@ fn wpm_handler_atomicity_rollback() {
         "HIGH_LIMIT should be rolled back after failed WPM"
     );
 }
+
+#[test]
+fn wpm_rollback_restores_out_of_service_reliability_and_saved_value() {
+    use bacnet_services::common::BACnetPropertyValue;
+    use bacnet_services::wpm::WriteAccessSpecification;
+    use bacnet_types::enums::Reliability;
+
+    let mut db = make_db_with_ai();
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let obj = db.get_mut(&oid).unwrap();
+    obj.set_reliability_internal(Reliability::OVER_RANGE.to_raw())
+        .unwrap();
+    obj.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    obj.write_property(
+        PropertyIdentifier::RELIABILITY,
+        None,
+        PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+        None,
+    )
+    .unwrap();
+
+    let mut oos_buf = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_boolean(&mut oos_buf, false);
+    let mut object_type_buf = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_enumerated(&mut object_type_buf, 0);
+    let request = bacnet_services::wpm::WritePropertyMultipleRequest {
+        list_of_write_access_specs: vec![WriteAccessSpecification {
+            object_identifier: oid,
+            list_of_properties: vec![
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::OUT_OF_SERVICE,
+                    property_array_index: None,
+                    value: oos_buf.to_vec(),
+                    priority: None,
+                },
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::OBJECT_TYPE,
+                    property_array_index: None,
+                    value: object_type_buf.to_vec(),
+                    priority: None,
+                },
+            ],
+        }],
+    };
+    let mut buf = BytesMut::new();
+    request.encode(&mut buf);
+
+    assert!(handle_write_property_multiple(&mut db, &buf).is_err());
+    let obj = db.get_mut(&oid).unwrap();
+    assert_eq!(
+        obj.read_property(PropertyIdentifier::OUT_OF_SERVICE, None)
+            .unwrap(),
+        PropertyValue::Boolean(true)
+    );
+    assert_eq!(
+        obj.read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+        "rollback must restore the client's simulated Reliability"
+    );
+
+    obj.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(false),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        obj.read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
+        "rollback must reconstruct the saved evaluated Reliability"
+    );
+}
 #[test]
 fn create_object_by_type_assigns_next_instance() {
     let mut db = make_db_with_device_and_ai();

--- a/crates/bacnet-server/src/handlers/write_property.rs
+++ b/crates/bacnet-server/src/handlers/write_property.rs
@@ -45,6 +45,13 @@ fn check_and_prepare_name_write(
 /// was relinquished) and the rollback restores that slot directly; a `Null`
 /// snapshot relinquishes the slot again. Non-commandable objects (where
 /// `PRIORITY_ARRAY` is not readable) fall back to the generic value snapshot.
+///
+/// `OUT_OF_SERVICE` writes on objects with `Reliability` snapshot both
+/// properties. Returning to service restores the pre-simulation Reliability,
+/// so rolling back only `OUT_OF_SERVICE` would destroy the client's simulated
+/// value and the object's saved evaluated value. Rollback replays
+/// `OUT_OF_SERVICE` first and then `RELIABILITY`, reconstructing both visible
+/// state and the object's private saved-value slot.
 pub fn handle_write_property_multiple(
     db: &mut ObjectDatabase,
     service_data: &[u8],
@@ -99,12 +106,12 @@ pub fn handle_write_property_multiple(
         // Capture a state-equivalent snapshot for rollback. For a commandable
         // PRESENT_VALUE the readable value is the resolved priority-array
         // output, not the slot being written, so snapshot the priority-array
-        // slot itself (see the function doc). `rollback_record` holds the
-        // (property, index, value) to restore; for the commandable case that is
-        // PRIORITY_ARRAY[priority], for every other case it is the property as
+        // slot itself (see the function doc). `rollback_records` holds the
+        // (property, index, value) entries to restore; for commandable
+        // PRESENT_VALUE that is PRIORITY_ARRAY[priority], for OUT_OF_SERVICE
+        // it can also include RELIABILITY, and otherwise it is the property as
         // written. `read_property` is best-effort: a write-only property has no
-        // readable value and yields no rollback record (matches the prior
-        // behavior).
+        // readable value and yields no rollback record (matches prior behavior).
         //
         // A non-commandable object (e.g. an AnalogInput placed out-of-service,
         // or a Command/Timer/Color object whose PRESENT_VALUE is always
@@ -114,7 +121,7 @@ pub fn handle_write_property_multiple(
         // Without this fallback a failed multi-write would leave the
         // non-commandable PRESENT_VALUE changed despite reporting failure
         // (ASHRAE 135-2020 §19.1.2).
-        let rollback_record = if *prop_id == PropertyIdentifier::PRESENT_VALUE {
+        let rollback_records = if *prop_id == PropertyIdentifier::PRESENT_VALUE {
             // The write targets priority `priority.unwrap_or(16)` (matching
             // `write_priority_array!`). Snapshot that exact slot so rollback
             // restores it rather than writing the resolved value to priority 16.
@@ -133,6 +140,8 @@ pub fn handle_write_property_multiple(
                             .ok()
                             .map(|v| (*prop_id, *array_index, v))
                     })
+                    .into_iter()
+                    .collect()
             } else {
                 // Out-of-range priority: a commandable write will fail (so the
                 // snapshot is discarded), but a non-commandable write ignores the
@@ -142,12 +151,27 @@ pub fn handle_write_property_multiple(
                     .read_property(*prop_id, *array_index)
                     .ok()
                     .map(|v| (*prop_id, *array_index, v))
+                    .into_iter()
+                    .collect()
             }
+        } else if *prop_id == PropertyIdentifier::OUT_OF_SERVICE {
+            let mut records = Vec::new();
+            if let Ok(reliability) = object.read_property(PropertyIdentifier::RELIABILITY, None) {
+                // Pushed before OUT_OF_SERVICE so reverse-order rollback
+                // restores OOS first, then the client simulation.
+                records.push((PropertyIdentifier::RELIABILITY, None, reliability));
+            }
+            if let Ok(out_of_service) = object.read_property(*prop_id, *array_index) {
+                records.push((*prop_id, *array_index, out_of_service));
+            }
+            records
         } else {
             object
                 .read_property(*prop_id, *array_index)
                 .ok()
                 .map(|v| (*prop_id, *array_index, v))
+                .into_iter()
+                .collect()
         };
         match object.write_property(*prop_id, *array_index, value.clone(), *priority) {
             Ok(()) => {
@@ -156,7 +180,7 @@ pub fn handle_write_property_multiple(
                 if *prop_id == PropertyIdentifier::OBJECT_NAME {
                     db.update_name_index(oid);
                 }
-                if let Some((rb_prop, rb_idx, rb_val)) = rollback_record {
+                for (rb_prop, rb_idx, rb_val) in rollback_records {
                     applied.push((*oid, rb_prop, rb_idx, rb_val));
                 }
             }

--- a/crates/bacnet-server/src/pics/truth_source_tests.rs
+++ b/crates/bacnet-server/src/pics/truth_source_tests.rs
@@ -128,6 +128,13 @@ fn is_writable_property_matches_write_property_on_all_core_types() {
 
     // AnalogOutput — commandable: PRIORITY_ARRAY + PRESENT_VALUE + event set.
     let mut ao = AnalogOutputObject::new(1, "ao", 95).unwrap();
+    ao.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
     assert_accepts(
         &mut ao,
         PropertyIdentifier::PRESENT_VALUE,
@@ -163,6 +170,13 @@ fn is_writable_property_matches_write_property_on_all_core_types() {
 
     // AnalogValue — same writable set as AnalogOutput.
     let mut av = AnalogValueObject::new(1, "av", 95).unwrap();
+    av.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
     assert_accepts(
         &mut av,
         PropertyIdentifier::PRESENT_VALUE,


### PR DESCRIPTION
Fixes #218. Resolves the open question in #238.

`Reliability` was handled three ways across the nine intrinsic-reporting object types. Analog Input/Output/Value accepted an **unconditional** `WriteProperty`; Binary Input/Output/Value and Multi-state Input/Output/Value **denied it outright** while still advertising `Reliability` in `Property_List`. All nine now follow one rule.

## The six were non-conformant

Every one of the nine object clauses carries this sentence in its `Out_Of_Service` description, under the lead-in *"When Out_Of_Service is TRUE:"*:

> *"the Present_Value property and the Reliability property, if present and capable of taking on values other than NO_FAULT_DETECTED, shall be writable to allow simulating specific conditions or for testing purposes"*

The standard names `Present_Value` and `Reliability` **together, under one condition** — and this codebase already gates `Present_Value` that way in three places. Treating `Reliability` differently was the anomaly, not the fix.

## Ownership is symmetric, and enforced at the boundary

| `Out_Of_Service` | Owner | Network write | Internal write |
|---|---|---|---|
| TRUE | the client (simulation) | accepted | refused |
| FALSE | the object's reliability-evaluation | refused (`WRITE_ACCESS_DENIED`) | accepted |

Returning to service **restores the pre-simulation value** rather than clearing it. Clearing to `NO_FAULT_DETECTED` was tried and rejected: it wipes a real physical fault on the analog types and lets `FaultDetector` re-derive it an interval later, producing FAULT → NORMAL → FAULT churn — now observable on the wire, since #216 made `Event_Detection_Enable` default TRUE. Save-and-restore is correct for both populations without the object needing to know whether a server-side evaluator exists, which it cannot know.

Without any transition handling at all, three ordinary WriteProperty requests left the six types permanently faulted and unclearable — a state unreachable before this change.

Written values are validated against `BACnetReliability` (`0..=10 | 12..=25 | 64..=65535`), refusing reserved and out-of-range values with `PROPERTY` / `VALUE_OUT_OF_RANGE`.

## Breaking changes

- **`BACnetObject::set_reliability_internal`** — new trait method, mirroring `set_event_state_internal` from #130. `FaultDetector` previously wrote through the public route, which the gate would have broken since its purpose is writing to *in-service* objects. Default returns `OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED`; a downstream implementor registered as an analog type must override it or lose fault detection, and that case now warns rather than failing silently.
- **`FaultDetector`** is no longer constructible with struct-literal syntax — use `FaultDetector::new(comm_timeout)`. Documented in the CHANGELOG because the compiler error names a private field rather than the cause.

`WritePropertyMultiple`'s rollback now snapshots `Reliability` alongside `Out_Of_Service`, since writing one mutates the other — the same class the handler already solves for `OBJECT_NAME` and `PRESENT_VALUE`'s priority-array slot.

## Validation

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | pass |
| `.github/scripts/check-file-size.sh` | pass |
| `cargo clippy --workspace --all-targets --locked` | pass, 0 errors |
| `cargo test --workspace --exclude rusty-bacnet` | **2345 passed, 0 failed** |
| `cargo check -p rusty-bacnet --tests` | pass |

**Mutation-verified rather than asserted** — each guard was removed and the corresponding test confirmed to fail, on a non-analog type where the fault-detection path cannot mask it: the network gate, the internal-route ownership guard, the value validation, the save, the restore, the fallback, and the WPM `Reliability` snapshot.

Rollback ordering was proven by execution, not by reading: removing `.rev()` and swapping the two snapshot pushes each break the test, so both orderings are load-bearing and covered.

## Review

Three independent spec-accuracy rounds against the 135-2020 text (final verdict **CONCUR**) and three adversarial rounds. Five defects were found and fixed before merge, two of them created by rulings in earlier revisions of this change: the permanent FAULT latch, the analog fault concealment, the unsound bypass contract, the missing value validation, and the WPM atomicity break. The final round included a 20,000-case randomized differential sweep over WPM write sequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)