### PR TITLE
fix(services): validate read property widths

### DIFF
--- a/crates/bacnet-services/src/read_property.rs
+++ b/crates/bacnet-services/src/read_property.rs
@@ -7,6 +7,29 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
 
+fn decode_context_u32(
+    data: &[u8],
+    offset: usize,
+    tag_number: u8,
+    context: &str,
+) -> Result<(u32, usize), Error> {
+    let (tag, pos) = tags::decode_tag(data, offset)?;
+    if !tag.is_context(tag_number) {
+        return Err(Error::decoding(
+            offset,
+            format!("{context} expected context tag {tag_number}"),
+        ));
+    }
+    let end = pos + tag.length as usize;
+    if end > data.len() {
+        return Err(Error::decoding(pos, format!("{context} truncated")));
+    }
+    let raw = primitives::decode_unsigned(&data[pos..end])?;
+    let value = u32::try_from(raw)
+        .map_err(|_| Error::decoding(pos, format!("{context} {raw} exceeds u32")))?;
+    Ok((value, end))
+}
+
 // ---------------------------------------------------------------------------
 // ReadPropertyRequest
 // ---------------------------------------------------------------------------
@@ -41,6 +64,12 @@ impl ReadPropertyRequest {
 
         // [0] object-identifier
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if !tag.is_context(0) {
+            return Err(Error::decoding(
+                offset,
+                "ReadProperty request expected context tag 0 for object-id",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(
@@ -52,31 +81,19 @@ impl ReadPropertyRequest {
         offset = end;
 
         // [1] property-identifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "ReadProperty request truncated at property-id",
-            ));
-        }
-        let prop_raw = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (prop_raw, end) =
+            decode_context_u32(data, offset, 1, "ReadProperty request property-id")?;
         let property_identifier = PropertyIdentifier::from_raw(prop_raw);
         offset = end;
 
         // [2] propertyArrayIndex (optional)
         let mut property_array_index = None;
         if offset < data.len() {
-            let (tag, pos) = tags::decode_tag(data, offset)?;
+            let (tag, _) = tags::decode_tag(data, offset)?;
             if tag.is_context(2) {
-                let end = pos + tag.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        pos,
-                        "ReadProperty request truncated at array-index",
-                    ));
-                }
-                property_array_index = Some(primitives::decode_unsigned(&data[pos..end])? as u32);
+                let (index, _) =
+                    decode_context_u32(data, offset, 2, "ReadProperty request array-index")?;
+                property_array_index = Some(index);
             }
         }
 
