### PR TITLE
fix(services): harden COV unsigned decoding

### DIFF
--- a/crates/bacnet-services/src/common.rs
+++ b/crates/bacnet-services/src/common.rs
@@ -44,6 +44,26 @@ pub(crate) fn decode_context_u32(
     Ok((value, end))
 }
 
+pub(crate) fn decode_context_bool(
+    data: &[u8],
+    offset: usize,
+    expected_tag: u8,
+    field: &str,
+) -> Result<(bool, usize), Error> {
+    let (content, end) = decode_context(data, offset, expected_tag, field)?;
+    let value = match content {
+        [0] => false,
+        [1] => true,
+        _ => {
+            return Err(Error::decoding(
+                offset,
+                format!("{field} expected Boolean 0 or 1"),
+            ));
+        }
+    };
+    Ok((value, end))
+}
+
 #[derive(Clone, Copy)]
 pub(crate) enum PropertyValueBoundary {
     End,

--- a/crates/bacnet-services/src/cov.rs
+++ b/crates/bacnet-services/src/cov.rs
@@ -7,7 +7,10 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
 
-use crate::common::{BACnetPropertyValue, MAX_DECODED_ITEMS};
+use crate::common::{
+    decode_context, decode_context_bool, decode_context_u32, BACnetPropertyValue,
+    PropertyReference, MAX_DECODED_ITEMS,
+};
 
 // ---------------------------------------------------------------------------
 // SubscribeCOVRequest
@@ -49,46 +52,39 @@ impl SubscribeCOVRequest {
         let mut offset = 0;
 
         // [0] subscriber-process-identifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(pos, "SubscribeCOV truncated at process-id"));
-        }
-        let subscriber_process_identifier = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (subscriber_process_identifier, end) =
+            decode_context_u32(data, offset, 0, "SubscribeCOV process-id")?;
         offset = end;
 
         // [1] monitored-object-identifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(pos, "SubscribeCOV truncated at object-id"));
-        }
-        let monitored_object_identifier = ObjectIdentifier::decode(&data[pos..end])?;
+        let (content, end) = decode_context(data, offset, 1, "SubscribeCOV object-id")?;
+        let monitored_object_identifier = ObjectIdentifier::decode(content)?;
         offset = end;
 
         // [2] issue-confirmed-notifications (optional)
         let mut issue_confirmed_notifications = None;
         if offset < data.len() {
-            let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 2)?;
-            if let Some(content) = opt_data {
-                if content.is_empty() {
-                    return Err(Error::decoding(
-                        offset,
-                        "SubscribeCOV: empty confirmed-notifications field",
-                    ));
-                }
-                issue_confirmed_notifications = Some(content[0] != 0);
-                offset = new_offset;
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(2) {
+                let (value, end) =
+                    decode_context_bool(data, offset, 2, "SubscribeCOV confirmed-notifications")?;
+                issue_confirmed_notifications = Some(value);
+                offset = end;
             }
         }
 
         // [3] lifetime (optional)
         let mut lifetime = None;
         if offset < data.len() {
-            let (opt_data, _new_offset) = tags::decode_optional_context(data, offset, 3)?;
-            if let Some(content) = opt_data {
-                lifetime = Some(primitives::decode_unsigned(content)? as u32);
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(3) {
+                let (value, end) = decode_context_u32(data, offset, 3, "SubscribeCOV lifetime")?;
+                lifetime = Some(value);
+                offset = end;
             }
+        }
+        if offset != data.len() {
+            return Err(Error::decoding(offset, "SubscribeCOV has trailing data"));
         }
 
         Ok(Self {
@@ -155,98 +151,87 @@ impl SubscribeCOVPropertyRequest {
         let mut offset = 0;
 
         // [0] subscriberProcessIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        if tag.number != 0 {
-            return Err(Error::decoding(pos, "expected context 0 for process-id"));
-        }
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::buffer_too_short(end, data.len()));
-        }
-        let subscriber_process_identifier = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (subscriber_process_identifier, end) =
+            decode_context_u32(data, offset, 0, "SubscribeCOVProperty process-id")?;
         offset = end;
 
         // [1] monitoredObjectIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        if tag.number != 1 {
-            return Err(Error::decoding(pos, "expected context 1 for object-id"));
-        }
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::buffer_too_short(end, data.len()));
-        }
-        let monitored_object_identifier = ObjectIdentifier::decode(&data[pos..end])?;
+        let (content, end) = decode_context(data, offset, 1, "SubscribeCOVProperty object-id")?;
+        let monitored_object_identifier = ObjectIdentifier::decode(content)?;
         offset = end;
 
         // [2] issueConfirmedNotifications (optional)
         let mut issue_confirmed_notifications = None;
         if offset < data.len() {
-            let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 2)?;
-            if let Some(content) = opt_data {
-                issue_confirmed_notifications = Some(!content.is_empty() && content[0] != 0);
-                offset = new_offset;
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(2) {
+                let (value, end) = decode_context_bool(
+                    data,
+                    offset,
+                    2,
+                    "SubscribeCOVProperty confirmed-notifications",
+                )?;
+                issue_confirmed_notifications = Some(value);
+                offset = end;
             }
         }
 
         // [3] lifetime (optional)
         let mut lifetime = None;
         if offset < data.len() {
-            let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 3)?;
-            if let Some(content) = opt_data {
-                lifetime = Some(primitives::decode_unsigned(content)? as u32);
-                offset = new_offset;
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(3) {
+                let (value, end) =
+                    decode_context_u32(data, offset, 3, "SubscribeCOVProperty lifetime")?;
+                lifetime = Some(value);
+                offset = end;
             }
         }
 
         // [4] monitoredPropertyIdentifier (BACnetPropertyReference)
         let (tag, pos) = tags::decode_tag(data, offset)?;
