### PR TITLE
fix(services): validate Who-Is and I-Am widths

### DIFF
--- a/crates/bacnet-services/src/who_is.rs
+++ b/crates/bacnet-services/src/who_is.rs
@@ -132,8 +132,11 @@ impl IAmRequest {
         let mut offset = 0;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        // Application L/V/T values 6 and 7 are reserved, but decode_tag treats
+        // them as extended lengths because they mark context opening/closing tags.
         if tag.class != tags::TagClass::Application
             || tag.number != tags::app_tag::OBJECT_IDENTIFIER
+            || data[offset] & 0x07 > 5
         {
             return Err(Error::decoding(
                 offset,
@@ -148,7 +151,10 @@ impl IAmRequest {
         offset = end;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
-        if tag.class != tags::TagClass::Application || tag.number != tags::app_tag::UNSIGNED {
+        if tag.class != tags::TagClass::Application
+            || tag.number != tags::app_tag::UNSIGNED
+            || data[offset] & 0x07 > 5
+        {
             return Err(Error::decoding(
                 offset,
                 "IAm max APDU length: expected application-tagged unsigned",
@@ -168,7 +174,10 @@ impl IAmRequest {
         offset = end;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
-        if tag.class != tags::TagClass::Application || tag.number != tags::app_tag::ENUMERATED {
+        if tag.class != tags::TagClass::Application
+            || tag.number != tags::app_tag::ENUMERATED
+            || data[offset] & 0x07 > 5
+        {
             return Err(Error::decoding(
                 offset,
                 "IAm segmentation: expected application-tagged enumerated",
@@ -185,7 +194,10 @@ impl IAmRequest {
         offset = end;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
-        if tag.class != tags::TagClass::Application || tag.number != tags::app_tag::UNSIGNED {
+        if tag.class != tags::TagClass::Application
+            || tag.number != tags::app_tag::UNSIGNED
+            || data[offset] & 0x07 > 5
+        {
             return Err(Error::decoding(
                 offset,
                 "IAm vendor ID: expected application-tagged unsigned",
@@ -444,6 +456,17 @@ mod tests {
                 "unexpected error for {field} tag: {error}"
             );
         }
+
+        let valid = encode_request(1476, 0, 999);
+        let mut reserved_lvt = BytesMut::from(&[0xc6, 4][..]);
+        reserved_lvt.extend_from_slice(&valid[1..]);
+        let error = IAmRequest::decode(&reserved_lvt).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("IAm object identifier: expected application-tagged"),
+            "unexpected error for reserved application L/V/T: {error}"
+        );
     }
 
     #[test]

--- a/crates/bacnet-services/src/who_is.rs
+++ b/crates/bacnet-services/src/who_is.rs
@@ -61,7 +61,10 @@ impl WhoIsRequest {
             if end > data.len() {
                 return Err(Error::decoding(pos, "WhoIs truncated at low-limit"));
             }
-            low_limit = Some(primitives::decode_unsigned(&data[pos..end])? as u32);
+            let low_limit_raw = primitives::decode_unsigned(&data[pos..end])?;
+            low_limit = Some(u32::try_from(low_limit_raw).map_err(|_| {
+                Error::decoding(pos, format!("WhoIs low-limit {low_limit_raw} exceeds u32"))
+            })?);
             offset = end;
         }
 
@@ -73,7 +76,13 @@ impl WhoIsRequest {
                 if end > data.len() {
                     return Err(Error::decoding(pos, "WhoIs truncated at high-limit"));
                 }
-                high_limit = Some(primitives::decode_unsigned(&data[pos..end])? as u32);
+                let high_limit_raw = primitives::decode_unsigned(&data[pos..end])?;
+                high_limit = Some(u32::try_from(high_limit_raw).map_err(|_| {
+                    Error::decoding(
+                        pos,
+                        format!("WhoIs high-limit {high_limit_raw} exceeds u32"),
+                    )
+                })?);
             }
         }
 
@@ -135,7 +144,13 @@ impl IAmRequest {
         if end > data.len() {
             return Err(Error::decoding(pos, "IAm truncated at max-apdu-length"));
         }
-        let max_apdu_length = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let max_apdu_length_raw = primitives::decode_unsigned(&data[pos..end])?;
+        let max_apdu_length = u32::try_from(max_apdu_length_raw).map_err(|_| {
+            Error::decoding(
+                pos,
+                format!("IAm max APDU length {max_apdu_length_raw} exceeds u32"),
+            )
+        })?;
         offset = end;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
@@ -143,7 +158,9 @@ impl IAmRequest {
         if end > data.len() {
             return Err(Error::decoding(pos, "IAm truncated at segmentation"));
         }
-        let seg_raw = primitives::decode_unsigned(&data[pos..end])? as u8;
+        let seg_raw = primitives::decode_unsigned(&data[pos..end])?;
+        let seg_raw = u8::try_from(seg_raw)
+            .map_err(|_| Error::decoding(pos, format!("IAm segmentation {seg_raw} exceeds u8")))?;
         let segmentation_supported = Segmentation::from_raw(seg_raw);
         offset = end;
 
@@ -152,7 +169,10 @@ impl IAmRequest {
         if end > data.len() {
             return Err(Error::decoding(pos, "IAm truncated at vendor-id"));
         }
-        let vendor_id = primitives::decode_unsigned(&data[pos..end])? as u16;
+        let vendor_id_raw = primitives::decode_unsigned(&data[pos..end])?;
+        let vendor_id = u16::try_from(vendor_id_raw).map_err(|_| {
+            Error::decoding(pos, format!("IAm vendor ID {vendor_id_raw} exceeds u16"))
+        })?;
 
         Ok(Self {
             object_identifier,
@@ -261,6 +281,85 @@ mod tests {
         let decoded = WhoIsRequest::decode(&buf).unwrap();
         assert_eq!(decoded.low_limit, Some(1500));
         assert_eq!(decoded.high_limit, Some(1500));
+    }
+
+    #[test]
+    fn who_is_limits_must_fit_u32() {
+        let encode_range = |low, high| {
+            let mut buf = BytesMut::new();
+            primitives::encode_ctx_unsigned(&mut buf, 0, low);
+            primitives::encode_ctx_unsigned(&mut buf, 1, high);
+            buf
+        };
+
+        for (low, high, field, value) in [
+            (4_294_967_297, 4_294_967_297, "low-limit", 4_294_967_297_u64),
+            (1, 4_294_967_297, "high-limit", 4_294_967_297),
+        ] {
+            let encoded = encode_range(low, high);
+            let error = WhoIsRequest::decode(&encoded).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("WhoIs {field} {value}")),
+                "unexpected error for {field} {value}: {error}"
+            );
+        }
+
+        let mut leading_zero = BytesMut::new();
+        for tag_number in [0, 1] {
+            tags::encode_tag(&mut leading_zero, tag_number, tags::TagClass::Context, 5);
+            leading_zero.extend_from_slice(&[0, 0xff, 0xff, 0xff, 0xff]);
+        }
+        let decoded = WhoIsRequest::decode(&leading_zero).unwrap();
+        assert_eq!(decoded.low_limit, Some(u32::MAX));
+        assert_eq!(decoded.high_limit, Some(u32::MAX));
+    }
+
+    #[test]
+    fn i_am_values_must_fit_field_widths() {
+        let object_identifier = ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap();
+        let encode_request = |max_apdu_length, segmentation, vendor_id| {
+            let mut buf = BytesMut::new();
+            primitives::encode_app_object_id(&mut buf, &object_identifier);
+            primitives::encode_app_unsigned(&mut buf, max_apdu_length);
+            primitives::encode_app_enumerated(&mut buf, segmentation);
+            primitives::encode_app_unsigned(&mut buf, vendor_id);
+            buf
+        };
+
+        for (max_apdu_length, segmentation, vendor_id, field, value) in [
+            (4_294_967_296, 0, 0, "max APDU length", 4_294_967_296_u64),
+            (1, 256, 0, "segmentation", 256),
+            (1, 0, 65_536, "vendor ID", 65_536),
+        ] {
+            let encoded = encode_request(max_apdu_length, segmentation, vendor_id);
+            let error = IAmRequest::decode(&encoded).unwrap_err();
+            assert!(
+                error.to_string().contains(&format!("IAm {field} {value}")),
+                "unexpected error for {field} {value}: {error}"
+            );
+        }
+
+        let mut leading_zero = BytesMut::new();
+        primitives::encode_app_object_id(&mut leading_zero, &object_identifier);
+        for (tag_number, content) in [
+            (tags::app_tag::UNSIGNED, &[0, 0xff, 0xff, 0xff, 0xff][..]),
+            (tags::app_tag::ENUMERATED, &[0, 0xff][..]),
+            (tags::app_tag::UNSIGNED, &[0, 0xff, 0xff][..]),
+        ] {
+            tags::encode_tag(
+                &mut leading_zero,
+                tag_number,
+                tags::TagClass::Application,
+                content.len() as u32,
+            );
+            leading_zero.extend_from_slice(content);
+        }
+        let decoded = IAmRequest::decode(&leading_zero).unwrap();
+        assert_eq!(decoded.max_apdu_length, u32::MAX);
+        assert_eq!(decoded.segmentation_supported.to_raw(), u8::MAX);
+        assert_eq!(decoded.vendor_id, u16::MAX);
     }
 
     #[test]

--- a/crates/bacnet-services/src/who_is.rs
+++ b/crates/bacnet-services/src/who_is.rs
@@ -132,6 +132,14 @@ impl IAmRequest {
         let mut offset = 0;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if tag.class != tags::TagClass::Application
+            || tag.number != tags::app_tag::OBJECT_IDENTIFIER
+        {
+            return Err(Error::decoding(
+                offset,
+                "IAm object identifier: expected application-tagged object identifier",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(pos, "IAm truncated at object-identifier"));
@@ -140,6 +148,12 @@ impl IAmRequest {
         offset = end;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if tag.class != tags::TagClass::Application || tag.number != tags::app_tag::UNSIGNED {
+            return Err(Error::decoding(
+                offset,
+                "IAm max APDU length: expected application-tagged unsigned",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(pos, "IAm truncated at max-apdu-length"));
@@ -154,6 +168,12 @@ impl IAmRequest {
         offset = end;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if tag.class != tags::TagClass::Application || tag.number != tags::app_tag::ENUMERATED {
+            return Err(Error::decoding(
+                offset,
+                "IAm segmentation: expected application-tagged enumerated",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(pos, "IAm truncated at segmentation"));
@@ -165,6 +185,12 @@ impl IAmRequest {
         offset = end;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if tag.class != tags::TagClass::Application || tag.number != tags::app_tag::UNSIGNED {
+            return Err(Error::decoding(
+                offset,
+                "IAm vendor ID: expected application-tagged unsigned",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(pos, "IAm truncated at vendor-id"));
@@ -360,6 +386,64 @@ mod tests {
         assert_eq!(decoded.max_apdu_length, u32::MAX);
         assert_eq!(decoded.segmentation_supported.to_raw(), u8::MAX);
         assert_eq!(decoded.vendor_id, u16::MAX);
+
+        let encode_with_tags = |object_tag, max_apdu_tag, segmentation_tag, vendor_tag| {
+            let mut buf = BytesMut::new();
+            for (tag_number, content) in [
+                (object_tag, &object_identifier.encode()[..]),
+                (max_apdu_tag, &1476_u16.to_be_bytes()[..]),
+                (segmentation_tag, &[0][..]),
+                (vendor_tag, &999_u16.to_be_bytes()[..]),
+            ] {
+                tags::encode_tag(
+                    &mut buf,
+                    tag_number,
+                    tags::TagClass::Application,
+                    content.len() as u32,
+                );
+                buf.extend_from_slice(content);
+            }
+            buf
+        };
+        for (object_tag, max_apdu_tag, segmentation_tag, vendor_tag, field) in [
+            (
+                tags::app_tag::UNSIGNED,
+                tags::app_tag::UNSIGNED,
+                tags::app_tag::ENUMERATED,
+                tags::app_tag::UNSIGNED,
+                "object identifier",
+            ),
+            (
+                tags::app_tag::OBJECT_IDENTIFIER,
+                tags::app_tag::ENUMERATED,
+                tags::app_tag::ENUMERATED,
+                tags::app_tag::UNSIGNED,
+                "max APDU length",
+            ),
+            (
+                tags::app_tag::OBJECT_IDENTIFIER,
+                tags::app_tag::UNSIGNED,
+                tags::app_tag::UNSIGNED,
+                tags::app_tag::UNSIGNED,
+                "segmentation",
+            ),
+            (
+                tags::app_tag::OBJECT_IDENTIFIER,
+                tags::app_tag::UNSIGNED,
+                tags::app_tag::ENUMERATED,
+                tags::app_tag::SIGNED,
+                "vendor ID",
+            ),
+        ] {
+            let encoded = encode_with_tags(object_tag, max_apdu_tag, segmentation_tag, vendor_tag);
+            let error = IAmRequest::decode(&encoded).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains(&format!("IAm {field}: expected application-tagged")),
+                "unexpected error for {field} tag: {error}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject Who-Is low and high limits above `u32::MAX`
- reject I-Am maximum APDU lengths above `u32::MAX`
- reject I-Am segmentation and vendor values above their `u8` and `u16` representations
- require the four I-Am fields to use their specified application tags
- preserve exact maxima and wider leading-zero encodings

Part of #309.

## Validation
- `cargo test -p bacnet-services --locked who_is`
- `cargo test -p bacnet-services --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`