### PR TITLE
fix(types): reject malformed legacy fault parameters

### DIFF
--- a/crates/bacnet-server/src/handlers/tests/framed_properties.rs
+++ b/crates/bacnet-server/src/handlers/tests/framed_properties.rs
@@ -1,6 +1,6 @@
-//! Wire-level integration for the ASN.1-framed properties (#154, #152):
-//! a conformant peer's framed WriteProperty must land and a ReadProperty
-//! must return the identical framed bytes.
+//! Wire-level integration for structured properties (#154, #152): conformant
+//! framed writes round-trip identically, while retained legacy flat forms are
+//! validated before mutation.
 
 use super::*;
 use bacnet_objects::event_enrollment::EventEnrollmentObject;
@@ -145,6 +145,49 @@ fn fault_parameters_framed_wire_round_trip() {
     assert_eq!(
         read_raw(&db, oid, PropertyIdentifier::FAULT_PARAMETERS),
         framed
+    );
+}
+
+#[test]
+fn malformed_legacy_fault_parameters_preserve_existing_value() {
+    let mut db = ObjectDatabase::new();
+    let mut ee = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
+    ee.set_fault_parameters(Some(FaultParameters::FaultOutOfRange {
+        min_normal: 0.0,
+        max_normal: 100.0,
+    }));
+    let oid = ee.object_identifier();
+    db.add(Box::new(ee)).unwrap();
+    let before = read_raw(&db, oid, PropertyIdentifier::FAULT_PARAMETERS);
+
+    let mut oversized_tag = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_unsigned(&mut oversized_tag, 256);
+    bacnet_encoding::primitives::encode_app_unsigned(&mut oversized_tag, 1);
+    assert!(write_framed(
+        &mut db,
+        oid,
+        PropertyIdentifier::FAULT_PARAMETERS,
+        oversized_tag.to_vec(),
+    )
+    .is_err());
+    assert_eq!(
+        read_raw(&db, oid, PropertyIdentifier::FAULT_PARAMETERS),
+        before
+    );
+
+    let mut trailing_value = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_unsigned(&mut trailing_value, 0);
+    bacnet_encoding::primitives::encode_app_boolean(&mut trailing_value, true);
+    assert!(write_framed(
+        &mut db,
+        oid,
+        PropertyIdentifier::FAULT_PARAMETERS,
+        trailing_value.to_vec(),
+    )
+    .is_err());
+    assert_eq!(
+        read_raw(&db, oid, PropertyIdentifier::FAULT_PARAMETERS),
+        before
     );
 }
 

