### PR TITLE
fix(services): validate text message widths

### DIFF
--- a/crates/bacnet-services/src/text_message.rs
+++ b/crates/bacnet-services/src/text_message.rs
@@ -62,6 +62,12 @@ impl TextMessageRequest {
 
         // [0] textMessageSourceDevice
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if !tag.is_context(0) {
+            return Err(Error::decoding(
+                offset,
+                "TextMessage expected context tag 0",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(
@@ -75,22 +81,48 @@ impl TextMessageRequest {
         // messageClass [1] CHOICE { numeric [0], character [1] } OPTIONAL
         let mut message_class = None;
         if offset < data.len() {
-            let (tag, _) = tags::decode_tag(data, offset)?;
+            let (tag, tag_end) = tags::decode_tag(data, offset)?;
             if tag.is_opening_tag(1) {
-                let (content, new_offset) = tags::extract_context_value(data, offset + 1, 1)?;
-                if !content.is_empty() {
-                    let (inner_tag, inner_pos) = tags::decode_tag(content, 0)?;
-                    let inner_end = inner_pos + inner_tag.length as usize;
-                    if inner_tag.is_context(0) {
-                        message_class = Some(MessageClass::Numeric(primitives::decode_unsigned(
-                            &content[inner_pos..inner_end],
-                        )?
-                            as u32));
-                    } else if inner_tag.is_context(1) {
-                        let s =
-                            primitives::decode_character_string(&content[inner_pos..inner_end])?;
-                        message_class = Some(MessageClass::Text(s));
-                    }
+                let (content, new_offset) = tags::extract_context_value(data, tag_end, 1)?;
+                if content.is_empty() {
+                    return Err(Error::decoding(
+                        tag_end,
+                        "TextMessage messageClass is empty",
+                    ));
+                }
+                let (inner_tag, inner_pos) = tags::decode_tag(content, 0)?;
+                let inner_end = inner_pos + inner_tag.length as usize;
+                if inner_end > content.len() {
+                    return Err(Error::decoding(
+                        tag_end + inner_pos,
+                        "TextMessage messageClass is truncated",
+                    ));
+                }
+                message_class = if inner_tag.is_context(0) {
+                    let value = primitives::decode_unsigned(&content[inner_pos..inner_end])?;
+                    Some(MessageClass::Numeric(u32::try_from(value).map_err(
+                        |_| {
+                            Error::decoding(
+                                tag_end + inner_pos,
+                                "TextMessage numeric class exceeds u32",
+                            )
+                        },
+                    )?))
+                } else if inner_tag.is_context(1) {
+                    Some(MessageClass::Text(primitives::decode_character_string(
+                        &content[inner_pos..inner_end],
+                    )?))
+                } else {
+                    return Err(Error::decoding(
+                        tag_end + inner_pos,
+                        "TextMessage messageClass expected context tag 0 or 1",
+                    ));
+                };
+                if inner_end != content.len() {
+                    return Err(Error::decoding(
+                        tag_end + inner_end,
+                        "TextMessage messageClass has trailing data",
+                    ));
                 }
                 offset = new_offset;
             }
@@ -98,6 +130,12 @@ impl TextMessageRequest {
 
         // [2] messagePriority (per Clause 16.5/16.6 ASN.1)
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if !tag.is_context(2) {
+            return Err(Error::decoding(
+                offset,
+                "TextMessage expected context tag 2",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(
@@ -105,17 +143,28 @@ impl TextMessageRequest {
                 "TextMessage truncated at messagePriority",
             ));
         }
-        let message_priority =
-            MessagePriority::from_raw(primitives::decode_unsigned(&data[pos..end])? as u32);
+        let message_priority = primitives::decode_unsigned(&data[pos..end])?;
+        let message_priority = u32::try_from(message_priority)
+            .map(MessagePriority::from_raw)
+            .map_err(|_| Error::decoding(pos, "TextMessage priority exceeds u32"))?;
         offset = end;
 
         // [3] message
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if !tag.is_context(3) {
+            return Err(Error::decoding(
+                offset,
+                "TextMessage expected context tag 3",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(pos, "TextMessage truncated at message"));
         }
         let message = primitives::decode_character_string(&data[pos..end])?;
+        if end != data.len() {
+            return Err(Error::decoding(end, "TextMessage has trailing data"));
+        }
 
         Ok(Self {
             source_device,
@@ -130,6 +179,35 @@ impl TextMessageRequest {
 mod tests {
     use super::*;
     use bacnet_types::enums::ObjectType;
+
+    fn append_required_fields(buf: &mut BytesMut, priority: &[u8]) {
+        primitives::encode_ctx_octet_string(buf, 2, priority);
+        primitives::encode_ctx_character_string(buf, 3, "message").unwrap();
+    }
+
+    fn request_with_numeric_fields(class: Option<&[u8]>, priority: &[u8]) -> BytesMut {
+        let mut buf = BytesMut::new();
+        let source = ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap();
+        primitives::encode_ctx_object_id(&mut buf, 0, &source);
+        if let Some(class) = class {
+            tags::encode_opening_tag(&mut buf, 1);
+            primitives::encode_ctx_octet_string(&mut buf, 0, class);
+            tags::encode_closing_tag(&mut buf, 1);
+        }
+        append_required_fields(&mut buf, priority);
+        buf
+    }
+
+    fn request_with_class_content(content: &[u8]) -> BytesMut {
+        let mut buf = BytesMut::new();
+        let source = ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap();
+        primitives::encode_ctx_object_id(&mut buf, 0, &source);
+        tags::encode_opening_tag(&mut buf, 1);
+        buf.extend_from_slice(content);
+        tags::encode_closing_tag(&mut buf, 1);
+        append_required_fields(&mut buf, &[0]);
+        buf
+    }
 
     #[test]
     fn request_numeric_class_round_trip() {
@@ -171,6 +249,65 @@ mod tests {
         req.encode(&mut buf).unwrap();
         let decoded = TextMessageRequest::decode(&buf).unwrap();
         assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn text_message_values_must_fit_u32() {
+        let max_with_leading_zero = [0, 0xFF, 0xFF, 0xFF, 0xFF];
+        let decoded = TextMessageRequest::decode(&request_with_numeric_fields(
+            Some(&max_with_leading_zero),
+            &max_with_leading_zero,
+        ))
+        .unwrap();
+        assert_eq!(decoded.message_class, Some(MessageClass::Numeric(u32::MAX)));
+        assert_eq!(decoded.message_priority.to_raw(), u32::MAX);
+
+        for overflow in [u32::MAX as u64 + 1, u64::MAX] {
+            let overflow = overflow.to_be_bytes();
+            assert!(TextMessageRequest::decode(&request_with_numeric_fields(
+                Some(&overflow),
+                &[0],
+            ))
+            .is_err());
+            assert!(
+                TextMessageRequest::decode(&request_with_numeric_fields(None, &overflow,)).is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn text_message_rejects_malformed_message_class() {
+        assert!(TextMessageRequest::decode(&request_with_class_content(&[])).is_err());
+        assert!(TextMessageRequest::decode(&request_with_class_content(&[0x0C, 0])).is_err());
+        assert!(
+            TextMessageRequest::decode(&request_with_class_content(&[0x09, 1, 0x09, 2,])).is_err()
+        );
+        assert!(TextMessageRequest::decode(&request_with_class_content(&[0x29, 1])).is_err());
+    }
+
+    #[test]
+    fn text_message_requires_owned_tags_and_complete_payload() {
+        let encoded = request_with_numeric_fields(None, &[0]);
+        let (source_tag, source_pos) = tags::decode_tag(&encoded, 0).unwrap();
+        let priority_offset = source_pos + source_tag.length as usize;
+        let (priority_tag, priority_pos) = tags::decode_tag(&encoded, priority_offset).unwrap();
+        let message_offset = priority_pos + priority_tag.length as usize;
+
+        let mut wrong_source = encoded.clone();
+        wrong_source[0] = 0x1C;
+        assert!(TextMessageRequest::decode(&wrong_source).is_err());
+
+        let mut wrong_priority = encoded.clone();
+        wrong_priority[priority_offset] = 0x19;
+        assert!(TextMessageRequest::decode(&wrong_priority).is_err());
+
+        let mut wrong_message = encoded.clone();
+        wrong_message[message_offset] = (wrong_message[message_offset] & 0x0F) | 0x40;
+        assert!(TextMessageRequest::decode(&wrong_message).is_err());
+
+        let mut trailing = encoded;
+        primitives::encode_app_null(&mut trailing);
+        assert!(TextMessageRequest::decode(&trailing).is_err());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- check TextMessage numeric class and priority values against their existing `u32` fields
- require source-device, priority, and message context tags
- validate the optional message-class CHOICE is present, bounded, recognized, and singular
- reject trailing top-level data
- cover overflow aliases, `u64::MAX`, exact maxima in wider leading-zero forms, malformed CHOICE payloads, wrong tags, and trailing bytes

## Why
The decoder narrowed peer values with `as` in both the numeric message-class alternative and message priority, allowing over-wide inputs to alias other values. Malformed inner lengths could also panic during slicing, and wrong or trailing fields were accepted by both confirmed and unconfirmed TextMessage handlers.

This preserves the shipped `u32` enum wrappers rather than introducing narrower protocol-domain enforcement.

## Testing
- `cargo test -p bacnet-services --locked text_message`
- `cargo test -p bacnet-services --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Related to #309.