-        if tag.number != 4 {
+        if !tag.is_opening_tag(4) {
             return Err(Error::decoding(
-                pos,
-                "expected context 4 for monitored-property",
+                offset,
+                "SubscribeCOVProperty expected opening tag 4",
             ));
         }
-        offset = pos;
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::buffer_too_short(end, data.len()));
-        }
-        let monitored_property_identifier =
-            PropertyIdentifier::from_raw(primitives::decode_unsigned(&data[pos..end])? as u32);
+        let (monitored_property, end) = PropertyReference::decode(data, pos)?;
         offset = end;
-
-        // [1] propertyArrayIndex (optional)
-        let mut monitored_property_array_index = None;
-        if offset < data.len() {
-            let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 1)?;
-            if let Some(content) = opt_data {
-                monitored_property_array_index = Some(primitives::decode_unsigned(content)? as u32);
-                offset = new_offset;
-            }
+        let (tag, end) = tags::decode_tag(data, offset)?;
+        if !tag.is_closing_tag(4) {
+            return Err(Error::decoding(
+                offset,
+                "SubscribeCOVProperty expected closing tag 4",
+            ));
         }
-
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        offset = pos;
+        offset = end;
 
         // [5] covIncrement (optional)
         let mut cov_increment = None;
         if offset < data.len() {
-            let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 5)?;
-            if let Some(content) = opt_data {
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(5) {
+                let (content, end) =
+                    decode_context(data, offset, 5, "SubscribeCOVProperty COV increment")?;
                 cov_increment = Some(primitives::decode_real(content)?);
-                offset = new_offset;
+                offset = end;
             }
         }
-        let _ = offset; // suppress unused
+        if offset != data.len() {
+            return Err(Error::decoding(
+                offset,
+                "SubscribeCOVProperty has trailing data",
+            ));
+        }
 
         Ok(Self {
             subscriber_process_identifier,
             monitored_object_identifier,
             issue_confirmed_notifications,
             lifetime,
-            monitored_property_identifier,
-            monitored_property_array_index,
+            monitored_property_identifier: monitored_property.property_identifier,
+            monitored_property_array_index: monitored_property.property_array_index,
             cov_increment,
         })
     }
@@ -290,51 +275,23 @@ impl COVNotificationRequest {
         let mut offset = 0;
 
         // [0] subscriber-process-identifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "COVNotification truncated at process-id",
-            ));
-        }
-        let subscriber_process_identifier = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (subscriber_process_identifier, end) =
+            decode_context_u32(data, offset, 0, "COVNotification process-id")?;
         offset = end;
 
         // [1] initiating-device-identifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "COVNotification truncated at device-id",
-            ));
-        }
-        let initiating_device_identifier = ObjectIdentifier::decode(&data[pos..end])?;
+        let (content, end) = decode_context(data, offset, 1, "COVNotification device-id")?;
+        let initiating_device_identifier = ObjectIdentifier::decode(content)?;
         offset = end;
 
         // [2] monitored-object-identifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "COVNotification truncated at monitored-id",
