### PR TITLE
fix(server): clear invalid enrollment reference state

### DIFF
--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -104,33 +104,37 @@ fn read_setpoint(
 /// Returns the monitored object, property, and optional device qualifier.
 fn read_object_property_ref(
     enrollment: &dyn BACnetObject,
-) -> Option<(
-    ObjectIdentifier,
-    PropertyIdentifier,
-    Option<ObjectIdentifier>,
-)> {
+) -> Result<
+    Option<(
+        ObjectIdentifier,
+        PropertyIdentifier,
+        Option<ObjectIdentifier>,
+    )>,
+    (),
+> {
     match enrollment.read_property(PropertyIdentifier::OBJECT_PROPERTY_REFERENCE, None) {
         Ok(PropertyValue::List(ref items)) if (2..=4).contains(&items.len()) => {
             let obj_id = match &items[0] {
                 PropertyValue::ObjectIdentifier(oid) => *oid,
-                _ => return None,
+                _ => return Ok(None),
             };
             let prop_id = match &items[1] {
                 PropertyValue::Unsigned(v) => PropertyIdentifier::from_raw(*v as u32),
-                _ => return None,
+                _ => return Ok(None),
             };
             match items.get(2) {
                 None | Some(PropertyValue::Null | PropertyValue::Unsigned(_)) => {}
-                Some(_) => return None,
+                Some(_) => return Ok(None),
             }
             let device_id = match items.get(3) {
                 None | Some(PropertyValue::Null) => None,
                 Some(PropertyValue::ObjectIdentifier(oid)) => Some(*oid),
-                Some(_) => return None,
+                Some(_) => return Ok(None),
             };
-            Some((obj_id, prop_id, device_id))
+            Ok(Some((obj_id, prop_id, device_id)))
         }
-        _ => None,
+        Ok(_) => Ok(None),
+        Err(_) => Err(()),
     }
 }
 
@@ -365,17 +369,16 @@ pub fn evaluate_event_enrollments(
             .unwrap_or_default();
         let mut eval_state_dirty = false;
 
-        // The reference is folded into the fingerprint, so it is read before
-        // the check. A malformed or unreadable value retains evaluation state
-        // as a transient failure. A valid but unresolvable device qualifier is
-        // configured state, so it clears state rather than resuming stale work
-        // if the enrollment is later retargeted locally.
-        let Some((monitored_oid, monitored_prop, reference_device_oid)) =
-            read_object_property_ref(enrollment)
-        else {
-            continue;
+        // A property read failure is transient and retains evaluation state.
+        // Any successfully read invalid or unresolvable configuration clears
+        // state so a later local retarget cannot resume stale work.
+        let reference = match read_object_property_ref(enrollment) {
+            Ok(reference) => reference,
+            Err(()) => continue,
         };
-        if reference_device_oid.is_some_and(|device_oid| Some(device_oid) != local_device_oid) {
+        let Some((monitored_oid, monitored_prop, _)) = reference.filter(|(_, _, device_oid)| {
+            device_oid.is_none_or(|oid| Some(oid) == local_device_oid)
+        }) else {
             if eval_state_supported && eval_state != EventEnrollmentEvalState::default() {
                 updates.push((
                     *oid,
@@ -383,7 +386,7 @@ pub fn evaluate_event_enrollments(
                 ));
             }
             continue;
-        }
+        };
 
         // A parameter (or reference) change mid-pending cancels the countdown
         // and re-gates from the current parameters; no partial countdown is

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -124,6 +124,9 @@ fn read_object_property_ref(
             let Ok(prop_id) = u32::try_from(*prop_id) else {
                 return Ok(None);
             };
+            if prop_id > 0x3F_FFFF {
+                return Ok(None);
+            }
             let prop_id = PropertyIdentifier::from_raw(prop_id);
             match items.get(2) {
                 None | Some(PropertyValue::Null | PropertyValue::Unsigned(_)) => {}
@@ -287,7 +290,7 @@ pub fn evaluate_event_enrollments(
         };
 
         // A property read failure is transient and retains evaluation state.
-        // Any successfully read invalid or unresolvable configuration clears
+        // Any successfully read invalid or unsupported-device reference clears
         // state before unrelated properties can short-circuit this pass.
         let eval_state_supported = enrollment.enrollment_eval_state_internal().is_some();
         let mut eval_state = enrollment

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -118,10 +118,13 @@ fn read_object_property_ref(
                 PropertyValue::ObjectIdentifier(oid) => *oid,
                 _ => return Ok(None),
             };
-            let prop_id = match &items[1] {
-                PropertyValue::Unsigned(v) => PropertyIdentifier::from_raw(*v as u32),
-                _ => return Ok(None),
+            let PropertyValue::Unsigned(prop_id) = &items[1] else {
+                return Ok(None);
             };
+            let Ok(prop_id) = u32::try_from(*prop_id) else {
+                return Ok(None);
+            };
+            let prop_id = PropertyIdentifier::from_raw(prop_id);
             match items.get(2) {
                 None | Some(PropertyValue::Null | PropertyValue::Unsigned(_)) => {}
                 Some(_) => return Ok(None),
@@ -283,6 +286,29 @@ pub fn evaluate_event_enrollments(
             continue;
         };
 
+        // A property read failure is transient and retains evaluation state.
+        // Any successfully read invalid or unresolvable configuration clears
+        // state before unrelated properties can short-circuit this pass.
+        let eval_state_supported = enrollment.enrollment_eval_state_internal().is_some();
+        let mut eval_state = enrollment
+            .enrollment_eval_state_internal()
+            .unwrap_or_default();
+        let reference = match read_object_property_ref(enrollment) {
+            Ok(reference) => reference,
+            Err(()) => continue,
+        };
+        let Some((monitored_oid, monitored_prop, _)) = reference.filter(|(_, _, device_oid)| {
+            device_oid.is_none_or(|oid| Some(oid) == local_device_oid)
+        }) else {
+            if eval_state_supported && eval_state != EventEnrollmentEvalState::default() {
+                updates.push((
+                    *oid,
+                    EnrollmentUpdate::eval_state_only(EventEnrollmentEvalState::default()),
+                ));
+            }
+            continue;
+        };
+
         if let Ok(PropertyValue::Boolean(true)) =
             enrollment.read_property(PropertyIdentifier::OUT_OF_SERVICE, None)
         {
@@ -357,36 +383,9 @@ pub fn evaluate_event_enrollments(
                 _ => 0,
             };
 
-        // Per-enrollment evaluation state owned by the object. An object whose
-        // trait impl predates the channel (a downstream custom EE type)
-        // reports `None`: evaluation still runs, but with no durable pending
-        // countdown (a nonzero delay then re-seeds every pass and never
-        // fires — delays are effectively unsupported for such objects) and no
-        // COV baseline (every pass is a first sample, so COV never indicates).
-        let eval_state_supported = enrollment.enrollment_eval_state_internal().is_some();
-        let mut eval_state = enrollment
-            .enrollment_eval_state_internal()
-            .unwrap_or_default();
+        // An object whose trait implementation predates the private state
+        // channel evaluates without a durable countdown or COV baseline.
         let mut eval_state_dirty = false;
-
-        // A property read failure is transient and retains evaluation state.
-        // Any successfully read invalid or unresolvable configuration clears
-        // state so a later local retarget cannot resume stale work.
-        let reference = match read_object_property_ref(enrollment) {
-            Ok(reference) => reference,
-            Err(()) => continue,
-        };
-        let Some((monitored_oid, monitored_prop, _)) = reference.filter(|(_, _, device_oid)| {
-            device_oid.is_none_or(|oid| Some(oid) == local_device_oid)
-        }) else {
-            if eval_state_supported && eval_state != EventEnrollmentEvalState::default() {
-                updates.push((
-                    *oid,
-                    EnrollmentUpdate::eval_state_only(EventEnrollmentEvalState::default()),
-                ));
-            }
-            continue;
-        };
 
         // A parameter (or reference) change mid-pending cancels the countdown
         // and re-gates from the current parameters; no partial countdown is

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -210,45 +210,97 @@ fn unresolvable_reference_clears_private_evaluator_state() {
     );
 }
 
-struct ReferenceValueObject(PropertyValue);
+struct ReferenceValueObject {
+    inner: EventEnrollmentObject,
+    reference: Option<PropertyValue>,
+}
+
+impl ReferenceValueObject {
+    fn new(reference: Option<PropertyValue>) -> Self {
+        let mut inner =
+            EventEnrollmentObject::new(999, "reference-value", EventType::OUT_OF_RANGE.to_raw())
+                .unwrap();
+        inner.set_event_parameters(BACnetEventParameter::OutOfRange {
+            time_delay: 2,
+            low_limit: 20.0,
+            high_limit: 80.0,
+            deadband: 2.0,
+        });
+        inner.set_event_enable(0x07);
+        Self { inner, reference }
+    }
+}
 
 impl BACnetObject for ReferenceValueObject {
     fn object_identifier(&self) -> ObjectIdentifier {
-        ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 999).unwrap()
+        self.inner.object_identifier()
     }
 
     fn object_name(&self) -> &str {
-        "reference-value"
+        self.inner.object_name()
     }
 
     fn read_property(
         &self,
         property: PropertyIdentifier,
-        _array_index: Option<u32>,
+        array_index: Option<u32>,
     ) -> Result<PropertyValue, bacnet_types::error::Error> {
         if property == PropertyIdentifier::OBJECT_PROPERTY_REFERENCE {
-            Ok(self.0.clone())
+            self.reference
+                .clone()
+                .ok_or_else(|| bacnet_types::error::Error::Encoding("reference read failed".into()))
         } else {
-            Err(bacnet_types::error::Error::Encoding(
-                "unsupported test property".into(),
-            ))
+            self.inner.read_property(property, array_index)
         }
     }
 
     fn write_property(
         &mut self,
-        _property: PropertyIdentifier,
-        _array_index: Option<u32>,
-        _value: PropertyValue,
-        _priority: Option<u8>,
+        property: PropertyIdentifier,
+        array_index: Option<u32>,
+        value: PropertyValue,
+        priority: Option<u8>,
     ) -> Result<(), bacnet_types::error::Error> {
-        Err(bacnet_types::error::Error::Encoding(
-            "test object is read-only".into(),
-        ))
+        if property == PropertyIdentifier::OBJECT_PROPERTY_REFERENCE {
+            self.reference = Some(value);
+            Ok(())
+        } else {
+            self.inner
+                .write_property(property, array_index, value, priority)
+        }
     }
 
     fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
-        Cow::Borrowed(&[])
+        self.inner.property_list()
+    }
+
+    fn enrollment_eval_state_internal(
+        &self,
+    ) -> Option<bacnet_objects::event_enrollment::EventEnrollmentEvalState> {
+        self.inner.enrollment_eval_state_internal()
+    }
+
+    fn set_enrollment_eval_state_internal(
+        &mut self,
+        state: bacnet_objects::event_enrollment::EventEnrollmentEvalState,
+    ) -> Result<(), bacnet_types::error::Error> {
+        self.inner.set_enrollment_eval_state_internal(state)
+    }
+
+    fn set_event_state_internal(
+        &mut self,
+        state: EventState,
+    ) -> Result<(), bacnet_types::error::Error> {
+        self.inner.set_event_state_internal(state)
+    }
+
+    fn set_acked_transitions_internal(
+        &mut self,
+        transition_bit: u8,
+        acknowledged: bool,
+    ) -> Result<(), bacnet_types::error::Error> {
+        self.inner
+            .set_acked_transitions_internal(transition_bit, acknowledged)
     }
 }
 
@@ -279,16 +331,109 @@ fn malformed_reference_shapes_do_not_become_local() {
     ];
 
     for items in malformed {
-        let enrollment = ReferenceValueObject(PropertyValue::List(items));
-        assert!(super::super::read_object_property_ref(&enrollment).is_none());
+        let enrollment = ReferenceValueObject::new(Some(PropertyValue::List(items)));
+        assert!(matches!(
+            super::super::read_object_property_ref(&enrollment),
+            Ok(None)
+        ));
     }
 
-    let legacy = ReferenceValueObject(PropertyValue::List(vec![
+    let legacy = ReferenceValueObject::new(Some(PropertyValue::List(vec![
         PropertyValue::ObjectIdentifier(target),
         PropertyValue::Unsigned(property.to_raw() as u64),
-    ]));
+    ])));
     assert_eq!(
         super::super::read_object_property_ref(&legacy),
-        Some((target, property, None))
+        Ok(Some((target, property, None)))
+    );
+}
+
+#[test]
+fn malformed_retarget_does_not_resume_stale_countdown() {
+    let mut db = ObjectDatabase::new();
+    let mut ai = AnalogInputObject::new(3, "AI-3", 62).unwrap();
+    ai.set_present_value(90.0);
+    let target = ai.object_identifier();
+    db.add(Box::new(ai)).unwrap();
+
+    let property = PropertyIdentifier::PRESENT_VALUE;
+    let valid = PropertyValue::List(vec![
+        PropertyValue::ObjectIdentifier(target),
+        PropertyValue::Unsigned(property.to_raw() as u64),
+    ]);
+    let enrollment = ReferenceValueObject::new(Some(valid.clone()));
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+
+    let malformed = PropertyValue::List(vec![
+        PropertyValue::ObjectIdentifier(target),
+        PropertyValue::Unsigned(property.to_raw() as u64),
+        PropertyValue::ObjectIdentifier(ObjectIdentifier::new(ObjectType::DEVICE, 200).unwrap()),
+    ]);
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            malformed,
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_state_internal()
+            .unwrap(),
+        bacnet_objects::event_enrollment::EventEnrollmentEvalState::default()
+    );
+
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            valid,
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        evaluate_event_enrollments(&mut db, 1)[0].change.to,
+        EventState::HIGH_LIMIT
+    );
+}
+
+#[test]
+fn unreadable_reference_retains_private_evaluator_state() {
+    let mut enrollment = ReferenceValueObject::new(None);
+    let state = bacnet_objects::event_enrollment::EventEnrollmentEvalState {
+        pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
+            state: EventState::HIGH_LIMIT,
+            remaining: 1,
+            condition: 0,
+            params_fingerprint: 1,
+        }),
+        cov_baseline: Some(PropertyValue::Real(90.0)),
+        last_offnormal_value: Some(1),
+    };
+    enrollment
+        .set_enrollment_eval_state_internal(state.clone())
+        .unwrap();
+    let enrollment_oid = enrollment.object_identifier();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_state_internal()
+            .unwrap(),
+        state
     );
 }

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -213,6 +213,7 @@ fn unresolvable_reference_clears_private_evaluator_state() {
 struct ReferenceValueObject {
     inner: EventEnrollmentObject,
     reference: Option<PropertyValue>,
+    event_parameters_readable: bool,
 }
 
 impl ReferenceValueObject {
@@ -227,7 +228,11 @@ impl ReferenceValueObject {
             deadband: 2.0,
         });
         inner.set_event_enable(0x07);
-        Self { inner, reference }
+        Self {
+            inner,
+            reference,
+            event_parameters_readable: true,
+        }
     }
 }
 
