### PR TITLE
fix(services): validate atomic file counts

### DIFF
--- a/crates/bacnet-services/src/file.rs
+++ b/crates/bacnet-services/src/file.rs
@@ -21,6 +21,31 @@ fn checked_slice<'a>(
     Ok((&content[p..end], end))
 }
 
+fn checked_unsigned_u32(
+    content: &[u8],
+    offset: usize,
+    context: &str,
+) -> Result<(u32, usize), Error> {
+    let (tag, pos) = tags::decode_tag(content, offset)?;
+    if tag.class != tags::TagClass::Application
+        || tag.number != tags::app_tag::UNSIGNED
+        || content[offset] & 0x07 > 5
+    {
+        return Err(Error::decoding(
+            offset,
+            format!("{context} expected application Unsigned"),
+        ));
+    }
+    let end = pos + tag.length as usize;
+    if end > content.len() {
+        return Err(Error::decoding(pos, format!("{context} truncated")));
+    }
+    let raw = primitives::decode_unsigned(&content[pos..end])?;
+    let value = u32::try_from(raw)
+        .map_err(|_| Error::decoding(pos, format!("{context} {raw} exceeds u32")))?;
+    Ok((value, end))
+}
+
 // ---------------------------------------------------------------------------
 // AtomicReadFile-Request
 // ---------------------------------------------------------------------------