-            ));
-        }
-        let monitored_object_identifier = ObjectIdentifier::decode(&data[pos..end])?;
+        let (content, end) = decode_context(data, offset, 2, "COVNotification monitored-id")?;
+        let monitored_object_identifier = ObjectIdentifier::decode(content)?;
         offset = end;
 
         // [3] time-remaining
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "COVNotification truncated at time-remaining",
-            ));
-        }
-        let time_remaining = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (time_remaining, end) =
+            decode_context_u32(data, offset, 3, "COVNotification time-remaining")?;
         offset = end;
 
         // [4] list-of-values (opening tag 4)
@@ -370,7 +327,9 @@ impl COVNotificationRequest {
             values.push(pv);
             offset = new_offset;
         }
-        let _ = offset;
+        if offset != data.len() {
+            return Err(Error::decoding(offset, "COVNotification has trailing data"));
+        }
 
         Ok(Self {
             subscriber_process_identifier,
@@ -381,6 +340,10 @@ impl COVNotificationRequest {
         })
     }
 }
+
+#[cfg(test)]
+#[path = "cov_width_tests.rs"]
+mod width_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/bacnet-services/src/cov_multiple.rs
+++ b/crates/bacnet-services/src/cov_multiple.rs
@@ -7,9 +7,10 @@ use bacnet_types::enums::PropertyIdentifier;
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier};
 use bytes::BytesMut;
-use std::convert::TryFrom;
 
-use crate::common::{PropertyReference, MAX_DECODED_ITEMS};
+use crate::common::{
+    decode_context, decode_context_bool, decode_context_u32, PropertyReference, MAX_DECODED_ITEMS,
+};
 
 // ---------------------------------------------------------------------------
 // SubscribeCOVPropertyMultipleRequest
@@ -86,61 +87,51 @@ impl SubscribeCOVPropertyMultipleRequest {
         let mut offset = 0;
 
         // [0] subscriberProcessIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "SubscribeCOVPropertyMultiple truncated at process-id",
-            ));
-        }
-        let subscriber_process_identifier = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (subscriber_process_identifier, end) =
+            decode_context_u32(data, offset, 0, "SubscribeCOVPropertyMultiple process-id")?;
         offset = end;
 
         // [1] issueConfirmedNotifications
         let mut issue_confirmed_notifications = None;
         if offset < data.len() {
-            let field_offset = offset;
-            let (opt, new_off) = tags::decode_optional_context(data, offset, 1)?;
-            if let Some(content) = opt {
-                if content.len() != 1 {
-                    return Err(Error::decoding(
-                        field_offset,
-                        "SubscribeCOVPropertyMultiple malformed issue-confirmed-notifications",
-                    ));
-                }
-                issue_confirmed_notifications = Some(content[0] != 0);
-                offset = new_off;
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(1) {
+                let (value, end) = decode_context_bool(
+                    data,
+                    offset,
+                    1,
+                    "SubscribeCOVPropertyMultiple confirmed-notifications",
+                )?;
+                issue_confirmed_notifications = Some(value);
+                offset = end;
             }
         }
 
         // [2] lifetime OPTIONAL
         let mut lifetime = None;
         if offset < data.len() {
-            let field_offset = offset;
-            let (opt, new_off) = tags::decode_optional_context(data, offset, 2)?;
-            if let Some(content) = opt {
-                lifetime = Some(decode_u32_context(
-                    content,
-                    field_offset,
-                    "SubscribeCOVPropertyMultiple lifetime",
-                )?);
-                offset = new_off;
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(2) {
+                let (value, end) =
+                    decode_context_u32(data, offset, 2, "SubscribeCOVPropertyMultiple lifetime")?;
+                lifetime = Some(value);
+                offset = end;
             }
         }
 
         // [3] maxNotificationDelay OPTIONAL
         let mut max_notification_delay = None;
         if offset < data.len() {
-            let field_offset = offset;
-            let (opt, new_off) = tags::decode_optional_context(data, offset, 3)?;
-            if let Some(content) = opt {
-                max_notification_delay = Some(decode_u32_context(
-                    content,
-                    field_offset,
+            let (tag, _) = tags::decode_tag(data, offset)?;
+            if tag.is_context(3) {
+                let (value, end) = decode_context_u32(
+                    data,
+                    offset,
+                    3,
                     "SubscribeCOVPropertyMultiple max-notification-delay",
-                )?);
-                offset = new_off;
+                )?;
+                max_notification_delay = Some(value);
+                offset = end;
             }
         }
 
@@ -172,14 +163,9 @@ impl SubscribeCOVPropertyMultipleRequest {
             }
 
             // [0] monitoredObjectIdentifier
-            let end = tag_end + tag.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(
-                    tag_end,
-                    "SubscribeCOVPropertyMultiple truncated at object-id",
-                ));
-            }
-            let oid = ObjectIdentifier::decode(&data[tag_end..end])?;
+            let (content, end) =
+                decode_context(data, offset, 0, "SubscribeCOVPropertyMultiple object-id")?;
+            let oid = ObjectIdentifier::decode(content)?;
             offset = end;
 
             // [1] listOfCovReferences — opening tag 1
@@ -218,7 +204,13 @@ impl SubscribeCOVPropertyMultipleRequest {
                 }
                 let (prop_ref, new_off) = PropertyReference::decode(data, tag_end)?;
                 offset = new_off;
-                let (_tag, tag_end) = tags::decode_tag(data, offset)?;
+                let (tag, tag_end) = tags::decode_tag(data, offset)?;
+                if !tag.is_closing_tag(0) {
+                    return Err(Error::decoding(
+                        offset,
+                        "SubscribeCOVPropertyMultiple expected closing tag 0",
+                    ));
+                }
                 offset = tag_end;
 
                 // [1] covIncrement OPTIONAL
@@ -234,10 +226,16 @@ impl SubscribeCOVPropertyMultipleRequest {
                 // [2] timestamped DEFAULT FALSE
                 let mut timestamped = false;
                 if offset < data.len() {
-                    let (opt, new_off) = tags::decode_optional_context(data, offset, 2)?;
-                    if let Some(content) = opt {
-                        timestamped = !content.is_empty() && content[0] != 0;
-                        offset = new_off;
+                    let (tag, _) = tags::decode_tag(data, offset)?;
+                    if tag.is_context(2) {
+                        let (value, end) = decode_context_bool(
+                            data,
+                            offset,
+                            2,
+                            "SubscribeCOVPropertyMultiple timestamped",
+                        )?;
+                        timestamped = value;
+                        offset = end;
                     }
                 }
 
@@ -253,7 +251,12 @@ impl SubscribeCOVPropertyMultipleRequest {
                 list_of_cov_references: refs,
             });
         }
-        let _ = offset;
+        if offset != data.len() {
+            return Err(Error::decoding(
+                offset,
+                "SubscribeCOVPropertyMultiple has trailing data",
+            ));
+        }
 
         Ok(Self {
             subscriber_process_identifier,
@@ -263,11 +266,6 @@ impl SubscribeCOVPropertyMultipleRequest {
             list_of_cov_subscription_specifications: specs,
         })
     }
-}
-
-fn decode_u32_context(content: &[u8], offset: usize, field: &str) -> Result<u32, Error> {
-    let value = primitives::decode_unsigned(content)?;
-    u32::try_from(value).map_err(|_| Error::decoding(offset, format!("{field} out of range")))
 }
 
 // ---------------------------------------------------------------------------
