### PR TITLE
fix(encoding): validate ErrorPDU enums before narrowing

### DIFF
--- a/crates/bacnet-encoding/src/apdu/mod.rs
+++ b/crates/bacnet-encoding/src/apdu/mod.rs
@@ -569,7 +569,13 @@ fn decode_error(data: Bytes) -> Result<ErrorPdu, Error> {
             "ErrorPDU truncated at error class",
         ));
     }
-    let error_class_raw = primitives::decode_unsigned(&data[tag_end..class_end])? as u16;
+    let error_class_raw = primitives::decode_unsigned(&data[tag_end..class_end])?;
+    let error_class_raw = u16::try_from(error_class_raw).map_err(|_| {
+        Error::decoding(
+            tag_end,
+            format!("ErrorPDU error class {error_class_raw} exceeds u16"),
+        )
+    })?;
     offset = class_end;
 
     let (tag, tag_end) = tags::decode_tag(&data, offset)?;
@@ -585,7 +591,13 @@ fn decode_error(data: Bytes) -> Result<ErrorPdu, Error> {
     if code_end > data.len() {
         return Err(Error::decoding(tag_end, "ErrorPDU truncated at error code"));
     }
-    let error_code_raw = primitives::decode_unsigned(&data[tag_end..code_end])? as u16;
+    let error_code_raw = primitives::decode_unsigned(&data[tag_end..code_end])?;
+    let error_code_raw = u16::try_from(error_code_raw).map_err(|_| {
+        Error::decoding(
+            tag_end,
+            format!("ErrorPDU error code {error_code_raw} exceeds u16"),
+        )
+    })?;
     offset = code_end;
 
     let error_data = if offset < data.len() {

--- a/crates/bacnet-encoding/src/apdu/tests.rs
+++ b/crates/bacnet-encoding/src/apdu/tests.rs
@@ -306,6 +306,49 @@ fn error_with_trailing_data_round_trip() {
     assert_eq!(apdu, decoded);
 }
 
+#[test]
+fn error_enumerated_values_must_fit_u16() {
+    let encode_error = |error_class, error_code| {
+        let mut buf = BytesMut::with_capacity(16);
+        buf.put_u8(0x50);
+        buf.put_u8(1);
+        buf.put_u8(ConfirmedServiceChoice::READ_PROPERTY.to_raw());
+        primitives::encode_app_enumerated(&mut buf, error_class);
+        primitives::encode_app_enumerated(&mut buf, error_code);
+        buf.freeze()
+    };
+
+    for (error_class, error_code, field, value) in
+        [(65_536, 0, "class", 65_536), (0, 65_537, "code", 65_537)]
+    {
+        let error = decode_apdu(encode_error(error_class, error_code)).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("ErrorPDU error {field} {value}")),
+            "unexpected error for error {field} {value}: {error}"
+        );
+    }
+
+    let decoded = decode_apdu(encode_error(u16::MAX as u32, u16::MAX as u32)).unwrap();
+    let Apdu::Error(decoded) = decoded else {
+        panic!("expected ErrorPDU");
+    };
+    assert_eq!(decoded.error_class.to_raw(), u16::MAX);
+    assert_eq!(decoded.error_code.to_raw(), u16::MAX);
+
+    // Three-octet representations of numeric class 2 and code 32 remain valid.
+    let decoded = decode_apdu(Bytes::from_static(&[
+        0x50, 1, 12, 0x93, 0, 0, 2, 0x93, 0, 0, 32,
+    ]))
+    .unwrap();
+    let Apdu::Error(decoded) = decoded else {
+        panic!("expected ErrorPDU");
+    };
+    assert_eq!(decoded.error_class, ErrorClass::PROPERTY);
+    assert_eq!(decoded.error_code, ErrorCode::UNKNOWN_PROPERTY);
+}
+
 // --- Reject ---
 
 #[test]


### PR DESCRIPTION
## Summary
- decode ErrorPDU Error Class and Error Code as full-width Unsigned values before converting to `u16`
- reject over-wide values such as `65,536` and `65,537` instead of aliasing standard errors
- preserve the valid `u16::MAX` proprietary boundary and wider leading-zero representations

This removes the final two direct `decode_unsigned(...)? as u8/u16/u32` sites from `bacnet-encoding`.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test -p bacnet-encoding --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo check -p rusty-bacnet --tests --locked`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Refs #309