### PR TITLE
fix(services): harden ReadRange decoding

### DIFF
--- a/crates/bacnet-client/src/client/file_list.rs
+++ b/crates/bacnet-client/src/client/file_list.rs
@@ -1,5 +1,46 @@
 use super::*;
 
+fn validate_read_range_ack(
+    request: &bacnet_services::read_range::ReadRangeRequest,
+    ack: &bacnet_services::read_range::ReadRangeAck,
+) -> Result<(), Error> {
+    if ack.object_identifier != request.object_identifier {
+        return Err(Error::decoding(
+            0,
+            "ReadRange ACK object identifier does not match the request",
+        ));
+    }
+    if ack.property_identifier != request.property_identifier {
+        return Err(Error::decoding(
+            0,
+            "ReadRange ACK property identifier does not match the request",
+        ));
+    }
+    if ack.property_array_index != request.property_array_index {
+        return Err(Error::decoding(
+            0,
+            "ReadRange ACK array index does not match the request",
+        ));
+    }
+
+    let sequence_range = matches!(
+        request.range.as_ref(),
+        Some(
+            bacnet_services::read_range::RangeSpec::BySequenceNumber { .. }
+                | bacnet_services::read_range::RangeSpec::ByTime { .. }
+        )
+    );
+    let permits_first_sequence_number = sequence_range && ack.item_count > 0;
+    if ack.first_sequence_number.is_some() && !permits_first_sequence_number {
+        return Err(Error::decoding(
+            0,
+            "ReadRange ACK first sequence number is invalid for the request range",
+        ));
+    }
+
+    Ok(())
+}
+
 impl<T: TransportPort + 'static> BACnetClient<T> {
     /// Get event information from a remote device.
     pub async fn get_event_information(
@@ -80,7 +121,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             .confirmed_request(destination_mac, ConfirmedServiceChoice::READ_RANGE, &buf)
             .await?;
 
-        ReadRangeAck::decode(&response_data)
+        let ack = ReadRangeAck::decode(&response_data)?;
+        validate_read_range_ack(&request, &ack)?;
+        Ok(ack)
     }
 
     /// Read file data from a remote device (stream or record access).
@@ -191,5 +234,93 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             .await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bacnet_services::read_range::{RangeSpec, ReadRangeAck, ReadRangeRequest};
+    use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+    use bacnet_types::primitives::{Date, ObjectIdentifier, Time};
+
+    fn request(range: Option<RangeSpec>) -> ReadRangeRequest {
+        ReadRangeRequest {
+            object_identifier: ObjectIdentifier::new(ObjectType::TREND_LOG, 1).unwrap(),
+            property_identifier: PropertyIdentifier::LOG_BUFFER,
+            property_array_index: Some(1),
+            range,
+        }
+    }
+
+    fn ack(request: &ReadRangeRequest, item_count: u32, first: Option<u32>) -> ReadRangeAck {
+        ReadRangeAck {
+            object_identifier: request.object_identifier,
+            property_identifier: request.property_identifier,
+            property_array_index: request.property_array_index,
+            result_flags: (true, true, false),
+            item_count,
+            item_data: Vec::new(),
+            first_sequence_number: first,
+        }
+    }
+
+    #[test]
+    fn read_range_ack_must_echo_the_request() {
+        let request = request(Some(RangeSpec::ByPosition {
+            reference_index: 1,
+            count: 1,
+        }));
+        let valid = ack(&request, 1, None);
+        assert!(validate_read_range_ack(&request, &valid).is_ok());
+
+        let mut wrong_object = valid.clone();
+        wrong_object.object_identifier = ObjectIdentifier::new(ObjectType::TREND_LOG, 2).unwrap();
+        assert!(validate_read_range_ack(&request, &wrong_object).is_err());
+
+        let mut wrong_property = valid.clone();
+        wrong_property.property_identifier = PropertyIdentifier::PRESENT_VALUE;
+        assert!(validate_read_range_ack(&request, &wrong_property).is_err());
+
+        let mut wrong_index = valid;
+        wrong_index.property_array_index = Some(2);
+        assert!(validate_read_range_ack(&request, &wrong_index).is_err());
+    }
+
+    #[test]
+    fn first_sequence_number_must_match_the_requested_range() {
+        let by_sequence = request(Some(RangeSpec::BySequenceNumber {
+            reference_seq: 1,
+            count: 1,
+        }));
+        assert!(validate_read_range_ack(&by_sequence, &ack(&by_sequence, 1, Some(1))).is_ok());
+        assert!(validate_read_range_ack(&by_sequence, &ack(&by_sequence, 1, None)).is_ok());
+        assert!(validate_read_range_ack(&by_sequence, &ack(&by_sequence, 0, None)).is_ok());
+        assert!(validate_read_range_ack(&by_sequence, &ack(&by_sequence, 0, Some(1))).is_err());
+
+        let by_time = request(Some(RangeSpec::ByTime {
+            reference_time: (
+                Date {
+                    year: 126,
+                    month: 3,
+                    day: 1,
+                    day_of_week: 7,
+                },
+                Time {
+                    hour: 14,
+                    minute: 30,
+                    second: 0,
+                    hundredths: 0,
+                },
+            ),
+            count: 1,
+        }));
+        assert!(validate_read_range_ack(&by_time, &ack(&by_time, 1, Some(1))).is_ok());
+
+        let by_position = request(Some(RangeSpec::ByPosition {
+            reference_index: 1,
+            count: 1,
+        }));
+        assert!(validate_read_range_ack(&by_position, &ack(&by_position, 1, Some(1))).is_err());
     }
 }

