### PR TITLE
fix(objects): derive enrollment status flags from event state

### DIFF
--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -300,6 +300,16 @@ impl BACnetObject for EventEnrollmentObject {
         property: PropertyIdentifier,
         array_index: Option<u32>,
     ) -> Result<PropertyValue, Error> {
+        if property == PropertyIdentifier::STATUS_FLAGS {
+            // Clause 12.12 fixes OVERRIDDEN and OUT_OF_SERVICE at FALSE;
+            // IN_ALARM follows Event_State and FAULT follows Reliability.
+            return Ok(common::compute_status_flags(
+                StatusFlags::empty(),
+                self.reliability,
+                false,
+                self.event_state,
+            ));
+        }
         if let Some(result) = read_common_properties!(self, property, array_index) {
             return result;
         }

--- a/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
@@ -2,4 +2,5 @@ mod alert;
 mod detection_enable;
 mod enrollment;
 mod fault_parameters;
+mod status_flags;
 mod time_delay_normal;

--- a/crates/bacnet-objects/src/event_enrollment/tests/status_flags.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/status_flags.rs
@@ -1,0 +1,36 @@
+use super::super::*;
+
+#[test]
+fn event_enrollment_status_flags_follow_event_state_and_force_out_of_service_false() {
+    let mut enrollment = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
+    enrollment
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    enrollment.set_event_state(EventState::HIGH_LIMIT.to_raw());
+
+    assert_eq!(
+        enrollment
+            .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 4,
+            data: vec![0b1000_0000],
+        }
+    );
+
+    enrollment.set_event_state(EventState::NORMAL.to_raw());
+    assert_eq!(
+        enrollment
+            .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 4,
+            data: vec![0],
+        }
+    );
+}

--- a/crates/bacnet-objects/src/event_enrollment/tests/status_flags.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/status_flags.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use bacnet_types::enums::Reliability;
 
 #[test]
 fn event_enrollment_status_flags_follow_event_state_and_force_out_of_service_false() {
@@ -24,6 +25,18 @@ fn event_enrollment_status_flags_follow_event_state_and_force_out_of_service_fal
     );
 
     enrollment.set_event_state(EventState::NORMAL.to_raw());
+    enrollment.reliability = Reliability::NO_SENSOR.to_raw();
+    assert_eq!(
+        enrollment
+            .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 4,
+            data: vec![0b0100_0000],
+        }
+    );
+
+    enrollment.reliability = Reliability::NO_FAULT_DETECTED.to_raw();
     assert_eq!(
         enrollment
             .read_property(PropertyIdentifier::STATUS_FLAGS, None)


### PR DESCRIPTION
## Summary
- derive Event Enrollment `IN_ALARM` from `Event_State`
- preserve the `FAULT` projection from `Reliability`
- force `OVERRIDDEN` and `OUT_OF_SERVICE` false as required by Clause 12.12
- add focused coverage for alarm, fault, and out-of-service interactions

## Verification
- `cargo test -p bacnet-objects`
- `cargo test -p bacnet-server`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo fmt --all --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Closes #179