### PR TITLE
feat(types): resolve enumeration, bit-string

### DIFF
--- a/crates/bacnet-types/src/bitstring.rs
+++ b/crates/bacnet-types/src/bitstring.rs
@@ -1,0 +1,339 @@
+//! Named BACnet bit-string types (ASHRAE 135-2020 Clause 21).
+//!
+//! Several properties carry a `BitString` whose bits have a fixed, named
+//! meaning defined by the standard. This module models those `BACnetXxx` BIT
+//! STRING productions so a decoded [`crate::primitives::PropertyValue::BitString`]
+//! can be promoted from raw `(unused_bits, data)` bytes to named flags, the same
+//! way [`crate::enums::ResolvedEnum`] promotes an `Enumerated`.
+//!
+//! ## Bit order
+//!
+//! BACnet bit strings are transmitted most-significant-bit-first: bit 0 of the
+//! string is the top bit (`0x80`) of the first content byte, bit 8 is the top
+//! bit of the second byte, and so on. Every type here reads bit *N* of the
+//! string as "feature N", matching how the device object packs these fields
+//! (see `bacnet-objects`'s `compute_object_types_supported`).
+//!
+//! [`crate::primitives::StatusFlags`] predates this module and keeps its own
+//! right-aligned representation; it is re-exported and mapped by the resolver as
+//! well.
+
+use crate::enums::{ObjectType, ServiceSupported};
+
+/// Read bit `n` of a BACnet bit string (MSB-first) from its content bytes.
+///
+/// `data` is the bit-string payload *without* the leading unused-bits count
+/// (i.e. `PropertyValue::BitString::data`). Bits past the end read as `false`.
+fn wire_bit(data: &[u8], n: usize) -> bool {
+    let mask = 0x80u8 >> (n % 8);
+    data.get(n / 8).is_some_and(|b| b & mask != 0)
+}
+
+/// Render a bitflags value as its set Clause-21 names (` NAME | NAME `), or `()`
+/// when none are set — for both `Display` and `Debug`, never a raw number.
+macro_rules! impl_named_bit_display {
+    ($t:ty) => {
+        impl core::fmt::Display for $t {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                let mut first = true;
+                for (name, _) in self.iter_names() {
+                    if !first {
+                        f.write_str(" | ")?;
+                    }
+                    f.write_str(name)?;
+                    first = false;
+                }
+                if first {
+                    f.write_str("()")?;
+                }
+                Ok(())
+            }
+        }
+
+        impl core::fmt::Debug for $t {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                core::fmt::Display::fmt(self, f)
+            }
+        }
+    };
+}
+
+/// Write `Display` items as ` A | B | C ` (or `()` when empty).
+fn write_joined<T: core::fmt::Display>(
+    f: &mut core::fmt::Formatter<'_>,
+    items: impl Iterator<Item = T>,
+) -> core::fmt::Result {
+    let mut first = true;
+    for item in items {
+        if !first {
+            f.write_str(" | ")?;
+        }
+        write!(f, "{item}")?;
+        first = false;
+    }
+    if first {
+        f.write_str("()")?;
+    }
+    Ok(())
+}
+
+bitflags::bitflags! {
+    /// `BACnetEventTransitionBits` — 3-bit string for `event-enable`,
+    /// `acked-transitions`, and `ack-required` (Clause 21).
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct EventTransitionBits: u8 {
+        /// Transition to an off-normal event state (bit 0).
+        const TO_OFFNORMAL = 1 << 0;
+        /// Transition to the fault event state (bit 1).
+        const TO_FAULT = 1 << 1;
+        /// Transition to the normal event state (bit 2).
+        const TO_NORMAL = 1 << 2;
+    }
+}
+
+impl EventTransitionBits {
+    /// Decode from a BACnet bit-string payload (MSB-first).
+    pub fn from_bacnet(data: &[u8]) -> Self {
+        let mut bits = Self::empty();
+        bits.set(Self::TO_OFFNORMAL, wire_bit(data, 0));
+        bits.set(Self::TO_FAULT, wire_bit(data, 1));
+        bits.set(Self::TO_NORMAL, wire_bit(data, 2));
+        bits
+    }
+}
+
+impl_named_bit_display!(EventTransitionBits);
+
+bitflags::bitflags! {
+    /// `BACnetLimitEnable` — 2-bit string for the `limit-enable` property
+    /// (Clause 21).
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+    pub struct LimitEnable: u8 {
+        /// Low-limit event detection is enabled (bit 0).
+        const LOW_LIMIT_ENABLE = 1 << 0;
+        /// High-limit event detection is enabled (bit 1).
+        const HIGH_LIMIT_ENABLE = 1 << 1;
+    }
+}
+
+impl LimitEnable {
+    /// Decode from a BACnet bit-string payload (MSB-first).
+    pub fn from_bacnet(data: &[u8]) -> Self {
+        let mut bits = Self::empty();
+        bits.set(Self::LOW_LIMIT_ENABLE, wire_bit(data, 0));
+        bits.set(Self::HIGH_LIMIT_ENABLE, wire_bit(data, 1));
+        bits
+    }
+}
+
+impl_named_bit_display!(LimitEnable);
+
+/// `BACnetServicesSupported` — the `protocol-services-supported` bit string,
+/// one bit per protocol service (Clause 21).
+///
+/// Stored as a `u64` bitset: bit *N* is set iff [`ServiceSupported`] value *N*
+/// is supported. `protocol-services-supported` is a closed enumeration whose
+/// highest defined bit is 48 (with no vendor-proprietary range), so a `u64`
+/// covers every standard service with headroom. Any nonstandard bit ≥ 64 — a
+/// protocol violation — is ignored on decode. The public API still yields named
+/// [`ServiceSupported`] values, and `Debug` prints names, never a raw number.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct ServicesSupported {
+    bits: u64,
+}
+
+impl ServicesSupported {
+    /// Decode a bit-string payload (the `data` of `PropertyValue::BitString`)
+    /// into the bitset of services it advertises.
+    pub fn from_bacnet(data: &[u8]) -> Self {
+        let mut bits = 0u64;
+        for (i, &byte) in data.iter().take(8).enumerate() {
+            bits |= (byte.reverse_bits() as u64) << (i * 8);
+        }
+        Self { bits }
+    }
+
+    /// Whether `service` is marked supported.
+    pub fn contains(&self, service: ServiceSupported) -> bool {
+        let n = service.to_raw() as u32;
+        n < 64 && self.bits & (1u64 << n) != 0
+    }
+
+    /// Iterate the supported services in ascending bit order.
+    pub fn iter(&self) -> impl Iterator<Item = ServiceSupported> + '_ {
+        let bits = self.bits;
+        (0..64)
+            .filter(move |&n| bits & (1u64 << n) != 0)
+            .map(|n| ServiceSupported::from_raw(n as u8))
+    }
+}
+
+impl core::fmt::Display for ServicesSupported {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write_joined(f, self.iter())
+    }
+}
+
+impl core::fmt::Debug for ServicesSupported {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self, f)
+    }
+}
+
+/// `BACnetObjectTypesSupported` — the `protocol-object-types-supported` bit
+/// string, one bit per object type (Clause 21).
+///
+/// Stored as a `[u64; 16]` bitset (1024 bits): bit *N* is set iff [`ObjectType`]
+/// value *N* is supported. Unlike the closed services enumeration, object types
+/// span the full 10-bit range 0–1023 (proprietary types live at 128–1023), so
+/// the set can't collapse to a single integer — hence the 16-word array, which
+/// is allocation-free and `Copy`. The public API still yields named
+/// [`ObjectType`] values (reusing that table rather than duplicating it), and
+/// `Debug` prints names, never raw numbers.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct ObjectTypesSupported {
+    bits: [u64; 16],
+}
+
+impl ObjectTypesSupported {
+    /// Decode a bit-string payload (the `data` of `PropertyValue::BitString`)
+    /// into the bitset of object types it advertises.
+    pub fn from_bacnet(data: &[u8]) -> Self {
+        let mut bits = [0u64; 16];
+        for (i, &byte) in data.iter().take(128).enumerate() {
+            bits[i / 8] |= (byte.reverse_bits() as u64) << ((i % 8) * 8);
+        }
+        Self { bits }
+    }
+
+    /// Whether `object_type` is marked supported.
+    pub fn contains(&self, object_type: ObjectType) -> bool {
+        let n = object_type.to_raw();
+        n < 1024 && self.bits[(n / 64) as usize] & (1u64 << (n % 64)) != 0
+    }
+
+    /// Iterate the supported object types in ascending bit order.
+    pub fn iter(&self) -> impl Iterator<Item = ObjectType> + '_ {
+        (0..1024u32)
+            .filter(move |&n| self.bits[(n / 64) as usize] & (1u64 << (n % 64)) != 0)
+            .map(ObjectType::from_raw)
+    }
+}
+
+impl core::fmt::Display for ObjectTypesSupported {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write_joined(f, self.iter())
+    }
+}
+
+impl core::fmt::Debug for ObjectTypesSupported {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::StatusFlags;
+
+    #[test]
+    fn event_transition_bits_msb_first() {
+        // Wire byte 0b1010_0000 => bit0 (to-offnormal) and bit2 (to-normal).
+        let bits = EventTransitionBits::from_bacnet(&[0b1010_0000]);
+        assert_eq!(
+            bits,
+            EventTransitionBits::TO_OFFNORMAL | EventTransitionBits::TO_NORMAL
+        );
+        assert_eq!(bits.to_string(), "TO_OFFNORMAL | TO_NORMAL");
+    }
+
+    #[test]
+    fn limit_enable_msb_first() {
+        assert_eq!(
+            LimitEnable::from_bacnet(&[0x80]),
+            LimitEnable::LOW_LIMIT_ENABLE
+        );
+        assert_eq!(
+            LimitEnable::from_bacnet(&[0xC0]),
+            LimitEnable::LOW_LIMIT_ENABLE | LimitEnable::HIGH_LIMIT_ENABLE
+        );
+        assert_eq!(LimitEnable::from_bacnet(&[]).to_string(), "()");
+    }
+
+    #[test]
+    fn object_types_supported_matches_device_layout() {
+        // Byte 8 = 0x80 sets bit 64 => ColorTemperature (per device object test).
+        let mut data = vec![0u8; 9];
+        data[8] = 0x80;
+        let ots = ObjectTypesSupported::from_bacnet(&data);
+        assert!(ots.contains(ObjectType::COLOR_TEMPERATURE));
+        assert!(!ots.contains(ObjectType::ANALOG_INPUT));
+        assert_eq!(
+            ots.iter().collect::<Vec<_>>(),
+            vec![ObjectType::COLOR_TEMPERATURE]
+        );
+
+        // Byte 4 = 0xFD: types 32-37,39 set, 38 (NetworkSecurity) unset.
+        let ss = ObjectTypesSupported::from_bacnet(&[0, 0, 0, 0, 0xFD]);
+        assert!(ss.contains(ObjectType::from_raw(32)));
+        assert!(!ss.contains(ObjectType::NETWORK_SECURITY)); // type 38
+        assert!(ss.contains(ObjectType::from_raw(39)));
+    }
+
+    #[test]
+    fn resolved_value_holds_names_not_bytes() {
+        // The whole point: the decoded value contains named variants, and even
+        // its Debug shows names rather than the raw wire bytes.
+        let ots = ObjectTypesSupported::from_bacnet(&[0b1110_0000]); // types 0,1,2
+        assert_eq!(
+            ots.iter().collect::<Vec<_>>(),
+            [
+                ObjectType::ANALOG_INPUT,
+                ObjectType::ANALOG_OUTPUT,
+                ObjectType::ANALOG_VALUE
+            ]
+        );
+        let dbg = format!("{ots:?}");
+        assert!(
+            dbg.contains("ANALOG_INPUT"),
+            "Debug should name types: {dbg}"
+        );
+        assert!(
+            !dbg.contains("224"),
+            "Debug must not show raw byte 0xE0: {dbg}"
+        );
+    }
+
+    #[test]
+    fn services_supported_follows_clause_21() {
+        // Device object's basic set: byte0=0xA4, byte1=0x0B, byte4=0x80.
+        let ss = ServicesSupported::from_bacnet(&[0xA4, 0x0B, 0x80, 0x35, 0x80, 0x00]);
+        assert!(ss.contains(ServiceSupported::ACKNOWLEDGE_ALARM)); // bit 0
+        assert!(ss.contains(ServiceSupported::SUBSCRIBE_COV)); // bit 5
+        assert!(ss.contains(ServiceSupported::READ_PROPERTY)); // bit 12
+        assert!(ss.contains(ServiceSupported::I_AM)); // bit 26
+        assert!(ss.contains(ServiceSupported::TIME_SYNCHRONIZATION)); // bit 32 (NOT who-is)
+        assert!(!ss.contains(ServiceSupported::WHO_IS)); // bit 34
+    }
+
+    #[test]
+    fn status_flags_render_names_not_numbers() {
+        assert_eq!(
+            (StatusFlags::IN_ALARM | StatusFlags::FAULT).to_string(),
+            "IN_ALARM | FAULT"
+        );
+        // Empty renders as "()", and Debug matches Display — never a raw number.
+        assert_eq!(StatusFlags::empty().to_string(), "()");
+        assert_eq!(format!("{:?}", StatusFlags::empty()), "()");
+        assert_eq!(format!("{:?}", StatusFlags::IN_ALARM), "IN_ALARM");
+    }
+
+    #[test]
+    fn small_types_debug_is_named_never_a_number() {
+        // bitflags' derived Debug prints 0x0 for an empty set; ours prints "()".
+        assert_eq!(format!("{:?}", EventTransitionBits::empty()), "()");
+        assert_eq!(format!("{:?}", LimitEnable::empty()), "()");
+        assert_eq!(format!("{:?}", EventTransitionBits::TO_FAULT), "TO_FAULT");
+    }
+}

