### PR TITLE
fix(objects): allow Event Enrollment renames

### DIFF
--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -512,6 +512,9 @@ impl BACnetObject for EventEnrollmentObject {
         {
             return result;
         }
+        if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
+            return result;
+        }
         if let Some(result) = common::write_description(&mut self.description, property, &value) {
             return result;
         }
@@ -661,16 +664,7 @@ impl BACnetObject for EventEnrollmentObject {
     }
 
     /// Mirrors the `write_property` arms above, so PICS reports what dispatch
-    /// actually accepts — with one known exception, `OBJECT_NAME`.
-    ///
-    /// `common::is_common_writable` includes `OBJECT_NAME`, but this object's
-    /// `write_property` has no arm for it and returns `WRITE_ACCESS_DENIED`, so
-    /// an Event Enrollment cannot be renamed while every core I/O/V type can
-    /// (they route it through `common::write_object_name`). That is a
-    /// pre-existing gap, not one this override introduces: the inherited
-    /// `historical_writable_default` already returned `true` for `OBJECT_NAME`,
-    /// so PICS reported the same thing before. Kept as-is to avoid a silent
-    /// PICS change here; the missing rename support is tracked separately.
+    /// actually accepts.
     ///
     /// Enumerated rather than reusing `common::is_event_property_writable`:
     /// that helper covers the intrinsic-reporting objects and includes

--- a/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
@@ -2,5 +2,6 @@ mod alert;
 mod detection_enable;
 mod enrollment;
 mod fault_parameters;
+mod object_name;
 mod status_flags;
 mod time_delay_normal;

--- a/crates/bacnet-objects/src/event_enrollment/tests/object_name.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/object_name.rs
@@ -1,0 +1,24 @@
+use super::super::*;
+
+#[test]
+fn event_enrollment_object_name_writability_matches_dispatch() {
+    let mut enrollment = EventEnrollmentObject::new(1, "EE-A", 0).unwrap();
+
+    assert!(enrollment.is_writable_property(PropertyIdentifier::OBJECT_NAME));
+    enrollment
+        .write_property(
+            PropertyIdentifier::OBJECT_NAME,
+            None,
+            PropertyValue::CharacterString("EE-Renamed".to_string()),
+            None,
+        )
+        .unwrap();
+
+    assert_eq!(enrollment.object_name(), "EE-Renamed");
+    assert_eq!(
+        enrollment
+            .read_property(PropertyIdentifier::OBJECT_NAME, None)
+            .unwrap(),
+        PropertyValue::CharacterString("EE-Renamed".to_string())
+    );
+}

--- a/crates/bacnet-server/src/handlers/tests/write_property_name.rs
+++ b/crates/bacnet-server/src/handlers/tests/write_property_name.rs
@@ -13,6 +13,7 @@
 
 use super::*;
 use bacnet_objects::binary::BinaryValueObject;
+use bacnet_objects::event_enrollment::EventEnrollmentObject;
 use bacnet_types::primitives::PropertyValue;
 
 /// Build a `WritePropertyRequest` body for `OBJECT_NAME` on `oid` set to `name`.
@@ -83,6 +84,37 @@ fn write_object_name_rename_refreshes_index() {
 
     // B was untouched by the rename.
     assert_eq!(db.get(&oid_b).unwrap().object_name(), "BV-B");
+}
+
+#[test]
+fn event_enrollment_name_write_refreshes_index_and_rejects_duplicate() {
+    let mut db = ObjectDatabase::new();
+    let enrollment = EventEnrollmentObject::new(1, "EE-A", 0).unwrap();
+    let occupied = BinaryValueObject::new(1, "Occupied").unwrap();
+    let oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+    db.add(Box::new(occupied)).unwrap();
+
+    handle_write_property(&mut db, &encode_name_write(oid, "EE-Renamed")).unwrap();
+
+    assert!(db.find_by_name("EE-A").is_none());
+    assert_eq!(
+        db.find_by_name("EE-Renamed").unwrap().object_identifier(),
+        oid
+    );
+
+    match handle_write_property(&mut db, &encode_name_write(oid, "Occupied")) {
+        Err(Error::Protocol { class, code }) => {
+            assert_eq!(class, ErrorClass::OBJECT.to_raw() as u32);
+            assert_eq!(code, ErrorCode::DUPLICATE_NAME.to_raw() as u32);
+        }
+        other => panic!("expected DUPLICATE_NAME, got {other:?}"),
+    }
+    assert_eq!(db.get(&oid).unwrap().object_name(), "EE-Renamed");
+    assert_eq!(
+        db.find_by_name("EE-Renamed").unwrap().object_identifier(),
+        oid
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- route Event Enrollment `Object_Name` writes through the shared validated rename helper
- align runtime dispatch with the existing PICS writability claim
- verify the WriteProperty path refreshes the database name index
- verify duplicate names return `OBJECT / DUPLICATE_NAME` without mutating the object or index

Alert Enrollment remains unchanged because it consistently reports and enforces `Object_Name` as non-writable.

## Verification
- `cargo test -p bacnet-objects`
- `cargo test -p bacnet-server`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo fmt --all --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Closes #208