@@ -249,6 +254,12 @@ impl BACnetObject for ReferenceValueObject {
             self.reference
                 .clone()
                 .ok_or_else(|| bacnet_types::error::Error::Encoding("reference read failed".into()))
+        } else if property == PropertyIdentifier::EVENT_PARAMETERS
+            && !self.event_parameters_readable
+        {
+            Err(bacnet_types::error::Error::Encoding(
+                "event parameters read failed".into(),
+            ))
         } else {
             self.inner.read_property(property, array_index)
         }
@@ -328,6 +339,10 @@ fn malformed_reference_shapes_do_not_become_local() {
             PropertyValue::Boolean(false),
             PropertyValue::Null,
         ],
+        vec![
+            PropertyValue::ObjectIdentifier(target),
+            PropertyValue::Unsigned(u32::MAX as u64 + 1 + property.to_raw() as u64),
+        ],
     ];
 
     for items in malformed {
@@ -346,6 +361,19 @@ fn malformed_reference_shapes_do_not_become_local() {
         super::super::read_object_property_ref(&legacy),
         Ok(Some((target, property, None)))
     );
+}
+
+fn stale_eval_state() -> bacnet_objects::event_enrollment::EventEnrollmentEvalState {
+    bacnet_objects::event_enrollment::EventEnrollmentEvalState {
+        pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
+            state: EventState::HIGH_LIMIT,
+            remaining: 1,
+            condition: 0,
+            params_fingerprint: 1,
+        }),
+        cov_baseline: Some(PropertyValue::Real(90.0)),
+        last_offnormal_value: Some(1),
+    }
 }
 
 #[test]
