### PR TITLE
fix(services): validate write property widths

### DIFF
--- a/crates/bacnet-services/src/write_property.rs
+++ b/crates/bacnet-services/src/write_property.rs
@@ -7,6 +7,29 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
 
+fn decode_context_u32(
+    data: &[u8],
+    offset: usize,
+    tag_number: u8,
+    context: &str,
+) -> Result<(u32, usize), Error> {
+    let (tag, pos) = tags::decode_tag(data, offset)?;
+    if !tag.is_context(tag_number) {
+        return Err(Error::decoding(
+            offset,
+            format!("{context} expected context tag {tag_number}"),
+        ));
+    }
+    let end = pos + tag.length as usize;
+    if end > data.len() {
+        return Err(Error::decoding(pos, format!("{context} truncated")));
+    }
+    let raw = primitives::decode_unsigned(&data[pos..end])?;
+    let value = u32::try_from(raw)
+        .map_err(|_| Error::decoding(pos, format!("{context} {raw} exceeds u32")))?;
+    Ok((value, end))
+}
+
 // ---------------------------------------------------------------------------
 // WritePropertyRequest
 // ---------------------------------------------------------------------------
@@ -53,6 +76,12 @@ impl WritePropertyRequest {
 
         // [0] object-identifier
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if !tag.is_context(0) {
+            return Err(Error::decoding(
+                offset,
+                "WriteProperty expected context tag 0 for object-id",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(pos, "WriteProperty truncated at object-id"));
@@ -61,30 +90,16 @@ impl WritePropertyRequest {
         offset = end;
 
         // [1] property-identifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "WriteProperty truncated at property-id",
-            ));
-        }
-        let prop_raw = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (prop_raw, end) = decode_context_u32(data, offset, 1, "WriteProperty property-id")?;
         let property_identifier = PropertyIdentifier::from_raw(prop_raw);
         offset = end;
 
         // [2] propertyArrayIndex (optional)
         let mut property_array_index = None;
-        let (tag, tag_end) = tags::decode_tag(data, offset)?;
+        let (tag, _) = tags::decode_tag(data, offset)?;
         if tag.class == TagClass::Context && tag.number == 2 && !tag.is_opening && !tag.is_closing {
-            let end = tag_end + tag.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(
-                    tag_end,
-                    "WriteProperty truncated at array-index",
-                ));
-            }
-            property_array_index = Some(primitives::decode_unsigned(&data[tag_end..end])? as u32);
+            let (index, end) = decode_context_u32(data, offset, 2, "WriteProperty array-index")?;
+            property_array_index = Some(index);
             offset = end;
         }
 
