### PR TITLE
fix(services): harden GetEventInformation end to end

### DIFF
--- a/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
@@ -19,16 +19,20 @@ pub fn handle_get_event_information(
     let request = GetEventInformationRequest::decode(service_data)?;
 
     let mut summaries = Vec::new();
-    let mut skipping = request.last_received_object_identifier.is_some();
     let mut more_events = false;
+    let cursor = request
+        .last_received_object_identifier
+        .map(|identifier| identifier.encode());
+    let mut object_identifiers = db.list_objects();
+    object_identifiers.sort_unstable_by_key(ObjectIdentifier::encode);
 
-    for (oid, object) in db.iter_objects() {
-        if skipping {
-            if Some(oid) == request.last_received_object_identifier {
-                skipping = false;
-            }
+    for oid in object_identifiers {
+        if cursor.is_some_and(|cursor| oid.encode() <= cursor) {
             continue;
         }
+        let Some(object) = db.get(&oid) else {
+            continue;
+        };
 
         // Clause 12.12: Event_Detection_Enable controls whether the object is
         // considered by the event-summarization services. Checked after the
@@ -50,7 +54,7 @@ pub fn handle_get_event_information(
                     .read_property(PropertyIdentifier::NOTIFICATION_CLASS, None)
                     .ok()
                     .and_then(|v| match v {
-                        PropertyValue::Unsigned(n) => Some(n as u32),
+                        PropertyValue::Unsigned(n) => u32::try_from(n).ok(),
                         _ => None,
                     })
                     .unwrap_or(0);
@@ -85,8 +89,20 @@ pub fn handle_get_event_information(
                                 .ok()
                         })
                         .and_then(|v| match v {
-                            PropertyValue::OctetString(bytes) if bytes.len() == 3 => {
-                                Some([bytes[0] as u32, bytes[1] as u32, bytes[2] as u32])
+                            PropertyValue::List(items) => {
+                                let [
+                                    PropertyValue::Unsigned(offnormal),
+                                    PropertyValue::Unsigned(fault),
+                                    PropertyValue::Unsigned(normal),
+                                ] = items.as_slice()
+                                else {
+                                    return None;
+                                };
+                                Some([
+                                    u32::try_from(*offnormal).ok()?,
+                                    u32::try_from(*fault).ok()?,
+                                    u32::try_from(*normal).ok()?,
+                                ])
                             }
                             _ => None,
                         })
@@ -107,7 +123,21 @@ pub fn handle_get_event_information(
                     .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
                     .ok()
                     .and_then(|v| match v {
-                        PropertyValue::List(items) if items.len() == 3 => None,
+                        PropertyValue::List(items) => {
+                            let [
+                                PropertyValue::Unsigned(offnormal),
+                                PropertyValue::Unsigned(fault),
+                                PropertyValue::Unsigned(normal),
+                            ] = items.as_slice()
+                            else {
+                                return None;
+                            };
+                            Some([
+                                BACnetTimeStamp::SequenceNumber(*offnormal),
+                                BACnetTimeStamp::SequenceNumber(*fault),
+                                BACnetTimeStamp::SequenceNumber(*normal),
+                            ])
+                        }
                         _ => None,
                     })
                     .unwrap_or([

--- a/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
@@ -25,6 +25,7 @@ pub fn handle_get_event_information(
         .map(|identifier| identifier.encode());
     let mut object_identifiers = db.list_objects();
     object_identifiers.sort_unstable_by_key(ObjectIdentifier::encode);
+    let notification_class_identifiers = db.find_by_type(ObjectType::NOTIFICATION_CLASS);
 
     for oid in object_identifiers {
         if cursor.is_some_and(|cursor| oid.encode() <= cursor) {
@@ -79,34 +80,41 @@ pub fn handle_get_event_information(
                     })
                     .unwrap_or(0);
 
-                let event_priorities =
-                    ObjectIdentifier::new(ObjectType::NOTIFICATION_CLASS, notification_class)
-                        .ok()
-                        .and_then(|nc_oid| db.get(&nc_oid))
-                        .and_then(|nc_obj| {
-                            nc_obj
-                                .read_property(PropertyIdentifier::PRIORITY, None)
-                                .ok()
-                        })
-                        .and_then(|v| match v {
-                            PropertyValue::List(items) => {
-                                let [
-                                    PropertyValue::Unsigned(offnormal),
-                                    PropertyValue::Unsigned(fault),
-                                    PropertyValue::Unsigned(normal),
-                                ] = items.as_slice()
-                                else {
-                                    return None;
-                                };
-                                Some([
-                                    u32::try_from(*offnormal).ok()?,
-                                    u32::try_from(*fault).ok()?,
-                                    u32::try_from(*normal).ok()?,
-                                ])
-                            }
-                            _ => None,
-                        })
-                        .unwrap_or([0, 0, 0]);
+                let matching_notification_class =
+                    notification_class_identifiers.iter().find_map(|nc_oid| {
+                        let nc_obj = db.get(nc_oid)?;
+                        matches!(
+                            nc_obj.read_property(PropertyIdentifier::NOTIFICATION_CLASS, None),
+                            Ok(PropertyValue::Unsigned(class_number))
+                                if class_number == u64::from(notification_class)
+                        )
+                        .then_some(nc_obj)
+                    });
+                let event_priorities = matching_notification_class
+                    .and_then(|nc_obj| {
+                        nc_obj
+                            .read_property(PropertyIdentifier::PRIORITY, None)
+                            .ok()
+                    })
+                    .and_then(|v| match v {
+                        PropertyValue::List(items) => {
+                            let [
+                                PropertyValue::Unsigned(offnormal),
+                                PropertyValue::Unsigned(fault),
+                                PropertyValue::Unsigned(normal),
+                            ] = items.as_slice()
+                            else {
+                                return None;
+                            };
+                            Some([
+                                u32::try_from(*offnormal).ok()?,
+                                u32::try_from(*fault).ok()?,
+                                u32::try_from(*normal).ok()?,
+                            ])
+                        }
+                        _ => None,
+                    })
+                    .unwrap_or([0, 0, 0]);
 
                 let acked = object
                     .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
@@ -132,10 +140,13 @@ pub fn handle_get_event_information(
                             else {
                                 return None;
                             };
+                            let offnormal = u16::try_from(*offnormal).ok()?;
+                            let fault = u16::try_from(*fault).ok()?;
+                            let normal = u16::try_from(*normal).ok()?;
                             Some([
-                                BACnetTimeStamp::SequenceNumber(*offnormal),
-                                BACnetTimeStamp::SequenceNumber(*fault),
-                                BACnetTimeStamp::SequenceNumber(*normal),
+                                BACnetTimeStamp::SequenceNumber(offnormal.into()),
+                                BACnetTimeStamp::SequenceNumber(fault.into()),
+                                BACnetTimeStamp::SequenceNumber(normal.into()),
                             ])
                         }
                         _ => None,

--- a/crates/bacnet-server/src/handlers/tests/device_event.rs
+++ b/crates/bacnet-server/src/handlers/tests/device_event.rs
@@ -303,7 +303,7 @@ fn get_event_information_reads_event_enable_notify_type_and_priorities() {
     ai.write_property(
         PropertyIdentifier::NOTIFICATION_CLASS,
         None,
-        PropertyValue::Unsigned(5),
+        PropertyValue::Unsigned(7),
         None,
     )
     .unwrap();
@@ -314,6 +314,7 @@ fn get_event_information_reads_event_enable_notify_type_and_priorities() {
 
     // Add NotificationClass object with custom priorities
     let mut nc = NotificationClass::new(5, "NC-5").unwrap();
+    nc.notification_class = 7;
     nc.priority = [100, 150, 200];
     db.add(Box::new(nc)).unwrap();
 
@@ -333,9 +334,11 @@ fn get_event_information_reads_event_enable_notify_type_and_priorities() {
 }
 
 #[test]
-fn get_event_information_forwards_sequence_timestamps() {
+fn get_event_information_forwards_valid_sequence_timestamps_and_defaults_invalid_array() {
     let mut db = ObjectDatabase::new();
-    db.add(Box::new(event_summary_fixture(1, [11, 22, 33])))
+    db.add(Box::new(event_summary_fixture(1, [11, 65535, 33])))
+        .unwrap();
+    db.add(Box::new(event_summary_fixture(2, [65536, 44, 55])))
         .unwrap();
 
     let ack = get_event_information_ack(&db, None);
@@ -343,8 +346,16 @@ fn get_event_information_forwards_sequence_timestamps() {
         ack.list_of_event_summaries[0].event_timestamps,
         [
             BACnetTimeStamp::SequenceNumber(11),
-            BACnetTimeStamp::SequenceNumber(22),
+            BACnetTimeStamp::SequenceNumber(65535),
             BACnetTimeStamp::SequenceNumber(33),
+        ]
+    );
+    assert_eq!(
+        ack.list_of_event_summaries[1].event_timestamps,
+        [
+            BACnetTimeStamp::SequenceNumber(0),
+            BACnetTimeStamp::SequenceNumber(0),
+            BACnetTimeStamp::SequenceNumber(0),
         ]
     );
 }

--- a/crates/bacnet-server/src/handlers/tests/device_event.rs
+++ b/crates/bacnet-server/src/handlers/tests/device_event.rs
@@ -1,5 +1,104 @@
 use super::*;
 
+struct EventSummaryFixture {
+    oid: ObjectIdentifier,
+    name: String,
+    timestamps: [u64; 3],
+}
+
+impl BACnetObject for EventSummaryFixture {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        &self.name
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        match property {
+            p if p == PropertyIdentifier::EVENT_DETECTION_ENABLE => {
+                Ok(PropertyValue::Boolean(true))
+            }
+            p if p == PropertyIdentifier::EVENT_STATE => {
+                Ok(PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw()))
+            }
+            p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(0)),
+            p if p == PropertyIdentifier::EVENT_ENABLE => Ok(PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0xa0],
+            }),
+            p if p == PropertyIdentifier::NOTIFY_TYPE => Ok(PropertyValue::Enumerated(1)),
+            p if p == PropertyIdentifier::ACKED_TRANSITIONS => Ok(PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0x40],
+            }),
+            p if p == PropertyIdentifier::EVENT_TIME_STAMPS => Ok(PropertyValue::List(
+                self.timestamps
+                    .into_iter()
+                    .map(PropertyValue::Unsigned)
+                    .collect(),
+            )),
+            _ => Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            }),
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> std::borrow::Cow<'static, [PropertyIdentifier]> {
+        static PROPERTIES: &[PropertyIdentifier] = &[
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+        ];
+        std::borrow::Cow::Borrowed(PROPERTIES)
+    }
+}
+
+fn event_summary_fixture(instance: u32, timestamps: [u64; 3]) -> EventSummaryFixture {
+    EventSummaryFixture {
+        oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap(),
+        name: format!("AI-{instance}"),
+        timestamps,
+    }
+}
+
+fn get_event_information_ack(
+    db: &ObjectDatabase,
+    cursor: Option<ObjectIdentifier>,
+) -> GetEventInformationAck {
+    let request = GetEventInformationRequest {
+        last_received_object_identifier: cursor,
+    };
+    let mut request_buf = BytesMut::new();
+    request.encode(&mut request_buf);
+    let mut ack_buf = BytesMut::new();
+    handle_get_event_information(db, &request_buf, &mut ack_buf).unwrap();
+    GetEventInformationAck::decode(&ack_buf).unwrap()
+}
+
 #[test]
 fn device_communication_control_handler() {
     let comm_state = AtomicU8::new(0);
@@ -145,7 +244,7 @@ fn get_event_information_reports_non_normal_objects() {
 }
 
 #[test]
-fn get_event_information_reads_event_enable_and_notify_type() {
+fn get_event_information_reads_event_enable_notify_type_and_priorities() {
     use bacnet_objects::event::LimitEnable;
     use bacnet_objects::notification_class::NotificationClass;
 
@@ -226,34 +325,55 @@ fn get_event_information_reads_event_enable_and_notify_type() {
 
     let mut ack_buf = BytesMut::new();
     handle_get_event_information(&db, &buf, &mut ack_buf).unwrap();
-    let ack_bytes = ack_buf.to_vec();
-    assert!(
-        ack_bytes.len() > 10,
-        "ACK should contain event summary data"
-    );
+    let ack = GetEventInformationAck::decode(&ack_buf).unwrap();
+    let summary = &ack.list_of_event_summaries[0];
+    assert_eq!(summary.event_enable, 0x05);
+    assert_eq!(summary.notify_type, 1);
+    assert_eq!(summary.event_priorities, [100, 150, 200]);
+}
 
-    // Verify the object reads EVENT_ENABLE=0x05 and NOTIFY_TYPE=1 (EVENT)
-    let ai_oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-    let ai_ref = db.get(&ai_oid).unwrap();
-    let ev_enable = ai_ref
-        .read_property(PropertyIdentifier::EVENT_ENABLE, None)
+#[test]
+fn get_event_information_forwards_sequence_timestamps() {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(event_summary_fixture(1, [11, 22, 33])))
         .unwrap();
-    match ev_enable {
-        PropertyValue::BitString { data, .. } => {
-            assert_eq!(
-                bacnet_types::bitstring::unpack_octet(&data, 3),
-                0x05,
-                "EVENT_ENABLE should be 0x05"
-            );
-        }
-        other => panic!("expected BitString, got {:?}", other),
-    }
-    let notify = ai_ref
-        .read_property(PropertyIdentifier::NOTIFY_TYPE, None)
-        .unwrap();
+
+    let ack = get_event_information_ack(&db, None);
     assert_eq!(
-        notify,
-        PropertyValue::Enumerated(1),
-        "NOTIFY_TYPE should be EVENT(1)"
+        ack.list_of_event_summaries[0].event_timestamps,
+        [
+            BACnetTimeStamp::SequenceNumber(11),
+            BACnetTimeStamp::SequenceNumber(22),
+            BACnetTimeStamp::SequenceNumber(33),
+        ]
     );
+}
+
+#[test]
+fn get_event_information_paginates_by_object_identifier_after_cursor_removal() {
+    let mut db = ObjectDatabase::new();
+    for instance in (1..=27).rev() {
+        db.add(Box::new(event_summary_fixture(instance, [0; 3])))
+            .unwrap();
+    }
+
+    let first_page = get_event_information_ack(&db, None);
+    let first_instances: Vec<_> = first_page
+        .list_of_event_summaries
+        .iter()
+        .map(|summary| summary.object_identifier.instance_number())
+        .collect();
+    assert_eq!(first_instances, (1..=25).collect::<Vec<_>>());
+    assert!(first_page.more_events);
+
+    let cursor = first_page.list_of_event_summaries[24].object_identifier;
+    db.remove(&cursor).unwrap();
+    let second_page = get_event_information_ack(&db, Some(cursor));
+    let second_instances: Vec<_> = second_page
+        .list_of_event_summaries
+        .iter()
+        .map(|summary| summary.object_identifier.instance_number())
+        .collect();
+    assert_eq!(second_instances, vec![26, 27]);
+    assert!(!second_page.more_events);
 }

--- a/crates/bacnet-services/src/alarm_event/get_event_information.rs
+++ b/crates/bacnet-services/src/alarm_event/get_event_information.rs
@@ -1,4 +1,42 @@
 use super::*;
+use crate::common::{decode_context, decode_context_bool, decode_context_u32};
+
+fn decode_event_transition_bits(
+    data: &[u8],
+    offset: usize,
+    expected_tag: u8,
+    field: &str,
+) -> Result<(u8, usize), Error> {
+    let (content, end) = decode_context(data, offset, expected_tag, field)?;
+    let (unused_bits, bits) = primitives::decode_bit_string(content)?;
+    if unused_bits != 5 || bits.len() != 1 || bits[0] & 0x1f != 0 {
+        return Err(Error::decoding(
+            offset,
+            format!("{field} must contain three bits with zero padding"),
+        ));
+    }
+    Ok((bacnet_types::bitstring::unpack_octet(&bits, 3), end))
+}
+
+fn decode_application_u32(data: &[u8], offset: usize, field: &str) -> Result<(u32, usize), Error> {
+    let (tag, pos) = tags::decode_tag(data, offset)?;
+    if tag.class != tags::TagClass::Application || tag.number != tags::app_tag::UNSIGNED {
+        return Err(Error::decoding(
+            offset,
+            format!("{field} expected application Unsigned"),
+        ));
+    }
+    let end = pos
+        .checked_add(tag.length as usize)
+        .ok_or_else(|| Error::decoding(pos, format!("{field} length overflow")))?;
+    if end > data.len() {
+        return Err(Error::decoding(pos, format!("{field} truncated")));
+    }
+    let value = primitives::decode_unsigned(&data[pos..end])?;
+    let value = u32::try_from(value)
+        .map_err(|_| Error::decoding(offset, format!("{field} exceeds u32")))?;
+    Ok((value, end))
+}
 
 // GetEventInformation
 // ---------------------------------------------------------------------------
@@ -22,12 +60,19 @@ impl GetEventInformationRequest {
                 last_received_object_identifier: None,
             });
         }
-        let (opt_data, _) = tags::decode_optional_context(data, 0, 0)?;
-        let last_received_object_identifier = if let Some(content) = opt_data {
-            Some(ObjectIdentifier::decode(content)?)
-        } else {
-            None
-        };
+        let (content, end) = decode_context(
+            data,
+            0,
+            0,
+            "GetEventInformation last-received-object-identifier",
+        )?;
+        if end != data.len() {
+            return Err(Error::decoding(
+                end,
+                "GetEventInformation request contains trailing data",
+            ));
+        }
+        let last_received_object_identifier = Some(ObjectIdentifier::decode(content)?);
         Ok(Self {
             last_received_object_identifier,
         })
@@ -62,134 +107,107 @@ pub struct EventSummary {
 impl GetEventInformationAck {
     /// Decode a GetEventInformationAck from wire bytes.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        let mut offset = 0;
-
-        // [0] listOfEventSummaries — opening tag
-        let (tag, pos) = tags::decode_tag(data, offset)?;
+        let (tag, mut offset) = tags::decode_tag(data, 0)?;
         if !tag.is_opening_tag(0) {
-            return Err(Error::decoding(offset, "expected opening tag [0]"));
+            return Err(Error::decoding(
+                0,
+                "GetEventInformation ACK expected opening tag 0",
+            ));
         }
-        offset = pos;
 
         let mut list_of_event_summaries = Vec::new();
-
-        // Parse event summaries until closing tag [0]
         loop {
-            let (tag, _) = tags::decode_tag(data, offset)?;
+            let (tag, next) = tags::decode_tag(data, offset)?;
             if tag.is_closing_tag(0) {
-                // advance past the closing tag byte(s)
-                let (_, close_pos) = tags::decode_tag(data, offset)?;
-                offset = close_pos;
+                offset = next;
                 break;
             }
-
-            // [0] objectIdentifier
-            let (tag, pos) = tags::decode_tag(data, offset)?;
-            let end = pos + tag.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(pos, "GetEventInfoAck truncated at oid"));
-            }
-            let object_identifier = ObjectIdentifier::decode(&data[pos..end])?;
-            offset = end;
-
-            // [1] eventState
-            let (tag, pos) = tags::decode_tag(data, offset)?;
-            let end = pos + tag.length as usize;
-            if end > data.len() {
+            if list_of_event_summaries.len() >= MAX_DECODED_ITEMS {
                 return Err(Error::decoding(
-                    pos,
-                    "GetEventInfoAck truncated at eventState",
+                    offset,
+                    format!("GetEventInformation ACK exceeds {MAX_DECODED_ITEMS} event summaries"),
                 ));
             }
-            let event_state = primitives::decode_unsigned(&data[pos..end])? as u32;
+
+            let (content, end) =
+                decode_context(data, offset, 0, "GetEventInformation ACK object-identifier")?;
+            let object_identifier = ObjectIdentifier::decode(content)?;
             offset = end;
 
-            // [2] acknowledgedTransitions (3-bit bitstring)
-            let (tag, pos) = tags::decode_tag(data, offset)?;
-            let end = pos + tag.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(pos, "truncated at ackedTransitions"));
-            }
-            // Content: [unused_bits_count, bit_data...]
-            let acknowledged_transitions = if end > pos + 1 {
-                bacnet_types::bitstring::unpack_octet(&[data[pos + 1]], 3)
-            } else {
-                0
-            };
+            let (event_state, end) =
+                decode_context_u32(data, offset, 1, "GetEventInformation ACK event-state")?;
             offset = end;
 
-            // [3] eventTimeStamps — opening tag
-            let (tag, pos) = tags::decode_tag(data, offset)?;
+            let (acknowledged_transitions, end) = decode_event_transition_bits(
+                data,
+                offset,
+                2,
+                "GetEventInformation ACK acknowledged-transitions",
+            )?;
+            offset = end;
+
+            let (tag, next) = tags::decode_tag(data, offset)?;
             if !tag.is_opening_tag(3) {
-                return Err(Error::decoding(offset, "expected opening tag [3]"));
+                return Err(Error::decoding(
+                    offset,
+                    "GetEventInformation ACK expected opening tag 3 for event-timestamps",
+                ));
             }
-            offset = pos;
+            offset = next;
             let mut event_timestamps = [
                 BACnetTimeStamp::SequenceNumber(0),
                 BACnetTimeStamp::SequenceNumber(0),
                 BACnetTimeStamp::SequenceNumber(0),
             ];
             for ts in &mut event_timestamps {
-                // Each BACnetTimeStamp is a bare CHOICE item of the
-                // SEQUENCE OF — the shared primitives codec owns the one
-                // conformant encoding (time [0] as a primitive ctx tag 0).
                 let (decoded_ts, new_offset) = primitives::decode_timestamp_choice(data, offset)?;
                 *ts = decoded_ts;
                 offset = new_offset;
             }
-            // closing tag [3]
-            let (tag, _) = tags::decode_tag(data, offset)?;
+            let (tag, next) = tags::decode_tag(data, offset)?;
             if !tag.is_closing_tag(3) {
-                return Err(Error::decoding(offset, "expected closing tag [3]"));
+                return Err(Error::decoding(
+                    offset,
+                    "GetEventInformation ACK expected closing tag 3 for event-timestamps",
+                ));
             }
-            let (_, close_pos) = tags::decode_tag(data, offset)?;
-            offset = close_pos;
+            offset = next;
 
-            // [4] notifyType
-            let (tag, pos) = tags::decode_tag(data, offset)?;
-            let end = pos + tag.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(pos, "truncated at notifyType"));
-            }
-            let notify_type = primitives::decode_unsigned(&data[pos..end])? as u32;
+            let (notify_type, end) =
+                decode_context_u32(data, offset, 4, "GetEventInformation ACK notify-type")?;
             offset = end;
 
-            // [5] eventEnable (3-bit bitstring)
-            let (tag, pos) = tags::decode_tag(data, offset)?;
-            let end = pos + tag.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(pos, "truncated at eventEnable"));
-            }
-            let event_enable = if end > pos + 1 {
-                bacnet_types::bitstring::unpack_octet(&[data[pos + 1]], 3)
-            } else {
-                0
-            };
+            let (event_enable, end) = decode_event_transition_bits(
+                data,
+                offset,
+                5,
+                "GetEventInformation ACK event-enable",
+            )?;
             offset = end;
 
-            // [6] eventPriorities — opening tag
-            let (tag, pos) = tags::decode_tag(data, offset)?;
+            let (tag, next) = tags::decode_tag(data, offset)?;
             if !tag.is_opening_tag(6) {
-                return Err(Error::decoding(offset, "expected opening tag [6]"));
+                return Err(Error::decoding(
+                    offset,
+                    "GetEventInformation ACK expected opening tag 6 for event-priorities",
+                ));
             }
-            offset = pos;
+            offset = next;
             let mut event_priorities = [0u32; 3];
             for pri in &mut event_priorities {
-                let (tag, pos) = tags::decode_tag(data, offset)?;
-                let end = pos + tag.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(pos, "truncated priority"));
-                }
-                *pri = primitives::decode_unsigned(&data[pos..end])? as u32;
+                let (value, end) =
+                    decode_application_u32(data, offset, "GetEventInformation ACK event-priority")?;
+                *pri = value;
                 offset = end;
             }
