### PR TITLE
fix(services): harden event notification envelope

### DIFF
--- a/crates/bacnet-services/src/alarm_event/event_notification.rs
+++ b/crates/bacnet-services/src/alarm_event/event_notification.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::common::{decode_context, decode_context_bool, decode_context_u32};
 
 // ---------------------------------------------------------------------------
 // EventNotification
@@ -75,147 +76,85 @@ impl EventNotificationRequest {
     }
 
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        let mut offset = 0;
-
-        // Helper: validate bounds after computing end from tag length
-        macro_rules! check_bounds {
-            ($pos:expr, $end:expr, $field:expr) => {
-                if $end > data.len() {
-                    return Err(Error::decoding(
-                        $pos,
-                        concat!("EventNotification truncated at ", $field),
-                    ));
-                }
-            };
-        }
-
         // [0] processIdentifier
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        check_bounds!(pos, end, "processIdentifier");
-        let process_identifier = primitives::decode_unsigned(&data[pos..end])? as u32;
-        offset = end;
+        let (process_identifier, mut offset) =
+            decode_context_u32(data, 0, 0, "EventNotification processIdentifier")?;
 
         // [1] initiatingDeviceIdentifier
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        check_bounds!(pos, end, "initiatingDeviceIdentifier");
-        let initiating_device_identifier = ObjectIdentifier::decode(&data[pos..end])?;
-        offset = end;
+        let (content, new_offset) = decode_context(
+            data,
+            offset,
+            1,
+            "EventNotification initiatingDeviceIdentifier",
+        )?;
+        let initiating_device_identifier = ObjectIdentifier::decode(content)?;
+        offset = new_offset;
 
         // [2] eventObjectIdentifier
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        check_bounds!(pos, end, "eventObjectIdentifier");
-        let event_object_identifier = ObjectIdentifier::decode(&data[pos..end])?;
-        offset = end;
+        let (content, new_offset) =
+            decode_context(data, offset, 2, "EventNotification eventObjectIdentifier")?;
+        let event_object_identifier = ObjectIdentifier::decode(content)?;
+        offset = new_offset;
 
         // [3] timeStamp
         let (timestamp, new_offset) = primitives::decode_timestamp(data, offset, 3)?;
         offset = new_offset;
 
         // [4] notificationClass
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        check_bounds!(pos, end, "notificationClass");
-        let notification_class = primitives::decode_unsigned(&data[pos..end])? as u32;
-        offset = end;
+        let (notification_class, new_offset) =
+            decode_context_u32(data, offset, 4, "EventNotification notificationClass")?;
+        offset = new_offset;
 
         // [5] priority
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        check_bounds!(pos, end, "priority");
-        let priority = primitives::decode_unsigned(&data[pos..end])? as u8;
-        offset = end;
+        let priority_offset = offset;
+        let (content, new_offset) = decode_context(data, offset, 5, "EventNotification priority")?;
+        let priority = primitives::decode_unsigned(content)?;
+        let priority = u8::try_from(priority).map_err(|_| {
+            Error::decoding(priority_offset, "EventNotification priority exceeds u8")
+        })?;
+        offset = new_offset;
 
         // [6] eventType
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        check_bounds!(pos, end, "eventType");
-        let event_type = primitives::decode_unsigned(&data[pos..end])? as u32;
-        offset = end;
+        let (event_type, new_offset) =
+            decode_context_u32(data, offset, 6, "EventNotification eventType")?;
+        offset = new_offset;
 
         // [7] messageText (optional)
         let mut message_text = None;
         if offset < data.len() {
-            let (peek, peek_pos) = tags::decode_tag(data, offset)?;
+            let (peek, _) = tags::decode_tag(data, offset)?;
             if peek.is_context(7) {
-                let mt_end = peek_pos + peek.length as usize;
-                if mt_end <= data.len() {
-                    message_text = Some(primitives::decode_character_string(
-                        &data[peek_pos..mt_end],
-                    )?);
-                }
-                offset = mt_end;
-            }
-        }
-
-        // Skip any remaining tags before [8] notifyType
-        let mut skip_count = 0u32;
-        while offset < data.len() {
-            skip_count += 1;
-            if skip_count > MAX_DECODED_ITEMS as u32 {
-                return Err(Error::decoding(
-                    offset,
-                    "too many tags skipped looking for notification-parameters",
-                ));
-            }
-            let (peek, peek_pos) = tags::decode_tag(data, offset)?;
-            if peek.is_context(8) {
-                break;
-            }
-            if peek.is_opening {
-                let (_, new_offset) = tags::extract_context_value(data, peek_pos, peek.number)?;
+                let (content, new_offset) =
+                    decode_context(data, offset, 7, "EventNotification messageText")?;
+                message_text = Some(primitives::decode_character_string(content)?);
                 offset = new_offset;
-            } else if peek.is_closing {
-                return Err(Error::decoding(
-                    offset,
-                    "unexpected closing tag skipping to notification-parameters",
-                ));
-            } else {
-                let skip_end = peek_pos + peek.length as usize;
-                if skip_end > data.len() {
-                    return Err(Error::decoding(
-                        peek_pos,
-                        "EventNotification truncated skipping messageText",
-                    ));
-                }
-                offset = skip_end;
             }
         }
 
         // [8] notifyType
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        check_bounds!(pos, end, "notifyType");
-        let notify_type = primitives::decode_unsigned(&data[pos..end])? as u32;
-        offset = end;
+        let (notify_type, new_offset) =
+            decode_context_u32(data, offset, 8, "EventNotification notifyType")?;
+        offset = new_offset;
 
         // [9] ackRequired (optional — present for ALARM/EVENT)
         let mut ack_required = false;
         if offset < data.len() {
-            let (peek, peek_pos) = tags::decode_tag(data, offset)?;
+            let (peek, _) = tags::decode_tag(data, offset)?;
             if peek.is_context(9) {
-                let end = peek_pos + peek.length as usize;
-                check_bounds!(peek_pos, end, "ackRequired");
-                ack_required = data[peek_pos] != 0;
-                offset = end;
+                (ack_required, offset) =
+                    decode_context_bool(data, offset, 9, "EventNotification ackRequired")?;
             }
         }
 
         // [10] fromState
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        check_bounds!(pos, end, "fromState");
-        let from_state = primitives::decode_unsigned(&data[pos..end])? as u32;
-        offset = end;
+        let (from_state, new_offset) =
+            decode_context_u32(data, offset, 10, "EventNotification fromState")?;
+        offset = new_offset;
 
         // [11] toState
