### PR TITLE
fix(objects,server): derive Protocol_Services_Supported from the dispatch table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The Device object's `Protocol_Services_Supported` is now derived from the
+  set of services the server dispatch actually executes, instead of a stale
+  hardcoded constant whose comment mislabeled three bits. The property gains
+  twenty executed-but-undeclared services (Who-Is and Who-Has among them),
+  drops four initiate-only bits (i-am, i-have,
+  confirmed/unconfirmed-event-notification — Clause 12.11 ties the property
+  to *executed* services), and is now sized for the full Clause 21 production
+  through you-Are (bit 48), so subscribe-cov-property-multiple (bit 41) is
+  representable. The PICS executor column derives from the same constant
+  (`bacnet_objects::device::EXECUTED_SERVICES`), a cross-check test ties both
+  to the dispatch table, and service choice → services-supported bit mapping
+  is now explicit via `ServiceSupported::from_confirmed_choice`/
+  `from_unconfirmed_choice`. Deployments embedding a different dispatch
+  surface can override via `DeviceObject::set_services_supported`. (#192)
+
 - **Breaking (wire format):** all ≤8-bit BACnet bit strings are now encoded
   MSB-first per Clause 20.2.10 — the first defined bit occupies bit 7 (`0x80`)
   of the octet. Previously `Event_Enable`/`Acked_Transitions` (here and in

--- a/README.md
+++ b/README.md
@@ -290,14 +290,14 @@ docs/                 API documentation and design plans
 | DeleteObject | ✓ | ✓ |
 | DeviceCommunicationControl | ✓ | ✓ |
 | ReinitializeDevice | ✓ | ✓ |
-| AcknowledgeAlarm | ✓ | — |
+| AcknowledgeAlarm | ✓ | ✓ |
 | GetAlarmSummary | ✓ | ✓ |
 | GetEnrollmentSummary | ✓ | ✓ |
 | GetEventInformation | ✓ | ✓ |
 | LifeSafetyOperation | ✓ | ✓ |
-| ReadRange | ✓ | — |
+| ReadRange | ✓ | ✓ |
 | AtomicReadFile / AtomicWriteFile | ✓ | ✓ |
-| AddListElement / RemoveListElement | ✓ | — |
+| AddListElement / RemoveListElement | ✓ | ✓ |
 | ConfirmedPrivateTransfer / UnconfirmedPrivateTransfer | ✓ | — |
 | ConfirmedTextMessage / UnconfirmedTextMessage | ✓ | ✓ |
 | WriteGroup | ✓ | ✓ |

--- a/crates/bacnet-objects/src/device/mod.rs
+++ b/crates/bacnet-objects/src/device/mod.rs
@@ -8,12 +8,74 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 
 use bacnet_types::constructed::BACnetCOVSubscription;
-use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier, Segmentation};
+use bacnet_types::enums::{
+    ErrorClass, ErrorCode, ObjectType, PropertyIdentifier, Segmentation, ServiceSupported,
+};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{Date, ObjectIdentifier, PropertyValue, Time};
 
 use crate::common::read_property_list_property;
 use crate::traits::BACnetObject;
+
+/// Every service the bundled `bacnet-server` dispatch executes, as
+/// `BACnetServicesSupported` bit positions (Clause 21).
+///
+/// Default source for `Protocol_Services_Supported`, which Clause 12.11 ties
+/// to services *executed* — the server's initiate-only services (I-Am,
+/// I-Have, COV/event notifications) are deliberately absent. Kept in lockstep
+/// with the dispatch arms by `bacnet-server`'s executed-services cross-check
+/// test; deployments with a different dispatch surface override via
+/// [`DeviceObject::set_services_supported`].
+pub const EXECUTED_SERVICES: &[ServiceSupported] = &[
+    ServiceSupported::ACKNOWLEDGE_ALARM,
+    ServiceSupported::GET_ALARM_SUMMARY,
+    ServiceSupported::GET_ENROLLMENT_SUMMARY,
+    ServiceSupported::SUBSCRIBE_COV,
+    ServiceSupported::ATOMIC_READ_FILE,
+    ServiceSupported::ATOMIC_WRITE_FILE,
+    ServiceSupported::ADD_LIST_ELEMENT,
+    ServiceSupported::REMOVE_LIST_ELEMENT,
+    ServiceSupported::CREATE_OBJECT,
+    ServiceSupported::DELETE_OBJECT,
+    ServiceSupported::READ_PROPERTY,
+    ServiceSupported::READ_PROPERTY_MULTIPLE,
+    ServiceSupported::WRITE_PROPERTY,
+    ServiceSupported::WRITE_PROPERTY_MULTIPLE,
+    ServiceSupported::DEVICE_COMMUNICATION_CONTROL,
+    ServiceSupported::CONFIRMED_TEXT_MESSAGE,
+    ServiceSupported::REINITIALIZE_DEVICE,
+    ServiceSupported::UNCONFIRMED_TEXT_MESSAGE,
+    ServiceSupported::TIME_SYNCHRONIZATION,
+    ServiceSupported::WHO_HAS,
+    ServiceSupported::WHO_IS,
+    ServiceSupported::READ_RANGE,
+    ServiceSupported::UTC_TIME_SYNCHRONIZATION,
+    // Dispatched but decode-only pending #177 (LifeSafetyOperation applies
+    // no life-safety semantics yet).
+    ServiceSupported::LIFE_SAFETY_OPERATION,
+    ServiceSupported::SUBSCRIBE_COV_PROPERTY,
+    ServiceSupported::GET_EVENT_INFORMATION,
+    ServiceSupported::WRITE_GROUP,
+    ServiceSupported::SUBSCRIBE_COV_PROPERTY_MULTIPLE,
+];
+
+/// Number of bits in the `BACnetServicesSupported` production: bits 0..=48
+/// (you-Are is the highest defined bit, Clause 21).
+const SERVICES_SUPPORTED_BITS: usize = 49;
+
+/// Build the `Protocol_Services_Supported` bit string from a service set,
+/// sized for the full production (7 octets, 7 unused bits) and packed
+/// MSB-first per Clause 20.2.10: bit N at byte N/8, position 7-(N%8).
+fn compute_services_supported(services: &[ServiceSupported]) -> Vec<u8> {
+    let mut bits = vec![0u8; SERVICES_SUPPORTED_BITS.div_ceil(8)];
+    for service in services {
+        let n = service.to_raw() as usize;
+        if n < SERVICES_SUPPORTED_BITS {
+            bits[n / 8] |= 0x80 >> (n % 8);
+        }
+    }
+    bits
+}
 
 /// Build a BACnet bitstring representing supported object types.
 /// Each type N sets bit at byte N/8, position 7-(N%8) (MSB-first within each byte).
@@ -288,20 +350,7 @@ impl DeviceObject {
             ObjectType::COLOR_TEMPERATURE.to_raw(),
         ]);
 