-            // closing tag [6]
-            let (tag, _) = tags::decode_tag(data, offset)?;
+            let (tag, next) = tags::decode_tag(data, offset)?;
             if !tag.is_closing_tag(6) {
-                return Err(Error::decoding(offset, "expected closing tag [6]"));
+                return Err(Error::decoding(
+                    offset,
+                    "GetEventInformation ACK expected closing tag 6 for event-priorities",
+                ));
             }
-            let (_, close_pos) = tags::decode_tag(data, offset)?;
-            offset = close_pos;
+            offset = next;
 
             list_of_event_summaries.push(EventSummary {
                 object_identifier,
@@ -203,13 +221,14 @@ impl GetEventInformationAck {
             });
         }
 
-        // [1] moreEvents
-        let (tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + tag.length as usize;
-        if end > data.len() {
-            return Err(Error::decoding(pos, "truncated at moreEvents"));
+        let (more_events, end) =
+            decode_context_bool(data, offset, 1, "GetEventInformation ACK more-events")?;
+        if end != data.len() {
+            return Err(Error::decoding(
+                end,
+                "GetEventInformation ACK contains trailing data",
+            ));
         }
-        let more_events = data[pos] != 0;
 
         Ok(Self {
             list_of_event_summaries,

--- a/crates/bacnet-services/src/alarm_event/get_event_information.rs
+++ b/crates/bacnet-services/src/alarm_event/get_event_information.rs
@@ -8,14 +8,13 @@ fn decode_event_transition_bits(
     field: &str,
 ) -> Result<(u8, usize), Error> {
     let (content, end) = decode_context(data, offset, expected_tag, field)?;
-    let (unused_bits, bits) = primitives::decode_bit_string(content)?;
-    if unused_bits != 5 || bits.len() != 1 || bits[0] & 0x1f != 0 {
+    if content.len() != 2 || content[0] != 5 || content[1] & 0x1f != 0 {
         return Err(Error::decoding(
             offset,
             format!("{field} must contain three bits with zero padding"),
         ));
     }
-    Ok((bacnet_types::bitstring::unpack_octet(&bits, 3), end))
+    Ok((bacnet_types::bitstring::unpack_octet(&content[1..], 3), end))
 }
 
 fn decode_application_u32(data: &[u8], offset: usize, field: &str) -> Result<(u32, usize), Error> {

--- a/crates/bacnet-services/src/alarm_event/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/mod.rs
@@ -1,8 +1,8 @@
-//! Alarm and event services per ASHRAE 135-2020 Clauses 13.2–13.9.
+//! Alarm and event services per ASHRAE 135-2020 Clauses 13.5, 13.8-13.9, and 13.12.
 //!
-//! - AcknowledgeAlarm (Clause 13.3)
-//! - ConfirmedEventNotification / UnconfirmedEventNotification (Clause 13.5/13.6)
-//! - GetEventInformation (Clause 13.9)
+//! - AcknowledgeAlarm (Clause 13.5)
+//! - ConfirmedEventNotification / UnconfirmedEventNotification (Clauses 13.8-13.9)
+//! - GetEventInformation (Clause 13.12)
 
 use bacnet_encoding::{primitives, tags};
 use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetPropertyStates};

--- a/crates/bacnet-services/src/alarm_event/tests/get_event_information_decode.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/get_event_information_decode.rs
@@ -1,0 +1,315 @@
+use super::*;
+use bacnet_encoding::tags::{self, TagClass};
+
+const ONE: &[u8] = &[1];
+const TRANSITIONS: &[u8] = &[5, 0xa0];
+const U32_MAX_PADDED: &[u8] = &[0, 0xff, 0xff, 0xff, 0xff];
+const U32_OVERFLOW: &[u8] = &[1, 0, 0, 0, 0];
+const U64_MAX: &[u8] = &[0xff; 8];
+
+#[derive(Clone, Copy)]
+struct AckTags {
+    list_open: u8,
+    list_close: u8,
+    object_identifier: u8,
+    event_state: u8,
+    acknowledged_transitions: u8,
+    timestamps_open: u8,
+    timestamps_close: u8,
+    notify_type: u8,
+    event_enable: u8,
+    priorities_open: u8,
+    priorities_close: u8,
+    more_events: u8,
+}
+
+impl Default for AckTags {
+    fn default() -> Self {
+        Self {
+            list_open: 0,
+            list_close: 0,
+            object_identifier: 0,
+            event_state: 1,
+            acknowledged_transitions: 2,
+            timestamps_open: 3,
+            timestamps_close: 3,
+            notify_type: 4,
+            event_enable: 5,
+            priorities_open: 6,
+            priorities_close: 6,
+            more_events: 1,
+        }
+    }
+}
+
+struct SummaryWire<'a> {
+    tags: AckTags,
+    event_state: &'a [u8],
+    acknowledged_transitions: &'a [u8],
+    timestamp_count: usize,
+    notify_type: &'a [u8],
+    event_enable: &'a [u8],
+    priorities: Vec<&'a [u8]>,
+    priority_class: TagClass,
+    priority_tag: u8,
+}
+
+fn valid_wire() -> SummaryWire<'static> {
+    SummaryWire {
+        tags: AckTags::default(),
+        event_state: ONE,
+        acknowledged_transitions: TRANSITIONS,
+        timestamp_count: 3,
+        notify_type: ONE,
+        event_enable: TRANSITIONS,
+        priorities: vec![ONE, ONE, ONE],
+        priority_class: TagClass::Application,
+        priority_tag: tags::app_tag::UNSIGNED,
+    }
+}
+
+fn encode_value(buf: &mut BytesMut, class: TagClass, number: u8, content: &[u8]) {
+    tags::encode_tag(buf, number, class, content.len() as u32);
+    buf.extend_from_slice(content);
+}
+
+fn encode_summary(buf: &mut BytesMut, wire: &SummaryWire<'_>) {
+    let object_identifier = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    primitives::encode_ctx_object_id(buf, wire.tags.object_identifier, &object_identifier);
+    encode_value(
+        buf,
+        TagClass::Context,
+        wire.tags.event_state,
+        wire.event_state,
+    );
+    encode_value(
+        buf,
+        TagClass::Context,
+        wire.tags.acknowledged_transitions,
+        wire.acknowledged_transitions,
+    );
+    tags::encode_opening_tag(buf, wire.tags.timestamps_open);
+    for value in 0..wire.timestamp_count {
+        primitives::encode_timestamp_choice(buf, &BACnetTimeStamp::SequenceNumber(value as u64))
+            .unwrap();
+    }
+    tags::encode_closing_tag(buf, wire.tags.timestamps_close);
+    encode_value(
+        buf,
+        TagClass::Context,
+        wire.tags.notify_type,
+        wire.notify_type,
+    );
+    encode_value(
+        buf,
+        TagClass::Context,
+        wire.tags.event_enable,
+        wire.event_enable,
+    );
+    tags::encode_opening_tag(buf, wire.tags.priorities_open);
+    for priority in &wire.priorities {
+        encode_value(buf, wire.priority_class, wire.priority_tag, priority);
+    }
+    tags::encode_closing_tag(buf, wire.tags.priorities_close);
+}
+
+fn encode_ack(
+    wire: &SummaryWire<'_>,
+    summary_count: usize,
+    more_events: &[u8],
+    trailing: &[u8],
+) -> BytesMut {
+    let mut buf = BytesMut::new();
+    tags::encode_opening_tag(&mut buf, wire.tags.list_open);
+    for _ in 0..summary_count {
+        encode_summary(&mut buf, wire);
+    }
+    tags::encode_closing_tag(&mut buf, wire.tags.list_close);
+    encode_value(
+        &mut buf,
+        TagClass::Context,
+        wire.tags.more_events,
+        more_events,
+    );
+    buf.extend_from_slice(trailing);
+    buf
+}
+
+#[test]
+fn request_rejects_wrong_tag_and_trailing_data() {
+    let object_identifier = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let mut wrong_tag = BytesMut::new();
+    primitives::encode_ctx_object_id(&mut wrong_tag, 1, &object_identifier);
+    assert!(GetEventInformationRequest::decode(&wrong_tag).is_err());
+
+    let mut trailing = BytesMut::new();
+    primitives::encode_ctx_object_id(&mut trailing, 0, &object_identifier);
+    trailing.extend_from_slice(&[0]);
+    assert!(GetEventInformationRequest::decode(&trailing).is_err());
+}
+
+#[test]
+fn ack_accepts_u32_max_with_leading_zero_octet() {
+    let mut wire = valid_wire();
+    wire.event_state = U32_MAX_PADDED;
+    wire.notify_type = U32_MAX_PADDED;
+    wire.priorities = vec![U32_MAX_PADDED; 3];
+
+    let decoded = GetEventInformationAck::decode(&encode_ack(&wire, 1, &[1], &[])).unwrap();
+    let summary = &decoded.list_of_event_summaries[0];
+    assert_eq!(summary.event_state, u32::MAX);
+    assert_eq!(summary.notify_type, u32::MAX);
+    assert_eq!(summary.event_priorities, [u32::MAX; 3]);
+}
+
+#[derive(Clone, Copy, Debug)]
+enum NumericField {
+    EventState,
+    NotifyType,
+    Priority(usize),
+}
+
+#[test]
+fn ack_rejects_all_unsigned_values_above_u32() {
+    let fields = [
+        NumericField::EventState,
+        NumericField::NotifyType,
+        NumericField::Priority(0),
+        NumericField::Priority(1),
+        NumericField::Priority(2),
+    ];
+    for value in [U32_OVERFLOW, U64_MAX] {
+        for field in fields {
+            let mut wire = valid_wire();
+            match field {
+                NumericField::EventState => wire.event_state = value,
+                NumericField::NotifyType => wire.notify_type = value,
+                NumericField::Priority(index) => wire.priorities[index] = value,
+            }
+            assert!(
+                GetEventInformationAck::decode(&encode_ack(&wire, 1, &[0], &[])).is_err(),
+                "{field:?} accepted {value:?}"
+            );
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum TagField {
+    ListOpen,
+    ListClose,
+    ObjectIdentifier,
+    EventState,
+    AcknowledgedTransitions,
+    TimestampsOpen,
+    TimestampsClose,
+    NotifyType,
+    EventEnable,
+    PrioritiesOpen,
+    PrioritiesClose,
+    MoreEvents,
+}
+
+#[test]
+fn ack_rejects_wrong_context_tags() {
+    let fields = [
+        TagField::ListOpen,
+        TagField::ListClose,
+        TagField::ObjectIdentifier,
+        TagField::EventState,
+        TagField::AcknowledgedTransitions,
+        TagField::TimestampsOpen,
+        TagField::TimestampsClose,
+        TagField::NotifyType,
+        TagField::EventEnable,
+        TagField::PrioritiesOpen,
+        TagField::PrioritiesClose,
+        TagField::MoreEvents,
+    ];
+    for field in fields {
+        let mut wire = valid_wire();
+        match field {
+            TagField::ListOpen => wire.tags.list_open = 7,
+            TagField::ListClose => wire.tags.list_close = 7,
+            TagField::ObjectIdentifier => wire.tags.object_identifier = 7,
+            TagField::EventState => wire.tags.event_state = 7,
+            TagField::AcknowledgedTransitions => wire.tags.acknowledged_transitions = 7,
+            TagField::TimestampsOpen => wire.tags.timestamps_open = 7,
+            TagField::TimestampsClose => wire.tags.timestamps_close = 7,
+            TagField::NotifyType => wire.tags.notify_type = 7,
+            TagField::EventEnable => wire.tags.event_enable = 7,
+            TagField::PrioritiesOpen => wire.tags.priorities_open = 7,
+            TagField::PrioritiesClose => wire.tags.priorities_close = 7,
+            TagField::MoreEvents => wire.tags.more_events = 7,
+        }
+        assert!(
+            GetEventInformationAck::decode(&encode_ack(&wire, 1, &[0], &[])).is_err(),
+            "{field:?} accepted the wrong tag"
+        );
+    }
+}
+
+#[test]
+fn ack_requires_exact_timestamp_and_priority_counts() {
+    for count in [2, 4] {
+        let mut wire = valid_wire();
+        wire.timestamp_count = count;
+        assert!(GetEventInformationAck::decode(&encode_ack(&wire, 1, &[0], &[])).is_err());
+    }
+    for count in [2, 4] {
+        let mut wire = valid_wire();
+        wire.priorities = vec![ONE; count];
+        assert!(GetEventInformationAck::decode(&encode_ack(&wire, 1, &[0], &[])).is_err());
+    }
+}
+
+#[test]
+fn ack_rejects_wrong_priority_datatype() {
+    let mut wrong_application_tag = valid_wire();
+    wrong_application_tag.priority_tag = tags::app_tag::ENUMERATED;
+    assert!(
+        GetEventInformationAck::decode(&encode_ack(&wrong_application_tag, 1, &[0], &[])).is_err()
+    );
+
+    let mut context_tag = valid_wire();
+    context_tag.priority_class = TagClass::Context;
+    assert!(GetEventInformationAck::decode(&encode_ack(&context_tag, 1, &[0], &[])).is_err());
+}
+
+#[test]
+fn ack_requires_three_bit_transition_fields_with_zero_padding() {
+    for malformed in [&[][..], &[5][..], &[4, 0][..], &[5, 1][..], &[5, 0, 0][..]] {
+        let mut acknowledged = valid_wire();
+        acknowledged.acknowledged_transitions = malformed;
+        assert!(GetEventInformationAck::decode(&encode_ack(&acknowledged, 1, &[0], &[])).is_err());
+
+        let mut enabled = valid_wire();
+        enabled.event_enable = malformed;
+        assert!(GetEventInformationAck::decode(&encode_ack(&enabled, 1, &[0], &[])).is_err());
+    }
+}
+
+#[test]
+fn ack_rejects_malformed_boolean_and_trailing_data() {
+    let wire = valid_wire();
+    for malformed in [&[][..], &[2][..], &[0, 0][..]] {
+        assert!(GetEventInformationAck::decode(&encode_ack(&wire, 1, malformed, &[])).is_err());
+    }
+    assert!(GetEventInformationAck::decode(&encode_ack(&wire, 1, &[0], &[0])).is_err());
+}
+
+#[test]
+fn ack_enforces_event_summary_limit() {
+    let wire = valid_wire();
+    let maximum = encode_ack(&wire, MAX_DECODED_ITEMS, &[0], &[]);
+    assert_eq!(
+        GetEventInformationAck::decode(&maximum)
+            .unwrap()
+            .list_of_event_summaries
+            .len(),
+        MAX_DECODED_ITEMS
+    );
+
+    let overflow = encode_ack(&wire, MAX_DECODED_ITEMS + 1, &[0], &[]);
+    assert!(GetEventInformationAck::decode(&overflow).is_err());
+}

--- a/crates/bacnet-services/src/alarm_event/tests/get_event_information_timestamps.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/get_event_information_timestamps.rs
@@ -5,7 +5,7 @@
 //! `time [0]` as a primitive context tag 0 (length 4, raw Time octets),
 //! `sequence-number [1]` constrained to `0..=65535`, `datetime [2]` as an
 //! opening/closing tag 2 pair around the application-tagged Date and Time
-//! (ASHRAE 135-2020 Clauses 13.9, 20.2.1.5, 21).
+//! (ASHRAE 135-2020 Clauses 13.12, 20.2.1.5, 21).
 
 use super::*;
 

--- a/crates/bacnet-services/src/alarm_event/tests/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use bacnet_types::enums::ObjectType;
 
+mod get_event_information_decode;
 mod get_event_information_timestamps;
 mod notification_parameters;
 mod service_round_trip;

--- a/crates/bacnet-services/src/alarm_event/tests/service_round_trip.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/service_round_trip.rs
@@ -384,9 +384,7 @@ fn test_decode_event_notification_invalid_tag() {
 
 #[test]
 fn test_decode_get_event_info_invalid_tag() {
-    // Non-matching context tag — decoder treats as no last_received (lenient)
-    let result = GetEventInformationRequest::decode(&[0x19, 0]).unwrap();
-    assert!(result.last_received_object_identifier.is_none());
+    assert!(GetEventInformationRequest::decode(&[0x19, 0]).is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Reject malformed or overflowing GetEventInformation request and ACK fields without changing public types.
- Remove per-summary transition-bit allocations from ACK decoding.
- Make server responses resumable in numeric object-identifier order and preserve Notification Class priorities and valid stored sequence timestamps.
- Reduce the #309 direct-cast inventory from 51 to 48 sites.

## Standard scope

- ANSI/ASHRAE 135-2020 Clause 13.12: GetEventInformation request, event-summary, and More Events semantics.
- Clause 21: `GetEventInformation-Request` and `GetEventInformation-ACK` productions.
- Clause 20.2.10: three-bit `BACnetEventTransitionBits` encoding and zero padding.

No public Rust/Python signature or conformance-ledger claim changes.

## Implementation

- Require optional request field `[0]` to own the complete nonempty payload.
- Decode Event State, Notify Type, and all three Event Priorities with value-based `u32` checks. Numerically valid five-octet leading-zero encodings remain accepted.
- Require exact context tags `[0]` through `[6]`, exactly three timestamps, exactly three application Unsigned priorities, matching constructed closings, a strict More Events Boolean, and complete ACK consumption.
- Parse fixed-width transition fields directly from their two content octets, avoiding the generic decoder owned `Vec` for up to 20,000 fields at the accepted summary limit.
- Cap decoded event summaries at `MAX_DECODED_ITEMS`.
- Sort server candidates by encoded object identifier and treat the request cursor as an exclusive numeric boundary. Pagination continues when the cursor object was removed between pages.
- Match Notification Class objects by their `NOTIFICATION_CLASS` property rather than assuming the class number equals the object instance, then project the three-item `PRIORITY` list into the ACK.
- Forward object API Event Time Stamps sequence values in the BACnet `0..=65535` range. A malformed array defaults to three zero sequence numbers without aborting other summaries. Other timestamp alternatives remain lossy in the object API pending #171.
- Correct touched alarm/event documentation to the 135-2020 Clause 13.5, 13.8-13.9, and 13.12 numbering.

## Tests

Commands run:

```bash
cargo test -p bacnet-services --locked
cargo test -p bacnet-server --locked
cargo test -p bacnet-client --locked
cargo check -p rusty-bacnet --tests --locked
cargo test --workspace --exclude bacnet-benchmarks --exclude rusty-bacnet --all-targets --locked
cargo test --workspace --exclude bacnet-benchmarks --exclude rusty-bacnet --all-targets --no-default-features --locked
cargo clippy --workspace --all-targets --locked -- -A missing-docs -A unused
cargo fmt --all -- --check
git diff --check
bash .github/scripts/check-file-size.sh
bash .github/scripts/check-no-secrets.sh
```

Decoder coverage includes all five numeric values at padded `u32::MAX`, `u32::MAX + 1`, and `u64::MAX`; every request/ACK context tag; wrong priority datatypes; two/four-element timestamp and priority sequences; malformed transition bits and Boolean values; trailing data; and the 10,000/10,001 boundary.

Server integration coverage decodes generated ACKs to verify a class number that differs from its Notification Class object instance, custom priorities, the sequence-number ceiling, malformed timestamp containment, and pagination across 27 reverse-inserted active objects after deleting the first-page cursor.

## Review

- Runtime: READY on `00b5c1ae8d00fe3862b979b9a9903331690ed29d`.
- Dataflow: READY on `00b5c1ae8d00fe3862b979b9a9903331690ed29d`.

## Known follow-ups

- Audit service codecs require a public wire-model correction before their #309 casts can be removed: #345.
- `BACnetPropertyStates` variants require a public tag-model correction before their #309 casts can be removed: #346.
- EventNotification and nested notification-parameter casts remain separate slices.

Progresses #309.