### PR TITLE
fix(services): validate alarm summary state

### DIFF
--- a/crates/bacnet-services/src/alarm_summary.rs
+++ b/crates/bacnet-services/src/alarm_summary.rs
@@ -2,6 +2,7 @@
 
 use bacnet_encoding::primitives;
 use bacnet_encoding::tags;
+use bacnet_encoding::tags::{app_tag, TagClass};
 use bacnet_types::enums::EventState;
 use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
@@ -57,6 +58,12 @@ impl GetAlarmSummaryAck {
 
             // objectIdentifier (app)
             let (tag, pos) = tags::decode_tag(data, offset)?;
+            if tag.class != TagClass::Application || tag.number != app_tag::OBJECT_IDENTIFIER {
+                return Err(Error::decoding(
+                    offset,
+                    "AlarmSummaryAck expected object-id application tag",
+                ));
+            }
             let end = pos + tag.length as usize;
             if end > data.len() {
                 return Err(Error::decoding(
@@ -69,6 +76,12 @@ impl GetAlarmSummaryAck {
 
             // alarmState (app enumerated)
             let (tag, pos) = tags::decode_tag(data, offset)?;
+            if tag.class != TagClass::Application || tag.number != app_tag::ENUMERATED {
+                return Err(Error::decoding(
+                    offset,
+                    "AlarmSummaryAck expected enumerated application tag",
+                ));
+            }
             let end = pos + tag.length as usize;
             if end > data.len() {
                 return Err(Error::decoding(
@@ -76,12 +89,20 @@ impl GetAlarmSummaryAck {
                     "AlarmSummaryAck truncated at alarmState",
                 ));
             }
-            let alarm_state =
-                EventState::from_raw(primitives::decode_unsigned(&data[pos..end])? as u32);
+            let alarm_state = primitives::decode_unsigned(&data[pos..end])?;
+            let alarm_state = u32::try_from(alarm_state)
+                .map(EventState::from_raw)
+                .map_err(|_| Error::decoding(pos, "AlarmSummaryAck alarmState exceeds u32"))?;
             offset = end;
 
             // acknowledgedTransitions (app bitstring)
             let (tag, pos) = tags::decode_tag(data, offset)?;
+            if tag.class != TagClass::Application || tag.number != app_tag::BIT_STRING {
+                return Err(Error::decoding(
+                    offset,
+                    "AlarmSummaryAck expected bit-string application tag",
+                ));
+            }
             let end = pos + tag.length as usize;
             if end > data.len() {
                 return Err(Error::decoding(
@@ -107,6 +128,21 @@ impl GetAlarmSummaryAck {
 mod tests {
     use super::*;
     use bacnet_types::enums::ObjectType;
+
+    fn ack_with_alarm_state(state: &[u8]) -> BytesMut {
+        let mut buf = BytesMut::new();
+        let object_identifier = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+        primitives::encode_app_object_id(&mut buf, &object_identifier);
+        tags::encode_tag(
+            &mut buf,
+            app_tag::ENUMERATED,
+            TagClass::Application,
+            state.len() as u32,
+        );
+        buf.extend_from_slice(state);
+        primitives::encode_app_bit_string(&mut buf, 5, &[0b10100000]);
+        buf
+    }
 
     #[test]
     fn ack_round_trip() {
@@ -153,6 +189,46 @@ mod tests {
         ack.encode(&mut buf);
         let decoded = GetAlarmSummaryAck::decode(&buf).unwrap();
         assert_eq!(ack, decoded);
+    }
+
+    #[test]
+    fn alarm_state_must_fit_u32() {
+        let max_with_leading_zero = [0, 0xFF, 0xFF, 0xFF, 0xFF];
+        let decoded =
+            GetAlarmSummaryAck::decode(&ack_with_alarm_state(&max_with_leading_zero)).unwrap();
+        assert_eq!(decoded.entries[0].alarm_state.to_raw(), u32::MAX);
+
+        for overflow in [u32::MAX as u64 + 1, u64::MAX] {
+            assert!(
+                GetAlarmSummaryAck::decode(&ack_with_alarm_state(&overflow.to_be_bytes())).is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn ack_requires_application_field_tags() {
+        let encoded = ack_with_alarm_state(&[0]);
+        let (object_tag, object_pos) = tags::decode_tag(&encoded, 0).unwrap();
+        let state_offset = object_pos + object_tag.length as usize;
+        let (state_tag, state_pos) = tags::decode_tag(&encoded, state_offset).unwrap();
+        let transitions_offset = state_pos + state_tag.length as usize;
+
+        let mut wrong_object = encoded.clone();
+        wrong_object[0] = (app_tag::OCTET_STRING << 4) | (wrong_object[0] & 0x0F);
+        assert!(GetAlarmSummaryAck::decode(&wrong_object).is_err());
+
+        let mut wrong_state = encoded.clone();
+        wrong_state[state_offset] = (app_tag::UNSIGNED << 4) | (wrong_state[state_offset] & 0x0F);
+        assert!(GetAlarmSummaryAck::decode(&wrong_state).is_err());
+
+        let mut wrong_transitions = encoded.clone();
+        wrong_transitions[transitions_offset] =
+            (app_tag::OCTET_STRING << 4) | (wrong_transitions[transitions_offset] & 0x0F);
+        assert!(GetAlarmSummaryAck::decode(&wrong_transitions).is_err());
+
+        let mut trailing = encoded;
+        primitives::encode_app_null(&mut trailing);
+        assert!(GetAlarmSummaryAck::decode(&trailing).is_err());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/bacnet-services/src/alarm_summary.rs
+++ b/crates/bacnet-services/src/alarm_summary.rs
@@ -58,7 +58,10 @@ impl GetAlarmSummaryAck {
 
             // objectIdentifier (app)
             let (tag, pos) = tags::decode_tag(data, offset)?;
-            if tag.class != TagClass::Application || tag.number != app_tag::OBJECT_IDENTIFIER {
+            if tag.class != TagClass::Application
+                || tag.number != app_tag::OBJECT_IDENTIFIER
+                || data[offset] & 0x07 > 5
+            {
                 return Err(Error::decoding(
                     offset,
                     "AlarmSummaryAck expected object-id application tag",
@@ -76,7 +79,10 @@ impl GetAlarmSummaryAck {
 
             // alarmState (app enumerated)
             let (tag, pos) = tags::decode_tag(data, offset)?;
-            if tag.class != TagClass::Application || tag.number != app_tag::ENUMERATED {
+            if tag.class != TagClass::Application
+                || tag.number != app_tag::ENUMERATED
+                || data[offset] & 0x07 > 5
+            {
                 return Err(Error::decoding(
                     offset,
                     "AlarmSummaryAck expected enumerated application tag",
@@ -97,7 +103,10 @@ impl GetAlarmSummaryAck {
 
             // acknowledgedTransitions (app bitstring)
             let (tag, pos) = tags::decode_tag(data, offset)?;
-            if tag.class != TagClass::Application || tag.number != app_tag::BIT_STRING {
+            if tag.class != TagClass::Application
+                || tag.number != app_tag::BIT_STRING
+                || data[offset] & 0x07 > 5
+            {
                 return Err(Error::decoding(
                     offset,
                     "AlarmSummaryAck expected bit-string application tag",
@@ -242,6 +251,24 @@ mod tests {
         let mut trailing = encoded;
         primitives::encode_app_null(&mut trailing);
         assert!(GetAlarmSummaryAck::decode(&trailing).is_err());
+    }
+
+    #[test]
+    fn ack_rejects_reserved_application_lvt_forms() {
+        let encoded = ack_with_alarm_state(&[0]);
+        let (object_tag, object_pos) = tags::decode_tag(&encoded, 0).unwrap();
+        let state_offset = object_pos + object_tag.length as usize;
+        let (state_tag, state_pos) = tags::decode_tag(&encoded, state_offset).unwrap();
+        let transitions_offset = state_pos + state_tag.length as usize;
+
+        for lvt in [6, 7] {
+            for (offset, declared_length) in [(0, 4), (state_offset, 1), (transitions_offset, 2)] {
+                let mut reserved = encoded.to_vec();
+                reserved[offset] = (reserved[offset] & 0xF8) | lvt;
+                reserved.insert(offset + 1, declared_length);
+                assert!(GetAlarmSummaryAck::decode(&reserved).is_err());
+            }
+        }
     }
 
     #[test]

--- a/crates/bacnet-services/src/alarm_summary.rs
+++ b/crates/bacnet-services/src/alarm_summary.rs
@@ -111,6 +111,12 @@ impl GetAlarmSummaryAck {
                 ));
             }
             let acknowledged_transitions = primitives::decode_bit_string(&data[pos..end])?;
+            if acknowledged_transitions.0 != 5 || acknowledged_transitions.1.len() != 1 {
+                return Err(Error::decoding(
+                    pos,
+                    "AlarmSummaryAck acknowledgedTransitions must contain three bits",
+                ));
+            }
             offset = end;
 
             entries.push(AlarmSummaryEntry {
@@ -129,7 +135,7 @@ mod tests {
     use super::*;
     use bacnet_types::enums::ObjectType;
 
-    fn ack_with_alarm_state(state: &[u8]) -> BytesMut {
+    fn ack_with_fields(state: &[u8], unused_bits: u8, transitions: &[u8]) -> BytesMut {
         let mut buf = BytesMut::new();
         let object_identifier = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
         primitives::encode_app_object_id(&mut buf, &object_identifier);
@@ -140,8 +146,12 @@ mod tests {
             state.len() as u32,
         );
         buf.extend_from_slice(state);
-        primitives::encode_app_bit_string(&mut buf, 5, &[0b10100000]);
+        primitives::encode_app_bit_string(&mut buf, unused_bits, transitions);
         buf
+    }
+
+    fn ack_with_alarm_state(state: &[u8]) -> BytesMut {
+        ack_with_fields(state, 5, &[0b10100000])
     }
 
     #[test]
@@ -229,6 +239,18 @@ mod tests {
         let mut trailing = encoded;
         primitives::encode_app_null(&mut trailing);
         assert!(GetAlarmSummaryAck::decode(&trailing).is_err());
+    }
+
+    #[test]
+    fn acknowledged_transitions_must_contain_three_bits() {
+        for (unused_bits, transitions) in
+            [(5, &[][..]), (4, &[0][..]), (0, &[0][..]), (5, &[0, 0][..])]
+        {
+            assert!(
+                GetAlarmSummaryAck::decode(&ack_with_fields(&[0], unused_bits, transitions,))
+                    .is_err()
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/crates/bacnet-services/src/alarm_summary.rs
+++ b/crates/bacnet-services/src/alarm_summary.rs
@@ -111,10 +111,13 @@ impl GetAlarmSummaryAck {
                 ));
             }
             let acknowledged_transitions = primitives::decode_bit_string(&data[pos..end])?;
-            if acknowledged_transitions.0 != 5 || acknowledged_transitions.1.len() != 1 {
+            if acknowledged_transitions.0 != 5
+                || acknowledged_transitions.1.len() != 1
+                || acknowledged_transitions.1[0] & 0x1F != 0
+            {
                 return Err(Error::decoding(
                     pos,
-                    "AlarmSummaryAck acknowledgedTransitions must contain three bits",
+                    "AlarmSummaryAck acknowledgedTransitions must contain three bits with zero padding",
                 ));
             }
             offset = end;
@@ -243,9 +246,13 @@ mod tests {
 
     #[test]
     fn acknowledged_transitions_must_contain_three_bits() {
-        for (unused_bits, transitions) in
-            [(5, &[][..]), (4, &[0][..]), (0, &[0][..]), (5, &[0, 0][..])]
-        {
+        for (unused_bits, transitions) in [
+            (5, &[][..]),
+            (4, &[0][..]),
+            (0, &[0][..]),
+            (5, &[0, 0][..]),
+            (5, &[0b00011111][..]),
+        ] {
             assert!(
                 GetAlarmSummaryAck::decode(&ack_with_fields(&[0], unused_bits, transitions,))
                     .is_err()


### PR DESCRIPTION
## Summary
- check GetAlarmSummary-ACK alarm-state values against the existing `u32` enum wrapper
- require object-identifier, enumerated, and bit-string application tags for each entry
- retain unknown in-range event-state values and wider leading-zero encodings
- test overflow aliases, `u64::MAX`, exact `u32::MAX`, wrong field tags, and trailing data

## Why
A peer response could encode an alarm state above `u32::MAX` and have it silently alias another `EventState`. The decoder also interpreted each entry by position without validating the required BACnet application datatype tags.

This keeps the shipped `EventState(u32)` contract rather than adding separate enum-domain enforcement.

## Testing
- `cargo test -p bacnet-services --locked alarm_summary`
- `cargo test -p bacnet-services --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Related to #309.