--- a/crates/bacnet-services/src/read_range.rs
+++ b/crates/bacnet-services/src/read_range.rs
@@ -8,18 +8,47 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::{Date, ObjectIdentifier, Time};
 use bytes::BytesMut;
 
-/// Decode a tag and validate the resulting slice bounds.
-fn checked_slice<'a>(
-    content: &'a [u8],
+use crate::common::{decode_context, decode_context_u32};
+
+fn decode_application<'a>(
+    data: &'a [u8],
     offset: usize,
-    context: &str,
+    expected_tag: u8,
+    field: &str,
 ) -> Result<(&'a [u8], usize), Error> {
-    let (t, p) = tags::decode_tag(content, offset)?;
-    let end = p + t.length as usize;
-    if end > content.len() {
-        return Err(Error::decoding(p, format!("{context} truncated")));
+    let (tag, pos) = tags::decode_tag(data, offset)?;
+    if tag.class != tags::TagClass::Application || tag.number != expected_tag {
+        return Err(Error::decoding(
+            offset,
+            format!("{field} expected application tag {expected_tag}"),
+        ));
     }
-    Ok((&content[p..end], end))
+    let end = pos
+        .checked_add(tag.length as usize)
+        .ok_or_else(|| Error::decoding(pos, format!("{field} length overflow")))?;
+    if end > data.len() {
+        return Err(Error::decoding(pos, format!("{field} truncated")));
+    }
+    Ok((&data[pos..end], end))
+}
+
+fn decode_application_u32(data: &[u8], offset: usize, field: &str) -> Result<(u32, usize), Error> {
+    let (content, end) = decode_application(data, offset, tags::app_tag::UNSIGNED, field)?;
+    let value = primitives::decode_unsigned(content)?;
+    let value = u32::try_from(value)
+        .map_err(|_| Error::decoding(offset, format!("{field} exceeds u32")))?;
+    Ok((value, end))
+}
+
+fn decode_count(data: &[u8], offset: usize, field: &str) -> Result<(i32, usize), Error> {
+    let (content, end) = decode_application(data, offset, tags::app_tag::SIGNED, field)?;
+    let value = primitives::decode_signed(content)?;
+    let value = i16::try_from(value)
+        .map_err(|_| Error::decoding(offset, format!("{field} exceeds INTEGER16")))?;
+    if value == 0 {
+        return Err(Error::decoding(offset, format!("{field} may not be zero")));
+    }
+    Ok((i32::from(value), end))
 }
 
 /// ReadRange-Request service parameters.
@@ -95,37 +124,40 @@ impl ReadRangeRequest {
         let mut offset = 0;
 
         // [0] objectIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "ReadRange request truncated at object-id",
-            ));
-        }
-        let object_identifier = ObjectIdentifier::decode(&data[pos..end])?;
+        let (content, end) = decode_context(data, offset, 0, "ReadRange request object-id")?;
+        let object_identifier = ObjectIdentifier::decode(content)?;
         offset = end;
 
         // [1] propertyIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
+        let (property_identifier, end) =
+            decode_context_u32(data, offset, 1, "ReadRange request property-id")?;
+        let property_identifier = PropertyIdentifier::from_raw(property_identifier);
+        if matches!(
+            property_identifier,
+            PropertyIdentifier::ALL | PropertyIdentifier::REQUIRED | PropertyIdentifier::OPTIONAL
+        ) {
             return Err(Error::decoding(
-                pos,
-                "ReadRange request truncated at property-id",
+                offset,
+                "ReadRange request property-id may not be ALL, REQUIRED, or OPTIONAL",
             ));
         }
-        let property_identifier =
-            PropertyIdentifier::from_raw(primitives::decode_unsigned(&data[pos..end])? as u32);
         offset = end;
 
         // [2] propertyArrayIndex (optional)
         let mut property_array_index = None;
         if offset < data.len() {
-            let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 2)?;
-            if let Some(content) = opt_data {
-                property_array_index = Some(primitives::decode_unsigned(content)? as u32);
-                offset = new_offset;
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(2) {
+                let (index, end) =
+                    decode_context_u32(data, offset, 2, "ReadRange request array-index")?;
+                if index == 0 {
+                    return Err(Error::decoding(
+                        offset,
+                        "ReadRange request array-index may not be zero",
+                    ));
+                }
+                property_array_index = Some(index);
+                offset = end;
             }
         }
 
