### PR TITLE
fix(services): harden enrollment summary decoding

### DIFF
--- a/crates/bacnet-services/src/enrollment_summary.rs
+++ b/crates/bacnet-services/src/enrollment_summary.rs
@@ -9,6 +9,10 @@ use bytes::BytesMut;
 
 use crate::common::MAX_DECODED_ITEMS;
 
+fn is_application_tag(tag: &tags::Tag, header: u8, number: u8) -> bool {
+    tag.class == tags::TagClass::Application && tag.number == number && header & 0x07 <= 5
+}
+
 // ---------------------------------------------------------------------------
 // GetEnrollmentSummaryRequest
 // ---------------------------------------------------------------------------
@@ -92,6 +96,12 @@ impl GetEnrollmentSummaryRequest {
 
         // [0] acknowledgmentFilter
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if !tag.is_context(0) {
+            return Err(Error::decoding(
+                offset,
+                "EnrollmentSummary expected context tag 0",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(
@@ -99,7 +109,10 @@ impl GetEnrollmentSummaryRequest {
                 "EnrollmentSummary truncated at acknowledgmentFilter",
             ));
         }
-        let acknowledgment_filter = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let acknowledgment_filter = primitives::decode_unsigned(&data[pos..end])?;
+        let acknowledgment_filter = u32::try_from(acknowledgment_filter).map_err(|_| {
+            Error::decoding(pos, "EnrollmentSummary acknowledgmentFilter exceeds u32")
+        })?;
         offset = end;
 
         // [1] enrollmentFilter (optional, constructed)
@@ -107,39 +120,68 @@ impl GetEnrollmentSummaryRequest {
         if offset < data.len() {
             let (tag, tag_end) = tags::decode_tag(data, offset)?;
             if tag.is_opening_tag(1) {
-                // Parse BACnetRecipientProcess
                 let mut device = None;
-                let mut process_id = 0u32;
                 let (content, new_offset) = tags::extract_context_value(data, tag_end, 1)?;
                 let mut inner_offset = 0;
-                while inner_offset < content.len() {
+
+                if inner_offset < content.len() {
                     let (inner_tag, inner_pos) = tags::decode_tag(content, inner_offset)?;
                     if inner_tag.is_opening_tag(0) {
-                        // recipient CHOICE — parse device [0]
                         let (recipient_content, recipient_end) =
                             tags::extract_context_value(content, inner_pos, 0)?;
-                        if !recipient_content.is_empty() {
-                            let (dev_tag, dev_pos) = tags::decode_tag(recipient_content, 0)?;
-                            if dev_tag.is_context(0) {
-                                let dev_end = dev_pos + dev_tag.length as usize;
-                                if dev_end <= recipient_content.len() {
-                                    device = Some(ObjectIdentifier::decode(
-                                        &recipient_content[dev_pos..dev_end],
-                                    )?);
-                                }
-                            }
+                        let (dev_tag, dev_pos) = tags::decode_tag(recipient_content, 0)?;
+                        if !dev_tag.is_context(0) {
+                            return Err(Error::decoding(
+                                tag_end + inner_pos,
+                                "EnrollmentSummary expected recipient device tag 0",
+                            ));
                         }
+                        let dev_end = dev_pos + dev_tag.length as usize;
+                        if dev_end > recipient_content.len() {
+                            return Err(Error::decoding(
+                                tag_end + dev_pos,
+                                "EnrollmentSummary truncated at recipient device",
+                            ));
+                        }
+                        if dev_end != recipient_content.len() {
+                            return Err(Error::decoding(
+                                tag_end + dev_end,
+                                "EnrollmentSummary recipient has trailing data",
+                            ));
+                        }
+                        device = Some(ObjectIdentifier::decode(
+                            &recipient_content[dev_pos..dev_end],
+                        )?);
                         inner_offset = recipient_end;
-                    } else if inner_tag.is_context(1) {
-                        let inner_end = inner_pos + inner_tag.length as usize;
-                        if inner_end <= content.len() {
-                            process_id =
-                                primitives::decode_unsigned(&content[inner_pos..inner_end])? as u32;
-                        }
-                        inner_offset = inner_end;
-                    } else {
-                        inner_offset = inner_pos + inner_tag.length as usize;
                     }
+                }
+
+                let (process_tag, process_pos) = tags::decode_tag(content, inner_offset)?;
+                if !process_tag.is_context(1) {
+                    return Err(Error::decoding(
+                        tag_end + inner_offset,
+                        "EnrollmentSummary expected processIdentifier tag 1",
+                    ));
+                }
+                let process_end = process_pos + process_tag.length as usize;
+                if process_end > content.len() {
+                    return Err(Error::decoding(
+                        tag_end + process_pos,
+                        "EnrollmentSummary truncated at processIdentifier",
+                    ));
+                }
+                let process_id = primitives::decode_unsigned(&content[process_pos..process_end])?;
+                let process_id = u32::try_from(process_id).map_err(|_| {
+                    Error::decoding(
+                        tag_end + process_pos,
+                        "EnrollmentSummary processIdentifier exceeds u32",
+                    )
+                })?;
+                if process_end != content.len() {
+                    return Err(Error::decoding(
+                        tag_end + process_end,
+                        "EnrollmentSummary enrollmentFilter has trailing data",
+                    ));
                 }
                 enrollment_filter = Some(RecipientProcess {
                     device,
@@ -153,9 +195,10 @@ impl GetEnrollmentSummaryRequest {
         let mut event_state_filter = None;
         let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 2)?;
         if let Some(content) = opt_data {
-            event_state_filter = Some(EventState::from_raw(
-                primitives::decode_unsigned(content)? as u32
-            ));
+            let value = primitives::decode_unsigned(content)?;
+            event_state_filter = Some(EventState::from_raw(u32::try_from(value).map_err(
+                |_| Error::decoding(offset, "EnrollmentSummary eventStateFilter exceeds u32"),
+            )?));
             offset = new_offset;
         }
 
@@ -163,9 +206,10 @@ impl GetEnrollmentSummaryRequest {
         let mut event_type_filter = None;
         let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 3)?;
         if let Some(content) = opt_data {
-            event_type_filter = Some(EventType::from_raw(
-                primitives::decode_unsigned(content)? as u32
-            ));
+            let value = primitives::decode_unsigned(content)?;
+            event_type_filter = Some(EventType::from_raw(u32::try_from(value).map_err(|_| {
+                Error::decoding(offset, "EnrollmentSummary eventTypeFilter exceeds u32")
+            })?));
             offset = new_offset;
         }
 
@@ -174,51 +218,93 @@ impl GetEnrollmentSummaryRequest {
         if offset < data.len() {
             let (tag, tag_end) = tags::decode_tag(data, offset)?;
             if tag.is_opening_tag(4) {
+                let (content, new_offset) = tags::extract_context_value(data, tag_end, 4)?;
+
                 // [0] minPriority
-                let (inner_tag, inner_pos) = tags::decode_tag(data, tag_end)?;
-                let inner_end = inner_pos + inner_tag.length as usize;
-                if inner_end > data.len() {
+                let (inner_tag, inner_pos) = tags::decode_tag(content, 0)?;
+                if !inner_tag.is_context(0) {
                     return Err(Error::decoding(
-                        inner_pos,
+                        tag_end,
+                        "EnrollmentSummary expected minPriority tag 0",
+                    ));
+                }
+                let inner_end = inner_pos + inner_tag.length as usize;
+                if inner_end > content.len() {
+                    return Err(Error::decoding(
+                        tag_end + inner_pos,
                         "EnrollmentSummary truncated at minPriority",
                     ));
                 }
-                let min_priority = primitives::decode_unsigned(&data[inner_pos..inner_end])? as u8;
+                let min_priority = primitives::decode_unsigned(&content[inner_pos..inner_end])?;
+                let min_priority = u8::try_from(min_priority).map_err(|_| {
+                    Error::decoding(
+                        tag_end + inner_pos,
+                        "EnrollmentSummary minPriority exceeds u8",
+                    )
+                })?;
 
                 // [1] maxPriority
-                let (inner_tag, inner_pos) = tags::decode_tag(data, inner_end)?;
-                let inner_end = inner_pos + inner_tag.length as usize;
-                if inner_end > data.len() {
+                let (inner_tag, inner_pos) = tags::decode_tag(content, inner_end)?;
+                if !inner_tag.is_context(1) {
                     return Err(Error::decoding(
-                        inner_pos,
+                        tag_end + inner_end,
+                        "EnrollmentSummary expected maxPriority tag 1",
+                    ));
+                }
+                let priority_end = inner_pos + inner_tag.length as usize;
+                if priority_end > content.len() {
+                    return Err(Error::decoding(
+                        tag_end + inner_pos,
                         "EnrollmentSummary truncated at maxPriority",
                     ));
                 }
-                let max_priority = primitives::decode_unsigned(&data[inner_pos..inner_end])? as u8;
-
-                // closing tag 4
-                let (close_tag, close_end) = tags::decode_tag(data, inner_end)?;
-                if !close_tag.is_closing_tag(4) {
+                let max_priority = primitives::decode_unsigned(&content[inner_pos..priority_end])?;
+                let max_priority = u8::try_from(max_priority).map_err(|_| {
+                    Error::decoding(
+                        tag_end + inner_pos,
+                        "EnrollmentSummary maxPriority exceeds u8",
+                    )
+                })?;
+                if priority_end != content.len() {
                     return Err(Error::decoding(
-                        inner_end,
-                        "EnrollmentSummary expected closing tag 4",
+                        tag_end + priority_end,
+                        "EnrollmentSummary priorityFilter has trailing data",
+                    ));
+                }
+                if min_priority > max_priority {
+                    return Err(Error::decoding(
+                        tag_end + inner_pos,
+                        "EnrollmentSummary minPriority exceeds maxPriority",
                     ));
                 }
                 priority_filter = Some(PriorityFilter {
                     min_priority,
                     max_priority,
                 });
-                offset = close_end;
+                offset = new_offset;
             }
         }
 
         // [5] notificationClassFilter (optional)
         let mut notification_class_filter = None;
         if offset < data.len() {
-            let (opt_data, _new_offset) = tags::decode_optional_context(data, offset, 5)?;
+            let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 5)?;
             if let Some(content) = opt_data {
-                notification_class_filter = Some(primitives::decode_unsigned(content)? as u16);
+                let value = primitives::decode_unsigned(content)?;
+                notification_class_filter = Some(u16::try_from(value).map_err(|_| {
+                    Error::decoding(
+                        offset,
+                        "EnrollmentSummary notificationClassFilter exceeds u16",
+                    )
+                })?);
+                offset = new_offset;
             }
+        }
+        if offset != data.len() {
+            return Err(Error::decoding(
+                offset,
+                "EnrollmentSummary has unexpected or trailing data",
+            ));
         }
 
         Ok(Self {
@@ -277,6 +363,12 @@ impl GetEnrollmentSummaryAck {
 
             // objectIdentifier (app)
             let (tag, pos) = tags::decode_tag(data, offset)?;
+            if !is_application_tag(&tag, data[offset], tags::app_tag::OBJECT_IDENTIFIER) {
+                return Err(Error::decoding(
+                    offset,
+                    "EnrollmentSummaryAck expected object-id application tag",
+                ));
+            }
             let end = pos + tag.length as usize;
             if end > data.len() {
                 return Err(Error::decoding(
@@ -289,6 +381,12 @@ impl GetEnrollmentSummaryAck {
 
             // eventType (app enumerated)
             let (tag, pos) = tags::decode_tag(data, offset)?;
+            if !is_application_tag(&tag, data[offset], tags::app_tag::ENUMERATED) {
+                return Err(Error::decoding(
+                    offset,
+                    "EnrollmentSummaryAck expected eventType enumerated tag",
+                ));
+            }
             let end = pos + tag.length as usize;
             if end > data.len() {
                 return Err(Error::decoding(
@@ -296,12 +394,20 @@ impl GetEnrollmentSummaryAck {
                     "EnrollmentSummaryAck truncated at eventType",
                 ));
             }
-            let event_type =
-                EventType::from_raw(primitives::decode_unsigned(&data[pos..end])? as u32);
+            let event_type = primitives::decode_unsigned(&data[pos..end])?;
+            let event_type = u32::try_from(event_type)
+                .map(EventType::from_raw)
+                .map_err(|_| Error::decoding(pos, "EnrollmentSummaryAck eventType exceeds u32"))?;
             offset = end;
 
             // eventState (app enumerated)
             let (tag, pos) = tags::decode_tag(data, offset)?;
+            if !is_application_tag(&tag, data[offset], tags::app_tag::ENUMERATED) {
+                return Err(Error::decoding(
+                    offset,
+                    "EnrollmentSummaryAck expected eventState enumerated tag",
+                ));
+            }
             let end = pos + tag.length as usize;
             if end > data.len() {
                 return Err(Error::decoding(
@@ -309,12 +415,20 @@ impl GetEnrollmentSummaryAck {
                     "EnrollmentSummaryAck truncated at eventState",
                 ));
             }
-            let event_state =
-                EventState::from_raw(primitives::decode_unsigned(&data[pos..end])? as u32);
+            let event_state = primitives::decode_unsigned(&data[pos..end])?;
+            let event_state = u32::try_from(event_state)
+                .map(EventState::from_raw)
+                .map_err(|_| Error::decoding(pos, "EnrollmentSummaryAck eventState exceeds u32"))?;
             offset = end;
 
             // priority (app unsigned)
             let (tag, pos) = tags::decode_tag(data, offset)?;
+            if !is_application_tag(&tag, data[offset], tags::app_tag::UNSIGNED) {
+                return Err(Error::decoding(
+                    offset,
+                    "EnrollmentSummaryAck expected priority unsigned tag",
+                ));
+            }
             let end = pos + tag.length as usize;
             if end > data.len() {
                 return Err(Error::decoding(
@@ -322,11 +436,19 @@ impl GetEnrollmentSummaryAck {
                     "EnrollmentSummaryAck truncated at priority",
                 ));
             }
-            let priority = primitives::decode_unsigned(&data[pos..end])? as u8;
+            let priority = primitives::decode_unsigned(&data[pos..end])?;
+            let priority = u8::try_from(priority)
+                .map_err(|_| Error::decoding(pos, "EnrollmentSummaryAck priority exceeds u8"))?;
             offset = end;
 
             // notificationClass (app unsigned)
             let (tag, pos) = tags::decode_tag(data, offset)?;
+            if !is_application_tag(&tag, data[offset], tags::app_tag::UNSIGNED) {
+                return Err(Error::decoding(
+                    offset,
+                    "EnrollmentSummaryAck expected notificationClass unsigned tag",
+                ));
+            }
             let end = pos + tag.length as usize;
             if end > data.len() {
                 return Err(Error::decoding(
@@ -334,7 +456,10 @@ impl GetEnrollmentSummaryAck {
                     "EnrollmentSummaryAck truncated at notificationClass",
                 ));
             }
-            let notification_class = primitives::decode_unsigned(&data[pos..end])? as u16;
+            let notification_class = primitives::decode_unsigned(&data[pos..end])?;
+            let notification_class = u16::try_from(notification_class).map_err(|_| {
+                Error::decoding(pos, "EnrollmentSummaryAck notificationClass exceeds u16")
+            })?;
             offset = end;
 
             entries.push(EnrollmentSummaryEntry {
@@ -349,6 +474,10 @@ impl GetEnrollmentSummaryAck {
         Ok(Self { entries })
     }
 }
+
+#[cfg(test)]
+#[path = "enrollment_summary_width_tests.rs"]
+mod width_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/bacnet-services/src/enrollment_summary.rs
+++ b/crates/bacnet-services/src/enrollment_summary.rs
@@ -31,7 +31,7 @@ pub struct PriorityFilter {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecipientProcess {
     /// Device object identifier (from BACnetRecipient CHOICE [0] device).
-    pub device: Option<ObjectIdentifier>,
+    pub device: ObjectIdentifier,
     /// Process identifier.
     pub process_identifier: u32,
 }
@@ -60,14 +60,8 @@ impl GetEnrollmentSummaryRequest {
         // [1] enrollmentFilter (optional, constructed)
         if let Some(ref ef) = self.enrollment_filter {
             tags::encode_opening_tag(buf, 1);
-            // recipient CHOICE: [0] device
-            if let Some(ref device) = ef.device {
-                tags::encode_opening_tag(buf, 0);
-                primitives::encode_ctx_object_id(buf, 0, device);
-                tags::encode_closing_tag(buf, 0);
-            }
-            // processIdentifier
-            primitives::encode_ctx_unsigned(buf, 1, ef.process_identifier as u64);
+            primitives::encode_ctx_object_id(buf, 0, &ef.device);
+            primitives::encode_app_unsigned(buf, ef.process_identifier as u64);
             tags::encode_closing_tag(buf, 1);
         }
         // [2] eventStateFilter (optional)
@@ -120,47 +114,28 @@ impl GetEnrollmentSummaryRequest {
         if offset < data.len() {
             let (tag, tag_end) = tags::decode_tag(data, offset)?;
             if tag.is_opening_tag(1) {
-                let mut device = None;
                 let (content, new_offset) = tags::extract_context_value(data, tag_end, 1)?;
-                let mut inner_offset = 0;
-
-                if inner_offset < content.len() {
-                    let (inner_tag, inner_pos) = tags::decode_tag(content, inner_offset)?;
-                    if inner_tag.is_opening_tag(0) {
-                        let (recipient_content, recipient_end) =
-                            tags::extract_context_value(content, inner_pos, 0)?;
-                        let (dev_tag, dev_pos) = tags::decode_tag(recipient_content, 0)?;
-                        if !dev_tag.is_context(0) {
-                            return Err(Error::decoding(
-                                tag_end + inner_pos,
-                                "EnrollmentSummary expected recipient device tag 0",
-                            ));
-                        }
-                        let dev_end = dev_pos + dev_tag.length as usize;
-                        if dev_end > recipient_content.len() {
-                            return Err(Error::decoding(
-                                tag_end + dev_pos,
-                                "EnrollmentSummary truncated at recipient device",
-                            ));
-                        }
-                        if dev_end != recipient_content.len() {
-                            return Err(Error::decoding(
-                                tag_end + dev_end,
-                                "EnrollmentSummary recipient has trailing data",
-                            ));
-                        }
-                        device = Some(ObjectIdentifier::decode(
-                            &recipient_content[dev_pos..dev_end],
-                        )?);
-                        inner_offset = recipient_end;
-                    }
-                }
-
-                let (process_tag, process_pos) = tags::decode_tag(content, inner_offset)?;
-                if !process_tag.is_context(1) {
+                let (device_tag, device_pos) = tags::decode_tag(content, 0)?;
+                if !device_tag.is_context(0) {
                     return Err(Error::decoding(
-                        tag_end + inner_offset,
-                        "EnrollmentSummary expected processIdentifier tag 1",
+                        tag_end,
+                        "EnrollmentSummary expected recipient device tag 0",
+                    ));
+                }
+                let device_end = device_pos + device_tag.length as usize;
+                if device_end > content.len() {
+                    return Err(Error::decoding(
+                        tag_end + device_pos,
+                        "EnrollmentSummary truncated at recipient device",
+                    ));
+                }
+                let device = ObjectIdentifier::decode(&content[device_pos..device_end])?;
+
+                let (process_tag, process_pos) = tags::decode_tag(content, device_end)?;
+                if !is_application_tag(&process_tag, content[device_end], tags::app_tag::UNSIGNED) {
+                    return Err(Error::decoding(
+                        tag_end + device_end,
+                        "EnrollmentSummary expected processIdentifier unsigned tag",
                     ));
                 }
                 let process_end = process_pos + process_tag.length as usize;

--- a/crates/bacnet-services/src/enrollment_summary.rs
+++ b/crates/bacnet-services/src/enrollment_summary.rs
@@ -54,7 +54,36 @@ pub struct GetEnrollmentSummaryRequest {
 }
 
 impl GetEnrollmentSummaryRequest {
+    /// Encode this request.
+    ///
+    /// # Panics
+    ///
+    /// Panics if an enrollment filter has no device or a priority range is reversed.
     pub fn encode(&self, buf: &mut BytesMut) {
+        self.try_encode(buf)
+            .expect("invalid GetEnrollmentSummary request");
+    }
+
+    /// Encode this request after validating representable filter invariants.
+    pub fn try_encode(&self, buf: &mut BytesMut) -> Result<(), Error> {
+        if self
+            .enrollment_filter
+            .as_ref()
+            .is_some_and(|filter| filter.device.is_none())
+        {
+            return Err(Error::Encoding(
+                "EnrollmentSummary enrollmentFilter requires a device".into(),
+            ));
+        }
+        if self
+            .priority_filter
+            .is_some_and(|filter| filter.min_priority > filter.max_priority)
+        {
+            return Err(Error::Encoding(
+                "EnrollmentSummary minPriority exceeds maxPriority".into(),
+            ));
+        }
+
         // [0] acknowledgmentFilter
         primitives::encode_ctx_enumerated(buf, 0, self.acknowledgment_filter);
         // [1] enrollmentFilter (optional, constructed)
@@ -87,6 +116,7 @@ impl GetEnrollmentSummaryRequest {
         if let Some(nc) = self.notification_class_filter {
             primitives::encode_ctx_unsigned(buf, 5, nc as u64);
         }
+        Ok(())
     }
 
     pub fn decode(data: &[u8]) -> Result<Self, Error> {

--- a/crates/bacnet-services/src/enrollment_summary.rs
+++ b/crates/bacnet-services/src/enrollment_summary.rs
@@ -31,7 +31,8 @@ pub struct PriorityFilter {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecipientProcess {
     /// Device object identifier (from BACnetRecipient CHOICE [0] device).
-    pub device: ObjectIdentifier,
+    /// A filter with no device is omitted because this type does not represent the address choice.
+    pub device: Option<ObjectIdentifier>,
     /// Process identifier.
     pub process_identifier: u32,
 }
@@ -59,10 +60,12 @@ impl GetEnrollmentSummaryRequest {
         primitives::encode_ctx_enumerated(buf, 0, self.acknowledgment_filter);
         // [1] enrollmentFilter (optional, constructed)
         if let Some(ref ef) = self.enrollment_filter {
-            tags::encode_opening_tag(buf, 1);
-            primitives::encode_ctx_object_id(buf, 0, &ef.device);
-            primitives::encode_app_unsigned(buf, ef.process_identifier as u64);
-            tags::encode_closing_tag(buf, 1);
+            if let Some(ref device) = ef.device {
+                tags::encode_opening_tag(buf, 1);
+                primitives::encode_ctx_object_id(buf, 0, device);
+                primitives::encode_app_unsigned(buf, ef.process_identifier as u64);
+                tags::encode_closing_tag(buf, 1);
+            }
         }
         // [2] eventStateFilter (optional)
         if let Some(es) = self.event_state_filter {
@@ -159,7 +162,7 @@ impl GetEnrollmentSummaryRequest {
                     ));
                 }
                 enrollment_filter = Some(RecipientProcess {
-                    device,
+                    device: Some(device),
                     process_identifier: process_id,
                 });
                 offset = new_offset;

--- a/crates/bacnet-services/src/enrollment_summary.rs
+++ b/crates/bacnet-services/src/enrollment_summary.rs
@@ -31,7 +31,6 @@ pub struct PriorityFilter {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecipientProcess {
     /// Device object identifier (from BACnetRecipient CHOICE [0] device).
-    /// A filter with no device is omitted because this type does not represent the address choice.
     pub device: Option<ObjectIdentifier>,
     /// Process identifier.
     pub process_identifier: u32,
@@ -60,12 +59,14 @@ impl GetEnrollmentSummaryRequest {
         primitives::encode_ctx_enumerated(buf, 0, self.acknowledgment_filter);
         // [1] enrollmentFilter (optional, constructed)
         if let Some(ref ef) = self.enrollment_filter {
+            tags::encode_opening_tag(buf, 1);
             if let Some(ref device) = ef.device {
-                tags::encode_opening_tag(buf, 1);
+                tags::encode_opening_tag(buf, 0);
                 primitives::encode_ctx_object_id(buf, 0, device);
-                primitives::encode_app_unsigned(buf, ef.process_identifier as u64);
-                tags::encode_closing_tag(buf, 1);
+                tags::encode_closing_tag(buf, 0);
             }
+            primitives::encode_ctx_unsigned(buf, 1, ef.process_identifier as u64);
+            tags::encode_closing_tag(buf, 1);
         }
         // [2] eventStateFilter (optional)
         if let Some(es) = self.event_state_filter {
@@ -118,27 +119,42 @@ impl GetEnrollmentSummaryRequest {
             let (tag, tag_end) = tags::decode_tag(data, offset)?;
             if tag.is_opening_tag(1) {
                 let (content, new_offset) = tags::extract_context_value(data, tag_end, 1)?;
-                let (device_tag, device_pos) = tags::decode_tag(content, 0)?;
-                if !device_tag.is_context(0) {
+                let (recipient_tag, recipient_pos) = tags::decode_tag(content, 0)?;
+                if !recipient_tag.is_opening_tag(0) {
                     return Err(Error::decoding(
                         tag_end,
+                        "EnrollmentSummary expected recipient tag 0",
+                    ));
+                }
+                let (recipient_content, recipient_end) =
+                    tags::extract_context_value(content, recipient_pos, 0)?;
+                let (device_tag, device_pos) = tags::decode_tag(recipient_content, 0)?;
+                if !device_tag.is_context(0) {
+                    return Err(Error::decoding(
+                        tag_end + recipient_pos,
                         "EnrollmentSummary expected recipient device tag 0",
                     ));
                 }
                 let device_end = device_pos + device_tag.length as usize;
-                if device_end > content.len() {
+                if device_end > recipient_content.len() {
                     return Err(Error::decoding(
                         tag_end + device_pos,
                         "EnrollmentSummary truncated at recipient device",
                     ));
                 }
-                let device = ObjectIdentifier::decode(&content[device_pos..device_end])?;
-
-                let (process_tag, process_pos) = tags::decode_tag(content, device_end)?;
-                if !is_application_tag(&process_tag, content[device_end], tags::app_tag::UNSIGNED) {
+                if device_end != recipient_content.len() {
                     return Err(Error::decoding(
                         tag_end + device_end,
-                        "EnrollmentSummary expected processIdentifier unsigned tag",
+                        "EnrollmentSummary recipient has trailing data",
+                    ));
+                }
+                let device = ObjectIdentifier::decode(&recipient_content[device_pos..device_end])?;
+
+                let (process_tag, process_pos) = tags::decode_tag(content, recipient_end)?;
+                if !process_tag.is_context(1) {
+                    return Err(Error::decoding(
+                        tag_end + recipient_end,
+                        "EnrollmentSummary expected processIdentifier tag 1",
                     ));
                 }
                 let process_end = process_pos + process_tag.length as usize;
@@ -307,6 +323,7 @@ pub struct EnrollmentSummaryEntry {
     pub event_type: EventType,
     pub event_state: EventState,
     pub priority: u8,
+    /// Zero when the optional notification-class member is absent.
     pub notification_class: u16,
 }
 
@@ -419,26 +436,25 @@ impl GetEnrollmentSummaryAck {
                 .map_err(|_| Error::decoding(pos, "EnrollmentSummaryAck priority exceeds u8"))?;
             offset = end;
 
-            // notificationClass (app unsigned)
-            let (tag, pos) = tags::decode_tag(data, offset)?;
-            if !is_application_tag(&tag, data[offset], tags::app_tag::UNSIGNED) {
-                return Err(Error::decoding(
-                    offset,
-                    "EnrollmentSummaryAck expected notificationClass unsigned tag",
-                ));
+            // notificationClass (app unsigned, optional)
+            let mut notification_class = 0;
+            if offset < data.len() {
+                let (tag, pos) = tags::decode_tag(data, offset)?;
+                if is_application_tag(&tag, data[offset], tags::app_tag::UNSIGNED) {
+                    let end = pos + tag.length as usize;
+                    if end > data.len() {
+                        return Err(Error::decoding(
+                            pos,
+                            "EnrollmentSummaryAck truncated at notificationClass",
+                        ));
+                    }
+                    let value = primitives::decode_unsigned(&data[pos..end])?;
+                    notification_class = u16::try_from(value).map_err(|_| {
+                        Error::decoding(pos, "EnrollmentSummaryAck notificationClass exceeds u16")
+                    })?;
+                    offset = end;
+                }
             }
-            let end = pos + tag.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(
-                    pos,
-                    "EnrollmentSummaryAck truncated at notificationClass",
-                ));
-            }
-            let notification_class = primitives::decode_unsigned(&data[pos..end])?;
-            let notification_class = u16::try_from(notification_class).map_err(|_| {
-                Error::decoding(pos, "EnrollmentSummaryAck notificationClass exceeds u16")
-            })?;
-            offset = end;
 
             entries.push(EnrollmentSummaryEntry {
                 object_identifier,

--- a/crates/bacnet-services/src/enrollment_summary.rs
+++ b/crates/bacnet-services/src/enrollment_summary.rs
@@ -58,7 +58,7 @@ impl GetEnrollmentSummaryRequest {
     ///
     /// # Panics
     ///
-    /// Panics if an enrollment filter has no device or a priority range is reversed.
+    /// Panics if an enrollment filter has no device.
     pub fn encode(&self, buf: &mut BytesMut) {
         self.try_encode(buf)
             .expect("invalid GetEnrollmentSummary request");
@@ -75,15 +75,6 @@ impl GetEnrollmentSummaryRequest {
                 "EnrollmentSummary enrollmentFilter requires a device".into(),
             ));
         }
-        if self
-            .priority_filter
-            .is_some_and(|filter| filter.min_priority > filter.max_priority)
-        {
-            return Err(Error::Encoding(
-                "EnrollmentSummary minPriority exceeds maxPriority".into(),
-            ));
-        }
-
         // [0] acknowledgmentFilter
         primitives::encode_ctx_enumerated(buf, 0, self.acknowledgment_filter);
         // [1] enrollmentFilter (optional, constructed)
@@ -293,12 +284,6 @@ impl GetEnrollmentSummaryRequest {
                     return Err(Error::decoding(
                         tag_end + priority_end,
                         "EnrollmentSummary priorityFilter has trailing data",
-                    ));
-                }
-                if min_priority > max_priority {
-                    return Err(Error::decoding(
-                        tag_end + inner_pos,
-                        "EnrollmentSummary minPriority exceeds maxPriority",
                     ));
                 }
                 priority_filter = Some(PriorityFilter {

--- a/crates/bacnet-services/src/enrollment_summary_width_tests.rs
+++ b/crates/bacnet-services/src/enrollment_summary_width_tests.rs
@@ -6,12 +6,16 @@ fn raw_request(fields: [&[u8]; 7], device: bool) -> BytesMut {
     primitives::encode_ctx_octet_string(&mut buf, 0, fields[0]);
     tags::encode_opening_tag(&mut buf, 1);
     if device {
-        tags::encode_opening_tag(&mut buf, 0);
         let object = ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap();
         primitives::encode_ctx_object_id(&mut buf, 0, &object);
-        tags::encode_closing_tag(&mut buf, 0);
     }
-    primitives::encode_ctx_octet_string(&mut buf, 1, fields[1]);
+    tags::encode_tag(
+        &mut buf,
+        tags::app_tag::UNSIGNED,
+        tags::TagClass::Application,
+        fields[1].len() as u32,
+    );
+    buf.extend_from_slice(fields[1]);
     tags::encode_closing_tag(&mut buf, 1);
     primitives::encode_ctx_octet_string(&mut buf, 2, fields[2]);
     primitives::encode_ctx_octet_string(&mut buf, 3, fields[3]);
@@ -104,11 +108,12 @@ fn request_values_must_fit_public_field_widths() {
 }
 
 #[test]
-fn request_enrollment_filter_round_trips_without_device() {
+fn request_enrollment_filter_uses_standard_recipient_process_framing() {
+    let device = ObjectIdentifier::new(ObjectType::DEVICE, 7).unwrap();
     let request = GetEnrollmentSummaryRequest {
         acknowledgment_filter: 0,
         enrollment_filter: Some(RecipientProcess {
-            device: None,
+            device,
             process_identifier: 7,
         }),
         event_state_filter: None,
@@ -122,6 +127,24 @@ fn request_enrollment_filter_round_trips_without_device() {
         GetEnrollmentSummaryRequest::decode(&encoded).unwrap(),
         request
     );
+    assert_eq!(
+        encoded.as_ref(),
+        &[0x09, 0, 0x1E, 0x0C, 0x02, 0, 0, 7, 0x21, 7, 0x1F]
+    );
+
+    let (acknowledgment_tag, acknowledgment_pos) = tags::decode_tag(&encoded, 0).unwrap();
+    let filter_offset = acknowledgment_pos + acknowledgment_tag.length as usize;
+    let (filter_tag, filter_start) = tags::decode_tag(&encoded, filter_offset).unwrap();
+    assert!(filter_tag.is_opening_tag(1));
+    let (recipient_tag, recipient_pos) = tags::decode_tag(&encoded, filter_start).unwrap();
+    assert!(recipient_tag.is_context(0));
+    assert_eq!(
+        ObjectIdentifier::decode(&encoded[recipient_pos..recipient_pos + 4]).unwrap(),
+        device
+    );
+    let (process_tag, _) = tags::decode_tag(&encoded, recipient_pos + 4).unwrap();
+    assert_eq!(process_tag.class, tags::TagClass::Application);
+    assert_eq!(process_tag.number, tags::app_tag::UNSIGNED);
 }
 
 #[test]

--- a/crates/bacnet-services/src/enrollment_summary_width_tests.rs
+++ b/crates/bacnet-services/src/enrollment_summary_width_tests.rs
@@ -1,0 +1,212 @@
+use super::*;
+use bacnet_types::enums::ObjectType;
+
+fn raw_request(fields: [&[u8]; 7], device: bool) -> BytesMut {
+    let mut buf = BytesMut::new();
+    primitives::encode_ctx_octet_string(&mut buf, 0, fields[0]);
+    tags::encode_opening_tag(&mut buf, 1);
+    if device {
+        tags::encode_opening_tag(&mut buf, 0);
+        let object = ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap();
+        primitives::encode_ctx_object_id(&mut buf, 0, &object);
+        tags::encode_closing_tag(&mut buf, 0);
+    }
+    primitives::encode_ctx_octet_string(&mut buf, 1, fields[1]);
+    tags::encode_closing_tag(&mut buf, 1);
+    primitives::encode_ctx_octet_string(&mut buf, 2, fields[2]);
+    primitives::encode_ctx_octet_string(&mut buf, 3, fields[3]);
+    tags::encode_opening_tag(&mut buf, 4);
+    primitives::encode_ctx_octet_string(&mut buf, 0, fields[4]);
+    primitives::encode_ctx_octet_string(&mut buf, 1, fields[5]);
+    tags::encode_closing_tag(&mut buf, 4);
+    primitives::encode_ctx_octet_string(&mut buf, 5, fields[6]);
+    buf
+}
+
+fn raw_ack(fields: [&[u8]; 4]) -> BytesMut {
+    let mut buf = BytesMut::new();
+    let object = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    primitives::encode_app_object_id(&mut buf, &object);
+    for (tag, value) in [
+        (tags::app_tag::ENUMERATED, fields[0]),
+        (tags::app_tag::ENUMERATED, fields[1]),
+        (tags::app_tag::UNSIGNED, fields[2]),
+        (tags::app_tag::UNSIGNED, fields[3]),
+    ] {
+        tags::encode_tag(
+            &mut buf,
+            tag,
+            tags::TagClass::Application,
+            value.len() as u32,
+        );
+        buf.extend_from_slice(value);
+    }
+    buf
+}
+
+fn field_offsets(data: &[u8], count: usize) -> Vec<usize> {
+    let mut offsets = Vec::with_capacity(count);
+    let mut offset = 0;
+    for _ in 0..count {
+        offsets.push(offset);
+        let (tag, pos) = tags::decode_tag(data, offset).unwrap();
+        offset = pos + tag.length as usize;
+    }
+    offsets
+}
+
+#[test]
+fn request_values_must_fit_public_field_widths() {
+    let max_u32 = [0, 0xFF, 0xFF, 0xFF, 0xFF];
+    let max_u8 = [0, 0xFF];
+    let max_u16 = [0, 0xFF, 0xFF];
+    let decoded = GetEnrollmentSummaryRequest::decode(&raw_request(
+        [
+            &max_u32, &max_u32, &max_u32, &max_u32, &max_u8, &max_u8, &max_u16,
+        ],
+        true,
+    ))
+    .unwrap();
+    assert_eq!(decoded.acknowledgment_filter, u32::MAX);
+    assert_eq!(
+        decoded.enrollment_filter.unwrap().process_identifier,
+        u32::MAX
+    );
+    assert_eq!(decoded.event_state_filter.unwrap().to_raw(), u32::MAX);
+    assert_eq!(decoded.event_type_filter.unwrap().to_raw(), u32::MAX);
+    assert_eq!(decoded.priority_filter.unwrap().min_priority, u8::MAX);
+    assert_eq!(decoded.notification_class_filter, Some(u16::MAX));
+
+    let zero = [0];
+    let base = [&zero[..]; 7];
+    let overflow_u32 = (u32::MAX as u64 + 1).to_be_bytes();
+    let overflow_u8 = [1, 0];
+    let overflow_u16 = [1, 0, 0];
+    for (field, overflow) in [
+        (0, &overflow_u32[..]),
+        (1, &overflow_u32[..]),
+        (2, &overflow_u32[..]),
+        (3, &overflow_u32[..]),
+        (4, &overflow_u8[..]),
+        (5, &overflow_u8[..]),
+        (6, &overflow_u16[..]),
+    ] {
+        let mut fields = base;
+        fields[field] = overflow;
+        assert!(GetEnrollmentSummaryRequest::decode(&raw_request(fields, true)).is_err());
+    }
+    let max_u64 = u64::MAX.to_be_bytes();
+    for field in 0..7 {
+        let mut fields = base;
+        fields[field] = &max_u64;
+        assert!(GetEnrollmentSummaryRequest::decode(&raw_request(fields, true)).is_err());
+    }
+}
+
+#[test]
+fn request_enrollment_filter_round_trips_without_device() {
+    let request = GetEnrollmentSummaryRequest {
+        acknowledgment_filter: 0,
+        enrollment_filter: Some(RecipientProcess {
+            device: None,
+            process_identifier: 7,
+        }),
+        event_state_filter: None,
+        event_type_filter: None,
+        priority_filter: None,
+        notification_class_filter: None,
+    };
+    let mut encoded = BytesMut::new();
+    request.encode(&mut encoded);
+    assert_eq!(
+        GetEnrollmentSummaryRequest::decode(&encoded).unwrap(),
+        request
+    );
+}
+
+#[test]
+fn request_rejects_malformed_nested_and_trailing_fields() {
+    let zero = [0];
+    let valid = raw_request([&zero; 7], true);
+
+    let mut wrong_ack = valid.clone();
+    wrong_ack[0] = 0x19;
+    assert!(GetEnrollmentSummaryRequest::decode(&wrong_ack).is_err());
+
+    let reversed = raw_request([&zero, &zero, &zero, &zero, &[2], &[1], &zero], true);
+    assert!(GetEnrollmentSummaryRequest::decode(&reversed).is_err());
+
+    let mut trailing = valid;
+    primitives::encode_app_null(&mut trailing);
+    assert!(GetEnrollmentSummaryRequest::decode(&trailing).is_err());
+
+    let mut missing_process = BytesMut::new();
+    primitives::encode_ctx_unsigned(&mut missing_process, 0, 0);
+    tags::encode_opening_tag(&mut missing_process, 1);
+    tags::encode_closing_tag(&mut missing_process, 1);
+    assert!(GetEnrollmentSummaryRequest::decode(&missing_process).is_err());
+}
+
+#[test]
+fn ack_values_must_fit_public_field_widths() {
+    let max_u32 = [0, 0xFF, 0xFF, 0xFF, 0xFF];
+    let max_u8 = [0, 0xFF];
+    let max_u16 = [0, 0xFF, 0xFF];
+    let decoded =
+        GetEnrollmentSummaryAck::decode(&raw_ack([&max_u32, &max_u32, &max_u8, &max_u16])).unwrap();
+    assert_eq!(decoded.entries[0].event_type.to_raw(), u32::MAX);
+    assert_eq!(decoded.entries[0].event_state.to_raw(), u32::MAX);
+    assert_eq!(decoded.entries[0].priority, u8::MAX);
+    assert_eq!(decoded.entries[0].notification_class, u16::MAX);
+
+    let zero = [0];
+    let base = [&zero[..]; 4];
+    let overflow_u32 = (u32::MAX as u64 + 1).to_be_bytes();
+    let overflow_u8 = [1, 0];
+    let overflow_u16 = [1, 0, 0];
+    for (field, overflow) in [
+        (0, &overflow_u32[..]),
+        (1, &overflow_u32[..]),
+        (2, &overflow_u8[..]),
+        (3, &overflow_u16[..]),
+    ] {
+        let mut fields = base;
+        fields[field] = overflow;
+        assert!(GetEnrollmentSummaryAck::decode(&raw_ack(fields)).is_err());
+    }
+    let max_u64 = u64::MAX.to_be_bytes();
+    for field in 0..4 {
+        let mut fields = base;
+        fields[field] = &max_u64;
+        assert!(GetEnrollmentSummaryAck::decode(&raw_ack(fields)).is_err());
+    }
+}
+
+#[test]
+fn ack_requires_exact_application_field_tags() {
+    let zero = [0];
+    let valid = raw_ack([&zero; 4]);
+    let offsets = field_offsets(&valid, 5);
+
+    for offset in offsets.iter().copied() {
+        let mut context = valid.clone();
+        context[offset] |= 0x08;
+        assert!(GetEnrollmentSummaryAck::decode(&context).is_err());
+
+        for lvt in [6, 7] {
+            let mut reserved = valid.to_vec();
+            let declared_length = if offset == 0 { 4 } else { 1 };
+            reserved[offset] = (reserved[offset] & 0xF8) | lvt;
+            reserved.insert(offset + 1, declared_length);
+            assert!(GetEnrollmentSummaryAck::decode(&reserved).is_err());
+        }
+    }
+
+    let mut wrong_type = valid.clone();
+    wrong_type[offsets[1]] = (tags::app_tag::UNSIGNED << 4) | (wrong_type[offsets[1]] & 0x0F);
+    assert!(GetEnrollmentSummaryAck::decode(&wrong_type).is_err());
+
+    let mut trailing = valid;
+    primitives::encode_app_null(&mut trailing);
+    assert!(GetEnrollmentSummaryAck::decode(&trailing).is_err());
+}

--- a/crates/bacnet-services/src/enrollment_summary_width_tests.rs
+++ b/crates/bacnet-services/src/enrollment_summary_width_tests.rs
@@ -113,7 +113,7 @@ fn request_enrollment_filter_uses_standard_recipient_process_framing() {
     let request = GetEnrollmentSummaryRequest {
         acknowledgment_filter: 0,
         enrollment_filter: Some(RecipientProcess {
-            device,
+            device: Some(device),
             process_identifier: 7,
         }),
         event_state_filter: None,
@@ -145,6 +145,29 @@ fn request_enrollment_filter_uses_standard_recipient_process_framing() {
     let (process_tag, _) = tags::decode_tag(&encoded, recipient_pos + 4).unwrap();
     assert_eq!(process_tag.class, tags::TagClass::Application);
     assert_eq!(process_tag.number, tags::app_tag::UNSIGNED);
+}
+
+#[test]
+fn request_omits_unrepresentable_device_less_filter() {
+    let request = GetEnrollmentSummaryRequest {
+        acknowledgment_filter: 0,
+        enrollment_filter: Some(RecipientProcess {
+            device: None,
+            process_identifier: 7,
+        }),
+        event_state_filter: None,
+        event_type_filter: None,
+        priority_filter: None,
+        notification_class_filter: None,
+    };
+    let mut encoded = BytesMut::new();
+    request.encode(&mut encoded);
+    assert_eq!(
+        GetEnrollmentSummaryRequest::decode(&encoded)
+            .unwrap()
+            .enrollment_filter,
+        None
+    );
 }
 
 #[test]

--- a/crates/bacnet-services/src/enrollment_summary_width_tests.rs
+++ b/crates/bacnet-services/src/enrollment_summary_width_tests.rs
@@ -170,6 +170,32 @@ fn request_rejects_malformed_nested_and_trailing_fields() {
 }
 
 #[test]
+fn request_try_encode_rejects_unrepresentable_filters_without_writing() {
+    let mut request = GetEnrollmentSummaryRequest {
+        acknowledgment_filter: 0,
+        enrollment_filter: Some(RecipientProcess {
+            device: None,
+            process_identifier: 7,
+        }),
+        event_state_filter: None,
+        event_type_filter: None,
+        priority_filter: None,
+        notification_class_filter: None,
+    };
+    let mut encoded = BytesMut::new();
+    assert!(request.try_encode(&mut encoded).is_err());
+    assert!(encoded.is_empty());
+
+    request.enrollment_filter = None;
+    request.priority_filter = Some(PriorityFilter {
+        min_priority: 2,
+        max_priority: 1,
+    });
+    assert!(request.try_encode(&mut encoded).is_err());
+    assert!(encoded.is_empty());
+}
+
+#[test]
 fn ack_values_must_fit_public_field_widths() {
     let max_u32 = [0, 0xFF, 0xFF, 0xFF, 0xFF];
     let max_u8 = [0, 0xFF];

--- a/crates/bacnet-services/src/enrollment_summary_width_tests.rs
+++ b/crates/bacnet-services/src/enrollment_summary_width_tests.rs
@@ -153,9 +153,6 @@ fn request_rejects_malformed_nested_and_trailing_fields() {
     wrong_ack[0] = 0x19;
     assert!(GetEnrollmentSummaryRequest::decode(&wrong_ack).is_err());
 
-    let reversed = raw_request([&zero, &zero, &zero, &zero, &[2], &[1], &zero], true);
-    assert!(GetEnrollmentSummaryRequest::decode(&reversed).is_err());
-
     assert!(GetEnrollmentSummaryRequest::decode(&raw_request([&zero[..]; 7], false)).is_err());
 
     let mut trailing = valid;
@@ -171,7 +168,7 @@ fn request_rejects_malformed_nested_and_trailing_fields() {
 
 #[test]
 fn request_try_encode_rejects_unrepresentable_filters_without_writing() {
-    let mut request = GetEnrollmentSummaryRequest {
+    let request = GetEnrollmentSummaryRequest {
         acknowledgment_filter: 0,
         enrollment_filter: Some(RecipientProcess {
             device: None,
@@ -183,14 +180,6 @@ fn request_try_encode_rejects_unrepresentable_filters_without_writing() {
         notification_class_filter: None,
     };
     let mut encoded = BytesMut::new();
-    assert!(request.try_encode(&mut encoded).is_err());
-    assert!(encoded.is_empty());
-
-    request.enrollment_filter = None;
-    request.priority_filter = Some(PriorityFilter {
-        min_priority: 2,
-        max_priority: 1,
-    });
     assert!(request.try_encode(&mut encoded).is_err());
     assert!(encoded.is_empty());
 }

--- a/crates/bacnet-services/src/enrollment_summary_width_tests.rs
+++ b/crates/bacnet-services/src/enrollment_summary_width_tests.rs
@@ -6,16 +6,12 @@ fn raw_request(fields: [&[u8]; 7], device: bool) -> BytesMut {
     primitives::encode_ctx_octet_string(&mut buf, 0, fields[0]);
     tags::encode_opening_tag(&mut buf, 1);
     if device {
+        tags::encode_opening_tag(&mut buf, 0);
         let object = ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap();
         primitives::encode_ctx_object_id(&mut buf, 0, &object);
+        tags::encode_closing_tag(&mut buf, 0);
     }
-    tags::encode_tag(
-        &mut buf,
-        tags::app_tag::UNSIGNED,
-        tags::TagClass::Application,
-        fields[1].len() as u32,
-    );
-    buf.extend_from_slice(fields[1]);
+    primitives::encode_ctx_octet_string(&mut buf, 1, fields[1]);
     tags::encode_closing_tag(&mut buf, 1);
     primitives::encode_ctx_octet_string(&mut buf, 2, fields[2]);
     primitives::encode_ctx_octet_string(&mut buf, 3, fields[3]);
@@ -129,7 +125,7 @@ fn request_enrollment_filter_uses_standard_recipient_process_framing() {
     );
     assert_eq!(
         encoded.as_ref(),
-        &[0x09, 0, 0x1E, 0x0C, 0x02, 0, 0, 7, 0x21, 7, 0x1F]
+        &[0x09, 0, 0x1E, 0x0E, 0x0C, 0x02, 0, 0, 7, 0x0F, 0x19, 7, 0x1F,]
     );
 
     let (acknowledgment_tag, acknowledgment_pos) = tags::decode_tag(&encoded, 0).unwrap();
@@ -137,37 +133,15 @@ fn request_enrollment_filter_uses_standard_recipient_process_framing() {
     let (filter_tag, filter_start) = tags::decode_tag(&encoded, filter_offset).unwrap();
     assert!(filter_tag.is_opening_tag(1));
     let (recipient_tag, recipient_pos) = tags::decode_tag(&encoded, filter_start).unwrap();
-    assert!(recipient_tag.is_context(0));
+    assert!(recipient_tag.is_opening_tag(0));
+    let (device_tag, device_pos) = tags::decode_tag(&encoded, recipient_pos).unwrap();
+    assert!(device_tag.is_context(0));
     assert_eq!(
-        ObjectIdentifier::decode(&encoded[recipient_pos..recipient_pos + 4]).unwrap(),
+        ObjectIdentifier::decode(&encoded[device_pos..device_pos + 4]).unwrap(),
         device
     );
-    let (process_tag, _) = tags::decode_tag(&encoded, recipient_pos + 4).unwrap();
-    assert_eq!(process_tag.class, tags::TagClass::Application);
-    assert_eq!(process_tag.number, tags::app_tag::UNSIGNED);
-}
-
-#[test]
-fn request_omits_unrepresentable_device_less_filter() {
-    let request = GetEnrollmentSummaryRequest {
-        acknowledgment_filter: 0,
-        enrollment_filter: Some(RecipientProcess {
-            device: None,
-            process_identifier: 7,
-        }),
-        event_state_filter: None,
-        event_type_filter: None,
-        priority_filter: None,
-        notification_class_filter: None,
-    };
-    let mut encoded = BytesMut::new();
-    request.encode(&mut encoded);
-    assert_eq!(
-        GetEnrollmentSummaryRequest::decode(&encoded)
-            .unwrap()
-            .enrollment_filter,
-        None
-    );
+    let (process_tag, _) = tags::decode_tag(&encoded, device_pos + 5).unwrap();
+    assert!(process_tag.is_context(1));
 }
 
 #[test]
@@ -181,6 +155,8 @@ fn request_rejects_malformed_nested_and_trailing_fields() {
 
     let reversed = raw_request([&zero, &zero, &zero, &zero, &[2], &[1], &zero], true);
     assert!(GetEnrollmentSummaryRequest::decode(&reversed).is_err());
+
+    assert!(GetEnrollmentSummaryRequest::decode(&raw_request([&zero[..]; 7], false)).is_err());
 
     let mut trailing = valid;
     primitives::encode_app_null(&mut trailing);
@@ -226,6 +202,26 @@ fn ack_values_must_fit_public_field_widths() {
         fields[field] = &max_u64;
         assert!(GetEnrollmentSummaryAck::decode(&raw_ack(fields)).is_err());
     }
+}
+
+#[test]
+fn ack_accepts_omitted_notification_class_between_entries() {
+    let zero = [0];
+    let encoded = raw_ack([&zero; 4]);
+    let notification_offset = field_offsets(&encoded, 5)[4];
+    let without_notification = &encoded[..notification_offset];
+
+    let decoded = GetEnrollmentSummaryAck::decode(without_notification).unwrap();
+    assert_eq!(decoded.entries[0].notification_class, 0);
+
+    let mut repeated = BytesMut::from(without_notification);
+    repeated.extend_from_slice(without_notification);
+    let decoded = GetEnrollmentSummaryAck::decode(&repeated).unwrap();
+    assert_eq!(decoded.entries.len(), 2);
+    assert!(decoded
+        .entries
+        .iter()
+        .all(|entry| entry.notification_class == 0));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace all 11 unchecked GetEnrollmentSummary request/ACK narrowing conversions with checked field-width conversions
- validate mandatory request tags, nested recipient/process and priority-filter members, priority ordering, and complete request consumption
- validate all five ACK application datatypes and reject reserved application L/V/T forms
- preserve public `u32` enum wrappers, unknown in-range values, and wider leading-zero encodings
- add grouped boundary, alias, `u64::MAX`, nested framing, wrong-tag, and trailing-data regressions

## Why
This service family accepted peer values above each destination width and silently aliased them into request filters or client-visible ACK entries. Its nested filters also defaulted or skipped malformed members, and ACK entries were interpreted by position without validating application datatypes.

The handler filtering behavior is unchanged; this PR is limited to request and response decode boundaries.

## Testing
- `cargo test -p bacnet-services --locked enrollment_summary`
- `cargo test -p bacnet-services --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`

Related to #309.