### PR TITLE
fix(server): reject remote enrollment references

### DIFF
--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -110,7 +110,7 @@ fn read_object_property_ref(
     Option<ObjectIdentifier>,
 )> {
     match enrollment.read_property(PropertyIdentifier::OBJECT_PROPERTY_REFERENCE, None) {
-        Ok(PropertyValue::List(ref items)) if items.len() >= 2 => {
+        Ok(PropertyValue::List(ref items)) if (2..=4).contains(&items.len()) => {
             let obj_id = match &items[0] {
                 PropertyValue::ObjectIdentifier(oid) => *oid,
                 _ => return None,
@@ -119,6 +119,10 @@ fn read_object_property_ref(
                 PropertyValue::Unsigned(v) => PropertyIdentifier::from_raw(*v as u32),
                 _ => return None,
             };
+            match items.get(2) {
+                None | Some(PropertyValue::Null | PropertyValue::Unsigned(_)) => {}
+                Some(_) => return None,
+            }
             let device_id = match items.get(3) {
                 None | Some(PropertyValue::Null) => None,
                 Some(PropertyValue::ObjectIdentifier(oid)) => Some(*oid),

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -101,10 +101,14 @@ fn read_setpoint(
 
 /// Read the object_property_reference from an EventEnrollment object.
 ///
-/// Returns (monitored_object_id, monitored_property_id) if valid.
+/// Returns the monitored object, property, and optional device qualifier.
 fn read_object_property_ref(
     enrollment: &dyn BACnetObject,
-) -> Option<(ObjectIdentifier, PropertyIdentifier)> {
+) -> Option<(
+    ObjectIdentifier,
+    PropertyIdentifier,
+    Option<ObjectIdentifier>,
+)> {
     match enrollment.read_property(PropertyIdentifier::OBJECT_PROPERTY_REFERENCE, None) {
         Ok(PropertyValue::List(ref items)) if items.len() >= 2 => {
             let obj_id = match &items[0] {
@@ -115,7 +119,12 @@ fn read_object_property_ref(
                 PropertyValue::Unsigned(v) => PropertyIdentifier::from_raw(*v as u32),
                 _ => return None,
             };
-            Some((obj_id, prop_id))
+            let device_id = match items.get(3) {
+                None | Some(PropertyValue::Null) => None,
+                Some(PropertyValue::ObjectIdentifier(oid)) => Some(*oid),
+                Some(_) => return None,
+            };
+            Some((obj_id, prop_id, device_id))
         }
         _ => None,
     }
@@ -251,6 +260,13 @@ pub fn evaluate_event_enrollments(
 ) -> Vec<EventEnrollmentTransition> {
     let interval_secs = interval_secs.max(1);
     let oids = db.find_by_type(ObjectType::EVENT_ENROLLMENT);
+    // A qualified reference can identify self only when the containing Device
+    // object is unambiguous. Unqualified references remain local regardless.
+    let device_oids = db.find_by_type(ObjectType::DEVICE);
+    let local_device_oid = match device_oids.as_slice() {
+        [oid] => Some(*oid),
+        _ => None,
+    };
 
     let mut updates: Vec<(ObjectIdentifier, EnrollmentUpdate)> = Vec::new();
 
@@ -345,14 +361,25 @@ pub fn evaluate_event_enrollments(
             .unwrap_or_default();
         let mut eval_state_dirty = false;
 
-        // The reference is folded into the fingerprint, so it is read BEFORE
-        // the check. An unreadable reference exits here — before the cancel —
-        // deliberately: a transiently unreadable reference retains the
-        // countdown, whereas every failure AFTER this point leaves the
-        // cancellation persisted (see the flush below).
-        let Some((monitored_oid, monitored_prop)) = read_object_property_ref(enrollment) else {
+        // The reference is folded into the fingerprint, so it is read before
+        // the check. A malformed or unreadable value retains evaluation state
+        // as a transient failure. A valid but unresolvable device qualifier is
+        // configured state, so it clears state rather than resuming stale work
+        // if the enrollment is later retargeted locally.
+        let Some((monitored_oid, monitored_prop, reference_device_oid)) =
+            read_object_property_ref(enrollment)
+        else {
             continue;
         };
+        if reference_device_oid.is_some_and(|device_oid| Some(device_oid) != local_device_oid) {
+            if eval_state_supported && eval_state != EventEnrollmentEvalState::default() {
+                updates.push((
+                    *oid,
+                    EnrollmentUpdate::eval_state_only(EventEnrollmentEvalState::default()),
+                ));
+            }
+            continue;
+        }
 
         // A parameter (or reference) change mid-pending cancels the countdown
         // and re-gates from the current parameters; no partial countdown is

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -268,7 +268,7 @@ pub fn evaluate_event_enrollments(
     // object is unambiguous. Unqualified references remain local regardless.
     let device_oids = db.find_by_type(ObjectType::DEVICE);
     let local_device_oid = match device_oids.as_slice() {
-        [oid] => Some(*oid),
+        [oid] if oid.instance_number() != ObjectIdentifier::WILDCARD_INSTANCE => Some(*oid),
         _ => None,
     };
 

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -8,6 +8,7 @@ use bacnet_objects::device::{DeviceConfig, DeviceObject};
 use bacnet_objects::event_enrollment::EventEnrollmentObject;
 use bacnet_objects::traits::BACnetObject;
 use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetEventParameter};
+use std::borrow::Cow;
 
 // ---- Integration: multiple enrollments ----
 
@@ -200,5 +201,88 @@ fn unresolvable_reference_clears_private_evaluator_state() {
             .enrollment_eval_state_internal()
             .unwrap(),
         bacnet_objects::event_enrollment::EventEnrollmentEvalState::default()
+    );
+}
+
+struct ReferenceValueObject(PropertyValue);
+
+impl BACnetObject for ReferenceValueObject {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 999).unwrap()
+    }
+
+    fn object_name(&self) -> &str {
+        "reference-value"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, bacnet_types::error::Error> {
+        if property == PropertyIdentifier::OBJECT_PROPERTY_REFERENCE {
+            Ok(self.0.clone())
+        } else {
+            Err(bacnet_types::error::Error::Encoding(
+                "unsupported test property".into(),
+            ))
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), bacnet_types::error::Error> {
+        Err(bacnet_types::error::Error::Encoding(
+            "test object is read-only".into(),
+        ))
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[])
+    }
+}
+
+#[test]
+fn malformed_reference_shapes_do_not_become_local() {
+    let target = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 3).unwrap();
+    let foreign_device = ObjectIdentifier::new(ObjectType::DEVICE, 200).unwrap();
+    let property = PropertyIdentifier::PRESENT_VALUE;
+    let malformed = [
+        vec![
+            PropertyValue::ObjectIdentifier(target),
+            PropertyValue::Unsigned(property.to_raw() as u64),
+            PropertyValue::ObjectIdentifier(foreign_device),
+        ],
+        vec![
+            PropertyValue::ObjectIdentifier(target),
+            PropertyValue::Unsigned(property.to_raw() as u64),
+            PropertyValue::Null,
+            PropertyValue::Null,
+            PropertyValue::ObjectIdentifier(foreign_device),
+        ],
+        vec![
+            PropertyValue::ObjectIdentifier(target),
+            PropertyValue::Unsigned(property.to_raw() as u64),
+            PropertyValue::Boolean(false),
+            PropertyValue::Null,
+        ],
+    ];
+
+    for items in malformed {
+        let enrollment = ReferenceValueObject(PropertyValue::List(items));
+        assert!(super::super::read_object_property_ref(&enrollment).is_none());
+    }
+
+    let legacy = ReferenceValueObject(PropertyValue::List(vec![
+        PropertyValue::ObjectIdentifier(target),
+        PropertyValue::Unsigned(property.to_raw() as u64),
+    ]));
+    assert_eq!(
+        super::super::read_object_property_ref(&legacy),
+        Some((target, property, None))
     );
 }

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -173,6 +173,12 @@ fn qualified_reference_requires_one_containing_device() {
 
     let (mut ambiguous, _, _) = setup_qualified_reference(&[100, 200], 100);
     assert!(evaluate_event_enrollments(&mut ambiguous, 1).is_empty());
+
+    let (mut wildcard, _, _) = setup_qualified_reference(
+        &[ObjectIdentifier::WILDCARD_INSTANCE],
+        ObjectIdentifier::WILDCARD_INSTANCE,
+    );
+    assert!(evaluate_event_enrollments(&mut wildcard, 1).is_empty());
 }
 
 #[test]

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -4,6 +4,7 @@
 
 use super::super::*;
 use bacnet_objects::analog::AnalogInputObject;
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
 use bacnet_objects::event_enrollment::EventEnrollmentObject;
 use bacnet_objects::traits::BACnetObject;
 use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetEventParameter};
@@ -85,4 +86,119 @@ fn missing_monitored_object_is_skipped() {
     // Should not panic or return transitions
     let transitions = evaluate_event_enrollments(&mut db, 1);
     assert!(transitions.is_empty());
+}
+
+fn setup_qualified_reference(
+    local_device_instances: &[u32],
+    reference_device_instance: u32,
+) -> (ObjectDatabase, ObjectIdentifier, ObjectIdentifier) {
+    let mut db = ObjectDatabase::new();
+    for instance in local_device_instances {
+        let device = DeviceObject::new(DeviceConfig {
+            instance: *instance,
+            name: format!("Device-{instance}"),
+            ..DeviceConfig::default()
+        })
+        .unwrap();
+        db.add(Box::new(device)).unwrap();
+    }
+
+    let mut ai = AnalogInputObject::new(3, "AI-3", 62).unwrap();
+    ai.set_present_value(90.0);
+    let ai_oid = ai.object_identifier();
+    db.add(Box::new(ai)).unwrap();
+
+    let reference_device_oid =
+        ObjectIdentifier::new(ObjectType::DEVICE, reference_device_instance).unwrap();
+    let mut ee = EventEnrollmentObject::new(3, "EE-3", EventType::OUT_OF_RANGE.to_raw()).unwrap();
+    ee.set_object_property_reference(Some(BACnetDeviceObjectPropertyReference::new_remote(
+        ai_oid,
+        PropertyIdentifier::PRESENT_VALUE.to_raw(),
+        reference_device_oid,
+    )));
+    ee.set_event_parameters(BACnetEventParameter::OutOfRange {
+        time_delay: 0,
+        low_limit: 20.0,
+        high_limit: 80.0,
+        deadband: 2.0,
+    });
+    ee.set_event_enable(0x07);
+    let ee_oid = ee.object_identifier();
+    db.add(Box::new(ee)).unwrap();
+
+    (db, ee_oid, ai_oid)
+}
+
+#[test]
+fn self_qualified_reference_evaluates_local_object() {
+    let (mut db, _ee_oid, ai_oid) = setup_qualified_reference(&[100], 100);
+
+    let transitions = evaluate_event_enrollments(&mut db, 1);
+    assert_eq!(transitions.len(), 1);
+    assert_eq!(transitions[0].monitored_oid, ai_oid);
+    assert_eq!(transitions[0].change.to, EventState::HIGH_LIMIT);
+}
+
+#[test]
+fn foreign_reference_does_not_evaluate_same_numbered_local_object() {
+    let (mut db, ee_oid, _ai_oid) = setup_qualified_reference(&[100], 200);
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&ee_oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        PropertyValue::Enumerated(EventState::NORMAL.to_raw())
+    );
+    let PropertyValue::List(reference) = db
+        .get(&ee_oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::OBJECT_PROPERTY_REFERENCE, None)
+        .unwrap()
+    else {
+        panic!("expected object property reference list");
+    };
+    assert_eq!(
+        reference[3],
+        PropertyValue::ObjectIdentifier(ObjectIdentifier::new(ObjectType::DEVICE, 200).unwrap())
+    );
+}
+
+#[test]
+fn qualified_reference_requires_one_containing_device() {
+    let (mut missing, _, _) = setup_qualified_reference(&[], 100);
+    assert!(evaluate_event_enrollments(&mut missing, 1).is_empty());
+
+    let (mut ambiguous, _, _) = setup_qualified_reference(&[100, 200], 100);
+    assert!(evaluate_event_enrollments(&mut ambiguous, 1).is_empty());
+}
+
+#[test]
+fn unresolvable_reference_clears_private_evaluator_state() {
+    let (mut db, ee_oid, _) = setup_qualified_reference(&[100], 200);
+    db.get_mut(&ee_oid)
+        .unwrap()
+        .set_enrollment_eval_state_internal(
+            bacnet_objects::event_enrollment::EventEnrollmentEvalState {
+                pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
+                    state: EventState::HIGH_LIMIT,
+                    remaining: 1,
+                    condition: 0,
+                    params_fingerprint: 1,
+                }),
+                cov_baseline: Some(PropertyValue::Real(90.0)),
+                last_offnormal_value: Some(1),
+            },
+        )
+        .unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&ee_oid)
+            .unwrap()
+            .enrollment_eval_state_internal()
+            .unwrap(),
+        bacnet_objects::event_enrollment::EventEnrollmentEvalState::default()
+    );
 }


### PR DESCRIPTION
## Summary
- retain the optional Device qualifier when resolving Event Enrollment `Object_Property_Reference`
- resolve an explicit qualifier locally only when it matches the sole concrete Device object
- fail closed for foreign, missing/ambiguous local Device, wildcard, and malformed reference shapes without evaluating a same-numbered local object
- clear private evaluator state for valid but unsupported remote configurations while preserving unqualified and canonical self-qualified behavior

Follow-ups #300 and #301 track malformed-reference state policy and array-index evaluation separately.

## Verification
- `cargo test -p bacnet-server`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo fmt --all --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- independent contract, dataflow, and adversarial immutable-head reviews

Closes #178