### PR TITLE
fix(services): harden alarm operation decoding

### DIFF
--- a/crates/bacnet-services/src/alarm_event/acknowledge_alarm.rs
+++ b/crates/bacnet-services/src/alarm_event/acknowledge_alarm.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+use crate::common::{decode_context, decode_context_u32};
+
 // ---------------------------------------------------------------------------
 // AcknowledgeAlarm
 // ---------------------------------------------------------------------------
@@ -37,39 +39,18 @@ impl AcknowledgeAlarmRequest {
         let mut offset = 0;
 
         // [0]
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "AcknowledgeAlarm truncated at process-id",
-            ));
-        }
-        let acknowledging_process_identifier = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (acknowledging_process_identifier, end) =
+            decode_context_u32(data, offset, 0, "AcknowledgeAlarm process-id")?;
         offset = end;
 
         // [1]
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "AcknowledgeAlarm truncated at object-id",
-            ));
-        }
-        let event_object_identifier = ObjectIdentifier::decode(&data[pos..end])?;
+        let (content, end) = decode_context(data, offset, 1, "AcknowledgeAlarm object-id")?;
+        let event_object_identifier = ObjectIdentifier::decode(content)?;
         offset = end;
 
         // [2]
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "AcknowledgeAlarm truncated at event-state",
-            ));
-        }
-        let event_state_acknowledged = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (event_state_acknowledged, end) =
+            decode_context_u32(data, offset, 2, "AcknowledgeAlarm event-state")?;
         offset = end;
 
         // [3] timestamp
