### PR TITLE
fix(encoding): reject enumerated values above u32

### DIFF
--- a/crates/bacnet-encoding/src/primitives/mod.rs
+++ b/crates/bacnet-encoding/src/primitives/mod.rs
@@ -521,7 +521,11 @@ pub fn decode_application_value(
                 data: bits,
             }
         }
-        app_tag::ENUMERATED => PropertyValue::Enumerated(decode_unsigned(content)? as u32),
+        app_tag::ENUMERATED => {
+            let value = u32::try_from(decode_unsigned(content)?)
+                .map_err(|_| Error::decoding(content_start, "ENUMERATED exceeds u32"))?;
+            PropertyValue::Enumerated(value)
+        }
         app_tag::DATE => PropertyValue::Date(Date::decode(content)?),
         app_tag::TIME => PropertyValue::Time(Time::decode(content)?),
         app_tag::OBJECT_IDENTIFIER => {

--- a/crates/bacnet-encoding/src/primitives/tests.rs
+++ b/crates/bacnet-encoding/src/primitives/tests.rs
@@ -261,6 +261,49 @@ fn app_enumerated_round_trip() {
     assert_eq!(end, bytes.len());
 }
 
+#[test]
+fn app_enumerated_rejects_values_exceeding_u32() {
+    for content in [
+        &[0x01, 0x00, 0x00, 0x00, 0x00][..],
+        &[0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02][..],
+    ] {
+        let mut bytes = BytesMut::new();
+        tags::encode_tag(
+            &mut bytes,
+            app_tag::ENUMERATED,
+            TagClass::Application,
+            u32::try_from(content.len()).unwrap(),
+        );
+        bytes.extend_from_slice(content);
+
+        assert!(decode_application_value(&bytes, 0).is_err());
+    }
+}
+
+#[test]
+fn app_enumerated_accepts_representable_values_with_leading_zeroes() {
+    for content in [
+        &[0x00, 0xFF, 0xFF, 0xFF, 0xFF][..],
+        &[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08][..],
+    ] {
+        let mut bytes = BytesMut::new();
+        tags::encode_tag(
+            &mut bytes,
+            app_tag::ENUMERATED,
+            TagClass::Application,
+            u32::try_from(content.len()).unwrap(),
+        );
+        bytes.extend_from_slice(content);
+
+        let (value, end) = decode_application_value(&bytes, 0).unwrap();
+        assert_eq!(
+            value,
+            PropertyValue::Enumerated(u32::try_from(decode_unsigned(content).unwrap()).unwrap())
+        );
+        assert_eq!(end, bytes.len());
+    }
+}
+
 /// Standard 135-2020 Clause 21 pins `record-access (0)` / `stream-access (1)`
 /// for `BACnetFileAccessMethod`; on the wire the enumerated application tag
 /// is 0x91 with the value octet after it (Clause 20.2.4). Guard against the

--- a/crates/bacnet-server/src/handlers/tests/write_validation.rs
+++ b/crates/bacnet-server/src/handlers/tests/write_validation.rs
@@ -249,6 +249,45 @@ fn assert_notify_type_validated(
     }
 }
 
+#[test]
+fn enumerated_overflow_is_invalid_data_encoding_without_mutation() {
+    let mut db = ObjectDatabase::new();
+    let ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+    let ai_oid = ai.object_identifier();
+    db.add(Box::new(ai)).unwrap();
+    let baseline = read_wire(&db, ai_oid, PropertyIdentifier::NOTIFY_TYPE);
+
+    let mut property_value = BytesMut::new();
+    bacnet_encoding::tags::encode_tag(
+        &mut property_value,
+        bacnet_encoding::tags::app_tag::ENUMERATED,
+        bacnet_encoding::tags::TagClass::Application,
+        8,
+    );
+    property_value.extend_from_slice(&[0, 0, 0, 1, 0, 0, 0, 2]);
+    let request = WritePropertyRequest {
+        object_identifier: ai_oid,
+        property_identifier: PropertyIdentifier::NOTIFY_TYPE,
+        property_array_index: None,
+        property_value: property_value.to_vec(),
+        priority: None,
+    };
+    let mut request_bytes = BytesMut::new();
+    request.encode(&mut request_bytes);
+
+    match handle_write_property(&mut db, &request_bytes).unwrap_err() {
+        Error::Protocol { class, code } => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(code, ErrorCode::INVALID_DATA_ENCODING.to_raw() as u32);
+        }
+        other => panic!("expected PROPERTY/INVALID_DATA_ENCODING, got {other:?}"),
+    }
+    assert_eq!(
+        read_wire(&db, ai_oid, PropertyIdentifier::NOTIFY_TYPE),
+        baseline
+    );
+}
+
 /// A fixed N-bit production has exactly one canonical encoding: one content
 /// octet whose high N bits are content (8-N unused). Any other shape is
 /// PROPERTY / INVALID_DATA_ENCODING per Clause 15.9.1.3.


### PR DESCRIPTION
## Summary
- replace the unchecked Enumerated narrowing cast with a checked `u32` conversion
- reject overflow payloads while accepting leading-zero encodings whose values remain representable
- verify WriteProperty returns `PROPERTY / INVALID_DATA_ENCODING` without mutating state

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test -p bacnet-encoding --locked`
- `cargo test -p bacnet-server --locked enumerated_overflow_is_invalid_data_encoding_without_mutation`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Closes #277