-        // Protocol_Services_Supported: 6 bytes (48 bits).  Bits set for
-        // services we handle:
-        //   0=AcknowledgeAlarm, 2=ConfirmedEventNotification,
-        //   5=SubscribeCOV, 12=ReadProperty, 14=ReadPropertyMultiple,
-        //   15=WriteProperty, 16=WritePropertyMultiple,
-        //   26=IAm, 27=IHave, 29=UnconfirmedCOVNotification,
-        //   31=WhoHas, 32=WhoIs
-        //   Byte 0: bits 0,2,5 → 0xA4
-        //   Byte 1: bits 12,14,15 → 0x0B
-        //   Byte 2: bit 16 → 0x80
-        //   Byte 3: bits 26,27,29,31 → 0x35
-        //   Byte 4: bit 32 → 0x80
-        //   Byte 5: 0x00
-        let protocol_services_supported = vec![0xA4, 0x0B, 0x80, 0x35, 0x80, 0x00];
+        let protocol_services_supported = compute_services_supported(EXECUTED_SERVICES);
 
         Ok(Self {
             oid,
@@ -316,6 +365,16 @@ impl DeviceObject {
     /// Update the object-list with the current database contents.
     pub fn set_object_list(&mut self, oids: Vec<ObjectIdentifier>) {
         self.object_list = oids;
+    }
+
+    /// Replace the advertised executed-service set (`Protocol_Services_Supported`,
+    /// Clause 12.11). For deployments whose dispatch surface differs from the
+    /// bundled server's [`EXECUTED_SERVICES`].
+    ///
+    /// The production is closed at you-Are (bit 48); values past it are not
+    /// representable and are dropped.
+    pub fn set_services_supported(&mut self, services: &[ServiceSupported]) {
+        self.protocol_services_supported = compute_services_supported(services);
     }
 
     /// Get the device instance number.
@@ -412,9 +471,10 @@ impl BACnetObject for DeviceObject {
         }
 
         if property == PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED {
-            // 6 bytes = 48 bits; 41 defined (services 0-40), 7 unused bits
+            let unused =
+                (self.protocol_services_supported.len() * 8 - SERVICES_SUPPORTED_BITS) as u8;
             return Ok(PropertyValue::BitString {
-                unused_bits: 7,
+                unused_bits: unused,
                 data: self.protocol_services_supported.clone(),
             });
         }

--- a/crates/bacnet-objects/src/device/tests.rs
+++ b/crates/bacnet-objects/src/device/tests.rs
@@ -232,23 +232,61 @@ fn read_protocol_object_types_supported() {
 
 #[test]
 fn read_protocol_services_supported() {
+    use bacnet_types::bitstring::ServicesSupported;
+    use bacnet_types::enums::ServiceSupported;
+
     let dev = make_device();
     let val = dev
         .read_property(PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED, None)
         .unwrap();
     match val {
         PropertyValue::BitString { unused_bits, data } => {
+            // Full Clause 21 production: bits 0..=48 → 7 octets, 7 unused.
             assert_eq!(unused_bits, 7);
-            assert_eq!(data.len(), 6);
-            // Byte 0: services 0,2,5
-            assert_eq!(data[0], 0xA4);
-            // Byte 1: services 12,14,15
-            assert_eq!(data[1], 0x0B);
-            // Byte 4: service 32 (WhoIs)
-            assert_eq!(data[4], 0x80);
+            assert_eq!(data.len(), 7);
+
+            let ss = ServicesSupported::from_bacnet(&data);
+            for service in EXECUTED_SERVICES {
+                assert!(ss.contains(*service), "missing {service}");
+            }
+            assert_eq!(
+                ss.iter().count(),
+                EXECUTED_SERVICES.len(),
+                "no bits beyond EXECUTED_SERVICES may be set"
+            );
+
+            // Semantic pins from #192: divergent-numbering services land on
+            // their bit-35+ positions (impossible in the old 41-bit string)…
+            assert!(ss.contains(ServiceSupported::WHO_IS));
+            assert!(ss.contains(ServiceSupported::READ_RANGE));
+            assert!(ss.contains(ServiceSupported::SUBSCRIBE_COV_PROPERTY_MULTIPLE));
+            // …and initiate-only services are not declared as executed.
+            assert!(!ss.contains(ServiceSupported::I_AM));
+            assert!(!ss.contains(ServiceSupported::I_HAVE));
+            assert!(!ss.contains(ServiceSupported::CONFIRMED_EVENT_NOTIFICATION));
+            assert!(!ss.contains(ServiceSupported::UNCONFIRMED_COV_NOTIFICATION));
         }
         _ => panic!("Expected BitString"),
     }
+}
+
+#[test]
+fn set_services_supported_overrides_default() {
+    use bacnet_types::bitstring::ServicesSupported;
+    use bacnet_types::enums::ServiceSupported;
+
+    let mut dev = make_device();
+    dev.set_services_supported(&[ServiceSupported::READ_PROPERTY]);
+    let val = dev
+        .read_property(PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED, None)
+        .unwrap();
+    let PropertyValue::BitString { unused_bits, data } = val else {
+        panic!("Expected BitString");
+    };
+    assert_eq!((unused_bits, data.len()), (7, 7));
+    let ss = ServicesSupported::from_bacnet(&data);
+    assert!(ss.contains(ServiceSupported::READ_PROPERTY));
+    assert_eq!(ss.iter().count(), 1);
 }
 
 #[test]

--- a/crates/bacnet-server/src/handlers/tests/read_rpm.rs
+++ b/crates/bacnet-server/src/handlers/tests/read_rpm.rs
@@ -340,3 +340,44 @@ fn rpm_handler_required_vs_optional() {
         );
     }
 }
+
+#[test]
+fn read_property_serves_derived_services_supported() {
+    // End-to-end pin for #192: the wire-level BitString a client receives for
+    // Protocol_Services_Supported, through the real ReadProperty handler path.
+    // Expected bytes derive from device::EXECUTED_SERVICES bits
+    // {0,3-12,14-17,19,20,31-41} packed MSB-first over the full production
+    // (49 defined bits, 7 octets, 7 unused).
+    let db = make_db_with_device_and_ai();
+    let oid = ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap();
+
+    let request = ReadPropertyRequest {
+        object_identifier: oid,
+        property_identifier: PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED,
+        property_array_index: None,
+    };
+    let mut buf = BytesMut::new();
+    request.encode(&mut buf);
+
+    let mut ack_buf = BytesMut::new();
+    handle_read_property(&db, &buf, &mut ack_buf).unwrap();
+    let ack = ReadPropertyACK::decode(&ack_buf.to_vec()).unwrap();
+
+    let (val, _) =
+        bacnet_encoding::primitives::decode_application_value(&ack.property_value, 0).unwrap();
+    assert_eq!(
+        val,
+        bacnet_types::primitives::PropertyValue::BitString {
+            unused_bits: 7,
+            data: vec![0x9F, 0xFB, 0xD8, 0x01, 0xFF, 0xC0, 0x00],
+        }
+    );
+
+    // The same bytes decode to the executed set by name.
+    let bacnet_types::primitives::PropertyValue::BitString { data, .. } = val else {
+        unreachable!()
+    };
+    let ss = bacnet_types::bitstring::ServicesSupported::from_bacnet(&data);
+    assert!(ss.contains(bacnet_types::enums::ServiceSupported::WHO_IS));
+    assert!(!ss.contains(bacnet_types::enums::ServiceSupported::I_AM));
+}

--- a/crates/bacnet-server/src/pics/mod.rs
+++ b/crates/bacnet-server/src/pics/mod.rs
@@ -7,7 +7,8 @@ use std::collections::BTreeMap;
 use std::fmt;
 
 use bacnet_objects::database::ObjectDatabase;
-use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_objects::device::EXECUTED_SERVICES;
+use bacnet_types::enums::{ObjectType, PropertyIdentifier, ServiceSupported};
 
 use crate::server::ServerConfig;
 
@@ -307,68 +308,47 @@ impl<'a> PicsGenerator<'a> {
     }
 
     /// Build the service support list based on what the server actually handles.
+    /// Services this server initiates (the PICS initiator column): replies
+    /// and notifications constructed outbound by `bacnet-server`. Distinct
+    /// from [`EXECUTED_SERVICES`], which Clause 12.11 ties to execution.
+    const INITIATED_SERVICES: &'static [ServiceSupported] = &[
+        ServiceSupported::I_AM,
+        ServiceSupported::I_HAVE,
+        ServiceSupported::CONFIRMED_COV_NOTIFICATION,
+        ServiceSupported::CONFIRMED_EVENT_NOTIFICATION,
+        ServiceSupported::UNCONFIRMED_COV_NOTIFICATION,
+        ServiceSupported::UNCONFIRMED_EVENT_NOTIFICATION,
+        ServiceSupported::CONFIRMED_COV_NOTIFICATION_MULTIPLE,
+        ServiceSupported::UNCONFIRMED_COV_NOTIFICATION_MULTIPLE,
+    ];
+
     fn build_services(&self) -> Vec<ServiceSupport> {
-        let mut services = Vec::new();
-
-        let executor_services = [
-            "ReadProperty",
-            "WriteProperty",
-            "ReadPropertyMultiple",
-            "WritePropertyMultiple",
-            "SubscribeCOV",
-            "SubscribeCOVProperty",
-            "CreateObject",
-            "DeleteObject",
-            "DeviceCommunicationControl",
-            "ReinitializeDevice",
-            "GetEventInformation",
-            "AcknowledgeAlarm",
-            "ReadRange",
-            "AtomicReadFile",
-            "AtomicWriteFile",
-            "AddListElement",
-            "RemoveListElement",
-        ];
-
-        let initiator_services = ["ConfirmedCOVNotification", "ConfirmedEventNotification"];
-
-        let unconfirmed_executor = [
-            "WhoIs",
-            "WhoHas",
-            "TimeSynchronization",
-            "UTCTimeSynchronization",
-        ];
-
-        let unconfirmed_initiator = [
-            "I-Am",
-            "I-Have",
-            "UnconfirmedCOVNotification",
-            "UnconfirmedEventNotification",
-        ];
-
-        let mut service_map: BTreeMap<&str, (bool, bool)> = BTreeMap::new();
-        for name in &executor_services {
-            service_map.entry(name).or_default().1 = true;
+        // Executor column comes from the same constant the Device object's
+        // Protocol_Services_Supported is built from, so the PICS cannot drift
+        // from the property (both are cross-checked against the dispatch
+        // table by `executed_services_match_dispatch_table`).
+        let mut service_map: BTreeMap<&'static str, (bool, bool)> = BTreeMap::new();
+        for service in EXECUTED_SERVICES {
+            service_map
+                .entry(service_display_name(*service))
+                .or_default()
+                .1 = true;
         }
-        for name in &initiator_services {
-            service_map.entry(name).or_default().0 = true;
-        }
-        for name in &unconfirmed_executor {
-            service_map.entry(name).or_default().1 = true;
-        }
-        for name in &unconfirmed_initiator {
-            service_map.entry(name).or_default().0 = true;
+        for service in Self::INITIATED_SERVICES {
+            service_map
+                .entry(service_display_name(*service))
+                .or_default()
+                .0 = true;
         }
 
-        for (name, (initiator, executor)) in &service_map {
-            services.push(ServiceSupport {
-                service_name: (*name).to_string(),
-                initiator: *initiator,
-                executor: *executor,
-            });
-        }
-
-        services
+        service_map
+            .into_iter()
+            .map(|(name, (initiator, executor))| ServiceSupport {
+                service_name: name.to_string(),
+                initiator,
+                executor,
+            })
+            .collect()
     }
 }
 
@@ -593,6 +573,59 @@ pub fn generate_pics(
 }
 
 // ─────────────────────────────── Tests ─────────────────────────────────────
+
+/// PICS display name for a `BACnetServicesSupported` bit position.
+fn service_display_name(service: ServiceSupported) -> &'static str {
+    match service.to_raw() {
+        0 => "AcknowledgeAlarm",
+        1 => "ConfirmedCOVNotification",
+        2 => "ConfirmedEventNotification",
+        3 => "GetAlarmSummary",
+        4 => "GetEnrollmentSummary",
+        5 => "SubscribeCOV",
+        6 => "AtomicReadFile",
+        7 => "AtomicWriteFile",
+        8 => "AddListElement",
+        9 => "RemoveListElement",
+        10 => "CreateObject",
+        11 => "DeleteObject",
+        12 => "ReadProperty",
+        14 => "ReadPropertyMultiple",
+        15 => "WriteProperty",
+        16 => "WritePropertyMultiple",
+        17 => "DeviceCommunicationControl",
+        18 => "ConfirmedPrivateTransfer",
+        19 => "ConfirmedTextMessage",
+        20 => "ReinitializeDevice",
+        21 => "VT-Open",
+        22 => "VT-Close",
+        23 => "VT-Data",
+        26 => "I-Am",
+        27 => "I-Have",
+        28 => "UnconfirmedCOVNotification",
+        29 => "UnconfirmedEventNotification",
+        30 => "UnconfirmedPrivateTransfer",
+        31 => "UnconfirmedTextMessage",
+        32 => "TimeSynchronization",
+        33 => "WhoHas",
+        34 => "WhoIs",
+        35 => "ReadRange",
+        36 => "UTCTimeSynchronization",
+        37 => "LifeSafetyOperation",
+        38 => "SubscribeCOVProperty",
+        39 => "GetEventInformation",
+        40 => "WriteGroup",
+        41 => "SubscribeCOVPropertyMultiple",
+        42 => "ConfirmedCOVNotificationMultiple",
+        43 => "UnconfirmedCOVNotificationMultiple",
+        44 => "ConfirmedAuditNotification",
+        45 => "AuditLogQuery",
+        46 => "UnconfirmedAuditNotification",
+        47 => "Who-Am-I",
+        48 => "You-Are",
+        _ => "Unknown",
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-server/src/pics/tests.rs
+++ b/crates/bacnet-server/src/pics/tests.rs
@@ -729,3 +729,40 @@ fn pics_writability_matches_runtime_write_property() {
         "write_property must reject STATUS_FLAGS, got: {result:?}"
     );
 }
+
+#[test]
+fn executed_services_match_dispatch_table() {
+    // The three-way truth chain for #192: dispatch arms (requests/mod.rs +
+    // unconfirmed.rs choice consts) -> BACnetServicesSupported bits ->
+    // device::EXECUTED_SERVICES, which feeds both the Device object's
+    // Protocol_Services_Supported and the PICS executor column. If a dispatch
+    // arm is added or removed without updating the choice const or the device
+    // constant, this test fails.
+    use bacnet_types::enums::ServiceSupported;
+
+    let mut from_dispatch: Vec<u8> = crate::server::EXECUTED_CONFIRMED
+        .iter()
+        .map(|c| {
+            ServiceSupported::from_confirmed_choice(*c)
+                .expect("dispatched confirmed choice has a defined bit")
+                .to_raw()
+        })
+        .chain(crate::server::EXECUTED_UNCONFIRMED.iter().map(|c| {
+            ServiceSupported::from_unconfirmed_choice(*c)
+                .expect("dispatched unconfirmed choice has a defined bit")
+                .to_raw()
+        }))
+        .collect();
+    from_dispatch.sort_unstable();
+
+    let mut declared: Vec<u8> = bacnet_objects::device::EXECUTED_SERVICES
+        .iter()
+        .map(|s| s.to_raw())
+        .collect();
+    declared.sort_unstable();
+
+    assert_eq!(
+        declared, from_dispatch,
+        "device::EXECUTED_SERVICES must equal the dispatch table's executed set"
+    );
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -770,6 +770,7 @@ mod dispatch;
 mod event_notifications;
 mod lifecycle;
 mod requests;
+pub(crate) use requests::{EXECUTED_CONFIRMED, EXECUTED_UNCONFIRMED};
 mod responses;
 mod segmentation;
 

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -1,6 +1,40 @@
 use super::*;
 
 mod unconfirmed;
+pub(crate) use unconfirmed::EXECUTED_UNCONFIRMED;
+
+/// Every confirmed service choice with an inbound execution arm in
+/// `handle_confirmed_request` below. Keep in lockstep with the `match` —
+/// the `executed_services_match_dispatch_table` test compares this list
+/// (mapped through [`ServiceSupported::from_confirmed_choice`]) against
+/// [`bacnet_objects::device::EXECUTED_SERVICES`], which is what the Device
+/// object advertises in `Protocol_Services_Supported`.
+///
+/// [`ServiceSupported::from_confirmed_choice`]: bacnet_types::enums::ServiceSupported::from_confirmed_choice
+pub(crate) const EXECUTED_CONFIRMED: &[ConfirmedServiceChoice] = &[
+    ConfirmedServiceChoice::ACKNOWLEDGE_ALARM,
+    ConfirmedServiceChoice::GET_ALARM_SUMMARY,
+    ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY,
+    ConfirmedServiceChoice::SUBSCRIBE_COV,
+    ConfirmedServiceChoice::ATOMIC_READ_FILE,
+    ConfirmedServiceChoice::ATOMIC_WRITE_FILE,
+    ConfirmedServiceChoice::ADD_LIST_ELEMENT,
+    ConfirmedServiceChoice::REMOVE_LIST_ELEMENT,
+    ConfirmedServiceChoice::CREATE_OBJECT,
+    ConfirmedServiceChoice::DELETE_OBJECT,
+    ConfirmedServiceChoice::READ_PROPERTY,
+    ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+    ConfirmedServiceChoice::WRITE_PROPERTY,
+    ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE,
+    ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+    ConfirmedServiceChoice::CONFIRMED_TEXT_MESSAGE,
+    ConfirmedServiceChoice::REINITIALIZE_DEVICE,
+    ConfirmedServiceChoice::READ_RANGE,
+    ConfirmedServiceChoice::LIFE_SAFETY_OPERATION,
+    ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY,
+    ConfirmedServiceChoice::GET_EVENT_INFORMATION,
+    ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY_MULTIPLE,
+];
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Handle a confirmed request.

--- a/crates/bacnet-server/src/server/requests/unconfirmed.rs
+++ b/crates/bacnet-server/src/server/requests/unconfirmed.rs
@@ -1,8 +1,22 @@
-//! Unconfirmed-service dispatch (Who-Is, I-Am, time sync, unconfirmed COV).
+//! Unconfirmed-service dispatch (Who-Is, Who-Has, time sync, WriteGroup,
+//! UnconfirmedTextMessage) — see [`EXECUTED_UNCONFIRMED`].
 //!
 //! Split out of `requests.rs` to keep every file under the 700-LOC cap.
 
 use super::super::*;
+
+/// Every unconfirmed service choice with an inbound execution arm in
+/// `handle_unconfirmed_request` below. Keep in lockstep with the dispatch
+/// chain — see `EXECUTED_CONFIRMED` in `requests/mod.rs` for the cross-check
+/// contract.
+pub(crate) const EXECUTED_UNCONFIRMED: &[UnconfirmedServiceChoice] = &[
+    UnconfirmedServiceChoice::WHO_IS,
+    UnconfirmedServiceChoice::WHO_HAS,
+    UnconfirmedServiceChoice::TIME_SYNCHRONIZATION,
+    UnconfirmedServiceChoice::UTC_TIME_SYNCHRONIZATION,
+    UnconfirmedServiceChoice::WRITE_GROUP,
+    UnconfirmedServiceChoice::UNCONFIRMED_TEXT_MESSAGE,
+];
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Handle an unconfirmed request (e.g., WhoIs).

--- a/crates/bacnet-types/src/bitstring.rs
+++ b/crates/bacnet-types/src/bitstring.rs
@@ -386,7 +386,8 @@ mod tests {
 
     #[test]
     fn services_supported_follows_clause_21() {
-        // Device object's basic set: byte0=0xA4, byte1=0x0B, byte4=0x80.
+        // Arbitrary decode vector (historically the device's pre-#192
+        // hardcoded constant — NOT the property the Device object serves).
         let ss = ServicesSupported::from_bacnet(&[0xA4, 0x0B, 0x80, 0x35, 0x80, 0x00]);
         assert!(ss.contains(ServiceSupported::ACKNOWLEDGE_ALARM)); // bit 0
         assert!(ss.contains(ServiceSupported::SUBSCRIBE_COV)); // bit 5

--- a/crates/bacnet-types/src/enums/misc.rs
+++ b/crates/bacnet-types/src/enums/misc.rs
@@ -2,6 +2,8 @@
 // Miscellaneous enums
 // ===========================================================================
 
+use super::{ConfirmedServiceChoice, UnconfirmedServiceChoice};
+
 bacnet_enum! {
     /// BACnet load control shed state (Clause 12.28).
     pub struct ShedState(u32);
@@ -112,6 +114,77 @@ bacnet_enum! {
     const YOU_ARE = 48;
 }
 
+impl ServiceSupported {
+    /// The `BACnetServicesSupported` bit for a confirmed service choice.
+    ///
+    /// The choice and bit numberings diverge for every service added after
+    /// the original standard (read-range is choice 26 but bit 35,
+    /// get-event-information choice 29 but bit 39, …) — always map through
+    /// here, never by reusing the choice number as a bit. `None` for choices
+    /// with no defined bit (reserved/unassigned values).
+    pub fn from_confirmed_choice(choice: ConfirmedServiceChoice) -> Option<Self> {
+        Some(match choice.to_raw() {
+            0 => Self::ACKNOWLEDGE_ALARM,
+            1 => Self::CONFIRMED_COV_NOTIFICATION,
+            2 => Self::CONFIRMED_EVENT_NOTIFICATION,
+            3 => Self::GET_ALARM_SUMMARY,
+            4 => Self::GET_ENROLLMENT_SUMMARY,
+            5 => Self::SUBSCRIBE_COV,
+            6 => Self::ATOMIC_READ_FILE,
+            7 => Self::ATOMIC_WRITE_FILE,
+            8 => Self::ADD_LIST_ELEMENT,
+            9 => Self::REMOVE_LIST_ELEMENT,
+            10 => Self::CREATE_OBJECT,
+            11 => Self::DELETE_OBJECT,
+            12 => Self::READ_PROPERTY,
+            14 => Self::READ_PROPERTY_MULTIPLE,
+            15 => Self::WRITE_PROPERTY,
+            16 => Self::WRITE_PROPERTY_MULTIPLE,
+            17 => Self::DEVICE_COMMUNICATION_CONTROL,
+            18 => Self::CONFIRMED_PRIVATE_TRANSFER,
+            19 => Self::CONFIRMED_TEXT_MESSAGE,
+            20 => Self::REINITIALIZE_DEVICE,
+            21 => Self::VT_OPEN,
+            22 => Self::VT_CLOSE,
+            23 => Self::VT_DATA,
+            26 => Self::READ_RANGE,
+            27 => Self::LIFE_SAFETY_OPERATION,
+            28 => Self::SUBSCRIBE_COV_PROPERTY,
+            29 => Self::GET_EVENT_INFORMATION,
+            30 => Self::SUBSCRIBE_COV_PROPERTY_MULTIPLE,
+            31 => Self::CONFIRMED_COV_NOTIFICATION_MULTIPLE,
+            32 => Self::CONFIRMED_AUDIT_NOTIFICATION,
+            33 => Self::AUDIT_LOG_QUERY,
+            _ => return None,
+        })
+    }
+
+    /// The `BACnetServicesSupported` bit for an unconfirmed service choice.
+    ///
+    /// Every unconfirmed choice diverges from its bit (who-is is choice 8 but
+    /// bit 34). `None` for choices with no defined bit.
+    pub fn from_unconfirmed_choice(choice: UnconfirmedServiceChoice) -> Option<Self> {
+        Some(match choice.to_raw() {
+            0 => Self::I_AM,
+            1 => Self::I_HAVE,
+            2 => Self::UNCONFIRMED_COV_NOTIFICATION,
+            3 => Self::UNCONFIRMED_EVENT_NOTIFICATION,
+            4 => Self::UNCONFIRMED_PRIVATE_TRANSFER,
+            5 => Self::UNCONFIRMED_TEXT_MESSAGE,
+            6 => Self::TIME_SYNCHRONIZATION,
+            7 => Self::WHO_HAS,
+            8 => Self::WHO_IS,
+            9 => Self::UTC_TIME_SYNCHRONIZATION,
+            10 => Self::WRITE_GROUP,
+            11 => Self::UNCONFIRMED_COV_NOTIFICATION_MULTIPLE,
+            12 => Self::UNCONFIRMED_AUDIT_NOTIFICATION,
+            13 => Self::WHO_AM_I,
+            14 => Self::YOU_ARE,
+            _ => return None,
+        })
+    }
+}
+
 bacnet_enum! {
     /// BACnet message priority for TextMessage services (Clause 16.5).
     pub struct MessagePriority(u32);
@@ -131,4 +204,77 @@ bacnet_enum! {
     const DEC_VT220 = 4;
     const HP_700_94 = 5;
     const IBM_3130 = 6;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_choice_to_bit_divergent_pairs() {
+        // The pairs where choice != bit — the exact confusions that produced
+        // the old hardcoded Protocol_Services_Supported constant (#192).
+        let confirmed = [
+            (26, ServiceSupported::READ_RANGE, 35),
+            (27, ServiceSupported::LIFE_SAFETY_OPERATION, 37),
+            (28, ServiceSupported::SUBSCRIBE_COV_PROPERTY, 38),
+            (29, ServiceSupported::GET_EVENT_INFORMATION, 39),
+            (30, ServiceSupported::SUBSCRIBE_COV_PROPERTY_MULTIPLE, 41),
+            (
+                31,
+                ServiceSupported::CONFIRMED_COV_NOTIFICATION_MULTIPLE,
+                42,
+            ),
+            (32, ServiceSupported::CONFIRMED_AUDIT_NOTIFICATION, 44),
+            (33, ServiceSupported::AUDIT_LOG_QUERY, 45),
+        ];
+        for (choice, expected, bit) in confirmed {
+            let got =
+                ServiceSupported::from_confirmed_choice(ConfirmedServiceChoice::from_raw(choice))
+                    .unwrap();
+            assert_eq!(got, expected);
+            assert_eq!(got.to_raw(), bit);
+        }
+
+        let unconfirmed = [
+            (0, ServiceSupported::I_AM, 26),
+            (5, ServiceSupported::UNCONFIRMED_TEXT_MESSAGE, 31),
+            (6, ServiceSupported::TIME_SYNCHRONIZATION, 32),
+            (7, ServiceSupported::WHO_HAS, 33),
+            (8, ServiceSupported::WHO_IS, 34),
+            (9, ServiceSupported::UTC_TIME_SYNCHRONIZATION, 36),
+            (10, ServiceSupported::WRITE_GROUP, 40),
+            (14, ServiceSupported::YOU_ARE, 48),
+        ];
+        for (choice, expected, bit) in unconfirmed {
+            let got = ServiceSupported::from_unconfirmed_choice(
+                UnconfirmedServiceChoice::from_raw(choice),
+            )
+            .unwrap();
+            assert_eq!(got, expected);
+            assert_eq!(got.to_raw(), bit);
+        }
+    }
+
+    #[test]
+    fn service_choice_identity_range_and_reserved() {
+        // Choices 0..=23 (minus reserved 13) map bit == choice.
+        for c in (0..=23u8).filter(|c| *c != 13) {
+            let bit = ServiceSupported::from_confirmed_choice(ConfirmedServiceChoice::from_raw(c))
+                .unwrap()
+                .to_raw();
+            assert_eq!(bit, c, "choice {c} should be the identity mapping");
+        }
+        // Reserved/unassigned choices have no bit.
+        assert!(
+            ServiceSupported::from_confirmed_choice(ConfirmedServiceChoice::from_raw(13)).is_none()
+        );
+        assert!(
+            ServiceSupported::from_confirmed_choice(ConfirmedServiceChoice::from_raw(34)).is_none()
+        );
+        assert!(
+            ServiceSupported::from_unconfirmed_choice(UnconfirmedServiceChoice::from_raw(15))
+                .is_none()
+        );
+    }
 }


### PR DESCRIPTION
Closes #192.

The Device object advertised a hardcoded six-byte constant whose comment mislabeled three bits: twenty executed services were undeclared (Who-Is and Who-Has among them), four initiate-only bits were declared (Clause 12.11 ties the property to services *executed*), and the 41-bit string couldn't represent subscribe-cov-property-multiple (bit 41).

**One truth chain now feeds everything:** choice consts colocated with the dispatch arms → `ServiceSupported::from_confirmed_choice`/`from_unconfirmed_choice` (the choice and bit numberings diverge for every post-1995 service — the confusion that produced the old constant) → `bacnet_objects::device::EXECUTED_SERVICES` (28 services) → the property (full production through you-Are(48), 7 octets) and the PICS executor column. The cross-check test `executed_services_match_dispatch_table` fails if any link drifts. New end-to-end test pins the exact wire bytes `[0x9F,0xFB,0xD8,0x01,0xFF,0xC0,0x00]` through the real ReadProperty handler path. README Server rows corrected for AcknowledgeAlarm/ReadRange/AddListElement/RemoveListElement; `DeviceObject::set_services_supported` added for deployments with a different dispatch surface.

**Rulings:** decode-only handlers count as executed — text messages are conformant per Clause 16; LifeSafetyOperation is tracked by #177 and WriteGroup by the new #248 (which also notes CHANNEL is over-declared in Protocol_Object_Types_Supported with no Channel object implementation).

**Gates:** Codex spec lane CONCUR ×5 (every mapping arm vs Clause 21 with quotes, Clause 12.11 "executed" reading, independent dispatch walk finding the exact 22+6 arms). Claude adversarial workflow (2 lanes): truth chain confirmed by independent re-derivation; all findings addressed (stale bitstring.rs comment relabeled, unconfirmed.rs header fixed, setter truncation documented, end-to-end handler test added). Accepted residuals, by design: the const↔match-arm link is guarded by colocation + comment rather than machine check, and the 8-entry PICS INITIATED_SERVICES list is hand-maintained (all 8 verified against outbound construction sites). Local: 34 suites green incl. conformance-ledger tests, fmt/clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)