--- a/crates/bacnet-types/src/constructed/event_parameter/fault.rs
+++ b/crates/bacnet-types/src/constructed/event_parameter/fault.rs
@@ -11,14 +11,14 @@ use crate::enums::FaultType;
 
 /// Variant tag carried as the leading element of the flat-`List` encoding.
 mod fault_parameter_tag {
-    pub const NONE: u8 = 0;
-    pub const CHARACTER_STRING: u8 = 1;
-    pub const EXTENDED: u8 = 2;
-    pub const LIFE_SAFETY: u8 = 3;
-    pub const STATE: u8 = 4;
-    pub const STATUS_FLAGS: u8 = 5;
-    pub const OUT_OF_RANGE: u8 = 6;
-    pub const LISTED: u8 = 7;
+    pub const NONE: u64 = 0;
+    pub const CHARACTER_STRING: u64 = 1;
+    pub const EXTENDED: u64 = 2;
+    pub const LIFE_SAFETY: u64 = 3;
+    pub const STATE: u64 = 4;
+    pub const STATUS_FLAGS: u64 = 5;
+    pub const OUT_OF_RANGE: u64 = 6;
+    pub const LISTED: u64 = 7;
 }
 
 impl crate::constructed::FaultParameters {
@@ -48,11 +48,11 @@ impl crate::constructed::FaultParameters {
     pub fn encode_property_value(&self) -> PropertyValue {
         use crate::constructed::FaultParameters as F;
         match self {
-            F::FaultNone => PropertyValue::List(vec![PropertyValue::Unsigned(
-                fault_parameter_tag::NONE as u64,
-            )]),
+            F::FaultNone => {
+                PropertyValue::List(vec![PropertyValue::Unsigned(fault_parameter_tag::NONE)])
+            }
             F::FaultCharacterString { fault_values } => PropertyValue::List(vec![
-                PropertyValue::Unsigned(fault_parameter_tag::CHARACTER_STRING as u64),
+                PropertyValue::Unsigned(fault_parameter_tag::CHARACTER_STRING),
                 PropertyValue::List(
                     fault_values
                         .iter()
@@ -65,7 +65,7 @@ impl crate::constructed::FaultParameters {
                 extended_fault_type,
                 parameters,
             } => PropertyValue::List(vec![
-                PropertyValue::Unsigned(fault_parameter_tag::EXTENDED as u64),
+                PropertyValue::Unsigned(fault_parameter_tag::EXTENDED),
                 PropertyValue::Unsigned(*vendor_id as u64),
                 PropertyValue::Unsigned(*extended_fault_type as u64),
                 PropertyValue::OctetString(parameters.clone()),
@@ -74,7 +74,7 @@ impl crate::constructed::FaultParameters {
                 fault_values,
                 mode_for_reference,
             } => PropertyValue::List(vec![
-                PropertyValue::Unsigned(fault_parameter_tag::LIFE_SAFETY as u64),
+                PropertyValue::Unsigned(fault_parameter_tag::LIFE_SAFETY),
                 PropertyValue::List(
                     fault_values
                         .iter()
@@ -84,23 +84,23 @@ impl crate::constructed::FaultParameters {
                 device_object_property_reference_pv(mode_for_reference),
             ]),
             F::FaultState { fault_values } => PropertyValue::List(vec![
-                PropertyValue::Unsigned(fault_parameter_tag::STATE as u64),
+                PropertyValue::Unsigned(fault_parameter_tag::STATE),
                 PropertyValue::List(fault_values.iter().map(property_state_pv).collect()),
             ]),
             F::FaultStatusFlags { reference } => PropertyValue::List(vec![
-                PropertyValue::Unsigned(fault_parameter_tag::STATUS_FLAGS as u64),
+                PropertyValue::Unsigned(fault_parameter_tag::STATUS_FLAGS),
                 device_object_property_reference_pv(reference),
             ]),
             F::FaultOutOfRange {
                 min_normal,
                 max_normal,
             } => PropertyValue::List(vec![
-                PropertyValue::Unsigned(fault_parameter_tag::OUT_OF_RANGE as u64),
+                PropertyValue::Unsigned(fault_parameter_tag::OUT_OF_RANGE),
                 PropertyValue::Double(*min_normal),
                 PropertyValue::Double(*max_normal),
             ]),
             F::FaultListed { reference } => PropertyValue::List(vec![
-                PropertyValue::Unsigned(fault_parameter_tag::LISTED as u64),
+                PropertyValue::Unsigned(fault_parameter_tag::LISTED),
                 device_object_property_reference_pv(reference),
             ]),
         }
@@ -120,7 +120,7 @@ impl crate::constructed::FaultParameters {
             return Err(Error::decoding(0, "Fault_Parameters tag is not Unsigned"));
         };
         let mut idx = 0;
-        Ok(match *tag as u8 {
+        let decoded = match *tag {
             fault_parameter_tag::NONE => F::FaultNone,
             fault_parameter_tag::CHARACTER_STRING => {
                 let Some(PropertyValue::List(inner)) = rest.get(idx) else {
@@ -198,6 +198,13 @@ impl crate::constructed::FaultParameters {
                 F::FaultListed { reference }
             }
             other => return Err(Error::decoding(0, format!("unknown fault tag {other}"))),
-        })
+        };
+        if idx != rest.len() {
+            return Err(Error::decoding(
+                idx + 1,
+                "Fault_Parameters has trailing values",
+            ));
+        }
+        Ok(decoded)
     }
 }

--- a/crates/bacnet-types/src/constructed/event_parameter/tests.rs
+++ b/crates/bacnet-types/src/constructed/event_parameter/tests.rs
@@ -151,3 +151,60 @@ fn fault_parameters_none_round_trip() {
         fp
     );
 }
+
+#[test]
+fn fault_parameters_reject_out_of_range_legacy_tags() {
+    for tag in [8, 255, 256, u64::MAX] {
+        assert!(
+            FaultParameters::decode_property_value(&PropertyValue::List(vec![
+                PropertyValue::Unsigned(tag),
+            ]))
+            .is_err()
+        );
+    }
+}
+
+#[test]
+fn fault_parameters_legacy_alternatives_require_exact_members() {
+    let reference = dopr(1);
+    let alternatives = vec![
+        FaultParameters::FaultNone,
+        FaultParameters::FaultCharacterString {
+            fault_values: vec!["fault".to_string()],
+        },
+        FaultParameters::FaultExtended {
+            vendor_id: 1,
+            extended_fault_type: 2,
+            parameters: vec![3],
+        },
+        FaultParameters::FaultLifeSafety {
+            fault_values: vec![1],
+            mode_for_reference: reference.clone(),
+        },
+        FaultParameters::FaultState {
+            fault_values: vec![BACnetPropertyStates::BooleanValue(true)],
+        },
+        FaultParameters::FaultStatusFlags {
+            reference: reference.clone(),
+        },
+        FaultParameters::FaultOutOfRange {
+            min_normal: 0.0,
+            max_normal: 1.0,
+        },
+        FaultParameters::FaultListed { reference },
+    ];
+
+    for parameters in alternatives {
+        let encoded = parameters.encode_property_value();
+        assert_eq!(
+            FaultParameters::decode_property_value(&encoded).unwrap(),
+            parameters
+        );
+
+        let PropertyValue::List(mut items) = encoded else {
+            unreachable!();
+        };
+        items.push(PropertyValue::Boolean(true));
+        assert!(FaultParameters::decode_property_value(&PropertyValue::List(items)).is_err());
+    }
+}


### PR DESCRIPTION
## Summary
- match legacy `Fault_Parameters` CHOICE tags at their full `u64` width instead of truncating to `u8`
- require exact top-level member consumption for all eight legacy alternatives
- retain valid legacy alternative round trips and the separate framed ASN.1 path
- verify malformed wire-level WriteProperty values cannot replace configured Event Enrollment fault parameters

Pre-existing nested legacy member validation is tracked separately in #298.

## Verification
- `cargo test -p bacnet-types`
- `cargo test -p bacnet-objects`
- `cargo test -p bacnet-server`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo fmt --all --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Closes #296