--- a/crates/bacnet-types/src/bitstring.rs
+++ b/crates/bacnet-types/src/bitstring.rs
@@ -20,6 +20,8 @@
 
 use crate::enums::{ObjectType, ServiceSupported};
 
+pub use crate::primitives::StatusFlags;
+
 /// Read bit `n` of a BACnet bit string (MSB-first) from its content bytes.
 ///
 /// `data` is the bit-string payload *without* the leading unused-bits count
@@ -27,6 +29,21 @@ use crate::enums::{ObjectType, ServiceSupported};
 fn wire_bit(data: &[u8], n: usize) -> bool {
     let mask = 0x80u8 >> (n % 8);
     data.get(n / 8).is_some_and(|b| b & mask != 0)
+}
+
+/// Decode a `BACnetStatusFlags` bit-string payload (MSB-first) into
+/// [`StatusFlags`], which keeps its right-aligned in-memory layout.
+///
+/// Reads wire bits 0–3 by position, so a peer that declares a wrong string
+/// length still decodes correctly — Clause 20.2.10 puts bit 0 in the most
+/// significant bit of the first octet regardless of length.
+pub fn status_flags_from_bacnet(data: &[u8]) -> StatusFlags {
+    let mut flags = StatusFlags::empty();
+    flags.set(StatusFlags::IN_ALARM, wire_bit(data, 0));
+    flags.set(StatusFlags::FAULT, wire_bit(data, 1));
+    flags.set(StatusFlags::OVERRIDDEN, wire_bit(data, 2));
+    flags.set(StatusFlags::OUT_OF_SERVICE, wire_bit(data, 3));
+    flags
 }
 
 /// Render a bitflags value as its set Clause-21 names (` NAME | NAME `), or `()`
