### PR TITLE
fix(objects,server,services)!: encode bit strings MSB-first per Clause 20.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking (wire format):** all ≤8-bit BACnet bit strings are now encoded
+  MSB-first per Clause 20.2.10 — the first defined bit occupies bit 7 (`0x80`)
+  of the octet. Previously `Event_Enable`/`Acked_Transitions` (here and in
+  GetEventInformation ACKs) and `Recipient_List`'s `valid_days`/`transitions`
+  were packed LSB-first within the octet, so TO_OFFNORMAL/TO_NORMAL arrived
+  swapped and the `valid_days` week was reversed for conformant peers
+  (Monday/Sunday inverted). Both encode and decode changed together; peers
+  that interoperated with the old bytes (including older releases of this
+  stack) will see transition and day masks bit-reversed until upgraded.
+  `Status_Flags`, `Limit_Enable`, `Ack_Required`,
+  `Protocol_Object_Types_Supported` and `Protocol_Services_Supported` were
+  already MSB-first and are unchanged. The conversion now lives in
+  `bacnet_types::bitstring::pack_octet`/`unpack_octet` (with typed
+  `to_bacnet()` on `EventTransitionBits`/`LimitEnable`), tested against
+  asymmetric spec vectors (`TO_OFFNORMAL → 0x80`, `monday → 0x80`). (#203)
+
 ### Added
 
 - `FaultDetector` gained a private field for warning suppression and is therefore

--- a/crates/bacnet-objects/src/analog/tests/input_output.rs
+++ b/crates/bacnet-objects/src/analog/tests/input_output.rs
@@ -320,7 +320,7 @@ fn ai_intrinsic_reporting_triggers_on_present_value_change() {
         None,
         PropertyValue::BitString {
             unused_bits: 5,
-            data: vec![0x07 << 5], // all transitions enabled
+            data: vec![0xE0], // all transitions, MSB-first
         },
         None,
     )
@@ -388,7 +388,7 @@ fn ao_intrinsic_reporting_after_priority_write() {
         None,
         PropertyValue::BitString {
             unused_bits: 5,
-            data: vec![0x07 << 5], // all transitions enabled
+            data: vec![0xE0], // all transitions, MSB-first
         },
         None,
     )

--- a/crates/bacnet-objects/src/analog/tests/value.rs
+++ b/crates/bacnet-objects/src/analog/tests/value.rs
@@ -344,7 +344,7 @@ fn av_intrinsic_reporting_normal_to_high_limit_to_normal() {
         None,
         PropertyValue::BitString {
             unused_bits: 5,
-            data: vec![0x07 << 5],
+            data: vec![0xE0], // all transitions, MSB-first
         },
         None,
     )
@@ -412,7 +412,7 @@ fn av_intrinsic_reporting_after_priority_write() {
         None,
         PropertyValue::BitString {
             unused_bits: 5,
-            data: vec![0x07 << 5],
+            data: vec![0xE0], // all transitions, MSB-first
         },
         None,
     )

--- a/crates/bacnet-objects/src/binary/input.rs
+++ b/crates/bacnet-objects/src/binary/input.rs
@@ -130,11 +130,15 @@ impl BACnetObject for BinaryInputObject {
             )),
             p if p == PropertyIdentifier::EVENT_ENABLE => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_detector.event_enable << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(
+                    self.event_detector.event_enable,
+                )],
             }),
             p if p == PropertyIdentifier::ACKED_TRANSITIONS => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_detector.acked_transitions << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(
+                    self.event_detector.acked_transitions,
+                )],
             }),
             p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(
                 self.event_detector.notification_class as u64,

--- a/crates/bacnet-objects/src/binary/tests/command_failure.rs
+++ b/crates/bacnet-objects/src/binary/tests/command_failure.rs
@@ -192,7 +192,7 @@ fn bo_time_delay_gates_command_failure() {
 
 #[test]
 fn bo_event_enable_to_offnormal_bit_controls_distribution() {
-    for (encoded, expected) in [(0x20, true), (0x00, false)] {
+    for (encoded, expected) in [(0x80, true), (0x00, false)] {
         let mut bo = BinaryOutputObject::new(1, "BO-1").unwrap();
         set_detection_enabled(&mut bo, true);
         write_event_enable(&mut bo, encoded);

--- a/crates/bacnet-objects/src/binary/value.rs
+++ b/crates/bacnet-objects/src/binary/value.rs
@@ -145,11 +145,15 @@ impl BACnetObject for BinaryValueObject {
             }
             p if p == PropertyIdentifier::EVENT_ENABLE => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_detector.event_enable << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(
+                    self.event_detector.event_enable,
+                )],
             }),
             p if p == PropertyIdentifier::ACKED_TRANSITIONS => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_detector.acked_transitions << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(
+                    self.event_detector.acked_transitions,
+                )],
             }),
             p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(
                 self.event_detector.notification_class as u64,

--- a/crates/bacnet-objects/src/common.rs
+++ b/crates/bacnet-objects/src/common.rs
@@ -400,7 +400,9 @@ macro_rules! read_generic_event_properties {
             p if p == bacnet_types::enums::PropertyIdentifier::EVENT_ENABLE => {
                 Some(Ok(bacnet_types::primitives::PropertyValue::BitString {
                     unused_bits: 5,
-                    data: vec![$self.event_detector.event_enable << 5],
+                    data: vec![bacnet_types::bitstring::pack_octet(
+                        $self.event_detector.event_enable,
+                    )],
                 }))
             }
             p if p == bacnet_types::enums::PropertyIdentifier::NOTIFY_TYPE => {
@@ -421,7 +423,9 @@ macro_rules! read_generic_event_properties {
             p if p == bacnet_types::enums::PropertyIdentifier::ACKED_TRANSITIONS => {
                 Some(Ok(bacnet_types::primitives::PropertyValue::BitString {
                     unused_bits: 5,
-                    data: vec![$self.event_detector.acked_transitions << 5],
+                    data: vec![bacnet_types::bitstring::pack_octet(
+                        $self.event_detector.acked_transitions,
+                    )],
                 }))
             }
             _ => None,
@@ -577,7 +581,8 @@ macro_rules! write_generic_event_properties {
             p if p == bacnet_types::enums::PropertyIdentifier::EVENT_ENABLE => {
                 if let bacnet_types::primitives::PropertyValue::BitString { data, .. } = &$value {
                     if let Some(&byte) = data.first() {
-                        $self.event_detector.event_enable = byte >> 5;
+                        $self.event_detector.event_enable =
+                            bacnet_types::bitstring::unpack_octet(&[byte], 3);
                         Some(Ok(()))
                     } else {
                         Some(Err($crate::common::invalid_data_type_error()))

--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -195,11 +195,11 @@ impl BACnetObject for EventEnrollmentObject {
             }
             p if p == PropertyIdentifier::EVENT_ENABLE => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_enable << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(self.event_enable)],
             }),
             p if p == PropertyIdentifier::ACKED_TRANSITIONS => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.acked_transitions << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(self.acked_transitions)],
             }),
             p if p == PropertyIdentifier::EVENT_DETECTION_ENABLE => {
                 Ok(PropertyValue::Boolean(self.event_detection_enable))
@@ -239,7 +239,7 @@ impl BACnetObject for EventEnrollmentObject {
         if property == PropertyIdentifier::EVENT_ENABLE {
             if let PropertyValue::BitString { data, .. } = &value {
                 if let Some(&byte) = data.first() {
-                    self.event_enable = byte >> 5;
+                    self.event_enable = bacnet_types::bitstring::unpack_octet(&[byte], 3);
                     return Ok(());
                 }
                 return Err(common::invalid_data_type_error());
@@ -466,7 +466,7 @@ impl BACnetObject for AlertEnrollmentObject {
             }
             p if p == PropertyIdentifier::EVENT_ENABLE => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_enable << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(self.event_enable)],
             }),
             p if p == PropertyIdentifier::NOTIFICATION_CLASS => {
                 Ok(PropertyValue::Unsigned(self.notification_class as u64))
@@ -495,7 +495,7 @@ impl BACnetObject for AlertEnrollmentObject {
         if property == PropertyIdentifier::EVENT_ENABLE {
             if let PropertyValue::BitString { data, .. } = &value {
                 if let Some(&byte) = data.first() {
-                    self.event_enable = byte >> 5;
+                    self.event_enable = bacnet_types::bitstring::unpack_octet(&[byte], 3);
                     return Ok(());
                 }
                 return Err(common::invalid_data_type_error());

--- a/crates/bacnet-objects/src/event_enrollment/tests/alert.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/alert.rs
@@ -70,7 +70,7 @@ fn alert_enrollment_event_enable() {
     let val = ae
         .read_property(PropertyIdentifier::EVENT_ENABLE, None)
         .unwrap();
-    // Default event_enable = 0b111, shifted left 5 = 0b1110_0000
+    // Default event_enable = 0b111 -> MSB-first wire byte 0b1110_0000
     assert_eq!(
         val,
         PropertyValue::BitString {

--- a/crates/bacnet-objects/src/event_enrollment/tests/detection_enable.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/detection_enable.rs
@@ -131,7 +131,7 @@ fn disabled_detection_reports_initial_acked_transitions() {
             .unwrap(),
         PropertyValue::BitString {
             unused_bits: 5,
-            // 0b111 << 5 — all three transition flags TRUE.
+            // All three transition flags TRUE, MSB-first.
             data: vec![0xE0],
         }
     );

--- a/crates/bacnet-objects/src/event_enrollment/tests/enrollment.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/enrollment.rs
@@ -42,7 +42,7 @@ fn read_event_enable() {
     let val = ee
         .read_property(PropertyIdentifier::EVENT_ENABLE, None)
         .unwrap();
-    // Default event_enable = 0b111, shifted left 5 = 0b1110_0000
+    // Default event_enable = 0b111 -> MSB-first wire byte 0b1110_0000
     assert_eq!(
         val,
         PropertyValue::BitString {
@@ -160,7 +160,7 @@ fn write_notification_class() {
 #[test]
 fn write_event_enable() {
     let mut ee = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
-    // Write only TO_OFFNORMAL enabled (bit 0 = 0b100 = 0x80 when shifted)
+    // Write only TO_OFFNORMAL enabled (wire bit 0 = 0x80, Clause 20.2.10)
     ee.write_property(
         PropertyIdentifier::EVENT_ENABLE,
         None,

--- a/crates/bacnet-objects/src/multistate/input.rs
+++ b/crates/bacnet-objects/src/multistate/input.rs
@@ -165,11 +165,15 @@ impl BACnetObject for MultiStateInputObject {
             )),
             p if p == PropertyIdentifier::EVENT_ENABLE => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_detector.event_enable << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(
+                    self.event_detector.event_enable,
+                )],
             }),
             p if p == PropertyIdentifier::ACKED_TRANSITIONS => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_detector.acked_transitions << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(
+                    self.event_detector.acked_transitions,
+                )],
             }),
             p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(
                 self.event_detector.notification_class as u64,

--- a/crates/bacnet-objects/src/multistate/output.rs
+++ b/crates/bacnet-objects/src/multistate/output.rs
@@ -524,7 +524,7 @@ mod command_failure_tests {
 
     #[test]
     fn event_enable_to_offnormal_bit_controls_distribution() {
-        for (encoded, expected) in [(0x20, true), (0x00, false)] {
+        for (encoded, expected) in [(0x80, true), (0x00, false)] {
             let mut mso = MultiStateOutputObject::new(1, "MSO-1", 3).unwrap();
             set_detection_enabled(&mut mso, true);
             mso.write_property(

--- a/crates/bacnet-objects/src/multistate/value.rs
+++ b/crates/bacnet-objects/src/multistate/value.rs
@@ -179,11 +179,15 @@ impl BACnetObject for MultiStateValueObject {
             )),
             p if p == PropertyIdentifier::EVENT_ENABLE => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_detector.event_enable << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(
+                    self.event_detector.event_enable,
+                )],
             }),
             p if p == PropertyIdentifier::ACKED_TRANSITIONS => Ok(PropertyValue::BitString {
                 unused_bits: 5,
-                data: vec![self.event_detector.acked_transitions << 5],
+                data: vec![bacnet_types::bitstring::pack_octet(
+                    self.event_detector.acked_transitions,
+                )],
             }),
             p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(
                 self.event_detector.notification_class as u64,

--- a/crates/bacnet-objects/src/notification_class/mod.rs
+++ b/crates/bacnet-objects/src/notification_class/mod.rs
@@ -7,15 +7,13 @@
 //! `BIT STRING { monday(0), tuesday(1), ..., sunday(6) }` (Clause 21): **bit 0
 //! is Monday and bit 6 is Sunday** in the in-memory `u8`. Callers must build
 //! `today_bit` with the same convention (`1 << dow` where `dow = 0` on
-//! Monday). This module serializes the 7-bit `valid_days` as the wire byte
-//! `valid_days << 1` with `unused_bits: 1`, and the 3-bit `transitions` as
-//! `transitions << 5` with `unused_bits: 5`; the matching decoders are
-//! `data[0] >> 1` and `data[0] >> 5`. These shifts pack the in-memory bits
-//! toward the MSB of the wire octet and round-trip within this codebase.
-//! (Clause 20.2.8 specifies true MSB-first packing, i.e. monday(0) at bit 7;
-//! the `<< 1` shift instead places monday at bit 1. That pre-existing
-//! wire-format deviation is out of scope for the day/time semantics fix and
-//! is not changed here.)
+//! Monday). On the wire both bit strings are packed MSB-first per Clause
+//! 20.2.10 — monday(0) at `0x80` of the `valid_days` octet (`unused_bits: 1`),
+//! to-offnormal(0) at `0x80` of the `transitions` octet (`unused_bits: 5`) —
+//! via [`bacnet_types::bitstring::pack_octet`]/[`unpack_octet`], which reverse
+//! the in-memory bit0-first byte.
+//!
+//! [`unpack_octet`]: bacnet_types::bitstring::unpack_octet
 //!
 //! `from_time`/`to_time` are BACnet `Time` values interpreted in the device's
 //! *local* time, derived from the wall clock plus the Device object's
@@ -152,7 +150,7 @@ impl BACnetObject for NotificationClass {
                             // valid_days as bitstring (7 bits used, 1 unused)
                             PropertyValue::BitString {
                                 unused_bits: 1,
-                                data: vec![dest.valid_days << 1],
+                                data: vec![bacnet_types::bitstring::pack_octet(dest.valid_days)],
                             },
                             PropertyValue::Time(dest.from_time),
                             PropertyValue::Time(dest.to_time),
@@ -176,7 +174,7 @@ impl BACnetObject for NotificationClass {
                             // transitions as bitstring (3 bits used, 5 unused)
                             PropertyValue::BitString {
                                 unused_bits: 5,
-                                data: vec![dest.transitions << 5],
+                                data: vec![bacnet_types::bitstring::pack_octet(dest.transitions)],
                             },
                         ])
                     })
@@ -211,7 +209,7 @@ impl BACnetObject for NotificationClass {
                         // [0] valid_days: BitString (7 bits, 1 unused)
                         let valid_days = match &fields[0] {
                             PropertyValue::BitString { data, .. } if !data.is_empty() => {
-                                data[0] >> 1
+                                bacnet_types::bitstring::unpack_octet(data, 7)
                             }
                             _ => return Err(common::invalid_data_type_error()),
                         };
@@ -258,7 +256,7 @@ impl BACnetObject for NotificationClass {
                         // [6] transitions: BitString (3 bits, 5 unused)
                         let transitions = match &fields[6] {
                             PropertyValue::BitString { data, .. } if !data.is_empty() => {
-                                data[0] >> 5
+                                bacnet_types::bitstring::unpack_octet(data, 3)
                             }
                             _ => return Err(common::invalid_data_type_error()),
                         };
@@ -532,7 +530,9 @@ pub fn filter_recipient_list(
 
         // [0] valid_days bitstring
         let valid_days = match &fields[0] {
-            PropertyValue::BitString { data, .. } if !data.is_empty() => data[0] >> 1,
+            PropertyValue::BitString { data, .. } if !data.is_empty() => {
+                bacnet_types::bitstring::unpack_octet(data, 7)
+            }
             _ => continue,
         };
         if valid_days & today_bit == 0 {
@@ -554,7 +554,9 @@ pub fn filter_recipient_list(
 
         // [6] transitions bitstring
         let transitions = match &fields[6] {
-            PropertyValue::BitString { data, .. } if !data.is_empty() => data[0] >> 5,
+            PropertyValue::BitString { data, .. } if !data.is_empty() => {
+                bacnet_types::bitstring::unpack_octet(data, 3)
+            }
             _ => continue,
         };
         if transitions & transition_mask == 0 {

--- a/crates/bacnet-objects/src/notification_class/tests/properties.rs
+++ b/crates/bacnet-objects/src/notification_class/tests/properties.rs
@@ -171,7 +171,7 @@ fn add_destination_device_and_read_back() {
     // 7 fields: valid_days, from_time, to_time, recipient, process_id, confirmed, transitions
     assert_eq!(fields.len(), 7);
 
-    // valid_days bitstring: all days = 0b0111_1111 << 1 = 0b1111_1110 = 0xFE
+    // valid_days bitstring: all seven days MSB-first = 0b1111_1110 = 0xFE
     assert_eq!(
         fields[0],
         PropertyValue::BitString {
@@ -196,7 +196,7 @@ fn add_destination_device_and_read_back() {
     // issue_confirmed_notifications
     assert_eq!(fields[5], PropertyValue::Boolean(true));
 
-    // transitions: all = 0b0000_0111 << 5 = 0b1110_0000 = 0xE0
+    // transitions: all three, MSB-first = 0b1110_0000 = 0xE0
     assert_eq!(
         fields[6],
         PropertyValue::BitString {
@@ -245,18 +245,29 @@ fn add_destination_address_variant() {
         ])
     );
 
+    // valid_days: Tue–Sat is asymmetric under bit reversal, so this byte —
+    // unlike the all-days 0xFE — actually witnesses the MSB-first packing:
+    // tuesday(1)=0x40 .. saturday(5)=0x04.
+    assert_eq!(
+        fields[0],
+        PropertyValue::BitString {
+            unused_bits: 1,
+            data: vec![0b0111_1100],
+        }
+    );
+
     // process_identifier = 42
     assert_eq!(fields[4], PropertyValue::Unsigned(42));
 
     // issue_confirmed = false
     assert_eq!(fields[5], PropertyValue::Boolean(false));
 
-    // transitions: bit 0 only = 0b0000_0001 << 5 = 0b0010_0000 = 0x20
+    // transitions: to-offnormal only = wire bit 0 = 0b1000_0000 (Clause 20.2.10)
     assert_eq!(
         fields[6],
         PropertyValue::BitString {
             unused_bits: 5,
-            data: vec![0b0010_0000],
+            data: vec![0b1000_0000],
         }
     );
 }

--- a/crates/bacnet-objects/src/notification_class/tests/recipient_list.rs
+++ b/crates/bacnet-objects/src/notification_class/tests/recipient_list.rs
@@ -125,3 +125,46 @@ fn write_recipient_list_rejects_malformed_address() {
         assert!(result.is_err(), "malformed address must be rejected");
     }
 }
+
+#[test]
+fn written_valid_days_decodes_msb_first() {
+    // Decode-side witness for #203: valid_days arrives as wire bytes and the
+    // filter observes the decoded internal mask, so a Monday-only wire byte
+    // (monday(0) = 0x80 per Clause 20.2.10) must match today_bit 0x01 (Monday)
+    // and not 0x40 (Sunday). Pure round trips cannot catch an inverted decode;
+    // this asymmetric byte can.
+    let mut nc = NotificationClass::new(1, "NC-1").unwrap();
+    let dev_oid = ObjectIdentifier::new(ObjectType::DEVICE, 10).unwrap();
+    let entry = PropertyValue::List(vec![
+        PropertyValue::BitString {
+            unused_bits: 1,
+            data: vec![0b1000_0000], // Monday only
+        },
+        PropertyValue::Time(make_time(0, 0)),
+        PropertyValue::Time(make_time(23, 59)),
+        PropertyValue::ObjectIdentifier(dev_oid),
+        PropertyValue::Unsigned(7),
+        PropertyValue::Boolean(false),
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0b1000_0000], // TO_OFFNORMAL only
+        },
+    ]);
+    nc.write_property(
+        PropertyIdentifier::RECIPIENT_LIST,
+        None,
+        PropertyValue::List(vec![entry]),
+        None,
+    )
+    .unwrap();
+
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(nc)).unwrap();
+    let noon = make_time(12, 0);
+
+    let monday = get_notification_recipients(&db, 1, EventTransition::ToOffnormal, 0x01, &noon);
+    assert_eq!(monday.len(), 1, "Monday-only entry must match Monday");
+
+    let sunday = get_notification_recipients(&db, 1, EventTransition::ToOffnormal, 0x40, &noon);
+    assert!(sunday.is_empty(), "Monday-only entry must not match Sunday");
+}

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -560,7 +560,9 @@ pub fn evaluate_event_enrollments(db: &mut ObjectDatabase) -> Vec<EventEnrollmen
         };
 
         let event_enable = match enrollment.read_property(PropertyIdentifier::EVENT_ENABLE, None) {
-            Ok(PropertyValue::BitString { data, .. }) => data.first().map(|b| b >> 5).unwrap_or(0),
+            Ok(PropertyValue::BitString { data, .. }) => {
+                bacnet_types::bitstring::unpack_octet(&data, 3)
+            }
             _ => 0,
         };
 

--- a/crates/bacnet-server/src/event_enrollment/tests/change_of_bitstring.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/change_of_bitstring.rs
@@ -37,7 +37,7 @@ fn change_of_bitstring_normal() {
     db.add(Box::new(ee)).unwrap();
 
     let transitions = evaluate_event_enrollments(&mut db);
-    // 0x05 << 5 = 0xA0, mask 0xFF → 0xA0, alarm 0xE0 → no match → NORMAL
+    // internal 0x05 -> wire 0xA0 (MSB-first), mask 0xFF → 0xA0, alarm 0xE0 → no match → NORMAL
     assert!(transitions.is_empty());
 }
 
@@ -67,7 +67,7 @@ fn change_of_bitstring_offnormal() {
     db.add(Box::new(ee)).unwrap();
 
     let transitions = evaluate_event_enrollments(&mut db);
-    // 0x07 << 5 = 0xE0, mask 0xE0 → 0xE0, alarm 0xE0 → match → OFFNORMAL
+    // internal 0x07 -> wire 0xE0 (MSB-first), mask 0xE0 → 0xE0, alarm 0xE0 → match → OFFNORMAL
     assert_eq!(transitions.len(), 1);
     assert_eq!(transitions[0].change.to, EventState::OFFNORMAL);
 }

--- a/crates/bacnet-server/src/event_enrollment/tests/compat.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/compat.rs
@@ -115,7 +115,7 @@ fn change_of_value_bitmask_criteria() {
 
     // Target object exposing a bitstring property (EVENT_ENABLE, 3 bits).
     let mut target = EventEnrollmentObject::new(96, "Tgt", EventType::NONE.to_raw()).unwrap();
-    target.set_event_enable(0x07); // 0x07 << 5 = 0xE0
+    target.set_event_enable(0x07); // internal 0x07 -> wire 0xE0 (MSB-first)
     let target_oid = target.object_identifier();
     db.add(Box::new(target)).unwrap();
 

--- a/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
@@ -59,7 +59,9 @@ pub fn handle_get_event_information(
                     .read_property(PropertyIdentifier::EVENT_ENABLE, None)
                     .ok()
                     .and_then(|v| match v {
-                        PropertyValue::BitString { data, .. } => data.first().map(|b| b >> 5),
+                        PropertyValue::BitString { data, .. } => {
+                            Some(bacnet_types::bitstring::unpack_octet(&data, 3))
+                        }
                         _ => None,
                     })
                     .unwrap_or(0x07);
@@ -94,7 +96,9 @@ pub fn handle_get_event_information(
                     .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
                     .ok()
                     .and_then(|v| match v {
-                        PropertyValue::BitString { data, .. } => data.first().map(|b| b >> 5),
+                        PropertyValue::BitString { data, .. } => {
+                            Some(bacnet_types::bitstring::unpack_octet(&data, 3))
+                        }
                         _ => None,
                     })
                     .unwrap_or(0x07);

--- a/crates/bacnet-server/src/handlers/tests/device_event.rs
+++ b/crates/bacnet-server/src/handlers/tests/device_event.rs
@@ -188,7 +188,7 @@ fn get_event_information_reads_event_enable_and_notify_type() {
         None,
         PropertyValue::BitString {
             unused_bits: 5,
-            data: vec![0x05 << 5],
+            data: vec![0xA0], // TO_OFFNORMAL|TO_NORMAL, MSB-first
         },
         None,
     )
@@ -240,7 +240,11 @@ fn get_event_information_reads_event_enable_and_notify_type() {
         .unwrap();
     match ev_enable {
         PropertyValue::BitString { data, .. } => {
-            assert_eq!(data[0] >> 5, 0x05, "EVENT_ENABLE should be 0x05");
+            assert_eq!(
+                bacnet_types::bitstring::unpack_octet(&data, 3),
+                0x05,
+                "EVENT_ENABLE should be 0x05"
+            );
         }
         other => panic!("expected BitString, got {:?}", other),
     }

--- a/crates/bacnet-server/src/intrinsic_reporting/mod.rs
+++ b/crates/bacnet-server/src/intrinsic_reporting/mod.rs
@@ -48,17 +48,15 @@ fn read_unsigned(
     }
 }
 
-/// Read EVENT_ENABLE as a 3-bit value.
+/// Read EVENT_ENABLE as a 3-bit value (bit0 = TO_OFFNORMAL).
 ///
-/// Objects store EVENT_ENABLE as `BitString { unused_bits: 5, data: [value << 5] }`.
-/// This helper handles both BitString and Unsigned representations for robustness.
+/// Objects encode EVENT_ENABLE MSB-first per Clause 20.2.10 (TO_OFFNORMAL at
+/// `0x80`). This helper handles both BitString and Unsigned representations
+/// for robustness.
 fn read_event_enable(obj: &dyn bacnet_objects::traits::BACnetObject) -> u8 {
     match obj.read_property(PropertyIdentifier::EVENT_ENABLE, None) {
-        Ok(PropertyValue::BitString { unused_bits, data }) => {
-            if data.is_empty() {
-                return 0;
-            }
-            data[0] >> unused_bits
+        Ok(PropertyValue::BitString { data, .. }) => {
+            bacnet_types::bitstring::unpack_octet(&data, 3)
         }
         Ok(PropertyValue::Unsigned(v)) => v as u8,
         _ => 0,

--- a/crates/bacnet-server/src/pics/truth_source_tests.rs
+++ b/crates/bacnet-server/src/pics/truth_source_tests.rs
@@ -206,8 +206,8 @@ fn is_writable_property_matches_write_property_on_all_core_types() {
         &mut av,
         PropertyIdentifier::EVENT_ENABLE,
         PropertyValue::BitString {
-            unused_bits: 6,
-            data: vec![LimitEnable::BOTH.to_bits()],
+            unused_bits: 5,
+            data: vec![0xE0], // all three transitions, MSB-first
         },
         "AV",
     );

--- a/crates/bacnet-server/src/server/event_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_tests.rs
@@ -446,12 +446,8 @@ async fn event_notification_event_notify_type_honors_class_ack_required() {
 /// set from `event_enable_byte`.
 ///
 /// `Event_Enable` is written through `write_property` rather than an internal
-/// setter, so these tests cover the same path a network client takes. Note the
-/// byte is the *current* on-the-wire encoding, which packs the 3-bit string
-/// LSB-first (`value << 5`) instead of the MSB-first order Clause 20.2.10
-/// requires — see #203. When that is corrected these constants must be
-/// re-derived; they are written as `internal << 5` below to make the
-/// dependency explicit rather than magic.
+/// setter, so these tests cover the same path a network client takes. Bytes
+/// are the Clause 20.2.10 wire encoding: MSB-first, TO_OFFNORMAL at `0x80`.
 fn db_with_high_limit_transition(
     event_enable_byte: u8,
 ) -> Arc<tokio::sync::RwLock<ObjectDatabase>> {
@@ -566,8 +562,8 @@ async fn event_enable_cleared_suppresses_per_write_send() {
 /// `Event_Enable` rather than to a constant.
 #[tokio::test]
 async fn event_enable_set_permits_per_write_send() {
-    // internal TO_OFFNORMAL = 0x01, encoded `<< 5` by the current codec (#203).
-    let db = db_with_high_limit_transition(0x01 << 5);
+    // TO_OFFNORMAL only: wire bit 0 = 0x80 (Clause 20.2.10).
+    let db = db_with_high_limit_transition(0x80);
     let sent = broadcasts_from_per_write_path(&db).await;
 
     assert_eq!(
@@ -727,7 +723,7 @@ async fn periodic_time_delay_carries_detector_event_type_to_wire() {
         None,
         PropertyValue::BitString {
             unused_bits: 5,
-            data: vec![0x20],
+            data: vec![0x80], // TO_OFFNORMAL at wire bit 0
         },
         None,
     )

--- a/crates/bacnet-services/src/alarm_event/get_event_information.rs
+++ b/crates/bacnet-services/src/alarm_event/get_event_information.rs
@@ -111,7 +111,11 @@ impl GetEventInformationAck {
                 return Err(Error::decoding(pos, "truncated at ackedTransitions"));
             }
             // Content: [unused_bits_count, bit_data...]
-            let acknowledged_transitions = if end > pos + 1 { data[pos + 1] >> 5 } else { 0 };
+            let acknowledged_transitions = if end > pos + 1 {
+                bacnet_types::bitstring::unpack_octet(&[data[pos + 1]], 3)
+            } else {
+                0
+            };
             offset = end;
 
             // [3] eventTimeStamps — opening tag
@@ -198,7 +202,11 @@ impl GetEventInformationAck {
             if end > data.len() {
                 return Err(Error::decoding(pos, "truncated at eventEnable"));
             }
-            let event_enable = if end > pos + 1 { data[pos + 1] >> 5 } else { 0 };
+            let event_enable = if end > pos + 1 {
+                bacnet_types::bitstring::unpack_octet(&[data[pos + 1]], 3)
+            } else {
+                0
+            };
             offset = end;
 
             // [6] eventPriorities — opening tag
@@ -260,7 +268,14 @@ impl GetEventInformationAck {
             // [1] eventState
             primitives::encode_ctx_enumerated(buf, 1, summary.event_state);
             // [2] acknowledgedTransitions (3-bit bitstring)
-            primitives::encode_ctx_bit_string(buf, 2, 5, &[summary.acknowledged_transitions << 5]);
+            primitives::encode_ctx_bit_string(
+                buf,
+                2,
+                5,
+                &[bacnet_types::bitstring::pack_octet(
+                    summary.acknowledged_transitions,
+                )],
+            );
             // [3] eventTimeStamps (SEQUENCE OF 3 BACnetTimeStamp)
             tags::encode_opening_tag(buf, 3);
             for ts in &summary.event_timestamps {
@@ -287,7 +302,12 @@ impl GetEventInformationAck {
             // [4] notifyType
             primitives::encode_ctx_enumerated(buf, 4, summary.notify_type);
             // [5] eventEnable (3-bit bitstring)
-            primitives::encode_ctx_bit_string(buf, 5, 5, &[summary.event_enable << 5]);
+            primitives::encode_ctx_bit_string(
+                buf,
+                5,
+                5,
+                &[bacnet_types::bitstring::pack_octet(summary.event_enable)],
+            );
             // [6] eventPriorities (SEQUENCE OF 3 Unsigned)
             tags::encode_opening_tag(buf, 6);
             for &p in &summary.event_priorities {

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters.rs
@@ -218,6 +218,13 @@ fn get_event_information_ack_round_trip() {
     };
     let mut buf = BytesMut::new();
     ack.encode(&mut buf);
+    // Wire-byte check, not just a round trip: internal 0b101 must appear as
+    // its MSB-first octet 0xA0 (a symmetric encode/decode inversion would
+    // still round-trip, so the raw byte is the only witness — Clause 20.2.10).
+    assert!(
+        buf.iter().any(|&b| b == 0xA0),
+        "encoded ACK should contain the MSB-first acknowledged-transitions octet 0xA0"
+    );
     let decoded = GetEventInformationAck::decode(&buf).unwrap();
     assert_eq!(decoded.list_of_event_summaries.len(), 1);
     assert!(decoded.more_events);

--- a/crates/bacnet-types/src/bitstring.rs
+++ b/crates/bacnet-types/src/bitstring.rs
@@ -31,6 +31,31 @@ fn wire_bit(data: &[u8], n: usize) -> bool {
     data.get(n / 8).is_some_and(|b| b & mask != 0)
 }
 
+/// Pack a bit0-first value into its Clause 20.2.10 wire octet.
+///
+/// Every ≤8-bit BACnet bit string in this stack keeps its internal layout as
+/// `bit0 = first defined bit` (`TO_OFFNORMAL`, `monday`, `low-limit-enable`,
+/// …), while the wire wants the first defined bit in the most significant bit
+/// of the octet. Reversing the byte is that whole conversion: bit 0 lands at
+/// `0x80`, bit 1 at `0x40`, and the result is left-aligned for any width.
+pub fn pack_octet(bits_lsb0: u8) -> u8 {
+    bits_lsb0.reverse_bits()
+}
+
+/// Inverse of [`pack_octet`]: read the first octet of a bit-string payload
+/// back into bit0-first form, masked to the string's `defined_bits`.
+///
+/// Masking (rather than trusting the peer's declared unused-bit count) keeps
+/// nonconformant padding out of the value; an empty payload reads as zero.
+pub fn unpack_octet(data: &[u8], defined_bits: u32) -> u8 {
+    let mask = if defined_bits >= 8 {
+        u8::MAX
+    } else {
+        (1u8 << defined_bits) - 1
+    };
+    data.first().copied().unwrap_or(0).reverse_bits() & mask
+}
+
 /// Decode a `BACnetStatusFlags` bit-string payload (MSB-first) into
 /// [`StatusFlags`], which keeps its right-aligned in-memory layout.
 ///
@@ -117,6 +142,12 @@ impl EventTransitionBits {
         bits.set(Self::TO_NORMAL, wire_bit(data, 2));
         bits
     }
+
+    /// Encode to the single Clause 20.2.10 wire octet (`unused_bits: 5`):
+    /// `TO_OFFNORMAL` at `0x80`, `TO_FAULT` at `0x40`, `TO_NORMAL` at `0x20`.
+    pub fn to_bacnet(self) -> u8 {
+        pack_octet(self.bits())
+    }
 }
 
 impl_named_bit_display!(EventTransitionBits);
@@ -140,6 +171,12 @@ impl LimitEnable {
         bits.set(Self::LOW_LIMIT_ENABLE, wire_bit(data, 0));
         bits.set(Self::HIGH_LIMIT_ENABLE, wire_bit(data, 1));
         bits
+    }
+
+    /// Encode to the single Clause 20.2.10 wire octet (`unused_bits: 6`):
+    /// `LOW_LIMIT_ENABLE` at `0x80`, `HIGH_LIMIT_ENABLE` at `0x40`.
+    pub fn to_bacnet(self) -> u8 {
+        pack_octet(self.bits())
     }
 }
 
@@ -255,6 +292,29 @@ impl core::fmt::Debug for ObjectTypesSupported {
 mod tests {
     use super::*;
     use crate::primitives::StatusFlags;
+
+    #[test]
+    fn pack_unpack_octet_spec_vectors() {
+        // Clause 20.2.10: first defined bit -> MSB. Deliberately asymmetric
+        // values — round trips alone cannot catch a symmetric encode/decode
+        // inversion, only literal wire bytes can.
+        assert_eq!(pack_octet(0b001), 0x80); // TO_OFFNORMAL / monday
+        assert_eq!(pack_octet(0b100), 0x20); // TO_NORMAL
+        assert_eq!(pack_octet(0b0100_0000), 0x02); // sunday (7-bit valid_days)
+        assert_eq!(unpack_octet(&[0x80], 3), 0b001);
+        assert_eq!(unpack_octet(&[0x20], 3), 0b100);
+        assert_eq!(unpack_octet(&[0xFE], 7), 0x7F); // all seven days
+        assert_eq!(unpack_octet(&[], 3), 0);
+        // Nonconformant junk past the defined bits is masked off.
+        assert_eq!(unpack_octet(&[0xFF], 3), 0b111);
+        // The octet helpers and the typed codecs agree.
+        assert_eq!(
+            EventTransitionBits::from_bacnet(&[pack_octet(0b001)]),
+            EventTransitionBits::TO_OFFNORMAL
+        );
+        assert_eq!(EventTransitionBits::TO_OFFNORMAL.to_bacnet(), 0x80);
+        assert_eq!(LimitEnable::LOW_LIMIT_ENABLE.to_bacnet(), 0x80);
+    }
 
     #[test]
     fn event_transition_bits_msb_first() {


### PR DESCRIPTION
Closes #203.

Every ≤8-bit bit string crossing the wire now packs its first defined bit into bit 7 (0x80) of the octet, as Clause 20.2.10 requires. Previously `Event_Enable`/`Acked_Transitions` (property reads/writes and GetEventInformation ACKs) and `Recipient_List` `valid_days`/`transitions` were packed LSB-first within the octet: TO_OFFNORMAL and TO_NORMAL arrived swapped and the valid_days week was reversed for conformant peers. The mirror-image decode hid the defect from every internal round trip — which is also why the new tests pin literal asymmetric wire bytes (`TO_OFFNORMAL → 0x80`, Tue–Sat → `0x7C`) rather than round-tripping.

**Shape:** one shared conversion in `bacnet_types::bitstring::pack_octet`/`unpack_octet` (byte reversal — self-inverse, left-aligns any width; decode masks to the defined bits per "Undefined bits shall be zero"), plus typed `to_bacnet()` on `EventTransitionBits`/`LimitEnable`. 16 encode + 11 decode sites flipped atomically across bacnet-objects, bacnet-server and bacnet-services.

**Verified already-correct and unchanged:** `Status_Flags`, `objects::event::LimitEnable` (issue #203's "unshifted" claim was stale), `Ack_Required`, `Protocol_Object_Types_Supported`, `Protocol_Services_Supported`, raw logged-bitstring pass-throughs.

**Breaking (wire format):** peers that interoperated with the old bytes — including older releases of this stack — see transition/day masks bit-reversed until upgraded. CHANGELOG entry included. #244's client-side decoders and this encode fix are now consistent, closing the same-stack misread window flagged in that review.

**Gates:** Codex spec lane CONCUR on all five questions with clause quotes (20.2.10, Clause 21 productions), including its own independent leftover sweep. The Claude adversarial workflow was blocked three times by API 529s, so its three lanes (completeness re-sweep, correctness/double-conversion trace, test adequacy) were executed inline by the orchestrator — finding one real gap, `valid_days` having only palindromic (0xFE) coverage, closed here with encode- and decode-side asymmetric tests. Local: 34 test suites green with ipv6+sc-tls, fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)