### PR TITLE
fix(types)!: FileAccessMethod swap, DoorAlarmState rename, remove invented StagingState (#273, #274, #275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -912,6 +912,17 @@ Deep-dive review of encoding, types, services, objects, client, server, and netw
   `File_Access_Method` by value and `FileAccessMethod::from_raw`
   consumers must switch to the corrected assignments.
 
+- **Breaking (API):** `DoorAlarmState::LOCK_FAULT` is renamed
+  `DoorAlarmState::LOCK_DOWN`: the Clause 21 `BACnetDoorAlarmState`
+  production names value 6 `lock-down` and has no `lock-fault` member
+  (#274, Tranche Q audit). The wire value (6) is unchanged; what changes is
+  the constant name, the `Display`/`FromStr` text
+  (`LOCK_FAULT`/`lock-fault` → `LOCK_DOWN`/`lock-down`), and every decode or
+  display of Access Door `Door_Alarm_State` value 6. The neighbouring
+  `LockStatus::LOCK_FAULT` is a member of a different, correctly named
+  production and is untouched — code that conflated the two must now name
+  each correctly.
+
 
 ## [0.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -923,6 +923,16 @@ Deep-dive review of encoding, types, services, objects, client, server, and netw
   production and is untouched — code that conflated the two must now name
   each correctly.
 
+- **Breaking (API):** the invented `StagingState` enumeration
+  (`NOT_STAGED`/`STAGING`/`STAGED`/`COMMITTING`/`COMMITTED`/`ABANDONING`/
+  `ABANDONED`) is deleted from `bacnet-types` (#275, Tranche Q audit): no
+  such production exists anywhere in 135-2020. The Staging object's
+  `Present_Stage` is an Unsigned array index into the `Stages` array
+  (Clause 12.62, Table 12-80), which is how the object model already
+  carried it — no object, resolve arm, or test referenced the enum, so
+  the removal is source-local. Downstream users must treat staging state
+  as a raw Unsigned index; per-stage meaning comes from `Stage_Names`.
+
 
 ## [0.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -891,7 +891,27 @@ Deep-dive review of encoding, types, services, objects, client, server, and netw
 ## [0.7.1]
 
 ### Fixed
-- **Fixed** maturin wheel build — removed invalid `python-source` setting from pyproject.toml that broke wheel builds for pure Rust extension module
+
+- **Breaking (wire format):** `FileAccessMethod`'s enumeration values were
+  swapped: the stack defined `STREAM_ACCESS = 0` / `RECORD_ACCESS = 1`, but
+  the Clause 21 production is `record-access (0), stream-access (1)` (#273,
+  Tranche Q audit). Every File object in a running server therefore
+  reported the *other* access method in `File_Access_Method` — a
+  stream-backed object read back as record-access and vice versa — and
+  `ResolvedEnum` mislabeled both values for clients. The constants are now
+  `RECORD_ACCESS = 0` / `STREAM_ACCESS = 1`; the `bacnet-objects` File
+  object stops restating the numbers as literals and derives them from the
+  enum. Consumer audit: no compensating swaps existed elsewhere — the
+  service layer (`bacnet-services::file::{FileAccessMethod,
+  FileWriteAccessMethod}`) selects stream vs record by the
+  AtomicReadFile/AtomicWriteFile CHOICE tags (`[0]`/`[1]`), which are a
+  separate Clause 15.6/15.7 production and are unchanged; server handlers,
+  clients, and the CLI pass those through. **Migration:** any peer,
+  configuration, or stored record that persisted the raw property value
+  must be remapped (old 0 → 1, old 1 → 0); reads of
+  `File_Access_Method` by value and `FileAccessMethod::from_raw`
+  consumers must switch to the corrected assignments.
+
 
 ## [0.7.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Breaking (wire format):** `FileAccessMethod`'s enumeration values were
+  swapped: the stack defined `STREAM_ACCESS = 0` / `RECORD_ACCESS = 1`, but
+  the Clause 21 production is `record-access (0), stream-access (1)` (#273,
+  Tranche Q audit). Every File object in a running server therefore
+  reported the *other* access method in `File_Access_Method` — a
+  stream-backed object read back as record-access and vice versa — and
+  `ResolvedEnum` mislabeled both values for clients. The constants are now
+  `RECORD_ACCESS = 0` / `STREAM_ACCESS = 1`; the `bacnet-objects` File
+  object stops restating the numbers as literals and derives them from the
+  enum. Consumer audit: no compensating swaps existed elsewhere — the
+  service layer (`bacnet-services::file::{FileAccessMethod,
+  FileWriteAccessMethod}`) selects stream vs record by the
+  AtomicReadFile/AtomicWriteFile access-method CHOICE tags (`[0]`/`[1]`),
+  Clause 21 ASN.1 productions for the Clause 14.1/14.2 services, so those
+  bytes are unchanged; server handlers, clients, and the CLI pass them
+  through. **Migration:** any peer, configuration, or stored record that
+  persisted the raw property value must be remapped (old 0 → 1, old 1 →
+  0); reads of `File_Access_Method` by value and
+  `FileAccessMethod::from_raw` consumers must switch to the corrected
+  assignments.
+
+- **Breaking (API):** `DoorAlarmState::LOCK_FAULT` is renamed
+  `DoorAlarmState::LOCK_DOWN`: the Clause 21 `BACnetDoorAlarmState`
+  production names value 6 `lock-down` and has no `lock-fault` member
+  (#274, Tranche Q audit). The wire value (6) is unchanged; what changes is
+  the constant name, the `Display`/`FromStr` text
+  (`LOCK_FAULT`/`lock-fault` → `LOCK_DOWN`/`lock-down`), and every decode or
+  display of Access Door `Door_Alarm_State` value 6. The neighbouring
+  `LockStatus::LOCK_FAULT` is a member of a different, correctly named
+  production and is untouched — code that conflated the two must now name
+  each correctly.
+
+- **Breaking (API):** the invented `StagingState` enumeration
+  (`NOT_STAGED`/`STAGING`/`STAGED`/`COMMITTING`/`COMMITTED`/`ABANDONING`/
+  `ABANDONED`) is deleted from `bacnet-types` (#275, Tranche Q audit): no
+  such production exists anywhere in 135-2020. The Staging object's
+  `Present_Stage` is an Unsigned array index into the `Stages` array
+  (Clause 12.62, Table 12-80), which is how the object model already
+  carried it — no object, resolve arm, or test referenced the enum, so
+  the removal is source-local. Downstream users must treat staging state
+  as a raw Unsigned index; per-stage meaning comes from `Stage_Names`.
+
 - Harden the Averaging `Object_Property_Reference` write arm, reachable
   over the network for the first time via the #182 multi-element decode:
   its `items.len() >= 2` acceptance silently dropped fourth-and-later
@@ -891,48 +933,7 @@ Deep-dive review of encoding, types, services, objects, client, server, and netw
 ## [0.7.1]
 
 ### Fixed
-
-- **Breaking (wire format):** `FileAccessMethod`'s enumeration values were
-  swapped: the stack defined `STREAM_ACCESS = 0` / `RECORD_ACCESS = 1`, but
-  the Clause 21 production is `record-access (0), stream-access (1)` (#273,
-  Tranche Q audit). Every File object in a running server therefore
-  reported the *other* access method in `File_Access_Method` — a
-  stream-backed object read back as record-access and vice versa — and
-  `ResolvedEnum` mislabeled both values for clients. The constants are now
-  `RECORD_ACCESS = 0` / `STREAM_ACCESS = 1`; the `bacnet-objects` File
-  object stops restating the numbers as literals and derives them from the
-  enum. Consumer audit: no compensating swaps existed elsewhere — the
-  service layer (`bacnet-services::file::{FileAccessMethod,
-  FileWriteAccessMethod}`) selects stream vs record by the
-  AtomicReadFile/AtomicWriteFile CHOICE tags (`[0]`/`[1]`), which are a
-  separate Clause 15.6/15.7 production and are unchanged; server handlers,
-  clients, and the CLI pass those through. **Migration:** any peer,
-  configuration, or stored record that persisted the raw property value
-  must be remapped (old 0 → 1, old 1 → 0); reads of
-  `File_Access_Method` by value and `FileAccessMethod::from_raw`
-  consumers must switch to the corrected assignments.
-
-- **Breaking (API):** `DoorAlarmState::LOCK_FAULT` is renamed
-  `DoorAlarmState::LOCK_DOWN`: the Clause 21 `BACnetDoorAlarmState`
-  production names value 6 `lock-down` and has no `lock-fault` member
-  (#274, Tranche Q audit). The wire value (6) is unchanged; what changes is
-  the constant name, the `Display`/`FromStr` text
-  (`LOCK_FAULT`/`lock-fault` → `LOCK_DOWN`/`lock-down`), and every decode or
-  display of Access Door `Door_Alarm_State` value 6. The neighbouring
-  `LockStatus::LOCK_FAULT` is a member of a different, correctly named
-  production and is untouched — code that conflated the two must now name
-  each correctly.
-
-- **Breaking (API):** the invented `StagingState` enumeration
-  (`NOT_STAGED`/`STAGING`/`STAGED`/`COMMITTING`/`COMMITTED`/`ABANDONING`/
-  `ABANDONED`) is deleted from `bacnet-types` (#275, Tranche Q audit): no
-  such production exists anywhere in 135-2020. The Staging object's
-  `Present_Stage` is an Unsigned array index into the `Stages` array
-  (Clause 12.62, Table 12-80), which is how the object model already
-  carried it — no object, resolve arm, or test referenced the enum, so
-  the removal is source-local. Downstream users must treat staging state
-  as a raw Unsigned index; per-stage meaning comes from `Stage_Names`.
-
+- **Fixed** maturin wheel build — removed invalid `python-source` setting from pyproject.toml that broke wheel builds for pure Rust extension module
 
 ## [0.7.0]
 

--- a/crates/bacnet-encoding/src/primitives/tests.rs
+++ b/crates/bacnet-encoding/src/primitives/tests.rs
@@ -261,6 +261,21 @@ fn app_enumerated_round_trip() {
     assert_eq!(end, bytes.len());
 }
 
+/// Standard 135-2020 Clause 21 pins `record-access (0)` / `stream-access (1)`
+/// for `BACnetFileAccessMethod`; on the wire the enumerated application tag
+/// is 0x91 with the value octet after it (Clause 20.2.4). Guard against the
+/// #273 swap regression at the encoder that puts the value on the wire.
+#[test]
+fn file_access_method_wire_values_match_clause_21() {
+    use bacnet_types::enums::FileAccessMethod;
+
+    let bytes = encode_to_vec(|buf| encode_app_enumerated(buf, FileAccessMethod::RECORD_ACCESS.to_raw()));
+    assert_eq!(bytes, [0x91, 0x00], "record-access encodes to value 0");
+
+    let bytes = encode_to_vec(|buf| encode_app_enumerated(buf, FileAccessMethod::STREAM_ACCESS.to_raw()));
+    assert_eq!(bytes, [0x91, 0x01], "stream-access encodes to value 1");
+}
+
 #[test]
 fn app_date_round_trip() {
     let date = Date {

--- a/crates/bacnet-encoding/src/primitives/tests.rs
+++ b/crates/bacnet-encoding/src/primitives/tests.rs
@@ -269,10 +269,12 @@ fn app_enumerated_round_trip() {
 fn file_access_method_wire_values_match_clause_21() {
     use bacnet_types::enums::FileAccessMethod;
 
-    let bytes = encode_to_vec(|buf| encode_app_enumerated(buf, FileAccessMethod::RECORD_ACCESS.to_raw()));
+    let bytes =
+        encode_to_vec(|buf| encode_app_enumerated(buf, FileAccessMethod::RECORD_ACCESS.to_raw()));
     assert_eq!(bytes, [0x91, 0x00], "record-access encodes to value 0");
 
-    let bytes = encode_to_vec(|buf| encode_app_enumerated(buf, FileAccessMethod::STREAM_ACCESS.to_raw()));
+    let bytes =
+        encode_to_vec(|buf| encode_app_enumerated(buf, FileAccessMethod::STREAM_ACCESS.to_raw()));
     assert_eq!(bytes, [0x91, 0x01], "stream-access encodes to value 1");
 }
 

--- a/crates/bacnet-objects/src/file.rs
+++ b/crates/bacnet-objects/src/file.rs
@@ -1,9 +1,9 @@
-//! File (type 10) object per ASHRAE 135-2020 Clause 12.11.
+//! File (type 10) object per ASHRAE 135-2020 Clause 12.13.
 //!
 //! Backs AtomicReadFile and AtomicWriteFile services. Supports both
 //! stream-access and record-access modes.
 
-use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{FileAccessMethod, ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{Date, ObjectIdentifier, PropertyValue, StatusFlags, Time};
 use std::borrow::Cow;
@@ -19,7 +19,8 @@ use crate::traits::BACnetObject;
 ///
 /// Represents a file accessible via AtomicReadFile / AtomicWriteFile services.
 /// The `file_access_method` determines whether the file is accessed as a
-/// byte stream (0) or as a sequence of fixed-length records (1).
+/// byte stream ([`FileAccessMethod::STREAM_ACCESS`]) or as a sequence of
+/// fixed-length records ([`FileAccessMethod::RECORD_ACCESS`]).
 pub struct FileObject {
     oid: ObjectIdentifier,
     name: String,
@@ -29,13 +30,14 @@ pub struct FileObject {
     modification_date: (Date, Time),
     archive: bool,
     read_only: bool,
-    /// 0 = stream access, 1 = record access.
+    /// Raw `BACnetFileAccessMethod` value; named in [`FileAccessMethod`]
+    /// (record-access = 0, stream-access = 1 per the Clause 21 production).
     file_access_method: u32,
     /// Record count (only meaningful for record-access files).
     record_count: Option<u64>,
-    /// Stream data (used when file_access_method == 0).
+    /// Stream data (used when file_access_method == STREAM_ACCESS).
     data: Vec<u8>,
-    /// Record data (used when file_access_method == 1).
+    /// Record data (used when file_access_method == RECORD_ACCESS).
     records: Vec<Vec<u8>>,
     status_flags: StatusFlags,
     out_of_service: bool,
@@ -46,8 +48,8 @@ pub struct FileObject {
 impl FileObject {
     /// Create a new File object.
     ///
-    /// Defaults to stream access (file_access_method = 0), empty data,
-    /// not read-only, archive = false.
+    /// Defaults to stream access (file_access_method = STREAM_ACCESS), empty
+    /// data, not read-only, archive = false.
     pub fn new(
         instance: u32,
         name: impl Into<String>,
@@ -76,7 +78,7 @@ impl FileObject {
             ),
             archive: false,
             read_only: false,
-            file_access_method: 0,
+            file_access_method: FileAccessMethod::STREAM_ACCESS.to_raw(),
             record_count: None,
             data: Vec::new(),
             records: Vec::new(),
@@ -107,10 +109,12 @@ impl FileObject {
         &self.data
     }
 
-    /// Set the file access method (0 = stream, 1 = record).
+    /// Set the file access method. Accepts the raw `BACnetFileAccessMethod`
+    /// value: [`FileAccessMethod::STREAM_ACCESS`] (1) or
+    /// [`FileAccessMethod::RECORD_ACCESS`] (0).
     pub fn set_file_access_method(&mut self, method: u32) {
         self.file_access_method = method;
-        if method == 1 {
+        if method == FileAccessMethod::RECORD_ACCESS.to_raw() {
             self.record_count = Some(self.records.len() as u64);
         } else {
             self.record_count = None;
@@ -449,7 +453,35 @@ mod tests {
         let val = file
             .read_property(PropertyIdentifier::FILE_ACCESS_METHOD, None)
             .unwrap();
-        assert_eq!(val, PropertyValue::Enumerated(0));
+        // stream-access is 1 per the Clause 21 production (#273).
+        assert_eq!(
+            val,
+            PropertyValue::Enumerated(FileAccessMethod::STREAM_ACCESS.to_raw())
+        );
+        assert_eq!(
+            val,
+            PropertyValue::Enumerated(1),
+            "stream-access enumeration value"
+        );
+    }
+
+    #[test]
+    fn file_read_file_access_method_record() {
+        let mut file = FileObject::new(1, "FILE-1", "text/plain").unwrap();
+        file.set_file_access_method(FileAccessMethod::RECORD_ACCESS.to_raw());
+        let val = file
+            .read_property(PropertyIdentifier::FILE_ACCESS_METHOD, None)
+            .unwrap();
+        // record-access is 0 per the Clause 21 production (#273).
+        assert_eq!(
+            val,
+            PropertyValue::Enumerated(FileAccessMethod::RECORD_ACCESS.to_raw())
+        );
+        assert_eq!(
+            val,
+            PropertyValue::Enumerated(0),
+            "record-access enumeration value"
+        );
     }
 
     #[test]
@@ -462,7 +494,7 @@ mod tests {
     #[test]
     fn file_set_records_updates_record_count_and_size() {
         let mut file = FileObject::new(1, "FILE-1", "text/plain").unwrap();
-        file.set_file_access_method(1);
+        file.set_file_access_method(FileAccessMethod::RECORD_ACCESS.to_raw());
         file.set_records(vec![vec![0x01, 0x02], vec![0x03, 0x04, 0x05]]);
         let count = file
             .read_property(PropertyIdentifier::RECORD_COUNT, None)
@@ -642,7 +674,7 @@ mod tests {
     #[test]
     fn file_property_list_record_access() {
         let mut file = FileObject::new(1, "FILE-1", "text/plain").unwrap();
-        file.set_file_access_method(1);
+        file.set_file_access_method(FileAccessMethod::RECORD_ACCESS.to_raw());
         let props = file.property_list();
         assert!(props.contains(&PropertyIdentifier::RECORD_COUNT));
     }

--- a/crates/bacnet-objects/src/staging.rs
+++ b/crates/bacnet-objects/src/staging.rs
@@ -262,6 +262,33 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// Clause 12.62 types Present_Stage as Unsigned (an index into the
+    /// Stages array), not an enumeration — there is no `StagingState`
+    /// production in 135-2020 (#275).
+    #[test]
+    fn staging_present_stage_is_unsigned_array_index() {
+        let mut stg = StagingObject::new(1, "STG-1", 3).unwrap();
+        assert_eq!(
+            stg.read_property(PropertyIdentifier::PRESENT_STAGE, None)
+                .unwrap(),
+            PropertyValue::Unsigned(0)
+        );
+        stg.write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Unsigned(2),
+            None,
+        )
+        .unwrap();
+        match stg
+            .read_property(PropertyIdentifier::PRESENT_STAGE, None)
+            .unwrap()
+        {
+            PropertyValue::Unsigned(stage) => assert_eq!(stage, 2),
+            other => panic!("Present_Stage must stay Unsigned, got {other:?}"),
+        }
+    }
+
     #[test]
     fn staging_read_target_references() {
         let stg = StagingObject::new(1, "STG-1", 2).unwrap();

--- a/crates/bacnet-types/src/enums/access.rs
+++ b/crates/bacnet-types/src/enums/access.rs
@@ -12,7 +12,7 @@ bacnet_enum! {
     const FORCED_OPEN = 3;
     const TAMPER = 4;
     const DOOR_FAULT = 5;
-    const LOCK_FAULT = 6;
+    const LOCK_DOWN = 6;
     const FREE_ACCESS = 7;
     const EGRESS_OPEN = 8;
 }

--- a/crates/bacnet-types/src/enums/access.rs
+++ b/crates/bacnet-types/src/enums/access.rs
@@ -151,7 +151,8 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
-    /// BACnet authentication status for Credential Data Input (Clause 21).
+    /// BACnet authentication status: the Access Point object's
+    /// Authentication_Status property (Table 12-36; Clause 21 production).
     pub struct AuthenticationStatus(u32);
 
     const NOT_READY = 0;

--- a/crates/bacnet-types/src/enums/audit.rs
+++ b/crates/bacnet-types/src/enums/audit.rs
@@ -1,19 +1,6 @@
 // ===========================================================================
-// Staging / Audit enums (new in 135-2020)
+// Audit enums (new in 135-2020)
 // ===========================================================================
-
-bacnet_enum! {
-    /// BACnet staging state (Clause 12.62, new in 135-2020).
-    pub struct StagingState(u32);
-
-    const NOT_STAGED = 0;
-    const STAGING = 1;
-    const STAGED = 2;
-    const COMMITTING = 3;
-    const COMMITTED = 4;
-    const ABANDONING = 5;
-    const ABANDONED = 6;
-}
 
 bacnet_enum! {
     /// BACnet audit level (Clause 19.6, new in 135-2020).

--- a/crates/bacnet-types/src/enums/object_level.rs
+++ b/crates/bacnet-types/src/enums/object_level.rs
@@ -114,11 +114,13 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
-    /// BACnet file access method (Clause 12.12).
+    /// BACnet file access method (Clause 21 production; File object,
+    /// Clause 12.13). Wire order mirrors the production: record-access
+    /// precedes stream-access.
     pub struct FileAccessMethod(u32);
 
-    const STREAM_ACCESS = 0;
-    const RECORD_ACCESS = 1;
+    const RECORD_ACCESS = 0;
+    const STREAM_ACCESS = 1;
 }
 
 bacnet_enum! {

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -187,6 +187,44 @@ fn file_access_method_values_match_clause_21() {
     );
 }
 
+/// Standard 135-2020 Clause 21 (`BACnetDoorAlarmState ::= ENUMERATED`):
+/// value 6 is `lock-down`, not a "lock fault" — no such member exists in the
+/// production. `LockStatus::LOCK_FAULT` (value 2 of a different production)
+/// is correct and must not be conflated with it (#274).
+#[test]
+fn door_alarm_state_values_match_clause_21() {
+    assert_production_values!(
+        DoorAlarmState,
+        [
+            ("NORMAL", 0),
+            ("ALARM", 1),
+            ("DOOR_OPEN_TOO_LONG", 2),
+            ("FORCED_OPEN", 3),
+            ("TAMPER", 4),
+            ("DOOR_FAULT", 5),
+            ("LOCK_DOWN", 6),
+            ("FREE_ACCESS", 7),
+            ("EGRESS_OPEN", 8),
+        ],
+    );
+
+    // door-alarm-state (226) resolves by name; 6 displays as LOCK_DOWN.
+    assert_eq!(
+        ResolvedEnum::from_property(PropertyIdentifier::DOOR_ALARM_STATE, 6),
+        ResolvedEnum::DoorAlarmState(DoorAlarmState::LOCK_DOWN)
+    );
+    assert_eq!(
+        ResolvedEnum::from_property(PropertyIdentifier::DOOR_ALARM_STATE, 6).to_string(),
+        "LOCK_DOWN"
+    );
+
+    // The conflation guard: lock-fault belongs to LockStatus, at value 2.
+    assert_eq!(LockStatus::LOCK_FAULT.to_raw(), 2);
+    assert!(DoorAlarmState::ALL_NAMED
+        .iter()
+        .all(|(name, _)| *name != "LOCK_FAULT"));
+}
+
 /// 135-2020 Clause 21 (`BACnetLifeSafetyState ::= ENUMERATED`) runs through
 /// test-oeo-unaffected (34): the eleven values past test-supervisory (23)
 /// must exist without renumbering anything below them.

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -170,7 +170,10 @@ macro_rules! assert_production_values {
 /// File object on the wire (#273).
 #[test]
 fn file_access_method_values_match_clause_21() {
-    assert_production_values!(FileAccessMethod, [("RECORD_ACCESS", 0), ("STREAM_ACCESS", 1)]);
+    assert_production_values!(
+        FileAccessMethod,
+        [("RECORD_ACCESS", 0), ("STREAM_ACCESS", 1)]
+    );
 
     // file-access-method (41) resolves by name with the corrected values.
     assert_eq!(

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -163,6 +163,30 @@ macro_rules! assert_production_values {
     };
 }
 
+/// Standard 135-2020 Clause 21 (`BACnetFileAccessMethod ::= ENUMERATED`)
+/// assigns `record-access (0)` and `stream-access (1)`. Guard against a swap
+/// regression: the constants were previously reversed (`STREAM_ACCESS = 0`,
+/// `RECORD_ACCESS = 1`), which reported the wrong access method for every
+/// File object on the wire (#273).
+#[test]
+fn file_access_method_values_match_clause_21() {
+    assert_production_values!(FileAccessMethod, [("RECORD_ACCESS", 0), ("STREAM_ACCESS", 1)]);
+
+    // file-access-method (41) resolves by name with the corrected values.
+    assert_eq!(
+        ResolvedEnum::from_property(PropertyIdentifier::FILE_ACCESS_METHOD, 0),
+        ResolvedEnum::FileAccessMethod(FileAccessMethod::RECORD_ACCESS)
+    );
+    assert_eq!(
+        ResolvedEnum::from_property(PropertyIdentifier::FILE_ACCESS_METHOD, 1),
+        ResolvedEnum::FileAccessMethod(FileAccessMethod::STREAM_ACCESS)
+    );
+    assert_eq!(
+        ResolvedEnum::from_property(PropertyIdentifier::FILE_ACCESS_METHOD, 1).to_string(),
+        "STREAM_ACCESS"
+    );
+}
+
 /// 135-2020 Clause 21 (`BACnetLifeSafetyState ::= ENUMERATED`) runs through
 /// test-oeo-unaffected (34): the eleven values past test-supervisory (23)
 /// must exist without renumbering anything below them.


### PR DESCRIPTION
Three breaking enum corrections from the Tranche Q audit, each verified against the local 135-2020 extract, plus a comment-only attribution fix.

> **Erratum:** commit `30c2e23`'s message cites the AtomicReadFile/AtomicWriteFile services as "Clause 15.6/15.7"; the correct reference is Clause 14.1/14.2 (Clause 21 holds the ASN.1 productions). The commit is immutable (no force-push); the text here and the changelog carry the correction.

## #273 — FileAccessMethod values were swapped (wire break)

Clause 21: `BACnetFileAccessMethod ::= ENUMERATED { record-access (0), stream-access (1) }` (extract 65866-65870). The stack defined `STREAM_ACCESS = 0` / `RECORD_ACCESS = 1`, so every File object's `File_Access_Method` reported the other access method to conformant peers.

### Consumer inventory (grep: FileAccessMethod, STREAM_ACCESS, RECORD_ACCESS, file_access_method, File_Access_Method)

| Consumer | Mechanism | Outcome |
|---|---|---|
| `bacnet-types/src/enums/object_level.rs` | the enum itself | **Fixed** — constants swapped, order mirrors the production, clause cite corrected (File object is 12.13) |
| `bacnet-types/src/enums/resolve.rs:79,157` | typed via `FileAccessMethod::from_raw` | Correct automatically after the swap; pinned by test |
| `bacnet-objects/src/file.rs` | **literal numbers** (default `0`, `method == 1` gating) | **Fixed** — derives from the enum constants; single truth now lives at the production |
| `bacnet-services/src/file.rs` (`FileAccessMethod`/`FileWriteAccessMethod` service enums) | AtomicReadFile/AtomicWriteFile `access-method CHOICE` context tags `[0]`/`[1]` (Clause 14.1/14.2 services; ASN.1 productions in Clause 21, extract 60938-61030) | Correct as-is — a separate production from the enumeration; **no compensating swap found** |
| `bacnet-server/src/handlers/file.rs` | matches the service CHOICE enum | Unaffected |
| `bacnet-client/src/client/file_list.rs`, `rusty-bacnet` client, `bacnet-cli`, `docs/rust-api.md` | pass the service CHOICE enum through | Unaffected |

**Compensating mirror-swaps found: none.**

### Before/after wire example (application-tagged Enumerated, tag 9)

ReadProperty of File:1 `File_Access_Method` (property 41), stream-backed file:

```
before:  91 00   → Encoded value 0  = record-access (peer uses record I/O against a stream file)
after:   91 01   → Encoded value 1  = stream-access (correct)
```

Record-backed file:

```
before:  91 01   → Encoded value 1  = stream-access (wrong)
after:   91 00   → Encoded value 0  = record-access (correct)
```

**Migration:** any peer, configuration, or stored data that persisted the raw property value remaps old 0 → 1 and old 1 → 0. AtomicReadFile/AtomicWriteFile request/ACK bytes are unchanged (CHOICE tags, not the enumeration).

## #274 — DoorAlarmState value 6 is lock-down, not lock-fault (API break)

Clause 21 `BACnetDoorAlarmState` (extract 63966-63986) names value 6 `lock-down (6)` and has no `lock-fault` member. `DoorAlarmState::LOCK_FAULT` renamed to `LOCK_DOWN`; the wire value 6 is unchanged. `LockStatus::LOCK_FAULT` (value 2 of `BACnetLockStatus`) is correct and untouched — a conflation-guard test pins both. Display/FromStr text changes `LOCK_FAULT`→`LOCK_DOWN` for DoorAlarmState.

## #275 — StagingState was invented (API break)

No `StagingState` production exists anywhere in 135-2020. The Staging object's `Present_Stage` is "of type Unsigned ... the array index (1 to Nstages) that corresponds to the current active stage" (Clause 12.62, Table 12-80). The enum is deleted; zero in-tree consumers existed (no resolve arm, no object state, no test), and the Staging object already carries stage state as raw Unsigned — now pinned by `staging_present_stage_is_unsigned_array_index`.

## Rider — comment only

`AuthenticationStatus` rustdoc attributed the production to Credential Data Input; `Authentication_Status` is a property of the Access Point object (Table 12-36).

## Verification

- `bash .github/scripts/check-file-size.sh` — OK
- `cargo fmt --all --check` — OK
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked` — exit 0 (pre-existing warnings only, none new from this change)
- `cargo test --workspace --exclude rusty-bacnet --exclude bacnet-wasm` — all suites ok
- `cargo check -p rusty-bacnet --tests` — OK
- `python3 scripts/generate-conformance-docs.py --check` — OK
- New tests: `file_access_method_values_match_clause_21`, `file_access_method_wire_values_match_clause_21` (record → `91 00`, stream → `91 01`), `file_read_file_access_method_default_stream` / `_record` (object property read), `door_alarm_state_values_match_clause_21` (+ LockStatus conflation guard), `staging_present_stage_is_unsigned_array_index`

Closes #273
Closes #274
Closes #275