@@ -77,21 +58,19 @@ impl AcknowledgeAlarmRequest {
         offset = new_offset;
 
         // [4] acknowledgmentSource
-        let (opt_data, _new_offset) = tags::decode_optional_context(data, offset, 4)?;
-        let acknowledgment_source = match opt_data {
-            Some(content) => primitives::decode_character_string(content)?,
-            None => {
-                return Err(Error::decoding(
-                    offset,
-                    "AcknowledgeAlarm missing required acknowledgment-source [4]",
-                ))
-            }
-        };
-
-        offset = _new_offset;
+        let (content, end) =
+            decode_context(data, offset, 4, "AcknowledgeAlarm acknowledgment-source")?;
+        let acknowledgment_source = primitives::decode_character_string(content)?;
+        offset = end;
 
         // [5] timeOfAcknowledgment
-        let (time_of_acknowledgment, _new_offset) = primitives::decode_timestamp(data, offset, 5)?;
+        let (time_of_acknowledgment, new_offset) = primitives::decode_timestamp(data, offset, 5)?;
+        if new_offset != data.len() {
+            return Err(Error::decoding(
+                new_offset,
+                "AcknowledgeAlarm trailing data after request",
+            ));
+        }
 
         Ok(Self {
             acknowledging_process_identifier,

--- a/crates/bacnet-services/src/alarm_event/tests/service_round_trip.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/service_round_trip.rs
@@ -1,5 +1,33 @@
 use super::*;
 
+fn raw_context_unsigned(buf: &mut BytesMut, tag_number: u8, value: &[u8]) {
+    bacnet_encoding::tags::encode_tag(
+        buf,
+        tag_number,
+        bacnet_encoding::tags::TagClass::Context,
+        value.len() as u32,
+    );
+    buf.extend_from_slice(value);
+}
+
+fn raw_acknowledge_alarm(process_id: &[u8], event_state: &[u8], field_tags: [u8; 6]) -> BytesMut {
+    let mut buf = BytesMut::new();
+    raw_context_unsigned(&mut buf, field_tags[0], process_id);
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    primitives::encode_ctx_object_id(&mut buf, field_tags[1], &oid);
+    raw_context_unsigned(&mut buf, field_tags[2], event_state);
+    primitives::encode_timestamp(
+        &mut buf,
+        field_tags[3],
+        &BACnetTimeStamp::SequenceNumber(42),
+    )
+    .unwrap();
+    primitives::encode_ctx_character_string(&mut buf, field_tags[4], "operator").unwrap();
+    primitives::encode_timestamp(&mut buf, field_tags[5], &BACnetTimeStamp::SequenceNumber(0))
+        .unwrap();
+    buf
+}
+
 #[test]
 fn acknowledge_alarm_round_trip() {
     let req = AcknowledgeAlarmRequest {
@@ -18,6 +46,56 @@ fn acknowledge_alarm_round_trip() {
     assert_eq!(decoded.event_state_acknowledged, 3);
     assert_eq!(decoded.timestamp, BACnetTimeStamp::SequenceNumber(42));
     assert_eq!(decoded.acknowledgment_source, "operator");
+}
+
+#[test]
+fn acknowledge_alarm_values_must_fit_u32() {
+    let max_with_leading_zero = [0, 0xff, 0xff, 0xff, 0xff];
+    let decoded = AcknowledgeAlarmRequest::decode(&raw_acknowledge_alarm(
+        &max_with_leading_zero,
+        &max_with_leading_zero,
+        [0, 1, 2, 3, 4, 5],
+    ))
+    .unwrap();
+    assert_eq!(decoded.acknowledging_process_identifier, u32::MAX);
+    assert_eq!(decoded.event_state_acknowledged, u32::MAX);
+
+    let too_wide = [1, 0, 0, 0, 0];
+    assert!(AcknowledgeAlarmRequest::decode(&raw_acknowledge_alarm(
+        &too_wide,
+        &[0],
+        [0, 1, 2, 3, 4, 5],
+    ))
+    .is_err());
+    assert!(AcknowledgeAlarmRequest::decode(&raw_acknowledge_alarm(
+        &[0],
+        &too_wide,
+        [0, 1, 2, 3, 4, 5],
+    ))
+    .is_err());
+}
+
+#[test]
+fn acknowledge_alarm_requires_owned_context_tags() {
+    for field in 0..6 {
+        let mut field_tags = [0, 1, 2, 3, 4, 5];
+        field_tags[field] = 6;
+        assert!(
+            AcknowledgeAlarmRequest::decode(&raw_acknowledge_alarm(&[1], &[1], field_tags))
+                .is_err()
+        );
+    }
+
+    let mut application_tagged = raw_acknowledge_alarm(&[1], &[1], [0, 1, 2, 3, 4, 5]);
+    application_tagged[0] &= !0x08;
+    assert!(AcknowledgeAlarmRequest::decode(&application_tagged).is_err());
+}
+
+#[test]
+fn acknowledge_alarm_rejects_trailing_data() {
+    let mut encoded = raw_acknowledge_alarm(&[1], &[1], [0, 1, 2, 3, 4, 5]);
+    primitives::encode_ctx_unsigned(&mut encoded, 6, 1);
+    assert!(AcknowledgeAlarmRequest::decode(&encoded).is_err());
 }
 
 #[test]

--- a/crates/bacnet-services/src/common.rs
+++ b/crates/bacnet-services/src/common.rs
@@ -9,12 +9,12 @@ use bytes::{BufMut, BytesMut};
 /// Safety limit for decoded sequences to prevent unbounded allocations.
 pub const MAX_DECODED_ITEMS: usize = 10_000;
 
-fn decode_context_u32(
-    data: &[u8],
+pub(crate) fn decode_context<'a>(
+    data: &'a [u8],
     offset: usize,
     expected_tag: u8,
     field: &str,
-) -> Result<(u32, usize), Error> {
+) -> Result<(&'a [u8], usize), Error> {
     let (tag, pos) = tags::decode_tag(data, offset)?;
     if !tag.is_context(expected_tag) {
         return Err(Error::decoding(
@@ -22,13 +22,25 @@ fn decode_context_u32(
             format!("{field} expected context tag {expected_tag}"),
         ));
     }
-    let end = pos + tag.length as usize;
+    let end = pos
+        .checked_add(tag.length as usize)
+        .ok_or_else(|| Error::decoding(pos, format!("{field} length overflow")))?;
     if end > data.len() {
         return Err(Error::decoding(pos, format!("{field} truncated")));
     }
-    let value = primitives::decode_unsigned(&data[pos..end])?;
-    let value =
-        u32::try_from(value).map_err(|_| Error::decoding(pos, format!("{field} exceeds u32")))?;
+    Ok((&data[pos..end], end))
+}
+
+pub(crate) fn decode_context_u32(
+    data: &[u8],
+    offset: usize,
+    expected_tag: u8,
+    field: &str,
+) -> Result<(u32, usize), Error> {
+    let (content, end) = decode_context(data, offset, expected_tag, field)?;
+    let value = primitives::decode_unsigned(content)?;
+    let value = u32::try_from(value)
+        .map_err(|_| Error::decoding(offset, format!("{field} exceeds u32")))?;
     Ok((value, end))
 }
 

--- a/crates/bacnet-services/src/life_safety.rs
+++ b/crates/bacnet-services/src/life_safety.rs
@@ -1,11 +1,12 @@
 //! LifeSafetyOperation service per ASHRAE 135-2020 Clause 15.2.7.
 
 use bacnet_encoding::primitives;
-use bacnet_encoding::tags;
 use bacnet_types::enums::LifeSafetyOperation;
 use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
+
+use crate::common::{decode_context, decode_context_u32};
 
 // ---------------------------------------------------------------------------
 // LifeSafetyOperationRequest
@@ -39,46 +40,32 @@ impl LifeSafetyOperationRequest {
         let mut offset = 0;
 
         // [0] requestingProcessIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "LifeSafetyOp truncated at processIdentifier",
-            ));
-        }
-        let requesting_process_identifier = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (requesting_process_identifier, end) =
+            decode_context_u32(data, offset, 0, "LifeSafetyOp processIdentifier")?;
         offset = end;
 
         // [1] requestingSource
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "LifeSafetyOp truncated at requestingSource",
-            ));
-        }
-        let requesting_source = primitives::decode_character_string(&data[pos..end])?;
+        let (content, end) = decode_context(data, offset, 1, "LifeSafetyOp requestingSource")?;
+        let requesting_source = primitives::decode_character_string(content)?;
         offset = end;
 
         // [2] request (BACnetLifeSafetyOperation)
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(pos, "LifeSafetyOp truncated at request"));
-        }
-        let request =
-            LifeSafetyOperation::from_raw(primitives::decode_unsigned(&data[pos..end])? as u32);
+        let (request_raw, end) = decode_context_u32(data, offset, 2, "LifeSafetyOp request")?;
+        let request = LifeSafetyOperation::from_raw(request_raw);
         offset = end;
 
         // [3] objectIdentifier (optional)
         let mut object_identifier = None;
         if offset < data.len() {
-            let (opt_data, _new_offset) = tags::decode_optional_context(data, offset, 3)?;
-            if let Some(content) = opt_data {
-                object_identifier = Some(ObjectIdentifier::decode(content)?);
-            }
+            let (content, end) = decode_context(data, offset, 3, "LifeSafetyOp objectIdentifier")?;
+            object_identifier = Some(ObjectIdentifier::decode(content)?);
+            offset = end;
+        }
+        if offset != data.len() {
+            return Err(Error::decoding(
+                offset,
+                "LifeSafetyOp trailing data after request",
+            ));
         }
 
         Ok(Self {
@@ -93,7 +80,21 @@ impl LifeSafetyOperationRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bacnet_encoding::tags::{self as wire_tags, TagClass};
     use bacnet_types::enums::ObjectType;
+
+    fn raw_context_unsigned(buf: &mut BytesMut, tag_number: u8, value: &[u8]) {
+        wire_tags::encode_tag(buf, tag_number, TagClass::Context, value.len() as u32);
+        buf.extend_from_slice(value);
+    }
+
+    fn raw_request(process_id: &[u8], operation: &[u8], field_tags: [u8; 3]) -> BytesMut {
+        let mut buf = BytesMut::new();
+        raw_context_unsigned(&mut buf, field_tags[0], process_id);
+        primitives::encode_ctx_character_string(&mut buf, field_tags[1], "Panel-1").unwrap();
+        raw_context_unsigned(&mut buf, field_tags[2], operation);
+        buf
+    }
 
     #[test]
     fn request_round_trip() {
@@ -123,6 +124,55 @@ mod tests {
         req.encode(&mut buf).unwrap();
         let decoded = LifeSafetyOperationRequest::decode(&buf).unwrap();
         assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn request_values_must_fit_u32() {
+        let max_with_leading_zero = [0, 0xff, 0xff, 0xff, 0xff];
+        let decoded = LifeSafetyOperationRequest::decode(&raw_request(
+            &max_with_leading_zero,
+            &max_with_leading_zero,
+            [0, 1, 2],
+        ))
+        .unwrap();
+        assert_eq!(decoded.requesting_process_identifier, u32::MAX);
+        assert_eq!(decoded.request.to_raw(), u32::MAX);
+
+        let too_wide = [1, 0, 0, 0, 0];
+        assert!(
+            LifeSafetyOperationRequest::decode(&raw_request(&too_wide, &[0], [0, 1, 2],)).is_err()
+        );
+        assert!(
+            LifeSafetyOperationRequest::decode(&raw_request(&[0], &too_wide, [0, 1, 2],)).is_err()
+        );
+    }
+
+    #[test]
+    fn request_requires_owned_context_tags() {
+        for field in 0..3 {
+            let mut field_tags = [0, 1, 2];
+            field_tags[field] = 6;
+            assert!(
+                LifeSafetyOperationRequest::decode(&raw_request(&[1], &[1], field_tags)).is_err()
+            );
+        }
+
+        let mut application_tagged = raw_request(&[1], &[1], [0, 1, 2]);
+        application_tagged[0] &= !0x08;
+        assert!(LifeSafetyOperationRequest::decode(&application_tagged).is_err());
+    }
+
+    #[test]
+    fn request_rejects_unknown_optional_and_trailing_fields() {
+        let mut unknown_optional = raw_request(&[1], &[1], [0, 1, 2]);
+        primitives::encode_ctx_unsigned(&mut unknown_optional, 4, 1);
+        assert!(LifeSafetyOperationRequest::decode(&unknown_optional).is_err());
+
+        let mut trailing = raw_request(&[1], &[1], [0, 1, 2]);
+        let oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 3).unwrap();
+        primitives::encode_ctx_object_id(&mut trailing, 3, &oid);
+        primitives::encode_ctx_unsigned(&mut trailing, 4, 1);
+        assert!(LifeSafetyOperationRequest::decode(&trailing).is_err());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- reject AcknowledgeAlarm and LifeSafetyOperation numeric fields above their existing `u32` contracts
- require the Standard context tags for every request member and consume the full payload
- share checked context-field decoding across service modules

## Verification
- `cargo test -p bacnet-services --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all -- --check`
- file-size and secret checks

Closes part of #309.