### PR TITLE
fix(encoding): reject noncanonical tag headers

### DIFF
--- a/crates/bacnet-encoding/src/constructed/event_parameter.rs
+++ b/crates/bacnet-encoding/src/constructed/event_parameter.rs
@@ -185,13 +185,21 @@ pub fn decode_event_parameter(
     // can reject ASHRAE-reserved tag number 255 everywhere else.
     if data.get(offset..offset.saturating_add(2)) == Some(&[0xFE, 0xFF]) {
         let body_start = offset + 2;
-        let (body, end) = tags::extract_raw_context(data, body_start, u8::MAX)?;
+        let body_end = data.len().checked_sub(2).ok_or_else(|| {
+            Error::decoding(offset, "BACnetEventParameter: truncated legacy wrapper")
+        })?;
+        if body_end < body_start || data.get(body_end..) != Some(&[0xFF, 0xFF]) {
+            return Err(Error::decoding(
+                offset,
+                "BACnetEventParameter: missing legacy closing tag",
+            ));
+        }
         return Ok((
             EP::Opaque {
                 tag: u8::MAX,
-                data: body.to_vec(),
+                data: data[body_start..body_end].to_vec(),
             },
-            end,
+            data.len(),
         ));
     }
 

--- a/crates/bacnet-encoding/src/constructed/event_parameter.rs
+++ b/crates/bacnet-encoding/src/constructed/event_parameter.rs
@@ -151,6 +151,10 @@ pub fn encode_event_parameter(buf: &mut BytesMut, value: &BACnetEventParameter) 
             tags::encode_closing_tag(buf, 2);
             tags::encode_closing_tag(buf, 9);
         }