@@ -136,12 +168,16 @@ impl ReadRangeRequest {
             if tag.is_opening_tag(3) {
                 // byPosition
                 let (content, new_offset) = tags::extract_context_value(data, tag_end, 3)?;
-                let (slice, inner_offset) =
-                    checked_slice(content, 0, "ReadRange byPosition reference-index")?;
-                let reference_index = primitives::decode_unsigned(slice)? as u32;
-                let (slice, _) =
-                    checked_slice(content, inner_offset, "ReadRange byPosition count")?;
-                let count = primitives::decode_signed(slice)?;
+                let (reference_index, inner_offset) =
+                    decode_application_u32(content, 0, "ReadRange byPosition reference-index")?;
+                let (count, inner_offset) =
+                    decode_count(content, inner_offset, "ReadRange byPosition count")?;
+                if inner_offset != content.len() {
+                    return Err(Error::decoding(
+                        inner_offset,
+                        "ReadRange byPosition has trailing data",
+                    ));
+                }
                 range = Some(RangeSpec::ByPosition {
                     reference_index,
                     count,
@@ -150,12 +186,16 @@ impl ReadRangeRequest {
             } else if tag.is_opening_tag(6) {
                 // bySequenceNumber
                 let (content, new_offset) = tags::extract_context_value(data, tag_end, 6)?;
-                let (slice, inner_offset) =
-                    checked_slice(content, 0, "ReadRange bySequenceNumber reference-seq")?;
-                let reference_seq = primitives::decode_unsigned(slice)? as u32;
-                let (slice, _) =
-                    checked_slice(content, inner_offset, "ReadRange bySequenceNumber count")?;
-                let count = primitives::decode_signed(slice)?;
+                let (reference_seq, inner_offset) =
+                    decode_application_u32(content, 0, "ReadRange bySequenceNumber reference-seq")?;
+                let (count, inner_offset) =
+                    decode_count(content, inner_offset, "ReadRange bySequenceNumber count")?;
+                if inner_offset != content.len() {
+                    return Err(Error::decoding(
+                        inner_offset,
+                        "ReadRange bySequenceNumber has trailing data",
+                    ));
+                }
                 range = Some(RangeSpec::BySequenceNumber {
                     reference_seq,
                     count,
@@ -164,31 +204,55 @@ impl ReadRangeRequest {
             } else if tag.is_opening_tag(7) {
                 // byTime
                 let (content, new_offset) = tags::extract_context_value(data, tag_end, 7)?;
-                let (slice, inner_offset) = checked_slice(content, 0, "ReadRange byTime date")?;
-                let date = Date::decode(slice)?;
-                let (slice, inner_offset) =
-                    checked_slice(content, inner_offset, "ReadRange byTime time")?;
-                let time = Time::decode(slice)?;
-                let (slice, _) = checked_slice(content, inner_offset, "ReadRange byTime count")?;
-                let count = primitives::decode_signed(slice)?;
+                let (date, inner_offset) =
+                    decode_application(content, 0, tags::app_tag::DATE, "ReadRange byTime date")?;
+                let date = Date::decode(date)?;
+                let (time, inner_offset) = decode_application(
+                    content,
+                    inner_offset,
+                    tags::app_tag::TIME,
+                    "ReadRange byTime time",
+                )?;
+                let time = Time::decode(time)?;
+                if date.year == Date::UNSPECIFIED
+                    || !(1..=12).contains(&date.month)
+                    || !(1..=31).contains(&date.day)
+                    || !(1..=7).contains(&date.day_of_week)
+                    || !(0..=23).contains(&time.hour)
+                    || !(0..=59).contains(&time.minute)
+                    || !(0..=59).contains(&time.second)
+                    || !(0..=99).contains(&time.hundredths)
+                {
+                    return Err(Error::decoding(
+                        inner_offset,
+                        "ReadRange byTime requires a specific datetime",
+                    ));
+                }
+                let (count, inner_offset) =
+                    decode_count(content, inner_offset, "ReadRange byTime count")?;
+                if inner_offset != content.len() {
+                    return Err(Error::decoding(
+                        inner_offset,
+                        "ReadRange byTime has trailing data",
+                    ));
+                }
                 range = Some(RangeSpec::ByTime {
                     reference_time: (date, time),
                     count,
                 });
                 offset = new_offset;
+            } else {
+                return Err(Error::decoding(
+                    offset,
+                    "ReadRange request has invalid range choice",
+                ));
             }
         }
-        let _ = offset;
-
-        if let Some(ref r) = range {
-            let count = match r {
-                RangeSpec::ByPosition { count, .. } => *count,
-                RangeSpec::BySequenceNumber { count, .. } => *count,
-                RangeSpec::ByTime { count, .. } => *count,
-            };
-            if count == 0 {
-                return Err(Error::Encoding("ReadRange count may not be zero".into()));
-            }
+        if offset != data.len() {
+            return Err(Error::decoding(
+                offset,
+                "ReadRange request has trailing data",
+            ));
         }
 
         Ok(Self {
@@ -253,77 +317,81 @@ impl ReadRangeAck {
         let mut offset = 0;
 
         // [0] objectIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(pos, "ReadRange ACK truncated at object-id"));
-        }
-        let object_identifier = ObjectIdentifier::decode(&data[pos..end])?;
+        let (content, end) = decode_context(data, offset, 0, "ReadRange ACK object-id")?;
+        let object_identifier = ObjectIdentifier::decode(content)?;
         offset = end;
 
         // [1] propertyIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "ReadRange ACK truncated at property-id",
-            ));
-        }
-        let property_identifier =
-            PropertyIdentifier::from_raw(primitives::decode_unsigned(&data[pos..end])? as u32);
+        let (property_identifier, end) =
+            decode_context_u32(data, offset, 1, "ReadRange ACK property-id")?;
+        let property_identifier = PropertyIdentifier::from_raw(property_identifier);
         offset = end;
 
         // [2] propertyArrayIndex (optional)
         let mut property_array_index = None;
-        let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 2)?;
-        if let Some(content) = opt_data {
-            property_array_index = Some(primitives::decode_unsigned(content)? as u32);
-            offset = new_offset;
+        if offset < data.len() {
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(2) {
+                let (index, end) =
+                    decode_context_u32(data, offset, 2, "ReadRange ACK array-index")?;
+                property_array_index = Some(index);
+                offset = end;
+            }
         }
 
         // [3] resultFlags
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
+        let (content, end) = decode_context(data, offset, 3, "ReadRange ACK result-flags")?;
+        let (unused_bits, bits) = primitives::decode_bit_string(content)?;
+        if unused_bits != 5 || bits.len() != 1 || bits[0] & 0x1f != 0 {
             return Err(Error::decoding(
-                pos,
-                "ReadRange ACK truncated at result-flags",
+                offset,
+                "ReadRange ACK result-flags must contain three bits with zero padding",
             ));
         }
-        let (_, bits) = primitives::decode_bit_string(&data[pos..end])?;
-        let b = bits.first().copied().unwrap_or(0);
+        let b = bits[0];
         let result_flags = (b & 0x80 != 0, b & 0x40 != 0, b & 0x20 != 0);
         offset = end;
 
         // [4] itemCount
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "ReadRange ACK truncated at item-count",
-            ));
-        }
-        let item_count = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (item_count, end) = decode_context_u32(data, offset, 4, "ReadRange ACK item-count")?;
         offset = end;
 
         // [5] itemData
-        let (_tag, tag_end) = tags::decode_tag(data, offset)?;
-        let (content, _new_offset) = tags::extract_context_value(data, tag_end, 5)?;
+        let (tag, tag_end) = tags::decode_tag(data, offset)?;
+        if !tag.is_opening_tag(5) {
+            return Err(Error::decoding(
+                offset,
+                "ReadRange ACK item-data expected opening tag 5",
+            ));
+        }
+        let (content, new_offset) = tags::extract_context_value(data, tag_end, 5)?;
         let item_data = content.to_vec();
-        let mut new_offset = _new_offset;
+        offset = new_offset;
 
         // [6] firstSequenceNumber (optional)
         let mut first_sequence_number = None;
-        if new_offset < data.len() {
-            let (opt_data, after) = tags::decode_optional_context(data, new_offset, 6)?;
-            if let Some(content) = opt_data {
-                first_sequence_number = Some(primitives::decode_unsigned(content)? as u32);
-                new_offset = after;
+        if offset < data.len() {
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if !tag.is_context(6) {
+                return Err(Error::decoding(
+                    offset,
+                    "ReadRange ACK expected context tag 6 for first-sequence-number",
+                ));
             }
+            if item_count == 0 {
+                return Err(Error::decoding(
+                    offset,
+                    "ReadRange ACK first-sequence-number requires a nonzero item-count",
+                ));
+            }
+            let (sequence_number, end) =
+                decode_context_u32(data, offset, 6, "ReadRange ACK first-sequence-number")?;
+            first_sequence_number = Some(sequence_number);
+            offset = end;
         }
-        let _ = new_offset;
+        if offset != data.len() {
+            return Err(Error::decoding(offset, "ReadRange ACK has trailing data"));
+        }
 
         Ok(Self {
             object_identifier,
@@ -336,6 +404,10 @@ impl ReadRangeAck {
         })
     }
 }
+
+#[cfg(test)]
+#[path = "read_range_width_tests.rs"]
+mod width_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/bacnet-services/src/read_range.rs
+++ b/crates/bacnet-services/src/read_range.rs
@@ -365,6 +365,12 @@ impl ReadRangeAck {
             ));
         }
         let (content, new_offset) = tags::extract_context_value(data, tag_end, 5)?;
+        if (item_count == 0) != content.is_empty() {
+            return Err(Error::decoding(
+                offset,
+                "ReadRange ACK item-count contradicts empty item-data",
+            ));
+        }
         let item_data = content.to_vec();
         offset = new_offset;
 

--- a/crates/bacnet-services/src/read_range_width_tests.rs
+++ b/crates/bacnet-services/src/read_range_width_tests.rs
@@ -81,6 +81,27 @@ fn encode_ack(
     item_count: &[u8],
     first_sequence_number: Option<&[u8]>,
 ) -> BytesMut {
+    let item_data = item_count
+        .iter()
+        .any(|octet| *octet != 0)
+        .then_some(&[0x00][..])
+        .unwrap_or_default();
+    encode_ack_with_item_data(
+        property,
+        array_index,
+        item_count,
+        item_data,
+        first_sequence_number,
+    )
+}
+
+fn encode_ack_with_item_data(
+    property: &[u8],
+    array_index: Option<&[u8]>,
+    item_count: &[u8],
+    item_data: &[u8],
+    first_sequence_number: Option<&[u8]>,
+) -> BytesMut {
     let mut buf = BytesMut::new();
     primitives::encode_ctx_object_id(&mut buf, 0, &object_identifier());
     encode_context_value(&mut buf, 1, property);
@@ -90,6 +111,7 @@ fn encode_ack(
     primitives::encode_ctx_bit_string(&mut buf, 3, 5, &[0xa0]);
     encode_context_value(&mut buf, 4, item_count);
     tags::encode_opening_tag(&mut buf, 5);
+    buf.extend_from_slice(item_data);
     tags::encode_closing_tag(&mut buf, 5);
     if let Some(sequence_number) = first_sequence_number {
         encode_context_value(&mut buf, 6, sequence_number);
@@ -367,6 +389,18 @@ fn acknowledgments_validate_flags_item_data_and_suffix() {
     let first_sequence_tag = wrong_first_sequence_tag.len() - 2;
     wrong_first_sequence_tag[first_sequence_tag] = 0x21;
     assert!(ReadRangeAck::decode(&wrong_first_sequence_tag).is_err());
+
+    assert!(
+        ReadRangeAck::decode(&encode_ack_with_item_data(&[0x83], None, &[1], &[], None,)).is_err()
+    );
+    assert!(ReadRangeAck::decode(&encode_ack_with_item_data(
+        &[0x83],
+        None,
+        &[0],
+        &[0x00],
+        None,
+    ))
+    .is_err());
 
     let mut trailing = encode_ack(&[0x83], None, &[1], None);
     encode_context_value(&mut trailing, 7, &[1]);

--- a/crates/bacnet-services/src/read_range_width_tests.rs
+++ b/crates/bacnet-services/src/read_range_width_tests.rs
@@ -1,0 +1,383 @@
+use super::*;
+use bacnet_types::enums::ObjectType;
+
+#[derive(Clone, Copy)]
+enum TestRange {
+    Position,
+    Sequence,
+    Time,
+}
+
+fn object_identifier() -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::TREND_LOG, 1).unwrap()
+}
+
+fn encode_context_value(buf: &mut BytesMut, number: u8, value: &[u8]) {
+    tags::encode_tag(buf, number, tags::TagClass::Context, value.len() as u32);
+    buf.extend_from_slice(value);
+}
+
+fn encode_application_value(buf: &mut BytesMut, number: u8, value: &[u8]) {
+    tags::encode_tag(buf, number, tags::TagClass::Application, value.len() as u32);
+    buf.extend_from_slice(value);
+}
+
+fn request_prefix(property: &[u8], array_index: Option<&[u8]>) -> BytesMut {
+    let mut buf = BytesMut::new();
+    primitives::encode_ctx_object_id(&mut buf, 0, &object_identifier());
+    encode_context_value(&mut buf, 1, property);
+    if let Some(index) = array_index {
+        encode_context_value(&mut buf, 2, index);
+    }
+    buf
+}
+
+fn append_range(
+    buf: &mut BytesMut,
+    range: TestRange,
+    reference_tag: u8,
+    reference: &[u8],
+    count_tag: u8,
+    count: &[u8],
+) {
+    let context_tag = match range {
+        TestRange::Position => 3,
+        TestRange::Sequence => 6,
+        TestRange::Time => 7,
+    };
+    tags::encode_opening_tag(buf, context_tag);
+    match range {
+        TestRange::Position | TestRange::Sequence => {
+            encode_application_value(buf, reference_tag, reference);
+        }
+        TestRange::Time => {
+            primitives::encode_app_date(
+                buf,
+                &Date {
+                    year: 126,
+                    month: 3,
+                    day: 1,
+                    day_of_week: 7,
+                },
+            );
+            primitives::encode_app_time(
+                buf,
+                &Time {
+                    hour: 14,
+                    minute: 30,
+                    second: 0,
+                    hundredths: 0,
+                },
+            );
+        }
+    }
+    encode_application_value(buf, count_tag, count);
+    tags::encode_closing_tag(buf, context_tag);
+}
+
+fn encode_ack(
+    property: &[u8],
+    array_index: Option<&[u8]>,
+    item_count: &[u8],
+    first_sequence_number: Option<&[u8]>,
+) -> BytesMut {
+    let mut buf = BytesMut::new();
+    primitives::encode_ctx_object_id(&mut buf, 0, &object_identifier());
+    encode_context_value(&mut buf, 1, property);
+    if let Some(index) = array_index {
+        encode_context_value(&mut buf, 2, index);
+    }
+    primitives::encode_ctx_bit_string(&mut buf, 3, 5, &[0xa0]);
+    encode_context_value(&mut buf, 4, item_count);
+    tags::encode_opening_tag(&mut buf, 5);
+    tags::encode_closing_tag(&mut buf, 5);
+    if let Some(sequence_number) = first_sequence_number {
+        encode_context_value(&mut buf, 6, sequence_number);
+    }
+    buf
+}
+
+#[test]
+fn request_unsigned_fields_accept_u32_max_with_leading_zero() {
+    let max = [0, 0xff, 0xff, 0xff, 0xff];
+    let mut by_position = request_prefix(&max, Some(&max));
+    append_range(
+        &mut by_position,
+        TestRange::Position,
+        tags::app_tag::UNSIGNED,
+        &max,
+        tags::app_tag::SIGNED,
+        &[1],
+    );
+    let decoded = ReadRangeRequest::decode(&by_position).unwrap();
+    assert_eq!(decoded.property_identifier.to_raw(), u32::MAX);
+    assert_eq!(decoded.property_array_index, Some(u32::MAX));
+    assert!(matches!(
+        decoded.range,
+        Some(RangeSpec::ByPosition {
+            reference_index: u32::MAX,
+            count: 1
+        })
+    ));
+
+    let mut by_sequence = request_prefix(&[0x83], None);
+    append_range(
+        &mut by_sequence,
+        TestRange::Sequence,
+        tags::app_tag::UNSIGNED,
+        &max,
+        tags::app_tag::SIGNED,
+        &[0xff],
+    );
+    assert!(matches!(
+        ReadRangeRequest::decode(&by_sequence).unwrap().range,
+        Some(RangeSpec::BySequenceNumber {
+            reference_seq: u32::MAX,
+            count: -1
+        })
+    ));
+}
+
+#[test]
+fn request_unsigned_fields_reject_u32_overflow() {
+    for value in [&[1, 0, 0, 0, 0][..], &[0xff; 8][..]] {
+        assert!(ReadRangeRequest::decode(&request_prefix(value, None)).is_err());
+        assert!(ReadRangeRequest::decode(&request_prefix(&[0x83], Some(value))).is_err());
+
+        for range in [TestRange::Position, TestRange::Sequence] {
+            let mut request = request_prefix(&[0x83], None);
+            append_range(
+                &mut request,
+                range,
+                tags::app_tag::UNSIGNED,
+                value,
+                tags::app_tag::SIGNED,
+                &[1],
+            );
+            assert!(ReadRangeRequest::decode(&request).is_err());
+        }
+    }
+}
+
+#[test]
+fn ack_unsigned_fields_enforce_u32_without_rejecting_leading_zero() {
+    let max = [0, 0xff, 0xff, 0xff, 0xff];
+    let decoded = ReadRangeAck::decode(&encode_ack(&max, Some(&max), &max, Some(&max))).unwrap();
+    assert_eq!(decoded.property_identifier.to_raw(), u32::MAX);
+    assert_eq!(decoded.property_array_index, Some(u32::MAX));
+    assert_eq!(decoded.item_count, u32::MAX);
+    assert_eq!(decoded.first_sequence_number, Some(u32::MAX));
+
+    for value in [&[1, 0, 0, 0, 0][..], &[0xff; 8][..]] {
+        assert!(ReadRangeAck::decode(&encode_ack(value, None, &[1], None)).is_err());
+        assert!(ReadRangeAck::decode(&encode_ack(&[0x83], Some(value), &[1], None)).is_err());
+        assert!(ReadRangeAck::decode(&encode_ack(&[0x83], None, value, None)).is_err());
+        assert!(ReadRangeAck::decode(&encode_ack(&[0x83], None, &[1], Some(value))).is_err());
+    }
+}
+
+#[test]
+fn range_counts_require_nonzero_integer16_values() {
+    for range in [TestRange::Position, TestRange::Sequence, TestRange::Time] {
+        for count in [
+            &[0][..],
+            &[0, 0][..],
+            &[0, 0x80, 0][..],
+            &[0xff, 0x7f, 0xff][..],
+        ] {
+            let mut request = request_prefix(&[0x83], None);
+            append_range(
+                &mut request,
+                range,
+                tags::app_tag::UNSIGNED,
+                &[1],
+                tags::app_tag::SIGNED,
+                count,
+            );
+            assert!(ReadRangeRequest::decode(&request).is_err());
+        }
+
+        for count in [&[0, 0x7f, 0xff][..], &[0xff, 0x80, 0][..]] {
+            let mut request = request_prefix(&[0x83], None);
+            append_range(
+                &mut request,
+                range,
+                tags::app_tag::UNSIGNED,
+                &[1],
+                tags::app_tag::SIGNED,
+                count,
+            );
+            assert!(ReadRangeRequest::decode(&request).is_ok());
+        }
+    }
+}
+
+#[test]
+fn range_members_require_their_application_tags_and_complete_content() {
+    let mut wrong_reference = request_prefix(&[0x83], None);
+    append_range(
+        &mut wrong_reference,
+        TestRange::Position,
+        tags::app_tag::ENUMERATED,
+        &[1],
+        tags::app_tag::SIGNED,
+        &[1],
+    );
+    assert!(ReadRangeRequest::decode(&wrong_reference).is_err());
+
+    let mut wrong_count = request_prefix(&[0x83], None);
+    append_range(
+        &mut wrong_count,
+        TestRange::Sequence,
+        tags::app_tag::UNSIGNED,
+        &[1],
+        tags::app_tag::UNSIGNED,
+        &[1],
+    );
+    assert!(ReadRangeRequest::decode(&wrong_count).is_err());
+
+    let mut wrong_date = request_prefix(&[0x83], None);
+    let date_offset = wrong_date.len() + 1;
+    append_range(
+        &mut wrong_date,
+        TestRange::Time,
+        tags::app_tag::UNSIGNED,
+        &[],
+        tags::app_tag::SIGNED,
+        &[1],
+    );
+    wrong_date[date_offset] = (tags::app_tag::TIME << 4) | 4;
+    assert!(ReadRangeRequest::decode(&wrong_date).is_err());
+
+    let mut wrong_time = request_prefix(&[0x83], None);
+    let time_offset = wrong_time.len() + 6;
+    append_range(
+        &mut wrong_time,
+        TestRange::Time,
+        tags::app_tag::UNSIGNED,
+        &[],
+        tags::app_tag::SIGNED,
+        &[1],
+    );
+    wrong_time[time_offset] = (tags::app_tag::DATE << 4) | 4;
+    assert!(ReadRangeRequest::decode(&wrong_time).is_err());
+
+    let mut trailing = request_prefix(&[0x83], None);
+    append_range(
+        &mut trailing,
+        TestRange::Position,
+        tags::app_tag::UNSIGNED,
+        &[1],
+        tags::app_tag::SIGNED,
+        &[1],
+    );
+    let closing_tag = trailing[trailing.len() - 1];
+    trailing.truncate(trailing.len() - 1);
+    trailing.extend_from_slice(&[0x00, closing_tag]);
+    assert!(ReadRangeRequest::decode(&trailing).is_err());
+}
+
+#[test]
+fn requests_require_normative_context_tags_and_range_choice() {
+    let mut wrong_object = request_prefix(&[0x83], None);
+    wrong_object[0] = 0x1c;
+    assert!(ReadRangeRequest::decode(&wrong_object).is_err());
+
+    let mut wrong_property = request_prefix(&[0x83], None);
+    wrong_property[5] = 0x09;
+    assert!(ReadRangeRequest::decode(&wrong_property).is_err());
+
+    assert!(ReadRangeRequest::decode(&request_prefix(&[0x83], Some(&[0]))).is_err());
+
+    for property_identifier in [8, 80, 105] {
+        assert!(ReadRangeRequest::decode(&request_prefix(&[property_identifier], None)).is_err());
+    }
+
+    let mut unknown_range = request_prefix(&[0x83], None);
+    tags::encode_opening_tag(&mut unknown_range, 4);
+    tags::encode_closing_tag(&mut unknown_range, 4);
+    assert!(ReadRangeRequest::decode(&unknown_range).is_err());
+
+    let mut trailing = request_prefix(&[0x83], None);
+    append_range(
+        &mut trailing,
+        TestRange::Position,
+        tags::app_tag::UNSIGNED,
+        &[1],
+        tags::app_tag::SIGNED,
+        &[1],
+    );
+    primitives::encode_app_null(&mut trailing);
+    assert!(ReadRangeRequest::decode(&trailing).is_err());
+}
+
+#[test]
+fn by_time_requires_a_specific_datetime() {
+    for (relative_offset, value) in [
+        (2, 0xff),
+        (3, 13),
+        (4, 32),
+        (5, 0xff),
+        (7, 24),
+        (8, 60),
+        (9, 60),
+        (10, 100),
+    ] {
+        let mut request = request_prefix(&[0x83], None);
+        let range_offset = request.len();
+        append_range(
+            &mut request,
+            TestRange::Time,
+            tags::app_tag::UNSIGNED,
+            &[],
+            tags::app_tag::SIGNED,
+            &[1],
+        );
+        request[range_offset + relative_offset] = value;
+        assert!(ReadRangeRequest::decode(&request).is_err());
+    }
+}
+
+#[test]
+fn acknowledgments_validate_flags_item_data_and_suffix() {
+    for (unused_bits, bits) in [
+        (4, &[0xa0][..]),
+        (5, &[][..]),
+        (5, &[0xa0, 0][..]),
+        (5, &[0xa1][..]),
+    ] {
+        let mut malformed_flags = BytesMut::new();
+        primitives::encode_ctx_object_id(&mut malformed_flags, 0, &object_identifier());
+        encode_context_value(&mut malformed_flags, 1, &[0x83]);
+        primitives::encode_ctx_bit_string(&mut malformed_flags, 3, unused_bits, bits);
+        encode_context_value(&mut malformed_flags, 4, &[1]);
+        tags::encode_opening_tag(&mut malformed_flags, 5);
+        tags::encode_closing_tag(&mut malformed_flags, 5);
+        assert!(ReadRangeAck::decode(&malformed_flags).is_err());
+    }
+
+    let mut primitive_item_data = encode_ack(&[0x83], None, &[1], None);
+    let opening = primitive_item_data.len() - 2;
+    primitive_item_data[opening] = 0x59;
+    assert!(ReadRangeAck::decode(&primitive_item_data).is_err());
+
+    assert!(ReadRangeAck::decode(&encode_ack(&[0x83], None, &[0], Some(&[1]))).is_err());
+
+    let mut wrong_first_sequence_tag = encode_ack(&[0x83], None, &[1], Some(&[1]));
+    let first_sequence_tag = wrong_first_sequence_tag.len() - 2;
+    wrong_first_sequence_tag[first_sequence_tag] = 0x21;
+    assert!(ReadRangeAck::decode(&wrong_first_sequence_tag).is_err());
+
+    let mut trailing = encode_ack(&[0x83], None, &[1], None);
+    encode_context_value(&mut trailing, 7, &[1]);
+    assert!(ReadRangeAck::decode(&trailing).is_err());
+}
+
+#[test]
+fn acknowledgments_require_mandatory_context_tags() {
+    for (offset, header) in [(0, 0x1c), (5, 0x09), (7, 0x2a), (10, 0x39)] {
+        let mut ack = encode_ack(&[0x83], None, &[1], None);
+        ack[offset] = header;
+        assert!(ReadRangeAck::decode(&ack).is_err());
+    }
+}

--- a/crates/rusty-bacnet/src/client/client_methods/object_device_alarm.rs
+++ b/crates/rusty-bacnet/src/client/client_methods/object_device_alarm.rs
@@ -291,6 +291,7 @@ impl BACnetClient {
                 dict.set_item("result_flags", ack.result_flags)?;
                 dict.set_item("item_count", ack.item_count)?;
                 dict.set_item("item_data", PyBytes::new(py, &ack.item_data))?;
+                dict.set_item("first_sequence_number", ack.first_sequence_number)?;
                 Ok(dict.into_any().unbind())
             })
         })

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -671,7 +671,7 @@ result = await client.read_range(
 )
 ```
 
-Return dict keys: `"object_id"`, `"property_id"`, `"array_index"`, `"result_flags"` (tuple of 3 bools), `"item_count"` (int), `"item_data"` (bytes).
+Return dict keys: `"object_id"`, `"property_id"`, `"array_index"`, `"result_flags"` (tuple of 3 bools), `"item_count"` (int), `"item_data"` (bytes), and `"first_sequence_number"` (int or `None`).
 
 ---
 


### PR DESCRIPTION
## Summary

- Reject ReadRange numeric overflow and malformed request/ACK framing before server lookup or client exposure.
- Preserve the existing public `u32`/`i32` fields and accept numerically in-range leading-zero Unsigned encodings.
- Reduce the #309 direct-cast inventory from 72 to 64 sites.

## Standard scope

- ANSI/ASHRAE 135-2020 Clause 15.8.1.1: request fields, prohibited special property identifiers, nonzero array index, optional Range CHOICE, nonzero `INTEGER16` Count, and specific By-Time datetime.
- Clause 15.8.1.2: Result Flags, Item Count, Item Data, and conditional First Sequence Number.
- Clause 21: `ReadRange-Request` and `ReadRange-ACK` formal productions.
- Clause 3: definitions of specific date, time, and datetime.

No conformance ledger or public support claim changes are included.

## Implementation

- Replace eight unchecked `u64 as u32` conversions with value-based checked decoding.
- Require the specified context and application tags, complete Range members, exact three-bit Result Flags, and complete service payload consumption.
- Reject `ALL`, `REQUIRED`, and `OPTIONAL`, zero request array indexes, invalid By-Time components, zero or out-of-range `INTEGER16` counts, impossible First Sequence Number values, and empty/nonempty Item Count contradictions.
- Validate echoed object, property, and array identifiers in the Rust client before returning an ACK.
- Include `first_sequence_number` in the Python result dictionary.

Valid wire output and public Rust/Python method signatures are unchanged. The Python result dictionary gains the decoded `first_sequence_number` field.

## Tests

Commands run:

```bash
cargo check -p rusty-bacnet --tests --locked
cargo test --workspace --exclude rusty-bacnet --locked
cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls
cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked
cargo fmt --all -- --check
git diff --cached --check
bash .github/scripts/check-file-size.sh
bash .github/scripts/check-no-secrets.sh
```

New tests cover every narrowed field, `u32::MAX` with a leading zero, overflow and `u64::MAX`, `INTEGER16` boundaries, wrong tags, invalid CHOICE members, incomplete/trailing sequences, malformed Result Flags, nonspecific datetimes, prohibited property selectors, Item Count contradictions, and request/ACK correlation.

## Known limitations

- Public `u32` fields do not represent the Unsigned64 reference values required for object types with Unsigned64 `Total_Record_Count`; this PR preserves the existing API boundary.
- The in-tree server still models By-Sequence selection as list position and omits First Sequence Number. That behavior is tracked in #339; the client rejects impossible First Sequence Number values but remains compatible with an omitted value.
- ComplexACK service-choice correlation belongs to the client TSM/APDU layer and is tracked in #341.
- Shared nested context-tag validation remains tracked in #327.

## Performance

No hot-path or allocation strategy changes; benchmarks were not required.

Progresses #309.
Follow-ups: #339, #341.