### PR TITLE
fix(services): harden life safety notification decoding

### DIFF
--- a/crates/bacnet-services/src/alarm_event/event_notification.rs
+++ b/crates/bacnet-services/src/alarm_event/event_notification.rs
@@ -225,30 +225,44 @@ impl EventNotificationRequest {
                 // Skip opening tag [12]
                 let (_, inner_start) = tags::decode_tag(data, offset)?;
                 event_values = Some(NotificationParameters::decode(data, inner_start)?);
-                // Find closing tag [12]
-                let mut scan = inner_start;
-                let mut depth: usize = 1;
-                while depth > 0 && scan < data.len() {
-                    let (t, next) = tags::decode_tag(data, scan)?;
-                    if t.is_opening {
-                        depth += 1;
-                        scan = next;
-                    } else if t.is_closing {
-                        depth -= 1;
-                        if depth == 0 {
-                            offset = next;
-                        } else {
+                let (variant, variant_start) = tags::decode_tag(data, inner_start)?;
+                if variant.number == 8 {
+                    let (_, variant_end) =
+                        tags::extract_context_value(data, variant_start, variant.number)?;
+                    let (closing, next) = tags::decode_tag(data, variant_end)?;
+                    if !closing.is_closing_tag(12) {
+                        return Err(Error::decoding(
+                            variant_end,
+                            "EventNotification expected closing tag 12 after eventValues",
+                        ));
+                    }
+                    offset = next;
+                } else {
+                    // Legacy variants may contain opaque bytes that cannot be scanned as tags.
+                    let mut scan = inner_start;
+                    let mut depth: usize = 1;
+                    while depth > 0 && scan < data.len() {
+                        let (tag, next) = tags::decode_tag(data, scan)?;
+                        if tag.is_opening {
+                            depth += 1;
                             scan = next;
+                        } else if tag.is_closing {
+                            depth -= 1;
+                            if depth == 0 {
+                                offset = next;
+                            } else {
+                                scan = next;
+                            }
+                        } else {
+                            let end = next.saturating_add(tag.length as usize);
+                            if end > data.len() {
+                                return Err(Error::decoding(
+                                    next,
+                                    "EventNotification: truncated tag in eventValues",
+                                ));
+                            }
+                            scan = end;
                         }
-                    } else {
-                        let end = next.saturating_add(t.length as usize);
-                        if end > data.len() {
-                            return Err(Error::decoding(
-                                next,
-                                "EventNotification: truncated tag in eventValues",
-                            ));
-                        }
-                        scan = end;
                     }
                 }
             }

--- a/crates/bacnet-services/src/alarm_event/event_notification.rs
+++ b/crates/bacnet-services/src/alarm_event/event_notification.rs
@@ -221,48 +221,58 @@ impl EventNotificationRequest {
         let mut event_values = None;
         if offset < data.len() {
             let (peek, _) = tags::decode_tag(data, offset)?;
-            if peek.is_opening && peek.number == 12 {
-                // Skip opening tag [12]
-                let (_, inner_start) = tags::decode_tag(data, offset)?;
-                event_values = Some(NotificationParameters::decode(data, inner_start)?);
-                let (variant, variant_start) = tags::decode_tag(data, inner_start)?;
-                if variant.number == 8 {
-                    let (_, variant_end) =
-                        tags::extract_context_value(data, variant_start, variant.number)?;
-                    let (closing, next) = tags::decode_tag(data, variant_end)?;
-                    if !closing.is_closing_tag(12) {
-                        return Err(Error::decoding(
-                            variant_end,
-                            "EventNotification expected closing tag 12 after eventValues",
-                        ));
-                    }
-                    offset = next;
-                } else {
-                    // Legacy variants may contain opaque bytes that cannot be scanned as tags.
-                    let mut scan = inner_start;
-                    let mut depth: usize = 1;
-                    while depth > 0 && scan < data.len() {
-                        let (tag, next) = tags::decode_tag(data, scan)?;
-                        if tag.is_opening {
-                            depth += 1;
-                            scan = next;
-                        } else if tag.is_closing {
-                            depth -= 1;
-                            if depth == 0 {
-                                offset = next;
-                            } else {
-                                scan = next;
-                            }
+            if !peek.is_opening || peek.number != 12 {
+                return Err(Error::decoding(
+                    offset,
+                    "EventNotification expected opening tag 12 for eventValues",
+                ));
+            }
+            // Skip opening tag [12]
+            let (_, inner_start) = tags::decode_tag(data, offset)?;
+            event_values = Some(NotificationParameters::decode(data, inner_start)?);
+            let (variant, variant_start) = tags::decode_tag(data, inner_start)?;
+            if variant.number == 8 {
+                let (_, variant_end) =
+                    tags::extract_context_value(data, variant_start, variant.number)?;
+                let (closing, next) = tags::decode_tag(data, variant_end)?;
+                if !closing.is_closing_tag(12) {
+                    return Err(Error::decoding(
+                        variant_end,
+                        "EventNotification expected closing tag 12 after eventValues",
+                    ));
+                }
+                if next != data.len() {
+                    return Err(Error::decoding(
+                        next,
+                        "EventNotification unexpected trailing data",
+                    ));
+                }
+                offset = next;
+            } else {
+                // Legacy variants may contain opaque bytes that cannot be scanned as tags.
+                let mut scan = inner_start;
+                let mut depth: usize = 1;
+                while depth > 0 && scan < data.len() {
+                    let (tag, next) = tags::decode_tag(data, scan)?;
+                    if tag.is_opening {
+                        depth += 1;
+                        scan = next;
+                    } else if tag.is_closing {
+                        depth -= 1;
+                        if depth == 0 {
+                            offset = next;
                         } else {
-                            let end = next.saturating_add(tag.length as usize);
-                            if end > data.len() {
-                                return Err(Error::decoding(
-                                    next,
-                                    "EventNotification: truncated tag in eventValues",
-                                ));
-                            }
-                            scan = end;
+                            scan = next;
                         }
+                    } else {
+                        let end = next.saturating_add(tag.length as usize);
+                        if end > data.len() {
+                            return Err(Error::decoding(
+                                next,
+                                "EventNotification: truncated tag in eventValues",
+                            ));
+                        }
+                        scan = end;
                     }
                 }
             }

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
@@ -1,5 +1,6 @@
 use super::decode_timer::{decode_change_of_discrete_value, decode_change_of_timer};
 use super::*;
+use crate::common::{decode_context, decode_context_u32};
 
 impl NotificationParameters {
     /// Decode notification parameters from a position just past the opening
@@ -341,48 +342,34 @@ impl NotificationParameters {
             }
             // [8] Change of life safety
             8 => {
-                let mut pos = inner_start;
-                // [0] new-state
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
+                let (new_state, pos) =
+                    decode_context_u32(data, inner_start, 0, "ChangeOfLifeSafety new-state")?;
+                let (new_mode, pos) =
+                    decode_context_u32(data, pos, 1, "ChangeOfLifeSafety new-mode")?;
+                let flags_offset = pos;
+                let (flags, pos) = decode_context(data, pos, 2, "ChangeOfLifeSafety status-flags")?;
+                let [4, bits] = flags else {
                     return Err(Error::decoding(
-                        p,
-                        "ChangeOfLifeSafety: truncated new_state",
+                        flags_offset,
+                        "ChangeOfLifeSafety status-flags must contain four bits",
+                    ));
+                };
+                if bits & 0x0f != 0 {
+                    return Err(Error::decoding(
+                        flags_offset,
+                        "ChangeOfLifeSafety status-flags must have zero padding",
                     ));
                 }
-                let new_state = primitives::decode_unsigned(&data[p..end])? as u32;
-                pos = end;
-                // [1] new-mode
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "ChangeOfLifeSafety: truncated new_mode"));
-                }
-                let new_mode = primitives::decode_unsigned(&data[p..end])? as u32;
-                pos = end;
-                // [2] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
+                let status_flags = bits >> 4;
+                let (operation_expected, pos) =
+                    decode_context_u32(data, pos, 3, "ChangeOfLifeSafety operation-expected")?;
+                let (closing, _) = tags::decode_tag(data, pos)?;
+                if !closing.is_closing_tag(8) {
                     return Err(Error::decoding(
-                        sf_pos,
-                        "ChangeOfLifeSafety: truncated flags",
+                        pos,
+                        "ChangeOfLifeSafety expected closing tag 8",
                     ));
                 }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
-                // [3] operation-expected
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "ChangeOfLifeSafety: truncated operation_expected",
-                    ));
-                }
-                let operation_expected = primitives::decode_unsigned(&data[p..end])? as u32;
-                let _ = (pos, end);
                 Ok(Self::ChangeOfLifeSafety {
                     new_state,
                     new_mode,

--- a/crates/bacnet-services/src/alarm_event/tests/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/mod.rs
@@ -4,4 +4,5 @@ use bacnet_types::enums::ObjectType;
 mod get_event_information_decode;
 mod get_event_information_timestamps;
 mod notification_parameters;
+mod notification_parameters_life_safety;
 mod service_round_trip;

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters_life_safety.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters_life_safety.rs
@@ -27,7 +27,7 @@ fn decode_params(data: &[u8]) -> Result<NotificationParameters, Error> {
     NotificationParameters::decode(data, 0)
 }
 
-fn encoded_event_notification() -> BytesMut {
+fn encoded_event_notification() -> (BytesMut, usize) {
     let request = EventNotificationRequest {
         process_identifier: 1,
         initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap(),
@@ -41,16 +41,22 @@ fn encoded_event_notification() -> BytesMut {
         ack_required: true,
         from_state: 0,
         to_state: 1,
-        event_values: Some(NotificationParameters::ChangeOfLifeSafety {
-            new_state: 1,
-            new_mode: 1,
-            status_flags: 8,
-            operation_expected: 1,
-        }),
+        event_values: None,
     };
     let mut buf = BytesMut::new();
     request.encode(&mut buf).unwrap();
-    buf
+    let event_values_offset = buf.len();
+    tags::encode_opening_tag(&mut buf, 12);
+    NotificationParameters::ChangeOfLifeSafety {
+        new_state: 1,
+        new_mode: 1,
+        status_flags: 8,
+        operation_expected: 1,
+    }
+    .encode(&mut buf)
+    .unwrap();
+    tags::encode_closing_tag(&mut buf, 12);
+    (buf, event_values_offset)
 }
 
 #[test]
@@ -170,8 +176,18 @@ fn change_of_life_safety_rejects_every_truncated_prefix() {
 
 #[test]
 fn event_notification_requires_event_values_outer_framing() {
-    let encoded = encoded_event_notification();
+    let (encoded, event_values_offset) = encoded_event_notification();
     assert!(EventNotificationRequest::decode(&encoded).is_ok());
+
+    let mut missing_opening = encoded.to_vec();
+    missing_opening.remove(event_values_offset);
+    assert!(EventNotificationRequest::decode(&missing_opening).is_err());
+
+    let mut wrong_opening = encoded.clone();
+    let mut tag = BytesMut::new();
+    tags::encode_opening_tag(&mut tag, 11);
+    wrong_opening[event_values_offset] = tag[0];
+    assert!(EventNotificationRequest::decode(&wrong_opening).is_err());
 
     let mut missing_closing = encoded.clone();
     missing_closing.truncate(missing_closing.len() - 1);
@@ -185,4 +201,8 @@ fn event_notification_requires_event_values_outer_framing() {
     raw_context_value(&mut extra_sibling, 4, &[1]);
     tags::encode_closing_tag(&mut extra_sibling, 12);
     assert!(EventNotificationRequest::decode(&extra_sibling).is_err());
+
+    let mut trailing_data = encoded;
+    raw_context_value(&mut trailing_data, 13, &[1]);
+    assert!(EventNotificationRequest::decode(&trailing_data).is_err());
 }

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters_life_safety.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters_life_safety.rs
@@ -1,0 +1,143 @@
+use super::*;
+
+fn raw_context_value(buf: &mut BytesMut, tag_number: u8, value: &[u8]) {
+    tags::encode_tag(buf, tag_number, tags::TagClass::Context, value.len() as u32);
+    buf.extend_from_slice(value);
+}
+
+fn raw_change_of_life_safety(
+    values: [&[u8]; 3],
+    field_tags: [u8; 4],
+    status_flags: &[u8],
+    closing_tag: Option<u8>,
+) -> BytesMut {
+    let mut buf = BytesMut::new();
+    tags::encode_opening_tag(&mut buf, 8);
+    raw_context_value(&mut buf, field_tags[0], values[0]);
+    raw_context_value(&mut buf, field_tags[1], values[1]);
+    raw_context_value(&mut buf, field_tags[2], status_flags);
+    raw_context_value(&mut buf, field_tags[3], values[2]);
+    if let Some(tag) = closing_tag {
+        tags::encode_closing_tag(&mut buf, tag);
+    }
+    buf
+}
+
+fn decode_params(data: &[u8]) -> Result<NotificationParameters, Error> {
+    NotificationParameters::decode(data, 0)
+}
+
+#[test]
+fn change_of_life_safety_accepts_u32_max_with_leading_zero() {
+    let max = [0, 0xff, 0xff, 0xff, 0xff];
+    let decoded = decode_params(&raw_change_of_life_safety(
+        [&max, &max, &max],
+        [0, 1, 2, 3],
+        &[4, 0xf0],
+        Some(8),
+    ))
+    .unwrap();
+
+    assert_eq!(
+        decoded,
+        NotificationParameters::ChangeOfLifeSafety {
+            new_state: u32::MAX,
+            new_mode: u32::MAX,
+            status_flags: 0x0f,
+            operation_expected: u32::MAX,
+        }
+    );
+}
+
+#[test]
+fn change_of_life_safety_rejects_values_above_u32() {
+    let one = [1];
+    let overflow_alias = [1, 0, 0, 0, 1];
+    let u64_max = [0xff; 8];
+
+    for field in 0..3 {
+        for invalid in [&overflow_alias[..], &u64_max] {
+            let mut values: [&[u8]; 3] = [&one, &one, &one];
+            values[field] = invalid;
+            assert!(decode_params(&raw_change_of_life_safety(
+                values,
+                [0, 1, 2, 3],
+                &[4, 0x80],
+                Some(8),
+            ))
+            .is_err());
+        }
+    }
+}
+
+#[test]
+fn change_of_life_safety_requires_exact_field_tags() {
+    for field in 0..4 {
+        let mut field_tags = [0, 1, 2, 3];
+        field_tags[field] = 7;
+        assert!(decode_params(&raw_change_of_life_safety(
+            [&[1], &[1], &[1]],
+            field_tags,
+            &[4, 0x80],
+            Some(8),
+        ))
+        .is_err());
+    }
+
+    let mut application_tagged =
+        raw_change_of_life_safety([&[1], &[1], &[1]], [0, 1, 2, 3], &[4, 0x80], Some(8));
+    application_tagged[1] &= !0x08;
+    assert!(decode_params(&application_tagged).is_err());
+}
+
+#[test]
+fn change_of_life_safety_requires_four_status_bits_with_zero_padding() {
+    for invalid in [
+        &[][..],
+        &[4][..],
+        &[3, 0xf0][..],
+        &[4, 0xf1][..],
+        &[4, 0xf0, 0][..],
+    ] {
+        assert!(decode_params(&raw_change_of_life_safety(
+            [&[1], &[1], &[1]],
+            [0, 1, 2, 3],
+            invalid,
+            Some(8),
+        ))
+        .is_err());
+    }
+}
+
+#[test]
+fn change_of_life_safety_requires_its_immediate_closing_tag() {
+    assert!(decode_params(&raw_change_of_life_safety(
+        [&[1], &[1], &[1]],
+        [0, 1, 2, 3],
+        &[4, 0x80],
+        None,
+    ))
+    .is_err());
+    assert!(decode_params(&raw_change_of_life_safety(
+        [&[1], &[1], &[1]],
+        [0, 1, 2, 3],
+        &[4, 0x80],
+        Some(9),
+    ))
+    .is_err());
+
+    let mut extra_field =
+        raw_change_of_life_safety([&[1], &[1], &[1]], [0, 1, 2, 3], &[4, 0x80], None);
+    raw_context_value(&mut extra_field, 4, &[1]);
+    tags::encode_closing_tag(&mut extra_field, 8);
+    assert!(decode_params(&extra_field).is_err());
+}
+
+#[test]
+fn change_of_life_safety_rejects_every_truncated_prefix() {
+    let encoded = raw_change_of_life_safety([&[1], &[1], &[1]], [0, 1, 2, 3], &[4, 0x80], Some(8));
+
+    for end in 0..encoded.len() {
+        assert!(decode_params(&encoded[..end]).is_err(), "prefix {end}");
+    }
+}

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters_life_safety.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters_life_safety.rs
@@ -27,6 +27,32 @@ fn decode_params(data: &[u8]) -> Result<NotificationParameters, Error> {
     NotificationParameters::decode(data, 0)
 }
 
+fn encoded_event_notification() -> BytesMut {
+    let request = EventNotificationRequest {
+        process_identifier: 1,
+        initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap(),
+        event_object_identifier: ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 1).unwrap(),
+        timestamp: BACnetTimeStamp::SequenceNumber(1),
+        notification_class: 1,
+        priority: 1,
+        event_type: 8,
+        message_text: None,
+        notify_type: 0,
+        ack_required: true,
+        from_state: 0,
+        to_state: 1,
+        event_values: Some(NotificationParameters::ChangeOfLifeSafety {
+            new_state: 1,
+            new_mode: 1,
+            status_flags: 8,
+            operation_expected: 1,
+        }),
+    };
+    let mut buf = BytesMut::new();
+    request.encode(&mut buf).unwrap();
+    buf
+}
+
 #[test]
 fn change_of_life_safety_accepts_u32_max_with_leading_zero() {
     let max = [0, 0xff, 0xff, 0xff, 0xff];
@@ -140,4 +166,23 @@ fn change_of_life_safety_rejects_every_truncated_prefix() {
     for end in 0..encoded.len() {
         assert!(decode_params(&encoded[..end]).is_err(), "prefix {end}");
     }
+}
+
+#[test]
+fn event_notification_requires_event_values_outer_framing() {
+    let encoded = encoded_event_notification();
+    assert!(EventNotificationRequest::decode(&encoded).is_ok());
+
+    let mut missing_closing = encoded.clone();
+    missing_closing.truncate(missing_closing.len() - 1);
+    assert!(EventNotificationRequest::decode(&missing_closing).is_err());
+
+    let mut wrong_closing = missing_closing.clone();
+    tags::encode_closing_tag(&mut wrong_closing, 9);
+    assert!(EventNotificationRequest::decode(&wrong_closing).is_err());
+
+    let mut extra_sibling = missing_closing;
+    raw_context_value(&mut extra_sibling, 4, &[1]);
+    tags::encode_closing_tag(&mut extra_sibling, 12);
+    assert!(EventNotificationRequest::decode(&extra_sibling).is_err());
 }


### PR DESCRIPTION
## Summary
- validate the Clause 21 ChangeOfLifeSafety field tags and inner/outer framing
- reject three unsigned overflow aliases while preserving in-range leading-zero encodings
- require a four-bit status-flags value with zero padding
- reject malformed `[12]` wrappers, extra siblings, and trailing data for ChangeOfLifeSafety
- add malformed-input coverage for tags, framing, truncation, bit strings, and integer widths

Part of #309. Legacy opaque-variant boundary ownership is tracked separately in #349.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- direct unchecked decode cast audit: 45 (down from 48)