@@ -346,39 +344,18 @@ impl COVNotificationMultipleRequest {
         let mut offset = 0;
 
         // [0] subscriberProcessIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "COVNotificationMultiple truncated at process-id",
-            ));
-        }
-        let subscriber_process_identifier = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (subscriber_process_identifier, end) =
+            decode_context_u32(data, offset, 0, "COVNotificationMultiple process-id")?;
         offset = end;
 
         // [1] initiatingDeviceIdentifier
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "COVNotificationMultiple truncated at device-id",
-            ));
-        }
-        let initiating_device_identifier = ObjectIdentifier::decode(&data[pos..end])?;
+        let (content, end) = decode_context(data, offset, 1, "COVNotificationMultiple device-id")?;
+        let initiating_device_identifier = ObjectIdentifier::decode(content)?;
         offset = end;
 
         // [2] timeRemaining
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(
-                pos,
-                "COVNotificationMultiple truncated at time-remaining",
-            ));
-        }
-        let time_remaining = primitives::decode_unsigned(&data[pos..end])? as u32;
+        let (time_remaining, end) =
+            decode_context_u32(data, offset, 2, "COVNotificationMultiple time-remaining")?;
         offset = end;
 
         // [3] timestamp
@@ -413,14 +390,9 @@ impl COVNotificationMultipleRequest {
             }
 
             // [0] monitoredObjectIdentifier
-            let end = tag_end + tag.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(
-                    tag_end,
-                    "COVNotificationMultiple truncated at monitored-id",
-                ));
-            }
-            let oid = ObjectIdentifier::decode(&data[tag_end..end])?;
+            let (content, end) =
+                decode_context(data, offset, 0, "COVNotificationMultiple monitored-id")?;
+            let oid = ObjectIdentifier::decode(content)?;
             offset = end;
 
             // [1] listOfValues — opening tag 1
