### PR TITLE
fix(server): honor Event Enrollment array indexes

### DIFF
--- a/crates/bacnet-objects/src/database.rs
+++ b/crates/bacnet-objects/src/database.rs
@@ -1,6 +1,6 @@
 //! ObjectDatabase — stores and retrieves BACnet objects by identifier.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType};
 use bacnet_types::error::Error;
@@ -18,6 +18,9 @@ pub struct ObjectDatabase {
     name_index: HashMap<String, ObjectIdentifier>,
     /// Type index: object type → set of ObjectIdentifiers for fast enumeration.
     type_index: HashMap<ObjectType, Vec<ObjectIdentifier>>,
+    /// Event Enrollment objects whose private evaluator state must be reset
+    /// before it can be used again.
+    invalid_enrollment_eval_state: HashSet<ObjectIdentifier>,
 }
 
 impl Default for ObjectDatabase {
@@ -33,6 +36,7 @@ impl ObjectDatabase {
             objects: HashMap::new(),
             name_index: HashMap::new(),
             type_index: HashMap::new(),
+            invalid_enrollment_eval_state: HashSet::new(),
         }
     }
 
@@ -62,6 +66,7 @@ impl ObjectDatabase {
 
         self.name_index.insert(name, oid);
         let is_new = !self.objects.contains_key(&oid);
+        self.invalid_enrollment_eval_state.remove(&oid);
         self.objects.insert(oid, object);
         if is_new {
             self.type_index
@@ -120,9 +125,29 @@ impl ObjectDatabase {
         self.objects.get_mut(oid)
     }
 
+    /// Whether an Event Enrollment object's private evaluator state requires a
+    /// successful reset before reuse.
+    pub fn enrollment_eval_state_invalidated(&self, oid: &ObjectIdentifier) -> bool {
+        self.invalid_enrollment_eval_state.contains(oid)
+    }
+
+    /// Mark or clear the reset requirement for Event Enrollment private state.
+    pub fn set_enrollment_eval_state_invalidated(
+        &mut self,
+        oid: ObjectIdentifier,
+        invalidated: bool,
+    ) {
+        if invalidated {
+            self.invalid_enrollment_eval_state.insert(oid);
+        } else {
+            self.invalid_enrollment_eval_state.remove(&oid);
+        }
+    }
+
     /// Remove an object by identifier.
     pub fn remove(&mut self, oid: &ObjectIdentifier) -> Option<Box<dyn BACnetObject>> {
         if let Some(obj) = self.objects.remove(oid) {
+            self.invalid_enrollment_eval_state.remove(oid);
             self.name_index.remove(obj.object_name());
             if let Some(type_set) = self.type_index.get_mut(&oid.object_type()) {
                 type_set.retain(|o| o != oid);

--- a/crates/bacnet-objects/src/database.rs
+++ b/crates/bacnet-objects/src/database.rs
@@ -73,7 +73,6 @@ impl ObjectDatabase {
 
         self.name_index.insert(name, oid);
         let is_new = !self.objects.contains_key(&oid);
-        self.invalid_enrollment_eval_state.remove(&oid);
         self.enrollment_eval_sources.remove(&oid);
         self.objects.insert(oid, object);
         if is_new {
@@ -197,9 +196,21 @@ impl ObjectDatabase {
         if self.objects.contains_key(oid) {
             self.invalidate_enrollments_monitoring(oid);
         }
-        if let Some(obj) = self.objects.remove(oid) {
-            self.invalid_enrollment_eval_state.remove(oid);
+        if let Some(mut obj) = self.objects.remove(oid) {
             self.enrollment_eval_sources.remove(oid);
+            if obj.enrollment_eval_state_internal().is_some() {
+                if obj
+                    .set_enrollment_eval_state_internal(Default::default())
+                    .is_err()
+                {
+                    self.invalid_enrollment_eval_state.insert(*oid);
+                } else {
+                    self.invalid_enrollment_eval_state.remove(oid);
+                }
+                let _ = obj.set_enrollment_eval_source_internal(None);
+            } else {
+                self.invalid_enrollment_eval_state.remove(oid);
+            }
             self.name_index.remove(obj.object_name());
             if let Some(type_set) = self.type_index.get_mut(&oid.object_type()) {
                 type_set.retain(|o| o != oid);

--- a/crates/bacnet-objects/src/database.rs
+++ b/crates/bacnet-objects/src/database.rs
@@ -6,6 +6,7 @@ use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 
+use crate::event_enrollment::EventEnrollmentMonitoredSource;
 use crate::traits::BACnetObject;
 
 /// A collection of BACnet objects, keyed by ObjectIdentifier.
@@ -21,6 +22,9 @@ pub struct ObjectDatabase {
     /// Event Enrollment objects whose private evaluator state must be reset
     /// before it can be used again.
     invalid_enrollment_eval_state: HashSet<ObjectIdentifier>,
+    /// Source ownership for custom Event Enrollment objects that implement
+    /// evaluation state but not the optional object-owned source channel.
+    enrollment_eval_sources: HashMap<ObjectIdentifier, EventEnrollmentMonitoredSource>,
 }
 
 impl Default for ObjectDatabase {
@@ -37,6 +41,7 @@ impl ObjectDatabase {
             name_index: HashMap::new(),
             type_index: HashMap::new(),
             invalid_enrollment_eval_state: HashSet::new(),
+            enrollment_eval_sources: HashMap::new(),
         }
     }
 
@@ -59,14 +64,17 @@ impl ObjectDatabase {
         }
 
         // If replacing an existing object, remove its old name from the index
+        // and invalidate state owned by enrollments that monitor it.
         if let Some(old) = self.objects.get(&oid) {
             let old_name = old.object_name().to_string();
             self.name_index.remove(&old_name);
+            self.invalidate_enrollments_monitoring(&oid);
         }
 
         self.name_index.insert(name, oid);
         let is_new = !self.objects.contains_key(&oid);
         self.invalid_enrollment_eval_state.remove(&oid);
+        self.enrollment_eval_sources.remove(&oid);
         self.objects.insert(oid, object);
         if is_new {
             self.type_index
@@ -144,10 +152,54 @@ impl ObjectDatabase {
         }
     }
 
+    /// Return database-owned monitored-source state for a custom Event
+    /// Enrollment object.
+    pub fn enrollment_eval_source(
+        &self,
+        oid: &ObjectIdentifier,
+    ) -> Option<EventEnrollmentMonitoredSource> {
+        self.enrollment_eval_sources.get(oid).copied()
+    }
+
+    /// Store database-owned monitored-source state for a custom Event
+    /// Enrollment object.
+    pub fn set_enrollment_eval_source(
+        &mut self,
+        oid: ObjectIdentifier,
+        source: Option<EventEnrollmentMonitoredSource>,
+    ) {
+        if let Some(source) = source {
+            self.enrollment_eval_sources.insert(oid, source);
+        } else {
+            self.enrollment_eval_sources.remove(&oid);
+        }
+    }
+
+    fn invalidate_enrollments_monitoring(&mut self, monitored_oid: &ObjectIdentifier) {
+        let affected = self
+            .objects
+            .iter()
+            .filter_map(|(oid, object)| {
+                let source = object
+                    .enrollment_eval_source_internal()
+                    .flatten()
+                    .or_else(|| self.enrollment_eval_sources.get(oid).copied());
+                source
+                    .is_some_and(|source| source.0 == *monitored_oid)
+                    .then_some(*oid)
+            })
+            .collect::<Vec<_>>();
+        self.invalid_enrollment_eval_state.extend(affected);
+    }
+
     /// Remove an object by identifier.
     pub fn remove(&mut self, oid: &ObjectIdentifier) -> Option<Box<dyn BACnetObject>> {
+        if self.objects.contains_key(oid) {
+            self.invalidate_enrollments_monitoring(oid);
+        }
         if let Some(obj) = self.objects.remove(oid) {
             self.invalid_enrollment_eval_state.remove(oid);
+            self.enrollment_eval_sources.remove(oid);
             self.name_index.remove(obj.object_name());
             if let Some(type_set) = self.type_index.get_mut(&oid.object_type()) {
                 type_set.retain(|o| o != oid);

--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -11,6 +11,9 @@ use std::borrow::Cow;
 use crate::common::{self, read_common_properties};
 use crate::traits::{BACnetObject, WritePropertyRollback};
 
+mod state;
+pub use state::{EventEnrollmentEvalState, EventEnrollmentPending};
+
 enum EventEnrollmentWriteRollback {
     Detection {
         enabled: bool,
@@ -25,79 +28,6 @@ struct AlertEnrollmentWriteRollback {
     enabled: bool,
     event_state: u32,
     acked_transitions: u8,
-}
-
-/// A delayed Event Enrollment transition, counting down its delay.
-///
-/// The enrollment counterpart of the intrinsic detectors'
-/// [`PendingTransition`](crate::event::PendingTransition), kept as a distinct
-/// type because the driving mechanism differs: the server evaluator advances
-/// `remaining` once per *evaluation pass* (the `event_enrollment_task`
-/// interval, configurable via #133), whereas the intrinsic detectors tick on
-/// a fixed one-second task and seed from per-write probes. Clause 13.2.4
-/// semantics are shared — the observable `Event_State` holds at the confirmed
-/// state while the countdown runs, a reverted condition cancels without
-/// firing, and a redundant qualifying observation never re-seeds — but the
-/// two implementations do not share code across the objects/server boundary.
-///
-/// In-memory only: like the intrinsic detectors' pending state and baselines,
-/// this is not persisted; a device restart re-evaluation starts from the
-/// confirmed `Event_State`, which is the same restart semantics the
-/// intrinsic-reporting path ships.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct EventEnrollmentPending {
-    /// The event state the algorithm indicated and will enter when the
-    /// countdown elapses.
-    pub state: EventState,
-    /// Evaluation passes remaining before the transition fires; seeded with
-    /// the direction-appropriate delay (pTimeDelay for offnormal targets,
-    /// pTimeDelayNormal — else pTimeDelay — for NORMAL), converted from
-    /// seconds by the evaluator as `ceil(delay_secs / interval_secs)`.
-    pub remaining: u32,
-    /// Identity of the indicating condition, per algorithm. CHANGE_OF_STATE
-    /// discriminates by the matched alarm value because Clause 13.3.2
-    /// conditions (a)/(c) key on *which* value the monitored value equals
-    /// ("remains equal to that value for pTimeDelay"); CHANGE_OF_BITSTRING by
-    /// the masked monitored bytes. Algorithms whose delay applies to the
-    /// threshold condition itself (OUT_OF_RANGE, FLOATING_LIMIT,
-    /// CHANGE_OF_VALUE) use `0` — the target alone identifies them.
-    pub condition: u64,
-    /// Fingerprint of the `Event_Parameters` (framed encoding) plus the
-    /// effective `Time_Delay_Normal` in force when this countdown was seeded.
-    /// The evaluator re-reads its parameters every pass; a mismatch cancels
-    /// the in-flight countdown and re-gates from the current parameters —
-    /// no partial countdown is resumed across a parameter change.
-    pub params_fingerprint: u64,
-}
-
-/// Algorithm-side evaluation state owned by an Event Enrollment object.
-///
-/// Not BACnet properties: none of the three slots maps to a Clause 12.12
-/// property (nor to the Table 12-14 `Time_Delay_Normal`, which is
-/// configuration and lives on the object directly). Clause 13.3 assigns the
-/// baseline's initialization and the countdown's existence to local matters,
-/// so they are reachable only through the internal trait channel
-/// ([`BACnetObject::enrollment_eval_state_internal`] /
-/// [`BACnetObject::set_enrollment_eval_state_internal`]), mirroring the
-/// `set_event_state_internal` precedent (issue #130).
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct EventEnrollmentEvalState {
-    /// Delayed transition in flight, if any.
-    pub pending: Option<EventEnrollmentPending>,
-    /// CHANGE_OF_VALUE detection baseline (Clause 13.3.3: "the value of the
-    /// monitored value when a transition to NORMAL is indicated shall be used
-    /// in evaluation of the conditions until the next transition to NORMAL is
-    /// indicated"). `None` before the first sample; the first observed value
-    /// initializes it without indicating a transition ("the initialization of
-    /// the value used in evaluation before the first transition to NORMAL is
-    /// indicated is a local matter" — the policy chosen here).
-    pub cov_baseline: Option<PropertyValue>,
-    /// The monitored value that caused the last transition to OFFNORMAL, for
-    /// CHANGE_OF_STATE condition (c) (Clause 13.3.2: a re-indication is
-    /// indicated only when the monitored value equals an alarm value
-    /// "different from the value that caused the last transition to
-    /// OFFNORMAL").
-    pub last_offnormal_value: Option<u32>,
 }
 
 /// BACnet EventEnrollment object.
@@ -133,6 +63,8 @@ pub struct EventEnrollmentObject {
     time_delay_normal: Option<u32>,
     /// Delayed transition counting down, if any. In-memory only.
     pending: Option<EventEnrollmentPending>,
+    /// Effective source of the private evaluation state. In-memory only.
+    monitored_reference: Option<(ObjectIdentifier, PropertyIdentifier, Option<u32>)>,
     /// CHANGE_OF_VALUE detection baseline (Clause 13.3.3). In-memory only.
     cov_baseline: Option<PropertyValue>,
     /// Monitored value that caused the last OFFNORMAL transition (Clause
@@ -175,6 +107,7 @@ impl EventEnrollmentObject {
             // never a zero.
             time_delay_normal: None,
             pending: None,
+            monitored_reference: None,
             cov_baseline: None,
             last_offnormal_value: None,
         })
@@ -195,19 +128,21 @@ impl EventEnrollmentObject {
     /// object yet (#264); when they are, their initial conditions belong here
     /// — X'FF' octets / sequence number 0, and the empty string respectively.
     ///
-    /// The pending countdown and both baselines are cleared too: they are
-    /// extensions of the same event-state-detection state machine the clause
-    /// freezes ("this state machine is not evaluated"), so a stale countdown
-    /// must not survive into the next enabled period and fire against a
-    /// condition the object no longer observes. The intrinsic types make the
-    /// same choice for their detectors (`analog/input.rs` clears
-    /// `detector.pending` on the identical write). The COV baseline's
-    /// initialization on re-enable is the local matter Clause 13.3.3 assigns
-    /// it; clearing is consistent with the first-sample policy.
+    /// The monitored-source identity, pending countdown, and both baselines
+    /// are cleared too: they are extensions of the same event-state-detection
+    /// state machine the clause freezes ("this state machine is not
+    /// evaluated"), so a stale countdown must not survive into the next
+    /// enabled period and fire against a condition the object no longer
+    /// observes. The intrinsic types make the same choice for their detectors
+    /// (`analog/input.rs` clears `detector.pending` on the identical write).
+    /// The COV baseline's initialization on re-enable is the local matter
+    /// Clause 13.3.3 assigns it; clearing is consistent with the first-sample
+    /// policy.
     fn apply_detection_disabled_reset(&mut self) {
         self.event_state = EventState::NORMAL.to_raw();
         self.acked_transitions = Self::RESET_ACKED_TRANSITIONS;
         self.pending = None;
+        self.monitored_reference = None;
         self.cov_baseline = None;
         self.last_offnormal_value = None;
     }
@@ -550,10 +485,11 @@ impl BACnetObject for EventEnrollmentObject {
         Ok(())
     }
 
-    /// Snapshot the enrollment evaluation state (pending countdown, COV
-    /// baseline, last offnormal-causing value) for the server evaluator.
+    /// Snapshot the monitored source, pending countdown, and algorithm
+    /// baselines for the server evaluator.
     fn enrollment_eval_state_internal(&self) -> Option<EventEnrollmentEvalState> {
         Some(EventEnrollmentEvalState {
+            monitored_reference: self.monitored_reference,
             pending: self.pending.clone(),
             cov_baseline: self.cov_baseline.clone(),
             last_offnormal_value: self.last_offnormal_value,
@@ -572,6 +508,7 @@ impl BACnetObject for EventEnrollmentObject {
         if !self.event_detection_enable {
             return Err(common::write_access_denied_error());
         }
+        self.monitored_reference = state.monitored_reference;
         self.pending = state.pending;
         self.cov_baseline = state.cov_baseline;
         self.last_offnormal_value = state.last_offnormal_value;
@@ -633,6 +570,7 @@ impl BACnetObject for EventEnrollmentObject {
                     event_state: self.event_state,
                     acked_transitions: self.acked_transitions,
                     evaluation: EventEnrollmentEvalState {
+                        monitored_reference: self.monitored_reference,
                         pending: self.pending.clone(),
                         cov_baseline: self.cov_baseline.clone(),
                         last_offnormal_value: self.last_offnormal_value,
@@ -660,6 +598,7 @@ impl BACnetObject for EventEnrollmentObject {
                 self.event_detection_enable = enabled;
                 self.event_state = event_state;
                 self.acked_transitions = acked_transitions;
+                self.monitored_reference = evaluation.monitored_reference;
                 self.pending = evaluation.pending;
                 self.cov_baseline = evaluation.cov_baseline;
                 self.last_offnormal_value = evaluation.last_offnormal_value;

--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -12,17 +12,8 @@ use crate::common::{self, read_common_properties};
 use crate::traits::{BACnetObject, WritePropertyRollback};
 
 mod state;
-pub use state::{EventEnrollmentEvalState, EventEnrollmentPending};
-
-enum EventEnrollmentWriteRollback {
-    Detection {
-        enabled: bool,
-        event_state: u32,
-        acked_transitions: u8,
-        evaluation: EventEnrollmentEvalState,
-    },
-    TimeDelayNormal(Option<u32>),
-}
+use state::EventEnrollmentWriteRollback;
+pub use state::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource, EventEnrollmentPending};
 
 struct AlertEnrollmentWriteRollback {
     enabled: bool,
@@ -64,7 +55,7 @@ pub struct EventEnrollmentObject {
     /// Delayed transition counting down, if any. In-memory only.
     pending: Option<EventEnrollmentPending>,
     /// Effective source of the private evaluation state. In-memory only.
-    monitored_reference: Option<(ObjectIdentifier, PropertyIdentifier, Option<u32>)>,
+    monitored_reference: Option<EventEnrollmentMonitoredSource>,
     /// CHANGE_OF_VALUE detection baseline (Clause 13.3.3). In-memory only.
     cov_baseline: Option<PropertyValue>,
     /// Monitored value that caused the last OFFNORMAL transition (Clause
@@ -485,11 +476,10 @@ impl BACnetObject for EventEnrollmentObject {
         Ok(())
     }
 
-    /// Snapshot the monitored source, pending countdown, and algorithm
-    /// baselines for the server evaluator.
+    /// Snapshot the pending countdown and algorithm baselines for the server
+    /// evaluator.
     fn enrollment_eval_state_internal(&self) -> Option<EventEnrollmentEvalState> {
         Some(EventEnrollmentEvalState {
-            monitored_reference: self.monitored_reference,
             pending: self.pending.clone(),
             cov_baseline: self.cov_baseline.clone(),
             last_offnormal_value: self.last_offnormal_value,
@@ -508,10 +498,24 @@ impl BACnetObject for EventEnrollmentObject {
         if !self.event_detection_enable {
             return Err(common::write_access_denied_error());
         }
-        self.monitored_reference = state.monitored_reference;
         self.pending = state.pending;
         self.cov_baseline = state.cov_baseline;
         self.last_offnormal_value = state.last_offnormal_value;
+        Ok(())
+    }
+
+    fn enrollment_eval_source_internal(&self) -> Option<Option<EventEnrollmentMonitoredSource>> {
+        Some(self.monitored_reference)
+    }
+
+    fn set_enrollment_eval_source_internal(
+        &mut self,
+        source: Option<EventEnrollmentMonitoredSource>,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(common::write_access_denied_error());
+        }
+        self.monitored_reference = source;
         Ok(())
     }
 
@@ -569,8 +573,8 @@ impl BACnetObject for EventEnrollmentObject {
                     enabled: self.event_detection_enable,
                     event_state: self.event_state,
                     acked_transitions: self.acked_transitions,
+                    monitored_reference: self.monitored_reference,
                     evaluation: EventEnrollmentEvalState {
-                        monitored_reference: self.monitored_reference,
                         pending: self.pending.clone(),
                         cov_baseline: self.cov_baseline.clone(),
                         last_offnormal_value: self.last_offnormal_value,
@@ -593,12 +597,13 @@ impl BACnetObject for EventEnrollmentObject {
                 enabled,
                 event_state,
                 acked_transitions,
+                monitored_reference,
                 evaluation,
             } => {
                 self.event_detection_enable = enabled;
                 self.event_state = event_state;
                 self.acked_transitions = acked_transitions;
-                self.monitored_reference = evaluation.monitored_reference;
+                self.monitored_reference = monitored_reference;
                 self.pending = evaluation.pending;
                 self.cov_baseline = evaluation.cov_baseline;
                 self.last_offnormal_value = evaluation.last_offnormal_value;

--- a/crates/bacnet-objects/src/event_enrollment/state.rs
+++ b/crates/bacnet-objects/src/event_enrollment/state.rs
@@ -1,6 +1,10 @@
 use bacnet_types::enums::{EventState, PropertyIdentifier};
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
+/// Effective object, property, and optional array index that own an Event
+/// Enrollment object's private evaluation state.
+pub type EventEnrollmentMonitoredSource = (ObjectIdentifier, PropertyIdentifier, Option<u32>);
+
 /// A delayed Event Enrollment transition, counting down its delay.
 ///
 /// The enrollment counterpart of the intrinsic detectors'
@@ -46,7 +50,7 @@ pub struct EventEnrollmentPending {
 
 /// Algorithm-side evaluation state owned by an Event Enrollment object.
 ///
-/// Not BACnet properties: none of the four slots maps to a Clause 12.12
+/// Not BACnet properties: none of the three slots maps to a Clause 12.12
 /// property (nor to the Table 12-14 `Time_Delay_Normal`, which is
 /// configuration and lives on the object directly). Clause 13.3 assigns the
 /// baseline's initialization and the countdown's existence to local matters,
@@ -56,10 +60,6 @@ pub struct EventEnrollmentPending {
 /// mirroring the `set_event_state_internal` precedent (issue #130).
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct EventEnrollmentEvalState {
-    /// Effective object, property, and optional array index that own the
-    /// countdown and algorithm baselines below. `None` means no monitored
-    /// source currently owns the private state.
-    pub monitored_reference: Option<(ObjectIdentifier, PropertyIdentifier, Option<u32>)>,
     /// Delayed transition in flight, if any.
     pub pending: Option<EventEnrollmentPending>,
     /// CHANGE_OF_VALUE detection baseline (Clause 13.3.3: "the value of the
@@ -76,4 +76,15 @@ pub struct EventEnrollmentEvalState {
     /// "different from the value that caused the last transition to
     /// OFFNORMAL").
     pub last_offnormal_value: Option<u32>,
+}
+
+pub(super) enum EventEnrollmentWriteRollback {
+    Detection {
+        enabled: bool,
+        event_state: u32,
+        acked_transitions: u8,
+        monitored_reference: Option<EventEnrollmentMonitoredSource>,
+        evaluation: EventEnrollmentEvalState,
+    },
+    TimeDelayNormal(Option<u32>),
 }

--- a/crates/bacnet-objects/src/event_enrollment/state.rs
+++ b/crates/bacnet-objects/src/event_enrollment/state.rs
@@ -1,0 +1,79 @@
+use bacnet_types::enums::{EventState, PropertyIdentifier};
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+
+/// A delayed Event Enrollment transition, counting down its delay.
+///
+/// The enrollment counterpart of the intrinsic detectors'
+/// [`PendingTransition`](crate::event::PendingTransition), kept as a distinct
+/// type because the driving mechanism differs: the server evaluator advances
+/// `remaining` once per *evaluation pass* (the `event_enrollment_task`
+/// interval, configurable via #133), whereas the intrinsic detectors tick on
+/// a fixed one-second task and seed from per-write probes. Clause 13.2.4
+/// semantics are shared — the observable `Event_State` holds at the confirmed
+/// state while the countdown runs, a reverted condition cancels without
+/// firing, and a redundant qualifying observation never re-seeds — but the
+/// two implementations do not share code across the objects/server boundary.
+///
+/// In-memory only: like the intrinsic detectors' pending state and baselines,
+/// this is not persisted; a device restart re-evaluation starts from the
+/// confirmed `Event_State`, which is the same restart semantics the
+/// intrinsic-reporting path ships.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventEnrollmentPending {
+    /// The event state the algorithm indicated and will enter when the
+    /// countdown elapses.
+    pub state: EventState,
+    /// Evaluation passes remaining before the transition fires; seeded with
+    /// the direction-appropriate delay (pTimeDelay for offnormal targets,
+    /// pTimeDelayNormal — else pTimeDelay — for NORMAL), converted from
+    /// seconds by the evaluator as `ceil(delay_secs / interval_secs)`.
+    pub remaining: u32,
+    /// Identity of the indicating condition, per algorithm. CHANGE_OF_STATE
+    /// discriminates by the matched alarm value because Clause 13.3.2
+    /// conditions (a)/(c) key on *which* value the monitored value equals
+    /// ("remains equal to that value for pTimeDelay"); CHANGE_OF_BITSTRING by
+    /// the masked monitored bytes. Algorithms whose delay applies to the
+    /// threshold condition itself (OUT_OF_RANGE, FLOATING_LIMIT,
+    /// CHANGE_OF_VALUE) use `0` — the target alone identifies them.
+    pub condition: u64,
+    /// Fingerprint of the `Event_Parameters` (framed encoding) plus the
+    /// effective `Time_Delay_Normal` in force when this countdown was seeded.
+    /// The evaluator re-reads its parameters every pass; a mismatch cancels
+    /// the in-flight countdown and re-gates from the current parameters —
+    /// no partial countdown is resumed across a parameter change.
+    pub params_fingerprint: u64,
+}
+
+/// Algorithm-side evaluation state owned by an Event Enrollment object.
+///
+/// Not BACnet properties: none of the four slots maps to a Clause 12.12
+/// property (nor to the Table 12-14 `Time_Delay_Normal`, which is
+/// configuration and lives on the object directly). Clause 13.3 assigns the
+/// baseline's initialization and the countdown's existence to local matters,
+/// so they are reachable only through the internal trait channel
+/// ([`BACnetObject::enrollment_eval_state_internal`](crate::traits::BACnetObject::enrollment_eval_state_internal) /
+/// [`BACnetObject::set_enrollment_eval_state_internal`](crate::traits::BACnetObject::set_enrollment_eval_state_internal)),
+/// mirroring the `set_event_state_internal` precedent (issue #130).
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct EventEnrollmentEvalState {
+    /// Effective object, property, and optional array index that own the
+    /// countdown and algorithm baselines below. `None` means no monitored
+    /// source currently owns the private state.
+    pub monitored_reference: Option<(ObjectIdentifier, PropertyIdentifier, Option<u32>)>,
+    /// Delayed transition in flight, if any.
+    pub pending: Option<EventEnrollmentPending>,
+    /// CHANGE_OF_VALUE detection baseline (Clause 13.3.3: "the value of the
+    /// monitored value when a transition to NORMAL is indicated shall be used
+    /// in evaluation of the conditions until the next transition to NORMAL is
+    /// indicated"). `None` before the first sample; the first observed value
+    /// initializes it without indicating a transition ("the initialization of
+    /// the value used in evaluation before the first transition to NORMAL is
+    /// indicated is a local matter" — the policy chosen here).
+    pub cov_baseline: Option<PropertyValue>,
+    /// The monitored value that caused the last transition to OFFNORMAL, for
+    /// CHANGE_OF_STATE condition (c) (Clause 13.3.2: a re-indication is
+    /// indicated only when the monitored value equals an alarm value
+    /// "different from the value that caused the last transition to
+    /// OFFNORMAL").
+    pub last_offnormal_value: Option<u32>,
+}

--- a/crates/bacnet-objects/src/event_enrollment/tests/time_delay_normal.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/time_delay_normal.rs
@@ -144,6 +144,11 @@ fn enrollment_eval_state_round_trip() {
     );
 
     let state = EventEnrollmentEvalState {
+        monitored_reference: Some((
+            ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+            PropertyIdentifier::PRESENT_VALUE,
+            Some(2),
+        )),
         pending: Some(EventEnrollmentPending {
             state: EventState::HIGH_LIMIT,
             remaining: 4,
@@ -173,6 +178,7 @@ fn enrollment_eval_state_round_trip() {
 fn disabling_detection_clears_eval_state_and_refuses_writes() {
     let mut ee = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
     ee.set_enrollment_eval_state_internal(EventEnrollmentEvalState {
+        monitored_reference: None,
         pending: Some(EventEnrollmentPending {
             state: EventState::OFFNORMAL,
             remaining: 1,

--- a/crates/bacnet-objects/src/event_enrollment/tests/time_delay_normal.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/time_delay_normal.rs
@@ -143,12 +143,12 @@ fn enrollment_eval_state_round_trip() {
         "construction starts empty"
     );
 
+    let source = (
+        ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+        PropertyIdentifier::PRESENT_VALUE,
+        Some(2),
+    );
     let state = EventEnrollmentEvalState {
-        monitored_reference: Some((
-            ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
-            PropertyIdentifier::PRESENT_VALUE,
-            Some(2),
-        )),
         pending: Some(EventEnrollmentPending {
             state: EventState::HIGH_LIMIT,
             remaining: 4,
@@ -160,15 +160,20 @@ fn enrollment_eval_state_round_trip() {
     };
     ee.set_enrollment_eval_state_internal(state.clone())
         .unwrap();
+    ee.set_enrollment_eval_source_internal(Some(source))
+        .unwrap();
     assert_eq!(ee.enrollment_eval_state_internal(), Some(state));
+    assert_eq!(ee.enrollment_eval_source_internal(), Some(Some(source)));
 
     // Storing a cleared state clears.
     ee.set_enrollment_eval_state_internal(EventEnrollmentEvalState::default())
         .unwrap();
+    ee.set_enrollment_eval_source_internal(None).unwrap();
     assert_eq!(
         ee.enrollment_eval_state_internal(),
         Some(EventEnrollmentEvalState::default())
     );
+    assert_eq!(ee.enrollment_eval_source_internal(), Some(None));
 }
 
 /// Clause 13.2.2.1's disable reset covers the evaluation state: "this state
@@ -177,8 +182,14 @@ fn enrollment_eval_state_round_trip() {
 #[test]
 fn disabling_detection_clears_eval_state_and_refuses_writes() {
     let mut ee = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
+    let source = (
+        ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+        PropertyIdentifier::PRESENT_VALUE,
+        Some(1),
+    );
+    ee.set_enrollment_eval_source_internal(Some(source))
+        .unwrap();
     ee.set_enrollment_eval_state_internal(EventEnrollmentEvalState {
-        monitored_reference: None,
         pending: Some(EventEnrollmentPending {
             state: EventState::OFFNORMAL,
             remaining: 1,
@@ -202,6 +213,7 @@ fn disabling_detection_clears_eval_state_and_refuses_writes() {
         Some(EventEnrollmentEvalState::default()),
         "the disable reset clears the evaluation state"
     );
+    assert_eq!(ee.enrollment_eval_source_internal(), Some(None));
 
     // And while disabled the internal write paths refuse — the invariant
     // holds by construction, as with set_event_state_internal (#130).
@@ -215,6 +227,9 @@ fn disabling_detection_clears_eval_state_and_refuses_writes() {
             }),
             ..EventEnrollmentEvalState::default()
         })
+        .is_err());
+    assert!(ee
+        .set_enrollment_eval_source_internal(Some(source))
         .is_err());
     assert!(ee.set_acked_transitions_internal(0x01, false).is_err());
 

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -327,8 +327,8 @@ pub trait BACnetObject: Send + Sync {
     /// The outer `Option` indicates whether the object supports this channel;
     /// the inner `Option` is empty before a source has been established.
     /// Objects that implement the evaluation-state channel must also implement
-    /// this channel to retain countdowns and baselines across evaluations.
-    /// Without source storage, the evaluator runs statelessly.
+    /// this channel to retain countdowns and baselines for indexed references.
+    /// Indexed evaluation runs statelessly without source storage.
     fn enrollment_eval_source_internal(&self) -> Option<Option<EventEnrollmentMonitoredSource>> {
         None
     }

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -270,7 +270,8 @@ pub trait BACnetObject: Send + Sync {
     /// [`EventState`], mirroring the inherent `set_event_state` builder and
     /// the existing read arm. Network-facing validation — rejecting all
     /// `Event_State` writes — lives in [`write_property`](Self::write_property),
-    /// not here.
+    /// not here. Implementations must leave `Event_State` unchanged when they
+    /// return `Err`.
     fn set_event_state_internal(&mut self, _state: EventState) -> Result<(), Error> {
         Err(Error::Protocol {
             class: ErrorClass::OBJECT.to_raw() as u32,

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -9,7 +9,7 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
 use crate::event::TransitionOutcome;
-use crate::event_enrollment::EventEnrollmentEvalState;
+use crate::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource};
 
 /// Object-owned state that cannot be reconstructed from property readback.
 ///
@@ -315,6 +315,26 @@ pub trait BACnetObject: Send + Sync {
     fn set_enrollment_eval_state_internal(
         &mut self,
         _state: EventEnrollmentEvalState,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::OBJECT.to_raw() as u32,
+            code: ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw() as u32,
+        })
+    }
+
+    /// Snapshot the monitored source that owns Event Enrollment private state.
+    ///
+    /// The outer `Option` indicates whether the object supports this channel;
+    /// the inner `Option` is empty before a source has been established. The
+    /// default opts out so existing custom objects retain their prior behavior.
+    fn enrollment_eval_source_internal(&self) -> Option<Option<EventEnrollmentMonitoredSource>> {
+        None
+    }
+
+    /// Store or clear the monitored source that owns Event Enrollment state.
+    fn set_enrollment_eval_source_internal(
+        &mut self,
+        _source: Option<EventEnrollmentMonitoredSource>,
     ) -> Result<(), Error> {
         Err(Error::Protocol {
             class: ErrorClass::OBJECT.to_raw() as u32,

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -325,8 +325,10 @@ pub trait BACnetObject: Send + Sync {
     /// Snapshot the monitored source that owns Event Enrollment private state.
     ///
     /// The outer `Option` indicates whether the object supports this channel;
-    /// the inner `Option` is empty before a source has been established. The
-    /// default opts out so existing custom objects retain their prior behavior.
+    /// the inner `Option` is empty before a source has been established.
+    /// Objects that implement the evaluation-state channel must also implement
+    /// this channel to retain countdowns and baselines across evaluations.
+    /// Without source storage, the evaluator runs statelessly.
     fn enrollment_eval_source_internal(&self) -> Option<Option<EventEnrollmentMonitoredSource>> {
         None
     }

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -327,8 +327,8 @@ pub trait BACnetObject: Send + Sync {
     /// The outer `Option` indicates whether the object supports this channel;
     /// the inner `Option` is empty before a source has been established.
     /// Objects that implement the evaluation-state channel must also implement
-    /// this channel to retain countdowns and baselines for indexed references.
-    /// Indexed evaluation runs statelessly without source storage.
+    /// this channel to retain indexed state or value-specific COV/COS
+    /// baselines. Those evaluations run statelessly without source storage.
     fn enrollment_eval_source_internal(&self) -> Option<Option<EventEnrollmentMonitoredSource>> {
         None
     }

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -326,9 +326,8 @@ pub trait BACnetObject: Send + Sync {
     ///
     /// The outer `Option` indicates whether the object supports this channel;
     /// the inner `Option` is empty before a source has been established.
-    /// Objects that implement the evaluation-state channel must also implement
-    /// this channel to retain indexed state or value-specific COV/COS
-    /// baselines. Those evaluations run statelessly without source storage.
+    /// The server stores source ownership in its object database when an
+    /// object implements evaluation state but leaves this channel unsupported.
     fn enrollment_eval_source_internal(&self) -> Option<Option<EventEnrollmentMonitoredSource>> {
         None
     }

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -809,7 +809,13 @@ pub fn evaluate_event_enrollments(
                     persisted_eval_state = true;
                 }
             }
-            if obj.set_event_state_internal(fired.to).is_err() {
+            let event_state_landed = fired.from == fired.to
+                || obj.set_event_state_internal(fired.to).is_ok()
+                || matches!(
+                    obj.read_property(PropertyIdentifier::EVENT_STATE, None),
+                    Ok(PropertyValue::Enumerated(state)) if state == fired.to.to_raw()
+                );
+            if !event_state_landed {
                 if persisted_eval_state {
                     if obj
                         .set_enrollment_eval_state_internal(EventEnrollmentEvalState::default())

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -60,7 +60,10 @@ use bacnet_objects::event::{EventStateChange, EventTransition};
 use bacnet_objects::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentPending};
 use bacnet_objects::traits::BACnetObject;
 use bacnet_types::constructed::BACnetEventParameter;
-use bacnet_types::enums::{EventState, EventType, ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{
+    ErrorClass, ErrorCode, EventState, EventType, ObjectType, PropertyIdentifier,
+};
+use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
 /// A state transition detected during event enrollment evaluation.
@@ -195,6 +198,31 @@ fn queue_eval_state_reset(
     }
 }
 
+fn queue_pending_cancellation(
+    updates: &mut Vec<(ObjectIdentifier, EnrollmentUpdate)>,
+    oid: ObjectIdentifier,
+    supported: bool,
+    state: &mut EventEnrollmentEvalState,
+) {
+    if state.pending.take().is_some() && supported {
+        updates.push((oid, EnrollmentUpdate::eval_state_only(state.clone())));
+    }
+}
+
+fn invalid_indexed_target_error(error: &Error) -> bool {
+    matches!(
+        error,
+        Error::Protocol { class, code }
+            if *class == ErrorClass::PROPERTY.to_raw() as u32
+                && matches!(
+                    *code,
+                    code if code == ErrorCode::INVALID_ARRAY_INDEX.to_raw() as u32
+                        || code == ErrorCode::PROPERTY_IS_NOT_AN_ARRAY.to_raw() as u32
+                        || code == ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32
+                )
+    )
+}
+
 /// Evaluate all EventEnrollment objects in the database.
 ///
 /// For each active enrollment, reads the monitored property, evaluates the
@@ -250,6 +278,20 @@ pub fn evaluate_event_enrollments(
         };
         let monitored_oid = monitored.object_identifier;
         let monitored_prop = monitored.property_identifier;
+        let monitored_reference = (monitored_oid, monitored_prop, monitored.array_index);
+        // Pending and baseline state belongs to one exact monitored source.
+        if eval_state
+            .monitored_reference
+            .is_some_and(|current| current != monitored_reference)
+        {
+            eval_state = EventEnrollmentEvalState::default();
+            eval_state.monitored_reference = Some(monitored_reference);
+            if eval_state_supported {
+                updates.push((*oid, EnrollmentUpdate::eval_state_only(eval_state.clone())));
+            }
+        } else {
+            eval_state.monitored_reference = Some(monitored_reference);
+        }
 
         if let Ok(PropertyValue::Boolean(true)) =
             enrollment.read_property(PropertyIdentifier::OUT_OF_SERVICE, None)
@@ -359,9 +401,9 @@ pub fn evaluate_event_enrollments(
             .read_property(monitored_prop, monitored.array_index)
         {
             Ok(v) => v,
-            Err(_) => {
-                if monitored.array_index.is_some() {
-                    // An invalid element is an invalid target, not a request to
+            Err(error) => {
+                if monitored.array_index.is_some() && invalid_indexed_target_error(&error) {
+                    // A definitive indexed-target error is not a request to
                     // retry the whole property.
                     queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
                 }
@@ -378,6 +420,12 @@ pub fn evaluate_event_enrollments(
                 time_delay,
             } => {
                 let Some(val) = extract_real(&monitored_value) else {
+                    queue_pending_cancellation(
+                        &mut updates,
+                        *oid,
+                        eval_state_supported,
+                        &mut eval_state,
+                    );
                     continue;
                 };
                 (
@@ -402,6 +450,12 @@ pub fn evaluate_event_enrollments(
                     continue;
                 };
                 let Some(val) = extract_real(&monitored_value) else {
+                    queue_pending_cancellation(
+                        &mut updates,
+                        *oid,
+                        eval_state_supported,
+                        &mut eval_state,
+                    );
                     continue;
                 };
                 (
@@ -421,6 +475,12 @@ pub fn evaluate_event_enrollments(
                 time_delay,
             } => {
                 let Some(val) = extract_enumerated(&monitored_value) else {
+                    queue_pending_cancellation(
+                        &mut updates,
+                        *oid,
+                        eval_state_supported,
+                        &mut eval_state,
+                    );
                     continue;
                 };
                 (
@@ -439,6 +499,12 @@ pub fn evaluate_event_enrollments(
                 time_delay,
             } => {
                 let Some(bits) = extract_bitstring(&monitored_value) else {
+                    queue_pending_cancellation(
+                        &mut updates,
+                        *oid,
+                        eval_state_supported,
+                        &mut eval_state,
+                    );
                     continue;
                 };
                 (
@@ -456,6 +522,12 @@ pub fn evaluate_event_enrollments(
                     eval_state.cov_baseline.as_ref(),
                     current_state,
                 ) else {
+                    queue_pending_cancellation(
+                        &mut updates,
+                        *oid,
+                        eval_state_supported,
+                        &mut eval_state,
+                    );
                     continue;
                 };
                 (*time_delay, eval)

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -300,6 +300,7 @@ pub fn evaluate_event_enrollments(
     };
 
     let mut updates: Vec<(ObjectIdentifier, EnrollmentUpdate)> = Vec::new();
+    let mut database_eval_sources = HashSet::new();
 
     for oid in &oids {
         let Some(enrollment) = db.get(oid) else {
@@ -309,11 +310,18 @@ pub fn evaluate_event_enrollments(
         // A property read failure is transient and retains evaluation state.
         // An invalid reference shape or unsupported device clears state before
         // unrelated properties can short-circuit this pass.
-        let mut eval_state_supported = enrollment.enrollment_eval_state_internal().is_some();
+        let eval_state_supported = enrollment.enrollment_eval_state_internal().is_some();
         let mut eval_state = enrollment
             .enrollment_eval_state_internal()
             .unwrap_or_default();
-        let eval_source = enrollment.enrollment_eval_source_internal();
+        let eval_source = match enrollment.enrollment_eval_source_internal() {
+            Some(source) => Some(source),
+            None if eval_state_supported => {
+                database_eval_sources.insert(*oid);
+                Some(db.enrollment_eval_source(oid))
+            }
+            None => None,
+        };
         let force_state_reset = db.enrollment_eval_state_invalidated(oid);
         let reference = match read_object_property_ref(enrollment) {
             Ok(reference) => reference,
@@ -466,21 +474,6 @@ pub fn evaluate_event_enrollments(
             }
         };
         let event_type = EventType::from_raw(event_type_raw);
-        // Indexed state and algorithm baselines cannot survive a source
-        // change without owner storage. Pending-only threshold algorithms are
-        // still safe because their fingerprint includes the full reference.
-        let stateless_source_state = eval_state_supported
-            && eval_source.is_none()
-            && (monitored.array_index.is_some()
-                || matches!(
-                    event_type,
-                    EventType::CHANGE_OF_VALUE | EventType::CHANGE_OF_STATE
-                ));
-        if stateless_source_state {
-            queue_eval_state_reset(&mut updates, *oid, true, &eval_state);
-            eval_state = EventEnrollmentEvalState::default();
-            eval_state_supported = false;
-        }
         if eval_source.is_some_and(|current| current != Some(monitored_reference)) {
             updates.push((
                 *oid,
@@ -661,12 +654,6 @@ pub fn evaluate_event_enrollments(
             }
             continue;
         };
-        if stateless_source_state && ind.target == current_state {
-            // CHANGE_OF_STATE needs its stored causing value to distinguish a
-            // real same-state re-indication from the same alarm value.
-            continue;
-        }
-
         // Direction-selected delay: pTimeDelay toward OFFNORMAL states,
         // pTimeDelayNormal (already the fallback-composed effective value)
         // toward NORMAL — the Clause 13.3 split, mirroring the intrinsic
@@ -764,6 +751,7 @@ pub fn evaluate_event_enrollments(
     let mut source_failures = HashSet::new();
     let mut state_failures = HashSet::new();
     let mut invalidation_changes = Vec::new();
+    let mut database_source_changes = Vec::new();
     for (oid, update) in updates {
         let source_failed = source_failures.contains(&oid);
         if state_failures.contains(&oid)
@@ -776,7 +764,9 @@ pub fn evaluate_event_enrollments(
             continue;
         };
         if let Some(source) = update.eval_source {
-            if obj.set_enrollment_eval_source_internal(source).is_err() {
+            if database_eval_sources.contains(&oid) {
+                database_source_changes.push((oid, source));
+            } else if obj.set_enrollment_eval_source_internal(source).is_err() {
                 // State written later in this pass would have no reliable
                 // owner. Clear it and suppress dependent state updates, while
                 // allowing an immediate stateless transition to proceed.
@@ -803,21 +793,37 @@ pub fn evaluate_event_enrollments(
             if source_failed && fired.from == fired.to {
                 continue;
             }
-            if obj.set_event_state_internal(fired.to).is_err() {
-                continue;
-            }
+            let mut persisted_eval_state = false;
             if !source_failed {
                 if let Some(state) = update.eval_state {
                     if obj.set_enrollment_eval_state_internal(state).is_err() {
-                        // Do not expose a transition whose baseline or
-                        // countdown update could not be stored.
-                        let _ = obj.set_event_state_internal(fired.from);
-                        let _ = obj.set_enrollment_eval_source_internal(None);
+                        if database_eval_sources.contains(&oid) {
+                            database_source_changes.push((oid, None));
+                        } else {
+                            let _ = obj.set_enrollment_eval_source_internal(None);
+                        }
                         state_failures.insert(oid);
                         invalidation_changes.push((oid, true));
                         continue;
                     }
+                    persisted_eval_state = true;
                 }
+            }
+            if obj.set_event_state_internal(fired.to).is_err() {
+                if persisted_eval_state {
+                    if obj
+                        .set_enrollment_eval_state_internal(EventEnrollmentEvalState::default())
+                        .is_err()
+                    {
+                        invalidation_changes.push((oid, true));
+                    }
+                    if database_eval_sources.contains(&oid) {
+                        database_source_changes.push((oid, None));
+                    } else {
+                        let _ = obj.set_enrollment_eval_source_internal(None);
+                    }
+                }
+                continue;
             }
             // 13.2.2.1.4's fourth action, alarm-acknowledgment half (13.2.3):
             // with the transition's Ack_Required bit set, the corresponding
@@ -838,7 +844,11 @@ pub fn evaluate_event_enrollments(
             if obj.set_enrollment_eval_state_internal(state).is_err() {
                 // A later source write must not claim state that failed to
                 // reset.
-                let _ = obj.set_enrollment_eval_source_internal(None);
+                if database_eval_sources.contains(&oid) {
+                    database_source_changes.push((oid, None));
+                } else {
+                    let _ = obj.set_enrollment_eval_source_internal(None);
+                }
                 state_failures.insert(oid);
                 invalidation_changes.push((oid, true));
             } else if update.clears_invalidation {
@@ -847,6 +857,9 @@ pub fn evaluate_event_enrollments(
         }
     }
 
+    for (oid, source) in database_source_changes {
+        db.set_enrollment_eval_source(oid, source);
+    }
     for (oid, invalidated) in invalidation_changes {
         db.set_enrollment_eval_state_invalidated(oid, invalidated);
     }

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -180,6 +180,8 @@ struct EnrollmentUpdate {
     eval_state: Option<EventEnrollmentEvalState>,
     /// Monitored-source ownership update for objects that support the channel.
     eval_source: Option<Option<EventEnrollmentMonitoredSource>>,
+    /// Clear the database-level reset requirement if this state write lands.
+    clears_invalidation: bool,
     /// A transition that fired this pass, with everything the transition
     /// actions need.
     fired: Option<FiredTransition>,
@@ -200,6 +202,7 @@ impl EnrollmentUpdate {
         Self {
             eval_state: Some(eval_state),
             eval_source: None,
+            clears_invalidation: false,
             fired: None,
         }
     }
@@ -208,6 +211,16 @@ impl EnrollmentUpdate {
         Self {
             eval_state: None,
             eval_source: Some(source),
+            clears_invalidation: false,
+            fired: None,
+        }
+    }
+
+    fn eval_state_reset() -> Self {
+        Self {
+            eval_state: Some(EventEnrollmentEvalState::default()),
+            eval_source: None,
+            clears_invalidation: true,
             fired: None,
         }
     }
@@ -220,10 +233,7 @@ fn queue_eval_state_reset(
     state: &EventEnrollmentEvalState,
 ) {
     if supported && *state != EventEnrollmentEvalState::default() {
-        updates.push((
-            oid,
-            EnrollmentUpdate::eval_state_only(EventEnrollmentEvalState::default()),
-        ));
+        updates.push((oid, EnrollmentUpdate::eval_state_reset()));
     }
 }
 
@@ -304,6 +314,7 @@ pub fn evaluate_event_enrollments(
             .enrollment_eval_state_internal()
             .unwrap_or_default();
         let eval_source = enrollment.enrollment_eval_source_internal();
+        let force_state_reset = db.enrollment_eval_state_invalidated(oid);
         let reference = match read_object_property_ref(enrollment) {
             Ok(reference) => reference,
             Err(()) => continue,
@@ -327,11 +338,11 @@ pub fn evaluate_event_enrollments(
             Some(None) => eval_state != EventEnrollmentEvalState::default(),
             None => false,
         };
-        if source_changed {
+        if source_changed || force_state_reset {
             let had_private_state = eval_state != EventEnrollmentEvalState::default();
             eval_state = EventEnrollmentEvalState::default();
-            if eval_state_supported && had_private_state {
-                updates.push((*oid, EnrollmentUpdate::eval_state_only(eval_state.clone())));
+            if eval_state_supported && (had_private_state || force_state_reset) {
+                updates.push((*oid, EnrollmentUpdate::eval_state_reset()));
             }
         }
 
@@ -735,6 +746,7 @@ pub fn evaluate_event_enrollments(
             EnrollmentUpdate {
                 eval_state: (eval_state_dirty && eval_state_supported).then_some(eval_state),
                 eval_source: None,
+                clears_invalidation: false,
                 fired: Some(FiredTransition {
                     monitored_oid,
                     event_type_raw,
@@ -751,6 +763,7 @@ pub fn evaluate_event_enrollments(
     let mut transitions = Vec::new();
     let mut source_failures = HashSet::new();
     let mut state_failures = HashSet::new();
+    let mut invalidation_changes = Vec::new();
     for (oid, update) in updates {
         let source_failed = source_failures.contains(&oid);
         if state_failures.contains(&oid)
@@ -772,6 +785,7 @@ pub fn evaluate_event_enrollments(
                     .is_err()
                 {
                     state_failures.insert(oid);
+                    invalidation_changes.push((oid, true));
                 }
                 source_failures.insert(oid);
                 continue;
@@ -800,6 +814,7 @@ pub fn evaluate_event_enrollments(
                         let _ = obj.set_event_state_internal(fired.from);
                         let _ = obj.set_enrollment_eval_source_internal(None);
                         state_failures.insert(oid);
+                        invalidation_changes.push((oid, true));
                         continue;
                     }
                 }
@@ -825,8 +840,15 @@ pub fn evaluate_event_enrollments(
                 // reset.
                 let _ = obj.set_enrollment_eval_source_internal(None);
                 state_failures.insert(oid);
+                invalidation_changes.push((oid, true));
+            } else if update.clears_invalidation {
+                invalidation_changes.push((oid, false));
             }
         }
+    }
+
+    for (oid, invalidated) in invalidation_changes {
+        db.set_enrollment_eval_state_invalidated(oid, invalidated);
     }
 
     transitions

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -41,6 +41,8 @@
 mod algorithms;
 mod reference;
 
+use std::collections::HashSet;
+
 pub use algorithms::{
     encode_change_of_bitstring_params, encode_change_of_state_params,
     encode_change_of_value_params, encode_floating_limit_params, encode_out_of_range_params,
@@ -297,7 +299,7 @@ pub fn evaluate_event_enrollments(
         // A property read failure is transient and retains evaluation state.
         // An invalid reference shape or unsupported device clears state before
         // unrelated properties can short-circuit this pass.
-        let eval_state_supported = enrollment.enrollment_eval_state_internal().is_some();
+        let mut eval_state_supported = enrollment.enrollment_eval_state_internal().is_some();
         let mut eval_state = enrollment
             .enrollment_eval_state_internal()
             .unwrap_or_default();
@@ -452,6 +454,14 @@ pub fn evaluate_event_enrollments(
                 continue;
             }
         };
+        // Evaluation state without its owning source cannot survive a
+        // reference change safely. Keep immediate evaluation available for
+        // older custom objects, but do not retain countdowns or baselines.
+        if eval_state_supported && eval_source.is_none() {
+            queue_eval_state_reset(&mut updates, *oid, true, &eval_state);
+            eval_state = EventEnrollmentEvalState::default();
+            eval_state_supported = false;
+        }
         if eval_source.is_some_and(|current| current != Some(monitored_reference)) {
             updates.push((
                 *oid,
@@ -727,10 +737,23 @@ pub fn evaluate_event_enrollments(
     }
 
     let mut transitions = Vec::new();
+    let mut source_failures = HashSet::new();
     for (oid, update) in updates {
+        if source_failures.contains(&oid) {
+            continue;
+        }
         let Some(obj) = db.get_mut(&oid) else {
             continue;
         };
+        if let Some(source) = update.eval_source {
+            if obj.set_enrollment_eval_source_internal(source).is_err() {
+                // State written later in this pass would have no reliable
+                // owner. Clear it and suppress the remaining updates.
+                let _ = obj.set_enrollment_eval_state_internal(EventEnrollmentEvalState::default());
+                source_failures.insert(oid);
+                continue;
+            }
+        }
         if let Some(fired) = update.fired {
             // Persist the transition through the internal lifecycle path, not
             // the network `write_property(EVENT_STATE, …)` route. `Event_State`
@@ -763,9 +786,6 @@ pub fn evaluate_event_enrollments(
             });
         } else if let Some(state) = update.eval_state {
             let _ = obj.set_enrollment_eval_state_internal(state);
-        }
-        if let Some(source) = update.eval_source {
-            let _ = obj.set_enrollment_eval_source_internal(source);
         }
     }
 

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -454,10 +454,11 @@ pub fn evaluate_event_enrollments(
                 continue;
             }
         };
-        // Evaluation state without its owning source cannot survive a
-        // reference change safely. Keep immediate evaluation available for
-        // older custom objects, but do not retain countdowns or baselines.
-        if eval_state_supported && eval_source.is_none() {
+        // Indexed evaluation state without its owning source cannot survive
+        // an index change safely. Keep immediate evaluation available for
+        // older custom objects, but do not retain indexed countdowns or
+        // baselines unless they implement the paired source channel.
+        if eval_state_supported && eval_source.is_none() && monitored.array_index.is_some() {
             queue_eval_state_reset(&mut updates, *oid, true, &eval_state);
             eval_state = EventEnrollmentEvalState::default();
             eval_state_supported = false;
@@ -738,8 +739,12 @@ pub fn evaluate_event_enrollments(
 
     let mut transitions = Vec::new();
     let mut source_failures = HashSet::new();
+    let mut state_failures = HashSet::new();
     for (oid, update) in updates {
-        if source_failures.contains(&oid) {
+        if state_failures.contains(&oid)
+            || (source_failures.contains(&oid)
+                && (update.eval_source.is_some() || update.eval_state.is_some()))
+        {
             continue;
         }
         let Some(obj) = db.get_mut(&oid) else {
@@ -748,8 +753,14 @@ pub fn evaluate_event_enrollments(
         if let Some(source) = update.eval_source {
             if obj.set_enrollment_eval_source_internal(source).is_err() {
                 // State written later in this pass would have no reliable
-                // owner. Clear it and suppress the remaining updates.
-                let _ = obj.set_enrollment_eval_state_internal(EventEnrollmentEvalState::default());
+                // owner. Clear it and suppress dependent state updates, while
+                // allowing an immediate stateless transition to proceed.
+                if obj
+                    .set_enrollment_eval_state_internal(EventEnrollmentEvalState::default())
+                    .is_err()
+                {
+                    state_failures.insert(oid);
+                }
                 source_failures.insert(oid);
                 continue;
             }
@@ -766,14 +777,20 @@ pub fn evaluate_event_enrollments(
             if obj.set_event_state_internal(fired.to).is_err() {
                 continue;
             }
+            if let Some(state) = update.eval_state {
+                if obj.set_enrollment_eval_state_internal(state).is_err() {
+                    // Do not expose a transition whose baseline or countdown
+                    // update could not be stored.
+                    let _ = obj.set_event_state_internal(fired.from);
+                    state_failures.insert(oid);
+                    continue;
+                }
+            }
             // 13.2.2.1.4's fourth action, alarm-acknowledgment half (13.2.3):
             // with the transition's Ack_Required bit set, the corresponding
             // Acked_Transitions bit is cleared (ack now owed); otherwise it is
             // set. The notification-distribution half is tranche E's #127.
             let _ = obj.set_acked_transitions_internal(fired.transition_bit, !fired.ack_required);
-            if let Some(state) = update.eval_state {
-                let _ = obj.set_enrollment_eval_state_internal(state);
-            }
             transitions.push(EventEnrollmentTransition {
                 enrollment_oid: oid,
                 monitored_oid: fired.monitored_oid,
@@ -785,7 +802,11 @@ pub fn evaluate_event_enrollments(
                 distribute: fired.distribute,
             });
         } else if let Some(state) = update.eval_state {
-            let _ = obj.set_enrollment_eval_state_internal(state);
+            if obj.set_enrollment_eval_state_internal(state).is_err() {
+                // A later source write must not claim state that failed to
+                // reset.
+                state_failures.insert(oid);
+            }
         }
     }
 

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -39,6 +39,7 @@
 //! the lifecycle task only logs the returned transitions.
 
 mod algorithms;
+mod reference;
 
 pub use algorithms::{
     encode_change_of_bitstring_params, encode_change_of_state_params,
@@ -50,6 +51,9 @@ use algorithms::{
     eval_floating_limit_struct, eval_legacy_le_arm, eval_out_of_range_struct, extract_bitstring,
     extract_enumerated, extract_real, ArmEvaluation,
 };
+#[cfg(test)]
+use reference::MonitoredReference;
+use reference::{params_fingerprint, read_object_property_ref};
 
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_objects::event::{EventStateChange, EventTransition};
@@ -99,51 +103,6 @@ fn read_setpoint(
     )
 }
 
-/// Read the object_property_reference from an EventEnrollment object.
-///
-/// Returns the monitored object, property, and optional device qualifier.
-fn read_object_property_ref(
-    enrollment: &dyn BACnetObject,
-) -> Result<
-    Option<(
-        ObjectIdentifier,
-        PropertyIdentifier,
-        Option<ObjectIdentifier>,
-    )>,
-    (),
-> {
-    match enrollment.read_property(PropertyIdentifier::OBJECT_PROPERTY_REFERENCE, None) {
-        Ok(PropertyValue::List(ref items)) if (2..=4).contains(&items.len()) => {
-            let obj_id = match &items[0] {
-                PropertyValue::ObjectIdentifier(oid) => *oid,
-                _ => return Ok(None),
-            };
-            let PropertyValue::Unsigned(prop_id) = &items[1] else {
-                return Ok(None);
-            };
-            let Ok(prop_id) = u32::try_from(*prop_id) else {
-                return Ok(None);
-            };
-            if prop_id > 0x3F_FFFF {
-                return Ok(None);
-            }
-            let prop_id = PropertyIdentifier::from_raw(prop_id);
-            match items.get(2) {
-                None | Some(PropertyValue::Null | PropertyValue::Unsigned(_)) => {}
-                Some(_) => return Ok(None),
-            }
-            let device_id = match items.get(3) {
-                None | Some(PropertyValue::Null) => None,
-                Some(PropertyValue::ObjectIdentifier(oid)) => Some(*oid),
-                Some(_) => return Ok(None),
-            };
-            Ok(Some((obj_id, prop_id, device_id)))
-        }
-        Ok(_) => Ok(None),
-        Err(_) => Err(()),
-    }
-}
-
 /// Convert a seconds delay to pending passes with never-fire-early ceiling
 /// semantics: `ceil(delay_secs / interval_secs)`. At the default 10s
 /// interval a 5s delay seeds 1 pass (fires when that pass elapses, ~10s
@@ -152,39 +111,6 @@ fn read_object_property_ref(
 fn passes_for_delay(delay_secs: u32, interval_secs: u64) -> u32 {
     let passes = (delay_secs as u64).div_ceil(interval_secs.max(1));
     u32::try_from(passes).unwrap_or(u32::MAX)
-}
-
-/// Fingerprint the configuration a pending countdown was gated under: the
-/// framed `Event_Parameters` encoding (which includes any algorithm-carried
-/// references, e.g. FLOATING_LIMIT's `setpoint_reference`), the effective
-/// normal-direction delay, the configured event type, and the monitored
-/// object+property the enrollment's `Object_Property_Reference` resolves to.
-/// A mismatch with [`EventEnrollmentPending::params_fingerprint`] cancels
-/// the in-flight countdown and re-gates from the current parameters — the
-/// pinned behavior for a mid-pending retarget or parameter change (the
-/// evaluator re-reads them every pass, so the change is observed on the pass
-/// after the write).
-fn params_fingerprint(
-    params: &BACnetEventParameter,
-    normal_delay: u64,
-    event_type_raw: u32,
-    monitored: &(ObjectIdentifier, PropertyIdentifier),
-) -> u64 {
-    let mut buf = bytes::BytesMut::new();
-    bacnet_encoding::constructed::encode_event_parameter(&mut buf, params);
-    let (monitored_oid, monitored_prop) = monitored;
-    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
-    for b in buf
-        .iter()
-        .copied()
-        .chain(normal_delay.to_le_bytes())
-        .chain(event_type_raw.to_le_bytes())
-        .chain(monitored_oid.encode())
-        .chain(monitored_prop.to_raw().to_le_bytes())
-    {
-        h = (h ^ b as u64).wrapping_mul(0x0000_0100_0000_01b3);
-    }
-    h
 }
 
 /// Resolve whether the Notification Class referenced by an enrollment
@@ -255,6 +181,20 @@ impl EnrollmentUpdate {
     }
 }
 
+fn queue_eval_state_reset(
+    updates: &mut Vec<(ObjectIdentifier, EnrollmentUpdate)>,
+    oid: ObjectIdentifier,
+    supported: bool,
+    state: &EventEnrollmentEvalState,
+) {
+    if supported && *state != EventEnrollmentEvalState::default() {
+        updates.push((
+            oid,
+            EnrollmentUpdate::eval_state_only(EventEnrollmentEvalState::default()),
+        ));
+    }
+}
+
 /// Evaluate all EventEnrollment objects in the database.
 ///
 /// For each active enrollment, reads the monitored property, evaluates the
@@ -290,8 +230,8 @@ pub fn evaluate_event_enrollments(
         };
 
         // A property read failure is transient and retains evaluation state.
-        // Any successfully read invalid or unsupported-device reference clears
-        // state before unrelated properties can short-circuit this pass.
+        // An invalid reference shape or unsupported device clears state before
+        // unrelated properties can short-circuit this pass.
         let eval_state_supported = enrollment.enrollment_eval_state_internal().is_some();
         let mut eval_state = enrollment
             .enrollment_eval_state_internal()
@@ -300,17 +240,16 @@ pub fn evaluate_event_enrollments(
             Ok(reference) => reference,
             Err(()) => continue,
         };
-        let Some((monitored_oid, monitored_prop, _)) = reference.filter(|(_, _, device_oid)| {
-            device_oid.is_none_or(|oid| Some(oid) == local_device_oid)
+        let Some(monitored) = reference.filter(|reference| {
+            reference
+                .device_identifier
+                .is_none_or(|oid| Some(oid) == local_device_oid)
         }) else {
-            if eval_state_supported && eval_state != EventEnrollmentEvalState::default() {
-                updates.push((
-                    *oid,
-                    EnrollmentUpdate::eval_state_only(EventEnrollmentEvalState::default()),
-                ));
-            }
+            queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
             continue;
         };
+        let monitored_oid = monitored.object_identifier;
+        let monitored_prop = monitored.property_identifier;
 
         if let Ok(PropertyValue::Boolean(true)) =
             enrollment.read_property(PropertyIdentifier::OUT_OF_SERVICE, None)
@@ -395,12 +334,8 @@ pub fn evaluate_event_enrollments(
         // resumed. The cancellation is flushed BEFORE any later exit — a
         // dropped write-back here is what let a params round-trip A→B→A
         // resume a stale countdown.
-        let fingerprint = params_fingerprint(
-            &params,
-            normal_delay as u64,
-            event_type_raw,
-            &(monitored_oid, monitored_prop),
-        );
+        let fingerprint =
+            params_fingerprint(&params, normal_delay as u64, event_type_raw, &monitored);
         if eval_state
             .pending
             .as_ref()
@@ -416,9 +351,22 @@ pub fn evaluate_event_enrollments(
         let Some(monitored_obj) = db.get(&monitored_oid) else {
             continue;
         };
-        let monitored_value = match monitored_obj.read_property(monitored_prop, None) {
+        if monitored.array_index.is_some() && !monitored_obj.is_array_property(monitored_prop) {
+            queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
+            continue;
+        }
+        let monitored_value = match monitored_obj
+            .read_property(monitored_prop, monitored.array_index)
+        {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(_) => {
+                if monitored.array_index.is_some() {
+                    // An invalid element is an invalid target, not a request to
+                    // retry the whole property.
+                    queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
+                }
+                continue;
+            }
         };
 
         let event_type = EventType::from_raw(event_type_raw);

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -454,11 +454,18 @@ pub fn evaluate_event_enrollments(
                 continue;
             }
         };
-        // Indexed evaluation state without its owning source cannot survive
-        // an index change safely. Keep immediate evaluation available for
-        // older custom objects, but do not retain indexed countdowns or
-        // baselines unless they implement the paired source channel.
-        if eval_state_supported && eval_source.is_none() && monitored.array_index.is_some() {
+        let event_type = EventType::from_raw(event_type_raw);
+        // Indexed state and algorithm baselines cannot survive a source
+        // change without owner storage. Pending-only threshold algorithms are
+        // still safe because their fingerprint includes the full reference.
+        let stateless_source_state = eval_state_supported
+            && eval_source.is_none()
+            && (monitored.array_index.is_some()
+                || matches!(
+                    event_type,
+                    EventType::CHANGE_OF_VALUE | EventType::CHANGE_OF_STATE
+                ));
+        if stateless_source_state {
             queue_eval_state_reset(&mut updates, *oid, true, &eval_state);
             eval_state = EventEnrollmentEvalState::default();
             eval_state_supported = false;
@@ -470,7 +477,6 @@ pub fn evaluate_event_enrollments(
             ));
         }
 
-        let event_type = EventType::from_raw(event_type_raw);
         let (time_delay, arm) = match &params {
             BACnetEventParameter::OutOfRange {
                 high_limit,
@@ -644,6 +650,11 @@ pub fn evaluate_event_enrollments(
             }
             continue;
         };
+        if stateless_source_state && ind.target == current_state {
+            // CHANGE_OF_STATE needs its stored causing value to distinguish a
+            // real same-state re-indication from the same alarm value.
+            continue;
+        }
 
         // Direction-selected delay: pTimeDelay toward OFFNORMAL states,
         // pTimeDelayNormal (already the fallback-composed effective value)
@@ -741,9 +752,10 @@ pub fn evaluate_event_enrollments(
     let mut source_failures = HashSet::new();
     let mut state_failures = HashSet::new();
     for (oid, update) in updates {
+        let source_failed = source_failures.contains(&oid);
         if state_failures.contains(&oid)
-            || (source_failures.contains(&oid)
-                && (update.eval_source.is_some() || update.eval_state.is_some()))
+            || (source_failed && update.eval_source.is_some())
+            || (source_failed && update.fired.is_none() && update.eval_state.is_some())
         {
             continue;
         }
@@ -774,16 +786,22 @@ pub fn evaluate_event_enrollments(
             // returned state is stored — 13.2.2.1.4 forbids collapsing
             // HIGH_LIMIT/LOW_LIMIT to OFFNORMAL — and the actions run for
             // same-state transitions too (`from == to`).
+            if source_failed && fired.from == fired.to {
+                continue;
+            }
             if obj.set_event_state_internal(fired.to).is_err() {
                 continue;
             }
-            if let Some(state) = update.eval_state {
-                if obj.set_enrollment_eval_state_internal(state).is_err() {
-                    // Do not expose a transition whose baseline or countdown
-                    // update could not be stored.
-                    let _ = obj.set_event_state_internal(fired.from);
-                    state_failures.insert(oid);
-                    continue;
+            if !source_failed {
+                if let Some(state) = update.eval_state {
+                    if obj.set_enrollment_eval_state_internal(state).is_err() {
+                        // Do not expose a transition whose baseline or
+                        // countdown update could not be stored.
+                        let _ = obj.set_event_state_internal(fired.from);
+                        let _ = obj.set_enrollment_eval_source_internal(None);
+                        state_failures.insert(oid);
+                        continue;
+                    }
                 }
             }
             // 13.2.2.1.4's fourth action, alarm-acknowledgment half (13.2.3):
@@ -805,6 +823,7 @@ pub fn evaluate_event_enrollments(
             if obj.set_enrollment_eval_state_internal(state).is_err() {
                 // A later source write must not claim state that failed to
                 // reset.
+                let _ = obj.set_enrollment_eval_source_internal(None);
                 state_failures.insert(oid);
             }
         }

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -57,7 +57,9 @@ use reference::{params_fingerprint, read_object_property_ref};
 
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_objects::event::{EventStateChange, EventTransition};
-use bacnet_objects::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentPending};
+use bacnet_objects::event_enrollment::{
+    EventEnrollmentEvalState, EventEnrollmentMonitoredSource, EventEnrollmentPending,
+};
 use bacnet_objects::traits::BACnetObject;
 use bacnet_types::constructed::BACnetEventParameter;
 use bacnet_types::enums::{
@@ -86,24 +88,38 @@ pub struct EventEnrollmentTransition {
     pub distribute: bool,
 }
 
-/// Read the setpoint referenced by a FLOATING_LIMIT enrollment.
-///
-/// Returns the referenced property's real value, or `None` if the reference is
-/// remote or unreadable.
+enum SetpointRead {
+    Value(f32),
+    Unusable,
+    Transient,
+}
+
 fn read_setpoint(
     db: &ObjectDatabase,
     reference: &bacnet_types::constructed::BACnetDeviceObjectPropertyReference,
-) -> Option<f32> {
+) -> SetpointRead {
     // Remote-device setpoint references are not resolvable from a local DB.
     if reference.device_identifier.is_some() {
-        return None;
+        return SetpointRead::Transient;
     }
-    let obj = db.get(&reference.object_identifier)?;
+    let Some(obj) = db.get(&reference.object_identifier) else {
+        return SetpointRead::Transient;
+    };
     let prop = PropertyIdentifier::from_raw(reference.property_identifier);
-    extract_real(
-        &obj.read_property(prop, reference.property_array_index)
-            .ok()?,
-    )
+    if reference.property_array_index.is_some() && !obj.is_array_property(prop) {
+        return SetpointRead::Unusable;
+    }
+    match obj.read_property(prop, reference.property_array_index) {
+        Ok(value) => extract_real(&value)
+            .map(SetpointRead::Value)
+            .unwrap_or(SetpointRead::Unusable),
+        Err(error)
+            if reference.property_array_index.is_some() && invalid_indexed_target_error(&error) =>
+        {
+            SetpointRead::Unusable
+        }
+        Err(_) => SetpointRead::Transient,
+    }
 }
 
 /// Convert a seconds delay to pending passes with never-fire-early ceiling
@@ -160,6 +176,8 @@ struct EnrollmentUpdate {
     /// Evaluation state to write back — pending countdown and/or baselines —
     /// when it changed this pass, even with no transition.
     eval_state: Option<EventEnrollmentEvalState>,
+    /// Monitored-source ownership update for objects that support the channel.
+    eval_source: Option<Option<EventEnrollmentMonitoredSource>>,
     /// A transition that fired this pass, with everything the transition
     /// actions need.
     fired: Option<FiredTransition>,
@@ -179,6 +197,15 @@ impl EnrollmentUpdate {
     fn eval_state_only(eval_state: EventEnrollmentEvalState) -> Self {
         Self {
             eval_state: Some(eval_state),
+            eval_source: None,
+            fired: None,
+        }
+    }
+
+    fn eval_source_only(source: Option<EventEnrollmentMonitoredSource>) -> Self {
+        Self {
+            eval_state: None,
+            eval_source: Some(source),
             fired: None,
         }
     }
@@ -206,6 +233,16 @@ fn queue_pending_cancellation(
 ) {
     if state.pending.take().is_some() && supported {
         updates.push((oid, EnrollmentUpdate::eval_state_only(state.clone())));
+    }
+}
+
+fn queue_eval_source_reset(
+    updates: &mut Vec<(ObjectIdentifier, EnrollmentUpdate)>,
+    oid: ObjectIdentifier,
+    source: Option<Option<EventEnrollmentMonitoredSource>>,
+) {
+    if source.flatten().is_some() {
+        updates.push((oid, EnrollmentUpdate::eval_source_only(None)));
     }
 }
 
@@ -264,6 +301,7 @@ pub fn evaluate_event_enrollments(
         let mut eval_state = enrollment
             .enrollment_eval_state_internal()
             .unwrap_or_default();
+        let eval_source = enrollment.enrollment_eval_source_internal();
         let reference = match read_object_property_ref(enrollment) {
             Ok(reference) => reference,
             Err(()) => continue,
@@ -274,23 +312,25 @@ pub fn evaluate_event_enrollments(
                 .is_none_or(|oid| Some(oid) == local_device_oid)
         }) else {
             queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
+            queue_eval_source_reset(&mut updates, *oid, eval_source);
             continue;
         };
         let monitored_oid = monitored.object_identifier;
         let monitored_prop = monitored.property_identifier;
         let monitored_reference = (monitored_oid, monitored_prop, monitored.array_index);
-        // Pending and baseline state belongs to one exact monitored source.
-        if eval_state
-            .monitored_reference
-            .is_some_and(|current| current != monitored_reference)
-        {
+        // Private evaluation state belongs to one exact monitored source. A
+        // nonempty ownerless state cannot be adopted safely.
+        let source_changed = match eval_source {
+            Some(Some(current)) => current != monitored_reference,
+            Some(None) => eval_state != EventEnrollmentEvalState::default(),
+            None => false,
+        };
+        if source_changed {
+            let had_private_state = eval_state != EventEnrollmentEvalState::default();
             eval_state = EventEnrollmentEvalState::default();
-            eval_state.monitored_reference = Some(monitored_reference);
-            if eval_state_supported {
+            if eval_state_supported && had_private_state {
                 updates.push((*oid, EnrollmentUpdate::eval_state_only(eval_state.clone())));
             }
-        } else {
-            eval_state.monitored_reference = Some(monitored_reference);
         }
 
         if let Ok(PropertyValue::Boolean(true)) =
@@ -395,6 +435,7 @@ pub fn evaluate_event_enrollments(
         };
         if monitored.array_index.is_some() && !monitored_obj.is_array_property(monitored_prop) {
             queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
+            queue_eval_source_reset(&mut updates, *oid, eval_source);
             continue;
         }
         let monitored_value = match monitored_obj
@@ -406,10 +447,17 @@ pub fn evaluate_event_enrollments(
                     // A definitive indexed-target error is not a request to
                     // retry the whole property.
                     queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
+                    queue_eval_source_reset(&mut updates, *oid, eval_source);
                 }
                 continue;
             }
         };
+        if eval_source.is_some_and(|current| current != Some(monitored_reference)) {
+            updates.push((
+                *oid,
+                EnrollmentUpdate::eval_source_only(Some(monitored_reference)),
+            ));
+        }
 
         let event_type = EventType::from_raw(event_type_raw);
         let (time_delay, arm) = match &params {
@@ -446,9 +494,6 @@ pub fn evaluate_event_enrollments(
                 deadband,
                 time_delay,
             } => {
-                let Some(setpoint) = read_setpoint(db, setpoint_reference) else {
-                    continue;
-                };
                 let Some(val) = extract_real(&monitored_value) else {
                     queue_pending_cancellation(
                         &mut updates,
@@ -457,6 +502,19 @@ pub fn evaluate_event_enrollments(
                         &mut eval_state,
                     );
                     continue;
+                };
+                let setpoint = match read_setpoint(db, setpoint_reference) {
+                    SetpointRead::Value(value) => value,
+                    SetpointRead::Unusable => {
+                        queue_pending_cancellation(
+                            &mut updates,
+                            *oid,
+                            eval_state_supported,
+                            &mut eval_state,
+                        );
+                        continue;
+                    }
+                    SetpointRead::Transient => continue,
                 };
                 (
                     *time_delay,
@@ -654,6 +712,7 @@ pub fn evaluate_event_enrollments(
             *oid,
             EnrollmentUpdate {
                 eval_state: (eval_state_dirty && eval_state_supported).then_some(eval_state),
+                eval_source: None,
                 fired: Some(FiredTransition {
                     monitored_oid,
                     event_type_raw,
@@ -704,6 +763,9 @@ pub fn evaluate_event_enrollments(
             });
         } else if let Some(state) = update.eval_state {
             let _ = obj.set_enrollment_eval_state_internal(state);
+        }
+        if let Some(source) = update.eval_source {
+            let _ = obj.set_enrollment_eval_source_internal(source);
         }
     }
 

--- a/crates/bacnet-server/src/event_enrollment/reference.rs
+++ b/crates/bacnet-server/src/event_enrollment/reference.rs
@@ -1,0 +1,104 @@
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::constructed::BACnetEventParameter;
+use bacnet_types::enums::PropertyIdentifier;
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct MonitoredReference {
+    pub(super) object_identifier: ObjectIdentifier,
+    pub(super) property_identifier: PropertyIdentifier,
+    pub(super) array_index: Option<u32>,
+    pub(super) device_identifier: Option<ObjectIdentifier>,
+}
+
+impl MonitoredReference {
+    #[cfg(test)]
+    pub(super) fn local(
+        object_identifier: ObjectIdentifier,
+        property_identifier: PropertyIdentifier,
+        array_index: Option<u32>,
+    ) -> Self {
+        Self {
+            object_identifier,
+            property_identifier,
+            array_index,
+            device_identifier: None,
+        }
+    }
+}
+
+/// Read the object-property reference from an Event Enrollment object.
+///
+/// `Err` means the property could not be read; `Ok(None)` means it was read but
+/// does not contain a usable local reference shape.
+pub(super) fn read_object_property_ref(
+    enrollment: &dyn BACnetObject,
+) -> Result<Option<MonitoredReference>, ()> {
+    match enrollment.read_property(PropertyIdentifier::OBJECT_PROPERTY_REFERENCE, None) {
+        Ok(PropertyValue::List(ref items)) if (2..=4).contains(&items.len()) => {
+            let object_identifier = match &items[0] {
+                PropertyValue::ObjectIdentifier(oid) => *oid,
+                _ => return Ok(None),
+            };
+            let PropertyValue::Unsigned(property_identifier) = &items[1] else {
+                return Ok(None);
+            };
+            let Ok(property_identifier) = u32::try_from(*property_identifier) else {
+                return Ok(None);
+            };
+            if property_identifier > 0x3F_FFFF {
+                return Ok(None);
+            }
+            let property_identifier = PropertyIdentifier::from_raw(property_identifier);
+            let array_index = match items.get(2) {
+                None | Some(PropertyValue::Null) => None,
+                Some(PropertyValue::Unsigned(index)) => match u32::try_from(*index) {
+                    Ok(index) => Some(index),
+                    Err(_) => return Ok(None),
+                },
+                Some(_) => return Ok(None),
+            };
+            let device_identifier = match items.get(3) {
+                None | Some(PropertyValue::Null) => None,
+                Some(PropertyValue::ObjectIdentifier(oid)) => Some(*oid),
+                Some(_) => return Ok(None),
+            };
+            Ok(Some(MonitoredReference {
+                object_identifier,
+                property_identifier,
+                array_index,
+                device_identifier,
+            }))
+        }
+        Ok(_) => Ok(None),
+        Err(_) => Err(()),
+    }
+}
+
+/// Hash the inputs that determine whether an in-flight countdown is still
+/// valid. The device qualifier is excluded because accepted qualified and
+/// unqualified references resolve to the same local target.
+pub(super) fn params_fingerprint(
+    params: &BACnetEventParameter,
+    normal_delay: u64,
+    event_type_raw: u32,
+    monitored: &MonitoredReference,
+) -> u64 {
+    let mut buf = bytes::BytesMut::new();
+    bacnet_encoding::constructed::encode_event_parameter(&mut buf, params);
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in buf
+        .iter()
+        .copied()
+        .chain(normal_delay.to_le_bytes())
+        .chain(event_type_raw.to_le_bytes())
+        .chain(monitored.object_identifier.encode())
+        .chain(monitored.property_identifier.to_raw().to_le_bytes())
+        // BACnet assigns different meanings to an omitted index and index 0.
+        .chain([u8::from(monitored.array_index.is_some())])
+        .chain(monitored.array_index.unwrap_or_default().to_le_bytes())
+    {
+        h = (h ^ b as u64).wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}

--- a/crates/bacnet-server/src/event_enrollment/tests/array_index.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/array_index.rs
@@ -212,7 +212,6 @@ fn out_of_range_index_clears_state_without_whole_property_fallback() {
         1,
     );
     let stale = EventEnrollmentEvalState {
-        monitored_reference: Some((value_oid, PropertyIdentifier::PRIORITY_ARRAY, Some(17))),
         pending: None,
         cov_baseline: Some(PropertyValue::Real(90.0)),
         last_offnormal_value: Some(1),
@@ -220,6 +219,14 @@ fn out_of_range_index_clears_state_without_whole_property_fallback() {
     db.get_mut(&enrollment_oid)
         .unwrap()
         .set_enrollment_eval_state_internal(stale)
+        .unwrap();
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .set_enrollment_eval_source_internal(Some((
+            value_oid,
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(17),
+        )))
         .unwrap();
 
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
@@ -229,6 +236,12 @@ fn out_of_range_index_clears_state_without_whole_property_fallback() {
             .unwrap()
             .enrollment_eval_state_internal(),
         Some(EventEnrollmentEvalState::default())
+    );
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_source_internal(),
+        Some(None)
     );
 }
 
@@ -357,8 +370,14 @@ fn index_change_discards_the_previous_element_baselines() {
     assert_eq!(state.cov_baseline, Some(PropertyValue::Real(90.0)));
     assert_eq!(state.last_offnormal_value, None);
     assert_eq!(
-        state.monitored_reference,
-        Some((value_oid, PropertyIdentifier::PRIORITY_ARRAY, Some(2)))
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_source_internal(),
+        Some(Some((
+            value_oid,
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(2)
+        )))
     );
 }
 
@@ -457,4 +476,80 @@ fn transient_indexed_read_failure_retains_private_state() {
             .enrollment_eval_state_internal(),
         Some(expected)
     );
+}
+
+#[test]
+fn null_indexed_floating_setpoint_interrupts_the_pending_delay() {
+    let mut db = ObjectDatabase::new();
+    let mut monitored = AnalogValueObject::new(9, "AV-floating-monitored", 62).unwrap();
+    monitored.set_present_value(90.0);
+    let monitored_oid = monitored.object_identifier();
+    db.add(Box::new(monitored)).unwrap();
+
+    let mut setpoint = AnalogValueObject::new(10, "AV-floating-setpoint", 62).unwrap();
+    setpoint
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(50.0),
+            Some(1),
+        )
+        .unwrap();
+    let setpoint_oid = setpoint.object_identifier();
+    db.add(Box::new(setpoint)).unwrap();
+
+    let mut enrollment =
+        EventEnrollmentObject::new(9, "EE-indexed-setpoint", EventType::FLOATING_LIMIT.to_raw())
+            .unwrap();
+    enrollment.set_object_property_reference(Some(BACnetDeviceObjectPropertyReference::new_local(
+        monitored_oid,
+        PropertyIdentifier::PRESENT_VALUE.to_raw(),
+    )));
+    enrollment.set_event_parameters(BACnetEventParameter::FloatingLimit {
+        time_delay: 2,
+        setpoint_reference: BACnetDeviceObjectPropertyReference::new_local(
+            setpoint_oid,
+            PropertyIdentifier::PRIORITY_ARRAY.to_raw(),
+        )
+        .with_index(1),
+        low_diff_limit: 10.0,
+        high_diff_limit: 10.0,
+        deadband: 1.0,
+    });
+    enrollment.set_event_enable(0x07);
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    db.get_mut(&setpoint_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(1),
+            PropertyValue::Null,
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(db
+        .get(&enrollment_oid)
+        .unwrap()
+        .enrollment_eval_state_internal()
+        .unwrap()
+        .pending
+        .is_none());
+
+    db.get_mut(&setpoint_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(1),
+            PropertyValue::Real(50.0),
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
 }

--- a/crates/bacnet-server/src/event_enrollment/tests/array_index.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/array_index.rs
@@ -1,10 +1,15 @@
 use super::super::*;
 use bacnet_objects::analog::AnalogValueObject;
-use bacnet_objects::event_enrollment::{
-    EventEnrollmentEvalState, EventEnrollmentObject, EventEnrollmentPending,
-};
+use bacnet_objects::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentObject};
 use bacnet_objects::traits::BACnetObject;
-use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetEventParameter};
+use bacnet_types::constructed::{
+    BACnetDeviceObjectPropertyReference, BACnetEventParameter, ChangeOfValueCriteria,
+};
+use bacnet_types::enums::{ErrorClass, ErrorCode};
+use bacnet_types::error::Error;
+use std::borrow::Cow;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 
 fn add_out_of_range_enrollment(
     db: &mut ObjectDatabase,
@@ -34,6 +39,113 @@ fn add_out_of_range_enrollment(
     let oid = enrollment.object_identifier();
     db.add(Box::new(enrollment)).unwrap();
     oid
+}
+
+fn add_cov_enrollment(
+    db: &mut ObjectDatabase,
+    instance: u32,
+    monitored_oid: ObjectIdentifier,
+    index: u32,
+) -> ObjectIdentifier {
+    let mut enrollment = EventEnrollmentObject::new(
+        instance,
+        format!("EE-COV-index-{instance}"),
+        EventType::CHANGE_OF_VALUE.to_raw(),
+    )
+    .unwrap();
+    enrollment.set_object_property_reference(Some(
+        BACnetDeviceObjectPropertyReference::new_local(
+            monitored_oid,
+            PropertyIdentifier::PRIORITY_ARRAY.to_raw(),
+        )
+        .with_index(index),
+    ));
+    enrollment.set_event_parameters(BACnetEventParameter::ChangeOfValue {
+        time_delay: 0,
+        criteria: ChangeOfValueCriteria::ReferencedPropertyIncrement(5.0),
+    });
+    enrollment.set_event_enable(0x07);
+    let oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+    oid
+}
+
+struct IndexedReadProbe {
+    inner: AnalogValueObject,
+    control: ProbeControl,
+}
+
+#[derive(Clone)]
+struct ProbeControl {
+    reads: Arc<Mutex<Vec<Option<u32>>>>,
+    transient_failure: Arc<AtomicBool>,
+}
+
+impl IndexedReadProbe {
+    fn new(instance: u32) -> (Self, ProbeControl) {
+        let control = ProbeControl {
+            reads: Arc::new(Mutex::new(Vec::new())),
+            transient_failure: Arc::new(AtomicBool::new(false)),
+        };
+        (
+            Self {
+                inner: AnalogValueObject::new(instance, format!("AV-probe-{instance}"), 62)
+                    .unwrap(),
+                control: control.clone(),
+            },
+            control,
+        )
+    }
+}
+
+impl BACnetObject for IndexedReadProbe {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.inner.object_identifier()
+    }
+
+    fn object_name(&self) -> &str {
+        self.inner.object_name()
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        if property != PropertyIdentifier::PRIORITY_ARRAY {
+            return self.inner.read_property(property, array_index);
+        }
+        self.control.reads.lock().unwrap().push(array_index);
+        if self.control.transient_failure.load(Ordering::SeqCst) {
+            return Err(Error::Encoding("transient indexed read".into()));
+        }
+        if array_index == Some(17) {
+            return Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::INVALID_ARRAY_INDEX.to_raw() as u32,
+            });
+        }
+        Ok(PropertyValue::Real(90.0))
+    }
+
+    fn write_property(
+        &mut self,
+        property: PropertyIdentifier,
+        array_index: Option<u32>,
+        value: PropertyValue,
+        priority: Option<u8>,
+    ) -> Result<(), Error> {
+        self.inner
+            .write_property(property, array_index, value, priority)
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        self.inner.property_list()
+    }
+
+    fn is_array_property(&self, property: PropertyIdentifier) -> bool {
+        self.inner.is_array_property(property)
+    }
 }
 
 #[test]
@@ -88,7 +200,7 @@ fn array_index_zero_monitors_the_element_count() {
 #[test]
 fn out_of_range_index_clears_state_without_whole_property_fallback() {
     let mut db = ObjectDatabase::new();
-    let value = AnalogValueObject::new(3, "AV-invalid-index", 62).unwrap();
+    let (value, control) = IndexedReadProbe::new(3);
     let value_oid = value.object_identifier();
     db.add(Box::new(value)).unwrap();
     let enrollment_oid = add_out_of_range_enrollment(
@@ -100,12 +212,8 @@ fn out_of_range_index_clears_state_without_whole_property_fallback() {
         1,
     );
     let stale = EventEnrollmentEvalState {
-        pending: Some(EventEnrollmentPending {
-            state: EventState::HIGH_LIMIT,
-            remaining: 1,
-            condition: 0,
-            params_fingerprint: 1,
-        }),
+        monitored_reference: Some((value_oid, PropertyIdentifier::PRIORITY_ARRAY, Some(17))),
+        pending: None,
         cov_baseline: Some(PropertyValue::Real(90.0)),
         last_offnormal_value: Some(1),
     };
@@ -115,6 +223,7 @@ fn out_of_range_index_clears_state_without_whole_property_fallback() {
         .unwrap();
 
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(*control.reads.lock().unwrap(), vec![Some(17)]);
     assert_eq!(
         db.get(&enrollment_oid)
             .unwrap()
@@ -203,4 +312,149 @@ fn index_change_restarts_the_pending_delay() {
     );
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
     assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}
+
+#[test]
+fn index_change_discards_the_previous_element_baselines() {
+    let mut db = ObjectDatabase::new();
+    let mut value = AnalogValueObject::new(6, "AV-COV-retarget", 62).unwrap();
+    for (priority, sample) in [(1, 10.0), (2, 90.0)] {
+        value
+            .write_property(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                PropertyValue::Real(sample),
+                Some(priority),
+            )
+            .unwrap();
+    }
+    let value_oid = value.object_identifier();
+    db.add(Box::new(value)).unwrap();
+    let enrollment_oid = add_cov_enrollment(&mut db, 6, value_oid, 1);
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    let mut prior_state = db
+        .get(&enrollment_oid)
+        .unwrap()
+        .enrollment_eval_state_internal()
+        .unwrap();
+    assert_eq!(prior_state.cov_baseline, Some(PropertyValue::Real(10.0)));
+    prior_state.last_offnormal_value = Some(7);
+
+    assert!(db.remove(&enrollment_oid).is_some());
+    assert_eq!(add_cov_enrollment(&mut db, 6, value_oid, 2), enrollment_oid);
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .set_enrollment_eval_state_internal(prior_state)
+        .unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    let state = db
+        .get(&enrollment_oid)
+        .unwrap()
+        .enrollment_eval_state_internal()
+        .unwrap();
+    assert_eq!(state.cov_baseline, Some(PropertyValue::Real(90.0)));
+    assert_eq!(state.last_offnormal_value, None);
+    assert_eq!(
+        state.monitored_reference,
+        Some((value_oid, PropertyIdentifier::PRIORITY_ARRAY, Some(2)))
+    );
+}
+
+#[test]
+fn null_indexed_element_interrupts_the_pending_delay() {
+    let mut db = ObjectDatabase::new();
+    let mut value = AnalogValueObject::new(7, "AV-null", 62).unwrap();
+    value
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let value_oid = value.object_identifier();
+    db.add(Box::new(value)).unwrap();
+    let enrollment_oid = add_out_of_range_enrollment(
+        &mut db,
+        7,
+        value_oid,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        2,
+    );
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    db.get_mut(&value_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(1),
+            PropertyValue::Null,
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(db
+        .get(&enrollment_oid)
+        .unwrap()
+        .enrollment_eval_state_internal()
+        .unwrap()
+        .pending
+        .is_none());
+
+    db.get_mut(&value_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(1),
+            PropertyValue::Real(90.0),
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}
+
+#[test]
+fn transient_indexed_read_failure_retains_private_state() {
+    let mut db = ObjectDatabase::new();
+    let (value, control) = IndexedReadProbe::new(8);
+    let value_oid = value.object_identifier();
+    db.add(Box::new(value)).unwrap();
+    let enrollment_oid = add_out_of_range_enrollment(
+        &mut db,
+        8,
+        value_oid,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        2,
+    );
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    let mut expected = db
+        .get(&enrollment_oid)
+        .unwrap()
+        .enrollment_eval_state_internal()
+        .unwrap();
+    expected.cov_baseline = Some(PropertyValue::Real(42.0));
+    expected.last_offnormal_value = Some(3);
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .set_enrollment_eval_state_internal(expected.clone())
+        .unwrap();
+    control.reads.lock().unwrap().clear();
+    control.transient_failure.store(true, Ordering::SeqCst);
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(*control.reads.lock().unwrap(), vec![Some(1)]);
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_state_internal(),
+        Some(expected)
+    );
 }

--- a/crates/bacnet-server/src/event_enrollment/tests/array_index.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/array_index.rs
@@ -1,0 +1,206 @@
+use super::super::*;
+use bacnet_objects::analog::AnalogValueObject;
+use bacnet_objects::event_enrollment::{
+    EventEnrollmentEvalState, EventEnrollmentObject, EventEnrollmentPending,
+};
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetEventParameter};
+
+fn add_out_of_range_enrollment(
+    db: &mut ObjectDatabase,
+    instance: u32,
+    monitored_oid: ObjectIdentifier,
+    property: PropertyIdentifier,
+    index: u32,
+    time_delay: u32,
+) -> ObjectIdentifier {
+    let mut enrollment = EventEnrollmentObject::new(
+        instance,
+        format!("EE-index-{instance}"),
+        EventType::OUT_OF_RANGE.to_raw(),
+    )
+    .unwrap();
+    enrollment.set_object_property_reference(Some(
+        BACnetDeviceObjectPropertyReference::new_local(monitored_oid, property.to_raw())
+            .with_index(index),
+    ));
+    enrollment.set_event_parameters(BACnetEventParameter::OutOfRange {
+        time_delay,
+        low_limit: 20.0,
+        high_limit: 80.0,
+        deadband: 1.0,
+    });
+    enrollment.set_event_enable(0x07);
+    let oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+    oid
+}
+
+#[test]
+fn indexed_priority_array_element_drives_evaluation() {
+    let mut db = ObjectDatabase::new();
+    let mut value = AnalogValueObject::new(1, "AV-indexed", 62).unwrap();
+    value
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let value_oid = value.object_identifier();
+    db.add(Box::new(value)).unwrap();
+    add_out_of_range_enrollment(
+        &mut db,
+        1,
+        value_oid,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        0,
+    );
+
+    let transitions = evaluate_event_enrollments(&mut db, 1);
+    assert_eq!(transitions.len(), 1);
+    assert_eq!(transitions[0].monitored_oid, value_oid);
+    assert_eq!(transitions[0].change.to, EventState::HIGH_LIMIT);
+}
+
+#[test]
+fn array_index_zero_monitors_the_element_count() {
+    let mut db = ObjectDatabase::new();
+    let value = AnalogValueObject::new(2, "AV-count", 62).unwrap();
+    let value_oid = value.object_identifier();
+    db.add(Box::new(value)).unwrap();
+    add_out_of_range_enrollment(
+        &mut db,
+        2,
+        value_oid,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        0,
+        0,
+    );
+
+    let transitions = evaluate_event_enrollments(&mut db, 1);
+    assert_eq!(transitions.len(), 1);
+    assert_eq!(transitions[0].change.to, EventState::LOW_LIMIT);
+}
+
+#[test]
+fn out_of_range_index_clears_state_without_whole_property_fallback() {
+    let mut db = ObjectDatabase::new();
+    let value = AnalogValueObject::new(3, "AV-invalid-index", 62).unwrap();
+    let value_oid = value.object_identifier();
+    db.add(Box::new(value)).unwrap();
+    let enrollment_oid = add_out_of_range_enrollment(
+        &mut db,
+        3,
+        value_oid,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        17,
+        1,
+    );
+    let stale = EventEnrollmentEvalState {
+        pending: Some(EventEnrollmentPending {
+            state: EventState::HIGH_LIMIT,
+            remaining: 1,
+            condition: 0,
+            params_fingerprint: 1,
+        }),
+        cov_baseline: Some(PropertyValue::Real(90.0)),
+        last_offnormal_value: Some(1),
+    };
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .set_enrollment_eval_state_internal(stale)
+        .unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_state_internal(),
+        Some(EventEnrollmentEvalState::default())
+    );
+}
+
+#[test]
+fn index_on_scalar_property_does_not_read_the_scalar() {
+    let mut db = ObjectDatabase::new();
+    let mut value = AnalogValueObject::new(4, "AV-scalar", 62).unwrap();
+    value.set_present_value(90.0);
+    let value_oid = value.object_identifier();
+    db.add(Box::new(value)).unwrap();
+    add_out_of_range_enrollment(
+        &mut db,
+        4,
+        value_oid,
+        PropertyIdentifier::PRESENT_VALUE,
+        1,
+        0,
+    );
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+}
+
+#[test]
+fn index_change_restarts_the_pending_delay() {
+    let mut db = ObjectDatabase::new();
+    let mut value = AnalogValueObject::new(5, "AV-retarget", 62).unwrap();
+    for priority in [1, 2] {
+        value
+            .write_property(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                PropertyValue::Real(90.0),
+                Some(priority),
+            )
+            .unwrap();
+    }
+    let value_oid = value.object_identifier();
+    db.add(Box::new(value)).unwrap();
+    let enrollment_oid = add_out_of_range_enrollment(
+        &mut db,
+        5,
+        value_oid,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        1,
+        2,
+    );
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    let pending = db
+        .get(&enrollment_oid)
+        .unwrap()
+        .enrollment_eval_state_internal()
+        .unwrap();
+    assert_eq!(pending.pending.as_ref().unwrap().remaining, 2);
+
+    assert!(db.remove(&enrollment_oid).is_some());
+    let replacement_oid = add_out_of_range_enrollment(
+        &mut db,
+        5,
+        value_oid,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        2,
+        2,
+    );
+    assert_eq!(replacement_oid, enrollment_oid);
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .set_enrollment_eval_state_internal(pending)
+        .unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_state_internal()
+            .unwrap()
+            .pending
+            .unwrap()
+            .remaining,
+        2
+    );
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}

--- a/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
@@ -419,3 +419,121 @@ fn failed_eval_state_write_cannot_leak_an_unreported_event_state() {
         PropertyValue::Enumerated(EventState::NORMAL.to_raw())
     );
 }
+
+#[test]
+fn same_state_transition_does_not_depend_on_rewriting_event_state() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(111, "AV-same-state-write", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(10.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new_for_event_type(
+        Some(indexed_reference_value(target_oid, 1)),
+        EventType::CHANGE_OF_VALUE,
+    );
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::ChangeOfValue {
+            time_delay: 0,
+            criteria: ChangeOfValueCriteria::ReferencedPropertyIncrement(5.0),
+        });
+    enrollment.normal_event_state_writable = false;
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    db.get_mut(&target_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(20.0),
+            Some(1),
+        )
+        .unwrap();
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}
+
+#[test]
+fn landed_event_state_is_reported_when_its_setter_returns_error() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(112, "AV-landed-error", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::OutOfRange {
+            time_delay: 0,
+            low_limit: 20.0,
+            high_limit: 80.0,
+            deadband: 2.0,
+        });
+    enrollment.event_state_error_after_write = true;
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw())
+    );
+}
+
+#[test]
+fn detached_enrollment_does_not_resume_state_after_target_replacement() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(113, "AV-detached-source", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+
+    let enrollment = db.remove(&enrollment_oid).unwrap();
+    db.remove(&target_oid).unwrap();
+    let mut replacement = AnalogValueObject::new(113, "AV-detached-replacement", 62).unwrap();
+    replacement
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    db.add(Box::new(replacement)).unwrap();
+    db.add(enrollment).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}

--- a/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
@@ -189,11 +189,64 @@ fn source_write_failure_allows_one_immediate_change_of_state_transition() {
             time_delay: 0,
             list_of_values: vec![BACnetPropertyStates::UnsignedValue(1)],
         });
-    enrollment.source_writable = false;
+    enrollment.source_writable.store(false, Ordering::SeqCst);
     db.add(Box::new(enrollment)).unwrap();
 
     assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+}
+
+#[test]
+fn invalidation_survives_failed_state_and_source_writes() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(107, "AV-double-failure", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    let state_writable = Arc::clone(&enrollment.state_writable);
+    let source_writable = Arc::clone(&enrollment.source_writable);
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    state_writable.store(false, Ordering::SeqCst);
+    source_writable.store(false, Ordering::SeqCst);
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            indexed_reference_value(target_oid, 17),
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
+
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            indexed_reference_value(target_oid, 1),
+            None,
+        )
+        .unwrap();
+    state_writable.store(true, Ordering::SeqCst);
+    source_writable.store(true, Ordering::SeqCst);
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(!db.enrollment_eval_state_invalidated(&enrollment_oid));
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
 }
 
 #[test]

--- a/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
@@ -1,0 +1,218 @@
+use super::super::*;
+use super::integration::{indexed_reference_value, ReferenceValueObject};
+use bacnet_objects::analog::{AnalogInputObject, AnalogValueObject};
+use bacnet_objects::binary::BinaryValueObject;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::constructed::{
+    BACnetEventParameter, BACnetPropertyStates, ChangeOfValueCriteria,
+};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+#[test]
+fn stateful_custom_enrollment_without_source_channel_runs_statelessly() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(98, "AV-custom-source", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(10.0),
+            Some(1),
+        )
+        .unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(2),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new_for_event_type(
+        Some(indexed_reference_value(target_oid, 1)),
+        EventType::CHANGE_OF_VALUE,
+    );
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::ChangeOfValue {
+            time_delay: 0,
+            criteria: ChangeOfValueCriteria::ReferencedPropertyIncrement(5.0),
+        });
+    enrollment.source_supported = false;
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_state_internal(),
+        Some(bacnet_objects::event_enrollment::EventEnrollmentEvalState::default())
+    );
+
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            indexed_reference_value(target_oid, 2),
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+}
+
+#[test]
+fn failed_indexed_reset_cannot_resume_after_restoring_the_reference() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(103, "AV-reset-retry", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    let state_writable = Arc::clone(&enrollment.state_writable);
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    state_writable.store(false, Ordering::SeqCst);
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            indexed_reference_value(target_oid, 17),
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_source_internal(),
+        Some(None)
+    );
+
+    state_writable.store(true, Ordering::SeqCst);
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            indexed_reference_value(target_oid, 1),
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}
+
+#[test]
+fn source_less_unindexed_cov_does_not_reuse_a_retargeted_baseline() {
+    let mut db = ObjectDatabase::new();
+    let mut first = AnalogInputObject::new(104, "AI-COV-first", 62).unwrap();
+    first.set_present_value(10.0);
+    let first_oid = first.object_identifier();
+    db.add(Box::new(first)).unwrap();
+    let mut second = AnalogInputObject::new(105, "AI-COV-second", 62).unwrap();
+    second.set_present_value(90.0);
+    let second_oid = second.object_identifier();
+    db.add(Box::new(second)).unwrap();
+
+    let reference = PropertyValue::List(vec![
+        PropertyValue::ObjectIdentifier(first_oid),
+        PropertyValue::Unsigned(PropertyIdentifier::PRESENT_VALUE.to_raw() as u64),
+    ]);
+    let mut enrollment =
+        ReferenceValueObject::new_for_event_type(Some(reference), EventType::CHANGE_OF_VALUE);
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::ChangeOfValue {
+            time_delay: 0,
+            criteria: ChangeOfValueCriteria::ReferencedPropertyIncrement(5.0),
+        });
+    enrollment.source_supported = false;
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            PropertyValue::List(vec![
+                PropertyValue::ObjectIdentifier(second_oid),
+                PropertyValue::Unsigned(PropertyIdentifier::PRESENT_VALUE.to_raw() as u64),
+            ]),
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+}
+
+#[test]
+fn source_write_failure_allows_one_immediate_change_of_state_transition() {
+    let mut db = ObjectDatabase::new();
+    let mut target = BinaryValueObject::new(106, "BV-source-failure").unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Enumerated(1),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new_for_event_type(
+        Some(indexed_reference_value(target_oid, 1)),
+        EventType::CHANGE_OF_STATE,
+    );
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::ChangeOfState {
+            time_delay: 0,
+            list_of_values: vec![BACnetPropertyStates::UnsignedValue(1)],
+        });
+    enrollment.source_writable = false;
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+}
+
+#[test]
+fn source_less_custom_enrollment_retains_unindexed_delay_behavior() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogInputObject::new(102, "AI-unindexed-source", 62).unwrap();
+    target.set_present_value(90.0);
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let reference = PropertyValue::List(vec![
+        PropertyValue::ObjectIdentifier(target_oid),
+        PropertyValue::Unsigned(PropertyIdentifier::PRESENT_VALUE.to_raw() as u64),
+    ]);
+    let mut enrollment = ReferenceValueObject::new(Some(reference));
+    enrollment.source_supported = false;
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}

--- a/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 #[test]
-fn stateful_custom_enrollment_without_source_channel_runs_statelessly() {
+fn source_less_indexed_cov_retains_its_baseline_and_retargets_safely() {
     let mut db = ObjectDatabase::new();
     let mut target = AnalogValueObject::new(98, "AV-custom-source", 62).unwrap();
     target
@@ -51,8 +51,23 @@ fn stateful_custom_enrollment_without_source_channel_runs_statelessly() {
         db.get(&enrollment_oid)
             .unwrap()
             .enrollment_eval_state_internal(),
-        Some(bacnet_objects::event_enrollment::EventEnrollmentEvalState::default())
+        Some(bacnet_objects::event_enrollment::EventEnrollmentEvalState {
+            pending: None,
+            cov_baseline: Some(PropertyValue::Real(10.0)),
+            last_offnormal_value: None,
+        })
     );
+
+    db.get_mut(&target_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(20.0),
+            Some(1),
+        )
+        .unwrap();
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
 
     db.get_mut(&enrollment_oid)
         .unwrap()
@@ -64,6 +79,17 @@ fn stateful_custom_enrollment_without_source_channel_runs_statelessly() {
         )
         .unwrap();
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+
+    db.get_mut(&target_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(100.0),
+            Some(2),
+        )
+        .unwrap();
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
 }
 
 #[test]
@@ -162,6 +188,35 @@ fn source_less_unindexed_cov_does_not_reuse_a_retargeted_baseline() {
         )
         .unwrap();
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+
+    db.get_mut(&second_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    db.get_mut(&second_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(100.0),
+            None,
+        )
+        .unwrap();
+    db.get_mut(&second_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .unwrap();
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
 }
 
 #[test]
@@ -268,4 +323,99 @@ fn source_less_custom_enrollment_retains_unindexed_delay_behavior() {
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
     assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}
+
+#[test]
+fn source_less_custom_enrollment_retains_indexed_delay_behavior() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(108, "AV-indexed-source", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    enrollment.source_supported = false;
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}
+
+#[test]
+fn replacing_the_monitored_object_restarts_an_indexed_delay() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(109, "AV-replaced-source", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+
+    let mut replacement = AnalogValueObject::new(109, "AV-replacement", 62).unwrap();
+    replacement
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    db.add(Box::new(replacement)).unwrap();
+    assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+}
+
+#[test]
+fn failed_eval_state_write_cannot_leak_an_unreported_event_state() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(110, "AV-event-state-order", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    enrollment.normal_event_state_writable = false;
+    let state_writable = Arc::clone(&enrollment.state_writable);
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    state_writable.store(false, Ordering::SeqCst);
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        PropertyValue::Enumerated(EventState::NORMAL.to_raw())
+    );
 }

--- a/crates/bacnet-server/src/event_enrollment/tests/delays.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/delays.rs
@@ -534,8 +534,8 @@ fn set_oor_params(
         .unwrap();
 }
 
-/// The monitored object+property is folded into the pending-condition
-/// fingerprint: a retarget must be observed as a parameter change.
+/// The monitored object, property, and array index are folded into the
+/// pending-condition fingerprint.
 #[test]
 fn fingerprint_covers_monitored_reference() {
     let params = BACnetEventParameter::OutOfRange {
@@ -548,21 +548,67 @@ fn fingerprint_covers_monitored_reference() {
     let ai2 = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 2).unwrap();
     let pv = PropertyIdentifier::PRESENT_VALUE;
     let cf = PropertyIdentifier::COV_INCREMENT;
-    let base =
-        super::super::params_fingerprint(&params, 2, EventType::OUT_OF_RANGE.to_raw(), &(ai1, pv));
+    let monitored =
+        |oid, property, index| super::super::MonitoredReference::local(oid, property, index);
+    let base = super::super::params_fingerprint(
+        &params,
+        2,
+        EventType::OUT_OF_RANGE.to_raw(),
+        &monitored(ai1, pv, None),
+    );
     assert_ne!(
         base,
-        super::super::params_fingerprint(&params, 2, EventType::OUT_OF_RANGE.to_raw(), &(ai2, pv)),
+        super::super::params_fingerprint(
+            &params,
+            2,
+            EventType::OUT_OF_RANGE.to_raw(),
+            &monitored(ai2, pv, None),
+        ),
         "different monitored object must fingerprint differently"
     );
     assert_ne!(
         base,
-        super::super::params_fingerprint(&params, 2, EventType::OUT_OF_RANGE.to_raw(), &(ai1, cf)),
+        super::super::params_fingerprint(
+            &params,
+            2,
+            EventType::OUT_OF_RANGE.to_raw(),
+            &monitored(ai1, cf, None),
+        ),
         "different monitored property must fingerprint differently"
+    );
+    assert_ne!(
+        base,
+        super::super::params_fingerprint(
+            &params,
+            2,
+            EventType::OUT_OF_RANGE.to_raw(),
+            &monitored(ai1, pv, Some(0)),
+        ),
+        "an omitted index must differ from index zero"
+    );
+    assert_ne!(
+        super::super::params_fingerprint(
+            &params,
+            2,
+            EventType::OUT_OF_RANGE.to_raw(),
+            &monitored(ai1, pv, Some(0)),
+        ),
+        super::super::params_fingerprint(
+            &params,
+            2,
+            EventType::OUT_OF_RANGE.to_raw(),
+            &monitored(ai1, pv, Some(1)),
+        ),
+        "different array indexes must fingerprint differently"
     );
     assert_eq!(
         base,
-        super::super::params_fingerprint(&params, 2, EventType::OUT_OF_RANGE.to_raw(), &(ai1, pv)),
+        super::super::params_fingerprint(
+            &params,
+            2,
+            EventType::OUT_OF_RANGE.to_raw(),
+            &monitored(ai1, pv, None),
+        ),
         "same configuration fingerprints stably"
     );
 }

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -218,7 +218,7 @@ pub(super) struct ReferenceValueObject {
     event_parameters_readable: bool,
     pub(super) state_writable: Arc<AtomicBool>,
     pub(super) source_supported: bool,
-    pub(super) source_writable: bool,
+    pub(super) source_writable: Arc<AtomicBool>,
 }
 
 impl ReferenceValueObject {
@@ -245,7 +245,7 @@ impl ReferenceValueObject {
             event_parameters_readable: true,
             state_writable: Arc::new(AtomicBool::new(true)),
             source_supported: true,
-            source_writable: true,
+            source_writable: Arc::new(AtomicBool::new(true)),
         }
     }
 }
@@ -328,7 +328,7 @@ impl BACnetObject for ReferenceValueObject {
         &mut self,
         source: Option<bacnet_objects::event_enrollment::EventEnrollmentMonitoredSource>,
     ) -> Result<(), bacnet_types::error::Error> {
-        if !self.source_writable {
+        if !self.source_writable.load(Ordering::SeqCst) {
             return Err(bacnet_types::error::Error::Encoding(
                 "source write failed".into(),
             ));
@@ -376,8 +376,8 @@ fn failed_source_write_does_not_persist_dependent_state() {
     let target_oid = target.object_identifier();
     db.add(Box::new(target)).unwrap();
 
-    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
-    enrollment.source_writable = false;
+    let enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    enrollment.source_writable.store(false, Ordering::SeqCst);
     let enrollment_oid = enrollment.object_identifier();
     db.add(Box::new(enrollment)).unwrap();
 
@@ -416,7 +416,7 @@ fn source_write_failure_still_allows_an_immediate_stateless_transition() {
             high_limit: 80.0,
             deadband: 2.0,
         });
-    enrollment.source_writable = false;
+    enrollment.source_writable.store(false, Ordering::SeqCst);
     let enrollment_oid = enrollment.object_identifier();
     db.add(Box::new(enrollment)).unwrap();
 

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -214,6 +214,7 @@ struct ReferenceValueObject {
     inner: EventEnrollmentObject,
     reference: Option<PropertyValue>,
     event_parameters_readable: bool,
+    state_writable: bool,
     source_supported: bool,
     source_writable: bool,
 }
@@ -237,6 +238,7 @@ impl ReferenceValueObject {
             inner,
             reference,
             event_parameters_readable: true,
+            state_writable: true,
             source_supported: true,
             source_writable: true,
         }
@@ -302,6 +304,11 @@ impl BACnetObject for ReferenceValueObject {
         &mut self,
         state: bacnet_objects::event_enrollment::EventEnrollmentEvalState,
     ) -> Result<(), bacnet_types::error::Error> {
+        if !self.state_writable {
+            return Err(bacnet_types::error::Error::Encoding(
+                "evaluation state write failed".into(),
+            ));
+        }
         self.inner.set_enrollment_eval_state_internal(state)
     }
 
@@ -437,6 +444,129 @@ fn failed_source_write_does_not_persist_dependent_state() {
             Some(bacnet_objects::event_enrollment::EventEnrollmentEvalState::default())
         );
     }
+}
+
+#[test]
+fn source_write_failure_still_allows_an_immediate_stateless_transition() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(100, "AV-immediate-source", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::OutOfRange {
+            time_delay: 0,
+            low_limit: 20.0,
+            high_limit: 80.0,
+            deadband: 2.0,
+        });
+    enrollment.source_writable = false;
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw())
+    );
+}
+
+#[test]
+fn failed_state_reset_does_not_advance_source_ownership() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(101, "AV-state-reset", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(10.0),
+            Some(1),
+        )
+        .unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(2),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let old_source = (target_oid, PropertyIdentifier::PRIORITY_ARRAY, Some(1));
+    let mut enrollment = ReferenceValueObject::new_for_event_type(
+        Some(indexed_reference_value(target_oid, 2)),
+        EventType::CHANGE_OF_VALUE,
+    );
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::ChangeOfValue {
+            time_delay: 0,
+            criteria: bacnet_types::constructed::ChangeOfValueCriteria::ReferencedPropertyIncrement(
+                5.0,
+            ),
+        });
+    enrollment
+        .inner
+        .set_enrollment_eval_state_internal(
+            bacnet_objects::event_enrollment::EventEnrollmentEvalState {
+                pending: None,
+                cov_baseline: Some(PropertyValue::Real(10.0)),
+                last_offnormal_value: None,
+            },
+        )
+        .unwrap();
+    enrollment
+        .inner
+        .set_enrollment_eval_source_internal(Some(old_source))
+        .unwrap();
+    enrollment.state_writable = false;
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_source_internal(),
+        Some(Some(old_source))
+    );
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+}
+
+#[test]
+fn source_less_custom_enrollment_retains_unindexed_delay_behavior() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogInputObject::new(102, "AI-unindexed-source", 62).unwrap();
+    target.set_present_value(90.0);
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let reference = PropertyValue::List(vec![
+        PropertyValue::ObjectIdentifier(target_oid),
+        PropertyValue::Unsigned(PropertyIdentifier::PRESENT_VALUE.to_raw() as u64),
+    ]);
+    let mut enrollment = ReferenceValueObject::new(Some(reference));
+    enrollment.source_supported = false;
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
 }
 
 #[test]

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -219,6 +219,7 @@ pub(super) struct ReferenceValueObject {
     pub(super) state_writable: Arc<AtomicBool>,
     pub(super) source_supported: bool,
     pub(super) source_writable: Arc<AtomicBool>,
+    pub(super) normal_event_state_writable: bool,
 }
 
 impl ReferenceValueObject {
@@ -246,6 +247,7 @@ impl ReferenceValueObject {
             state_writable: Arc::new(AtomicBool::new(true)),
             source_supported: true,
             source_writable: Arc::new(AtomicBool::new(true)),
+            normal_event_state_writable: true,
         }
     }
 }
@@ -340,6 +342,11 @@ impl BACnetObject for ReferenceValueObject {
         &mut self,
         state: EventState,
     ) -> Result<(), bacnet_types::error::Error> {
+        if state == EventState::NORMAL && !self.normal_event_state_writable {
+            return Err(bacnet_types::error::Error::Encoding(
+                "event state write failed".into(),
+            ));
+        }
         self.inner.set_event_state_internal(state)
     }
 

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -9,6 +9,8 @@ use bacnet_objects::event_enrollment::EventEnrollmentObject;
 use bacnet_objects::traits::BACnetObject;
 use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetEventParameter};
 use std::borrow::Cow;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 // ---- Integration: multiple enrollments ----
 
@@ -210,21 +212,24 @@ fn unresolvable_reference_clears_private_evaluator_state() {
     );
 }
 
-struct ReferenceValueObject {
-    inner: EventEnrollmentObject,
+pub(super) struct ReferenceValueObject {
+    pub(super) inner: EventEnrollmentObject,
     reference: Option<PropertyValue>,
     event_parameters_readable: bool,
-    state_writable: bool,
-    source_supported: bool,
-    source_writable: bool,
+    pub(super) state_writable: Arc<AtomicBool>,
+    pub(super) source_supported: bool,
+    pub(super) source_writable: bool,
 }
 
 impl ReferenceValueObject {
-    fn new(reference: Option<PropertyValue>) -> Self {
+    pub(super) fn new(reference: Option<PropertyValue>) -> Self {
         Self::new_for_event_type(reference, EventType::OUT_OF_RANGE)
     }
 
-    fn new_for_event_type(reference: Option<PropertyValue>, event_type: EventType) -> Self {
+    pub(super) fn new_for_event_type(
+        reference: Option<PropertyValue>,
+        event_type: EventType,
+    ) -> Self {
         let mut inner =
             EventEnrollmentObject::new(999, "reference-value", event_type.to_raw()).unwrap();
         inner.set_event_parameters(BACnetEventParameter::OutOfRange {
@@ -238,7 +243,7 @@ impl ReferenceValueObject {
             inner,
             reference,
             event_parameters_readable: true,
-            state_writable: true,
+            state_writable: Arc::new(AtomicBool::new(true)),
             source_supported: true,
             source_writable: true,
         }
@@ -304,7 +309,7 @@ impl BACnetObject for ReferenceValueObject {
         &mut self,
         state: bacnet_objects::event_enrollment::EventEnrollmentEvalState,
     ) -> Result<(), bacnet_types::error::Error> {
-        if !self.state_writable {
+        if !self.state_writable.load(Ordering::SeqCst) {
             return Err(bacnet_types::error::Error::Encoding(
                 "evaluation state write failed".into(),
             ));
@@ -348,71 +353,12 @@ impl BACnetObject for ReferenceValueObject {
     }
 }
 
-fn indexed_reference_value(target: ObjectIdentifier, index: u32) -> PropertyValue {
+pub(super) fn indexed_reference_value(target: ObjectIdentifier, index: u32) -> PropertyValue {
     PropertyValue::List(vec![
         PropertyValue::ObjectIdentifier(target),
         PropertyValue::Unsigned(PropertyIdentifier::PRIORITY_ARRAY.to_raw() as u64),
         PropertyValue::Unsigned(index as u64),
     ])
-}
-
-#[test]
-fn stateful_custom_enrollment_without_source_channel_runs_statelessly() {
-    let mut db = ObjectDatabase::new();
-    let mut target = AnalogValueObject::new(98, "AV-custom-source", 62).unwrap();
-    target
-        .write_property(
-            PropertyIdentifier::PRESENT_VALUE,
-            None,
-            PropertyValue::Real(10.0),
-            Some(1),
-        )
-        .unwrap();
-    target
-        .write_property(
-            PropertyIdentifier::PRESENT_VALUE,
-            None,
-            PropertyValue::Real(90.0),
-            Some(2),
-        )
-        .unwrap();
-    let target_oid = target.object_identifier();
-    db.add(Box::new(target)).unwrap();
-
-    let mut enrollment = ReferenceValueObject::new_for_event_type(
-        Some(indexed_reference_value(target_oid, 1)),
-        EventType::CHANGE_OF_VALUE,
-    );
-    enrollment
-        .inner
-        .set_event_parameters(BACnetEventParameter::ChangeOfValue {
-            time_delay: 0,
-            criteria: bacnet_types::constructed::ChangeOfValueCriteria::ReferencedPropertyIncrement(
-                5.0,
-            ),
-        });
-    enrollment.source_supported = false;
-    let enrollment_oid = enrollment.object_identifier();
-    db.add(Box::new(enrollment)).unwrap();
-
-    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
-    assert_eq!(
-        db.get(&enrollment_oid)
-            .unwrap()
-            .enrollment_eval_state_internal(),
-        Some(bacnet_objects::event_enrollment::EventEnrollmentEvalState::default())
-    );
-
-    db.get_mut(&enrollment_oid)
-        .unwrap()
-        .write_property(
-            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
-            None,
-            indexed_reference_value(target_oid, 2),
-            None,
-        )
-        .unwrap();
-    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
 }
 
 #[test]
@@ -485,7 +431,7 @@ fn source_write_failure_still_allows_an_immediate_stateless_transition() {
 }
 
 #[test]
-fn failed_state_reset_does_not_advance_source_ownership() {
+fn failed_state_reset_clears_source_ownership() {
     let mut db = ObjectDatabase::new();
     let mut target = AnalogValueObject::new(101, "AV-state-reset", 62).unwrap();
     target
@@ -534,7 +480,7 @@ fn failed_state_reset_does_not_advance_source_ownership() {
         .inner
         .set_enrollment_eval_source_internal(Some(old_source))
         .unwrap();
-    enrollment.state_writable = false;
+    enrollment.state_writable.store(false, Ordering::SeqCst);
     let enrollment_oid = enrollment.object_identifier();
     db.add(Box::new(enrollment)).unwrap();
 
@@ -543,30 +489,9 @@ fn failed_state_reset_does_not_advance_source_ownership() {
         db.get(&enrollment_oid)
             .unwrap()
             .enrollment_eval_source_internal(),
-        Some(Some(old_source))
+        Some(None)
     );
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
-}
-
-#[test]
-fn source_less_custom_enrollment_retains_unindexed_delay_behavior() {
-    let mut db = ObjectDatabase::new();
-    let mut target = AnalogInputObject::new(102, "AI-unindexed-source", 62).unwrap();
-    target.set_present_value(90.0);
-    let target_oid = target.object_identifier();
-    db.add(Box::new(target)).unwrap();
-
-    let reference = PropertyValue::List(vec![
-        PropertyValue::ObjectIdentifier(target_oid),
-        PropertyValue::Unsigned(PropertyIdentifier::PRESENT_VALUE.to_raw() as u64),
-    ]);
-    let mut enrollment = ReferenceValueObject::new(Some(reference));
-    enrollment.source_supported = false;
-    db.add(Box::new(enrollment)).unwrap();
-
-    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
-    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
-    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
 }
 
 #[test]

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -3,7 +3,7 @@
 //! Split out of `tests.rs` to keep every file under the 700-LOC cap.
 
 use super::super::*;
-use bacnet_objects::analog::AnalogInputObject;
+use bacnet_objects::analog::{AnalogInputObject, AnalogValueObject};
 use bacnet_objects::device::{DeviceConfig, DeviceObject};
 use bacnet_objects::event_enrollment::EventEnrollmentObject;
 use bacnet_objects::traits::BACnetObject;
@@ -214,13 +214,18 @@ struct ReferenceValueObject {
     inner: EventEnrollmentObject,
     reference: Option<PropertyValue>,
     event_parameters_readable: bool,
+    source_supported: bool,
+    source_writable: bool,
 }
 
 impl ReferenceValueObject {
     fn new(reference: Option<PropertyValue>) -> Self {
+        Self::new_for_event_type(reference, EventType::OUT_OF_RANGE)
+    }
+
+    fn new_for_event_type(reference: Option<PropertyValue>, event_type: EventType) -> Self {
         let mut inner =
-            EventEnrollmentObject::new(999, "reference-value", EventType::OUT_OF_RANGE.to_raw())
-                .unwrap();
+            EventEnrollmentObject::new(999, "reference-value", event_type.to_raw()).unwrap();
         inner.set_event_parameters(BACnetEventParameter::OutOfRange {
             time_delay: 2,
             low_limit: 20.0,
@@ -232,6 +237,8 @@ impl ReferenceValueObject {
             inner,
             reference,
             event_parameters_readable: true,
+            source_supported: true,
+            source_writable: true,
         }
     }
 }
@@ -298,6 +305,25 @@ impl BACnetObject for ReferenceValueObject {
         self.inner.set_enrollment_eval_state_internal(state)
     }
 
+    fn enrollment_eval_source_internal(
+        &self,
+    ) -> Option<Option<bacnet_objects::event_enrollment::EventEnrollmentMonitoredSource>> {
+        self.source_supported
+            .then(|| self.inner.enrollment_eval_source_internal().flatten())
+    }
+
+    fn set_enrollment_eval_source_internal(
+        &mut self,
+        source: Option<bacnet_objects::event_enrollment::EventEnrollmentMonitoredSource>,
+    ) -> Result<(), bacnet_types::error::Error> {
+        if !self.source_writable {
+            return Err(bacnet_types::error::Error::Encoding(
+                "source write failed".into(),
+            ));
+        }
+        self.inner.set_enrollment_eval_source_internal(source)
+    }
+
     fn set_event_state_internal(
         &mut self,
         state: EventState,
@@ -312,6 +338,104 @@ impl BACnetObject for ReferenceValueObject {
     ) -> Result<(), bacnet_types::error::Error> {
         self.inner
             .set_acked_transitions_internal(transition_bit, acknowledged)
+    }
+}
+
+fn indexed_reference_value(target: ObjectIdentifier, index: u32) -> PropertyValue {
+    PropertyValue::List(vec![
+        PropertyValue::ObjectIdentifier(target),
+        PropertyValue::Unsigned(PropertyIdentifier::PRIORITY_ARRAY.to_raw() as u64),
+        PropertyValue::Unsigned(index as u64),
+    ])
+}
+
+#[test]
+fn stateful_custom_enrollment_without_source_channel_runs_statelessly() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(98, "AV-custom-source", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(10.0),
+            Some(1),
+        )
+        .unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(2),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new_for_event_type(
+        Some(indexed_reference_value(target_oid, 1)),
+        EventType::CHANGE_OF_VALUE,
+    );
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::ChangeOfValue {
+            time_delay: 0,
+            criteria: bacnet_types::constructed::ChangeOfValueCriteria::ReferencedPropertyIncrement(
+                5.0,
+            ),
+        });
+    enrollment.source_supported = false;
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_state_internal(),
+        Some(bacnet_objects::event_enrollment::EventEnrollmentEvalState::default())
+    );
+
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            indexed_reference_value(target_oid, 2),
+            None,
+        )
+        .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+}
+
+#[test]
+fn failed_source_write_does_not_persist_dependent_state() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(99, "AV-failed-source", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    enrollment.source_writable = false;
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    for _ in 0..4 {
+        assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+        assert_eq!(
+            db.get(&enrollment_oid)
+                .unwrap()
+                .enrollment_eval_state_internal(),
+            Some(bacnet_objects::event_enrollment::EventEnrollmentEvalState::default())
+        );
     }
 }
 

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -347,6 +347,11 @@ fn malformed_reference_shapes_do_not_become_local() {
             PropertyValue::ObjectIdentifier(target),
             PropertyValue::Unsigned(u32::MAX as u64 + 1 + property.to_raw() as u64),
         ],
+        vec![
+            PropertyValue::ObjectIdentifier(target),
+            PropertyValue::Unsigned(property.to_raw() as u64),
+            PropertyValue::Unsigned(u32::MAX as u64 + 1),
+        ],
     ];
 
     for items in malformed {
@@ -363,7 +368,9 @@ fn malformed_reference_shapes_do_not_become_local() {
     ])));
     assert_eq!(
         super::super::read_object_property_ref(&legacy),
-        Ok(Some((target, property, None)))
+        Ok(Some(super::super::MonitoredReference::local(
+            target, property, None
+        )))
     );
 }
 

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -188,6 +188,7 @@ fn unresolvable_reference_clears_private_evaluator_state() {
         .unwrap()
         .set_enrollment_eval_state_internal(
             bacnet_objects::event_enrollment::EventEnrollmentEvalState {
+                monitored_reference: None,
                 pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
                     state: EventState::HIGH_LIMIT,
                     remaining: 1,
@@ -376,6 +377,7 @@ fn malformed_reference_shapes_do_not_become_local() {
 
 fn stale_eval_state() -> bacnet_objects::event_enrollment::EventEnrollmentEvalState {
     bacnet_objects::event_enrollment::EventEnrollmentEvalState {
+        monitored_reference: None,
         pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
             state: EventState::HIGH_LIMIT,
             remaining: 1,

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -188,7 +188,6 @@ fn unresolvable_reference_clears_private_evaluator_state() {
         .unwrap()
         .set_enrollment_eval_state_internal(
             bacnet_objects::event_enrollment::EventEnrollmentEvalState {
-                monitored_reference: None,
                 pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
                     state: EventState::HIGH_LIMIT,
                     remaining: 1,
@@ -377,7 +376,6 @@ fn malformed_reference_shapes_do_not_become_local() {
 
 fn stale_eval_state() -> bacnet_objects::event_enrollment::EventEnrollmentEvalState {
     bacnet_objects::event_enrollment::EventEnrollmentEvalState {
-        monitored_reference: None,
         pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
             state: EventState::HIGH_LIMIT,
             remaining: 1,

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -220,6 +220,7 @@ pub(super) struct ReferenceValueObject {
     pub(super) source_supported: bool,
     pub(super) source_writable: Arc<AtomicBool>,
     pub(super) normal_event_state_writable: bool,
+    pub(super) event_state_error_after_write: bool,
 }
 
 impl ReferenceValueObject {
@@ -248,6 +249,7 @@ impl ReferenceValueObject {
             source_supported: true,
             source_writable: Arc::new(AtomicBool::new(true)),
             normal_event_state_writable: true,
+            event_state_error_after_write: false,
         }
     }
 }
@@ -347,7 +349,14 @@ impl BACnetObject for ReferenceValueObject {
                 "event state write failed".into(),
             ));
         }
-        self.inner.set_event_state_internal(state)
+        self.inner.set_event_state_internal(state)?;
+        if self.event_state_error_after_write {
+            Err(bacnet_types::error::Error::Encoding(
+                "event state write reported failure".into(),
+            ))
+        } else {
+            Ok(())
+        }
     }
 
     fn set_acked_transitions_internal(

--- a/crates/bacnet-server/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/mod.rs
@@ -1,3 +1,4 @@
+mod array_index;
 mod change_of_bitstring;
 mod change_of_state;
 mod change_of_value;

--- a/crates/bacnet-server/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/mod.rs
@@ -3,6 +3,7 @@ mod change_of_bitstring;
 mod change_of_state;
 mod change_of_value;
 mod compat;
+mod custom_state;
 mod delays;
 mod detection_enable;
 mod floating_limit;

--- a/crates/bacnet-server/src/handlers/tests/wpm_event_rollback.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_event_rollback.rs
@@ -151,6 +151,11 @@ fn wpm_rollback_restores_event_enrollment_detection_state() {
         .set_acked_transitions_internal(0x01, false)
         .unwrap();
     let evaluation = EventEnrollmentEvalState {
+        monitored_reference: Some((
+            ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+            PropertyIdentifier::PRESENT_VALUE,
+            Some(2),
+        )),
         pending: Some(EventEnrollmentPending {
             state: EventState::NORMAL,
             remaining: 4,

--- a/crates/bacnet-server/src/handlers/tests/wpm_event_rollback.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_event_rollback.rs
@@ -150,12 +150,12 @@ fn wpm_rollback_restores_event_enrollment_detection_state() {
     enrollment
         .set_acked_transitions_internal(0x01, false)
         .unwrap();
+    let source = (
+        ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+        PropertyIdentifier::PRESENT_VALUE,
+        Some(2),
+    );
     let evaluation = EventEnrollmentEvalState {
-        monitored_reference: Some((
-            ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
-            PropertyIdentifier::PRESENT_VALUE,
-            Some(2),
-        )),
         pending: Some(EventEnrollmentPending {
             state: EventState::NORMAL,
             remaining: 4,
@@ -167,6 +167,9 @@ fn wpm_rollback_restores_event_enrollment_detection_state() {
     };
     enrollment
         .set_enrollment_eval_state_internal(evaluation.clone())
+        .unwrap();
+    enrollment
+        .set_enrollment_eval_source_internal(Some(source))
         .unwrap();
     let oid = enrollment.object_identifier();
     db.add(Box::new(enrollment)).unwrap();
@@ -203,6 +206,7 @@ fn wpm_rollback_restores_event_enrollment_detection_state() {
         }
     );
     assert_eq!(object.enrollment_eval_state_internal(), Some(evaluation));
+    assert_eq!(object.enrollment_eval_source_internal(), Some(Some(source)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- carry `Object_Property_Reference` array indexes through parsing, pending identity, and exact monitored-property reads
- isolate evaluator state by monitored source across retargets, invalid indexed reads, object replacement, and custom Event Enrollment implementations
- make state/source updates fail closed without leaking unreported transitions or resuming stale countdowns

## Verification
- `cargo test -p bacnet-server` (394 passed)
- `cargo test -p bacnet-objects` (994 passed)
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo fmt --all --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`
- four-lens immutable review, with final approval from all reviewers

Closes #301