-        let (_tag, pos) = tags::decode_tag(data, offset)?;
-        let end = pos + _tag.length as usize;
-        check_bounds!(pos, end, "toState");
-        let to_state = primitives::decode_unsigned(&data[pos..end])? as u32;
-        offset = end;
+        let (to_state, new_offset) =
+            decode_context_u32(data, offset, 11, "EventNotification toState")?;
+        offset = new_offset;
 
         // [12] eventValues — optional
         let mut event_values = None;

--- a/crates/bacnet-services/src/alarm_event/tests/event_notification_decode.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/event_notification_decode.rs
@@ -1,0 +1,230 @@
+use super::*;
+
+const U32_FIELD_VALUE_INDEXES: [usize; 6] = [0, 1, 3, 4, 5, 6];
+
+fn canonical_tags() -> [(u8, tags::TagClass); 9] {
+    [
+        (0, tags::TagClass::Context),
+        (1, tags::TagClass::Context),
+        (2, tags::TagClass::Context),
+        (4, tags::TagClass::Context),
+        (5, tags::TagClass::Context),
+        (6, tags::TagClass::Context),
+        (8, tags::TagClass::Context),
+        (10, tags::TagClass::Context),
+        (11, tags::TagClass::Context),
+    ]
+}
+
+fn canonical_values() -> [&'static [u8]; 7] {
+    [&[1], &[5], &[100], &[5], &[0], &[0], &[3]]
+}
+
+fn raw_tagged_value(buf: &mut BytesMut, tag: (u8, tags::TagClass), content: &[u8]) {
+    tags::encode_tag(buf, tag.0, tag.1, content.len() as u32);
+    buf.extend_from_slice(content);
+}
+
+fn raw_event_notification(
+    values: [&[u8]; 7],
+    field_tags: [(u8, tags::TagClass); 9],
+    ack_required: Option<&[u8]>,
+    unknown_before_notify_type: bool,
+) -> BytesMut {
+    let mut buf = BytesMut::new();
+    raw_tagged_value(&mut buf, field_tags[0], values[0]);
+
+    let initiating_device = ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap();
+    raw_tagged_value(&mut buf, field_tags[1], &initiating_device.encode());
+
+    let event_object = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 3).unwrap();
+    raw_tagged_value(&mut buf, field_tags[2], &event_object.encode());
+
+    primitives::encode_timestamp(&mut buf, 3, &BACnetTimeStamp::SequenceNumber(7)).unwrap();
+    raw_tagged_value(&mut buf, field_tags[3], values[1]);
+    raw_tagged_value(&mut buf, field_tags[4], values[2]);
+    raw_tagged_value(&mut buf, field_tags[5], values[3]);
+
+    if unknown_before_notify_type {
+        primitives::encode_ctx_unsigned(&mut buf, 13, 1);
+    }
+
+    raw_tagged_value(&mut buf, field_tags[6], values[4]);
+    if let Some(value) = ack_required {
+        raw_tagged_value(&mut buf, (9, tags::TagClass::Context), value);
+    }
+    raw_tagged_value(&mut buf, field_tags[7], values[5]);
+    raw_tagged_value(&mut buf, field_tags[8], values[6]);
+    buf
+}
+
+#[test]
+fn event_notification_u32_fields_reject_overflow_aliases() {
+    for field in U32_FIELD_VALUE_INDEXES {
+        for value in [[1, 0, 0, 0, 0].as_slice(), [0xff; 8].as_slice()] {
+            let mut values = canonical_values();
+            values[field] = value;
+            assert!(EventNotificationRequest::decode(&raw_event_notification(
+                values,
+                canonical_tags(),
+                Some(&[1]),
+                false,
+            ))
+            .is_err());
+        }
+    }
+}
+
+#[test]
+fn event_notification_priority_rejects_values_above_u8() {
+    for value in [[1, 0].as_slice(), [1, 1].as_slice(), [0xff; 8].as_slice()] {
+        let mut values = canonical_values();
+        values[2] = value;
+        assert!(EventNotificationRequest::decode(&raw_event_notification(
+            values,
+            canonical_tags(),
+            Some(&[1]),
+            false,
+        ))
+        .is_err());
+    }
+}
+
+#[test]
+fn event_notification_numeric_fields_accept_fitting_leading_zero() {
+    let max_u32 = [0, 0xff, 0xff, 0xff, 0xff];
+    let max_u8 = [0, 0xff];
+    let values = [
+        max_u32.as_slice(),
+        max_u32.as_slice(),
+        max_u8.as_slice(),
+        max_u32.as_slice(),
+        max_u32.as_slice(),
+        max_u32.as_slice(),
+        max_u32.as_slice(),
+    ];
+    let decoded = EventNotificationRequest::decode(&raw_event_notification(
+        values,
+        canonical_tags(),
+        Some(&[1]),
+        false,
+    ))
+    .unwrap();
+
+    assert_eq!(decoded.process_identifier, u32::MAX);
+    assert_eq!(decoded.notification_class, u32::MAX);
+    assert_eq!(decoded.priority, u8::MAX);
+    assert_eq!(decoded.event_type, u32::MAX);
+    assert_eq!(decoded.notify_type, u32::MAX);
+    assert_eq!(decoded.from_state, u32::MAX);
+    assert_eq!(decoded.to_state, u32::MAX);
+}
+
+#[test]
+fn event_notification_fields_require_owned_context_tags() {
+    for field in 0..canonical_tags().len() {
+        let mut field_tags = canonical_tags();
+        field_tags[field].0 = 13;
+        assert!(EventNotificationRequest::decode(&raw_event_notification(
+            canonical_values(),
+            field_tags,
+            Some(&[1]),
+            false,
+        ))
+        .is_err());
+
+        let mut field_tags = canonical_tags();
+        field_tags[field].1 = tags::TagClass::Application;
+        assert!(EventNotificationRequest::decode(&raw_event_notification(
+            canonical_values(),
+            field_tags,
+            Some(&[1]),
+            false,
+        ))
+        .is_err());
+    }
+}
+
+#[test]
+fn event_notification_rejects_unknown_fields_before_notify_type() {
+    assert!(EventNotificationRequest::decode(&raw_event_notification(
+        canonical_values(),
+        canonical_tags(),
+        Some(&[1]),
+        true,
+    ))
+    .is_err());
+}
+
+#[test]
+fn event_notification_ack_required_must_be_boolean() {
+    for value in [&[][..], &[2], &[0, 1]] {
+        assert!(EventNotificationRequest::decode(&raw_event_notification(
+            canonical_values(),
+            canonical_tags(),
+            Some(value),
+            false,
+        ))
+        .is_err());
+    }
+}
+
+#[test]
+fn event_notification_preserves_optional_envelope_fields() {
+    let request = EventNotificationRequest {
+        process_identifier: 1,
+        initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap(),
+        event_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 3).unwrap(),
+        timestamp: BACnetTimeStamp::SequenceNumber(7),
+        notification_class: 5,
+        priority: 100,
+        event_type: 5,
+        message_text: Some("high limit".into()),
+        notify_type: 0,
+        ack_required: true,
+        from_state: 0,
+        to_state: 3,
+        event_values: None,
+    };
+    let mut encoded = BytesMut::new();
+    request.encode(&mut encoded).unwrap();
+    let decoded = EventNotificationRequest::decode(&encoded).unwrap();
+    assert_eq!(decoded.message_text.as_deref(), Some("high limit"));
+    assert!(decoded.ack_required);
+
+    let mut ack_values = canonical_values();
+    ack_values[4] = &[2];
+    let decoded = EventNotificationRequest::decode(&raw_event_notification(
+        ack_values,
+        canonical_tags(),
+        None,
+        false,
+    ))
+    .unwrap();
+    assert!(!decoded.ack_required);
+}
+
+#[test]
+fn event_notification_rejects_every_truncated_prefix() {
+    let request = EventNotificationRequest {
+        process_identifier: 1,
+        initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap(),
+        event_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 3).unwrap(),
+        timestamp: BACnetTimeStamp::SequenceNumber(7),
+        notification_class: 5,
+        priority: 100,
+        event_type: 5,
+        message_text: Some("high limit".into()),
+        notify_type: 0,
+        ack_required: true,
+        from_state: 0,
+        to_state: 3,
+        event_values: None,
+    };
+    let mut encoded = BytesMut::new();
+    request.encode(&mut encoded).unwrap();
+
+    for end in 0..encoded.len() {
+        assert!(EventNotificationRequest::decode(&encoded[..end]).is_err());
+    }
+}

--- a/crates/bacnet-services/src/alarm_event/tests/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 use bacnet_types::enums::ObjectType;
 
+mod event_notification_decode;
 mod get_event_information_decode;
 mod get_event_information_timestamps;
 mod notification_parameters;


### PR DESCRIPTION
## Summary
- decode six EventNotification `u32` fields and the `u8` priority without numeric truncation
- require the Clause 21 context tags for the scalar and object-identifier envelope fields through `[11]`
- validate optional `[7]` bounds and `[9]` Boolean content
- reject unknown fields inserted before required `[8] notifyType`
- add hostile coverage for overflow aliases, wrong tag class/number, malformed Booleans, truncation, and fitting leading-zero encodings

## Scope

This tranche preserves the public raw-enum fields and the existing conditional-field behavior. Outbound Message Text/Event Values population remains in #135, ACK_NOTIFICATION generation and field presence remain in #175, and opaque NotificationParameters boundary ownership remains in #349.

Part of #309. The direct unchecked-cast inventory falls from 45 to 38.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test -p bacnet-services --locked`
- `cargo test -p bacnet-server event_notification --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`