@@ -451,23 +423,23 @@ impl COVNotificationMultipleRequest {
                 }
 
                 // [0] propertyIdentifier
-                let end = tag_end + tag.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        tag_end,
-                        "COVNotificationMultiple truncated at property-id",
-                    ));
-                }
-                let prop_id = primitives::decode_unsigned(&data[tag_end..end])? as u32;
+                let (prop_id, end) =
+                    decode_context_u32(data, offset, 0, "COVNotificationMultiple property-id")?;
                 offset = end;
 
                 // [1] propertyArrayIndex OPTIONAL
                 let mut array_index = None;
                 if offset < data.len() {
-                    let (opt, new_off) = tags::decode_optional_context(data, offset, 1)?;
-                    if let Some(content) = opt {
-                        array_index = Some(primitives::decode_unsigned(content)? as u32);
-                        offset = new_off;
+                    let (tag, _) = tags::decode_tag(data, offset)?;
+                    if tag.is_context(1) {
+                        let (value, end) = decode_context_u32(
+                            data,
+                            offset,
+                            1,
+                            "COVNotificationMultiple array-index",
+                        )?;
+                        array_index = Some(value);
+                        offset = end;
                     }
                 }
 
@@ -509,7 +481,12 @@ impl COVNotificationMultipleRequest {
                 list_of_values: values,
             });
         }
-        let _ = offset;
+        if offset != data.len() {
+            return Err(Error::decoding(
+                offset,
+                "COVNotificationMultiple has trailing data",
+            ));
+        }
 
         Ok(Self {
             subscriber_process_identifier,
@@ -520,6 +497,10 @@ impl COVNotificationMultipleRequest {
         })
     }
 }