@@ -411,16 +439,7 @@ fn malformed_retarget_does_not_resume_stale_countdown() {
 #[test]
 fn unreadable_reference_retains_private_evaluator_state() {
     let mut enrollment = ReferenceValueObject::new(None);
-    let state = bacnet_objects::event_enrollment::EventEnrollmentEvalState {
-        pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
-            state: EventState::HIGH_LIMIT,
-            remaining: 1,
-            condition: 0,
-            params_fingerprint: 1,
-        }),
-        cov_baseline: Some(PropertyValue::Real(90.0)),
-        last_offnormal_value: Some(1),
-    };
+    let state = stale_eval_state();
     enrollment
         .set_enrollment_eval_state_internal(state.clone())
         .unwrap();
@@ -435,5 +454,31 @@ fn unreadable_reference_retains_private_evaluator_state() {
             .enrollment_eval_state_internal()
             .unwrap(),
         state
+    );
+}
+
+#[test]
+fn invalid_reference_clears_before_other_property_failure() {
+    let target = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 3).unwrap();
+    let mut enrollment = ReferenceValueObject::new(Some(PropertyValue::List(vec![
+        PropertyValue::ObjectIdentifier(target),
+        PropertyValue::Unsigned(PropertyIdentifier::PRESENT_VALUE.to_raw() as u64),
+        PropertyValue::ObjectIdentifier(ObjectIdentifier::new(ObjectType::DEVICE, 200).unwrap()),
+    ])));
+    enrollment.event_parameters_readable = false;
+    enrollment
+        .set_enrollment_eval_state_internal(stale_eval_state())
+        .unwrap();
+    let enrollment_oid = enrollment.object_identifier();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_state_internal()
+            .unwrap(),
+        bacnet_objects::event_enrollment::EventEnrollmentEvalState::default()
     );
 }

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -341,6 +341,10 @@ fn malformed_reference_shapes_do_not_become_local() {
         ],
         vec![
             PropertyValue::ObjectIdentifier(target),
+            PropertyValue::Unsigned(4_194_304),
+        ],
+        vec![
+            PropertyValue::ObjectIdentifier(target),
             PropertyValue::Unsigned(u32::MAX as u64 + 1 + property.to_raw() as u64),
         ],
     ];