@@ -104,22 +119,30 @@ impl WritePropertyRequest {
         let mut priority = None;
         if offset < data.len() {
             let (tag, pos) = tags::decode_tag(data, offset)?;
-            if tag.is_context(4) {
-                let end = pos + tag.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(pos, "WriteProperty truncated at priority"));
-                }
-                let prio = primitives::decode_unsigned(&data[pos..end])?;
-                if !(1..=16).contains(&prio) {
-                    return Err(Error::decoding(
-                        pos,
-                        format!("WriteProperty priority {prio} out of range 1-16"),
-                    ));
-                }
-                priority = Some(u8::try_from(prio).map_err(|_| {
+            if !tag.is_context(4) {
+                return Err(Error::decoding(
+                    offset,
+                    "WriteProperty expected context tag 4 for priority",
+                ));
+            }
+            let end = pos + tag.length as usize;
+            if end > data.len() {
+                return Err(Error::decoding(pos, "WriteProperty truncated at priority"));
+            }
+            let prio = primitives::decode_unsigned(&data[pos..end])?;
+            if !(1..=16).contains(&prio) {
+                return Err(Error::decoding(
+                    pos,
+                    format!("WriteProperty priority {prio} out of range 1-16"),
+                ));
+            }
+            if end != data.len() {
+                return Err(Error::decoding(end, "WriteProperty has trailing data"));
+            }
+            priority =
+                Some(u8::try_from(prio).map_err(|_| {
                     Error::decoding(pos, "WriteProperty priority conversion failed")
                 })?);
-            }
         }
 
         Ok(Self {
@@ -136,6 +159,42 @@ impl WritePropertyRequest {
 mod tests {
     use super::*;
     use bacnet_types::enums::ObjectType;
+
+    fn object_id() -> ObjectIdentifier {
+        ObjectIdentifier::new(ObjectType::ANALOG_OUTPUT, 1).unwrap()
+    }
+
+    fn encode_context_value(buf: &mut BytesMut, tag_number: u8, value: u64, leading_zero: bool) {
+        if leading_zero {
+            tags::encode_tag(buf, tag_number, TagClass::Context, 5);
+            buf.extend_from_slice(&value.to_be_bytes()[3..]);
+        } else {
+            primitives::encode_ctx_unsigned(buf, tag_number, value);
+        }
+    }
+
+    fn encode_fields(
+        object_tag: u8,
+        property_tag: u8,
+        property: u64,
+        index: Option<(u8, u64)>,
+        priority: Option<(u8, u64)>,
+        leading_zero: bool,
+    ) -> BytesMut {
+        let mut buf = BytesMut::new();
+        primitives::encode_ctx_object_id(&mut buf, object_tag, &object_id());
+        encode_context_value(&mut buf, property_tag, property, leading_zero);
+        if let Some((tag_number, value)) = index {
+            encode_context_value(&mut buf, tag_number, value, leading_zero);
+        }
+        tags::encode_opening_tag(&mut buf, 3);
+        primitives::encode_app_null(&mut buf);
+        tags::encode_closing_tag(&mut buf, 3);
+        if let Some((tag_number, value)) = priority {
+            primitives::encode_ctx_unsigned(&mut buf, tag_number, value);
+        }
+        buf
+    }
 
     #[test]
     fn request_round_trip() {
@@ -165,6 +224,51 @@ mod tests {
         req.encode(&mut buf);
         let decoded = WritePropertyRequest::decode(&buf).unwrap();
         assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn write_property_values_must_fit_u32() {
+        let maximum = u64::from(u32::MAX);
+        let encoded = encode_fields(0, 1, maximum, Some((2, maximum)), None, true);
+        let request = WritePropertyRequest::decode(&encoded).unwrap();
+        assert_eq!(request.property_identifier.to_raw(), u32::MAX);
+        assert_eq!(request.property_array_index, Some(u32::MAX));
+
+        for value in [maximum + 1, u64::MAX] {
+            let property = encode_fields(0, 1, value, None, None, false);
+            assert!(WritePropertyRequest::decode(&property).is_err());
+
+            let index = encode_fields(0, 1, 1, Some((2, value)), None, false);
+            assert!(WritePropertyRequest::decode(&index).is_err());
+        }
+    }
+
+    #[test]
+    fn write_property_requires_mandatory_context_tags() {
+        let wrong_object = encode_fields(1, 1, 1, None, None, false);
+        assert!(WritePropertyRequest::decode(&wrong_object).is_err());
+
+        let wrong_property = encode_fields(0, 0, 1, None, None, false);
+        assert!(WritePropertyRequest::decode(&wrong_property).is_err());
+
+        let mut application_property = BytesMut::new();
+        primitives::encode_ctx_object_id(&mut application_property, 0, &object_id());
+        primitives::encode_app_unsigned(&mut application_property, 1);
+        assert!(WritePropertyRequest::decode(&application_property).is_err());
+    }
+
+    #[test]
+    fn write_property_rejects_malformed_priority_and_trailing_fields() {
+        let wrong_priority = encode_fields(0, 1, 1, None, Some((5, 1)), false);
+        assert!(WritePropertyRequest::decode(&wrong_priority).is_err());
+
+        let mut malformed_priority = encode_fields(0, 1, 1, None, None, false);
+        tags::encode_opening_tag(&mut malformed_priority, 4);
+        assert!(WritePropertyRequest::decode(&malformed_priority).is_err());
+
+        let mut trailing = encode_fields(0, 1, 1, None, Some((4, 8)), false);
+        primitives::encode_ctx_unsigned(&mut trailing, 5, 1);
+        assert!(WritePropertyRequest::decode(&trailing).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- check WriteProperty property identifiers and optional array indexes against their existing `u32` fields
- require mandatory context tags 0 and 1
- require any post-value field to be priority tag 4 and reject trailing fields
- cover overflow aliases, exact maxima, wider leading-zero encodings, wrong tags, malformed priorities, and trailing data

## Why
The decoder converted peer `u64` identifiers and indexes with `as`, allowing over-wide values to alias a different property or array element before the server performed object lookup, value decoding, name-index work, or database mutation. It also ignored unknown or trailing fields after the property value.

This preserves the shipped `u32` `PropertyIdentifier` contract. Enforcing its documented 22-bit BACnet domain remains a separate compatibility decision.

## Testing
- `cargo test -p bacnet-services --locked write_property`
- `cargo test -p bacnet-services --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Related to #309.