+        BACnetEventParameter::Opaque { tag, data } if *tag == u8::MAX => {
+            // Legacy pre-framing EventEnrollment values used an Octet String.
+            primitives::encode_app_octet_string(buf, data);
+        }
         BACnetEventParameter::Opaque { tag, data } => {
             // Preserved alternative: its captured bytes are the complete
             // SEQUENCE body, re-emitted under its own opening/closing pair.
@@ -193,6 +197,22 @@ pub fn decode_event_parameter(
 
     let (tag, pos) = tags::decode_tag(data, offset)?;
     let what = "BACnetEventParameter";
+
+    if tag.class == tags::TagClass::Application && tag.number == tags::app_tag::OCTET_STRING {
+        let end = pos
+            .checked_add(tag.length as usize)
+            .ok_or_else(|| Error::decoding(pos, "BACnetEventParameter: length overflow"))?;
+        if end > data.len() {
+            return Err(Error::buffer_too_short(end, data.len()));
+        }
+        return Ok((
+            EP::Opaque {
+                tag: u8::MAX,
+                data: data[pos..end].to_vec(),
+            },
+            end,
+        ));
+    }
 
     if RESERVED_EVENT_TAGS.contains(&tag.number) {
         return Err(Error::decoding(

--- a/crates/bacnet-encoding/src/constructed/event_parameter.rs
+++ b/crates/bacnet-encoding/src/constructed/event_parameter.rs
@@ -175,6 +175,22 @@ pub fn decode_event_parameter(
     offset: usize,
 ) -> Result<(BACnetEventParameter, usize), Error> {
     use BACnetEventParameter as EP;
+
+    // Pre-framing EventEnrollment writes use [255] as an internal wrapper.
+    // Keep this shipped compatibility form local so the generic tag parser
+    // can reject ASHRAE-reserved tag number 255 everywhere else.
+    if data.get(offset..offset.saturating_add(2)) == Some(&[0xFE, 0xFF]) {
+        let body_start = offset + 2;
+        let (body, end) = tags::extract_raw_context(data, body_start, u8::MAX)?;
+        return Ok((
+            EP::Opaque {
+                tag: u8::MAX,
+                data: body.to_vec(),
+            },
+            end,
+        ));
+    }
+
     let (tag, pos) = tags::decode_tag(data, offset)?;
     let what = "BACnetEventParameter";
 

--- a/crates/bacnet-encoding/src/constructed/tests/event_parameter.rs
+++ b/crates/bacnet-encoding/src/constructed/tests/event_parameter.rs
@@ -267,6 +267,21 @@ fn opaque_unmodeled_alternatives_preserved() {
     }
 }
 
+#[test]
+fn legacy_opaque_sentinel_stays_local_to_event_parameters() {
+    let value = BACnetEventParameter::Opaque {
+        tag: u8::MAX,
+        data: vec![0xFF, 0x01, 0x02],
+    };
+    let mut encoded = BytesMut::new();
+    encode_event_parameter(&mut encoded, &value);
+
+    assert!(tags::decode_tag(&encoded, 0).is_err());
+    let (decoded, end) = decode_event_parameter(&encoded, 0).unwrap();
+    assert_eq!(decoded, value);
+    assert_eq!(end, encoded.len());
+}
+
 // --- Negatives ----------------------------------------------------------------
 
 #[test]

--- a/crates/bacnet-encoding/src/constructed/tests/event_parameter.rs
+++ b/crates/bacnet-encoding/src/constructed/tests/event_parameter.rs
@@ -283,14 +283,14 @@ fn legacy_opaque_sentinel_stays_local_to_event_parameters() {
     assert_eq!(decoded, value);
     assert_eq!(end, encoded.len());
 
-    let historical = [0xFE, 0xFF, 1, 2, 3, 0xFF, 0xFF];
+    let historical = [0xFE, 0xFF, 1, 0xFF, 0xFF, 2, 0xFF, 0xFF];
     assert!(tags::decode_tag(&historical, 0).is_err());
     let (decoded, end) = decode_event_parameter(&historical, 0).unwrap();
     assert_eq!(
         decoded,
         BACnetEventParameter::Opaque {
             tag: u8::MAX,
-            data: vec![1, 2, 3],
+            data: vec![1, 0xFF, 0xFF, 2],
         }
     );
     assert_eq!(end, historical.len());

--- a/crates/bacnet-encoding/src/constructed/tests/event_parameter.rs
+++ b/crates/bacnet-encoding/src/constructed/tests/event_parameter.rs
@@ -276,10 +276,24 @@ fn legacy_opaque_sentinel_stays_local_to_event_parameters() {
     let mut encoded = BytesMut::new();
     encode_event_parameter(&mut encoded, &value);
 
-    assert!(tags::decode_tag(&encoded, 0).is_err());
+    let (tag, _) = tags::decode_tag(&encoded, 0).unwrap();
+    assert_eq!(tag.class, tags::TagClass::Application);
+    assert_eq!(tag.number, tags::app_tag::OCTET_STRING);
     let (decoded, end) = decode_event_parameter(&encoded, 0).unwrap();
     assert_eq!(decoded, value);
     assert_eq!(end, encoded.len());
+
+    let historical = [0xFE, 0xFF, 1, 2, 3, 0xFF, 0xFF];
+    assert!(tags::decode_tag(&historical, 0).is_err());
+    let (decoded, end) = decode_event_parameter(&historical, 0).unwrap();
+    assert_eq!(
+        decoded,
+        BACnetEventParameter::Opaque {
+            tag: u8::MAX,
+            data: vec![1, 2, 3],
+        }
+    );
+    assert_eq!(end, historical.len());
 }
 
 // --- Negatives ----------------------------------------------------------------

--- a/crates/bacnet-encoding/src/constructed/tests/event_parameter.rs
+++ b/crates/bacnet-encoding/src/constructed/tests/event_parameter.rs
@@ -283,14 +283,14 @@ fn legacy_opaque_sentinel_stays_local_to_event_parameters() {
     assert_eq!(decoded, value);
     assert_eq!(end, encoded.len());
 
-    let historical = [0xFE, 0xFF, 1, 0xFF, 0xFF, 2, 0xFF, 0xFF];
+    let historical = [0xFE, 0xFF, 1, 0xFF, 0xFF, 0x2F, 2, 0xFF, 0xFF];
     assert!(tags::decode_tag(&historical, 0).is_err());
     let (decoded, end) = decode_event_parameter(&historical, 0).unwrap();
     assert_eq!(
         decoded,
         BACnetEventParameter::Opaque {
             tag: u8::MAX,
-            data: vec![1, 0xFF, 0xFF, 2],
+            data: vec![1, 0xFF, 0xFF, 0x2F, 2],
         }
     );
     assert_eq!(end, historical.len());

--- a/crates/bacnet-encoding/src/lib.rs
+++ b/crates/bacnet-encoding/src/lib.rs
@@ -12,3 +12,6 @@ pub mod npdu;
 pub mod primitives;
 pub mod segmentation;
 pub mod tags;
+
+#[cfg(test)]
+mod tags_canonical_tests;

--- a/crates/bacnet-encoding/src/tags.rs
+++ b/crates/bacnet-encoding/src/tags.rs
@@ -178,6 +178,9 @@ pub fn decode_tag(data: &[u8], offset: usize) -> Result<(Tag, usize), Error> {
         TagClass::Application
     };
     let lvt = initial & 0x07;
+    if class == TagClass::Application && lvt > 5 {
+        return Err(Error::decoding(offset, "reserved application tag L/V/T"));
+    }
 
     if tag_number == 0x0F {
         if pos >= data.len() {
@@ -587,15 +590,6 @@ mod tests {
     }
 
     #[test]
-    fn decode_rejects_invalid_extended_tag_numbers() {
-        for initial in [0xF1, 0xF9, 0xFE, 0xFF] {
-            for tag_number in [0, 1, 14, 255] {
-                assert!(decode_tag(&[initial, tag_number], 0).is_err());
-            }
-        }
-    }
-
-    #[test]
     fn decode_extended_length() {
         // Tag 2, Application, length 100: 0x25, 100
         let (tag, pos) = decode_tag(&[0x25, 100], 0).unwrap();
@@ -614,35 +608,6 @@ mod tests {
         assert_eq!(tag.number, 2);
         assert_eq!(tag.length, 100000);
         assert_eq!(pos, 6);
-    }
-
-    #[test]
-    fn decode_rejects_noncanonical_extended_lengths() {
-        for length in 0..=4 {
-            assert!(decode_tag(&[0x0D, length], 0).is_err());
-        }
-
-        assert!(decode_tag(&[0x0D, 254, 0x00, 0xFD], 0).is_err());
-        assert!(decode_tag(&[0x0D, 255, 0x00, 0x00, 0xFF, 0xFF], 0).is_err());
-    }
-
-    #[test]
-    fn decode_accepts_canonical_extended_length_boundaries() {
-        let cases: &[(&[u8], u32)] = &[
-            (&[0x0D, 5], 5),
-            (&[0x0D, 253], 253),
-            (&[0x0D, 254, 0x00, 0xFE], 254),
-            (&[0x0D, 254, 0xFF, 0xFF], 65_535),
-            (&[0x0D, 255, 0x00, 0x01, 0x00, 0x00], 65_536),
-        ];
-
-        for &(encoded, expected_length) in cases {
-            let (tag, pos) = decode_tag(encoded, 0).unwrap();
-            assert_eq!(tag.number, 0);
-            assert_eq!(tag.class, TagClass::Context);
-            assert_eq!(tag.length, expected_length);
-            assert_eq!(pos, encoded.len());
-        }
     }
 
     #[test]

--- a/crates/bacnet-encoding/src/tags.rs
+++ b/crates/bacnet-encoding/src/tags.rs
@@ -184,6 +184,12 @@ pub fn decode_tag(data: &[u8], offset: usize) -> Result<(Tag, usize), Error> {
             return Err(Error::decoding(pos, "truncated extended tag number"));
         }
         tag_number = data[pos];
+        if !(15..=254).contains(&tag_number) {
+            return Err(Error::decoding(
+                pos,
+                format!("invalid extended tag number {tag_number}"),
+            ));
+        }
         pos += 1;
     }
 
@@ -224,12 +230,24 @@ pub fn decode_tag(data: &[u8], offset: usize) -> Result<(Tag, usize), Error> {
         pos += 1;
 
         match ext {
-            0..=253 => ext as u32,
+            0..=4 => {
+                return Err(Error::decoding(
+                    pos - 1,
+                    format!("non-canonical extended tag length {ext}"),
+                ));
+            }
+            5..=253 => ext as u32,
             254 => {
                 if pos + 2 > data.len() {
                     return Err(Error::decoding(pos, "truncated 2-byte extended length"));
                 }
                 let len = u16::from_be_bytes([data[pos], data[pos + 1]]) as u32;
+                if len < 254 {
+                    return Err(Error::decoding(
+                        pos,
+                        format!("non-canonical 2-byte extended tag length {len}"),
+                    ));
+                }
                 pos += 2;
                 len
             }
@@ -239,6 +257,12 @@ pub fn decode_tag(data: &[u8], offset: usize) -> Result<(Tag, usize), Error> {
                 }
                 let len =
                     u32::from_be_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
+                if len < 65_536 {
+                    return Err(Error::decoding(
+                        pos,
+                        format!("non-canonical 4-byte extended tag length {len}"),
+                    ));
+                }
                 pos += 4;
                 len
             }
@@ -563,6 +587,15 @@ mod tests {
     }
 
     #[test]
+    fn decode_rejects_invalid_extended_tag_numbers() {
+        for initial in [0xF1, 0xF9, 0xFE, 0xFF] {
+            for tag_number in [0, 1, 14, 255] {
+                assert!(decode_tag(&[initial, tag_number], 0).is_err());
+            }
+        }
+    }
+
+    #[test]
     fn decode_extended_length() {
         // Tag 2, Application, length 100: 0x25, 100
         let (tag, pos) = decode_tag(&[0x25, 100], 0).unwrap();
@@ -581,6 +614,35 @@ mod tests {
         assert_eq!(tag.number, 2);
         assert_eq!(tag.length, 100000);
         assert_eq!(pos, 6);
+    }
+
+    #[test]
+    fn decode_rejects_noncanonical_extended_lengths() {
+        for length in 0..=4 {
+            assert!(decode_tag(&[0x0D, length], 0).is_err());
+        }
+
+        assert!(decode_tag(&[0x0D, 254, 0x00, 0xFD], 0).is_err());
+        assert!(decode_tag(&[0x0D, 255, 0x00, 0x00, 0xFF, 0xFF], 0).is_err());
+    }
+
+    #[test]
+    fn decode_accepts_canonical_extended_length_boundaries() {
+        let cases: &[(&[u8], u32)] = &[
+            (&[0x0D, 5], 5),
+            (&[0x0D, 253], 253),
+            (&[0x0D, 254, 0x00, 0xFE], 254),
+            (&[0x0D, 254, 0xFF, 0xFF], 65_535),
+            (&[0x0D, 255, 0x00, 0x01, 0x00, 0x00], 65_536),
+        ];
+
+        for &(encoded, expected_length) in cases {
+            let (tag, pos) = decode_tag(encoded, 0).unwrap();
+            assert_eq!(tag.number, 0);
+            assert_eq!(tag.class, TagClass::Context);
+            assert_eq!(tag.length, expected_length);
+            assert_eq!(pos, encoded.len());
+        }
     }
 
     #[test]

--- a/crates/bacnet-encoding/src/tags_canonical_tests.rs
+++ b/crates/bacnet-encoding/src/tags_canonical_tests.rs
@@ -1,0 +1,48 @@
+use crate::tags::{self, TagClass};
+
+#[test]
+fn rejects_invalid_extended_tag_numbers() {
+    for initial in [0xF1, 0xF9, 0xFE, 0xFF] {
+        for tag_number in [0, 1, 14, 255] {
+            assert!(tags::decode_tag(&[initial, tag_number], 0).is_err());
+        }
+    }
+}
+
+#[test]
+fn rejects_noncanonical_extended_lengths() {
+    for length in 0..=4 {
+        assert!(tags::decode_tag(&[0x0D, length], 0).is_err());
+    }
+
+    assert!(tags::decode_tag(&[0x0D, 254, 0x00, 0xFD], 0).is_err());
+    assert!(tags::decode_tag(&[0x0D, 255, 0x00, 0x00, 0xFF, 0xFF], 0).is_err());
+}
+
+#[test]
+fn accepts_canonical_extended_length_boundaries() {
+    let cases: &[(&[u8], u32)] = &[
+        (&[0x0D, 5], 5),
+        (&[0x0D, 253], 253),
+        (&[0x0D, 254, 0x00, 0xFE], 254),
+        (&[0x0D, 254, 0xFF, 0xFF], 65_535),
+        (&[0x0D, 255, 0x00, 0x01, 0x00, 0x00], 65_536),
+    ];
+
+    for &(encoded, expected_length) in cases {
+        let (tag, pos) = tags::decode_tag(encoded, 0).unwrap();
+        assert_eq!(tag.number, 0);
+        assert_eq!(tag.class, TagClass::Context);
+        assert_eq!(tag.length, expected_length);
+        assert_eq!(pos, encoded.len());
+    }
+}
+
+#[test]
+fn rejects_reserved_application_lvt_forms() {
+    for lvt in [6, 7] {
+        let encoded = [0x20 | lvt, 5, 0, 0, 0, 0, 1];
+        assert!(tags::decode_tag(&encoded, 0).is_err());
+        assert!(crate::primitives::decode_application_value(&encoded, 0).is_err());
+    }
+}

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -401,9 +401,9 @@ pub fn evaluate_event_enrollments(
             // full ASN.1 CHOICE framing).
             Ok(PropertyValue::ApplicationData(bytes)) => {
                 match bacnet_encoding::constructed::decode_event_parameter(&bytes, 0) {
-                    Ok((ep, _)) => ep,
+                    Ok((ep, consumed)) if consumed == bytes.len() => ep,
                     // Malformed framed value: nothing to evaluate.
-                    Err(_) => continue,
+                    _ => continue,
                 }
             }
             // Legacy flat application-tagged form (downstream/custom object

--- a/crates/bacnet-server/src/handlers/tests/framed_properties.rs
+++ b/crates/bacnet-server/src/handlers/tests/framed_properties.rs
@@ -134,7 +134,7 @@ fn legacy_event_parameters_wire_write_is_canonicalized() {
     let oid = ee.object_identifier();
     db.add(Box::new(ee)).unwrap();
 
-    let payload = vec![1, 0xff, 0xff, 2];
+    let payload = vec![1, 0xff, 0xff, 0x3f, 2];
     let mut historical = vec![0xfe, 0xff];
     historical.extend_from_slice(&payload);
     historical.extend_from_slice(&[0xff, 0xff]);

--- a/crates/bacnet-server/src/handlers/tests/framed_properties.rs
+++ b/crates/bacnet-server/src/handlers/tests/framed_properties.rs
@@ -128,6 +128,33 @@ fn event_parameters_framed_wire_round_trip() {
 }
 
 #[test]
+fn legacy_event_parameters_wire_write_is_canonicalized() {
+    let mut db = ObjectDatabase::new();
+    let ee = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
+    let oid = ee.object_identifier();
+    db.add(Box::new(ee)).unwrap();
+
+    let payload = vec![1, 0xff, 0xff, 2];
+    let mut historical = vec![0xfe, 0xff];
+    historical.extend_from_slice(&payload);
+    historical.extend_from_slice(&[0xff, 0xff]);
+    write_framed(
+        &mut db,
+        oid,
+        PropertyIdentifier::EVENT_PARAMETERS,
+        historical,
+    )
+    .unwrap();
+
+    let mut canonical = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_octet_string(&mut canonical, &payload);
+    assert_eq!(
+        read_raw(&db, oid, PropertyIdentifier::EVENT_PARAMETERS),
+        canonical.to_vec()
+    );
+}
+
+#[test]
 fn fault_parameters_framed_wire_round_trip() {
     let mut db = ObjectDatabase::new();
     let ee = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();

--- a/crates/bacnet-server/src/handlers/write_property.rs
+++ b/crates/bacnet-server/src/handlers/write_property.rs
@@ -456,6 +456,18 @@ pub(crate) fn decode_write_property_value(
     property: PropertyIdentifier,
     bytes: &[u8],
 ) -> Result<PropertyValue, Error> {
+    if property == PropertyIdentifier::EVENT_PARAMETERS && bytes.starts_with(&[0xfe, 0xff]) {
+        use bacnet_types::constructed::BACnetEventParameter;
+
+        return match bacnet_encoding::constructed::decode_event_parameter(bytes, 0) {
+            Ok((BACnetEventParameter::Opaque { tag, data }, consumed))
+                if tag == u8::MAX && consumed == bytes.len() =>
+            {
+                Ok(PropertyValue::OctetString(data))
+            }
+            _ => Err(invalid_data_encoding_error()),
+        };
+    }
     if property == PropertyIdentifier::RECIPIENT_LIST {
         return Ok(PropertyValue::ApplicationData(bytes.to_vec()));
     }

--- a/crates/bacnet-services/src/alarm_event/tests/service_round_trip.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/service_round_trip.rs
@@ -385,7 +385,7 @@ fn test_decode_event_notification_invalid_tag() {
 #[test]
 fn test_decode_get_event_info_invalid_tag() {
     // Non-matching context tag — decoder treats as no last_received (lenient)
-    let result = GetEventInformationRequest::decode(&[0xFF, 0xFF]).unwrap();
+    let result = GetEventInformationRequest::decode(&[0x19, 0]).unwrap();
     assert!(result.last_received_object_identifier.is_none());
 }
 

--- a/crates/bacnet-services/src/common.rs
+++ b/crates/bacnet-services/src/common.rs
@@ -48,6 +48,7 @@ pub(crate) fn decode_context_u32(
 pub(crate) enum PropertyValueBoundary {
     End,
     Context(u8),
+    ContextToEnd(u8),
     Closing(u8),
 }
 
@@ -56,6 +57,14 @@ fn matches_property_boundary(data: &[u8], offset: usize, boundary: PropertyValue
         PropertyValueBoundary::End => offset == data.len(),
         PropertyValueBoundary::Context(number) => {
             tags::decode_tag(data, offset).is_ok_and(|(tag, _)| tag.is_context(number))
+        }
+        PropertyValueBoundary::ContextToEnd(number) => {
+            tags::decode_tag(data, offset).is_ok_and(|(tag, content_start)| {
+                tag.is_context(number)
+                    && content_start
+                        .checked_add(tag.length as usize)
+                        .is_some_and(|end| end == data.len())
+            })
         }
         PropertyValueBoundary::Closing(number) => {
             tags::decode_tag(data, offset).is_ok_and(|(tag, _)| tag.is_closing_tag(number))
@@ -75,8 +84,10 @@ pub(crate) fn extract_property_value<'a>(
     {
         // Before EventParameter framing, tag 255 wrapped arbitrary octets. Use
         // the enclosing service grammar to distinguish a payload marker from
-        // the wrapper terminator without consuming a sibling property.
+        // the wrapper terminator without consuming a sibling property. Reject
+        // multiple valid boundaries because the old format cannot disambiguate them.
         let outer_close = (closing_tag << 4) | 0x0f;
+        let mut candidate = None;
         for pos in offset.saturating_add(4)..data.len() {
             let end = pos + 1;
             if data[pos] == outer_close
@@ -85,8 +96,17 @@ pub(crate) fn extract_property_value<'a>(
                     .iter()
                     .any(|boundary| matches_property_boundary(data, end, *boundary))
             {
-                return Ok((&data[offset..pos], end));
+                if candidate.is_some() {
+                    return Err(Error::decoding(
+                        offset,
+                        "legacy EventParameters value has ambiguous closing tags",
+                    ));
+                }
+                candidate = Some((pos, end));
             }
+        }
+        if let Some((pos, end)) = candidate {
+            return Ok((&data[offset..pos], end));
         }
         return Err(Error::decoding(
             offset,
@@ -199,7 +219,7 @@ impl BACnetPropertyValue {
             offset,
             &[
                 PropertyValueBoundary::End,
-                PropertyValueBoundary::Context(3),
+                PropertyValueBoundary::ContextToEnd(3),
             ],
         )
     }

--- a/crates/bacnet-services/src/common.rs
+++ b/crates/bacnet-services/src/common.rs
@@ -53,11 +53,11 @@ pub(crate) fn extract_property_value(
     if property == PropertyIdentifier::EVENT_PARAMETERS
         && data.get(offset..offset.saturating_add(2)) == Some(&[0xfe, 0xff])
     {
-        // Before EventParameter framing, tag 255 wrapped arbitrary octets. Find
-        // its terminal marker next to the enclosing property tag so payload
-        // bytes that happen to contain FF FF remain opaque.
+        // Before EventParameter framing, tag 255 wrapped arbitrary octets. Its
+        // closing marker is only unambiguous beside the enclosing property tag;
+        // taking the first such marker prevents one value consuming siblings.
         let outer_close = (closing_tag << 4) | 0x0f;
-        for pos in (offset.saturating_add(4)..data.len()).rev() {
+        for pos in offset.saturating_add(4)..data.len() {
             if data[pos] == outer_close && data.get(pos - 2..pos) == Some(&[0xff, 0xff]) {
                 return Ok((&data[offset..pos], pos + 1));
             }

--- a/crates/bacnet-services/src/common.rs
+++ b/crates/bacnet-services/src/common.rs
@@ -44,22 +44,48 @@ pub(crate) fn decode_context_u32(
     Ok((value, end))
 }
 
-pub(crate) fn extract_property_value(
-    data: &[u8],
+#[derive(Clone, Copy)]
+pub(crate) enum PropertyValueBoundary {
+    End,
+    Context(u8),
+    Closing(u8),
+}
+
+fn matches_property_boundary(data: &[u8], offset: usize, boundary: PropertyValueBoundary) -> bool {
+    match boundary {
+        PropertyValueBoundary::End => offset == data.len(),
+        PropertyValueBoundary::Context(number) => {
+            tags::decode_tag(data, offset).is_ok_and(|(tag, _)| tag.is_context(number))
+        }
+        PropertyValueBoundary::Closing(number) => {
+            tags::decode_tag(data, offset).is_ok_and(|(tag, _)| tag.is_closing_tag(number))
+        }
+    }
+}
+
+pub(crate) fn extract_property_value<'a>(
+    data: &'a [u8],
     offset: usize,
     closing_tag: u8,
     property: PropertyIdentifier,
-) -> Result<(&[u8], usize), Error> {
+    boundaries: &[PropertyValueBoundary],
+) -> Result<(&'a [u8], usize), Error> {
     if property == PropertyIdentifier::EVENT_PARAMETERS
         && data.get(offset..offset.saturating_add(2)) == Some(&[0xfe, 0xff])
     {
-        // Before EventParameter framing, tag 255 wrapped arbitrary octets. Its
-        // closing marker is only unambiguous beside the enclosing property tag;
-        // taking the first such marker prevents one value consuming siblings.
+        // Before EventParameter framing, tag 255 wrapped arbitrary octets. Use
+        // the enclosing service grammar to distinguish a payload marker from
+        // the wrapper terminator without consuming a sibling property.
         let outer_close = (closing_tag << 4) | 0x0f;
         for pos in offset.saturating_add(4)..data.len() {
-            if data[pos] == outer_close && data.get(pos - 2..pos) == Some(&[0xff, 0xff]) {
-                return Ok((&data[offset..pos], pos + 1));
+            let end = pos + 1;
+            if data[pos] == outer_close
+                && data.get(pos - 2..pos) == Some(&[0xff, 0xff])
+                && boundaries
+                    .iter()
+                    .any(|boundary| matches_property_boundary(data, end, *boundary))
+            {
+                return Ok((&data[offset..pos], end));
             }
         }
         return Err(Error::decoding(
@@ -168,6 +194,37 @@ impl BACnetPropertyValue {
     }
 
     pub fn decode(data: &[u8], offset: usize) -> Result<(Self, usize), Error> {
+        Self::decode_with_boundaries(
+            data,
+            offset,
+            &[
+                PropertyValueBoundary::End,
+                PropertyValueBoundary::Context(3),
+            ],
+        )
+    }
+
+    pub(crate) fn decode_in_list(
+        data: &[u8],
+        offset: usize,
+        closing_tag: u8,
+    ) -> Result<(Self, usize), Error> {
+        Self::decode_with_boundaries(
+            data,
+            offset,
+            &[
+                PropertyValueBoundary::Context(3),
+                PropertyValueBoundary::Context(0),
+                PropertyValueBoundary::Closing(closing_tag),
+            ],
+        )
+    }
+
+    fn decode_with_boundaries(
+        data: &[u8],
+        offset: usize,
+        boundaries: &[PropertyValueBoundary],
+    ) -> Result<(Self, usize), Error> {
         // [0] propertyIdentifier
         let (prop_id, mut offset) =
             decode_context_u32(data, offset, 0, "BACnetPropertyValue property-id")?;
@@ -193,7 +250,8 @@ impl BACnetPropertyValue {
             ));
         }
         let property_identifier = PropertyIdentifier::from_raw(prop_id);
-        let (value_bytes, offset) = extract_property_value(data, tag_end, 2, property_identifier)?;
+        let (value_bytes, offset) =
+            extract_property_value(data, tag_end, 2, property_identifier, boundaries)?;
         let value = value_bytes.to_vec();
 
         // [3] priority (optional)
@@ -320,7 +378,7 @@ mod tests {
         let pv = BACnetPropertyValue {
             property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
             property_array_index: None,
-            value: vec![0xfe, 0xff, 1, 0xff, 0xff, 2, 0xff, 0xff],
+            value: vec![0xfe, 0xff, 1, 0xff, 0xff, 0x2f, 2, 0xff, 0xff],
             priority: None,
         };
         let mut buf = BytesMut::new();

--- a/crates/bacnet-services/src/common.rs
+++ b/crates/bacnet-services/src/common.rs
@@ -44,6 +44,33 @@ pub(crate) fn decode_context_u32(
     Ok((value, end))
 }
 
+pub(crate) fn extract_property_value(
+    data: &[u8],
+    offset: usize,
+    closing_tag: u8,
+    property: PropertyIdentifier,
+) -> Result<(&[u8], usize), Error> {
+    if property == PropertyIdentifier::EVENT_PARAMETERS
+        && data.get(offset..offset.saturating_add(2)) == Some(&[0xfe, 0xff])
+    {
+        // Before EventParameter framing, tag 255 wrapped arbitrary octets. Find
+        // its terminal marker next to the enclosing property tag so payload
+        // bytes that happen to contain FF FF remain opaque.
+        let outer_close = (closing_tag << 4) | 0x0f;
+        for pos in (offset.saturating_add(4)..data.len()).rev() {
+            if data[pos] == outer_close && data.get(pos - 2..pos) == Some(&[0xff, 0xff]) {
+                return Ok((&data[offset..pos], pos + 1));
+            }
+        }
+        return Err(Error::decoding(
+            offset,
+            "legacy EventParameters value is missing its closing tags",
+        ));
+    }
+
+    tags::extract_context_value(data, offset, closing_tag)
+}
+
 // ---------------------------------------------------------------------------
 // PropertyReference
 // ---------------------------------------------------------------------------
@@ -165,7 +192,8 @@ impl BACnetPropertyValue {
                 "BACnetPropertyValue expected opening tag 2",
             ));
         }
-        let (value_bytes, offset) = tags::extract_context_value(data, tag_end, 2)?;
+        let property_identifier = PropertyIdentifier::from_raw(prop_id);
+        let (value_bytes, offset) = extract_property_value(data, tag_end, 2, property_identifier)?;
         let value = value_bytes.to_vec();
 
         // [3] priority (optional)
@@ -192,7 +220,7 @@ impl BACnetPropertyValue {
                 })?);
                 return Ok((
                     Self {
-                        property_identifier: PropertyIdentifier::from_raw(prop_id),
+                        property_identifier,
                         property_array_index: array_index,
                         value,
                         priority,
@@ -204,7 +232,7 @@ impl BACnetPropertyValue {
 
         Ok((
             Self {
-                property_identifier: PropertyIdentifier::from_raw(prop_id),
+                property_identifier,
                 property_array_index: array_index,
                 value,
                 priority,
@@ -285,6 +313,36 @@ mod tests {
         pv.encode(&mut buf);
         let (decoded, _) = BACnetPropertyValue::decode(&buf, 0).unwrap();
         assert_eq!(pv, decoded);
+    }
+
+    #[test]
+    fn bacnet_property_value_preserves_legacy_event_parameters() {
+        let pv = BACnetPropertyValue {
+            property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+            property_array_index: None,
+            value: vec![0xfe, 0xff, 1, 0xff, 0xff, 2, 0xff, 0xff],
+            priority: None,
+        };
+        let mut buf = BytesMut::new();
+        pv.encode(&mut buf);
+
+        let (decoded, consumed) = BACnetPropertyValue::decode(&buf, 0).unwrap();
+        assert_eq!(decoded, pv);
+        assert_eq!(consumed, buf.len());
+    }
+
+    #[test]
+    fn bacnet_property_value_rejects_unclosed_legacy_event_parameters() {
+        let pv = BACnetPropertyValue {
+            property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+            property_array_index: None,
+            value: vec![0xfe, 0xff, 1, 2],
+            priority: None,
+        };
+        let mut buf = BytesMut::new();
+        pv.encode(&mut buf);
+
+        assert!(BACnetPropertyValue::decode(&buf, 0).is_err());
     }
 
     #[test]

--- a/crates/bacnet-services/src/cov.rs
+++ b/crates/bacnet-services/src/cov.rs
@@ -366,7 +366,7 @@ impl COVNotificationRequest {
                 offset = tag_end;
                 break;
             }
-            let (pv, new_offset) = BACnetPropertyValue::decode(data, offset)?;
+            let (pv, new_offset) = BACnetPropertyValue::decode_in_list(data, offset, 4)?;
             values.push(pv);
             offset = new_offset;
         }

--- a/crates/bacnet-services/src/object_mgmt.rs
+++ b/crates/bacnet-services/src/object_mgmt.rs
@@ -123,7 +123,7 @@ impl CreateObjectRequest {
                     if values.len() >= MAX_DECODED_ITEMS {
                         return Err(Error::decoding(offset, "CreateObject values exceeds max"));
                     }
-                    let (pv, new_offset) = BACnetPropertyValue::decode(data, offset)?;
+                    let (pv, new_offset) = BACnetPropertyValue::decode_in_list(data, offset, 1)?;
                     values.push(pv);
                     offset = new_offset;
                 }

--- a/crates/bacnet-services/src/read_property.rs
+++ b/crates/bacnet-services/src/read_property.rs
@@ -318,6 +318,48 @@ mod tests {
     }
 
     #[test]
+    fn legacy_event_parameters_cross_property_framing() {
+        use crate::write_property::WritePropertyRequest;
+        use bacnet_types::constructed::BACnetEventParameter;
+
+        let value = BACnetEventParameter::Opaque {
+            tag: u8::MAX,
+            data: vec![0xff, 1, 2],
+        };
+        let mut property_value = BytesMut::new();
+        bacnet_encoding::constructed::encode_event_parameter(&mut property_value, &value);
+        let object_identifier = ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap();
+
+        let ack = ReadPropertyACK {
+            object_identifier,
+            property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+            property_array_index: None,
+            property_value: property_value.to_vec(),
+        };
+        let mut encoded = BytesMut::new();
+        ack.encode(&mut encoded);
+        let decoded = ReadPropertyACK::decode(&encoded).unwrap();
+        assert_eq!(decoded, ack);
+
+        let request = WritePropertyRequest {
+            object_identifier,
+            property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+            property_array_index: None,
+            property_value: property_value.to_vec(),
+            priority: None,
+        };
+        encoded.clear();
+        request.encode(&mut encoded);
+        let decoded = WritePropertyRequest::decode(&encoded).unwrap();
+        assert_eq!(decoded, request);
+
+        let (decoded, end) =
+            bacnet_encoding::constructed::decode_event_parameter(&property_value, 0).unwrap();
+        assert_eq!(decoded, value);
+        assert_eq!(end, property_value.len());
+    }
+
+    #[test]
     fn read_property_values_must_fit_u32() {
         let maximum = u64::from(u32::MAX);
         let request = encode_fields(0, 1, maximum, Some((2, maximum)), false, true);

--- a/crates/bacnet-services/src/read_property.rs
+++ b/crates/bacnet-services/src/read_property.rs
@@ -377,7 +377,7 @@ mod tests {
     fn historical_event_parameters_cross_property_framing() {
         use crate::write_property::WritePropertyRequest;
 
-        let property_value = vec![0xfe, 0xff, 1, 0xff, 0xff, 0x3f, 2, 0xff, 0xff];
+        let property_value = vec![0xfe, 0xff, 1, 0xff, 0xff, 0x3f, 0x49, 8, 2, 0xff, 0xff];
         let object_identifier = ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap();
         let ack = ReadPropertyACK {
             object_identifier,

--- a/crates/bacnet-services/src/read_property.rs
+++ b/crates/bacnet-services/src/read_property.rs
@@ -7,6 +7,8 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
 
+use crate::common::extract_property_value;
+
 fn decode_context_u32(
     data: &[u8],
     offset: usize,
@@ -191,7 +193,7 @@ impl ReadPropertyACK {
                     "ReadPropertyACK expected opening tag 3",
                 ));
             }
-            let (value_bytes, end) = tags::extract_context_value(data, tag_end, 3)?;
+            let (value_bytes, end) = extract_property_value(data, tag_end, 3, property_identifier)?;
             if end != data.len() {
                 return Err(Error::decoding(end, "ReadPropertyACK has trailing data"));
             }
@@ -209,7 +211,7 @@ impl ReadPropertyACK {
                 "ReadPropertyACK expected opening tag 3",
             ));
         }
-        let (value_bytes, end) = tags::extract_context_value(data, tag_end, 3)?;
+        let (value_bytes, end) = extract_property_value(data, tag_end, 3, property_identifier)?;
         if end != data.len() {
             return Err(Error::decoding(end, "ReadPropertyACK has trailing data"));
         }
@@ -357,6 +359,34 @@ mod tests {
             bacnet_encoding::constructed::decode_event_parameter(&property_value, 0).unwrap();
         assert_eq!(decoded, value);
         assert_eq!(end, property_value.len());
+    }
+
+    #[test]
+    fn historical_event_parameters_cross_property_framing() {
+        use crate::write_property::WritePropertyRequest;
+
+        let property_value = vec![0xfe, 0xff, 1, 0xff, 0xff, 2, 0xff, 0xff];
+        let object_identifier = ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap();
+        let ack = ReadPropertyACK {
+            object_identifier,
+            property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+            property_array_index: None,
+            property_value: property_value.clone(),
+        };
+        let mut encoded = BytesMut::new();
+        ack.encode(&mut encoded);
+        assert_eq!(ReadPropertyACK::decode(&encoded).unwrap(), ack);
+
+        let request = WritePropertyRequest {
+            object_identifier,
+            property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+            property_array_index: None,
+            property_value,
+            priority: Some(8),
+        };
+        encoded.clear();
+        request.encode(&mut encoded);
+        assert_eq!(WritePropertyRequest::decode(&encoded).unwrap(), request);
     }
 
     #[test]

--- a/crates/bacnet-services/src/read_property.rs
+++ b/crates/bacnet-services/src/read_property.rs
@@ -7,7 +7,7 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
 
-use crate::common::extract_property_value;
+use crate::common::{extract_property_value, PropertyValueBoundary};
 
 fn decode_context_u32(
     data: &[u8],
@@ -193,7 +193,13 @@ impl ReadPropertyACK {
                     "ReadPropertyACK expected opening tag 3",
                 ));
             }
-            let (value_bytes, end) = extract_property_value(data, tag_end, 3, property_identifier)?;
+            let (value_bytes, end) = extract_property_value(
+                data,
+                tag_end,
+                3,
+                property_identifier,
+                &[PropertyValueBoundary::End],
+            )?;
             if end != data.len() {
                 return Err(Error::decoding(end, "ReadPropertyACK has trailing data"));
             }
@@ -211,7 +217,13 @@ impl ReadPropertyACK {
                 "ReadPropertyACK expected opening tag 3",
             ));
         }
-        let (value_bytes, end) = extract_property_value(data, tag_end, 3, property_identifier)?;
+        let (value_bytes, end) = extract_property_value(
+            data,
+            tag_end,
+            3,
+            property_identifier,
+            &[PropertyValueBoundary::End],
+        )?;
         if end != data.len() {
             return Err(Error::decoding(end, "ReadPropertyACK has trailing data"));
         }
@@ -365,7 +377,7 @@ mod tests {
     fn historical_event_parameters_cross_property_framing() {
         use crate::write_property::WritePropertyRequest;
 
-        let property_value = vec![0xfe, 0xff, 1, 0xff, 0xff, 2, 0xff, 0xff];
+        let property_value = vec![0xfe, 0xff, 1, 0xff, 0xff, 0x3f, 2, 0xff, 0xff];
         let object_identifier = ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap();
         let ack = ReadPropertyACK {
             object_identifier,

--- a/crates/bacnet-services/src/rpm.rs
+++ b/crates/bacnet-services/src/rpm.rs
@@ -7,7 +7,9 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
 
-use crate::common::{extract_property_value, PropertyReference, MAX_DECODED_ITEMS};
+use crate::common::{
+    extract_property_value, PropertyReference, PropertyValueBoundary, MAX_DECODED_ITEMS,
+};
 
 // ---------------------------------------------------------------------------
 // ReadPropertyMultipleRequest
@@ -239,8 +241,16 @@ impl ReadPropertyMultipleACK {
                     offset = end;
                     let (tag, tag_end) = tags::decode_tag(data, offset)?;
                     if tag.is_opening_tag(4) {
-                        let (value_bytes, new_offset) =
-                            extract_property_value(data, tag_end, 4, property_identifier)?;
+                        let (value_bytes, new_offset) = extract_property_value(
+                            data,
+                            tag_end,
+                            4,
+                            property_identifier,
+                            &[
+                                PropertyValueBoundary::Context(2),
+                                PropertyValueBoundary::Closing(1),
+                            ],
+                        )?;
                         elements.push(ReadResultElement {
                             property_identifier,
                             property_array_index: array_index,
@@ -263,8 +273,16 @@ impl ReadPropertyMultipleACK {
                     }
                 } else if tag.is_opening_tag(4) {
                     // [4] property-value
-                    let (value_bytes, new_offset) =
-                        extract_property_value(data, tag_end, 4, property_identifier)?;
+                    let (value_bytes, new_offset) = extract_property_value(
+                        data,
+                        tag_end,
+                        4,
+                        property_identifier,
+                        &[
+                            PropertyValueBoundary::Context(2),
+                            PropertyValueBoundary::Closing(1),
+                        ],
+                    )?;
                     elements.push(ReadResultElement {
                         property_identifier,
                         property_array_index: array_index,
@@ -477,7 +495,7 @@ mod tests {
                     ReadResultElement {
                         property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
                         property_array_index: None,
-                        property_value: Some(vec![0xfe, 0xff, 1, 0xff, 0xff, 2, 0xff, 0xff]),
+                        property_value: Some(vec![0xfe, 0xff, 1, 0xff, 0xff, 0x4f, 2, 0xff, 0xff]),
                         error: None,
                     },
                     ReadResultElement {

--- a/crates/bacnet-services/src/rpm.rs
+++ b/crates/bacnet-services/src/rpm.rs
@@ -501,7 +501,7 @@ mod tests {
                     ReadResultElement {
                         property_identifier: PropertyIdentifier::NOTIFICATION_CLASS,
                         property_array_index: None,
-                        property_value: Some(vec![0x22, 0xff, 0xff]),
+                        property_value: Some(vec![0x21, 8]),
                         error: None,
                     },
                 ],
@@ -511,6 +511,28 @@ mod tests {
         ack.encode(&mut buf);
 
         assert_eq!(ReadPropertyMultipleACK::decode(&buf).unwrap(), ack);
+    }
+
+    #[test]
+    fn ambiguous_legacy_event_parameters_result_is_rejected() {
+        let ack = ReadPropertyMultipleACK {
+            list_of_read_access_results: vec![ReadAccessResult {
+                object_identifier: ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap(),
+                list_of_results: vec![ReadResultElement {
+                    property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+                    property_array_index: None,
+                    property_value: Some(vec![
+                        0xfe, 0xff, 0xaa, 0xff, 0xff, 0x4f, 0x29, 0x53, 0x4e, 0xfe, 0xff, 0xbb,
+                        0xff, 0xff,
+                    ]),
+                    error: None,
+                }],
+            }],
+        };
+        let mut buf = BytesMut::new();
+        ack.encode(&mut buf);
+
+        assert!(ReadPropertyMultipleACK::decode(&buf).is_err());
     }
 
     #[test]

--- a/crates/bacnet-services/src/rpm.rs
+++ b/crates/bacnet-services/src/rpm.rs
@@ -7,7 +7,7 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
 
-use crate::common::{PropertyReference, MAX_DECODED_ITEMS};
+use crate::common::{extract_property_value, PropertyReference, MAX_DECODED_ITEMS};
 
 // ---------------------------------------------------------------------------
 // ReadPropertyMultipleRequest
@@ -240,7 +240,7 @@ impl ReadPropertyMultipleACK {
                     let (tag, tag_end) = tags::decode_tag(data, offset)?;
                     if tag.is_opening_tag(4) {
                         let (value_bytes, new_offset) =
-                            tags::extract_context_value(data, tag_end, 4)?;
+                            extract_property_value(data, tag_end, 4, property_identifier)?;
                         elements.push(ReadResultElement {
                             property_identifier,
                             property_array_index: array_index,
@@ -263,7 +263,8 @@ impl ReadPropertyMultipleACK {
                     }
                 } else if tag.is_opening_tag(4) {
                     // [4] property-value
-                    let (value_bytes, new_offset) = tags::extract_context_value(data, tag_end, 4)?;
+                    let (value_bytes, new_offset) =
+                        extract_property_value(data, tag_end, 4, property_identifier)?;
                     elements.push(ReadResultElement {
                         property_identifier,
                         property_array_index: array_index,
@@ -465,6 +466,33 @@ mod tests {
         ack.encode(&mut buf);
         let decoded = ReadPropertyMultipleACK::decode(&buf).unwrap();
         assert_eq!(ack, decoded);
+    }
+
+    #[test]
+    fn legacy_event_parameters_do_not_consume_the_next_result() {
+        let ack = ReadPropertyMultipleACK {
+            list_of_read_access_results: vec![ReadAccessResult {
+                object_identifier: ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap(),
+                list_of_results: vec![
+                    ReadResultElement {
+                        property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+                        property_array_index: None,
+                        property_value: Some(vec![0xfe, 0xff, 1, 0xff, 0xff, 2, 0xff, 0xff]),
+                        error: None,
+                    },
+                    ReadResultElement {
+                        property_identifier: PropertyIdentifier::NOTIFICATION_CLASS,
+                        property_array_index: None,
+                        property_value: Some(vec![0x22, 0xff, 0xff]),
+                        error: None,
+                    },
+                ],
+            }],
+        };
+        let mut buf = BytesMut::new();
+        ack.encode(&mut buf);
+
+        assert_eq!(ReadPropertyMultipleACK::decode(&buf).unwrap(), ack);
     }
 
     #[test]

--- a/crates/bacnet-services/src/who_is.rs
+++ b/crates/bacnet-services/src/who_is.rs
@@ -294,7 +294,7 @@ mod tests {
     #[test]
     fn test_decode_who_is_invalid_tag() {
         // Non-empty but with non-matching context tags — decoder treats as unbounded
-        let result = WhoIsRequest::decode(&[0xFF, 0xFF]).unwrap();
+        let result = WhoIsRequest::decode(&[0x29, 0]).unwrap();
         assert_eq!(result.low_limit, None);
         assert_eq!(result.high_limit, None);
     }
@@ -460,13 +460,7 @@ mod tests {
         let valid = encode_request(1476, 0, 999);
         let mut reserved_lvt = BytesMut::from(&[0xc6, 4][..]);
         reserved_lvt.extend_from_slice(&valid[1..]);
-        let error = IAmRequest::decode(&reserved_lvt).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("IAm object identifier: expected application-tagged"),
-            "unexpected error for reserved application L/V/T: {error}"
-        );
+        assert!(IAmRequest::decode(&reserved_lvt).is_err());
     }
 
     #[test]

--- a/crates/bacnet-services/src/wpm.rs
+++ b/crates/bacnet-services/src/wpm.rs
@@ -83,7 +83,7 @@ impl WritePropertyMultipleRequest {
                     offset = tag_end;
                     break;
                 }
-                let (pv, new_offset) = BACnetPropertyValue::decode(data, offset)?;
+                let (pv, new_offset) = BACnetPropertyValue::decode_in_list(data, offset, 1)?;
                 props.push(pv);
                 offset = new_offset;
             }
@@ -163,7 +163,7 @@ mod tests {
                     BACnetPropertyValue {
                         property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
                         property_array_index: None,
-                        value: vec![0xfe, 0xff, 1, 0xff, 0xff, 2, 0xff, 0xff],
+                        value: vec![0xfe, 0xff, 1, 0xff, 0xff, 0x2f, 2, 0xff, 0xff],
                         priority: None,
                     },
                     BACnetPropertyValue {

--- a/crates/bacnet-services/src/wpm.rs
+++ b/crates/bacnet-services/src/wpm.rs
@@ -169,7 +169,7 @@ mod tests {
                     BACnetPropertyValue {
                         property_identifier: PropertyIdentifier::NOTIFICATION_CLASS,
                         property_array_index: None,
-                        value: vec![0x22, 0xff, 0xff],
+                        value: vec![0x21, 8],
                         priority: None,
                     },
                 ],
@@ -179,6 +179,28 @@ mod tests {
         req.encode(&mut buf);
 
         assert_eq!(WritePropertyMultipleRequest::decode(&buf).unwrap(), req);
+    }
+
+    #[test]
+    fn ambiguous_legacy_event_parameters_are_rejected() {
+        let req = WritePropertyMultipleRequest {
+            list_of_write_access_specs: vec![WriteAccessSpecification {
+                object_identifier: ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap(),
+                list_of_properties: vec![BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+                    property_array_index: None,
+                    value: vec![
+                        0xfe, 0xff, 0xaa, 0xff, 0xff, 0x2f, 0x09, 0x53, 0x2e, 0xfe, 0xff, 0xbb,
+                        0xff, 0xff,
+                    ],
+                    priority: None,
+                }],
+            }],
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+
+        assert!(WritePropertyMultipleRequest::decode(&buf).is_err());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/bacnet-services/src/wpm.rs
+++ b/crates/bacnet-services/src/wpm.rs
@@ -154,6 +154,33 @@ mod tests {
         assert_eq!(req, decoded);
     }
 
+    #[test]
+    fn legacy_event_parameters_do_not_consume_the_next_property() {
+        let req = WritePropertyMultipleRequest {
+            list_of_write_access_specs: vec![WriteAccessSpecification {
+                object_identifier: ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap(),
+                list_of_properties: vec![
+                    BACnetPropertyValue {
+                        property_identifier: PropertyIdentifier::EVENT_PARAMETERS,
+                        property_array_index: None,
+                        value: vec![0xfe, 0xff, 1, 0xff, 0xff, 2, 0xff, 0xff],
+                        priority: None,
+                    },
+                    BACnetPropertyValue {
+                        property_identifier: PropertyIdentifier::NOTIFICATION_CLASS,
+                        property_array_index: None,
+                        value: vec![0x22, 0xff, 0xff],
+                        priority: None,
+                    },
+                ],
+            }],
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+
+        assert_eq!(WritePropertyMultipleRequest::decode(&buf).unwrap(), req);
+    }
+
     // -----------------------------------------------------------------------
     // Malformed-input decode error tests
     // -----------------------------------------------------------------------

--- a/crates/bacnet-services/src/write_property.rs
+++ b/crates/bacnet-services/src/write_property.rs
@@ -7,7 +7,7 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
 
-use crate::common::extract_property_value;
+use crate::common::{extract_property_value, PropertyValueBoundary};
 
 fn decode_context_u32(
     data: &[u8],
@@ -113,8 +113,16 @@ impl WritePropertyRequest {
                 "WriteProperty expected opening tag 3",
             ));
         }
-        let (value_bytes, new_offset) =
-            extract_property_value(data, tag_end, 3, property_identifier)?;
+        let (value_bytes, new_offset) = extract_property_value(
+            data,
+            tag_end,
+            3,
+            property_identifier,
+            &[
+                PropertyValueBoundary::End,
+                PropertyValueBoundary::Context(4),
+            ],
+        )?;
         let property_value = value_bytes.to_vec();
         offset = new_offset;
 

--- a/crates/bacnet-services/src/write_property.rs
+++ b/crates/bacnet-services/src/write_property.rs
@@ -120,7 +120,7 @@ impl WritePropertyRequest {
             property_identifier,
             &[
                 PropertyValueBoundary::End,
-                PropertyValueBoundary::Context(4),
+                PropertyValueBoundary::ContextToEnd(4),
             ],
         )?;
         let property_value = value_bytes.to_vec();

--- a/crates/bacnet-services/src/write_property.rs
+++ b/crates/bacnet-services/src/write_property.rs
@@ -7,6 +7,8 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
 
+use crate::common::extract_property_value;
+
 fn decode_context_u32(
     data: &[u8],
     offset: usize,
@@ -111,7 +113,8 @@ impl WritePropertyRequest {
                 "WriteProperty expected opening tag 3",
             ));
         }
-        let (value_bytes, new_offset) = tags::extract_context_value(data, tag_end, 3)?;
+        let (value_bytes, new_offset) =
+            extract_property_value(data, tag_end, 3, property_identifier)?;
         let property_value = value_bytes.to_vec();
         offset = new_offset;
 


### PR DESCRIPTION
## Summary
- reject extended tag-number headers for values outside the Standard 15..=254 range
- reject extended-length headers when the decoded length belongs to a shorter form
- preserve the shipped EventEnrollment tag-255 legacy sentinel only inside its constructed codec
- update lenient service fixtures to use canonical non-matching tags

## Standard
ASHRAE 135-2020 Clause 20.2.1.2 assigns the extended tag-number form to 15..=254. Clause 20.2.1.3 assigns the one-, two-, and four-octet length extensions to 5..=253, 254..=65535, and 65536..=2^32-1 respectively.

## Verification
- `cargo test -p bacnet-encoding --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all -- --check`
- file-size and secret checks

Closes #337.