### PR TITLE
docs(agents): avoid duplicate ready reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ Default behavior:
 - Use read-only exploration first.
 - Spawn subagents only for complex, parallel, or verification-heavy work.
 - Keep subagent prompts scoped and evidence-led.
+- Treat a READY review as final for that head SHA. If the head changes, rerun only review lanes affected by the new diff.
 - Synthesize findings into a single decision or plan.
 - Record commands, files, symbols, and sources used as evidence.
 - Keep PRs small: one BACnet layer, state-machine family, or measured hotspot per PR.


### PR DESCRIPTION
## Summary

- Treat READY as final for the reviewed head SHA.
- After a head change, rerun only review lanes affected by the new diff.

This reduces duplicate review-agent usage without weakening review coverage after code changes.

## Tests

Documentation-only agent guidance change; `git diff --check` passes.