@@ -462,8 +466,7 @@ fn invalid_reference_clears_before_other_property_failure() {
     let target = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 3).unwrap();
     let mut enrollment = ReferenceValueObject::new(Some(PropertyValue::List(vec![
         PropertyValue::ObjectIdentifier(target),
-        PropertyValue::Unsigned(PropertyIdentifier::PRESENT_VALUE.to_raw() as u64),
-        PropertyValue::ObjectIdentifier(ObjectIdentifier::new(ObjectType::DEVICE, 200).unwrap()),
+        PropertyValue::Unsigned(4_194_304),
     ])));
     enrollment.event_parameters_readable = false;
     enrollment


### PR DESCRIPTION
## Summary
- distinguish transient `Object_Property_Reference` read failures from successfully read invalid configurations
- clear pending, COV baseline, and last-offnormal private state for absent, malformed, out-of-range, or unsupported-device references before other evaluator exits
- reject property identifiers outside BACnet's 22-bit range instead of narrowing or treating them as usable targets
- prove malformed-to-local retargets run the full delay again while genuine reference read failures retain state

Review follow-ups are tracked separately in #301, #303, #304, and #305.

## Verification
- `cargo test -p bacnet-server`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo fmt --all --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- independent dataflow, adversarial, and runtime immutable-head reviews

Closes #300