### PR TITLE
fix(client): preserve over-wide discovered APDU limits

### DIFF
--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -62,7 +62,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     let dt = self.device_table.lock().await;
                     let device = dt.get_by_mac(mac);
                     let max_apdu = device
-                        .map(|d| d.max_apdu_length as u16)
+                        .map(|d| u16::try_from(d.max_apdu_length).unwrap_or(u16::MAX))
                         .unwrap_or(self.config.max_apdu_length);
                     let max_seg = device.and_then(|d| d.max_segments_accepted);
                     (max_apdu.min(target_transport_max_apdu), max_seg)

--- a/crates/bacnet-client/src/client/tests.rs
+++ b/crates/bacnet-client/src/client/tests.rs
@@ -302,6 +302,64 @@ async fn confirmed_request_simple_ack() {
 }
 
 #[tokio::test]
+async fn confirmed_request_does_not_wrap_discovered_max_apdu_length() {
+    let client_mac = vec![0x01];
+    let remote_mac = vec![0x02];
+    let (client_transport, remote_transport) =
+        LoopbackTransport::pair(client_mac, remote_mac.clone());
+    let mut remote_network = NetworkLayer::new(remote_transport);
+    let mut remote_rx = remote_network.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(DiscoveredDevice {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 2002).unwrap(),
+        mac_address: MacAddr::from_slice(&remote_mac),
+        max_apdu_length: u32::from(u16::MAX) + 1,
+        segmentation_supported: Segmentation::NONE,
+        max_segments_accepted: None,
+        vendor_id: 42,
+        last_seen: Instant::now(),
+        source_network: None,
+        source_address: None,
+    });
+
+    let responder = tokio::spawn(async move {
+        let received = timeout(Duration::from_secs(1), remote_rx.recv())
+            .await
+            .expect("remote timed out")
+            .expect("remote channel closed");
+        let Apdu::ConfirmedRequest(req) = apdu::decode_apdu(received.apdu).unwrap() else {
+            panic!("expected ConfirmedRequest");
+        };
+        assert!(!req.segmented);
+
+        let ack = Apdu::SimpleAck(SimpleAck {
+            invoke_id: req.invoke_id,
+            service_choice: req.service_choice,
+        });
+        let mut buf = BytesMut::new();
+        encode_apdu(&mut buf, &ack).unwrap();
+        remote_network
+            .send_apdu(&buf, &received.source_mac, false, NetworkPriority::NORMAL)
+            .await
+            .unwrap();
+        remote_network.stop().await.unwrap();
+    });
+
+    let result = client
+        .confirmed_request(&remote_mac, ConfirmedServiceChoice::READ_PROPERTY, &[0x01])
+        .await;
+
+    assert!(result.unwrap().is_empty());
+    responder.await.unwrap();
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn confirmed_request_complex_ack() {
     let mut client_a = make_client().await;
 


### PR DESCRIPTION
## Summary
- convert discovered `u32` maximum APDU lengths to `u16` without modulo wrapping
- cap values above `u16::MAX` before applying the transport limit
- cover the `65,536 -> 0` alias with a loopback confirmed-request regression

## Why
I-Am decoding now preserves the full `u32` maximum APDU length. The client request path still used `as u16`, so a peer advertising 65,536 caused a non-empty request to enter segmentation with a zero-byte segment limit.

## Testing
- `cargo test -p bacnet-client --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Related to #309.