### PR TITLE
fix(server): keep event detection active during DCC

### DIFF
--- a/crates/bacnet-server/src/server/dcc_event_detection_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_event_detection_tests.rs
@@ -1,0 +1,147 @@
+use super::event_notifications_tests::{
+    broadcasts_from_per_write_path, db_with_high_limit_transition, RecordingTransport,
+};
+use super::*;
+use bacnet_objects::analog::AnalogInputObject;
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::enums::EventState;
+use bytes::Bytes;
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
+
+#[tokio::test]
+async fn dcc_states_preserve_per_write_detection_but_suppress_distribution() {
+    for comm_state in [1, 2] {
+        let db = db_with_high_limit_transition(0x80);
+        let sent = broadcasts_from_per_write_path(&db, comm_state).await;
+
+        assert!(
+            sent.is_empty(),
+            "DCC state {comm_state} must suppress event notification distribution"
+        );
+        let db = db.read().await;
+        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+        assert_eq!(
+            db.get(&oid)
+                .unwrap()
+                .read_property(PropertyIdentifier::EVENT_STATE, None)
+                .unwrap(),
+            PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw()),
+            "DCC state {comm_state} must not suppress event-state detection"
+        );
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_states_preserve_delayed_detection_but_suppress_distribution() {
+    for comm_state in [1, 2] {
+        let sent = StdArc::new(StdMutex::new(Vec::<Bytes>::new()));
+        let transport = RecordingTransport {
+            sent_broadcast: StdArc::clone(&sent),
+            local_mac: vec![127, 0, 0, 1, 0xBA, 0xC0],
+        };
+        let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+        for (property, value) in [
+            (PropertyIdentifier::HIGH_LIMIT, 80.0),
+            (PropertyIdentifier::LOW_LIMIT, 20.0),
+            (PropertyIdentifier::DEADBAND, 2.0),
+        ] {
+            ai.write_property(property, None, PropertyValue::Real(value), None)
+                .unwrap();
+        }
+        ai.write_property(
+            PropertyIdentifier::LIMIT_ENABLE,
+            None,
+            PropertyValue::BitString {
+                unused_bits: 6,
+                data: vec![0xC0],
+            },
+            None,
+        )
+        .unwrap();
+        ai.write_property(
+            PropertyIdentifier::EVENT_ENABLE,
+            None,
+            PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0x80], // TO_OFFNORMAL at wire bit 0
+            },
+            None,
+        )
+        .unwrap();
+        ai.write_property(
+            PropertyIdentifier::TIME_DELAY,
+            None,
+            PropertyValue::Unsigned(2),
+            None,
+        )
+        .unwrap();
+        ai.write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+        ai.set_present_value(62.0);
+        let oid = ai.object_identifier();
+
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(ai)).unwrap();
+        db.add(Box::new(
+            DeviceObject::new(DeviceConfig {
+                instance: 1,
+                name: "Dev".into(),
+                ..DeviceConfig::default()
+            })
+            .unwrap(),
+        ))
+        .unwrap();
+
+        let mut server = BACnetServer::start(ServerConfig::default(), db, transport)
+            .await
+            .expect("server should start");
+        server.comm_state.store(comm_state, Ordering::Release);
+        server
+            .write_local(
+                &oid,
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                PropertyValue::Real(81.0),
+                None,
+            )
+            .await
+            .expect("local Present_Value write should seed delayed detection");
+
+        {
+            let db = server.database().read().await;
+            assert_eq!(
+                db.get(&oid)
+                    .unwrap()
+                    .read_property(PropertyIdentifier::EVENT_STATE, None)
+                    .unwrap(),
+                PropertyValue::Enumerated(EventState::NORMAL.to_raw()),
+                "DCC state {comm_state} must honor Time_Delay before transitioning"
+            );
+        }
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        assert!(
+            sent.lock().unwrap().is_empty(),
+            "DCC state {comm_state} must suppress delayed event notification distribution"
+        );
+        {
+            let db = server.database().read().await;
+            assert_eq!(
+                db.get(&oid)
+                    .unwrap()
+                    .read_property(PropertyIdentifier::EVENT_STATE, None)
+                    .unwrap(),
+                PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw()),
+                "DCC state {comm_state} must not pause the Time_Delay countdown"
+            );
+        }
+        server.stop().await.unwrap();
+    }
+}

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -15,7 +15,9 @@ impl From<(EventStateChange, EventType)> for NotificationTransition {
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Evaluate intrinsic reporting on an object and send event notifications
     /// to NotificationClass recipients (or broadcast if none configured).
-    /// Skipped when DCC is active (comm_state >= 1).
+    /// DCC gates network-message initiation (Clause 16.1), not the local
+    /// transition actions in Clause 13.2.2.1.4. The outbound sender below
+    /// suppresses distribution while communications are disabled.
     ///
     /// This is the per-write entry point: it probes the detector, which fires
     /// immediately only when `Time_Delay == 0`. For a nonzero delay the probe
@@ -30,10 +32,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         oid: &ObjectIdentifier,
         retry_timeout_ms: u64,
     ) {
-        if comm_state.load(Ordering::Acquire) >= 1 {
-            return;
-        }
-
         let outcome = {
             let mut db = db.write().await;
             match db.get_mut(oid) {

--- a/crates/bacnet-server/src/server/event_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_tests.rs
@@ -13,9 +13,9 @@ use tokio::sync::mpsc;
 /// discards unicasts. Used to capture the EventNotification a server
 /// actually puts on the wire.
 #[derive(Clone, Default)]
-struct RecordingTransport {
-    sent_broadcast: StdArc<StdMutex<Vec<Bytes>>>,
-    local_mac: Vec<u8>,
+pub(super) struct RecordingTransport {
+    pub(super) sent_broadcast: StdArc<StdMutex<Vec<Bytes>>>,
+    pub(super) local_mac: Vec<u8>,
 }
 impl TransportPort for RecordingTransport {
     async fn start(
@@ -448,7 +448,7 @@ async fn event_notification_event_notify_type_honors_class_ack_required() {
 /// `Event_Enable` is written through `write_property` rather than an internal
 /// setter, so these tests cover the same path a network client takes. Bytes
 /// are the Clause 20.2.10 wire encoding: MSB-first, TO_OFFNORMAL at `0x80`.
-fn db_with_high_limit_transition(
+pub(super) fn db_with_high_limit_transition(
     event_enable_byte: u8,
 ) -> Arc<tokio::sync::RwLock<ObjectDatabase>> {
     let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
@@ -497,8 +497,9 @@ fn db_with_high_limit_transition(
 }
 
 /// Drive the per-write path once and return the broadcasts it produced.
-async fn broadcasts_from_per_write_path(
+pub(super) async fn broadcasts_from_per_write_path(
     db: &Arc<tokio::sync::RwLock<ObjectDatabase>>,
+    comm_state_value: u8,
 ) -> Vec<Bytes> {
     let sent = StdArc::new(StdMutex::new(Vec::new()));
     let transport = RecordingTransport {
@@ -506,12 +507,12 @@ async fn broadcasts_from_per_write_path(
         local_mac: vec![127, 0, 0, 1, 0xBA, 0xC0],
     };
     let network = Arc::new(NetworkLayer::new(transport));
-    let comm_state = Arc::new(AtomicU8::new(0)); // DCC not blocking
+    let comm_state = Arc::new(AtomicU8::new(comm_state_value));
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
     let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
 
     BACnetServer::<RecordingTransport>::fire_event_notifications(
-        &db,
+        db,
         &network,
         &comm_state,
         &server_tsm,
@@ -534,7 +535,7 @@ async fn broadcasts_from_per_write_path(
 #[tokio::test]
 async fn event_enable_cleared_suppresses_per_write_send() {
     let db = db_with_high_limit_transition(0x00); // no transition distributable
-    let sent = broadcasts_from_per_write_path(&db).await;
+    let sent = broadcasts_from_per_write_path(&db, 0).await;
 
     assert!(
         sent.is_empty(),
@@ -564,7 +565,7 @@ async fn event_enable_cleared_suppresses_per_write_send() {
 async fn event_enable_set_permits_per_write_send() {
     // TO_OFFNORMAL only: wire bit 0 = 0x80 (Clause 20.2.10).
     let db = db_with_high_limit_transition(0x80);
-    let sent = broadcasts_from_per_write_path(&db).await;
+    let sent = broadcasts_from_per_write_path(&db, 0).await;
 
     assert_eq!(
         sent.len(),

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -482,12 +482,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         // Reliability is *derived* from limits, never whether a Reliability that
         // exists is honored.
         //
-        // Two caveats, both pre-existing and tracked rather than fixed here. The
-        // loop below bails while DeviceCommunicationControl is active, so
-        // detection is suspended for the duration even though confirmed writes
-        // still execute (#220). And six of the nine wired object types have no
-        // route that can set Reliability at all, so the fault path is correct but
-        // inert on them (#218).
+        // Six of the nine wired object types have no route that can set
+        // Reliability, so the fault path is correct but inert on them (#218).
         let db_intrinsic = Arc::clone(&db);
         let network_intrinsic = Arc::clone(&network);
         let comm_state_intrinsic = Arc::clone(&comm_state);
@@ -503,9 +499,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 interval.tick().await;
-                if comm_state_intrinsic.load(Ordering::Acquire) >= 1 {
-                    continue;
-                }
+                // DCC gates the outbound sender, not event-state detection or
+                // the local transition actions in Clause 13.2.2.1.4.
                 // Collect confirmed transitions under a brief write lock, then
                 // drop it before sending (never hold the db lock across a
                 // network send — matches the per-write notification path).

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -777,6 +777,8 @@ mod segmentation;
 #[cfg(test)]
 mod cov_notifications_tests;
 #[cfg(test)]
+mod dcc_event_detection_tests;
+#[cfg(test)]
 mod event_enable_distribution_tests;
 #[cfg(test)]
 mod event_enrollment_task_tests;


### PR DESCRIPTION
## Summary
- keep per-write intrinsic event detection active during both DCC disabled states
- keep periodic `Time_Delay` countdowns and local transition actions active while outbound EventNotifications remain suppressed
- add regression tests for immediate and delayed transitions under DCC states 1 and 2

## Standard basis
Clause 16.1 controls network-message initiation. The local transition actions in Clause 13.2.2.1.4 continue independently of notification distribution.

## Verification
- `cargo test -p bacnet-server`
- `cargo test -p bacnet-integration-tests --test server dcc`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo fmt --all --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Closes #220