### PR TITLE
feat(types): add missing 135-2020 scalar enumerations and resolve arms (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Tranche-Q 135-2020 enumeration parity (#253): the `bacnet-types` enum
+  catalogue now covers the Clause 21 productions the audit found missing,
+  and enumerated resolution promotes their raw wire values by property.
+
+  - `LifeSafetyState` gains the production tail — non-default-mode (24)
+    through test-oeo-unaffected (34) — without renumbering any existing
+    value; life-safety states past 23 no longer display as bare numbers.
+  - New `EscalatorOperationDirection` (unknown / stopped / up-rated-speed /
+    up-reduced-speed / down-rated-speed / down-reduced-speed): the
+    Escalator object's `operation_direction` (477) now resolves and
+    displays by name instead of falling through to `ResolvedEnum::Unknown`.
+    The object still stores a raw `u32`; retyping is follow-up work.
+  - New `BinaryLightingPV` (off / on / warn / warn-off / warn-relinquish /
+    stop) and `LightingTransition` (none / fade / ramp); `transition` (385)
+    now resolves. No resolve arm exists for `BinaryLightingPV` — it types
+    only object-type-dependent present values, which stay numeric by
+    policy. Binary Lighting Output docs no longer cite a nonexistent
+    "fade-on" value (4 is warn-relinquish; 5 is stop); its write
+    validation behavior is unchanged.
+  - Access family: new `AuthenticationStatus`,
+    `AuthorizationExemption`, `AccessZoneOccupancyState`, and `DoorValue`,
+    with `authentication-status` (260), `authorization-exemptions` (364),
+    and `occupancy-state` (296) resolving by name. `AccessDoorObject`'s
+    `Relinquish_Default` validation now bounds against
+    `DoorValue::EXTENDED_PULSE_UNLOCK` instead of a literal `0..=3`, so the
+    write domain cannot drift from the Clause 21 production.
+  - New `ProgramError` (normal / load-failed / internal / program /
+    other), `RestartReason` (unknown..activate-changes, 0-8),
+    `Maintenance` (none..need-service-inoperative, 0-3), and
+    `Relationship` (unknown/default plus the even/odd forward/reverse
+    pairs 2-29, mirroring the production's pairing note). The properties
+    `reason-for-halt` (100), `last-restart-reason` (196), and
+    `maintenance-required` (158) resolve as scalars;
+    `subordinate-relationships` (489, a BACnetARRAY) and
+    `authorization-exemptions` (364, a BACnetLIST) resolve element-wise
+    through `resolve_value`'s list recursion — the same convention the
+    pre-existing `accepted-modes` (175) arm follows. `represents` (491)
+    deliberately has no arm: the Structured View object types it as
+    `BACnetDeviceObjectReference`, not `BACnetRelationship`.
+  - Two comment corrections binding comments to the production text:
+    `NetworkType::NON_BACNET` was removed in version 1, revision 18 (not
+    "protocol revision 16"), and `EventType`'s tag-6/tag-7 gap note now
+    mirrors the Clause 21 production (tag 6 kept clear for the
+    `complex-event-type` CHOICE of `BACnetNotificationParameters`; tag 7
+    deprecated).
+
 ### Changed
 
 - WriteProperty and WritePropertyMultiple now decode the ENTIRE

--- a/crates/bacnet-objects/src/access_control/credential_data_input.rs
+++ b/crates/bacnet-objects/src/access_control/credential_data_input.rs
@@ -6,12 +6,16 @@ use super::*;
 /// BACnet Credential Data Input object (type 37).
 ///
 /// Represents a credential reader device (card reader, biometric scanner, etc.).
-/// Present value indicates the authentication status.
+/// Its Present_Value is a BACnetAuthenticationFactor *structure* (Clause
+/// 12.36), not an enumerated status: Authentication_Status — the
+/// BACnetAuthenticationStatus property whose values run 0=not-ready,
+/// 1=ready, … — belongs to the Access Point object (Clause 12.31,
+/// Table 12-36).
 pub struct CredentialDataInputObject {
     oid: ObjectIdentifier,
     name: String,
     description: String,
-    present_value: u32,              // AuthenticationStatus: 0=not-ready, 1=ready
+    present_value: u32, // BACnetAuthenticationFactor structure (12.36), stored raw
     update_time: ([u8; 4], [u8; 4]), // (Date, Time) as raw bytes
     supported_formats: Vec<u64>,
     supported_format_classes: Vec<u64>,
@@ -28,7 +32,7 @@ impl CredentialDataInputObject {
             oid,
             name: name.into(),
             description: String::new(),
-            present_value: 0, // notReady
+            present_value: 0, // empty factor placeholder (see field note)
             update_time: ([0xFF, 0xFF, 0xFF, 0xFF], [0xFF, 0xFF, 0xFF, 0xFF]),
             supported_formats: Vec::new(),
             supported_format_classes: Vec::new(),

--- a/crates/bacnet-objects/src/access_control/credential_data_input.rs
+++ b/crates/bacnet-objects/src/access_control/credential_data_input.rs
@@ -11,7 +11,7 @@ pub struct CredentialDataInputObject {
     oid: ObjectIdentifier,
     name: String,
     description: String,
-    present_value: u32,              // AuthenticationStatus: 0=notReady, 1=waiting
+    present_value: u32,              // AuthenticationStatus: 0=not-ready, 1=ready
     update_time: ([u8; 4], [u8; 4]), // (Date, Time) as raw bytes
     supported_formats: Vec<u64>,
     supported_format_classes: Vec<u64>,

--- a/crates/bacnet-objects/src/access_control/door.rs
+++ b/crates/bacnet-objects/src/access_control/door.rs
@@ -54,13 +54,13 @@ impl AccessDoorObject {
     ///
     /// Table 12-30 types both Present_Value and Relinquish_Default as
     /// BACnetDoorValue, whose Clause 21 production is a closed set of four:
-    /// lock(0), unlock(1), pulse-unlock(2), extended-pulse-unlock(3) — so the
-    /// valid domain is 0..=3, matching what the priority-slot Present_Value
-    /// arm accepts for value 3. After the store, Present_Value is resolved
-    /// anew from the priority array so an empty array falls back to the new
-    /// default immediately.
+    /// the accepted domain is `DoorValue::LOCK..=DoorValue::EXTENDED_PULSE_UNLOCK`
+    /// (0..=3), matching what the priority-slot Present_Value arm accepts
+    /// for value 3. After the store, Present_Value is resolved anew from the
+    /// priority array so an empty array falls back to the new default
+    /// immediately.
     pub fn set_relinquish_default(&mut self, value: u32) -> Result<(), Error> {
-        if value > 3 {
+        if value > DoorValue::EXTENDED_PULSE_UNLOCK.to_raw() {
             return Err(common::value_out_of_range_error());
         }
         self.relinquish_default = value;

--- a/crates/bacnet-objects/src/access_control/door.rs
+++ b/crates/bacnet-objects/src/access_control/door.rs
@@ -6,12 +6,13 @@ use super::*;
 /// BACnet Access Door object (type 30).
 ///
 /// Represents a physical door or barrier in an access control system.
-/// Present value indicates the door command status (DoorStatus enumeration).
+/// Present value carries the door command (BACnetDoorValue); Door_Status
+/// reports the physical DoorStatus.
 pub struct AccessDoorObject {
     oid: ObjectIdentifier,
     name: String,
     description: String,
-    present_value: u32,    // DoorStatus: 0=closed, 1=opened, 2=unknown
+    present_value: u32,    // BACnetDoorValue: 0=lock, 1=unlock
     door_status: u32,      // DoorStatus enumeration
     lock_status: u32,      // LockStatus enumeration
     secured_status: u32,   // DoorSecuredStatus enumeration
@@ -35,7 +36,7 @@ impl AccessDoorObject {
             oid,
             name: name.into(),
             description: String::new(),
-            present_value: 0, // closed
+            present_value: 0, // lock
             door_status: 0,   // closed
             lock_status: 0,
             secured_status: 0,
@@ -46,7 +47,7 @@ impl AccessDoorObject {
             out_of_service: false,
             reliability: 0,
             priority_array: Default::default(),
-            relinquish_default: 0, // closed
+            relinquish_default: 0, // lock
         })
     }
 
@@ -56,9 +57,11 @@ impl AccessDoorObject {
     /// BACnetDoorValue, whose Clause 21 production is a closed set of four:
     /// the accepted domain is `DoorValue::LOCK..=DoorValue::EXTENDED_PULSE_UNLOCK`
     /// (0..=3), matching what the priority-slot Present_Value arm accepts
-    /// for value 3. After the store, Present_Value is resolved anew from the
-    /// priority array so an empty array falls back to the new default
-    /// immediately.
+    /// for value 3. The bacnet-types test `door_value_values_match_clause_21`
+    /// pins the production's closed-set length, so this derivation cannot
+    /// silently drift from the enum. After the store, Present_Value is
+    /// resolved anew from the priority array so an empty array falls back
+    /// to the new default immediately.
     pub fn set_relinquish_default(&mut self, value: u32) -> Result<(), Error> {
         if value > DoorValue::EXTENDED_PULSE_UNLOCK.to_raw() {
             return Err(common::value_out_of_range_error());

--- a/crates/bacnet-objects/src/access_control/mod.rs
+++ b/crates/bacnet-objects/src/access_control/mod.rs
@@ -9,7 +9,7 @@
 //! - AccessZone (type 36)
 //! - CredentialDataInput (type 37)
 
-use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{DoorValue, ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{Date, ObjectIdentifier, PropertyValue, StatusFlags, Time};
 use std::borrow::Cow;

--- a/crates/bacnet-objects/src/access_control/tests.rs
+++ b/crates/bacnet-objects/src/access_control/tests.rs
@@ -552,7 +552,8 @@ fn access_door_relinquish_default_write_recaptures_present_value() {
 
     // Every named BACnetDoorValue is accepted, including
     // extended-pulse-unlock (3) — matching the priority-slot PV arm.
-    for named in [0u32, 2, 3] {
+    for &(_, value) in DoorValue::ALL_NAMED {
+        let named = value.to_raw();
         door.write_property(
             PropertyIdentifier::RELINQUISH_DEFAULT,
             None,

--- a/crates/bacnet-objects/src/elevator.rs
+++ b/crates/bacnet-objects/src/elevator.rs
@@ -186,7 +186,10 @@ pub struct EscalatorObject {
     energy_meter_ref: Vec<u8>,
     /// Power mode (Boolean).
     power_mode: bool,
-    /// Operation direction (Enumerated: 0=unknown, 1=up, 2=down, 3=stopped).
+    /// Operation direction (BACnetEscalatorOperationDirection, Clause 21):
+    /// 0=unknown, 1=stopped, 2=up-rated-speed, 3=up-reduced-speed,
+    /// 4=down-rated-speed, 5=down-reduced-speed. Retyping this raw `u32` to
+    /// the enum is tracked in #284.
     operation_direction: u32,
     status_flags: StatusFlags,
     out_of_service: bool,

--- a/crates/bacnet-objects/src/lighting/mod.rs
+++ b/crates/bacnet-objects/src/lighting/mod.rs
@@ -319,7 +319,7 @@ pub struct BinaryLightingOutputObject {
 impl BinaryLightingOutputObject {
     /// Highest BinaryLightingPV value accepted in writes. The Clause 21
     /// production runs off=0, on=1, warn=2, warn-off=3, warn-relinquish=4,
-    /// stop=5; this object accepts 0..=4 (stop is a known gap, #253).
+    /// stop=5; this object accepts 0..=4 (stop is a known gap, #283).
     const MAX_PV: u32 = 4;
 
     /// Create a new Binary Lighting Output object.

--- a/crates/bacnet-objects/src/lighting/mod.rs
+++ b/crates/bacnet-objects/src/lighting/mod.rs
@@ -298,7 +298,8 @@ impl BACnetObject for LightingOutputObject {
 /// BACnet Binary Lighting Output object.
 ///
 /// Commandable output with a 16-level priority array controlling an
-/// Enumerated present-value: 0=off, 1=on, 2=warn, 3=warn-off, 4=fade-on.
+/// Enumerated present-value (BACnetBinaryLightingPV, Clause 21): 0=off,
+/// 1=on, 2=warn, 3=warn-off, 4=warn-relinquish, 5=stop.
 pub struct BinaryLightingOutputObject {
     oid: ObjectIdentifier,
     name: String,
@@ -316,7 +317,9 @@ pub struct BinaryLightingOutputObject {
 }
 
 impl BinaryLightingOutputObject {
-    /// Valid BinaryLightingPV values: off=0, on=1, warn=2, warn-off=3, fade-on=4.
+    /// Highest BinaryLightingPV value accepted in writes. The Clause 21
+    /// production runs off=0, on=1, warn=2, warn-off=3, warn-relinquish=4,
+    /// stop=5; this object accepts 0..=4 (stop is a known gap, #253).
     const MAX_PV: u32 = 4;
 
     /// Create a new Binary Lighting Output object.
@@ -352,7 +355,8 @@ impl BinaryLightingOutputObject {
     /// Set the Relinquish_Default (#270).
     ///
     /// Validated the same way a commanded Present_Value is (BinaryLightingPV
-    /// 0..=4: off, on, warn, warn-off, fade-on) per Table 12-69; after the
+    /// 0..=4 of the Clause 21 production: off, on, warn, warn-off,
+    /// warn-relinquish) per Table 12-69; after the
     /// store, Present_Value is resolved anew from the priority array so an
     /// empty array falls back to the new default immediately.
     pub fn set_relinquish_default(&mut self, value: u32) -> Result<(), Error> {

--- a/crates/bacnet-objects/src/lighting/tests.rs
+++ b/crates/bacnet-objects/src/lighting/tests.rs
@@ -362,7 +362,7 @@ fn binary_lighting_output_priority_array_direct_write() {
     obj.write_property(
         PropertyIdentifier::PRIORITY_ARRAY,
         Some(3),
-        PropertyValue::Enumerated(4), // fade-on
+        PropertyValue::Enumerated(4), // warn-relinquish
         None,
     )
     .unwrap();
@@ -594,14 +594,15 @@ fn binary_lighting_output_relinquish_default_write_recaptures_present_value() {
     }
 }
 
-/// Binary Lighting Output: `Enumerated(5)` is past the BinaryLightingPV set
-/// (Table 12-69 types Relinquish_Default as BACnetBinaryLightingPV); the
-/// refuse carries PROPERTY / VALUE_OUT_OF_RANGE and the stored default is
-/// byte-identical afterward.
+/// Binary Lighting Output: `Enumerated(5)` is `stop` — inside the Clause 21
+/// BinaryLightingPV production (Table 12-69 types Relinquish_Default that
+/// way) but past the 0..=4 domain this object accepts; the refuse carries
+/// PROPERTY / VALUE_OUT_OF_RANGE and the stored default is byte-identical
+/// afterward.
 #[test]
 fn blo_relinquish_default_rejects_values_past_binary_lighting_pv() {
     let mut blo = BinaryLightingOutputObject::new(1, "BLO-1").unwrap();
-    blo.set_relinquish_default(4).unwrap(); // fade-on: the production ceiling
+    blo.set_relinquish_default(4).unwrap(); // warn-relinquish: the accepted-write ceiling
 
     for value in [
         PropertyValue::Enumerated(5),

--- a/crates/bacnet-types/src/enums/access.rs
+++ b/crates/bacnet-types/src/enums/access.rs
@@ -54,6 +54,16 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
+    /// BACnet door command for Access Door present values (Clause 21).
+    pub struct DoorValue(u32);
+
+    const LOCK = 0;
+    const UNLOCK = 1;
+    const PULSE_UNLOCK = 2;
+    const EXTENDED_PULSE_UNLOCK = 3;
+}
+
+bacnet_enum! {
     /// BACnet access event (Clause 12.33).
     pub struct AccessEvent(u32);
 
@@ -141,6 +151,19 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
+    /// BACnet authentication status for Credential Data Input (Clause 21).
+    pub struct AuthenticationStatus(u32);
+
+    const NOT_READY = 0;
+    const READY = 1;
+    const DISABLED = 2;
+    const WAITING_FOR_AUTHENTICATION_FACTOR = 3;
+    const WAITING_FOR_ACCOMPANIMENT = 4;
+    const WAITING_FOR_VERIFICATION = 5;
+    const IN_PROGRESS = 6;
+}
+
+bacnet_enum! {
     /// BACnet access user type (Clause 12.35).
     pub struct AccessUserType(u32);
 
@@ -162,10 +185,36 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
+    /// BACnet authorization check a credential is exempt from (Clause 21).
+    pub struct AuthorizationExemption(u32);
+
+    const PASSBACK = 0;
+    const OCCUPANCY_CHECK = 1;
+    const ACCESS_RIGHTS = 2;
+    const LOCKOUT = 3;
+    const DENY = 4;
+    const VERIFICATION = 5;
+    const AUTHORIZATION_DELAY = 6;
+}
+
+bacnet_enum! {
     /// BACnet access passback mode (Clause 12.32).
     pub struct AccessPassbackMode(u32);
 
     const PASSBACK_OFF = 0;
     const HARD_PASSBACK = 1;
     const SOFT_PASSBACK = 2;
+}
+
+bacnet_enum! {
+    /// BACnet access zone occupancy state (Clause 21).
+    pub struct AccessZoneOccupancyState(u32);
+
+    const NORMAL = 0;
+    const BELOW_LOWER_LIMIT = 1;
+    const AT_LOWER_LIMIT = 2;
+    const AT_UPPER_LIMIT = 3;
+    const ABOVE_UPPER_LIMIT = 4;
+    const DISABLED = 5;
+    const NOT_SUPPORTED = 6;
 }

--- a/crates/bacnet-types/src/enums/life_safety.rs
+++ b/crates/bacnet-types/src/enums/life_safety.rs
@@ -30,6 +30,17 @@ bacnet_enum! {
     const GENERAL_ALARM = 21;
     const SUPERVISORY = 22;
     const TEST_SUPERVISORY = 23;
+    const NON_DEFAULT_MODE = 24;
+    const OEO_UNAVAILABLE = 25;
+    const OEO_ALARM = 26;
+    const OEO_PHASE1_RECALL = 27;
+    const OEO_EVACUATE = 28;
+    const OEO_UNAFFECTED = 29;
+    const TEST_OEO_UNAVAILABLE = 30;
+    const TEST_OEO_ALARM = 31;
+    const TEST_OEO_PHASE1_RECALL = 32;
+    const TEST_OEO_EVACUATE = 33;
+    const TEST_OEO_UNAFFECTED = 34;
 }
 
 bacnet_enum! {

--- a/crates/bacnet-types/src/enums/lift.rs
+++ b/crates/bacnet-types/src/enums/lift.rs
@@ -30,6 +30,18 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
+    /// BACnet escalator operation direction and speed (Clause 21).
+    pub struct EscalatorOperationDirection(u32);
+
+    const UNKNOWN = 0;
+    const STOPPED = 1;
+    const UP_RATED_SPEED = 2;
+    const UP_REDUCED_SPEED = 3;
+    const DOWN_RATED_SPEED = 4;
+    const DOWN_REDUCED_SPEED = 5;
+}
+
+bacnet_enum! {
     /// BACnet lift car travel direction (Clause 12.59).
     pub struct LiftCarDirection(u32);
 

--- a/crates/bacnet-types/src/enums/lighting.rs
+++ b/crates/bacnet-types/src/enums/lighting.rs
@@ -1,6 +1,18 @@
 // ===========================================================================
-// Lighting enums (Clause 12.54)
+// Lighting enums (Clause 12.54, 12.55)
 // ===========================================================================
+
+bacnet_enum! {
+    /// BACnet binary lighting present value (Clause 21).
+    pub struct BinaryLightingPV(u32);
+
+    const OFF = 0;
+    const ON = 1;
+    const WARN = 2;
+    const WARN_OFF = 3;
+    const WARN_RELINQUISH = 4;
+    const STOP = 5;
+}
 
 bacnet_enum! {
     /// BACnet lighting operation (Clause 12.54).
@@ -28,4 +40,13 @@ bacnet_enum! {
     const RAMP_ACTIVE = 2;
     const NOT_CONTROLLED = 3;
     const OTHER = 4;
+}
+
+bacnet_enum! {
+    /// BACnet lighting transition kind (Clause 21).
+    pub struct LightingTransition(u32);
+
+    const NONE = 0;
+    const FADE = 1;
+    const RAMP = 2;
 }

--- a/crates/bacnet-types/src/enums/misc.rs
+++ b/crates/bacnet-types/src/enums/misc.rs
@@ -43,6 +43,59 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
+    /// BACnet maintenance type (Clause 21); used by life safety point/zone
+    /// and access door Maintenance_Required.
+    pub struct Maintenance(u32);
+
+    const NONE = 0;
+    const PERIODIC_TEST = 1;
+    const NEED_SERVICE_OPERATIONAL = 2;
+    const NEED_SERVICE_INOPERATIVE = 3;
+}
+
+bacnet_enum! {
+    /// BACnet subordinate/parent relationship for Structured View
+    /// (Clause 21).
+    ///
+    /// Values above `DEFAULT` come in even/odd forward/reverse pairs
+    /// (e.g. `CONTAINS`(2) / `CONTAINED_BY`(3)); proprietary extensions
+    /// follow the same pairing so the opposite of a relationship `n > 1` is
+    /// always `n ^ 1`.
+    pub struct Relationship(u32);
+
+    const UNKNOWN = 0;
+    const DEFAULT = 1;
+    const CONTAINS = 2;
+    const CONTAINED_BY = 3;
+    const USES = 4;
+    const USED_BY = 5;
+    const COMMANDS = 6;
+    const COMMANDED_BY = 7;
+    const ADJUSTS = 8;
+    const ADJUSTED_BY = 9;
+    const INGRESS = 10;
+    const EGRESS = 11;
+    const SUPPLIES_AIR = 12;
+    const RECEIVES_AIR = 13;
+    const SUPPLIES_HOT_AIR = 14;
+    const RECEIVES_HOT_AIR = 15;
+    const SUPPLIES_COOL_AIR = 16;
+    const RECEIVES_COOL_AIR = 17;
+    const SUPPLIES_POWER = 18;
+    const RECEIVES_POWER = 19;
+    const SUPPLIES_GAS = 20;
+    const RECEIVES_GAS = 21;
+    const SUPPLIES_WATER = 22;
+    const RECEIVES_WATER = 23;
+    const SUPPLIES_HOT_WATER = 24;
+    const RECEIVES_HOT_WATER = 25;
+    const SUPPLIES_COOL_WATER = 26;
+    const RECEIVES_COOL_WATER = 27;
+    const SUPPLIES_STEAM = 28;
+    const RECEIVES_STEAM = 29;
+}
+
+bacnet_enum! {
     /// BACnet acknowledgment filter for GetEnrollmentSummary (Clause 13.7.1).
     pub struct AcknowledgmentFilter(u32);
 

--- a/crates/bacnet-types/src/enums/network_port.rs
+++ b/crates/bacnet-types/src/enums/network_port.rs
@@ -14,7 +14,7 @@ bacnet_enum! {
     const IPV4 = 5;
     const ZIGBEE = 6;
     const VIRTUAL = 7;
-    /// Removed in protocol revision 16.
+    /// Removed in version 1, revision 18 (Clause 21 production comment).
     const NON_BACNET = 8;
     const IPV6 = 9;
     const SERIAL = 10;

--- a/crates/bacnet-types/src/enums/object_level.rs
+++ b/crates/bacnet-types/src/enums/object_level.rs
@@ -75,6 +75,21 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
+    /// BACnet restart reason for a Device's Last_Restart_Reason (Clause 12.11).
+    pub struct RestartReason(u32);
+
+    const UNKNOWN = 0;
+    const COLDSTART = 1;
+    const WARMSTART = 2;
+    const DETECTED_POWER_LOST = 3;
+    const DETECTED_POWERED_OFF = 4;
+    const HARDWARE_WATCHDOG = 5;
+    const SOFTWARE_WATCHDOG = 6;
+    const SUSPENDED = 7;
+    const ACTIVATE_CHANGES = 8;
+}
+
+bacnet_enum! {
     /// BACnet enable/disable (Clause 16.4).
     pub struct EnableDisable(u32);
 
@@ -128,6 +143,17 @@ bacnet_enum! {
     const HALT = 3;
     const RESTART = 4;
     const UNLOAD = 5;
+}
+
+bacnet_enum! {
+    /// BACnet program error for Reason_For_Halt (Clause 12.22).
+    pub struct ProgramError(u32);
+
+    const NORMAL = 0;
+    const LOAD_FAILED = 1;
+    const INTERNAL = 2;
+    const PROGRAM = 3;
+    const OTHER = 4;
 }
 
 bacnet_enum! {

--- a/crates/bacnet-types/src/enums/object_level.rs
+++ b/crates/bacnet-types/src/enums/object_level.rs
@@ -174,7 +174,10 @@ bacnet_enum! {
     const COMMAND_FAILURE = 3;
     const FLOATING_LIMIT = 4;
     const OUT_OF_RANGE = 5;
-    // 6-7: reserved
+    // 6: kept clear for proprietary event types — the parameters ride the
+    //    complex-event-type CHOICE [6] of BACnetNotificationParameters, so
+    //    the enumeration itself assigns no tag-6 enumerand (Clause 21).
+    // 7: context tag 7 is deprecated (Clause 21 production comment).
     const CHANGE_OF_LIFE_SAFETY = 8;
     const EXTENDED = 9;
     const BUFFER_READY = 10;

--- a/crates/bacnet-types/src/enums/resolve.rs
+++ b/crates/bacnet-types/src/enums/resolve.rs
@@ -73,14 +73,17 @@ resolved_enum! {
     BinaryPV(BinaryPV),
     ProgramState(ProgramState),
     ProgramChange(ProgramChange),
+    ProgramError(ProgramError),
     NodeType(NodeType),
     LoggingType(LoggingType),
     FileAccessMethod(FileAccessMethod),
     BackupAndRestoreState(BackupAndRestoreState),
+    RestartReason(RestartReason),
     LifeSafetyMode(LifeSafetyMode),
     LifeSafetyState(LifeSafetyState),
     LifeSafetyOperation(LifeSafetyOperation),
     SilencedState(SilencedState),
+    Maintenance(Maintenance),
     DoorStatus(DoorStatus),
     DoorAlarmState(DoorAlarmState),
     DoorSecuredStatus(DoorSecuredStatus),
@@ -91,18 +94,24 @@ resolved_enum! {
     AccessUserType(AccessUserType),
     AccessCredentialDisable(AccessCredentialDisable),
     AccessCredentialDisableReason(AccessCredentialDisableReason),
+    AuthenticationStatus(AuthenticationStatus),
+    AuthorizationExemption(AuthorizationExemption),
+    AccessZoneOccupancyState(AccessZoneOccupancyState),
+    Relationship(Relationship),
     NetworkType(NetworkType),
     NetworkNumberQuality(NetworkNumberQuality),
     IPMode(IPMode),
     NetworkPortCommand(NetworkPortCommand),
     ProtocolLevel(ProtocolLevel),
     LightingInProgress(LightingInProgress),
+    LightingTransition(LightingTransition),
     TimerState(TimerState),
     TimerTransition(TimerTransition),
     WriteStatus(WriteStatus),
     LiftCarMode(LiftCarMode),
     LiftGroupMode(LiftGroupMode),
     EscalatorMode(EscalatorMode),
+    EscalatorOperationDirection(EscalatorOperationDirection),
     LiftCarDriveStatus(LiftCarDriveStatus),
     LiftCarDirection(LiftCarDirection),
     LiftCarDoorCommand(LiftCarDoorCommand),
@@ -142,10 +151,12 @@ impl ResolvedEnum {
             6 => Self::BinaryPV(BinaryPV::from_raw(value)),
             92 => Self::ProgramState(ProgramState::from_raw(value)), // program-state
             90 => Self::ProgramChange(ProgramChange::from_raw(value)), // program-change
+            100 => Self::ProgramError(ProgramError::from_raw(value)), // reason-for-halt
             208 => Self::NodeType(NodeType::from_raw(value)),        // node-type
             197 => Self::LoggingType(LoggingType::from_raw(value)),  // logging-type
             41 => Self::FileAccessMethod(FileAccessMethod::from_raw(value)), // file-access-method
             338 => Self::BackupAndRestoreState(BackupAndRestoreState::from_raw(value)), // backup-and-restore-state
+            196 => Self::RestartReason(RestartReason::from_raw(value)), // last-restart-reason
 
             // Life safety.
             160 | 175 => Self::LifeSafetyMode(LifeSafetyMode::from_raw(value)), // mode / accepted-modes
@@ -154,6 +165,9 @@ impl ResolvedEnum {
             164 => Self::LifeSafetyState(LifeSafetyState::from_raw(value)),
             161 => Self::LifeSafetyOperation(LifeSafetyOperation::from_raw(value)), // operation-expected
             163 => Self::SilencedState(SilencedState::from_raw(value)),             // silenced
+            // maintenance-required: BACnetMaintenance on life safety
+            // point/zone (12.15/12.16) and access door (12.26).
+            158 => Self::Maintenance(Maintenance::from_raw(value)),
 
             // Access door.
             231 => Self::DoorStatus(DoorStatus::from_raw(value)), // door-status
@@ -170,6 +184,11 @@ impl ResolvedEnum {
             303 => {
                 Self::AccessCredentialDisableReason(AccessCredentialDisableReason::from_raw(value))
             } // reason-for-disable
+            260 => Self::AuthenticationStatus(AuthenticationStatus::from_raw(value)), // authentication-status
+            296 => Self::AccessZoneOccupancyState(AccessZoneOccupancyState::from_raw(value)), // occupancy-state
+            // authorization-exemptions is BACnetLIST of the exemption type;
+            // resolve_value recurses into list elements with the same arm.
+            364 => Self::AuthorizationExemption(AuthorizationExemption::from_raw(value)),
 
             // Network port.
             427 => Self::NetworkType(NetworkType::from_raw(value)), // network-type
@@ -178,8 +197,16 @@ impl ResolvedEnum {
             417 => Self::NetworkPortCommand(NetworkPortCommand::from_raw(value)), // command
             482 => Self::ProtocolLevel(ProtocolLevel::from_raw(value)), // protocol-level
 
+            // Structured view (12.29): subordinate-relationships is
+            // BACnetARRAY[N] of BACnetRelationship (resolve_value recurses
+            // into elements); default-subordinate-relationship is the scalar
+            // companion. Represents (491) is BACnetDeviceObjectReference, so
+            // it has no enumerating arm here.
+            489 | 490 => Self::Relationship(Relationship::from_raw(value)),
+
             // Lighting / timer / channel.
             378 => Self::LightingInProgress(LightingInProgress::from_raw(value)), // in-progress
+            385 => Self::LightingTransition(LightingTransition::from_raw(value)), // transition
             398 => Self::TimerState(TimerState::from_raw(value)),                 // timer-state
             395 => Self::TimerTransition(TimerTransition::from_raw(value)), // last-state-change
             370 => Self::WriteStatus(WriteStatus::from_raw(value)),         // write-status
@@ -188,6 +215,7 @@ impl ResolvedEnum {
             456 => Self::LiftCarMode(LiftCarMode::from_raw(value)), // car-mode
             467 => Self::LiftGroupMode(LiftGroupMode::from_raw(value)), // group-mode
             462 => Self::EscalatorMode(EscalatorMode::from_raw(value)), // escalator-mode
+            477 => Self::EscalatorOperationDirection(EscalatorOperationDirection::from_raw(value)), // operation-direction
             453 => Self::LiftCarDriveStatus(LiftCarDriveStatus::from_raw(value)), // car-drive-status
             448 | 457 => Self::LiftCarDirection(LiftCarDirection::from_raw(value)), // car-assigned/moving-direction
             449 => Self::LiftCarDoorCommand(LiftCarDoorCommand::from_raw(value)), // car-door-command

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -242,6 +242,93 @@ fn lighting_transition_values_match_clause_21() {
     }
 }
 
+/// 135-2020 Clause 21 (`BACnetDoorValue ::= ENUMERATED`): a closed set of
+/// four, exactly matching the domain Access Door writes validate against.
+#[test]
+fn door_value_values_match_clause_21() {
+    let all = [
+        ("LOCK", 0),
+        ("UNLOCK", 1),
+        ("PULSE_UNLOCK", 2),
+        ("EXTENDED_PULSE_UNLOCK", 3),
+    ];
+    assert_eq!(DoorValue::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = DoorValue::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(DoorValue::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
+/// 135-2020 Clause 21 (`BACnetAuthenticationStatus ::= ENUMERATED`): 1 is
+/// ready, *not* "waiting" — the wait-for-* states start at 3.
+#[test]
+fn authentication_status_values_match_clause_21() {
+    let all = [
+        ("NOT_READY", 0),
+        ("READY", 1),
+        ("DISABLED", 2),
+        ("WAITING_FOR_AUTHENTICATION_FACTOR", 3),
+        ("WAITING_FOR_ACCOMPANIMENT", 4),
+        ("WAITING_FOR_VERIFICATION", 5),
+        ("IN_PROGRESS", 6),
+    ];
+    assert_eq!(AuthenticationStatus::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = AuthenticationStatus::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(AuthenticationStatus::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
+/// 135-2020 Clause 21 (`BACnetAuthorizationExemption ::= ENUMERATED`).
+#[test]
+fn authorization_exemption_values_match_clause_21() {
+    let all = [
+        ("PASSBACK", 0),
+        ("OCCUPANCY_CHECK", 1),
+        ("ACCESS_RIGHTS", 2),
+        ("LOCKOUT", 3),
+        ("DENY", 4),
+        ("VERIFICATION", 5),
+        ("AUTHORIZATION_DELAY", 6),
+    ];
+    assert_eq!(AuthorizationExemption::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = AuthorizationExemption::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(AuthorizationExemption::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
+/// 135-2020 Clause 21 (`BACnetAccessZoneOccupancyState ::= ENUMERATED`).
+#[test]
+fn access_zone_occupancy_state_values_match_clause_21() {
+    let all = [
+        ("NORMAL", 0),
+        ("BELOW_LOWER_LIMIT", 1),
+        ("AT_LOWER_LIMIT", 2),
+        ("AT_UPPER_LIMIT", 3),
+        ("ABOVE_UPPER_LIMIT", 4),
+        ("DISABLED", 5),
+        ("NOT_SUPPORTED", 6),
+    ];
+    assert_eq!(AccessZoneOccupancyState::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = AccessZoneOccupancyState::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(AccessZoneOccupancyState::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
 #[test]
 fn backup_and_restore_state_failure_values() {
     // A device reporting either failure state during a Clause 19.1

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -145,6 +145,42 @@ fn reliability_multi_state_out_of_range() {
     );
 }
 
+/// 135-2020 Clause 21 (`BACnetLifeSafetyState ::= ENUMERATED`) runs through
+/// test-oeo-unaffected (34): the eleven values past test-supervisory (23)
+/// must exist without renumbering anything below them.
+#[test]
+fn life_safety_state_tail_values_match_clause_21() {
+    // Existing numbering is untouched.
+    assert_eq!(LifeSafetyState::TEST_SUPERVISORY.to_raw(), 23);
+    let tail = [
+        (LifeSafetyState::NON_DEFAULT_MODE, 24),
+        (LifeSafetyState::OEO_UNAVAILABLE, 25),
+        (LifeSafetyState::OEO_ALARM, 26),
+        (LifeSafetyState::OEO_PHASE1_RECALL, 27),
+        (LifeSafetyState::OEO_EVACUATE, 28),
+        (LifeSafetyState::OEO_UNAFFECTED, 29),
+        (LifeSafetyState::TEST_OEO_UNAVAILABLE, 30),
+        (LifeSafetyState::TEST_OEO_ALARM, 31),
+        (LifeSafetyState::TEST_OEO_PHASE1_RECALL, 32),
+        (LifeSafetyState::TEST_OEO_EVACUATE, 33),
+        (LifeSafetyState::TEST_OEO_UNAFFECTED, 34),
+    ];
+    for (state, raw) in tail {
+        assert_eq!(state.to_raw(), raw);
+        assert_eq!(LifeSafetyState::from_raw(raw), state);
+        assert_eq!(LifeSafetyState::ALL_NAMED[raw as usize].1, state);
+    }
+    assert_eq!(LifeSafetyState::ALL_NAMED.len(), 35);
+    assert_eq!(
+        format!("{}", LifeSafetyState::OEO_PHASE1_RECALL),
+        "OEO_PHASE1_RECALL"
+    );
+    assert_eq!(
+        format!("{}", LifeSafetyState::TEST_OEO_UNAFFECTED),
+        "TEST_OEO_UNAFFECTED"
+    );
+}
+
 #[test]
 fn backup_and_restore_state_failure_values() {
     // A device reporting either failure state during a Clause 19.1

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -181,6 +181,29 @@ fn life_safety_state_tail_values_match_clause_21() {
     );
 }
 
+/// 135-2020 Clause 21 (`BACnetEscalatorOperationDirection ::= ENUMERATED`):
+/// the values are direction *and* speed combined (reduced vs rated), not a
+/// plain up/down triplet.
+#[test]
+fn escalator_operation_direction_values_match_clause_21() {
+    let all = [
+        ("UNKNOWN", 0),
+        ("STOPPED", 1),
+        ("UP_RATED_SPEED", 2),
+        ("UP_REDUCED_SPEED", 3),
+        ("DOWN_RATED_SPEED", 4),
+        ("DOWN_REDUCED_SPEED", 5),
+    ];
+    assert_eq!(EscalatorOperationDirection::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = EscalatorOperationDirection::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(EscalatorOperationDirection::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
 #[test]
 fn backup_and_restore_state_failure_values() {
     // A device reporting either failure state during a Clause 19.1

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -329,6 +329,125 @@ fn access_zone_occupancy_state_values_match_clause_21() {
     }
 }
 
+/// 135-2020 Clause 21 (`BACnetProgramError ::= ENUMERATED`), the type of the
+/// Program object's Reason_For_Halt.
+#[test]
+fn program_error_values_match_clause_21() {
+    let all = [
+        ("NORMAL", 0),
+        ("LOAD_FAILED", 1),
+        ("INTERNAL", 2),
+        ("PROGRAM", 3),
+        ("OTHER", 4),
+    ];
+    assert_eq!(ProgramError::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = ProgramError::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(ProgramError::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
+/// 135-2020 Clause 21 (`BACnetRestartReason ::= ENUMERATED`), the type of the
+/// Device object's Last_Restart_Reason.
+#[test]
+fn restart_reason_values_match_clause_21() {
+    let all = [
+        ("UNKNOWN", 0),
+        ("COLDSTART", 1),
+        ("WARMSTART", 2),
+        ("DETECTED_POWER_LOST", 3),
+        ("DETECTED_POWERED_OFF", 4),
+        ("HARDWARE_WATCHDOG", 5),
+        ("SOFTWARE_WATCHDOG", 6),
+        ("SUSPENDED", 7),
+        ("ACTIVATE_CHANGES", 8),
+    ];
+    assert_eq!(RestartReason::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = RestartReason::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(RestartReason::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
+/// 135-2020 Clause 21 (`BACnetMaintenance ::= ENUMERATED`).
+#[test]
+fn maintenance_values_match_clause_21() {
+    let all = [
+        ("NONE", 0),
+        ("PERIODIC_TEST", 1),
+        ("NEED_SERVICE_OPERATIONAL", 2),
+        ("NEED_SERVICE_INOPERATIVE", 3),
+    ];
+    assert_eq!(Maintenance::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = Maintenance::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(Maintenance::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
+/// 135-2020 Clause 21 (`BACnetRelationship ::= ENUMERATED`): after
+/// unknown/default, every value is one half of an even/odd forward/reverse
+/// pair, so `n ^ 1` must always name the opposite relationship.
+#[test]
+fn relationship_values_match_clause_21() {
+    let all = [
+        ("UNKNOWN", 0),
+        ("DEFAULT", 1),
+        ("CONTAINS", 2),
+        ("CONTAINED_BY", 3),
+        ("USES", 4),
+        ("USED_BY", 5),
+        ("COMMANDS", 6),
+        ("COMMANDED_BY", 7),
+        ("ADJUSTS", 8),
+        ("ADJUSTED_BY", 9),
+        ("INGRESS", 10),
+        ("EGRESS", 11),
+        ("SUPPLIES_AIR", 12),
+        ("RECEIVES_AIR", 13),
+        ("SUPPLIES_HOT_AIR", 14),
+        ("RECEIVES_HOT_AIR", 15),
+        ("SUPPLIES_COOL_AIR", 16),
+        ("RECEIVES_COOL_AIR", 17),
+        ("SUPPLIES_POWER", 18),
+        ("RECEIVES_POWER", 19),
+        ("SUPPLIES_GAS", 20),
+        ("RECEIVES_GAS", 21),
+        ("SUPPLIES_WATER", 22),
+        ("RECEIVES_WATER", 23),
+        ("SUPPLIES_HOT_WATER", 24),
+        ("RECEIVES_HOT_WATER", 25),
+        ("SUPPLIES_COOL_WATER", 26),
+        ("RECEIVES_COOL_WATER", 27),
+        ("SUPPLIES_STEAM", 28),
+        ("RECEIVES_STEAM", 29),
+    ];
+    assert_eq!(Relationship::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = Relationship::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(Relationship::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+    // The forward/reverse pairing is structural in the production.
+    for pair in all[2..].chunks_exact(2) {
+        let (fwd_name, fwd) = pair[0];
+        let (rev_name, rev) = pair[1];
+        assert_eq!(fwd ^ 1, rev, "{fwd_name} / {rev_name}");
+        assert!(fwd_name.starts_with("SUPPLIES") || rev_name.ends_with("_BY") || rev_name == "EGRESS");
+    }
+}
+
 #[test]
 fn backup_and_restore_state_failure_values() {
     // A device reporting either failure state during a Clause 19.1
@@ -399,6 +518,17 @@ fn from_str_round_trips_display_for_all_named() {
         Reliability,
         BackupAndRestoreState,
         LifeSafetyState,
+        EscalatorOperationDirection,
+        BinaryLightingPV,
+        LightingTransition,
+        DoorValue,
+        AuthenticationStatus,
+        AuthorizationExemption,
+        AccessZoneOccupancyState,
+        ProgramError,
+        RestartReason,
+        Maintenance,
+        Relationship,
     );
 }
 

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -204,6 +204,44 @@ fn escalator_operation_direction_values_match_clause_21() {
     }
 }
 
+/// 135-2020 Clause 21 (`BACnetBinaryLightingPV ::= ENUMERATED`): the set is
+/// off/on/warn/warn-off/warn-relinquish/stop. There is no "fade-on" value —
+/// 4 is warn-relinquish and 5 is stop — and both reserved-value comments and
+/// object-code caps that assumed otherwise were wrong.
+#[test]
+fn binary_lighting_pv_values_match_clause_21() {
+    let all = [
+        ("OFF", 0),
+        ("ON", 1),
+        ("WARN", 2),
+        ("WARN_OFF", 3),
+        ("WARN_RELINQUISH", 4),
+        ("STOP", 5),
+    ];
+    assert_eq!(BinaryLightingPV::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = BinaryLightingPV::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(BinaryLightingPV::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
+/// 135-2020 Clause 21 (`BACnetLightingTransition ::= ENUMERATED`).
+#[test]
+fn lighting_transition_values_match_clause_21() {
+    let all = [("NONE", 0), ("FADE", 1), ("RAMP", 2)];
+    assert_eq!(LightingTransition::ALL_NAMED.len(), all.len());
+    for (i, &(name, raw)) in all.iter().enumerate() {
+        let (named_name, value) = LightingTransition::ALL_NAMED[i];
+        assert_eq!(named_name, name);
+        assert_eq!(value.to_raw(), raw);
+        assert_eq!(LightingTransition::from_raw(raw), value);
+        assert_eq!(format!("{value}"), name);
+    }
+}
+
 #[test]
 fn backup_and_restore_state_failure_values() {
     // A device reporting either failure state during a Clause 19.1

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::primitives::PropertyValue;
 
 #[test]
 fn object_type_round_trip() {
@@ -145,6 +146,23 @@ fn reliability_multi_state_out_of_range() {
     );
 }
 
+/// Assert a table of (`Display` name, raw value) pairs against a
+/// `bacnet_enum!` type's `ALL_NAMED`: same length, same order, and every
+/// entry round-trips `from_raw` / `Display`.
+macro_rules! assert_production_values {
+    ($Ty:ident, [$($pair:expr),+ $(,)?] $(,)?) => {
+        let all = [$($pair),+];
+        assert_eq!($Ty::ALL_NAMED.len(), all.len(), "{} count", stringify!($Ty));
+        for (i, &(name, raw)) in all.iter().enumerate() {
+            let (named_name, value) = $Ty::ALL_NAMED[i];
+            assert_eq!(named_name, name, "{} [{i}]", stringify!($Ty));
+            assert_eq!(value.to_raw(), raw, "{} [{i}]", stringify!($Ty));
+            assert_eq!($Ty::from_raw(raw), value, "{} [{i}]", stringify!($Ty));
+            assert_eq!(format!("{value}"), name, "{} [{i}]", stringify!($Ty));
+        }
+    };
+}
+
 /// 135-2020 Clause 21 (`BACnetLifeSafetyState ::= ENUMERATED`) runs through
 /// test-oeo-unaffected (34): the eleven values past test-supervisory (23)
 /// must exist without renumbering anything below them.
@@ -186,212 +204,158 @@ fn life_safety_state_tail_values_match_clause_21() {
 /// plain up/down triplet.
 #[test]
 fn escalator_operation_direction_values_match_clause_21() {
-    let all = [
-        ("UNKNOWN", 0),
-        ("STOPPED", 1),
-        ("UP_RATED_SPEED", 2),
-        ("UP_REDUCED_SPEED", 3),
-        ("DOWN_RATED_SPEED", 4),
-        ("DOWN_REDUCED_SPEED", 5),
-    ];
-    assert_eq!(EscalatorOperationDirection::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = EscalatorOperationDirection::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(EscalatorOperationDirection::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        EscalatorOperationDirection,
+        [
+            ("UNKNOWN", 0),
+            ("STOPPED", 1),
+            ("UP_RATED_SPEED", 2),
+            ("UP_REDUCED_SPEED", 3),
+            ("DOWN_RATED_SPEED", 4),
+            ("DOWN_REDUCED_SPEED", 5),
+        ],
+    );
 }
 
 /// 135-2020 Clause 21 (`BACnetBinaryLightingPV ::= ENUMERATED`): the set is
 /// off/on/warn/warn-off/warn-relinquish/stop. There is no "fade-on" value —
-/// 4 is warn-relinquish and 5 is stop — and both reserved-value comments and
-/// object-code caps that assumed otherwise were wrong.
+/// 4 is warn-relinquish and 5 is stop.
 #[test]
 fn binary_lighting_pv_values_match_clause_21() {
-    let all = [
-        ("OFF", 0),
-        ("ON", 1),
-        ("WARN", 2),
-        ("WARN_OFF", 3),
-        ("WARN_RELINQUISH", 4),
-        ("STOP", 5),
-    ];
-    assert_eq!(BinaryLightingPV::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = BinaryLightingPV::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(BinaryLightingPV::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        BinaryLightingPV,
+        [
+            ("OFF", 0),
+            ("ON", 1),
+            ("WARN", 2),
+            ("WARN_OFF", 3),
+            ("WARN_RELINQUISH", 4),
+            ("STOP", 5),
+        ],
+    );
 }
 
 /// 135-2020 Clause 21 (`BACnetLightingTransition ::= ENUMERATED`).
 #[test]
 fn lighting_transition_values_match_clause_21() {
-    let all = [("NONE", 0), ("FADE", 1), ("RAMP", 2)];
-    assert_eq!(LightingTransition::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = LightingTransition::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(LightingTransition::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(LightingTransition, [("NONE", 0), ("FADE", 1), ("RAMP", 2)]);
 }
 
 /// 135-2020 Clause 21 (`BACnetDoorValue ::= ENUMERATED`): a closed set of
 /// four, exactly matching the domain Access Door writes validate against.
 #[test]
 fn door_value_values_match_clause_21() {
-    let all = [
-        ("LOCK", 0),
-        ("UNLOCK", 1),
-        ("PULSE_UNLOCK", 2),
-        ("EXTENDED_PULSE_UNLOCK", 3),
-    ];
-    assert_eq!(DoorValue::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = DoorValue::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(DoorValue::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        DoorValue,
+        [
+            ("LOCK", 0),
+            ("UNLOCK", 1),
+            ("PULSE_UNLOCK", 2),
+            ("EXTENDED_PULSE_UNLOCK", 3),
+        ],
+    );
 }
 
 /// 135-2020 Clause 21 (`BACnetAuthenticationStatus ::= ENUMERATED`): 1 is
 /// ready, *not* "waiting" — the wait-for-* states start at 3.
 #[test]
 fn authentication_status_values_match_clause_21() {
-    let all = [
-        ("NOT_READY", 0),
-        ("READY", 1),
-        ("DISABLED", 2),
-        ("WAITING_FOR_AUTHENTICATION_FACTOR", 3),
-        ("WAITING_FOR_ACCOMPANIMENT", 4),
-        ("WAITING_FOR_VERIFICATION", 5),
-        ("IN_PROGRESS", 6),
-    ];
-    assert_eq!(AuthenticationStatus::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = AuthenticationStatus::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(AuthenticationStatus::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        AuthenticationStatus,
+        [
+            ("NOT_READY", 0),
+            ("READY", 1),
+            ("DISABLED", 2),
+            ("WAITING_FOR_AUTHENTICATION_FACTOR", 3),
+            ("WAITING_FOR_ACCOMPANIMENT", 4),
+            ("WAITING_FOR_VERIFICATION", 5),
+            ("IN_PROGRESS", 6),
+        ],
+    );
 }
 
 /// 135-2020 Clause 21 (`BACnetAuthorizationExemption ::= ENUMERATED`).
 #[test]
 fn authorization_exemption_values_match_clause_21() {
-    let all = [
-        ("PASSBACK", 0),
-        ("OCCUPANCY_CHECK", 1),
-        ("ACCESS_RIGHTS", 2),
-        ("LOCKOUT", 3),
-        ("DENY", 4),
-        ("VERIFICATION", 5),
-        ("AUTHORIZATION_DELAY", 6),
-    ];
-    assert_eq!(AuthorizationExemption::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = AuthorizationExemption::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(AuthorizationExemption::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        AuthorizationExemption,
+        [
+            ("PASSBACK", 0),
+            ("OCCUPANCY_CHECK", 1),
+            ("ACCESS_RIGHTS", 2),
+            ("LOCKOUT", 3),
+            ("DENY", 4),
+            ("VERIFICATION", 5),
+            ("AUTHORIZATION_DELAY", 6),
+        ],
+    );
 }
 
 /// 135-2020 Clause 21 (`BACnetAccessZoneOccupancyState ::= ENUMERATED`).
 #[test]
 fn access_zone_occupancy_state_values_match_clause_21() {
-    let all = [
-        ("NORMAL", 0),
-        ("BELOW_LOWER_LIMIT", 1),
-        ("AT_LOWER_LIMIT", 2),
-        ("AT_UPPER_LIMIT", 3),
-        ("ABOVE_UPPER_LIMIT", 4),
-        ("DISABLED", 5),
-        ("NOT_SUPPORTED", 6),
-    ];
-    assert_eq!(AccessZoneOccupancyState::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = AccessZoneOccupancyState::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(AccessZoneOccupancyState::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        AccessZoneOccupancyState,
+        [
+            ("NORMAL", 0),
+            ("BELOW_LOWER_LIMIT", 1),
+            ("AT_LOWER_LIMIT", 2),
+            ("AT_UPPER_LIMIT", 3),
+            ("ABOVE_UPPER_LIMIT", 4),
+            ("DISABLED", 5),
+            ("NOT_SUPPORTED", 6),
+        ],
+    );
 }
 
 /// 135-2020 Clause 21 (`BACnetProgramError ::= ENUMERATED`), the type of the
 /// Program object's Reason_For_Halt.
 #[test]
 fn program_error_values_match_clause_21() {
-    let all = [
-        ("NORMAL", 0),
-        ("LOAD_FAILED", 1),
-        ("INTERNAL", 2),
-        ("PROGRAM", 3),
-        ("OTHER", 4),
-    ];
-    assert_eq!(ProgramError::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = ProgramError::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(ProgramError::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        ProgramError,
+        [
+            ("NORMAL", 0),
+            ("LOAD_FAILED", 1),
+            ("INTERNAL", 2),
+            ("PROGRAM", 3),
+            ("OTHER", 4),
+        ],
+    );
 }
 
 /// 135-2020 Clause 21 (`BACnetRestartReason ::= ENUMERATED`), the type of the
 /// Device object's Last_Restart_Reason.
 #[test]
 fn restart_reason_values_match_clause_21() {
-    let all = [
-        ("UNKNOWN", 0),
-        ("COLDSTART", 1),
-        ("WARMSTART", 2),
-        ("DETECTED_POWER_LOST", 3),
-        ("DETECTED_POWERED_OFF", 4),
-        ("HARDWARE_WATCHDOG", 5),
-        ("SOFTWARE_WATCHDOG", 6),
-        ("SUSPENDED", 7),
-        ("ACTIVATE_CHANGES", 8),
-    ];
-    assert_eq!(RestartReason::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = RestartReason::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(RestartReason::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        RestartReason,
+        [
+            ("UNKNOWN", 0),
+            ("COLDSTART", 1),
+            ("WARMSTART", 2),
+            ("DETECTED_POWER_LOST", 3),
+            ("DETECTED_POWERED_OFF", 4),
+            ("HARDWARE_WATCHDOG", 5),
+            ("SOFTWARE_WATCHDOG", 6),
+            ("SUSPENDED", 7),
+            ("ACTIVATE_CHANGES", 8),
+        ],
+    );
 }
 
 /// 135-2020 Clause 21 (`BACnetMaintenance ::= ENUMERATED`).
 #[test]
 fn maintenance_values_match_clause_21() {
-    let all = [
-        ("NONE", 0),
-        ("PERIODIC_TEST", 1),
-        ("NEED_SERVICE_OPERATIONAL", 2),
-        ("NEED_SERVICE_INOPERATIVE", 3),
-    ];
-    assert_eq!(Maintenance::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = Maintenance::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(Maintenance::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        Maintenance,
+        [
+            ("NONE", 0),
+            ("PERIODIC_TEST", 1),
+            ("NEED_SERVICE_OPERATIONAL", 2),
+            ("NEED_SERVICE_INOPERATIVE", 3),
+        ],
+    );
 }
 
 /// 135-2020 Clause 21 (`BACnetRelationship ::= ENUMERATED`): after
@@ -399,52 +363,49 @@ fn maintenance_values_match_clause_21() {
 /// pair, so `n ^ 1` must always name the opposite relationship.
 #[test]
 fn relationship_values_match_clause_21() {
-    let all = [
-        ("UNKNOWN", 0),
-        ("DEFAULT", 1),
-        ("CONTAINS", 2),
-        ("CONTAINED_BY", 3),
-        ("USES", 4),
-        ("USED_BY", 5),
-        ("COMMANDS", 6),
-        ("COMMANDED_BY", 7),
-        ("ADJUSTS", 8),
-        ("ADJUSTED_BY", 9),
-        ("INGRESS", 10),
-        ("EGRESS", 11),
-        ("SUPPLIES_AIR", 12),
-        ("RECEIVES_AIR", 13),
-        ("SUPPLIES_HOT_AIR", 14),
-        ("RECEIVES_HOT_AIR", 15),
-        ("SUPPLIES_COOL_AIR", 16),
-        ("RECEIVES_COOL_AIR", 17),
-        ("SUPPLIES_POWER", 18),
-        ("RECEIVES_POWER", 19),
-        ("SUPPLIES_GAS", 20),
-        ("RECEIVES_GAS", 21),
-        ("SUPPLIES_WATER", 22),
-        ("RECEIVES_WATER", 23),
-        ("SUPPLIES_HOT_WATER", 24),
-        ("RECEIVES_HOT_WATER", 25),
-        ("SUPPLIES_COOL_WATER", 26),
-        ("RECEIVES_COOL_WATER", 27),
-        ("SUPPLIES_STEAM", 28),
-        ("RECEIVES_STEAM", 29),
-    ];
-    assert_eq!(Relationship::ALL_NAMED.len(), all.len());
-    for (i, &(name, raw)) in all.iter().enumerate() {
-        let (named_name, value) = Relationship::ALL_NAMED[i];
-        assert_eq!(named_name, name);
-        assert_eq!(value.to_raw(), raw);
-        assert_eq!(Relationship::from_raw(raw), value);
-        assert_eq!(format!("{value}"), name);
-    }
+    assert_production_values!(
+        Relationship,
+        [
+            ("UNKNOWN", 0),
+            ("DEFAULT", 1),
+            ("CONTAINS", 2),
+            ("CONTAINED_BY", 3),
+            ("USES", 4),
+            ("USED_BY", 5),
+            ("COMMANDS", 6),
+            ("COMMANDED_BY", 7),
+            ("ADJUSTS", 8),
+            ("ADJUSTED_BY", 9),
+            ("INGRESS", 10),
+            ("EGRESS", 11),
+            ("SUPPLIES_AIR", 12),
+            ("RECEIVES_AIR", 13),
+            ("SUPPLIES_HOT_AIR", 14),
+            ("RECEIVES_HOT_AIR", 15),
+            ("SUPPLIES_COOL_AIR", 16),
+            ("RECEIVES_COOL_AIR", 17),
+            ("SUPPLIES_POWER", 18),
+            ("RECEIVES_POWER", 19),
+            ("SUPPLIES_GAS", 20),
+            ("RECEIVES_GAS", 21),
+            ("SUPPLIES_WATER", 22),
+            ("RECEIVES_WATER", 23),
+            ("SUPPLIES_HOT_WATER", 24),
+            ("RECEIVES_HOT_WATER", 25),
+            ("SUPPLIES_COOL_WATER", 26),
+            ("RECEIVES_COOL_WATER", 27),
+            ("SUPPLIES_STEAM", 28),
+            ("RECEIVES_STEAM", 29),
+        ],
+    );
     // The forward/reverse pairing is structural in the production.
-    for pair in all[2..].chunks_exact(2) {
+    for pair in Relationship::ALL_NAMED[2..].chunks_exact(2) {
         let (fwd_name, fwd) = pair[0];
         let (rev_name, rev) = pair[1];
-        assert_eq!(fwd ^ 1, rev, "{fwd_name} / {rev_name}");
-        assert!(fwd_name.starts_with("SUPPLIES") || rev_name.ends_with("_BY") || rev_name == "EGRESS");
+        assert_eq!(fwd.to_raw() ^ 1, rev.to_raw(), "{fwd_name} / {rev_name}");
+        assert!(
+            fwd_name.starts_with("SUPPLIES") || rev_name.ends_with("_BY") || rev_name == "EGRESS"
+        );
     }
 }
 
@@ -461,6 +422,153 @@ fn backup_and_restore_state_failure_values() {
     assert_eq!(
         format!("{}", BackupAndRestoreState::from_raw(6)),
         "RESTORE_FAILURE"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// ResolvedEnum arms added for #253
+// ---------------------------------------------------------------------------
+
+/// Each property identifier mapped in `resolve.rs` by the #253 additions
+/// promotes a raw number to its named enumeration.
+#[test]
+fn resolves_253_properties_by_name() {
+    let cases: [(PropertyIdentifier, u32, ResolvedEnum, &str); 12] = [
+        (
+            PropertyIdentifier::OPERATION_DIRECTION,
+            2,
+            ResolvedEnum::EscalatorOperationDirection(EscalatorOperationDirection::UP_RATED_SPEED),
+            "UP_RATED_SPEED",
+        ),
+        (
+            PropertyIdentifier::LAST_RESTART_REASON,
+            5,
+            ResolvedEnum::RestartReason(RestartReason::HARDWARE_WATCHDOG),
+            "HARDWARE_WATCHDOG",
+        ),
+        (
+            PropertyIdentifier::REASON_FOR_HALT,
+            1,
+            ResolvedEnum::ProgramError(ProgramError::LOAD_FAILED),
+            "LOAD_FAILED",
+        ),
+        (
+            PropertyIdentifier::AUTHENTICATION_STATUS,
+            3,
+            ResolvedEnum::AuthenticationStatus(
+                AuthenticationStatus::WAITING_FOR_AUTHENTICATION_FACTOR,
+            ),
+            "WAITING_FOR_AUTHENTICATION_FACTOR",
+        ),
+        (
+            PropertyIdentifier::MAINTENANCE_REQUIRED,
+            2,
+            ResolvedEnum::Maintenance(Maintenance::NEED_SERVICE_OPERATIONAL),
+            "NEED_SERVICE_OPERATIONAL",
+        ),
+        (
+            PropertyIdentifier::SUBORDINATE_RELATIONSHIPS,
+            12,
+            ResolvedEnum::Relationship(Relationship::SUPPLIES_AIR),
+            "SUPPLIES_AIR",
+        ),
+        (
+            PropertyIdentifier::DEFAULT_SUBORDINATE_RELATIONSHIP,
+            1,
+            ResolvedEnum::Relationship(Relationship::DEFAULT),
+            "DEFAULT",
+        ),
+        (
+            PropertyIdentifier::OCCUPANCY_STATE,
+            4,
+            ResolvedEnum::AccessZoneOccupancyState(AccessZoneOccupancyState::ABOVE_UPPER_LIMIT),
+            "ABOVE_UPPER_LIMIT",
+        ),
+        (
+            PropertyIdentifier::AUTHORIZATION_EXEMPTIONS,
+            0,
+            ResolvedEnum::AuthorizationExemption(AuthorizationExemption::PASSBACK),
+            "PASSBACK",
+        ),
+        (
+            PropertyIdentifier::TRANSITION,
+            1,
+            ResolvedEnum::LightingTransition(LightingTransition::FADE),
+            "FADE",
+        ),
+        (
+            PropertyIdentifier::TRACKING_VALUE,
+            25,
+            ResolvedEnum::LifeSafetyState(LifeSafetyState::OEO_UNAVAILABLE),
+            "OEO_UNAVAILABLE",
+        ),
+        (
+            PropertyIdentifier::TRACKING_VALUE,
+            33,
+            ResolvedEnum::LifeSafetyState(LifeSafetyState::TEST_OEO_EVACUATE),
+            "TEST_OEO_EVACUATE",
+        ),
+    ];
+    for (property, raw, expected, display) in cases {
+        let resolved = ResolvedEnum::from_property(property, raw);
+        assert_eq!(resolved, expected, "{property}");
+        assert_eq!(resolved.to_string(), display, "{property}");
+    }
+}
+
+/// Out-of-production values stay named-but-numeric through the arms (the
+/// newtype keeps the raw number; Display falls back to it).
+#[test]
+fn resolves_253_properties_unknown_values_stay_numeric() {
+    let r = ResolvedEnum::from_property(PropertyIdentifier::OPERATION_DIRECTION, 42);
+    assert_eq!(
+        r,
+        ResolvedEnum::EscalatorOperationDirection(EscalatorOperationDirection::from_raw(42))
+    );
+    assert_eq!(r.to_string(), "42");
+}
+
+/// The two list-valued properties (subordinate-relationships is a
+/// BACnetARRAY, authorization-exemptions a BACnetLIST) resolve each element
+/// through the same arm via `resolve_value`'s recursion.
+#[test]
+fn resolves_253_list_properties_elementwise() {
+    let list = PropertyValue::List(vec![
+        PropertyValue::Enumerated(2),  // contains
+        PropertyValue::Enumerated(28), // supplies-steam
+    ]);
+    let ResolvedValue::List(items) =
+        resolve_value(PropertyIdentifier::SUBORDINATE_RELATIONSHIPS, list)
+    else {
+        panic!("expected list");
+    };
+    assert_eq!(
+        items,
+        [
+            ResolvedValue::Enumerated(ResolvedEnum::Relationship(Relationship::CONTAINS)),
+            ResolvedValue::Enumerated(ResolvedEnum::Relationship(Relationship::SUPPLIES_STEAM)),
+        ]
+    );
+
+    let list = PropertyValue::List(vec![
+        PropertyValue::Enumerated(3), // lockout
+        PropertyValue::Enumerated(5), // verification
+    ]);
+    let ResolvedValue::List(items) =
+        resolve_value(PropertyIdentifier::AUTHORIZATION_EXEMPTIONS, list)
+    else {
+        panic!("expected list");
+    };
+    assert_eq!(
+        items,
+        [
+            ResolvedValue::Enumerated(ResolvedEnum::AuthorizationExemption(
+                AuthorizationExemption::LOCKOUT
+            )),
+            ResolvedValue::Enumerated(ResolvedEnum::AuthorizationExemption(
+                AuthorizationExemption::VERIFICATION
+            )),
+        ]
     );
 }
 


### PR DESCRIPTION
## What

Additive 135-2020 enumeration parity for the missing Clause 21 productions found by the Tranche-Q audit, plus the `resolve.rs` arms that promote their wire values to named variants, and two comment/one-doc corrections the audit surfaced. Only one production was *edited*: `LifeSafetyState` gains its tail; everything else is new types.

All values below were transcribed from the local extract
(`std135-2020.txt`, extracted from `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf`) and **verified name↔number by reading the surrounding lines**, because the two-column page layout interleaves names and `(N)` fragments near page breaks (see *Verification* below).

### New / completed enumerations (production cites = verified extract lines)

| Type (crate name) | Values | Production (extract lines) |
|---|---|---|
| `LifeSafetyState` — appended tail | non-default-mode(24)…test-oeo-unaffected(34) | 66032–66115; breaks at page 910→911 between `general-alarm (21)` and `supervisory (22)`, pairing stays sequential; no existing value renumbered (existing tail `TEST_SUPERVISORY = 23` at life_safety.rs:32 retained) |
| `EscalatorOperationDirection` | unknown(0), stopped(1), up-rated-speed(2), up-reduced-speed(3), down-rated-speed(4), down-reduced-speed(5) | 65358–65372 |
| `BinaryLightingPV` | off(0), on(1), warn(2), warn-off(3), warn-relinquish(4), stop(5) | 63711–63725 |
| `LightingTransition` | none(0), fade(1), ramp(2) | 66340–66350 |
| `ProgramError` | normal(0), load-failed(1), internal(2), program(3), other(4) | 67557–67569 |
| `RestartReason` | unknown(0), coldstart(1), warmstart(2), detected-power-lost(3), detected-powered-off(4), hardware-watchdog(5), software-watchdog(6), suspended(7), activate-changes(8) | 70050–70069 (945-page trailer) |
| `AuthenticationStatus` | not-ready(0), ready(1), disabled(2), waiting-for-authentication-factor(3), waiting-for-accompaniment(4), waiting-for-verification(5), in-progress(6); **closed set** (no `...`) | 63625–63640 |
| `Maintenance` | none(0), periodic-test(1), need-service-operational(2), need-service-inoperative(3) | 66490–66500 |
| `Relationship` | unknown(0), default(1), then even/odd forward/reverse pairs contains(2)…receives-steam(29); the production's own pairing comment (69918–69920) is mirrored in the type docs and asserted structurally (`n^1`) in the test | 69914–69989; breaks at page 944→945 between `supplies-hot-water (24)` and `receives-hot-water (25)`, pairing stays sequential |
| `AccessZoneOccupancyState` | normal(0), below-lower-limit(1), at-lower-limit(2), at-upper-limit(3), above-upper-limit(4), disabled(5), not-supported(6) | 63189–63205 |
| `AuthorizationExemption` | passback(0), occupancy-check(1), access-rights(2), lockout(3), deny(4), verification(5), authorization-delay(6) | 63641–63656 (starts immediately after AuthenticationStatus's `}`) |
| `DoorValue` | lock(0), unlock(1), pulse-unlock(2), extended-pulse-unlock(3); **closed set**, names block then `(0),(1),(2),(3)` — the within-`enum` two-column pattern | 64024–64034 |

### Resolve arms (`resolve.rs`, keyed by PropertyIdentifier number)

Every arm's property number was verified by positional pairing in the alphabetical `BACnetPropertyIdentifier` production **and** the property's Clause 12 prose typing:

| Arm | Property | Verified pair (name line ↔ number line) | Clause 12 typing prose |
|---|---|---|---|
| 100 | reason-for-halt | `reason-for-halt` @68365 ↔ `(100),` @68424 | 20887–20890 (Program object: `BACnetProgramError`) |
| 158 | maintenance-required | @68208 ↔ 68267 | 17723 (Life Safety Point `BACnetMaintenance`), 23160 (Access Door) |
| 196 | last-restart-reason | @68102 ↔ 68161; also--see reference @69088–69090 | 16078 (Device: `BACnetRestartReason`) |
| 260 | authentication-status | @67716 ↔ 67775 | 25833–25834 (Access Point (12.31), Table 12-36 at 25591–25593: `BACnetAuthenticationStatus`; this prose is NOT the Credential Data Input object, whose Present_Value is a `BACnetAuthenticationFactor` structure, 12.36 at 28761–28762) |
| 296 | occupancy-state | @68325 ↔ 68384 | 26967 (Access Zone: `BACnetAccessZoneOccupancyState`) |
| 364 | authorization-exemptions | @67717 ↔ 67776 | 28051 / 28487–28488 (`BACnetLIST of BACnetAuthorizationExemption`, Access Credential) |
| 385 | transition | name @68573 ↔ number @68632; also-reference @69432 + @69491 | 36748 (Lighting Output: `BACnetLightingTransition`) |
| 477 | operation-direction | @68328 ↔ 68387 | 41844 (Escalator: `BACnetEscalatorOperationDirection`) |
| 489 | subordinate-relationships | @68487 ↔ 68546; also-reference @69668–69669 | 24586 / 24807–24812 (`BACnetARRAY[N] of BACnetRelationship`) |
| 490 | default-subordinate-relationship | @67848 ↔ 67907; also-reference @69670–69671 | 24814–24815 (scalar `BACnetRelationship`) |

**Pairing verification method.** The extract splits each page's two-column layout into a names stream and a numbers stream. Every target pair above was located positionally and cross-checked against ~60 independently-known anchors on the same pages (object-type=79, present-value=85, reliability=103, status-flags=111, system-status=112, event-state=36, event-type=37, file-access-method=41, limit-enable=52, list-of-group-members=53, local-date=56, local-time=57, notify-type=72, silenced=163, tracking-value=164, mode=160, operation-expected=161, secured-status=235, door-alarm-state=226, door-status=231, lock-status=233, authorization-mode=261, credential-disable=263, reason-for-disable=303, backup-and-restore-state=338, member-status-flags=347, timer-state=398, last-state-change=395, network-number-quality=426, network-type=427, audit-level=498, in-progress=378, escalator-mode=462, car-door-status=450, car-drive-status=453, car-mode=456, car-moving-direction=457, group-mode=467, units=117, update-time=189, timer-running=397, trace-flag=308, total-record-count=145, user-name=317, user-type=318, subscribed-recipients=362, subordinate-list=210, subordinate-node-types=211, subordinate-tags=488, tags=486, target-references=496, threat-authority=306/307). Result: all 11 target pairs sit at a **uniform +59-line offset** between name and `(N)` across the entire listing region — the pairing is structurally locked, not guessed. All `PropertyIdentifier` constants used for arms (`REASON_FOR_HALT=100`, …) agree with the extract.

**List-valued properties (489, 364):** `resolve_value` already recurses into `PropertyValue::List` resolving each element with the same arm — the existing convention (e.g. accepted-modes 175, `resolve_value_recurses_into_lists`). No new mechanism was needed; both get a dedicated element-wise test.

**491 (represents) deliberately has NO arm — deviation from the audit's arm list.** Clause 12.29 (Structured View) types `Represents` as `BACnetDeviceObjectReference`, not `BACnetRelationship`: Table 12-51 (extract 24588–24589) and the prose at 24818–24820 ("This property, of type BACnetDeviceObjectReference, can be used to indicate the entity for which this Structured View is modeling the subordinates."). An Enumerated never legitimately carries it; an arm would be dead code that could only mis-label vendor junk. The only `BACnetRelationship`-typed properties are 489 (array) and 490 (scalar) — grep of the extract for `of type BACnetRelationship` / `of BACnetRelationship` returns exactly those two (24808, 24815). resolve.rs carries a comment recording this at the 489|490 arm.

### Comment / doc corrections (audit items 3, 6, 13, 14)

- `network_port.rs`: `NON_BACNET(8)` comment — production says `-- formerly: non-bacnet (8), removed in version 1 revision 18` (extract 66566–66567); the code cited "protocol revision 16". Fixed.
- `object_level.rs` `EventType` gap note — production (extract 65682–65683: `-- complex-event-type (6), see comment below`, `-- context tag 7 is deprecated`, trailer 65716–65718) plus the `BACnetNotificationParameters` CHOICE (66717–66719: `complex-event-type [6] SEQUENCE OF BACnetPropertyValue, -- complex tag 7 is deprecated`). The old `// 6-7: reserved` is replaced with the faithful version.
- `credential_data_input.rs`: `present_value` comment said `1=waiting` — 1 is `READY` (production above, 63625–63640). Fixed.
- `lighting/mod.rs` + tests: the invented `fade-on=4` is corrected at the *current* line locations (mod.rs:301, :319, :355; tests.rs:365, :597–604 — the audit's `:277` ref predates the #276 merge). 4 is warn-relinquish; 5 is stop; there is no fade-on.

### Wired validation

`AccessDoorObject::set_relinquish_default` now bounds against `DoorValue::EXTENDED_PULSE_UNLOCK.to_raw()` instead of a literal `3` — the write domain can no longer drift from the production (as it did pre-#246 with Reliability). The relinquish-default test iterates `DoorValue::ALL_NAMED`. `BACnetPropertyStates::DoorValue(u32)` (`constructed/mod.rs:460`) keeps its raw `u32` field — retyping is follow-up.

### Tests

- Per enum: production-value table asserted against `ALL_NAMED` (count, order, name), `from_raw`/`to_raw` round-trip, `Display` names; the new types join `from_str_round_trips_display_for_all_named` (Display→parse identity) via a shared `assert_production_values!` table macro.
- `LifeSafetyState` additionally pins `TEST_SUPERVISORY=23` (renumber guard) and full-list length 35; `Relationship` additionally asserts the production's structural even/odd `n^1` pairing.
- Resolve arms: one table test over all 10 armed property ids (input → named variant + Display), an unknown-value pass-through check (out-of-production value stays named-but-numeric, `"42"`), and element-wise list resolution for 489 and 364.
- Existing door RD tests pass against `DoorValue::ALL_NAMED`; no snapshot changes anywhere else.

### Gates (all run locally on this branch, cold `target/`)

- `bash .github/scripts/check-file-size.sh` — OK (resolve.rs 696/700, tests.rs 679/700)
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked` — exit 0 (only pre-existing style/doc warning classes; no new lints on touched files)
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm` — all suites ok, 0 failed
- `cargo check -p rusty-bacnet --tests` — exit 0
- `python3 scripts/generate-conformance-docs.py --check` — exit 0

### Conformance ledger

Untouched, deliberately. This is types-layer parity (enum catalogue + display-side resolution), not service behavior. The only ledger row whose scope text names these productions is `BACNET-12-RELINQUISH-DEFAULT-WRITABILITY`, which describes *implemented write-acceptance domains* (Binary Lighting Output 0..=4, Access Door 0..=3) — unchanged by this PR, so the row stays accurate.

### Out of scope (tracked elsewhere — untouched)

#273 (FileAccessMethod swap), #274 (DoorAlarmState rename), #275 (StagingState removal), deferred AuthenticationFactor pair + BACnetFaultType, ObjectType 63/64 + PropertyIdentifier 508–510 Addendum-bj citation decision, elevator.rs operation_direction retyping, BACnetPropertyStates::DoorValue field retyping.

### Follow-ups found *while verifying* (not fixed here, per scope fences)

1. **audit correction**: 491/represents is `BACnetDeviceObjectReference` — see above; the #253 audit's arm list needs amending.
2. `elevator.rs:189` field comment claims `operation_direction` is `0=unknown, 1=up, 2=down, 3=stopped` — contradicts the production (stopped=1; up/down are speed-qualified). Comment fix can ride with the field retyping.
3. `BinaryLightingOutputObject::MAX_PV = 4` (lighting/mod.rs:320): the production includes `stop (5)`; moreover Clause 12.55 (extract 37387–37392) says a *writable* `Relinquish_Default` shall accept only OFF/ON, and 37190–37193 defines present-value special/command values. Current behavior accepts 0..=4 for both paths. Now tracked as #283; the in-code gap comment points there.
4. `LifeSafetyState` numbering of `alarm-values`-style properties stays object-type-dependent and unmapped, per resolve.rs's existing policy — no change.

Closes #253

### Panel record (post-push review round)

- **runtime lane: READY** — no correctness findings; three PR-body citation slips corrected post-review (non-bacnet production note 66561–66562→66566–66567; complex-event-type CHOICE note 66714–66715→66717–66719; the Authentication_Status prose attribution fixed to Access Point 12.31 / Table 12-36).
- **adversary lane: READY** — comment nits now folded: the door `set_relinquish_default` rustdoc records that `door_value_values_match_clause_21` pins `DoorValue`'s closed-set length, guarding the derived write bound (finding 3).
- **dataflow lane: READY** — 3 doc nits folded: elevator `operation_direction` comment now matches the production (→#284 for the retype); Access Door `lock`-vs-`closed` comments corrected (PV is `BACnetDoorValue`); CDI rustdoc re-attributed to `BACnetAuthenticationFactor` (12.36) vs Access Point's Authentication_Status.

Follow-up issues: #283 (Binary Lighting Output stop/write domains), #284 (elevator operation_direction retyping + write domain).
