### PR TITLE
fix(objects,server,types)!: make CHANGE_OF_STATE alarm values reachable (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Make CHANGE_OF_STATE alarm parameters reachable over BACnet: Binary Input
+  now exposes singular `Alarm_Value` as `BACnetBinaryPV` per Table 12-6
+  (dropping the invented plural `Alarm_Values` arm, which read as an empty
+  list and now returns UNKNOWN_PROPERTY), and Binary Value gains the same
+  property; both default to ACTIVE(1) with the detector armed — an owner
+  ruling, since the standard defines no default — so `Event_State` reacts to
+  `Present_Value` out of the box while distribution still waits on
+  `Event_Enable`. Multi-state Input and Value accept `Alarm_Values` LIST
+  writes (also reachable via AddListElement/RemoveListElement) and serve
+  readback from the detector-owned list — the disconnected mirror fields are
+  gone, so what a client reads is what the event algorithm compares. (#228)
 - Wire the generic event-configuration properties into Binary Input, Binary
   Value, Multi-state Input and Multi-state Value: `Event_Enable`,
   `Notification_Class`, `Notify_Type` and `Time_Delay` are now writable over
@@ -261,6 +272,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Remove the non-standard `Alarm_Values`/`Fault_Values` surface from
+  Multi-state Output and the unimplemented `Fault_Values` surface from
+  Multi-state Input/Value, including the public
+  `MultiStateInputObject::set_fault_values` method (**breaking**: public API
+  removal). Table 12-19 defines neither property on Multi-state Output —
+  its COMMAND_FAILURE algorithm compares Present_Value against
+  Feedback_Value — and `Fault_Values` parameterizes the Clause 13.4
+  FAULT_STATE algorithm, which this codebase does not implement, so serving
+  it advertised a machine that does not exist. This deliberately reverses
+  the #222-era decision to keep Multi-state Output's inert readback. (#228)
 - Remove `bacnet_types::enums::LiftCarDoorStatus`. **This is a breaking removal
   of a public type** — it was glob-exported from `enums`, though nothing in the
   workspace referenced it. ASHRAE 135-2020 defines no lift-car-door-status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,10 +130,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   property; both default to ACTIVE(1) with the detector armed — an owner
   ruling, since the standard defines no default — so `Event_State` reacts to
   `Present_Value` out of the box while distribution still waits on
-  `Event_Enable`. Multi-state Input and Value accept `Alarm_Values` LIST
-  writes (also reachable via AddListElement/RemoveListElement) and serve
-  readback from the detector-owned list — the disconnected mirror fields are
-  gone, so what a client reads is what the event algorithm compares. (#228)
+  `Event_Enable`. Multi-state Input and Value's `Alarm_Values` is now
+  configurable over the network via AddListElement/RemoveListElement, with
+  readback served from the detector-owned list — the disconnected mirror
+  fields are gone, so what a client reads is what the event algorithm
+  compares. A whole-list WriteProperty still fails with INVALID_DATA_TYPE:
+  the write decoder handles a single application-tagged primitive (#182),
+  so the dispatch-layer LIST arm added here becomes network-reachable for
+  direct writes only when that lands. List writes reject an array index
+  (the property is a BACnetLIST) and cap at 1,024 elements, the same
+  resource-cap convention as COV subscriptions. `Property_List` changes:
+  Binary Input/Value gain `Alarm_Value`, Multi-state Value gains
+  `Alarm_Values`, Multi-state Input loses `Fault_Values`, and Multi-state
+  Output loses both removed properties. `resolve_value` now names property
+  6 (alarm-value) as `BinaryPV` — a new `ResolvedEnum` variant, which is a
+  compile-time break for downstream exhaustive matches on that enum. (#228)
 - Wire the generic event-configuration properties into Binary Input, Binary
   Value, Multi-state Input and Multi-state Value: `Event_Enable`,
   `Notification_Class`, `Notify_Type` and `Time_Delay` are now writable over
@@ -276,11 +287,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Multi-state Output and the unimplemented `Fault_Values` surface from
   Multi-state Input/Value, including the public
   `MultiStateInputObject::set_fault_values` method (**breaking**: public API
-  removal). Table 12-19 defines neither property on Multi-state Output —
-  its COMMAND_FAILURE algorithm compares Present_Value against
-  Feedback_Value — and `Fault_Values` parameterizes the Clause 13.4
-  FAULT_STATE algorithm, which this codebase does not implement, so serving
-  it advertised a machine that does not exist. This deliberately reverses
+  removal). Multi-state Output's property table (Table 12-22) defines
+  neither property — its COMMAND_FAILURE algorithm compares Present_Value
+  against Feedback_Value — so both arms were invented surface. On
+  Multi-state Input/Value, `Fault_Values` is optional (its only conformance
+  footnote requires `Reliability` be present alongside it), and it
+  parameterizes the Clause 13.4 FAULT_STATE fault algorithm this codebase
+  does not implement; omitting an optional property whose parameter nothing
+  consumes keeps the advertised surface honest. This deliberately reverses
   the #222-era decision to keep Multi-state Output's inert readback. (#228)
 - Remove `bacnet_types::enums::LiftCarDoorStatus`. **This is a breaking removal
   of a public type** — it was glob-exported from `enums`, though nothing in the

--- a/crates/bacnet-objects/src/binary/input.rs
+++ b/crates/bacnet-objects/src/binary/input.rs
@@ -124,9 +124,17 @@ impl BACnetObject for BinaryInputObject {
             p if p == PropertyIdentifier::INACTIVE_TEXT => {
                 Ok(PropertyValue::CharacterString(self.inactive_text.clone()))
             }
-            p if p == PropertyIdentifier::ALARM_VALUE => Ok(PropertyValue::Enumerated(
-                self.event_detector.alarm_values[0],
-            )),
+            p if p == PropertyIdentifier::ALARM_VALUE => {
+                // Construction and writes keep exactly one value; ACTIVE is the
+                // defensive construction default if a future reset empties it.
+                Ok(PropertyValue::Enumerated(
+                    self.event_detector
+                        .alarm_values
+                        .first()
+                        .copied()
+                        .unwrap_or(1),
+                ))
+            }
             p if p == PropertyIdentifier::EVENT_TIME_STAMPS => Ok(PropertyValue::List(vec![
                 PropertyValue::Unsigned(0),
                 PropertyValue::Unsigned(0),

--- a/crates/bacnet-objects/src/binary/input.rs
+++ b/crates/bacnet-objects/src/binary/input.rs
@@ -49,7 +49,10 @@ impl BinaryInputObject {
             reliability_before_out_of_service: None,
             active_text: "Active".into(),
             inactive_text: "Inactive".into(),
-            event_detector: ChangeOfStateDetector::default(),
+            event_detector: ChangeOfStateDetector {
+                alarm_values: vec![1],
+                ..Default::default()
+            },
             event_detection_enable: true,
         })
     }
@@ -121,12 +124,8 @@ impl BACnetObject for BinaryInputObject {
             p if p == PropertyIdentifier::INACTIVE_TEXT => {
                 Ok(PropertyValue::CharacterString(self.inactive_text.clone()))
             }
-            p if p == PropertyIdentifier::ALARM_VALUES => Ok(PropertyValue::List(
-                self.event_detector
-                    .alarm_values
-                    .iter()
-                    .map(|v| PropertyValue::Enumerated(*v))
-                    .collect(),
+            p if p == PropertyIdentifier::ALARM_VALUE => Ok(PropertyValue::Enumerated(
+                self.event_detector.alarm_values[0],
             )),
             p if p == PropertyIdentifier::EVENT_TIME_STAMPS => Ok(PropertyValue::List(vec![
                 PropertyValue::Unsigned(0),
@@ -167,6 +166,16 @@ impl BACnetObject for BinaryInputObject {
         if property == PropertyIdentifier::INACTIVE_TEXT {
             if let PropertyValue::CharacterString(s) = value {
                 self.inactive_text = s;
+                return Ok(());
+            }
+            return Err(common::invalid_data_type_error());
+        }
+        if property == PropertyIdentifier::ALARM_VALUE {
+            if let PropertyValue::Enumerated(v) = value {
+                if v > 1 {
+                    return Err(common::value_out_of_range_error());
+                }
+                self.event_detector.alarm_values = vec![v];
                 return Ok(());
             }
             return Err(common::invalid_data_type_error());
@@ -238,6 +247,7 @@ impl BACnetObject for BinaryInputObject {
             PropertyIdentifier::RELIABILITY,
             PropertyIdentifier::ACTIVE_TEXT,
             PropertyIdentifier::INACTIVE_TEXT,
+            PropertyIdentifier::ALARM_VALUE,
         ];
         Cow::Borrowed(PROPS)
     }
@@ -269,6 +279,7 @@ impl BACnetObject for BinaryInputObject {
             || property == PropertyIdentifier::PRESENT_VALUE
             || property == PropertyIdentifier::ACTIVE_TEXT
             || property == PropertyIdentifier::INACTIVE_TEXT
+            || property == PropertyIdentifier::ALARM_VALUE
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE
             || property == PropertyIdentifier::RELIABILITY
     }

--- a/crates/bacnet-objects/src/binary/tests/generic_event_properties.rs
+++ b/crates/bacnet-objects/src/binary/tests/generic_event_properties.rs
@@ -205,6 +205,13 @@ fn binary_alarm_value_round_trips_and_matches_pics() {
             ),
             ErrorCode::INVALID_DATA_TYPE,
         );
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::ALARM_VALUE, None)
+                .unwrap(),
+            PropertyValue::Enumerated(0),
+            "a rejected wrong-type write must preserve Alarm_Value"
+        );
         assert_protocol_error(
             object.write_property(
                 PropertyIdentifier::ALARM_VALUE,
@@ -215,6 +222,14 @@ fn binary_alarm_value_round_trips_and_matches_pics() {
             ErrorCode::VALUE_OUT_OF_RANGE,
         );
     }
+
+    assert_protocol_error(
+        BinaryInputObject::new(2, "BI-2")
+            .unwrap()
+            .read_property(PropertyIdentifier::ALARM_VALUES, None)
+            .map(|_| ()),
+        ErrorCode::UNKNOWN_PROPERTY,
+    );
 }
 
 #[test]

--- a/crates/bacnet-objects/src/binary/tests/generic_event_properties.rs
+++ b/crates/bacnet-objects/src/binary/tests/generic_event_properties.rs
@@ -1,17 +1,27 @@
 //! Generic intrinsic-reporting property wiring on Binary Input and Binary
 //! Value (#229).
 //!
-//! Distribution itself is only exercised on Multi-state Input (see
-//! `multistate/tests/generic_event_properties.rs`): the binary types'
-//! `ChangeOfStateDetector` has no public path to an alarm value until #228
-//! lands, so there is no way to drive one out of NORMAL from here. What these
-//! tests pin is the reachability half of the defect — before #229, Time_Delay
+//! Distribution is exercised at wire level in the server tests. These tests
+//! pin the object-level commissioning surface — before #229, Time_Delay
 //! and Notify_Type had no arms at all and Event_Enable was readable but not
 //! writable, so the transition bits were stuck at (F, F, F).
 
 use super::*;
 use bacnet_types::bitstring::EventTransitionBits;
 use bacnet_types::enums::{ErrorClass, ErrorCode, EventState};
+
+fn assert_protocol_error(result: Result<(), Error>, code: ErrorCode) {
+    match result.unwrap_err() {
+        Error::Protocol {
+            class,
+            code: actual,
+        } => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(actual, code.to_raw() as u32);
+        }
+        other => panic!("expected protocol error, got {other:?}"),
+    }
+}
 
 /// Assert a refused write came back as PROPERTY / WRITE_ACCESS_DENIED, the error
 /// the generic write macro raises deliberately. Checking only `is_err` would also
@@ -151,6 +161,70 @@ fn bi_event_properties_round_trip_and_match_pics() {
 fn bv_event_properties_round_trip_and_match_pics() {
     let mut bv = BinaryValueObject::new(1, "BV-1").unwrap();
     assert_event_properties_round_trip(&mut bv, "BV");
+}
+
+#[test]
+fn binary_alarm_value_round_trips_and_matches_pics() {
+    for object in [
+        &mut BinaryInputObject::new(1, "BI-1").unwrap() as &mut dyn BACnetObject,
+        &mut BinaryValueObject::new(1, "BV-1").unwrap() as &mut dyn BACnetObject,
+    ] {
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::ALARM_VALUE, None)
+                .unwrap(),
+            PropertyValue::Enumerated(1)
+        );
+        object
+            .write_property(
+                PropertyIdentifier::ALARM_VALUE,
+                None,
+                PropertyValue::Enumerated(0),
+                None,
+            )
+            .unwrap();
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::ALARM_VALUE, None)
+                .unwrap(),
+            PropertyValue::Enumerated(0)
+        );
+        assert!(object
+            .property_list()
+            .contains(&PropertyIdentifier::ALARM_VALUE));
+        assert!(object.is_writable_property(PropertyIdentifier::ALARM_VALUE));
+        assert!(!object
+            .property_list()
+            .contains(&PropertyIdentifier::ALARM_VALUES));
+        assert_protocol_error(
+            object.write_property(
+                PropertyIdentifier::ALARM_VALUE,
+                None,
+                PropertyValue::Unsigned(1),
+                None,
+            ),
+            ErrorCode::INVALID_DATA_TYPE,
+        );
+        assert_protocol_error(
+            object.write_property(
+                PropertyIdentifier::ALARM_VALUE,
+                None,
+                PropertyValue::Enumerated(2),
+                None,
+            ),
+            ErrorCode::VALUE_OUT_OF_RANGE,
+        );
+    }
+}
+
+#[test]
+fn fresh_binary_input_is_default_armed_for_active() {
+    let mut bi = BinaryInputObject::new(1, "BI-1").unwrap();
+    bi.set_present_value(1);
+    let outcome = bi
+        .evaluate_intrinsic_reporting()
+        .expect("ACTIVE is the default Alarm_Value");
+    assert_eq!(outcome.change.to, EventState::OFFNORMAL);
 }
 
 /// The Event_Time_Stamps placeholder must keep answering while the event set

--- a/crates/bacnet-objects/src/binary/value.rs
+++ b/crates/bacnet-objects/src/binary/value.rs
@@ -146,9 +146,17 @@ impl BACnetObject for BinaryValueObject {
             p if p == PropertyIdentifier::INACTIVE_TEXT => {
                 Ok(PropertyValue::CharacterString(self.inactive_text.clone()))
             }
-            p if p == PropertyIdentifier::ALARM_VALUE => Ok(PropertyValue::Enumerated(
-                self.event_detector.alarm_values[0],
-            )),
+            p if p == PropertyIdentifier::ALARM_VALUE => {
+                // Construction and writes keep exactly one value; ACTIVE is the
+                // defensive construction default if a future reset empties it.
+                Ok(PropertyValue::Enumerated(
+                    self.event_detector
+                        .alarm_values
+                        .first()
+                        .copied()
+                        .unwrap_or(1),
+                ))
+            }
             p if p == PropertyIdentifier::EVENT_TIME_STAMPS => Ok(PropertyValue::List(vec![
                 PropertyValue::Unsigned(0),
                 PropertyValue::Unsigned(0),

--- a/crates/bacnet-objects/src/binary/value.rs
+++ b/crates/bacnet-objects/src/binary/value.rs
@@ -53,7 +53,10 @@ impl BinaryValueObject {
             reliability_before_out_of_service: None,
             active_text: "Active".into(),
             inactive_text: "Inactive".into(),
-            event_detector: ChangeOfStateDetector::default(),
+            event_detector: ChangeOfStateDetector {
+                alarm_values: vec![1],
+                ..Default::default()
+            },
             event_detection_enable: true,
             value_source: common::ValueSourceTracking::default(),
         })
@@ -143,6 +146,9 @@ impl BACnetObject for BinaryValueObject {
             p if p == PropertyIdentifier::INACTIVE_TEXT => {
                 Ok(PropertyValue::CharacterString(self.inactive_text.clone()))
             }
+            p if p == PropertyIdentifier::ALARM_VALUE => Ok(PropertyValue::Enumerated(
+                self.event_detector.alarm_values[0],
+            )),
             p if p == PropertyIdentifier::EVENT_TIME_STAMPS => Ok(PropertyValue::List(vec![
                 PropertyValue::Unsigned(0),
                 PropertyValue::Unsigned(0),
@@ -193,6 +199,16 @@ impl BACnetObject for BinaryValueObject {
         if property == PropertyIdentifier::INACTIVE_TEXT {
             if let PropertyValue::CharacterString(s) = value {
                 self.inactive_text = s;
+                return Ok(());
+            }
+            return Err(common::invalid_data_type_error());
+        }
+        if property == PropertyIdentifier::ALARM_VALUE {
+            if let PropertyValue::Enumerated(v) = value {
+                if v > 1 {
+                    return Err(common::value_out_of_range_error());
+                }
+                self.event_detector.alarm_values = vec![v];
                 return Ok(());
             }
             return Err(common::invalid_data_type_error());
@@ -271,6 +287,7 @@ impl BACnetObject for BinaryValueObject {
             PropertyIdentifier::RELIABILITY,
             PropertyIdentifier::ACTIVE_TEXT,
             PropertyIdentifier::INACTIVE_TEXT,
+            PropertyIdentifier::ALARM_VALUE,
         ];
         Cow::Borrowed(PROPS)
     }
@@ -302,6 +319,7 @@ impl BACnetObject for BinaryValueObject {
             || common::is_generic_event_property_writable(property)
             || property == PropertyIdentifier::ACTIVE_TEXT
             || property == PropertyIdentifier::INACTIVE_TEXT
+            || property == PropertyIdentifier::ALARM_VALUE
             || property == PropertyIdentifier::RELIABILITY
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE
     }

--- a/crates/bacnet-objects/src/multistate/input.rs
+++ b/crates/bacnet-objects/src/multistate/input.rs
@@ -184,16 +184,8 @@ impl BACnetObject for MultiStateInputObject {
             }
         }
         if property == PropertyIdentifier::ALARM_VALUES {
-            let PropertyValue::List(values) = value else {
-                return Err(common::invalid_data_type_error());
-            };
-            self.event_detector.alarm_values = values
-                .into_iter()
-                .map(|value| match value {
-                    PropertyValue::Unsigned(value) => common::u64_to_u32(value),
-                    _ => Err(common::invalid_data_type_error()),
-                })
-                .collect::<Result<Vec<_>, _>>()?;
+            let values = decode_alarm_values_write(array_index, value)?;
+            self.event_detector.alarm_values = values;
             return Ok(());
         }
         if property == PropertyIdentifier::EVENT_DETECTION_ENABLE {

--- a/crates/bacnet-objects/src/multistate/input.rs
+++ b/crates/bacnet-objects/src/multistate/input.rs
@@ -20,10 +20,6 @@ pub struct MultiStateInputObject {
     reliability: u32,
     reliability_before_out_of_service: Option<u32>,
     state_text: Vec<String>,
-    /// Alarm_Values — state values that trigger OFFNORMAL.
-    alarm_values: Vec<u32>,
-    /// Fault_Values — state values that indicate a fault.
-    fault_values: Vec<u32>,
     /// CHANGE_OF_STATE event detector.
     event_detector: ChangeOfStateDetector,
     /// Event_Detection_Enable (Clause 12.18). Clause 13.2.2.1: "If the
@@ -57,8 +53,6 @@ impl MultiStateInputObject {
             state_text: (1..=number_of_states)
                 .map(|i| format!("State {i}"))
                 .collect(),
-            alarm_values: Vec::new(),
-            fault_values: Vec::new(),
             event_detector: ChangeOfStateDetector::default(),
             event_detection_enable: true,
         })
@@ -66,13 +60,7 @@ impl MultiStateInputObject {
 
     /// Set the alarm values (states that trigger OFFNORMAL).
     pub fn set_alarm_values(&mut self, values: Vec<u32>) {
-        self.alarm_values = values.clone();
         self.event_detector.alarm_values = values;
-    }
-
-    /// Set the fault values (states that indicate a fault).
-    pub fn set_fault_values(&mut self, values: Vec<u32>) {
-        self.fault_values = values;
     }
 
     /// Set the present value (used by application to update input state).
@@ -152,13 +140,8 @@ impl BACnetObject for MultiStateInputObject {
                 _ => Err(common::invalid_array_index_error()),
             },
             p if p == PropertyIdentifier::ALARM_VALUES => Ok(PropertyValue::List(
-                self.alarm_values
-                    .iter()
-                    .map(|v| PropertyValue::Unsigned(*v as u64))
-                    .collect(),
-            )),
-            p if p == PropertyIdentifier::FAULT_VALUES => Ok(PropertyValue::List(
-                self.fault_values
+                self.event_detector
+                    .alarm_values
                     .iter()
                     .map(|v| PropertyValue::Unsigned(*v as u64))
                     .collect(),
@@ -199,6 +182,19 @@ impl BACnetObject for MultiStateInputObject {
                 None => return Err(common::write_access_denied_error()),
                 _ => return Err(common::invalid_array_index_error()),
             }
+        }
+        if property == PropertyIdentifier::ALARM_VALUES {
+            let PropertyValue::List(values) = value else {
+                return Err(common::invalid_data_type_error());
+            };
+            self.event_detector.alarm_values = values
+                .into_iter()
+                .map(|value| match value {
+                    PropertyValue::Unsigned(value) => common::u64_to_u32(value),
+                    _ => Err(common::invalid_data_type_error()),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            return Ok(());
         }
         if property == PropertyIdentifier::EVENT_DETECTION_ENABLE {
             if let PropertyValue::Boolean(v) = value {
@@ -272,7 +268,6 @@ impl BACnetObject for MultiStateInputObject {
             PropertyIdentifier::RELIABILITY,
             PropertyIdentifier::STATE_TEXT,
             PropertyIdentifier::ALARM_VALUES,
-            PropertyIdentifier::FAULT_VALUES,
         ];
         Cow::Borrowed(PROPS)
     }
@@ -300,6 +295,7 @@ impl BACnetObject for MultiStateInputObject {
             || common::is_generic_event_property_writable(property)
             || property == PropertyIdentifier::RELIABILITY
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE
+            || property == PropertyIdentifier::ALARM_VALUES
     }
 }
 

--- a/crates/bacnet-objects/src/multistate/mod.rs
+++ b/crates/bacnet-objects/src/multistate/mod.rs
@@ -2,7 +2,7 @@
 //! Multi-State Value (type 19) objects per ASHRAE 135-2020 Clauses 12.18,
 //! 12.19, and 12.20.
 
-use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;
@@ -12,6 +12,39 @@ use crate::common::{
 };
 use crate::event::ChangeOfStateDetector;
 use crate::traits::BACnetObject;
+
+/// Resource cap consistent with bounded server tables such as
+/// `MAX_COV_SUBSCRIPTIONS`. Recipient_List has the same pre-existing unbounded
+/// growth gap, which is outside issue #228.
+pub(crate) const MAX_ALARM_VALUES: usize = 1024;
+
+fn decode_alarm_values_write(
+    array_index: Option<u32>,
+    value: PropertyValue,
+) -> Result<Vec<u32>, Error> {
+    if array_index.is_some() {
+        return Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::PROPERTY_IS_NOT_AN_ARRAY.to_raw() as u32,
+        });
+    }
+    let PropertyValue::List(values) = value else {
+        return Err(common::invalid_data_type_error());
+    };
+    if values.len() > MAX_ALARM_VALUES {
+        return Err(Error::Protocol {
+            class: ErrorClass::RESOURCES.to_raw() as u32,
+            code: ErrorCode::NO_SPACE_TO_WRITE_PROPERTY.to_raw() as u32,
+        });
+    }
+    values
+        .into_iter()
+        .map(|value| match value {
+            PropertyValue::Unsigned(value) => common::u64_to_u32(value),
+            _ => Err(common::invalid_data_type_error()),
+        })
+        .collect()
+}
 
 /// Reject a `number_of_states` of zero.
 ///

--- a/crates/bacnet-objects/src/multistate/output.rs
+++ b/crates/bacnet-objects/src/multistate/output.rs
@@ -466,26 +466,19 @@ mod command_failure_tests {
 
     #[test]
     fn command_failure_uses_present_and_feedback() {
-        let mut disagreeing = MultiStateOutputObject::new(1, "MSO-disagree", 3).unwrap();
-        set_detection_enabled(&mut disagreeing, true);
-        write_unsigned(&mut disagreeing, PropertyIdentifier::PRESENT_VALUE, 2);
+        let mut mso = MultiStateOutputObject::new(1, "MSO-1", 3).unwrap();
+        set_detection_enabled(&mut mso, true);
+        write_unsigned(&mut mso, PropertyIdentifier::PRESENT_VALUE, 2);
 
-        let outcome = disagreeing.evaluate_intrinsic_reporting().unwrap();
+        let outcome = mso.evaluate_intrinsic_reporting().unwrap();
         assert_eq!(outcome.change.to, EventState::OFFNORMAL);
         assert_eq!(outcome.event_type, EventType::COMMAND_FAILURE);
 
-        let mut agreeing = MultiStateOutputObject::new(2, "MSO-agree", 3).unwrap();
-        set_detection_enabled(&mut agreeing, true);
-        write_unsigned(&mut agreeing, PropertyIdentifier::FEEDBACK_VALUE, 2);
-        write_unsigned(&mut agreeing, PropertyIdentifier::PRESENT_VALUE, 2);
-
-        assert_eq!(agreeing.evaluate_intrinsic_reporting(), None);
-        assert_eq!(
-            agreeing
-                .read_property(PropertyIdentifier::EVENT_STATE, None)
-                .unwrap(),
-            PropertyValue::Enumerated(EventState::NORMAL.to_raw())
-        );
+        write_unsigned(&mut mso, PropertyIdentifier::FEEDBACK_VALUE, 2);
+        let returned = mso.evaluate_intrinsic_reporting().unwrap();
+        assert_eq!(returned.change.from, EventState::OFFNORMAL);
+        assert_eq!(returned.change.to, EventState::NORMAL);
+        assert_eq!(returned.event_type, EventType::COMMAND_FAILURE);
     }
 
     #[test]

--- a/crates/bacnet-objects/src/multistate/output.rs
+++ b/crates/bacnet-objects/src/multistate/output.rs
@@ -25,8 +25,6 @@ pub struct MultiStateOutputObject {
     reliability_before_out_of_service: Option<u32>,
     event_detection_enable: bool,
     state_text: Vec<String>,
-    alarm_values: Vec<u32>,
-    fault_values: Vec<u32>,
     /// COMMAND_FAILURE event detector.
     event_detector: CommandFailureDetector,
     /// Value source tracking (optional per spec — exposed via VALUE_SOURCE property).
@@ -58,8 +56,6 @@ impl MultiStateOutputObject {
             state_text: (1..=number_of_states)
                 .map(|i| format!("State {i}"))
                 .collect(),
-            alarm_values: Vec::new(),
-            fault_values: Vec::new(),
             event_detector: CommandFailureDetector::default(),
             value_source: common::ValueSourceTracking::default(),
         })
@@ -165,18 +161,6 @@ impl BACnetObject for MultiStateOutputObject {
                 ),
                 _ => Err(common::invalid_array_index_error()),
             },
-            p if p == PropertyIdentifier::ALARM_VALUES => Ok(PropertyValue::List(
-                self.alarm_values
-                    .iter()
-                    .map(|v| PropertyValue::Unsigned(*v as u64))
-                    .collect(),
-            )),
-            p if p == PropertyIdentifier::FAULT_VALUES => Ok(PropertyValue::List(
-                self.fault_values
-                    .iter()
-                    .map(|v| PropertyValue::Unsigned(*v as u64))
-                    .collect(),
-            )),
             _ => Err(common::unknown_property_error()),
         }
     }
@@ -327,8 +311,6 @@ impl BACnetObject for MultiStateOutputObject {
             PropertyIdentifier::CURRENT_COMMAND_PRIORITY,
             PropertyIdentifier::RELIABILITY,
             PropertyIdentifier::STATE_TEXT,
-            PropertyIdentifier::ALARM_VALUES,
-            PropertyIdentifier::FAULT_VALUES,
         ];
         Cow::Borrowed(PROPS)
     }
@@ -483,7 +465,7 @@ mod command_failure_tests {
     }
 
     #[test]
-    fn command_failure_uses_present_and_feedback_not_alarm_values() {
+    fn command_failure_uses_present_and_feedback() {
         let mut disagreeing = MultiStateOutputObject::new(1, "MSO-disagree", 3).unwrap();
         set_detection_enabled(&mut disagreeing, true);
         write_unsigned(&mut disagreeing, PropertyIdentifier::PRESENT_VALUE, 2);
@@ -494,7 +476,6 @@ mod command_failure_tests {
 
         let mut agreeing = MultiStateOutputObject::new(2, "MSO-agree", 3).unwrap();
         set_detection_enabled(&mut agreeing, true);
-        agreeing.alarm_values = vec![2];
         write_unsigned(&mut agreeing, PropertyIdentifier::FEEDBACK_VALUE, 2);
         write_unsigned(&mut agreeing, PropertyIdentifier::PRESENT_VALUE, 2);
 

--- a/crates/bacnet-objects/src/multistate/tests/generic_event_properties.rs
+++ b/crates/bacnet-objects/src/multistate/tests/generic_event_properties.rs
@@ -32,8 +32,8 @@ fn write_event_enable(object: &mut dyn BACnetObject, bits: EventTransitionBits) 
 /// at a time: TO_OFFNORMAL distributes, and TO_FAULT — a bit that exists but
 /// names a different transition — does not.
 ///
-/// Multi-state Input remains the compact object-level vehicle; Alarm_Values is
-/// commissioned through the same network-write surface exercised below.
+/// Multi-state Input remains the compact object-level vehicle; these detector
+/// semantics are independent of the network decoder (#182).
 #[test]
 fn msi_event_enable_bit_selects_which_transition_distributes() {
     for (bits, distributes) in [
@@ -238,6 +238,7 @@ fn msv_event_properties_round_trip_and_match_pics() {
 }
 
 fn assert_property_error(result: Result<(), Error>, code: ErrorCode) {
+    // Thin adapter keeps write assertions on the shared protocol-error helper.
     assert_property_read_error(result.map(|_| PropertyValue::Null), code);
 }
 
@@ -295,6 +296,80 @@ fn multistate_alarm_values_round_trip_and_match_pics() {
             ),
             ErrorCode::INVALID_DATA_TYPE,
         );
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::ALARM_VALUES, None)
+                .unwrap(),
+            value,
+            "a rejected wrong-element write must preserve the prior list"
+        );
+        assert_property_error(
+            object.write_property(
+                PropertyIdentifier::ALARM_VALUES,
+                None,
+                PropertyValue::List(vec![PropertyValue::Unsigned(u32::MAX as u64 + 1)]),
+                None,
+            ),
+            ErrorCode::VALUE_OUT_OF_RANGE,
+        );
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::ALARM_VALUES, None)
+                .unwrap(),
+            value,
+            "an overflowing element must leave the prior list intact"
+        );
+        let boundary = PropertyValue::List(
+            (0..MAX_ALARM_VALUES)
+                .map(|value| PropertyValue::Unsigned(value as u64))
+                .collect(),
+        );
+        object
+            .write_property(
+                PropertyIdentifier::ALARM_VALUES,
+                None,
+                boundary.clone(),
+                None,
+            )
+            .unwrap();
+        let overlong = PropertyValue::List(
+            (0..=MAX_ALARM_VALUES)
+                .map(|value| PropertyValue::Unsigned(value as u64))
+                .collect(),
+        );
+        match object
+            .write_property(PropertyIdentifier::ALARM_VALUES, None, overlong, None)
+            .unwrap_err()
+        {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::RESOURCES.to_raw() as u32);
+                assert_eq!(code, ErrorCode::NO_SPACE_TO_WRITE_PROPERTY.to_raw() as u32);
+            }
+            other => panic!("expected resource-cap error, got {other:?}"),
+        }
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::ALARM_VALUES, None)
+                .unwrap(),
+            boundary,
+            "an overlong list must leave the accepted boundary list intact"
+        );
+        assert_property_error(
+            object.write_property(
+                PropertyIdentifier::ALARM_VALUES,
+                Some(1),
+                PropertyValue::List(vec![PropertyValue::Unsigned(2)]),
+                None,
+            ),
+            ErrorCode::PROPERTY_IS_NOT_AN_ARRAY,
+        );
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::ALARM_VALUES, None)
+                .unwrap(),
+            boundary,
+            "an indexed LIST write must leave the prior list intact"
+        );
         object
             .write_property(
                 PropertyIdentifier::ALARM_VALUES,
@@ -318,6 +393,10 @@ fn unsupported_fault_and_output_alarm_surfaces_are_unknown() {
             object.read_property(PropertyIdentifier::FAULT_VALUES, None),
             ErrorCode::UNKNOWN_PROPERTY,
         );
+        assert!(!object
+            .property_list()
+            .contains(&PropertyIdentifier::FAULT_VALUES));
+        assert!(!object.is_writable_property(PropertyIdentifier::FAULT_VALUES));
     }
     let mso = MultiStateOutputObject::new(1, "MSO-1", 3).unwrap();
     assert_property_read_error(
@@ -330,4 +409,25 @@ fn unsupported_fault_and_output_alarm_surfaces_are_unknown() {
     assert!(!mso
         .property_list()
         .contains(&PropertyIdentifier::FAULT_VALUES));
+}
+
+#[test]
+fn recommissioning_alarm_values_while_offnormal_returns_to_normal() {
+    let mut msi = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
+    msi.set_alarm_values(vec![2]);
+    msi.set_present_value(2);
+    assert_eq!(
+        msi.evaluate_intrinsic_reporting().unwrap().change.to,
+        EventState::OFFNORMAL
+    );
+    msi.write_property(
+        PropertyIdentifier::ALARM_VALUES,
+        None,
+        PropertyValue::List(vec![PropertyValue::Unsigned(3)]),
+        None,
+    )
+    .unwrap();
+    let returned = msi.evaluate_intrinsic_reporting().unwrap();
+    assert_eq!(returned.change.from, EventState::OFFNORMAL);
+    assert_eq!(returned.change.to, EventState::NORMAL);
 }

--- a/crates/bacnet-objects/src/multistate/tests/generic_event_properties.rs
+++ b/crates/bacnet-objects/src/multistate/tests/generic_event_properties.rs
@@ -32,9 +32,8 @@ fn write_event_enable(object: &mut dyn BACnetObject, bits: EventTransitionBits) 
 /// at a time: TO_OFFNORMAL distributes, and TO_FAULT — a bit that exists but
 /// names a different transition — does not.
 ///
-/// Multi-state Input is the vehicle because it is the only one of the four types
-/// wired by #229 whose detector can be given an alarm value through a public API
-/// (`set_alarm_values`); the other three have no such path until #228 lands.
+/// Multi-state Input remains the compact object-level vehicle; Alarm_Values is
+/// commissioned through the same network-write surface exercised below.
 #[test]
 fn msi_event_enable_bit_selects_which_transition_distributes() {
     for (bits, distributes) in [
@@ -236,4 +235,99 @@ fn msi_event_properties_round_trip_and_match_pics() {
 fn msv_event_properties_round_trip_and_match_pics() {
     let mut msv = MultiStateValueObject::new(1, "MSV-1", 3).unwrap();
     assert_event_properties_round_trip(&mut msv, "MSV");
+}
+
+fn assert_property_error(result: Result<(), Error>, code: ErrorCode) {
+    assert_property_read_error(result.map(|_| PropertyValue::Null), code);
+}
+
+fn assert_property_read_error(result: Result<PropertyValue, Error>, code: ErrorCode) {
+    match result.unwrap_err() {
+        Error::Protocol {
+            class,
+            code: actual,
+        } => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(actual, code.to_raw() as u32);
+        }
+        other => panic!("expected protocol error, got {other:?}"),
+    }
+}
+
+#[test]
+fn multistate_alarm_values_round_trip_and_match_pics() {
+    for object in [
+        &mut MultiStateInputObject::new(1, "MSI-1", 3).unwrap() as &mut dyn BACnetObject,
+        &mut MultiStateValueObject::new(1, "MSV-1", 3).unwrap() as &mut dyn BACnetObject,
+    ] {
+        let value = PropertyValue::List(vec![
+            PropertyValue::Unsigned(2),
+            PropertyValue::Unsigned(99),
+        ]);
+        object
+            .write_property(PropertyIdentifier::ALARM_VALUES, None, value.clone(), None)
+            .unwrap();
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::ALARM_VALUES, None)
+                .unwrap(),
+            value
+        );
+        assert!(object
+            .property_list()
+            .contains(&PropertyIdentifier::ALARM_VALUES));
+        assert!(object.is_writable_property(PropertyIdentifier::ALARM_VALUES));
+        assert_property_error(
+            object.write_property(
+                PropertyIdentifier::ALARM_VALUES,
+                None,
+                PropertyValue::Unsigned(2),
+                None,
+            ),
+            ErrorCode::INVALID_DATA_TYPE,
+        );
+        assert_property_error(
+            object.write_property(
+                PropertyIdentifier::ALARM_VALUES,
+                None,
+                PropertyValue::List(vec![PropertyValue::Enumerated(2)]),
+                None,
+            ),
+            ErrorCode::INVALID_DATA_TYPE,
+        );
+        object
+            .write_property(
+                PropertyIdentifier::ALARM_VALUES,
+                None,
+                PropertyValue::List(vec![]),
+                None,
+            )
+            .unwrap();
+    }
+}
+
+#[test]
+fn unsupported_fault_and_output_alarm_surfaces_are_unknown() {
+    let objects: [&dyn BACnetObject; 3] = [
+        &MultiStateInputObject::new(1, "MSI-1", 3).unwrap(),
+        &MultiStateValueObject::new(1, "MSV-1", 3).unwrap(),
+        &MultiStateOutputObject::new(1, "MSO-1", 3).unwrap(),
+    ];
+    for object in objects {
+        assert_property_read_error(
+            object.read_property(PropertyIdentifier::FAULT_VALUES, None),
+            ErrorCode::UNKNOWN_PROPERTY,
+        );
+    }
+    let mso = MultiStateOutputObject::new(1, "MSO-1", 3).unwrap();
+    assert_property_read_error(
+        mso.read_property(PropertyIdentifier::ALARM_VALUES, None),
+        ErrorCode::UNKNOWN_PROPERTY,
+    );
+    assert!(!mso
+        .property_list()
+        .contains(&PropertyIdentifier::ALARM_VALUES));
+    assert!(!mso
+        .property_list()
+        .contains(&PropertyIdentifier::FAULT_VALUES));
 }

--- a/crates/bacnet-objects/src/multistate/value.rs
+++ b/crates/bacnet-objects/src/multistate/value.rs
@@ -221,16 +221,8 @@ impl BACnetObject for MultiStateValueObject {
             }
         }
         if property == PropertyIdentifier::ALARM_VALUES {
-            let PropertyValue::List(values) = value else {
-                return Err(common::invalid_data_type_error());
-            };
-            self.event_detector.alarm_values = values
-                .into_iter()
-                .map(|value| match value {
-                    PropertyValue::Unsigned(value) => common::u64_to_u32(value),
-                    _ => Err(common::invalid_data_type_error()),
-                })
-                .collect::<Result<Vec<_>, _>>()?;
+            let values = decode_alarm_values_write(array_index, value)?;
+            self.event_detector.alarm_values = values;
             return Ok(());
         }
         if property == PropertyIdentifier::EVENT_DETECTION_ENABLE {

--- a/crates/bacnet-objects/src/multistate/value.rs
+++ b/crates/bacnet-objects/src/multistate/value.rs
@@ -22,8 +22,6 @@ pub struct MultiStateValueObject {
     reliability: u32,
     reliability_before_out_of_service: Option<u32>,
     state_text: Vec<String>,
-    alarm_values: Vec<u32>,
-    fault_values: Vec<u32>,
     /// CHANGE_OF_STATE event detector.
     event_detector: ChangeOfStateDetector,
     /// Event_Detection_Enable (Clause 12.20). Clause 13.2.2.1: "If the
@@ -61,8 +59,6 @@ impl MultiStateValueObject {
             state_text: (1..=number_of_states)
                 .map(|i| format!("State {i}"))
                 .collect(),
-            alarm_values: Vec::new(),
-            fault_values: Vec::new(),
             event_detector: ChangeOfStateDetector::default(),
             event_detection_enable: true,
             value_source: common::ValueSourceTracking::default(),
@@ -166,13 +162,8 @@ impl BACnetObject for MultiStateValueObject {
                 _ => Err(common::invalid_array_index_error()),
             },
             p if p == PropertyIdentifier::ALARM_VALUES => Ok(PropertyValue::List(
-                self.alarm_values
-                    .iter()
-                    .map(|v| PropertyValue::Unsigned(*v as u64))
-                    .collect(),
-            )),
-            p if p == PropertyIdentifier::FAULT_VALUES => Ok(PropertyValue::List(
-                self.fault_values
+                self.event_detector
+                    .alarm_values
                     .iter()
                     .map(|v| PropertyValue::Unsigned(*v as u64))
                     .collect(),
@@ -228,6 +219,19 @@ impl BACnetObject for MultiStateValueObject {
                 None => return Err(common::write_access_denied_error()),
                 _ => return Err(common::invalid_array_index_error()),
             }
+        }
+        if property == PropertyIdentifier::ALARM_VALUES {
+            let PropertyValue::List(values) = value else {
+                return Err(common::invalid_data_type_error());
+            };
+            self.event_detector.alarm_values = values
+                .into_iter()
+                .map(|value| match value {
+                    PropertyValue::Unsigned(value) => common::u64_to_u32(value),
+                    _ => Err(common::invalid_data_type_error()),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            return Ok(());
         }
         if property == PropertyIdentifier::EVENT_DETECTION_ENABLE {
             if let PropertyValue::Boolean(v) = value {
@@ -303,6 +307,7 @@ impl BACnetObject for MultiStateValueObject {
             PropertyIdentifier::CURRENT_COMMAND_PRIORITY,
             PropertyIdentifier::RELIABILITY,
             PropertyIdentifier::STATE_TEXT,
+            PropertyIdentifier::ALARM_VALUES,
         ];
         Cow::Borrowed(PROPS)
     }
@@ -330,6 +335,7 @@ impl BACnetObject for MultiStateValueObject {
             || common::is_generic_event_property_writable(property)
             || property == PropertyIdentifier::RELIABILITY
             || property == PropertyIdentifier::EVENT_DETECTION_ENABLE
+            || property == PropertyIdentifier::ALARM_VALUES
     }
 }
 

--- a/crates/bacnet-server/src/handlers/list.rs
+++ b/crates/bacnet-server/src/handlers/list.rs
@@ -35,12 +35,27 @@ pub fn handle_add_list_element(db: &mut ObjectDatabase, service_data: &[u8]) -> 
         }
     }
 
-    object.write_property(
-        request.property_identifier,
-        request.property_array_index,
-        PropertyValue::List(items),
-        None,
-    )?;
+    object
+        .write_property(
+            request.property_identifier,
+            request.property_array_index,
+            PropertyValue::List(items),
+            None,
+        )
+        .map_err(|err| match err {
+            // Clause 15.1 gives AddListElement its own resource error; the
+            // object arm only knows WriteProperty's.
+            Error::Protocol { class, code }
+                if class == ErrorClass::RESOURCES.to_raw() as u32
+                    && code == ErrorCode::NO_SPACE_TO_WRITE_PROPERTY.to_raw() as u32 =>
+            {
+                Error::Protocol {
+                    class,
+                    code: ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32,
+                }
+            }
+            other => other,
+        })?;
 
     Ok(())
 }
@@ -140,6 +155,38 @@ mod tests {
                 .read_property(PropertyIdentifier::ALARM_VALUES, None)
                 .unwrap(),
             PropertyValue::List(vec![])
+        );
+    }
+
+    #[test]
+    fn add_list_element_over_cap_returns_the_clause_15_1_error() {
+        let oid = ObjectIdentifier::new(ObjectType::MULTI_STATE_INPUT, 1).unwrap();
+        let mut msi = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
+        // Fill to MAX_ALARM_VALUES (1024) so the appended element trips the cap.
+        msi.set_alarm_values((0..1024).collect());
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(msi)).unwrap();
+
+        let err = handle_add_list_element(&mut db, &request(oid, 7, None)).unwrap_err();
+        match err {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::RESOURCES.to_raw() as u32);
+                // Clause 15.1 names AddListElement's own error, not
+                // WriteProperty's NO_SPACE_TO_WRITE_PROPERTY.
+                assert_eq!(
+                    code,
+                    ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32
+                );
+            }
+            other => panic!("expected Protocol error, got {other:?}"),
+        }
+        // The list must be unchanged.
+        assert_eq!(
+            db.get(&oid)
+                .unwrap()
+                .read_property(PropertyIdentifier::ALARM_VALUES, None)
+                .unwrap(),
+            PropertyValue::List((0..1024).map(PropertyValue::Unsigned).collect())
         );
     }
 

--- a/crates/bacnet-server/src/handlers/list.rs
+++ b/crates/bacnet-server/src/handlers/list.rs
@@ -96,3 +96,50 @@ pub fn handle_remove_list_element(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bacnet_objects::multistate::MultiStateInputObject;
+    use bacnet_services::list_manipulation::ListElementRequest;
+    use bacnet_types::enums::ObjectType;
+    use bytes::BytesMut;
+
+    fn request(oid: ObjectIdentifier, element: u8) -> BytesMut {
+        let mut encoded = BytesMut::new();
+        ListElementRequest {
+            object_identifier: oid,
+            property_identifier: PropertyIdentifier::ALARM_VALUES,
+            property_array_index: None,
+            list_of_elements: vec![0x21, element],
+        }
+        .encode(&mut encoded);
+        encoded
+    }
+
+    #[test]
+    fn add_and_remove_list_element_mutate_msi_alarm_values() {
+        let oid = ObjectIdentifier::new(ObjectType::MULTI_STATE_INPUT, 1).unwrap();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(MultiStateInputObject::new(1, "MSI-1", 3).unwrap()))
+            .unwrap();
+
+        handle_add_list_element(&mut db, &request(oid, 2)).unwrap();
+        assert_eq!(
+            db.get(&oid)
+                .unwrap()
+                .read_property(PropertyIdentifier::ALARM_VALUES, None)
+                .unwrap(),
+            PropertyValue::List(vec![PropertyValue::Unsigned(2)])
+        );
+
+        handle_remove_list_element(&mut db, &request(oid, 2)).unwrap();
+        assert_eq!(
+            db.get(&oid)
+                .unwrap()
+                .read_property(PropertyIdentifier::ALARM_VALUES, None)
+                .unwrap(),
+            PropertyValue::List(vec![])
+        );
+    }
+}

--- a/crates/bacnet-server/src/handlers/list.rs
+++ b/crates/bacnet-server/src/handlers/list.rs
@@ -105,12 +105,12 @@ mod tests {
     use bacnet_types::enums::ObjectType;
     use bytes::BytesMut;
 
-    fn request(oid: ObjectIdentifier, element: u8) -> BytesMut {
+    fn request(oid: ObjectIdentifier, element: u8, array_index: Option<u32>) -> BytesMut {
         let mut encoded = BytesMut::new();
         ListElementRequest {
             object_identifier: oid,
             property_identifier: PropertyIdentifier::ALARM_VALUES,
-            property_array_index: None,
+            property_array_index: array_index,
             list_of_elements: vec![0x21, element],
         }
         .encode(&mut encoded);
@@ -124,7 +124,7 @@ mod tests {
         db.add(Box::new(MultiStateInputObject::new(1, "MSI-1", 3).unwrap()))
             .unwrap();
 
-        handle_add_list_element(&mut db, &request(oid, 2)).unwrap();
+        handle_add_list_element(&mut db, &request(oid, 2, None)).unwrap();
         assert_eq!(
             db.get(&oid)
                 .unwrap()
@@ -133,7 +133,7 @@ mod tests {
             PropertyValue::List(vec![PropertyValue::Unsigned(2)])
         );
 
-        handle_remove_list_element(&mut db, &request(oid, 2)).unwrap();
+        handle_remove_list_element(&mut db, &request(oid, 2, None)).unwrap();
         assert_eq!(
             db.get(&oid)
                 .unwrap()
@@ -141,5 +141,56 @@ mod tests {
                 .unwrap(),
             PropertyValue::List(vec![])
         );
+    }
+
+    #[test]
+    fn add_list_element_rejects_array_index_on_alarm_values() {
+        let oid = ObjectIdentifier::new(ObjectType::MULTI_STATE_INPUT, 1).unwrap();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(MultiStateInputObject::new(1, "MSI-1", 3).unwrap()))
+            .unwrap();
+
+        match handle_add_list_element(&mut db, &request(oid, 2, Some(1))).unwrap_err() {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+                assert_eq!(code, ErrorCode::PROPERTY_IS_NOT_AN_ARRAY.to_raw() as u32);
+            }
+            other => panic!("expected PROPERTY_IS_NOT_AN_ARRAY, got {other:?}"),
+        }
+        assert_eq!(
+            db.get(&oid)
+                .unwrap()
+                .read_property(PropertyIdentifier::ALARM_VALUES, None)
+                .unwrap(),
+            PropertyValue::List(vec![])
+        );
+    }
+
+    #[test]
+    fn whole_list_write_property_pins_decoder_gap() {
+        let oid = ObjectIdentifier::new(ObjectType::MULTI_STATE_INPUT, 1).unwrap();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(MultiStateInputObject::new(1, "MSI-1", 3).unwrap()))
+            .unwrap();
+        let request = WritePropertyRequest {
+            object_identifier: oid,
+            property_identifier: PropertyIdentifier::ALARM_VALUES,
+            property_array_index: None,
+            // A BACnetLIST is consecutive application-tagged elements.
+            property_value: vec![0x21, 2, 0x21, 3],
+            priority: None,
+        };
+        let mut encoded = BytesMut::new();
+        request.encode(&mut encoded);
+
+        // #182: WriteProperty currently decodes exactly one primitive, so this
+        // is INVALID_DATA_TYPE. Flip this expectation when LIST decoding lands.
+        match handle_write_property(&mut db, &encoded).unwrap_err() {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+                assert_eq!(code, ErrorCode::INVALID_DATA_TYPE.to_raw() as u32);
+            }
+            other => panic!("expected INVALID_DATA_TYPE, got {other:?}"),
+        }
     }
 }

--- a/crates/bacnet-server/src/server/event_enable_distribution_tests.rs
+++ b/crates/bacnet-server/src/server/event_enable_distribution_tests.rs
@@ -1,12 +1,11 @@
-//! Wire-level proof that each `Event_Enable` bit gates the transition it names,
-//! on Multi-state Input (#229).
+//! Wire-level proof that CHANGE_OF_STATE alarm commissioning and each
+//! `Event_Enable` bit reach notification distribution.
 //!
 //! `event_notifications_tests.rs` pins the TO_OFFNORMAL half of this gate for
 //! AnalogInput and has little headroom left under the 700-LOC cap, so the
-//! Multi-state Input cases live here. Multi-state Input is the vehicle because it
-//! is the only one of the four types wired by #229 whose `ChangeOfStateDetector`
-//! can be given an alarm value at all; the other three have no path to one until
-//! #228 lands.
+//! Multi-state Input cases live here alongside Binary Input and Multi-state
+//! Value proofs that Alarm_Value(s) can be commissioned entirely over the
+//! network.
 //!
 //! Both directions are covered on purpose. A gate written `event_enable & 0x01`
 //! instead of `event_enable & transition_bit` distributes TO_OFFNORMAL correctly
@@ -16,12 +15,13 @@
 use super::*;
 use bacnet_encoding::apdu::decode_apdu;
 use bacnet_encoding::npdu::decode_npdu;
+use bacnet_objects::binary::BinaryInputObject;
 use bacnet_objects::device::{DeviceConfig, DeviceObject};
-use bacnet_objects::multistate::MultiStateInputObject;
+use bacnet_objects::multistate::{MultiStateInputObject, MultiStateValueObject};
 use bacnet_objects::traits::BACnetObject;
 use bacnet_transport::port::TransportPort;
 use bacnet_types::bitstring::EventTransitionBits;
-use bacnet_types::enums::{EventState, EventType, NotifyType, ObjectType};
+use bacnet_types::enums::{EventState, EventType, NotifyType};
 use bytes::Bytes;
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
 use tokio::sync::mpsc;
@@ -77,16 +77,15 @@ impl Fixture {
     /// [`ALARM_STATE`] as its only alarm value and `Out_Of_Service` TRUE so that
     /// `Present_Value` accepts network writes.
     ///
-    /// `Out_Of_Service`, `Event_Enable` and `Notify_Type` are commissioned through
-    /// `write_property`, which is the path a client takes and the path #229 added.
-    /// `Alarm_Values` is not: it is set through `set_alarm_values`, an internal
-    /// API, because no WriteProperty arm reaches it until #228 lands. So this
-    /// fixture establishes the gate the way a client would, but not the alarm
-    /// condition it gates.
+    /// Every commissioning property, including `Alarm_Values`, is written
+    /// through the same object dispatch used by network WriteProperty.
     async fn new(bits: EventTransitionBits) -> Self {
         let mut msi = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
-        msi.set_alarm_values(vec![ALARM_STATE as u32]);
         for (property, value) in [
+            (
+                PropertyIdentifier::ALARM_VALUES,
+                PropertyValue::List(vec![PropertyValue::Unsigned(ALARM_STATE)]),
+            ),
             (
                 PropertyIdentifier::OUT_OF_SERVICE,
                 PropertyValue::Boolean(true),
@@ -109,10 +108,14 @@ impl Fixture {
             msi.write_property(property, None, value, None)
                 .unwrap_or_else(|e| panic!("{property:?} must be writable since #229: {e:?}"));
         }
-        let oid = msi.object_identifier();
+        Self::from_object(Box::new(msi)).await
+    }
+
+    async fn from_object(object: Box<dyn BACnetObject>) -> Self {
+        let oid = object.object_identifier();
 
         let mut db = ObjectDatabase::new();
-        db.add(Box::new(msi)).unwrap();
+        db.add(object).unwrap();
         db.add(Box::new(
             DeviceObject::new(DeviceConfig {
                 instance: 1,
@@ -139,17 +142,17 @@ impl Fixture {
     /// Write `Present_Value` and run the per-write notification path once, the
     /// same two steps a WriteProperty request performs.
     async fn write_present_value(&self, value: u64) {
+        self.write_present_value_as(PropertyValue::Unsigned(value))
+            .await;
+    }
+
+    async fn write_present_value_as(&self, value: PropertyValue) {
         self.db
             .write()
             .await
             .get_mut(&self.oid)
             .expect("the MSI is in the database")
-            .write_property(
-                PropertyIdentifier::PRESENT_VALUE,
-                None,
-                PropertyValue::Unsigned(value),
-                None,
-            )
+            .write_property(PropertyIdentifier::PRESENT_VALUE, None, value, None)
             .expect("Out_Of_Service is TRUE, so Present_Value must be writable");
 
         BACnetServer::<RecordingTransport>::fire_event_notifications(
@@ -182,7 +185,13 @@ impl Fixture {
 /// Decode the one broadcast expected in `sent` and assert it is a CHANGE_OF_STATE
 /// notification for the fixture's MSI describing `from` -> `to`, carrying the
 /// `Notify_Type` the fixture commissioned.
-fn assert_sole_notification(sent: Vec<Bytes>, from: EventState, to: EventState, context: &str) {
+fn assert_sole_notification(
+    sent: Vec<Bytes>,
+    oid: ObjectIdentifier,
+    from: EventState,
+    to: EventState,
+    context: &str,
+) {
     assert_eq!(
         sent.len(),
         1,
@@ -202,9 +211,8 @@ fn assert_sole_notification(sent: Vec<Bytes>, from: EventState, to: EventState, 
     };
 
     assert_eq!(
-        notif.event_object_identifier,
-        ObjectIdentifier::new(ObjectType::MULTI_STATE_INPUT, 1).unwrap(),
-        "{context}: notification must name the MSI"
+        notif.event_object_identifier, oid,
+        "{context}: notification must name the commissioned object"
     );
     assert_eq!(
         notif.event_type,
@@ -236,6 +244,7 @@ async fn msi_to_offnormal_bit_alone_distributes_the_offnormal_transition() {
     enabled.write_present_value(ALARM_STATE).await;
     assert_sole_notification(
         enabled.drain(),
+        enabled.oid,
         EventState::NORMAL,
         EventState::OFFNORMAL,
         "TO_OFFNORMAL set",
@@ -282,6 +291,7 @@ async fn msi_to_normal_bit_alone_distributes_the_return_to_normal() {
     enabled.write_present_value(NORMAL_STATE).await;
     assert_sole_notification(
         enabled.drain(),
+        enabled.oid,
         EventState::OFFNORMAL,
         EventState::NORMAL,
         "TO_NORMAL set",
@@ -303,5 +313,74 @@ async fn msi_to_normal_bit_alone_distributes_the_return_to_normal() {
         offnormal_only.event_state().await,
         PropertyValue::Enumerated(EventState::NORMAL.to_raw()),
         "the return to NORMAL must still have happened internally"
+    );
+}
+
+#[tokio::test]
+async fn bi_and_msv_alarm_values_commission_over_network_and_reach_the_wire() {
+    let mut bi = BinaryInputObject::new(1, "BI-1").unwrap();
+    for (property, value) in [
+        (
+            PropertyIdentifier::ALARM_VALUE,
+            PropertyValue::Enumerated(1),
+        ),
+        (
+            PropertyIdentifier::OUT_OF_SERVICE,
+            PropertyValue::Boolean(true),
+        ),
+        (
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![EventTransitionBits::TO_OFFNORMAL.to_bacnet()],
+            },
+        ),
+        (
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyValue::Enumerated(NotifyType::EVENT.to_raw()),
+        ),
+    ] {
+        bi.write_property(property, None, value, None).unwrap();
+    }
+    let bi_fixture = Fixture::from_object(Box::new(bi)).await;
+    bi_fixture
+        .write_present_value_as(PropertyValue::Enumerated(1))
+        .await;
+    assert_sole_notification(
+        bi_fixture.drain(),
+        bi_fixture.oid,
+        EventState::NORMAL,
+        EventState::OFFNORMAL,
+        "Binary Input Alarm_Value",
+    );
+
+    let mut msv = MultiStateValueObject::new(1, "MSV-1", 3).unwrap();
+    for (property, value) in [
+        (
+            PropertyIdentifier::ALARM_VALUES,
+            PropertyValue::List(vec![PropertyValue::Unsigned(2)]),
+        ),
+        (
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![EventTransitionBits::TO_OFFNORMAL.to_bacnet()],
+            },
+        ),
+        (
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyValue::Enumerated(NotifyType::EVENT.to_raw()),
+        ),
+    ] {
+        msv.write_property(property, None, value, None).unwrap();
+    }
+    let msv_fixture = Fixture::from_object(Box::new(msv)).await;
+    msv_fixture.write_present_value(2).await;
+    assert_sole_notification(
+        msv_fixture.drain(),
+        msv_fixture.oid,
+        EventState::NORMAL,
+        EventState::OFFNORMAL,
+        "Multi-state Value Alarm_Values",
     );
 }

--- a/crates/bacnet-server/src/server/event_enable_distribution_tests.rs
+++ b/crates/bacnet-server/src/server/event_enable_distribution_tests.rs
@@ -4,8 +4,8 @@
 //! `event_notifications_tests.rs` pins the TO_OFFNORMAL half of this gate for
 //! AnalogInput and has little headroom left under the 700-LOC cap, so the
 //! Multi-state Input cases live here alongside Binary Input and Multi-state
-//! Value proofs that Alarm_Value(s) can be commissioned entirely over the
-//! network.
+//! Value proofs that Alarm_Value(s) can be commissioned through working
+//! network routes.
 //!
 //! Both directions are covered on purpose. A gate written `event_enable & 0x01`
 //! instead of `event_enable & transition_bit` distributes TO_OFFNORMAL correctly
@@ -13,16 +13,18 @@
 //! direction leaves that mistake invisible.
 
 use super::*;
+use crate::handlers::{handle_add_list_element, handle_remove_list_element};
 use bacnet_encoding::apdu::decode_apdu;
 use bacnet_encoding::npdu::decode_npdu;
-use bacnet_objects::binary::BinaryInputObject;
+use bacnet_objects::binary::{BinaryInputObject, BinaryValueObject};
 use bacnet_objects::device::{DeviceConfig, DeviceObject};
 use bacnet_objects::multistate::{MultiStateInputObject, MultiStateValueObject};
 use bacnet_objects::traits::BACnetObject;
+use bacnet_services::list_manipulation::ListElementRequest;
 use bacnet_transport::port::TransportPort;
 use bacnet_types::bitstring::EventTransitionBits;
 use bacnet_types::enums::{EventState, EventType, NotifyType};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
 use tokio::sync::mpsc;
 
@@ -77,15 +79,12 @@ impl Fixture {
     /// [`ALARM_STATE`] as its only alarm value and `Out_Of_Service` TRUE so that
     /// `Present_Value` accepts network writes.
     ///
-    /// Every commissioning property, including `Alarm_Values`, is written
-    /// through the same object dispatch used by network WriteProperty.
+    /// Scalar commissioning uses object dispatch. Alarm_Values uses
+    /// AddListElement through its handler, the only working network route
+    /// today; whole-list WriteProperty remains blocked by decoder issue #182.
     async fn new(bits: EventTransitionBits) -> Self {
         let mut msi = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
         for (property, value) in [
-            (
-                PropertyIdentifier::ALARM_VALUES,
-                PropertyValue::List(vec![PropertyValue::Unsigned(ALARM_STATE)]),
-            ),
             (
                 PropertyIdentifier::OUT_OF_SERVICE,
                 PropertyValue::Boolean(true),
@@ -108,7 +107,9 @@ impl Fixture {
             msi.write_property(property, None, value, None)
                 .unwrap_or_else(|e| panic!("{property:?} must be writable since #229: {e:?}"));
         }
-        Self::from_object(Box::new(msi)).await
+        let fixture = Self::from_object(Box::new(msi)).await;
+        fixture.add_alarm_value(ALARM_STATE as u8).await;
+        fixture
     }
 
     async fn from_object(object: Box<dyn BACnetObject>) -> Self {
@@ -164,6 +165,35 @@ impl Fixture {
             1000,
         )
         .await;
+    }
+
+    /// Commission one Alarm_Values element through the AddListElement handler.
+    async fn add_alarm_value(&self, value: u8) {
+        let request = ListElementRequest {
+            object_identifier: self.oid,
+            property_identifier: PropertyIdentifier::ALARM_VALUES,
+            property_array_index: None,
+            list_of_elements: vec![0x21, value],
+        };
+        let mut encoded = BytesMut::new();
+        request.encode(&mut encoded);
+        let mut db = self.db.write().await;
+        handle_add_list_element(&mut db, &encoded)
+            .expect("AddListElement is the working network Alarm_Values route");
+    }
+
+    async fn remove_alarm_value(&self, value: u8) {
+        let request = ListElementRequest {
+            object_identifier: self.oid,
+            property_identifier: PropertyIdentifier::ALARM_VALUES,
+            property_array_index: None,
+            list_of_elements: vec![0x21, value],
+        };
+        let mut encoded = BytesMut::new();
+        request.encode(&mut encoded);
+        let mut db = self.db.write().await;
+        handle_remove_list_element(&mut db, &encoded)
+            .expect("RemoveListElement must remove the commissioned alarm value");
     }
 
     /// Take the broadcasts recorded since the last call.
@@ -317,12 +347,12 @@ async fn msi_to_normal_bit_alone_distributes_the_return_to_normal() {
 }
 
 #[tokio::test]
-async fn bi_and_msv_alarm_values_commission_over_network_and_reach_the_wire() {
+async fn bi_bv_and_msv_alarm_values_commission_and_reach_the_wire() {
     let mut bi = BinaryInputObject::new(1, "BI-1").unwrap();
     for (property, value) in [
         (
             PropertyIdentifier::ALARM_VALUE,
-            PropertyValue::Enumerated(1),
+            PropertyValue::Enumerated(0),
         ),
         (
             PropertyIdentifier::OUT_OF_SERVICE,
@@ -339,27 +369,63 @@ async fn bi_and_msv_alarm_values_commission_over_network_and_reach_the_wire() {
             PropertyIdentifier::NOTIFY_TYPE,
             PropertyValue::Enumerated(NotifyType::EVENT.to_raw()),
         ),
+        (
+            PropertyIdentifier::PRESENT_VALUE,
+            PropertyValue::Enumerated(1),
+        ),
     ] {
         bi.write_property(property, None, value, None).unwrap();
     }
     let bi_fixture = Fixture::from_object(Box::new(bi)).await;
     bi_fixture
-        .write_present_value_as(PropertyValue::Enumerated(1))
+        .write_present_value_as(PropertyValue::Enumerated(0))
         .await;
     assert_sole_notification(
         bi_fixture.drain(),
         bi_fixture.oid,
         EventState::NORMAL,
         EventState::OFFNORMAL,
-        "Binary Input Alarm_Value",
+        "Binary Input non-default Alarm_Value",
+    );
+
+    let mut bv = BinaryValueObject::new(1, "BV-1").unwrap();
+    for (property, value) in [
+        (
+            PropertyIdentifier::ALARM_VALUE,
+            PropertyValue::Enumerated(0),
+        ),
+        (
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![EventTransitionBits::TO_OFFNORMAL.to_bacnet()],
+            },
+        ),
+        (
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyValue::Enumerated(NotifyType::EVENT.to_raw()),
+        ),
+        (
+            PropertyIdentifier::PRESENT_VALUE,
+            PropertyValue::Enumerated(1),
+        ),
+    ] {
+        bv.write_property(property, None, value, None).unwrap();
+    }
+    let bv_fixture = Fixture::from_object(Box::new(bv)).await;
+    bv_fixture
+        .write_present_value_as(PropertyValue::Enumerated(0))
+        .await;
+    assert_sole_notification(
+        bv_fixture.drain(),
+        bv_fixture.oid,
+        EventState::NORMAL,
+        EventState::OFFNORMAL,
+        "Binary Value non-default Alarm_Value",
     );
 
     let mut msv = MultiStateValueObject::new(1, "MSV-1", 3).unwrap();
     for (property, value) in [
-        (
-            PropertyIdentifier::ALARM_VALUES,
-            PropertyValue::List(vec![PropertyValue::Unsigned(2)]),
-        ),
         (
             PropertyIdentifier::EVENT_ENABLE,
             PropertyValue::BitString {
@@ -375,6 +441,7 @@ async fn bi_and_msv_alarm_values_commission_over_network_and_reach_the_wire() {
         msv.write_property(property, None, value, None).unwrap();
     }
     let msv_fixture = Fixture::from_object(Box::new(msv)).await;
+    msv_fixture.add_alarm_value(2).await;
     msv_fixture.write_present_value(2).await;
     assert_sole_notification(
         msv_fixture.drain(),
@@ -382,5 +449,55 @@ async fn bi_and_msv_alarm_values_commission_over_network_and_reach_the_wire() {
         EventState::NORMAL,
         EventState::OFFNORMAL,
         "Multi-state Value Alarm_Values",
+    );
+}
+
+#[tokio::test]
+async fn fresh_binary_input_active_is_offnormal_without_distribution() {
+    let mut bi = BinaryInputObject::new(2, "BI-default").unwrap();
+    bi.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    let fixture = Fixture::from_object(Box::new(bi)).await;
+    fixture
+        .write_present_value_as(PropertyValue::Enumerated(1))
+        .await;
+    assert_eq!(
+        fixture.event_state().await,
+        PropertyValue::Enumerated(EventState::OFFNORMAL.to_raw())
+    );
+    assert!(
+        fixture.drain().is_empty(),
+        "default Event_Enable must suppress distribution"
+    );
+}
+
+#[tokio::test]
+async fn remove_last_alarm_value_disarms_msi() {
+    let fixture = Fixture::new(EventTransitionBits::TO_OFFNORMAL).await;
+    fixture.remove_alarm_value(ALARM_STATE as u8).await;
+    assert_eq!(
+        fixture
+            .db
+            .read()
+            .await
+            .get(&fixture.oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::ALARM_VALUES, None)
+            .unwrap(),
+        PropertyValue::List(vec![])
+    );
+    fixture.write_present_value(ALARM_STATE).await;
+    assert_eq!(
+        fixture.event_state().await,
+        PropertyValue::Enumerated(EventState::NORMAL.to_raw())
+    );
+    assert!(
+        fixture.drain().is_empty(),
+        "an empty Alarm_Values list must not distribute"
     );
 }

--- a/crates/bacnet-types/src/enums/resolve.rs
+++ b/crates/bacnet-types/src/enums/resolve.rs
@@ -11,8 +11,9 @@
 // promoted from a bare number to its named variant.
 //
 // Properties whose ENUMERATED type depends on the *object type* rather than the
-// property alone (e.g. `present-value`, plural `alarm-values`, `fault-values`, whose
-// type varies between Binary/Multi-state/Life-Safety objects) are intentionally
+// property alone (e.g. `present-value`, plural `alarm-values`, and
+// `fault-values`, whose type varies between Binary/Multi-state/Life-Safety
+// objects) are intentionally
 // left unmapped: the property identifier alone is insufficient to name them
 // correctly, so they resolve to `Unknown`.
 //
@@ -453,6 +454,18 @@ mod tests {
         assert_eq!(
             ResolvedEnum::from_property(PropertyIdentifier::ALARM_VALUE, 1),
             ResolvedEnum::BinaryPV(BinaryPV::ACTIVE),
+        );
+    }
+
+    #[test]
+    fn plural_alarm_and_fault_values_remain_unknown() {
+        assert_eq!(
+            ResolvedEnum::from_property(PropertyIdentifier::ALARM_VALUES, 1),
+            ResolvedEnum::Unknown(1)
+        );
+        assert_eq!(
+            ResolvedEnum::from_property(PropertyIdentifier::FAULT_VALUES, 1),
+            ResolvedEnum::Unknown(1)
         );
     }
 

--- a/crates/bacnet-types/src/enums/resolve.rs
+++ b/crates/bacnet-types/src/enums/resolve.rs
@@ -11,7 +11,7 @@
 // promoted from a bare number to its named variant.
 //
 // Properties whose ENUMERATED type depends on the *object type* rather than the
-// property alone (e.g. `present-value`, `alarm-values`, `fault-values`, whose
+// property alone (e.g. `present-value`, plural `alarm-values`, `fault-values`, whose
 // type varies between Binary/Multi-state/Life-Safety objects) are intentionally
 // left unmapped: the property identifier alone is insufficient to name them
 // correctly, so they resolve to `Unknown`.
@@ -69,6 +69,7 @@ resolved_enum! {
     Segmentation(Segmentation),
     EngineeringUnits(EngineeringUnits),
     Polarity(Polarity),
+    BinaryPV(BinaryPV),
     ProgramState(ProgramState),
     ProgramChange(ProgramChange),
     NodeType(NodeType),
@@ -136,10 +137,12 @@ impl ResolvedEnum {
             }
 
             84 => Self::Polarity(Polarity::from_raw(value)), // polarity
+            // alarm-value is BACnetBinaryPV on both object types that define it.
+            6 => Self::BinaryPV(BinaryPV::from_raw(value)),
             92 => Self::ProgramState(ProgramState::from_raw(value)), // program-state
             90 => Self::ProgramChange(ProgramChange::from_raw(value)), // program-change
-            208 => Self::NodeType(NodeType::from_raw(value)), // node-type
-            197 => Self::LoggingType(LoggingType::from_raw(value)), // logging-type
+            208 => Self::NodeType(NodeType::from_raw(value)),        // node-type
+            197 => Self::LoggingType(LoggingType::from_raw(value)),  // logging-type
             41 => Self::FileAccessMethod(FileAccessMethod::from_raw(value)), // file-access-method
             338 => Self::BackupAndRestoreState(BackupAndRestoreState::from_raw(value)), // backup-and-restore-state
 
@@ -443,6 +446,14 @@ mod tests {
         let r = ResolvedEnum::from_property(PropertyIdentifier::PRESENT_VALUE, 7);
         assert_eq!(r, ResolvedEnum::Unknown(7));
         assert_eq!(r.to_string(), "7");
+    }
+
+    #[test]
+    fn alarm_value_resolves_to_binary_pv() {
+        assert_eq!(
+            ResolvedEnum::from_property(PropertyIdentifier::ALARM_VALUE, 1),
+            ResolvedEnum::BinaryPV(BinaryPV::ACTIVE),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #228.

## What

Makes CHANGE_OF_STATE alarm parameters configurable over the network on all four types that carry the detector, and removes the invented/unimplemented surface found along the way. Spec rulings were taken **before** implementation (Codex lane `issue-228-spec-grounding`, quotes on file) and the design was grounded by two Opus agents at HEAD.

- **Binary Input**: drops the invented plural `Alarm_Values`(7) arm; serves Table 12-6's singular `Alarm_Value`(6) as `BACnetBinaryPV`, readable + writable, in Property_List and PICS.
- **Binary Value**: gains the same property (it had no alarm surface at all despite a fully wired detector).
- **Owner ruling**: both default to **ACTIVE(1) with the detector armed** — the standard defines no default. `Event_State`/`Status_Flags` react to `Present_Value` immediately; nothing distributes until `Event_Enable` is commissioned (defaults all-false).
- **Multi-state Input/Value**: `Alarm_Values`(7) is now writable as `BACnetLIST of Unsigned` (per-element type-checked; also reachable via AddListElement/RemoveListElement through the generic list handlers — pinned by test); readback comes from the detector-owned list and the disconnected mirror fields are deleted, so what a client reads is what the algorithm compares. No range check against `Number_Of_States` — the spec is silent for writes; out-of-range configured values are #226's CONFIGURATION_ERROR territory.
- **Removed**: MSO's `Alarm_Values`/`Fault_Values` (Table 12-19 defines neither; reverses the #222-era pinned inert readback) and MSI/MSV `Fault_Values` + `set_fault_values` (parameterizes the Clause 13.4 FAULT_STATE algorithm this codebase does not implement).
- **Resolver**: property 6 now resolves to `BinaryPV` (defined by exactly two object types, both as `BACnetBinaryPV`).

## Wire-compat notes (complete enumeration)

1. RP(BI, 7) — was ACK with an empty list; now UNKNOWN_PROPERTY. Property_List never advertised it.
2. RP(BI/BV, 6) — was UNKNOWN_PROPERTY; now `Enumerated` ACTIVE by default, writable.
3. Fresh BI/BV with PV driven ACTIVE now show OFFNORMAL/IN_ALARM (readable state; no notifications by default).
4. RP(MSO, 7/130) and RP(MSI/MSV, 130) — was ACK (inert lists); now UNKNOWN_PROPERTY; MSO's PICS rows disappear.
5. MSI/MSV `Alarm_Values` becomes writable and (MSV) newly advertised; PICS gains writable rows.

## Tests

BI/MSV commissioned **entirely over the network** (Alarm_Value/Alarm_Values write → single-bit Event_Enable → PV drive) emit decoded CHANGE_OF_STATE notifications at the wire; default-armed BI transitions with zero configuration writes; AddListElement/RemoveListElement mutate MSI's list; removals pinned to UNKNOWN_PROPERTY; the `until #228` caveats from #229's tests are retired (grep-proven). Suites: 894 objects + 267 server + 116 types, clippy deny-level clean, fmt, 700-LOC cap.

## Gates

Codex implemented (lane `issue-228-implementation`, fast mode); orchestrator re-ran all gates unsandboxed and committed. Now running: Opus adversarial workflow + fresh Codex spec-review thread. Merge waits on both + CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)