+
+#[cfg(test)]
+#[path = "cov_multiple_width_tests.rs"]
+mod width_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/bacnet-services/src/cov_multiple_width_tests.rs
+++ b/crates/bacnet-services/src/cov_multiple_width_tests.rs
@@ -1,0 +1,167 @@
+use super::*;
+use bacnet_types::enums::ObjectType;
+
+const MAX_WITH_LEADING_ZERO: &[u8] = &[0, 0xff, 0xff, 0xff, 0xff];
+const ONE: &[u8] = &[1];
+
+fn encode_context_value(buf: &mut BytesMut, number: u8, value: &[u8]) {
+    tags::encode_tag(buf, number, tags::TagClass::Context, value.len() as u32);
+    buf.extend_from_slice(value);
+}
+
+fn subscribe_cov_multiple(
+    process_id: &[u8],
+    lifetime: Option<&[u8]>,
+    max_notification_delay: Option<&[u8]>,
+) -> BytesMut {
+    let mut buf = BytesMut::new();
+    encode_context_value(&mut buf, 0, process_id);
+    primitives::encode_ctx_boolean(&mut buf, 1, true);
+    if let Some(lifetime) = lifetime {
+        encode_context_value(&mut buf, 2, lifetime);
+    }
+    if let Some(delay) = max_notification_delay {
+        encode_context_value(&mut buf, 3, delay);
+    }
+    tags::encode_opening_tag(&mut buf, 4);
+    tags::encode_closing_tag(&mut buf, 4);
+    buf
+}
+
+fn cov_notification_multiple(
+    process_id: &[u8],
+    time_remaining: &[u8],
+    property_id: &[u8],
+    array_index: Option<&[u8]>,
+) -> BytesMut {
+    let mut buf = BytesMut::new();
+    encode_context_value(&mut buf, 0, process_id);
+    primitives::encode_ctx_object_id(
+        &mut buf,
+        1,
+        &ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap(),
+    );
+    encode_context_value(&mut buf, 2, time_remaining);
+    primitives::encode_timestamp(&mut buf, 3, &BACnetTimeStamp::SequenceNumber(1)).unwrap();
+    tags::encode_opening_tag(&mut buf, 4);
+    primitives::encode_ctx_object_id(
+        &mut buf,
+        0,
+        &ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+    );
+    tags::encode_opening_tag(&mut buf, 1);
+    encode_context_value(&mut buf, 0, property_id);
+    if let Some(array_index) = array_index {
+        encode_context_value(&mut buf, 1, array_index);
+    }
+    tags::encode_opening_tag(&mut buf, 2);
+    buf.extend_from_slice(&[0]);
+    tags::encode_closing_tag(&mut buf, 2);
+    tags::encode_closing_tag(&mut buf, 1);
+    tags::encode_closing_tag(&mut buf, 4);
+    buf
+}
+
+#[test]
+fn cov_multiple_unsigned_fields_accept_u32_max_with_leading_zero() {
+    let decoded = SubscribeCOVPropertyMultipleRequest::decode(&subscribe_cov_multiple(
+        MAX_WITH_LEADING_ZERO,
+        Some(MAX_WITH_LEADING_ZERO),
+        Some(MAX_WITH_LEADING_ZERO),
+    ))
+    .unwrap();
+    assert_eq!(decoded.subscriber_process_identifier, u32::MAX);
+    assert_eq!(decoded.lifetime, Some(u32::MAX));
+    assert_eq!(decoded.max_notification_delay, Some(u32::MAX));
+
+    let decoded = COVNotificationMultipleRequest::decode(&cov_notification_multiple(
+        MAX_WITH_LEADING_ZERO,
+        MAX_WITH_LEADING_ZERO,
+        MAX_WITH_LEADING_ZERO,
+        Some(MAX_WITH_LEADING_ZERO),
+    ))
+    .unwrap();
+    assert_eq!(decoded.subscriber_process_identifier, u32::MAX);
+    assert_eq!(decoded.time_remaining, u32::MAX);
+    let value = &decoded.list_of_cov_notifications[0].list_of_values[0];
+    assert_eq!(value.property_identifier.to_raw(), u32::MAX);
+    assert_eq!(value.property_array_index, Some(u32::MAX));
+}
+
+#[test]
+fn cov_multiple_unsigned_fields_reject_u32_overflow() {
+    for value in [&[1, 0, 0, 0, 0][..], &[0xff; 8][..]] {
+        assert!(
+            SubscribeCOVPropertyMultipleRequest::decode(
+                &subscribe_cov_multiple(value, None, None,)
+            )
+            .is_err()
+        );
+        assert!(
+            SubscribeCOVPropertyMultipleRequest::decode(&subscribe_cov_multiple(
+                ONE,
+                Some(value),
+                None,
+            ))
+            .is_err()
+        );
+        assert!(
+            SubscribeCOVPropertyMultipleRequest::decode(&subscribe_cov_multiple(
+                ONE,
+                None,
+                Some(value),
+            ))
+            .is_err()
+        );
+
+        assert!(
+            COVNotificationMultipleRequest::decode(&cov_notification_multiple(
+                value, ONE, ONE, None,
+            ))
+            .is_err()
+        );
+        assert!(
+            COVNotificationMultipleRequest::decode(&cov_notification_multiple(
+                ONE, value, ONE, None,
+            ))
+            .is_err()
+        );
+        assert!(
+            COVNotificationMultipleRequest::decode(&cov_notification_multiple(
+                ONE, ONE, value, None,
+            ))
+            .is_err()
+        );
+        assert!(
+            COVNotificationMultipleRequest::decode(&cov_notification_multiple(
+                ONE,
+                ONE,
+                ONE,
+                Some(value),
+            ))
+            .is_err()
+        );
+    }
+}
+
+#[test]
+fn cov_multiple_decoders_reject_wrong_tags_malformed_booleans_and_trailing_data() {
+    let mut wrong_tag = subscribe_cov_multiple(ONE, None, None);
+    wrong_tag[0] = 0x21;
+    assert!(SubscribeCOVPropertyMultipleRequest::decode(&wrong_tag).is_err());
+
+    let mut malformed_boolean = BytesMut::new();
+    encode_context_value(&mut malformed_boolean, 0, ONE);
+    encode_context_value(&mut malformed_boolean, 1, &[2]);
+    tags::encode_opening_tag(&mut malformed_boolean, 4);
+    tags::encode_closing_tag(&mut malformed_boolean, 4);
+    assert!(SubscribeCOVPropertyMultipleRequest::decode(&malformed_boolean).is_err());
+
+    let mut subscription = subscribe_cov_multiple(ONE, None, None);
+    subscription.extend_from_slice(&[0]);
+    assert!(SubscribeCOVPropertyMultipleRequest::decode(&subscription).is_err());
+
+    let mut notification = cov_notification_multiple(ONE, ONE, ONE, None);
+    notification.extend_from_slice(&[0]);
+    assert!(COVNotificationMultipleRequest::decode(&notification).is_err());
+}

