### PR TITLE
fix(objects): pair enrollment fault type and parameters

### DIFF
--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -284,6 +284,12 @@ impl EventEnrollmentObject {
             _ => 0,
         }
     }
+
+    fn effective_fault_parameters(&self) -> &FaultParameters {
+        self.fault_parameters
+            .as_ref()
+            .unwrap_or(&FaultParameters::FaultNone)
+    }
 }
 
 impl BACnetObject for EventEnrollmentObject {
@@ -365,14 +371,17 @@ impl BACnetObject for EventEnrollmentObject {
             p if p == PropertyIdentifier::NOTIFICATION_CLASS => {
                 Ok(PropertyValue::Unsigned(self.notification_class as u64))
             }
-            p if p == PropertyIdentifier::FAULT_PARAMETERS => match &self.fault_parameters {
-                None => Ok(PropertyValue::Null),
-                Some(fp) => {
-                    let mut buf = bytes::BytesMut::new();
-                    bacnet_encoding::constructed::encode_fault_parameters(&mut buf, fp)?;
-                    Ok(PropertyValue::ApplicationData(buf.to_vec()))
-                }
-            },
+            p if p == PropertyIdentifier::FAULT_TYPE => Ok(PropertyValue::Enumerated(
+                self.effective_fault_parameters().fault_type().to_raw(),
+            )),
+            p if p == PropertyIdentifier::FAULT_PARAMETERS => {
+                let mut buf = bytes::BytesMut::new();
+                bacnet_encoding::constructed::encode_fault_parameters(
+                    &mut buf,
+                    self.effective_fault_parameters(),
+                )?;
+                Ok(PropertyValue::ApplicationData(buf.to_vec()))
+            }
             p if p == PropertyIdentifier::TIME_DELAY_NORMAL => {
                 // Clause 13.3: "If no value is available for this parameter,
                 // then it takes on the value of the pTimeDelay parameter" —
@@ -712,6 +721,7 @@ impl BACnetObject for EventEnrollmentObject {
             PropertyIdentifier::ACKED_TRANSITIONS,
             PropertyIdentifier::EVENT_DETECTION_ENABLE,
             PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::FAULT_TYPE,
             PropertyIdentifier::FAULT_PARAMETERS,
             PropertyIdentifier::TIME_DELAY_NORMAL,
             PropertyIdentifier::STATUS_FLAGS,

--- a/crates/bacnet-objects/src/event_enrollment/tests/fault_parameters.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/fault_parameters.rs
@@ -3,6 +3,7 @@
 //! Split out to keep every file under the 700-LOC cap.
 
 use super::super::*;
+use bacnet_types::enums::FaultType;
 
 /// Decode the read arm's framed wire form back to a structured value.
 fn decode_framed(val: PropertyValue) -> FaultParameters {
@@ -14,16 +15,92 @@ fn decode_framed(val: PropertyValue) -> FaultParameters {
         .0
 }
 
+fn read_fault_type(ee: &EventEnrollmentObject) -> u32 {
+    let PropertyValue::Enumerated(value) = ee
+        .read_property(PropertyIdentifier::FAULT_TYPE, None)
+        .unwrap()
+    else {
+        panic!("Fault_Type must be Enumerated");
+    };
+    value
+}
+
 // FaultParameters tests
 // -----------------------------------------------------------------------
 
 #[test]
-fn fault_parameters_default_none() {
+fn fault_parameters_default_to_none_choice() {
     let ee = EventEnrollmentObject::new(1, "EE-FP", 0).unwrap();
     let val = ee
         .read_property(PropertyIdentifier::FAULT_PARAMETERS, None)
         .unwrap();
-    assert_eq!(val, PropertyValue::Null);
+    assert_eq!(decode_framed(val), FaultParameters::FaultNone);
+    assert_eq!(read_fault_type(&ee), FaultType::NONE.to_raw());
+}
+
+#[test]
+fn fault_type_tracks_each_fault_parameters_alternative() {
+    use bacnet_types::constructed::BACnetPropertyStates;
+
+    let reference = BACnetDeviceObjectPropertyReference {
+        object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+        property_identifier: PropertyIdentifier::PRESENT_VALUE.to_raw(),
+        property_array_index: None,
+        device_identifier: None,
+    };
+    let cases = vec![
+        (FaultParameters::FaultNone, FaultType::NONE),
+        (
+            FaultParameters::FaultCharacterString {
+                fault_values: vec!["fault".to_string()],
+            },
+            FaultType::FAULT_CHARACTERSTRING,
+        ),
+        (
+            FaultParameters::FaultExtended {
+                vendor_id: 1,
+                extended_fault_type: 2,
+                parameters: vec![],
+            },
+            FaultType::FAULT_EXTENDED,
+        ),
+        (
+            FaultParameters::FaultLifeSafety {
+                fault_values: vec![1],
+                mode_for_reference: reference.clone(),
+            },
+            FaultType::FAULT_LIFE_SAFETY,
+        ),
+        (
+            FaultParameters::FaultState {
+                fault_values: vec![BACnetPropertyStates::BooleanValue(true)],
+            },
+            FaultType::FAULT_STATE,
+        ),
+        (
+            FaultParameters::FaultStatusFlags {
+                reference: reference.clone(),
+            },
+            FaultType::FAULT_STATUS_FLAGS,
+        ),
+        (
+            FaultParameters::FaultOutOfRange {
+                min_normal: 0.0,
+                max_normal: 1.0,
+            },
+            FaultType::FAULT_OUT_OF_RANGE,
+        ),
+        (
+            FaultParameters::FaultListed { reference },
+            FaultType::FAULT_LISTED,
+        ),
+    ];
+    let mut ee = EventEnrollmentObject::new(1, "EE-FP", 0).unwrap();
+
+    for (parameters, expected) in cases {
+        ee.set_fault_parameters(Some(parameters));
+        assert_eq!(read_fault_type(&ee), expected.to_raw());
+    }
 }
 
 #[test]
@@ -152,10 +229,20 @@ fn fault_parameters_listed() {
 }
 
 #[test]
-fn fault_parameters_in_property_list() {
-    let ee = EventEnrollmentObject::new(1, "EE-FP", 0).unwrap();
+fn fault_properties_are_advertised_together() {
+    let mut ee = EventEnrollmentObject::new(1, "EE-FP", 0).unwrap();
     let props = ee.property_list();
+    assert!(props.contains(&PropertyIdentifier::FAULT_TYPE));
     assert!(props.contains(&PropertyIdentifier::FAULT_PARAMETERS));
+    assert!(!ee.is_writable_property(PropertyIdentifier::FAULT_TYPE));
+    assert!(ee
+        .write_property(
+            PropertyIdentifier::FAULT_TYPE,
+            None,
+            PropertyValue::Enumerated(FaultType::FAULT_LISTED.to_raw()),
+            None,
+        )
+        .is_err());
 }
 
 #[test]
@@ -225,11 +312,11 @@ fn fault_parameters_framed_trailing_garbage_rejected() {
             None,
         );
         assert!(result.is_err(), "trailing {extra} byte(s) must be rejected");
-        // Untouched: Fault_Parameters still reads as Null (never set).
+        // Untouched: the effective choice remains FaultNone.
         let val = ee
             .read_property(PropertyIdentifier::FAULT_PARAMETERS, None)
             .unwrap();
-        assert_eq!(val, PropertyValue::Null);
+        assert_eq!(decode_framed(val), FaultParameters::FaultNone);
     }
 }
 
@@ -260,7 +347,8 @@ fn fault_parameters_write_clear_to_null() {
     let val = ee
         .read_property(PropertyIdentifier::FAULT_PARAMETERS, None)
         .unwrap();
-    assert_eq!(val, PropertyValue::Null);
+    assert_eq!(decode_framed(val), FaultParameters::FaultNone);
+    assert_eq!(read_fault_type(&ee), FaultType::NONE.to_raw());
 }
 
 #[test]
@@ -272,12 +360,13 @@ fn fault_parameters_clear() {
         .unwrap();
     assert_eq!(decode_framed(val), FaultParameters::FaultNone);
 
-    // Clear back to None
+    // Clear back to the effective NONE alternative.
     ee.set_fault_parameters(None);
     let val = ee
         .read_property(PropertyIdentifier::FAULT_PARAMETERS, None)
         .unwrap();
-    assert_eq!(val, PropertyValue::Null);
+    assert_eq!(decode_framed(val), FaultParameters::FaultNone);
+    assert_eq!(read_fault_type(&ee), FaultType::NONE.to_raw());
 }
 
 // -----------------------------------------------------------------------

--- a/crates/bacnet-types/src/constructed/event_parameter/fault.rs
+++ b/crates/bacnet-types/src/constructed/event_parameter/fault.rs
@@ -3,6 +3,7 @@
 //! Split out of `mod.rs` to keep every file under the 700-LOC cap.
 
 use super::*;
+use crate::enums::FaultType;
 
 // ---------------------------------------------------------------------------
 // FaultParameters structured round trip (Clause 12.12.50 -- Fault_Parameters)
@@ -21,6 +22,21 @@ mod fault_parameter_tag {
 }
 
 impl crate::constructed::FaultParameters {
+    /// Return the fault algorithm selected by this parameter alternative.
+    pub const fn fault_type(&self) -> FaultType {
+        use crate::constructed::FaultParameters as F;
+        match self {
+            F::FaultNone => FaultType::NONE,
+            F::FaultCharacterString { .. } => FaultType::FAULT_CHARACTERSTRING,
+            F::FaultExtended { .. } => FaultType::FAULT_EXTENDED,
+            F::FaultLifeSafety { .. } => FaultType::FAULT_LIFE_SAFETY,
+            F::FaultState { .. } => FaultType::FAULT_STATE,
+            F::FaultStatusFlags { .. } => FaultType::FAULT_STATUS_FLAGS,
+            F::FaultOutOfRange { .. } => FaultType::FAULT_OUT_OF_RANGE,
+            F::FaultListed { .. } => FaultType::FAULT_LISTED,
+        }
+    }
+
     /// Encode this fault-parameter set as a flat [`PropertyValue::List`].
     ///
     /// The first element is the variant tag as [`PropertyValue::Unsigned`],

--- a/crates/bacnet-types/src/enums/object_level.rs
+++ b/crates/bacnet-types/src/enums/object_level.rs
@@ -198,6 +198,20 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
+    /// BACnet fault algorithm type (Clause 21.6).
+    pub struct FaultType(u32);
+
+    const NONE = 0;
+    const FAULT_CHARACTERSTRING = 1;
+    const FAULT_EXTENDED = 2;
+    const FAULT_LIFE_SAFETY = 3;
+    const FAULT_STATE = 4;
+    const FAULT_STATUS_FLAGS = 5;
+    const FAULT_OUT_OF_RANGE = 6;
+    const FAULT_LISTED = 7;
+}
+
+bacnet_enum! {
     /// BACnet notify type (Clause 12.21).
     pub struct NotifyType(u32);
 

--- a/crates/bacnet-types/src/enums/resolve.rs
+++ b/crates/bacnet-types/src/enums/resolve.rs
@@ -64,6 +64,7 @@ resolved_enum! {
     ObjectType(ObjectType),
     EventState(EventState),
     EventType(EventType),
+    FaultType(FaultType),
     NotifyType(NotifyType),
     Reliability(Reliability),
     DeviceStatus(DeviceStatus),
@@ -131,6 +132,7 @@ impl ResolvedEnum {
             79 => Self::ObjectType(ObjectType::from_raw(value)), // object-type
             36 => Self::EventState(EventState::from_raw(value)), // event-state
             37 => Self::EventType(EventType::from_raw(value)),   // event-type
+            359 => Self::FaultType(FaultType::from_raw(value)),  // fault-type
             72 => Self::NotifyType(NotifyType::from_raw(value)), // notify-type
             103 => Self::Reliability(Reliability::from_raw(value)), // reliability
             112 => Self::DeviceStatus(DeviceStatus::from_raw(value)), // system-status

--- a/crates/bacnet-types/src/enums/tests.rs
+++ b/crates/bacnet-types/src/enums/tests.rs
@@ -581,6 +581,27 @@ fn resolves_253_properties_by_name() {
     }
 }
 
+#[test]
+fn resolves_fault_type_by_name() {
+    let resolved = ResolvedEnum::from_property(PropertyIdentifier::FAULT_TYPE, 6);
+    assert_eq!(
+        resolved,
+        ResolvedEnum::FaultType(FaultType::FAULT_OUT_OF_RANGE)
+    );
+    assert_eq!(resolved.to_string(), "FAULT_OUT_OF_RANGE");
+}
+
+#[test]
+fn fault_type_codes_match_clause_21_6() {
+    assert_eq!(
+        FaultType::ALL_NAMED
+            .iter()
+            .map(|(_, value)| value.to_raw())
+            .collect::<Vec<_>>(),
+        (0..=7).collect::<Vec<_>>()
+    );
+}
+
 /// Out-of-production values stay named-but-numeric through the arms (the
 /// newtype keeps the raw number; Display falls back to it).
 #[test]
@@ -688,6 +709,7 @@ fn from_str_round_trips_display_for_all_named() {
         EngineeringUnits,
         EventState,
         EventType,
+        FaultType,
         Reliability,
         BackupAndRestoreState,
         LifeSafetyState,


### PR DESCRIPTION
## Summary
- add the Clause 21.6 `FaultType` scalar enumeration and property resolver
- derive Event Enrollment `Fault_Type` directly from the effective `Fault_Parameters` CHOICE
- advertise `Fault_Type` and `Fault_Parameters` together while keeping `Fault_Type` read-only
- encode the unconfigured/cleared case as the normative framed `FaultNone` alternative instead of application `Null`
- cover all eight fault alternatives and the default, clear, malformed-write, resolver, and PICS-facing property-list contracts

Fault algorithm execution remains in the separate reliability slice. Pre-existing legacy flat-list decoder hardening found during review is tracked in #296.

## Verification
- `cargo test -p bacnet-types`
- `cargo test -p bacnet-objects`
- `cargo test -p bacnet-server`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo fmt --all --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Closes #180