### PR TITLE
fix(types): add missing BackupAndRestoreState and Reliability values (#246, #241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Name the missing tail values of two enumerations, completing them against
+  their 135-2020 productions: `BackupAndRestoreState` gains `BACKUP_FAILURE`
+  (5) and `RESTORE_FAILURE` (6) — states a device legitimately reports during
+  Clause 19.1 backup/restore procedures — and `Reliability` gains
+  `MULTI_STATE_OUT_OF_RANGE` (25). Both are open enums, so the raw values
+  already round-tripped; what changes is that they now display by name
+  (previously a device reporting backup-failure showed as the bare number
+  `5`, including through `resolve_value` on Backup_And_Restore_State).
+  Purely additive, no wire-format change. (#246, #241)
 - `FaultDetector` gained a private field for warning suppression and is therefore
   no longer constructible with struct-literal syntax. `FaultDetector { comm_timeout }`
   becomes a compile error; use `FaultDetector::new(comm_timeout)`, which has been

--- a/crates/bacnet-types/src/enums/object_level.rs
+++ b/crates/bacnet-types/src/enums/object_level.rs
@@ -59,6 +59,7 @@ bacnet_enum! {
     const PROPRIETARY_COMMAND_FAILURE = 22;
     const FAULTS_LISTED = 23;
     const REFERENCED_OBJECT_FAULT = 24;
+    const MULTI_STATE_OUT_OF_RANGE = 25;
 }
 
 bacnet_enum! {
@@ -183,6 +184,8 @@ bacnet_enum! {
     const PREPARING_FOR_RESTORE = 2;
     const PERFORMING_A_BACKUP = 3;
     const PERFORMING_A_RESTORE = 4;
+    const BACKUP_FAILURE = 5;
+    const RESTORE_FAILURE = 6;
 }
 
 bacnet_enum! {

--- a/crates/bacnet-types/src/enums/object_level.rs
+++ b/crates/bacnet-types/src/enums/object_level.rs
@@ -45,7 +45,7 @@ bacnet_enum! {
     const PROCESS_ERROR = 8;
     const MULTI_STATE_FAULT = 9;
     const CONFIGURATION_ERROR = 10;
-    // 11: removed from standard
+    // 11: reserved for a future addendum (135-2020 BACnetReliability production)
     const COMMUNICATION_FAILURE = 12;
     const MEMBER_FAULT = 13;
     const MONITORED_OBJECT_FAULT = 14;

--- a/crates/bacnet-types/src/enums/resolve.rs
+++ b/crates/bacnet-types/src/enums/resolve.rs
@@ -537,6 +537,24 @@ mod tests {
     }
 
     #[test]
+    fn backup_and_restore_state_failure_states_resolve_by_name() {
+        // Backup_And_Restore_State (338) legitimately reports both failure
+        // states during Clause 19.1 procedures; they must not surface as
+        // bare numbers.
+        let r = ResolvedEnum::from_property(PropertyIdentifier::BACKUP_AND_RESTORE_STATE, 5);
+        assert_eq!(
+            r,
+            ResolvedEnum::BackupAndRestoreState(BackupAndRestoreState::BACKUP_FAILURE)
+        );
+        assert_eq!(r.to_string(), "BACKUP_FAILURE");
+        assert_eq!(
+            ResolvedEnum::from_property(PropertyIdentifier::BACKUP_AND_RESTORE_STATE, 6)
+                .to_string(),
+            "RESTORE_FAILURE"
+        );
+    }
+
+    #[test]
     fn resolves_limit_enable_and_event_enable() {
         assert!(matches!(
             ResolvedBits::from_property(PropertyIdentifier::LIMIT_ENABLE, 6, &[0xC0]),

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -131,3 +131,32 @@ fn reliability_gap_at_11() {
     assert_eq!(Reliability::CONFIGURATION_ERROR.to_raw(), 10);
     assert_eq!(Reliability::COMMUNICATION_FAILURE.to_raw(), 12);
 }
+
+#[test]
+fn reliability_multi_state_out_of_range() {
+    assert_eq!(Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw(), 25);
+    assert_eq!(
+        Reliability::from_raw(25),
+        Reliability::MULTI_STATE_OUT_OF_RANGE
+    );
+    assert_eq!(
+        format!("{}", Reliability::MULTI_STATE_OUT_OF_RANGE),
+        "MULTI_STATE_OUT_OF_RANGE"
+    );
+}
+
+#[test]
+fn backup_and_restore_state_failure_values() {
+    // A device reporting either failure state during a Clause 19.1
+    // backup/restore procedure now displays by name, not as a bare number.
+    assert_eq!(BackupAndRestoreState::BACKUP_FAILURE.to_raw(), 5);
+    assert_eq!(BackupAndRestoreState::RESTORE_FAILURE.to_raw(), 6);
+    assert_eq!(
+        format!("{}", BackupAndRestoreState::from_raw(5)),
+        "BACKUP_FAILURE"
+    );
+    assert_eq!(
+        format!("{}", BackupAndRestoreState::from_raw(6)),
+        "RESTORE_FAILURE"
+    );
+}


### PR DESCRIPTION
Closes #246. Closes #241.

## What

Adds three named constants to two open enums in `crates/bacnet-types/src/enums/object_level.rs`:

- `BackupAndRestoreState::BACKUP_FAILURE = 5` and `::RESTORE_FAILURE = 6` (#246) — the `BACnetBackupState` production's last two values, states a device legitimately reports during Clause 19.1 backup/restore procedures.
- `Reliability::MULTI_STATE_OUT_OF_RANGE = 25` (#241) — verified in the production immediately after referenced-object-fault (24).

Plus tests pinning raw values, Display names, and resolver behavior for property 338, and a CHANGELOG entry.

## Why it's this small

The `bacnet_enum!` open-enum design means unknown wire values already round-tripped losslessly — a device reporting backup-failure just displayed as the bare number `5` (including through `resolve_value` on `Backup_And_Restore_State`, which PR #244 made name-aware). Adding a constant is purely additive naming: `ALL_NAMED`, `Display`, and `Debug` are macro-generated, the PyO3 bindings don't expose these enums, and the conformance JSON has no entries keyed to them. No wire-format change, no breaking change.

## Gates

- Codex spec lane `issue-246-241-spec-review` + Claude adversarial workflow (running; merge waits on both).
- Local: bacnet-types tests 115+2 green (three new), clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)