--- a/crates/bacnet-services/src/cov_width_tests.rs
+++ b/crates/bacnet-services/src/cov_width_tests.rs
@@ -1,0 +1,155 @@
+use super::*;
+use bacnet_types::enums::ObjectType;
+
+const MAX_WITH_LEADING_ZERO: &[u8] = &[0, 0xff, 0xff, 0xff, 0xff];
+const ONE: &[u8] = &[1];
+
+fn object_identifier() -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap()
+}
+
+fn encode_context_value(buf: &mut BytesMut, number: u8, value: &[u8]) {
+    tags::encode_tag(buf, number, tags::TagClass::Context, value.len() as u32);
+    buf.extend_from_slice(value);
+}
+
+fn subscribe_cov(process_id: &[u8], lifetime: Option<&[u8]>) -> BytesMut {
+    let mut buf = BytesMut::new();
+    encode_context_value(&mut buf, 0, process_id);
+    primitives::encode_ctx_object_id(&mut buf, 1, &object_identifier());
+    primitives::encode_ctx_boolean(&mut buf, 2, true);
+    if let Some(lifetime) = lifetime {
+        encode_context_value(&mut buf, 3, lifetime);
+    }
+    buf
+}
+
+fn subscribe_cov_property(
+    process_id: &[u8],
+    lifetime: &[u8],
+    property_id: &[u8],
+    array_index: Option<&[u8]>,
+) -> BytesMut {
+    let mut buf = BytesMut::new();
+    encode_context_value(&mut buf, 0, process_id);
+    primitives::encode_ctx_object_id(&mut buf, 1, &object_identifier());
+    primitives::encode_ctx_boolean(&mut buf, 2, true);
+    encode_context_value(&mut buf, 3, lifetime);
+    tags::encode_opening_tag(&mut buf, 4);
+    encode_context_value(&mut buf, 0, property_id);
+    if let Some(array_index) = array_index {
+        encode_context_value(&mut buf, 1, array_index);
+    }
+    tags::encode_closing_tag(&mut buf, 4);
+    buf
+}
+
+fn cov_notification(process_id: &[u8], time_remaining: &[u8]) -> BytesMut {
+    let mut buf = BytesMut::new();
+    encode_context_value(&mut buf, 0, process_id);
+    primitives::encode_ctx_object_id(
+        &mut buf,
+        1,
+        &ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap(),
+    );
+    primitives::encode_ctx_object_id(&mut buf, 2, &object_identifier());
+    encode_context_value(&mut buf, 3, time_remaining);
+    tags::encode_opening_tag(&mut buf, 4);
+    BACnetPropertyValue {
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+        value: vec![0],
+        priority: None,
+    }
+    .encode(&mut buf);
+    tags::encode_closing_tag(&mut buf, 4);
+    buf
+}
+
+#[test]
+fn cov_unsigned_fields_accept_u32_max_with_leading_zero() {
+    let decoded = SubscribeCOVRequest::decode(&subscribe_cov(
+        MAX_WITH_LEADING_ZERO,
+        Some(MAX_WITH_LEADING_ZERO),
+    ))
+    .unwrap();
+    assert_eq!(decoded.subscriber_process_identifier, u32::MAX);
+    assert_eq!(decoded.lifetime, Some(u32::MAX));
+
+    let decoded = SubscribeCOVPropertyRequest::decode(&subscribe_cov_property(
+        MAX_WITH_LEADING_ZERO,
+        MAX_WITH_LEADING_ZERO,
+        MAX_WITH_LEADING_ZERO,
+        Some(MAX_WITH_LEADING_ZERO),
+    ))
+    .unwrap();
+    assert_eq!(decoded.subscriber_process_identifier, u32::MAX);
+    assert_eq!(decoded.lifetime, Some(u32::MAX));
+    assert_eq!(decoded.monitored_property_identifier.to_raw(), u32::MAX);
+    assert_eq!(decoded.monitored_property_array_index, Some(u32::MAX));
+
+    let decoded = COVNotificationRequest::decode(&cov_notification(
+        MAX_WITH_LEADING_ZERO,
+        MAX_WITH_LEADING_ZERO,
+    ))
+    .unwrap();
+    assert_eq!(decoded.subscriber_process_identifier, u32::MAX);
+    assert_eq!(decoded.time_remaining, u32::MAX);
+}
+
+#[test]
+fn cov_unsigned_fields_reject_u32_overflow() {
+    for value in [&[1, 0, 0, 0, 0][..], &[0xff; 8][..]] {
+        assert!(SubscribeCOVRequest::decode(&subscribe_cov(value, Some(ONE))).is_err());
+        assert!(SubscribeCOVRequest::decode(&subscribe_cov(ONE, Some(value))).is_err());
+
+        assert!(SubscribeCOVPropertyRequest::decode(&subscribe_cov_property(
+            value, ONE, ONE, None,
+        ))
+        .is_err());
+        assert!(SubscribeCOVPropertyRequest::decode(&subscribe_cov_property(
+            ONE, value, ONE, None,
+        ))
+        .is_err());
+        assert!(SubscribeCOVPropertyRequest::decode(&subscribe_cov_property(
+            ONE, ONE, value, None,
+        ))
+        .is_err());
+        assert!(SubscribeCOVPropertyRequest::decode(&subscribe_cov_property(
+            ONE,
+            ONE,
+            ONE,
+            Some(value),
+        ))
+        .is_err());
+
+        assert!(COVNotificationRequest::decode(&cov_notification(value, ONE)).is_err());
+        assert!(COVNotificationRequest::decode(&cov_notification(ONE, value)).is_err());
+    }
+}
+
+#[test]
+fn cov_decoders_reject_wrong_tags_malformed_booleans_and_trailing_data() {
+    let mut wrong_tag = subscribe_cov(ONE, Some(ONE));
+    wrong_tag[0] = 0x21;
+    assert!(SubscribeCOVRequest::decode(&wrong_tag).is_err());
+
+    let mut malformed_boolean = BytesMut::new();
+    encode_context_value(&mut malformed_boolean, 0, ONE);
+    primitives::encode_ctx_object_id(&mut malformed_boolean, 1, &object_identifier());
+    encode_context_value(&mut malformed_boolean, 2, &[2]);
+    encode_context_value(&mut malformed_boolean, 3, ONE);
+    assert!(SubscribeCOVRequest::decode(&malformed_boolean).is_err());
+
+    let mut subscription = subscribe_cov(ONE, Some(ONE));
+    subscription.extend_from_slice(&[0]);
+    assert!(SubscribeCOVRequest::decode(&subscription).is_err());
+
+    let mut property = subscribe_cov_property(ONE, ONE, ONE, None);
+    property.extend_from_slice(&[0]);
+    assert!(SubscribeCOVPropertyRequest::decode(&property).is_err());
+
+    let mut notification = cov_notification(ONE, ONE);
+    notification.extend_from_slice(&[0]);
+    assert!(COVNotificationRequest::decode(&notification).is_err());
+}