@@ -184,10 +201,12 @@ impl core::fmt::Debug for ServicesSupported {
 /// string, one bit per object type (Clause 21).
 ///
 /// Stored as a `[u64; 16]` bitset (1024 bits): bit *N* is set iff [`ObjectType`]
-/// value *N* is supported. Unlike the closed services enumeration, object types
-/// span the full 10-bit range 0–1023 (proprietary types live at 128–1023), so
-/// the set can't collapse to a single integer — hence the 16-word array, which
-/// is allocation-free and `Copy`. The public API still yields named
+/// value *N* is supported. The property covers only standardized object types
+/// (Clause 12.11.15) and the bit-string production is closed, but
+/// `BACnetObjectType` values run to 1023, so decode tolerates the enumeration's
+/// full 10-bit range instead of discarding a nonconformant peer's extra bits —
+/// hence the 16-word array, which is allocation-free and `Copy`. The public API
+/// still yields named
 /// [`ObjectType`] values (reusing that table rather than duplicating it), and
 /// `Debug` prints names, never raw numbers.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]

--- a/crates/bacnet-types/src/enums/access.rs
+++ b/crates/bacnet-types/src/enums/access.rs
@@ -24,6 +24,13 @@ bacnet_enum! {
     const CLOSED = 0;
     const OPENED = 1;
     const UNKNOWN = 2;
+    const DOOR_FAULT = 3;
+    const UNUSED = 4;
+    const NONE = 5;
+    const CLOSING = 6;
+    const OPENING = 7;
+    const SAFETY_LOCKED = 8;
+    const LIMITED_OPENED = 9;
 }
 
 bacnet_enum! {

--- a/crates/bacnet-types/src/enums/misc.rs
+++ b/crates/bacnet-types/src/enums/misc.rs
@@ -59,6 +59,60 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
+    /// Bit positions within a `BACnetServicesSupported` bit string (Clause 21).
+    pub struct ServiceSupported(u8);
+
+    const ACKNOWLEDGE_ALARM = 0;
+    const CONFIRMED_COV_NOTIFICATION = 1;
+    const CONFIRMED_EVENT_NOTIFICATION = 2;
+    const GET_ALARM_SUMMARY = 3;
+    const GET_ENROLLMENT_SUMMARY = 4;
+    const SUBSCRIBE_COV = 5;
+    const ATOMIC_READ_FILE = 6;
+    const ATOMIC_WRITE_FILE = 7;
+    const ADD_LIST_ELEMENT = 8;
+    const REMOVE_LIST_ELEMENT = 9;
+    const CREATE_OBJECT = 10;
+    const DELETE_OBJECT = 11;
+    const READ_PROPERTY = 12;
+    // 13: readPropertyConditional (removed)
+    const READ_PROPERTY_MULTIPLE = 14;
+    const WRITE_PROPERTY = 15;
+    const WRITE_PROPERTY_MULTIPLE = 16;
+    const DEVICE_COMMUNICATION_CONTROL = 17;
+    const CONFIRMED_PRIVATE_TRANSFER = 18;
+    const CONFIRMED_TEXT_MESSAGE = 19;
+    const REINITIALIZE_DEVICE = 20;
+    const VT_OPEN = 21;
+    const VT_CLOSE = 22;
+    const VT_DATA = 23;
+    // 24: authenticate (removed), 25: requestKey (removed)
+    const I_AM = 26;
+    const I_HAVE = 27;
+    const UNCONFIRMED_COV_NOTIFICATION = 28;
+    const UNCONFIRMED_EVENT_NOTIFICATION = 29;
+    const UNCONFIRMED_PRIVATE_TRANSFER = 30;
+    const UNCONFIRMED_TEXT_MESSAGE = 31;
+    const TIME_SYNCHRONIZATION = 32;
+    const WHO_HAS = 33;
+    const WHO_IS = 34;
+    const READ_RANGE = 35;
+    const UTC_TIME_SYNCHRONIZATION = 36;
+    const LIFE_SAFETY_OPERATION = 37;
+    const SUBSCRIBE_COV_PROPERTY = 38;
+    const GET_EVENT_INFORMATION = 39;
+    const WRITE_GROUP = 40;
+    const SUBSCRIBE_COV_PROPERTY_MULTIPLE = 41;
+    const CONFIRMED_COV_NOTIFICATION_MULTIPLE = 42;
+    const UNCONFIRMED_COV_NOTIFICATION_MULTIPLE = 43;
+    const CONFIRMED_AUDIT_NOTIFICATION = 44;
+    const AUDIT_LOG_QUERY = 45;
+    const UNCONFIRMED_AUDIT_NOTIFICATION = 46;
+    const WHO_AM_I = 47;
+    const YOU_ARE = 48;
+}
+
+bacnet_enum! {
     /// BACnet message priority for TextMessage services (Clause 16.5).
     pub struct MessagePriority(u32);
 

--- a/crates/bacnet-types/src/enums/mod.rs
+++ b/crates/bacnet-types/src/enums/mod.rs
@@ -101,6 +101,8 @@ mod audit;
 pub use audit::*;
 mod units;
 pub use units::*;
+mod resolve;
+pub use resolve::*;
 
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-types/src/enums/resolve.rs
+++ b/crates/bacnet-types/src/enums/resolve.rs
@@ -15,6 +15,11 @@
 // type varies between Binary/Multi-state/Life-Safety objects) are intentionally
 // left unmapped: the property identifier alone is insufficient to name them
 // correctly, so they resolve to `Unknown`.
+//
+// One deliberate exception: `tracking-value` (164) is object-type-dependent
+// (Lighting Output types it REAL), but `BACnetLifeSafetyState` is its only
+// ENUMERATED form in the standard, so promoting the `Enumerated` case is
+// unambiguous and the arm is kept.
 
 #[cfg(not(feature = "std"))]
 use alloc::{string::String, vec::Vec};
@@ -99,7 +104,6 @@ resolved_enum! {
     LiftCarDriveStatus(LiftCarDriveStatus),
     LiftCarDirection(LiftCarDirection),
     LiftCarDoorCommand(LiftCarDoorCommand),
-    LiftCarDoorStatus(LiftCarDoorStatus),
     AuditLevel(AuditLevel),
 }
 
@@ -119,7 +123,12 @@ impl ResolvedEnum {
             72 => Self::NotifyType(NotifyType::from_raw(value)), // notify-type
             103 => Self::Reliability(Reliability::from_raw(value)), // reliability
             112 => Self::DeviceStatus(DeviceStatus::from_raw(value)), // system-status
-            107 => Self::Segmentation(Segmentation::from_raw(value as u8)), // segmentation-supported
+            // segmentation-supported: Segmentation is the one u8-backed enum,
+            // so out-of-range wire values fall through to `Unknown` instead of
+            // wrapping into a valid-looking named variant.
+            107 if value <= u8::MAX as u32 => {
+                Self::Segmentation(Segmentation::from_raw(value as u8))
+            }
 
             // engineering-units: units + the various *-units properties.
             20 | 27 | 50 | 82 | 94 | 117 | 455 => {
@@ -136,7 +145,9 @@ impl ResolvedEnum {
 
             // Life safety.
             160 | 175 => Self::LifeSafetyMode(LifeSafetyMode::from_raw(value)), // mode / accepted-modes
-            164 => Self::LifeSafetyState(LifeSafetyState::from_raw(value)),     // tracking-value
+            // tracking-value: BACnetLifeSafetyState is its only ENUMERATED
+            // form; Lighting Output's REAL never reaches this arm.
+            164 => Self::LifeSafetyState(LifeSafetyState::from_raw(value)),
             161 => Self::LifeSafetyOperation(LifeSafetyOperation::from_raw(value)), // operation-expected
             163 => Self::SilencedState(SilencedState::from_raw(value)),             // silenced
 
@@ -176,7 +187,10 @@ impl ResolvedEnum {
             453 => Self::LiftCarDriveStatus(LiftCarDriveStatus::from_raw(value)), // car-drive-status
             448 | 457 => Self::LiftCarDirection(LiftCarDirection::from_raw(value)), // car-assigned/moving-direction
             449 => Self::LiftCarDoorCommand(LiftCarDoorCommand::from_raw(value)), // car-door-command
-            450 => Self::LiftCarDoorStatus(LiftCarDoorStatus::from_raw(value)),   // car-door-status
+            // car-door-status is `BACnetARRAY[N] of BACnetDoorStatus` (Lift
+            // object, Clause 12); the standard defines no lift-specific door
+            // status enumeration.
+            450 => Self::DoorStatus(DoorStatus::from_raw(value)),
 
             // Audit.
             498 => Self::AuditLevel(AuditLevel::from_raw(value)), // audit-level
@@ -255,11 +269,8 @@ impl ResolvedBits {
     /// [`ResolvedBits::Unknown`] with the bytes intact.
     pub fn from_property(property: PropertyIdentifier, unused_bits: u8, data: &[u8]) -> Self {
         match property.to_raw() {
-            // status-flags / member-status-flags. StatusFlags keeps its own
-            // right-aligned representation, so decode via `first_byte >> unused`.
-            111 | 347 => Self::StatusFlags(StatusFlags::from_bits_truncate(
-                data.first().copied().unwrap_or(0) >> unused_bits.min(7),
-            )),
+            // status-flags / member-status-flags.
+            111 | 347 => Self::StatusFlags(crate::bitstring::status_flags_from_bacnet(data)),
 
             // event-enable / acked-transitions / ack-required.
             0 | 1 | 35 => Self::EventTransitionBits(EventTransitionBits::from_bacnet(data)),
@@ -484,6 +495,45 @@ mod tests {
         let bits = ResolvedBits::from_property(PropertyIdentifier::STATUS_FLAGS, 4, &[0x80]);
         assert_eq!(bits, ResolvedBits::StatusFlags(StatusFlags::IN_ALARM));
         assert_eq!(bits.to_string(), "IN_ALARM");
+    }
+
+    #[test]
+    fn status_flags_decode_ignores_declared_length() {
+        // Clause 20.2.10 fixes bit 0 at the MSB of the first octet, so the
+        // flags survive a peer that declares the wrong unused-bit count.
+        for unused in [0, 4, 5] {
+            assert_eq!(
+                ResolvedBits::from_property(PropertyIdentifier::STATUS_FLAGS, unused, &[0xC0]),
+                ResolvedBits::StatusFlags(StatusFlags::IN_ALARM | StatusFlags::FAULT),
+            );
+        }
+    }
+
+    #[test]
+    fn segmentation_out_of_range_stays_unknown() {
+        // Segmentation is u8-backed; a wire value past u8 must not wrap into a
+        // valid-looking named variant (259 & 0xFF would be NONE).
+        assert_eq!(
+            ResolvedEnum::from_property(PropertyIdentifier::SEGMENTATION_SUPPORTED, 259),
+            ResolvedEnum::Unknown(259),
+        );
+        assert_eq!(
+            ResolvedEnum::from_property(PropertyIdentifier::SEGMENTATION_SUPPORTED, 3),
+            ResolvedEnum::Segmentation(Segmentation::NONE),
+        );
+    }
+
+    #[test]
+    fn car_door_status_resolves_to_door_status() {
+        // Car_Door_Status is BACnetARRAY[N] of BACnetDoorStatus (Lift object);
+        // 135-2020 has no lift-specific door status enumeration.
+        let r = ResolvedEnum::from_property(PropertyIdentifier::CAR_DOOR_STATUS, 3);
+        assert_eq!(r, ResolvedEnum::DoorStatus(DoorStatus::DOOR_FAULT));
+        assert_eq!(r.to_string(), "DOOR_FAULT");
+        assert_eq!(
+            ResolvedEnum::from_property(PropertyIdentifier::CAR_DOOR_STATUS, 0),
+            ResolvedEnum::DoorStatus(DoorStatus::CLOSED),
+        );
     }
 
     #[test]

--- a/crates/bacnet-types/src/enums/resolve.rs
+++ b/crates/bacnet-types/src/enums/resolve.rs
@@ -1,0 +1,570 @@
+// ===========================================================================
+// Enumerated resolution: raw number -> named enum, keyed by property
+// ===========================================================================
+//
+// On the wire a BACnet `Enumerated` is just a number (see
+// `PropertyValue::Enumerated(u32)`). The number carries no information about
+// *which* enumeration it belongs to; that is determined by the property being
+// read. ASHRAE 135 Clause 12 (object properties) and Clause 21 (application
+// types) fix, per property, the concrete `BACnetXxx` ENUMERATED type. This
+// module encodes that property -> enum-type mapping so a decoded value can be
+// promoted from a bare number to its named variant.
+//
+// Properties whose ENUMERATED type depends on the *object type* rather than the
+// property alone (e.g. `present-value`, `alarm-values`, `fault-values`, whose
+// type varies between Binary/Multi-state/Life-Safety objects) are intentionally
+// left unmapped: the property identifier alone is insufficient to name them
+// correctly, so they resolve to `Unknown`.
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+use crate::bitstring::{EventTransitionBits, LimitEnable, ObjectTypesSupported, ServicesSupported};
+use crate::primitives::{Date, ObjectIdentifier, PropertyValue, StatusFlags, Time};
+
+use super::*;
+
+macro_rules! resolved_enum {
+    ($($variant:ident($ty:ty)),+ $(,)?) => {
+        /// A BACnet `Enumerated` value promoted to its named enumeration.
+        ///
+        /// Produced by [`ResolvedEnum::from_property`], which uses the property
+        /// identifier to decide which `BACnetXxx` enum a raw number denotes.
+        /// Values whose enumeration cannot be determined from the property alone
+        /// (vendor-proprietary or object-type-dependent properties) become
+        /// [`ResolvedEnum::Unknown`], preserving the raw number.
+        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+        pub enum ResolvedEnum {
+            $(
+                #[doc = concat!("A [`", stringify!($ty), "`] value.")]
+                $variant($ty),
+            )+
+            /// No known enumeration for this property; the raw wire value is kept.
+            Unknown(u32),
+        }
+
+        impl core::fmt::Display for ResolvedEnum {
+            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                match self {
+                    $( Self::$variant(v) => core::fmt::Display::fmt(v, f), )+
+                    Self::Unknown(n) => write!(f, "{n}"),
+                }
+            }
+        }
+    };
+}
+
+resolved_enum! {
+    ObjectType(ObjectType),
+    EventState(EventState),
+    EventType(EventType),
+    NotifyType(NotifyType),
+    Reliability(Reliability),
+    DeviceStatus(DeviceStatus),
+    Segmentation(Segmentation),
+    EngineeringUnits(EngineeringUnits),
+    Polarity(Polarity),
+    ProgramState(ProgramState),
+    ProgramChange(ProgramChange),
+    NodeType(NodeType),
+    LoggingType(LoggingType),
+    FileAccessMethod(FileAccessMethod),
+    BackupAndRestoreState(BackupAndRestoreState),
+    LifeSafetyMode(LifeSafetyMode),
+    LifeSafetyState(LifeSafetyState),
+    LifeSafetyOperation(LifeSafetyOperation),
+    SilencedState(SilencedState),
+    DoorStatus(DoorStatus),
+    DoorAlarmState(DoorAlarmState),
+    DoorSecuredStatus(DoorSecuredStatus),
+    LockStatus(LockStatus),
+    AccessEvent(AccessEvent),
+    AuthorizationMode(AuthorizationMode),
+    AccessPassbackMode(AccessPassbackMode),
+    AccessUserType(AccessUserType),
+    AccessCredentialDisable(AccessCredentialDisable),
+    AccessCredentialDisableReason(AccessCredentialDisableReason),
+    NetworkType(NetworkType),
+    NetworkNumberQuality(NetworkNumberQuality),
+    IPMode(IPMode),
+    NetworkPortCommand(NetworkPortCommand),
+    ProtocolLevel(ProtocolLevel),
+    LightingInProgress(LightingInProgress),
+    TimerState(TimerState),
+    TimerTransition(TimerTransition),
+    WriteStatus(WriteStatus),
+    LiftCarMode(LiftCarMode),
+    LiftGroupMode(LiftGroupMode),
+    EscalatorMode(EscalatorMode),
+    LiftCarDriveStatus(LiftCarDriveStatus),
+    LiftCarDirection(LiftCarDirection),
+    LiftCarDoorCommand(LiftCarDoorCommand),
+    LiftCarDoorStatus(LiftCarDoorStatus),
+    AuditLevel(AuditLevel),
+}
+
+impl ResolvedEnum {
+    /// Promote a raw `Enumerated` wire value to its named enumeration using the
+    /// property it was read from.
+    ///
+    /// The property numbers below are the identifiers defined in
+    /// [`PropertyIdentifier`] (ASHRAE 135 Clause 21). A property with no known
+    /// scalar ENUMERATED type — including vendor-proprietary properties and ones
+    /// whose type depends on the object type — yields [`ResolvedEnum::Unknown`].
+    pub fn from_property(property: PropertyIdentifier, value: u32) -> Self {
+        match property.to_raw() {
+            79 => Self::ObjectType(ObjectType::from_raw(value)), // object-type
+            36 => Self::EventState(EventState::from_raw(value)), // event-state
+            37 => Self::EventType(EventType::from_raw(value)),   // event-type
+            72 => Self::NotifyType(NotifyType::from_raw(value)), // notify-type
+            103 => Self::Reliability(Reliability::from_raw(value)), // reliability
+            112 => Self::DeviceStatus(DeviceStatus::from_raw(value)), // system-status
+            107 => Self::Segmentation(Segmentation::from_raw(value as u8)), // segmentation-supported
+
+            // engineering-units: units + the various *-units properties.
+            20 | 27 | 50 | 82 | 94 | 117 | 455 => {
+                Self::EngineeringUnits(EngineeringUnits::from_raw(value))
+            }
+
+            84 => Self::Polarity(Polarity::from_raw(value)), // polarity
+            92 => Self::ProgramState(ProgramState::from_raw(value)), // program-state
+            90 => Self::ProgramChange(ProgramChange::from_raw(value)), // program-change
+            208 => Self::NodeType(NodeType::from_raw(value)), // node-type
+            197 => Self::LoggingType(LoggingType::from_raw(value)), // logging-type
+            41 => Self::FileAccessMethod(FileAccessMethod::from_raw(value)), // file-access-method
+            338 => Self::BackupAndRestoreState(BackupAndRestoreState::from_raw(value)), // backup-and-restore-state
+
+            // Life safety.
+            160 | 175 => Self::LifeSafetyMode(LifeSafetyMode::from_raw(value)), // mode / accepted-modes
+            164 => Self::LifeSafetyState(LifeSafetyState::from_raw(value)),     // tracking-value
+            161 => Self::LifeSafetyOperation(LifeSafetyOperation::from_raw(value)), // operation-expected
+            163 => Self::SilencedState(SilencedState::from_raw(value)),             // silenced
+
+            // Access door.
+            231 => Self::DoorStatus(DoorStatus::from_raw(value)), // door-status
+            226 => Self::DoorAlarmState(DoorAlarmState::from_raw(value)), // door-alarm-state
+            233 => Self::LockStatus(LockStatus::from_raw(value)), // lock-status
+            235 => Self::DoorSecuredStatus(DoorSecuredStatus::from_raw(value)), // secured-status
+
+            // Access control.
+            247 | 275 => Self::AccessEvent(AccessEvent::from_raw(value)), // access-event / last-access-event
+            261 => Self::AuthorizationMode(AuthorizationMode::from_raw(value)), // authorization-mode
+            300 => Self::AccessPassbackMode(AccessPassbackMode::from_raw(value)), // passback-mode
+            318 => Self::AccessUserType(AccessUserType::from_raw(value)),       // user-type
+            263 => Self::AccessCredentialDisable(AccessCredentialDisable::from_raw(value)), // credential-disable
+            303 => {
+                Self::AccessCredentialDisableReason(AccessCredentialDisableReason::from_raw(value))
+            } // reason-for-disable
+
+            // Network port.
+            427 => Self::NetworkType(NetworkType::from_raw(value)), // network-type
+            426 => Self::NetworkNumberQuality(NetworkNumberQuality::from_raw(value)), // network-number-quality
+            408 | 435 => Self::IPMode(IPMode::from_raw(value)), // bacnet-ip-mode / bacnet-ipv6-mode
+            417 => Self::NetworkPortCommand(NetworkPortCommand::from_raw(value)), // command
+            482 => Self::ProtocolLevel(ProtocolLevel::from_raw(value)), // protocol-level
+
+            // Lighting / timer / channel.
+            378 => Self::LightingInProgress(LightingInProgress::from_raw(value)), // in-progress
+            398 => Self::TimerState(TimerState::from_raw(value)),                 // timer-state
+            395 => Self::TimerTransition(TimerTransition::from_raw(value)), // last-state-change
+            370 => Self::WriteStatus(WriteStatus::from_raw(value)),         // write-status
+
+            // Lift / escalator.
+            456 => Self::LiftCarMode(LiftCarMode::from_raw(value)), // car-mode
+            467 => Self::LiftGroupMode(LiftGroupMode::from_raw(value)), // group-mode
+            462 => Self::EscalatorMode(EscalatorMode::from_raw(value)), // escalator-mode
+            453 => Self::LiftCarDriveStatus(LiftCarDriveStatus::from_raw(value)), // car-drive-status
+            448 | 457 => Self::LiftCarDirection(LiftCarDirection::from_raw(value)), // car-assigned/moving-direction
+            449 => Self::LiftCarDoorCommand(LiftCarDoorCommand::from_raw(value)), // car-door-command
+            450 => Self::LiftCarDoorStatus(LiftCarDoorStatus::from_raw(value)),   // car-door-status
+
+            // Audit.
+            498 => Self::AuditLevel(AuditLevel::from_raw(value)), // audit-level
+
+            _ => Self::Unknown(value),
+        }
+    }
+}
+
+/// Finish the job that `decode_application_value` starts: if `value` is an
+/// `Enumerated`, resolve it to its named enumeration for `property`.
+///
+/// Returns `None` for any non-enumerated value (there is nothing to promote).
+/// For a `PropertyValue::List`, resolve each element with
+/// [`ResolvedEnum::from_property`] yourself — the element enumeration is the
+/// same as the scalar case for that property.
+///
+/// ```
+/// use bacnet_types::enums::{resolve_enum, PropertyIdentifier, ResolvedEnum};
+/// use bacnet_types::primitives::PropertyValue;
+///
+/// // Suppose `decode_application_value` returned this for the `object-type`
+/// // property of some object:
+/// let decoded = PropertyValue::Enumerated(19);
+///
+/// match resolve_enum(PropertyIdentifier::OBJECT_TYPE, &decoded) {
+///     Some(ResolvedEnum::ObjectType(t)) => {
+///         assert_eq!(t, bacnet_types::enums::ObjectType::MULTI_STATE_VALUE);
+///         assert_eq!(t.to_string(), "MULTI_STATE_VALUE");
+///     }
+///     _ => unreachable!(),
+/// }
+/// ```
+pub fn resolve_enum(property: PropertyIdentifier, value: &PropertyValue) -> Option<ResolvedEnum> {
+    match value {
+        PropertyValue::Enumerated(n) => Some(ResolvedEnum::from_property(property, *n)),
+        _ => None,
+    }
+}
+
+/// A BACnet `BitString` promoted to its named bit-string type, keyed by property.
+///
+/// The bit-string analogue of [`ResolvedEnum`]: on the wire a `BitString` is
+/// just `(unused_bits, data)` bytes with no type identity, so the property
+/// decides which `BACnetXxx` BIT STRING it is (ASHRAE 135 Clause 21). A property
+/// with no known named bit-string type yields [`ResolvedBits::Unknown`],
+/// preserving the raw bytes.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ResolvedBits {
+    /// `status-flags` / `member-status-flags` → [`StatusFlags`].
+    StatusFlags(StatusFlags),
+    /// `event-enable` / `acked-transitions` / `ack-required` → [`EventTransitionBits`].
+    EventTransitionBits(EventTransitionBits),
+    /// `limit-enable` → [`LimitEnable`].
+    LimitEnable(LimitEnable),
+    /// `protocol-services-supported` → [`ServicesSupported`].
+    ServicesSupported(ServicesSupported),
+    /// `protocol-object-types-supported` → [`ObjectTypesSupported`].
+    ObjectTypesSupported(ObjectTypesSupported),
+    /// No known named bit string for this property; raw bytes preserved.
+    Unknown {
+        /// Number of unused bits in the last byte.
+        unused_bits: u8,
+        /// The bit data bytes.
+        data: Vec<u8>,
+    },
+}
+
+impl ResolvedBits {
+    /// Promote a raw `BitString` payload to its named bit-string type using the
+    /// property it was read from.
+    ///
+    /// `unused_bits` and `data` are the fields of
+    /// [`PropertyValue::BitString`]. A property with no known named bit-string
+    /// type — vendor-proprietary or object-type-dependent — yields
+    /// [`ResolvedBits::Unknown`] with the bytes intact.
+    pub fn from_property(property: PropertyIdentifier, unused_bits: u8, data: &[u8]) -> Self {
+        match property.to_raw() {
+            // status-flags / member-status-flags. StatusFlags keeps its own
+            // right-aligned representation, so decode via `first_byte >> unused`.
+            111 | 347 => Self::StatusFlags(StatusFlags::from_bits_truncate(
+                data.first().copied().unwrap_or(0) >> unused_bits.min(7),
+            )),
+
+            // event-enable / acked-transitions / ack-required.
+            0 | 1 | 35 => Self::EventTransitionBits(EventTransitionBits::from_bacnet(data)),
+
+            // limit-enable.
+            52 => Self::LimitEnable(LimitEnable::from_bacnet(data)),
+
+            // protocol-services-supported.
+            97 => Self::ServicesSupported(ServicesSupported::from_bacnet(data)),
+
+            // protocol-object-types-supported.
+            96 => Self::ObjectTypesSupported(ObjectTypesSupported::from_bacnet(data)),
+
+            _ => Self::Unknown {
+                unused_bits,
+                data: data.to_vec(),
+            },
+        }
+    }
+}
+
+impl core::fmt::Display for ResolvedBits {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::StatusFlags(v) => core::fmt::Display::fmt(v, f),
+            Self::EventTransitionBits(v) => core::fmt::Display::fmt(v, f),
+            Self::LimitEnable(v) => core::fmt::Display::fmt(v, f),
+            Self::ServicesSupported(v) => core::fmt::Display::fmt(v, f),
+            Self::ObjectTypesSupported(v) => core::fmt::Display::fmt(v, f),
+            Self::Unknown { data, .. } => {
+                f.write_str("0x")?;
+                for byte in data {
+                    write!(f, "{byte:02X}")?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+/// Bit-string analogue of [`resolve_enum`]: if `value` is a `BitString`, resolve
+/// it to its named bit-string type for `property`; otherwise return `None`.
+pub fn resolve_bits(property: PropertyIdentifier, value: &PropertyValue) -> Option<ResolvedBits> {
+    match value {
+        PropertyValue::BitString { unused_bits, data } => {
+            Some(ResolvedBits::from_property(property, *unused_bits, data))
+        }
+        _ => None,
+    }
+}
+
+/// A decoded property value with every `Enumerated` promoted to its named enum.
+///
+/// This mirrors [`PropertyValue`] one-to-one, except that
+/// [`PropertyValue::Enumerated`]'s bare `u32` is replaced by a resolved
+/// [`ResolvedEnum`], and [`PropertyValue::BitString`]'s raw bytes by a resolved
+/// [`ResolvedBits`]. Every other variant carries exactly the same data as its
+/// `PropertyValue` counterpart. Build one with [`resolve_value`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResolvedValue {
+    /// Null value.
+    Null,
+    /// Boolean value.
+    Boolean(bool),
+    /// Unsigned integer (up to 64-bit for BACnet Unsigned64).
+    Unsigned(u64),
+    /// Signed integer.
+    Signed(i32),
+    /// IEEE 754 single-precision float.
+    Real(f32),
+    /// IEEE 754 double-precision float.
+    Double(f64),
+    /// Octet string (raw bytes).
+    OctetString(Vec<u8>),
+    /// Character string (UTF-8).
+    CharacterString(String),
+    /// Bit string, resolved to its named bit-string type for the property.
+    BitString(ResolvedBits),
+    /// Enumerated value, resolved to its named enumeration for the property.
+    Enumerated(ResolvedEnum),
+    /// Date value.
+    Date(Date),
+    /// Time value.
+    Time(Time),
+    /// Object identifier.
+    ObjectIdentifier(ObjectIdentifier),
+    /// A sequence (array) of resolved values.
+    List(Vec<ResolvedValue>),
+}
+
+/// Finish the job `decode_application_value` starts: take its decoded
+/// [`PropertyValue`] and return the same value with every `Enumerated` promoted
+/// to its named [`ResolvedEnum`] for `property`. All non-enumerated data is
+/// carried through unchanged. `List` elements are resolved recursively against
+/// the same property.
+///
+/// ```
+/// use bacnet_types::enums::{resolve_value, PropertyIdentifier, ResolvedEnum, ResolvedValue, ObjectType};
+/// use bacnet_types::primitives::PropertyValue;
+///
+/// // What decode_application_value() gave you for the `object-type` property:
+/// let decoded = PropertyValue::Enumerated(19);
+///
+/// let resolved = resolve_value(PropertyIdentifier::OBJECT_TYPE, decoded);
+/// assert_eq!(
+///     resolved,
+///     ResolvedValue::Enumerated(ResolvedEnum::ObjectType(ObjectType::MULTI_STATE_VALUE)),
+/// );
+///
+/// // Non-enum data is untouched:
+/// let n = resolve_value(PropertyIdentifier::PRESENT_VALUE, PropertyValue::Real(21.5));
+/// assert_eq!(n, ResolvedValue::Real(21.5));
+/// ```
+pub fn resolve_value(property: PropertyIdentifier, value: PropertyValue) -> ResolvedValue {
+    match value {
+        PropertyValue::Null => ResolvedValue::Null,
+        PropertyValue::Boolean(v) => ResolvedValue::Boolean(v),
+        PropertyValue::Unsigned(v) => ResolvedValue::Unsigned(v),
+        PropertyValue::Signed(v) => ResolvedValue::Signed(v),
+        PropertyValue::Real(v) => ResolvedValue::Real(v),
+        PropertyValue::Double(v) => ResolvedValue::Double(v),
+        PropertyValue::OctetString(v) => ResolvedValue::OctetString(v),
+        PropertyValue::CharacterString(v) => ResolvedValue::CharacterString(v),
+        PropertyValue::BitString { unused_bits, data } => {
+            ResolvedValue::BitString(ResolvedBits::from_property(property, unused_bits, &data))
+        }
+        PropertyValue::Enumerated(n) => {
+            ResolvedValue::Enumerated(ResolvedEnum::from_property(property, n))
+        }
+        PropertyValue::Date(v) => ResolvedValue::Date(v),
+        PropertyValue::Time(v) => ResolvedValue::Time(v),
+        PropertyValue::ObjectIdentifier(v) => ResolvedValue::ObjectIdentifier(v),
+        PropertyValue::List(values) => ResolvedValue::List(
+            values
+                .into_iter()
+                .map(|v| resolve_value(property, v))
+                .collect(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_object_type() {
+        let r = ResolvedEnum::from_property(PropertyIdentifier::OBJECT_TYPE, 19);
+        assert_eq!(r, ResolvedEnum::ObjectType(ObjectType::MULTI_STATE_VALUE));
+        assert_eq!(r.to_string(), "MULTI_STATE_VALUE");
+    }
+
+    #[test]
+    fn resolves_units_across_aliases() {
+        for prop in [
+            PropertyIdentifier::UNITS,
+            PropertyIdentifier::OUTPUT_UNITS,
+            PropertyIdentifier::CAR_LOAD_UNITS,
+        ] {
+            assert!(matches!(
+                ResolvedEnum::from_property(prop, 0),
+                ResolvedEnum::EngineeringUnits(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn unmapped_property_is_unknown() {
+        // present-value is object-type-dependent, so it stays Unknown.
+        let r = ResolvedEnum::from_property(PropertyIdentifier::PRESENT_VALUE, 7);
+        assert_eq!(r, ResolvedEnum::Unknown(7));
+        assert_eq!(r.to_string(), "7");
+    }
+
+    #[test]
+    fn vendor_object_type_passes_through() {
+        // 128 is a vendor-proprietary object type: named enum keeps the number.
+        let r = ResolvedEnum::from_property(PropertyIdentifier::OBJECT_TYPE, 128);
+        assert_eq!(r, ResolvedEnum::ObjectType(ObjectType::from_raw(128)));
+        assert_eq!(r.to_string(), "128");
+    }
+
+    #[test]
+    fn resolve_value_promotes_enum_and_keeps_rest() {
+        // Enum gets a named variant.
+        assert_eq!(
+            resolve_value(
+                PropertyIdentifier::EVENT_STATE,
+                PropertyValue::Enumerated(0)
+            ),
+            ResolvedValue::Enumerated(ResolvedEnum::EventState(EventState::from_raw(0))),
+        );
+        // Non-enum data passes through byte-for-byte.
+        assert_eq!(
+            resolve_value(
+                PropertyIdentifier::OBJECT_NAME,
+                PropertyValue::CharacterString("AI-1".into())
+            ),
+            ResolvedValue::CharacterString("AI-1".into()),
+        );
+    }
+
+    #[test]
+    fn resolve_value_recurses_into_lists() {
+        let list = PropertyValue::List(vec![
+            PropertyValue::Enumerated(0),
+            PropertyValue::Enumerated(1),
+        ]);
+        let ResolvedValue::List(items) = resolve_value(PropertyIdentifier::ACCEPTED_MODES, list)
+        else {
+            panic!("expected list");
+        };
+        assert!(items.iter().all(|i| matches!(
+            i,
+            ResolvedValue::Enumerated(ResolvedEnum::LifeSafetyMode(_))
+        )));
+    }
+
+    #[test]
+    fn resolves_status_flags_bitstring() {
+        // 4-bit status-flags, 4 unused: wire byte 0x80 (in-alarm set), unused=4.
+        let bits = ResolvedBits::from_property(PropertyIdentifier::STATUS_FLAGS, 4, &[0x80]);
+        assert_eq!(bits, ResolvedBits::StatusFlags(StatusFlags::IN_ALARM));
+        assert_eq!(bits.to_string(), "IN_ALARM");
+    }
+
+    #[test]
+    fn resolves_limit_enable_and_event_enable() {
+        assert!(matches!(
+            ResolvedBits::from_property(PropertyIdentifier::LIMIT_ENABLE, 6, &[0xC0]),
+            ResolvedBits::LimitEnable(_)
+        ));
+        assert!(matches!(
+            ResolvedBits::from_property(PropertyIdentifier::EVENT_ENABLE, 5, &[0xE0]),
+            ResolvedBits::EventTransitionBits(_)
+        ));
+    }
+
+    #[test]
+    fn resolves_object_types_supported() {
+        let mut data = vec![0u8; 9];
+        data[8] = 0x80; // bit 64 => ColorTemperature
+        let bits = ResolvedBits::from_property(
+            PropertyIdentifier::PROTOCOL_OBJECT_TYPES_SUPPORTED,
+            7,
+            &data,
+        );
+        match bits {
+            ResolvedBits::ObjectTypesSupported(ots) => {
+                assert!(ots.contains(ObjectType::COLOR_TEMPERATURE));
+            }
+            _ => panic!("expected ObjectTypesSupported"),
+        }
+    }
+
+    #[test]
+    fn unmapped_bitstring_is_unknown() {
+        let bits = ResolvedBits::from_property(PropertyIdentifier::PROPERTY_LIST, 0, &[0xAB]);
+        assert_eq!(
+            bits,
+            ResolvedBits::Unknown {
+                unused_bits: 0,
+                data: vec![0xAB],
+            }
+        );
+        assert_eq!(bits.to_string(), "0xAB");
+    }
+
+    #[test]
+    fn resolve_value_promotes_bitstring() {
+        let v = resolve_value(
+            PropertyIdentifier::STATUS_FLAGS,
+            PropertyValue::BitString {
+                unused_bits: 4,
+                data: vec![0x40], // fault set
+            },
+        );
+        assert_eq!(
+            v,
+            ResolvedValue::BitString(ResolvedBits::StatusFlags(StatusFlags::FAULT)),
+        );
+    }
+
+    #[test]
+    fn resolve_bits_ignores_non_bitstring() {
+        assert!(resolve_bits(
+            PropertyIdentifier::STATUS_FLAGS,
+            &PropertyValue::Unsigned(1)
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn resolve_enum_ignores_non_enumerated() {
+        assert!(resolve_enum(
+            PropertyIdentifier::OBJECT_TYPE,
+            &PropertyValue::Unsigned(19)
+        )
+        .is_none());
+        assert!(matches!(
+            resolve_enum(
+                PropertyIdentifier::EVENT_STATE,
+                &PropertyValue::Enumerated(0)
+            ),
+            Some(ResolvedEnum::EventState(_))
+        ));
+    }
+}

--- a/crates/bacnet-types/src/lib.rs
+++ b/crates/bacnet-types/src/lib.rs
@@ -11,6 +11,7 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+pub mod bitstring;
 pub mod constructed;
 pub mod enums;
 pub mod error;

--- a/crates/bacnet-types/src/primitives.rs
+++ b/crates/bacnet-types/src/primitives.rs
@@ -307,7 +307,7 @@ pub enum BACnetTimeStamp {
 
 bitflags::bitflags! {
     /// BACnet StatusFlags -- 4-bit bitstring present on most objects.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash)]
     pub struct StatusFlags: u8 {
         const IN_ALARM = 0b1000;
         const FAULT = 0b0100;
@@ -316,6 +316,30 @@ bitflags::bitflags! {
     }
 }
 
+impl core::fmt::Display for StatusFlags {
+    /// Renders the set flags by their Clause-21 names (`IN_ALARM | FAULT`), or
+    /// `()` when none are set — never a raw number.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut first = true;
+        for (name, _) in self.iter_names() {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str(name)?;
+            first = false;
+        }
+        if first {
+            f.write_str("()")?;
+        }
+        Ok(())
+    }
+}
+
+impl core::fmt::Debug for StatusFlags {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(self, f)
+    }
+}
 bitflags::bitflags! {
     /// BACnet DaysOfWeek -- 7-bit bitstring (Clause 21).
     ///


### PR DESCRIPTION
`decode_application_value()` returns `PropertyValue` which leaves `Enumerated` and `BitString` as wrapped raw data instead of the human-readable enum variants the value should correspond to according to the specs clause 21. 

This PR introduces the function `resolve_value()`, which transforms the `PropertyValue` into an equivalent `ResolvedValue` where everything is the same except that `Enumerated` and `BitString` are replaced with the human-readable enum variant given in Clause 21. 

Example code for how to use `resolve_value()`:

``` rust
  let p = match bc
      .read_property(&mac_address, ob_id, gi.property, None)
      .await
  {
      Ok(p) => p,
      Err(e) => {
          error!(?e, ?object_type, ?gi.property, ?gi.instance_number);
          continue;
      }
  };

  if p.property_value.is_empty() {
      continue;
  }

  let (v, _) = decode_application_value(&p.property_value, 0).unwrap();

  let r = resolve_value(p.property_identifier, v);

  info!(?p.object_identifier, ?p.property_identifier, ?r);
``` 


## Output Comparison Examples: `decode_application_value()` vs `resolve_value()`

SYSTEM_STATUS v=Enumerated(0)
SYSTEM_STATUS r=Enumerated(DeviceStatus(DeviceStatus::OPERATIONAL))

PROTOCOL_SERVICES_SUPPORTED v=BitString { unused_bits: 1, data: [68, 11, 72, 40, 170] }
PROTOCOL_SERVICES_SUPPORTED r=BitString(ServicesSupported(CONFIRMED_COV_NOTIFICATION | SUBSCRIBE_COV | READ_PROPERTY | READ_PROPERTY_MULTIPLE | WRITE_PROPERTY | DEVICE_COMMUNICATION_CONTROL | REINITIALIZE_DEVICE | I_AM | UNCONFIRMED_COV_NOTIFICATION | TIME_SYNCHRONIZATION | WHO_IS | UTC_TIME_SYNCHRONIZATION | SUBSCRIBE_COV_PROPERTY))

SEGMENTATION_SUPPORTED v=Enumerated(0)
SEGMENTATION_SUPPORTED r=Enumerated(Segmentation(Segmentation::BOTH))

UNITS v=Enumerated(64)
UNITS r=Enumerated(EngineeringUnits(EngineeringUnits::DEGREES_FAHRENHEIT))