@@ -112,12 +137,11 @@ impl AtomicReadFileRequest {
             let (slice, inner) =
                 checked_slice(content, 0, "AtomicReadFile stream file-start-position")?;
             let file_start_position = primitives::decode_signed(slice)?;
-            let (slice, _) = checked_slice(
+            let (requested_octet_count, _) = checked_unsigned_u32(
                 content,
                 inner,
                 "AtomicReadFile stream requested-octet-count",
             )?;
-            let requested_octet_count = primitives::decode_unsigned(slice)? as u32;
             FileAccessMethod::Stream {
                 file_start_position,
                 requested_octet_count,
@@ -127,12 +151,11 @@ impl AtomicReadFileRequest {
             let (slice, inner) =
                 checked_slice(content, 0, "AtomicReadFile record file-start-record")?;
             let file_start_record = primitives::decode_signed(slice)?;
-            let (slice, _) = checked_slice(
+            let (requested_record_count, _) = checked_unsigned_u32(
                 content,
                 inner,
                 "AtomicReadFile record requested-record-count",
             )?;
-            let requested_record_count = primitives::decode_unsigned(slice)? as u32;
             FileAccessMethod::Record {
                 file_start_record,
                 requested_record_count,
@@ -205,9 +228,8 @@ impl AtomicWriteFileRequest {
             let (slice, mut inner) =
                 checked_slice(content, 0, "AtomicWriteFile record file-start-record")?;
             let file_start_record = primitives::decode_signed(slice)?;
-            let (slice, new_inner) =
-                checked_slice(content, inner, "AtomicWriteFile record record-count")?;
-            let record_count = primitives::decode_unsigned(slice)? as u32;
+            let (record_count, new_inner) =
+                checked_unsigned_u32(content, inner, "AtomicWriteFile record record-count")?;
             inner = new_inner;
             if record_count as usize > MAX_DECODED_ITEMS {
                 return Err(Error::decoding(0, "record count exceeds maximum"));
@@ -318,12 +340,11 @@ impl AtomicReadFileAck {
             let (slice, mut inner) =
                 checked_slice(content, 0, "AtomicReadFileAck record file-start-record")?;
             let file_start_record = primitives::decode_signed(slice)?;
-            let (slice, new_inner) = checked_slice(
+            let (returned_record_count, new_inner) = checked_unsigned_u32(
                 content,
                 inner,
                 "AtomicReadFileAck record returned-record-count",
             )?;
-            let returned_record_count = primitives::decode_unsigned(slice)? as u32;
             inner = new_inner;
             if returned_record_count as usize > MAX_DECODED_ITEMS {
                 return Err(Error::decoding(0, "record count exceeds maximum"));
@@ -782,3 +803,7 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "file_width_tests.rs"]
+mod width_tests;

--- a/crates/bacnet-services/src/file_width_tests.rs
+++ b/crates/bacnet-services/src/file_width_tests.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+fn file_oid() -> ObjectIdentifier {
+    ObjectIdentifier::new(bacnet_types::enums::ObjectType::FILE, 1).unwrap()
+}
+
+fn encode_count(buf: &mut BytesMut, tag_number: u8, value: u64, leading_zero: bool) {
+    if leading_zero {
+        tags::encode_tag(buf, tag_number, tags::TagClass::Application, 5);
+        buf.extend_from_slice(&value.to_be_bytes()[3..]);
+    } else {
+        let offset = buf.len();
+        primitives::encode_app_unsigned(buf, value);
+        buf[offset] = (tag_number << 4) | (buf[offset] & 0x0f);
+    }
+}
+
+fn encode_read_request(access_tag: u8, count_tag: u8, value: u64, leading_zero: bool) -> BytesMut {
+    let mut buf = BytesMut::new();
+    primitives::encode_app_object_id(&mut buf, &file_oid());
+    tags::encode_opening_tag(&mut buf, access_tag);
+    primitives::encode_app_signed(&mut buf, 0);
+    encode_count(&mut buf, count_tag, value, leading_zero);
+    tags::encode_closing_tag(&mut buf, access_tag);
+    buf
+}
+
+fn encode_read_ack(count_tag: u8, value: u64, leading_zero: bool) -> BytesMut {
+    let mut buf = BytesMut::new();
+    primitives::encode_app_boolean(&mut buf, false);
+    tags::encode_opening_tag(&mut buf, 1);
+    primitives::encode_app_signed(&mut buf, 0);
+    encode_count(&mut buf, count_tag, value, leading_zero);
+    tags::encode_closing_tag(&mut buf, 1);
+    buf
+}
+
+#[test]
+fn read_request_counts_accept_u32_max_with_leading_zero() {
+    let stream = AtomicReadFileRequest::decode(&encode_read_request(
+        0,
+        tags::app_tag::UNSIGNED,
+        u64::from(u32::MAX),
+        true,
+    ))
+    .unwrap();
+    assert!(matches!(
+        stream.access,
+        FileAccessMethod::Stream {
+            requested_octet_count: u32::MAX,
+            ..
+        }
+    ));
+
+    let record = AtomicReadFileRequest::decode(&encode_read_request(
+        1,
+        tags::app_tag::UNSIGNED,
+        u64::from(u32::MAX),
+        true,
+    ))
+    .unwrap();
+    assert!(matches!(
+        record.access,
+        FileAccessMethod::Record {
+            requested_record_count: u32::MAX,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn bounded_record_counts_accept_limit_with_leading_zero() {
+    let value = MAX_DECODED_ITEMS as u64;
+    let request = encode_read_request(1, tags::app_tag::UNSIGNED, value, true);
+    let write = AtomicWriteFileRequest::decode(&request).unwrap();
+    assert!(matches!(
+        write.access,
+        FileWriteAccessMethod::Record {
+            record_count,
+            ..
+        } if record_count == MAX_DECODED_ITEMS as u32
+    ));
+
+    let ack =
+        AtomicReadFileAck::decode(&encode_read_ack(tags::app_tag::UNSIGNED, value, true)).unwrap();
+    assert!(matches!(
+        ack.access,
+        FileReadAckMethod::Record {
+            returned_record_count,
+            ..
+        } if returned_record_count == MAX_DECODED_ITEMS as u32
+    ));
+}
+
+#[test]
+fn atomic_file_counts_reject_u32_overflow() {
+    for value in [u64::from(u32::MAX) + 1, u64::MAX] {
+        assert!(AtomicReadFileRequest::decode(&encode_read_request(
+            0,
+            tags::app_tag::UNSIGNED,
+            value,
+            false,
+        ))
+        .is_err());
+        let record = encode_read_request(1, tags::app_tag::UNSIGNED, value, false);
+        assert!(AtomicReadFileRequest::decode(&record).is_err());
+        assert!(AtomicWriteFileRequest::decode(&record).is_err());
+        assert!(AtomicReadFileAck::decode(
+            &encode_read_ack(tags::app_tag::UNSIGNED, value, false,)
+        )
+        .is_err());
+    }
+}
+
+#[test]
+fn atomic_file_counts_require_application_unsigned_tags() {
+    let stream = encode_read_request(0, tags::app_tag::ENUMERATED, 1, false);
+    assert!(AtomicReadFileRequest::decode(&stream).is_err());
+
+    let record = encode_read_request(1, tags::app_tag::ENUMERATED, 1, false);
+    assert!(AtomicReadFileRequest::decode(&record).is_err());
+    assert!(AtomicWriteFileRequest::decode(&record).is_err());
+
+    let ack = encode_read_ack(tags::app_tag::ENUMERATED, 1, false);
+    assert!(AtomicReadFileAck::decode(&ack).is_err());
+}
+
+#[test]
+fn atomic_file_counts_reject_reserved_application_lvt() {
+    let mut stream = BytesMut::new();
+    primitives::encode_app_object_id(&mut stream, &file_oid());
+    tags::encode_opening_tag(&mut stream, 0);
+    primitives::encode_app_signed(&mut stream, 0);
+    stream.extend_from_slice(&[0x26, 0x01, 0x00]);
+    tags::encode_closing_tag(&mut stream, 0);
+    assert!(AtomicReadFileRequest::decode(&stream).is_err());
+}

--- a/crates/bacnet-services/src/file_width_tests.rs
+++ b/crates/bacnet-services/src/file_width_tests.rs
@@ -35,6 +35,15 @@ fn encode_read_ack(count_tag: u8, value: u64, leading_zero: bool) -> BytesMut {
     buf
 }
 
+fn append_empty_records(mut buf: BytesMut) -> BytesMut {
+    buf.truncate(buf.len() - 1);
+    for _ in 0..MAX_DECODED_ITEMS {
+        primitives::encode_app_octet_string(&mut buf, &[]);
+    }
+    tags::encode_closing_tag(&mut buf, 1);
+    buf
+}
+
 #[test]
 fn read_request_counts_accept_u32_max_with_leading_zero() {
     let stream = AtomicReadFileRequest::decode(&encode_read_request(
@@ -71,24 +80,33 @@ fn read_request_counts_accept_u32_max_with_leading_zero() {
 #[test]
 fn bounded_record_counts_accept_limit_with_leading_zero() {
     let value = MAX_DECODED_ITEMS as u64;
-    let request = encode_read_request(1, tags::app_tag::UNSIGNED, value, true);
+    let request =
+        append_empty_records(encode_read_request(1, tags::app_tag::UNSIGNED, value, true));
     let write = AtomicWriteFileRequest::decode(&request).unwrap();
     assert!(matches!(
         write.access,
         FileWriteAccessMethod::Record {
             record_count,
+            file_record_data,
             ..
         } if record_count == MAX_DECODED_ITEMS as u32
+            && file_record_data.len() == MAX_DECODED_ITEMS
     ));
 
-    let ack =
-        AtomicReadFileAck::decode(&encode_read_ack(tags::app_tag::UNSIGNED, value, true)).unwrap();
+    let ack = AtomicReadFileAck::decode(&append_empty_records(encode_read_ack(
+        tags::app_tag::UNSIGNED,
+        value,
+        true,
+    )))
+    .unwrap();
     assert!(matches!(
         ack.access,
         FileReadAckMethod::Record {
             returned_record_count,
+            file_record_data,
             ..
         } if returned_record_count == MAX_DECODED_ITEMS as u32
+            && file_record_data.len() == MAX_DECODED_ITEMS
     ));
 }
 
@@ -123,15 +141,25 @@ fn atomic_file_counts_require_application_unsigned_tags() {
 
     let ack = encode_read_ack(tags::app_tag::ENUMERATED, 1, false);
     assert!(AtomicReadFileAck::decode(&ack).is_err());
+
+    let mut context = BytesMut::new();
+    primitives::encode_app_object_id(&mut context, &file_oid());
+    tags::encode_opening_tag(&mut context, 0);
+    primitives::encode_app_signed(&mut context, 0);
+    primitives::encode_ctx_unsigned(&mut context, 2, 1);
+    tags::encode_closing_tag(&mut context, 0);
+    assert!(AtomicReadFileRequest::decode(&context).is_err());
 }
 
 #[test]
 fn atomic_file_counts_reject_reserved_application_lvt() {
-    let mut stream = BytesMut::new();
-    primitives::encode_app_object_id(&mut stream, &file_oid());
-    tags::encode_opening_tag(&mut stream, 0);
-    primitives::encode_app_signed(&mut stream, 0);
-    stream.extend_from_slice(&[0x26, 0x01, 0x00]);
-    tags::encode_closing_tag(&mut stream, 0);
-    assert!(AtomicReadFileRequest::decode(&stream).is_err());
+    for header in [0x26, 0x27] {
+        let mut stream = BytesMut::new();
+        primitives::encode_app_object_id(&mut stream, &file_oid());
+        tags::encode_opening_tag(&mut stream, 0);
+        primitives::encode_app_signed(&mut stream, 0);
+        stream.extend_from_slice(&[header, 0x01, 0x00]);
+        tags::encode_closing_tag(&mut stream, 0);
+        assert!(AtomicReadFileRequest::decode(&stream).is_err());
+    }
 }


### PR DESCRIPTION
## Summary
- check AtomicReadFile requested octet and record counts against `u32`
- check AtomicWriteFile record counts and AtomicReadFileAck returned counts against `u32`
- require application Unsigned tags and reject reserved application L/V/T forms for these fields
- preserve the existing `MAX_DECODED_ITEMS` cap for record payload decoders
- cover overflow aliases, exact accepted limits, wider leading-zero encodings, wrong tags, and reserved forms

## Why
The file-service decoders converted peer `u64` counts with `as`. Over-wide record counts could alias below `MAX_DECODED_ITEMS` before record iteration or server dispatch, while over-wide read counts could alias before read sizing.

The boundary tests live in a separate module so the existing `file.rs` remains within the repository source-size cap.

## Testing
- `cargo test -p bacnet-services --locked file::`
- `cargo test -p bacnet-services --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Related to #309.