@@ -129,6 +146,12 @@ impl ReadPropertyACK {
 
         // [0] object-identifier
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if !tag.is_context(0) {
+            return Err(Error::decoding(
+                offset,
+                "ReadPropertyACK expected context tag 0 for object-id",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(
@@ -140,15 +163,7 @@ impl ReadPropertyACK {
         offset = end;
 
         // [1] property-identifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "ReadPropertyACK truncated at property-id",
-            ));
-        }
-        let prop_raw = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (prop_raw, end) = decode_context_u32(data, offset, 1, "ReadPropertyACK property-id")?;
         let property_identifier = PropertyIdentifier::from_raw(prop_raw);
         offset = end;
 
@@ -156,14 +171,8 @@ impl ReadPropertyACK {
         let mut property_array_index = None;
         let (tag, tag_end) = tags::decode_tag(data, offset)?;
         if tag.class == TagClass::Context && tag.number == 2 && !tag.is_opening && !tag.is_closing {
-            let end = tag_end + tag.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(
-                    tag_end,
-                    "ReadPropertyACK truncated at array-index",
-                ));
-            }
-            property_array_index = Some(primitives::decode_unsigned(&data[tag_end..end])? as u32);
+            let (index, end) = decode_context_u32(data, offset, 2, "ReadPropertyACK array-index")?;
+            property_array_index = Some(index);
             offset = end;
             let (tag, tag_end) = tags::decode_tag(data, offset)?;
             if !tag.is_opening_tag(3) {
@@ -202,6 +211,41 @@ impl ReadPropertyACK {
 mod tests {
     use super::*;
     use bacnet_types::enums::ObjectType;
+
+    fn object_id() -> ObjectIdentifier {
+        ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap()
+    }
+
+    fn encode_context_value(buf: &mut BytesMut, tag_number: u8, value: u64, leading_zero: bool) {
+        if leading_zero {
+            tags::encode_tag(buf, tag_number, TagClass::Context, 5);
+            buf.extend_from_slice(&value.to_be_bytes()[3..]);
+        } else {
+            primitives::encode_ctx_unsigned(buf, tag_number, value);
+        }
+    }
+
+    fn encode_fields(
+        object_tag: u8,
+        property_tag: u8,
+        property: u64,
+        index: Option<(u8, u64)>,
+        ack: bool,
+        leading_zero: bool,
+    ) -> BytesMut {
+        let mut buf = BytesMut::new();
+        primitives::encode_ctx_object_id(&mut buf, object_tag, &object_id());
+        encode_context_value(&mut buf, property_tag, property, leading_zero);
+        if let Some((tag_number, value)) = index {
+            encode_context_value(&mut buf, tag_number, value, leading_zero);
+        }
+        if ack {
+            tags::encode_opening_tag(&mut buf, 3);
+            primitives::encode_app_null(&mut buf);
+            tags::encode_closing_tag(&mut buf, 3);
+        }
+        buf
+    }
 
     #[test]
     fn request_round_trip() {
@@ -255,6 +299,50 @@ mod tests {
         ack.encode(&mut buf);
         let decoded = ReadPropertyACK::decode(&buf).unwrap();
         assert_eq!(ack, decoded);
+    }
+
+    #[test]
+    fn read_property_values_must_fit_u32() {
+        let maximum = u64::from(u32::MAX);
+        let request = encode_fields(0, 1, maximum, Some((2, maximum)), false, true);
+        let request = ReadPropertyRequest::decode(&request).unwrap();
+        assert_eq!(request.property_identifier.to_raw(), u32::MAX);
+        assert_eq!(request.property_array_index, Some(u32::MAX));
+
+        let ack = encode_fields(0, 1, maximum, Some((2, maximum)), true, true);
+        let ack = ReadPropertyACK::decode(&ack).unwrap();
+        assert_eq!(ack.property_identifier.to_raw(), u32::MAX);
+        assert_eq!(ack.property_array_index, Some(u32::MAX));
+
+        for value in [maximum + 1, u64::MAX] {
+            let request_property = encode_fields(0, 1, value, None, false, false);
+            assert!(ReadPropertyRequest::decode(&request_property).is_err());
+            let request_index = encode_fields(0, 1, 1, Some((2, value)), false, false);
+            assert!(ReadPropertyRequest::decode(&request_index).is_err());
+
+            let ack_property = encode_fields(0, 1, value, None, true, false);
+            assert!(ReadPropertyACK::decode(&ack_property).is_err());
+            let ack_index = encode_fields(0, 1, 1, Some((2, value)), true, false);
+            assert!(ReadPropertyACK::decode(&ack_index).is_err());
+        }
+    }
+
+    #[test]
+    fn read_property_requires_mandatory_context_tags() {
+        let wrong_object = encode_fields(1, 1, 1, None, false, false);
+        assert!(ReadPropertyRequest::decode(&wrong_object).is_err());
+        let wrong_object_ack = encode_fields(1, 1, 1, None, true, false);
+        assert!(ReadPropertyACK::decode(&wrong_object_ack).is_err());
+
+        let wrong_property = encode_fields(0, 0, 1, None, false, false);
+        assert!(ReadPropertyRequest::decode(&wrong_property).is_err());
+        let wrong_property_ack = encode_fields(0, 0, 1, None, true, false);
+        assert!(ReadPropertyACK::decode(&wrong_property_ack).is_err());
+
+        let mut application_property = BytesMut::new();
+        primitives::encode_ctx_object_id(&mut application_property, 0, &object_id());
+        primitives::encode_app_unsigned(&mut application_property, 1);
+        assert!(ReadPropertyRequest::decode(&application_property).is_err());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/bacnet-services/src/read_property.rs
+++ b/crates/bacnet-services/src/read_property.rs
@@ -90,11 +90,21 @@ impl ReadPropertyRequest {
         let mut property_array_index = None;
         if offset < data.len() {
             let (tag, _) = tags::decode_tag(data, offset)?;
-            if tag.is_context(2) {
-                let (index, _) =
-                    decode_context_u32(data, offset, 2, "ReadProperty request array-index")?;
-                property_array_index = Some(index);
+            if !tag.is_context(2) {
+                return Err(Error::decoding(
+                    offset,
+                    "ReadProperty request expected context tag 2 for array-index",
+                ));
             }
+            let (index, end) =
+                decode_context_u32(data, offset, 2, "ReadProperty request array-index")?;
+            if end != data.len() {
+                return Err(Error::decoding(
+                    end,
+                    "ReadProperty request has trailing data",
+                ));
+            }
+            property_array_index = Some(index);
         }
 
         Ok(Self {
@@ -181,7 +191,10 @@ impl ReadPropertyACK {
                     "ReadPropertyACK expected opening tag 3",
                 ));
             }
-            let (value_bytes, _end) = tags::extract_context_value(data, tag_end, 3)?;
+            let (value_bytes, end) = tags::extract_context_value(data, tag_end, 3)?;
+            if end != data.len() {
+                return Err(Error::decoding(end, "ReadPropertyACK has trailing data"));
+            }
             return Ok(Self {
                 object_identifier,
                 property_identifier,
@@ -196,7 +209,10 @@ impl ReadPropertyACK {
                 "ReadPropertyACK expected opening tag 3",
             ));
         }
-        let (value_bytes, _) = tags::extract_context_value(data, tag_end, 3)?;
+        let (value_bytes, end) = tags::extract_context_value(data, tag_end, 3)?;
+        if end != data.len() {
+            return Err(Error::decoding(end, "ReadPropertyACK has trailing data"));
+        }
 
         Ok(Self {
             object_identifier,
@@ -343,6 +359,31 @@ mod tests {
         primitives::encode_ctx_object_id(&mut application_property, 0, &object_id());
         primitives::encode_app_unsigned(&mut application_property, 1);
         assert!(ReadPropertyRequest::decode(&application_property).is_err());
+    }
+
+    #[test]
+    fn read_property_rejects_malformed_optional_and_trailing_fields() {
+        let request = ReadPropertyRequest {
+            object_identifier: object_id(),
+            property_identifier: PropertyIdentifier::PRESENT_VALUE,
+            property_array_index: None,
+        };
+        let mut request_data = BytesMut::new();
+        request.encode(&mut request_data);
+        request_data.extend_from_slice(&[0x2e]);
+        assert!(ReadPropertyRequest::decode(&request_data).is_err());
+
+        let mut indexed_request = encode_fields(0, 1, 1, Some((2, 1)), false, false);
+        primitives::encode_ctx_unsigned(&mut indexed_request, 4, 1);
+        assert!(ReadPropertyRequest::decode(&indexed_request).is_err());
+
+        let mut ack = encode_fields(0, 1, 1, None, true, false);
+        primitives::encode_ctx_unsigned(&mut ack, 4, 1);
+        assert!(ReadPropertyACK::decode(&ack).is_err());
+
+        let mut indexed_ack = encode_fields(0, 1, 1, Some((2, 1)), true, false);
+        primitives::encode_ctx_unsigned(&mut indexed_ack, 4, 1);
+        assert!(ReadPropertyACK::decode(&indexed_ack).is_err());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- check ReadProperty request and ACK property identifiers against their existing `u32` wrapper
- check optional request and ACK property array indexes against `u32`
- require mandatory context tags 0 and 1 in both decoders
- cover overflow aliases, exact maxima, wider leading-zero encodings, and wrong tags

## Why
Both ReadProperty decoders converted peer `u64` identifiers and array indexes with `as`. Over-wide request values could alias a different property or array element before database lookup; over-wide ACK values could similarly reach Rust and Python callers as valid-looking metadata.

This preserves the shipped `u32` `PropertyIdentifier` contract. Enforcing its documented 22-bit BACnet domain would be a separate compatibility change.

## Testing
- `cargo test -p bacnet-services --locked read_property`
- `cargo test -p bacnet-services --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Related to #309.