### PR DESCRIPTION
## Summary

- Reject COV-family Unsigned values whose numeric value exceeds the existing public `u32` fields.
- Require the expected primitive context tags, Boolean encodings, local property-reference closings, and complete service payload consumption.
- Preserve numerically in-range leading-zero Unsigned encodings and reduce the #309 direct-cast inventory from 64 to 51 sites.

## Standard scope

- ANSI/ASHRAE 135-2020 Clauses 13.14 through 13.17: SubscribeCOV, SubscribeCOVProperty, SubscribeCOVPropertyMultiple, and COV notification service parameters.
- Clause 21: the corresponding request productions and context tag numbers.
- Clause 21 `Unsigned32` boundaries for subscriber process identifiers; existing `u32` API boundaries for lifetime, delay, property, array-index, and time-remaining fields.

No conformance ledger or public support claim changes are included.

## Implementation

- Route all 13 former unchecked `u64 as u32` conversions in `cov.rs` and `cov_multiple.rs` through value-based checked decoding.
- Reuse the shared checked context decoder for exact primitive context tags and add a private strict context Boolean decoder accepting only one-octet `00` and `01`.
- Decode the SubscribeCOVProperty nested property reference through the shared checked codec.
- Validate explicit local property-reference closing tags and reject trailing service bytes in all five affected decoders.

Public Rust and Python field types and method signatures are unchanged.

## Tests

Commands run:

```bash
cargo check -p rusty-bacnet --tests --locked
cargo test --workspace --exclude rusty-bacnet --locked
cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls
cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked
cargo fmt --all -- --check
git diff --cached --check
bash .github/scripts/check-file-size.sh
bash .github/scripts/check-no-secrets.sh
```

Focused tests cover all affected fields with five-octet leading-zero `u32::MAX`, `u32::MAX + 1`, and `u64::MAX`, plus wrong tag classes, malformed context Booleans, and trailing data. Existing codec, server mutation, client notification, integration, and Python checks also pass.

## Known limitations

- The COV Multiple public wire model differs from the Standard for request-level timestamp, time-of-change, and required Boolean fields; the API-level correction is tracked in #342.
- Shared nested constructed closing-tag validation remains tracked in #327.
- Subscription policy, retry/renewal behavior, and service-specific error mapping are unchanged.

## Performance

No hot-path allocation strategy changes; benchmarks were not required.

Progresses #309.
Follow-up: #342.