### PR TITLE
fix(services): harden notification parameter boundaries

### DIFF
--- a/crates/bacnet-services/src/alarm_event/event_notification.rs
+++ b/crates/bacnet-services/src/alarm_event/event_notification.rs
@@ -159,62 +159,35 @@ impl EventNotificationRequest {
         // [12] eventValues — optional
         let mut event_values = None;
         if offset < data.len() {
-            let (peek, _) = tags::decode_tag(data, offset)?;
-            if !peek.is_opening || peek.number != 12 {
+            let (opening, inner_start) = tags::decode_tag(data, offset)?;
+            if !opening.is_opening_tag(12) {
                 return Err(Error::decoding(
                     offset,
                     "EventNotification expected opening tag 12 for eventValues",
                 ));
             }
-            // Skip opening tag [12]
-            let (_, inner_start) = tags::decode_tag(data, offset)?;
-            event_values = Some(NotificationParameters::decode(data, inner_start)?);
-            let (variant, variant_start) = tags::decode_tag(data, inner_start)?;
-            if variant.number == 8 {
-                let (_, variant_end) =
-                    tags::extract_context_value(data, variant_start, variant.number)?;
-                let (closing, next) = tags::decode_tag(data, variant_end)?;
-                if !closing.is_closing_tag(12) {
-                    return Err(Error::decoding(
-                        variant_end,
-                        "EventNotification expected closing tag 12 after eventValues",
-                    ));
-                }
-                if next != data.len() {
-                    return Err(Error::decoding(
-                        next,
-                        "EventNotification unexpected trailing data",
-                    ));
-                }
-                offset = next;
-            } else {
-                // Legacy variants may contain opaque bytes that cannot be scanned as tags.
-                let mut scan = inner_start;
-                let mut depth: usize = 1;
-                while depth > 0 && scan < data.len() {
-                    let (tag, next) = tags::decode_tag(data, scan)?;
-                    if tag.is_opening {
-                        depth += 1;
-                        scan = next;
-                    } else if tag.is_closing {
-                        depth -= 1;
-                        if depth == 0 {
-                            offset = next;
-                        } else {
-                            scan = next;
-                        }
-                    } else {
-                        let end = next.saturating_add(tag.length as usize);
-                        if end > data.len() {
-                            return Err(Error::decoding(
-                                next,
-                                "EventNotification: truncated tag in eventValues",
-                            ));
-                        }
-                        scan = end;
-                    }
-                }
+            let closing_offset = data.len().checked_sub(1).ok_or_else(|| {
+                Error::decoding(offset, "EventNotification missing closing tag 12")
+            })?;
+            if closing_offset < inner_start {
+                return Err(Error::decoding(
+                    inner_start,
+                    "EventNotification empty eventValues",
+                ));
             }
+            let (closing, next) = tags::decode_tag(data, closing_offset)?;
+            if !closing.is_closing_tag(12) || next != data.len() {
+                return Err(Error::decoding(
+                    closing_offset,
+                    "EventNotification expected closing tag 12 after eventValues",
+                ));
+            }
+            event_values = Some(NotificationParameters::decode_bounded(
+                data,
+                inner_start,
+                closing_offset,
+            )?);
+            offset = next;
         }
         let _ = offset;
 

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
@@ -1,29 +1,25 @@
 use super::decode_helpers::{
     closing_tag_start, decode_context_status_flags, decode_context_u16,
-    extract_trailing_raw_context,
+    extract_trailing_raw_context, finish_variant as check_variant_end,
 };
 use super::decode_timer::{decode_change_of_discrete_value, decode_change_of_timer};
 use super::*;
 use crate::common::{decode_context, decode_context_u32};
 
 impl NotificationParameters {
-    /// Decode notification parameters from a position just past the opening
-    /// tag of the eventValues wrapper.
+    /// Decode one notification-parameter choice ending at the end of `data`.
     pub fn decode(data: &[u8], offset: usize) -> Result<Self, Error> {
-        Self::decode_impl(data, offset, None)
+        Self::decode_impl(data, offset, data.len())
     }
 
     pub(crate) fn decode_bounded(data: &[u8], offset: usize, end: usize) -> Result<Self, Error> {
-        Self::decode_impl(data, offset, Some(end))
+        Self::decode_impl(data, offset, end)
     }
 
-    fn decode_impl(data: &[u8], offset: usize, end: Option<usize>) -> Result<Self, Error> {
-        let data = match end {
-            Some(end) => data.get(..end).ok_or_else(|| {
-                Error::decoding(end, "NotificationParameters boundary exceeds input")
-            })?,
-            None => data,
-        };
+    fn decode_impl(data: &[u8], offset: usize, end: usize) -> Result<Self, Error> {
+        let data = data
+            .get(..end)
+            .ok_or_else(|| Error::decoding(end, "NotificationParameters boundary exceeds input"))?;
         // Peek the inner opening tag to determine the variant
         if offset >= data.len() {
             return Err(Error::decoding(
@@ -39,16 +35,14 @@ impl NotificationParameters {
             ));
         }
         let variant_tag = inner_tag.number;
-        let variant_body_end = end
-            .map(|_| {
-                closing_tag_start(
-                    data,
-                    data.len(),
-                    variant_tag,
-                    "NotificationParameters variant",
-                )
-            })
-            .transpose()?;
+        let variant_body_end = closing_tag_start(
+            data,
+            data.len(),
+            variant_tag,
+            "NotificationParameters variant",
+        )?;
+        let finish_variant =
+            |value, consumed| check_variant_end(value, consumed, variant_body_end, variant_tag);
 
         match variant_tag {
             // [1] Change of state
@@ -77,10 +71,13 @@ impl NotificationParameters {
                     return Err(Error::decoding(sf_pos, "ChangeOfState: truncated flags"));
                 }
                 let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                Ok(Self::ChangeOfState {
-                    new_state,
-                    status_flags,
-                })
+                finish_variant(
+                    Self::ChangeOfState {
+                        new_state,
+                        status_flags,
+                    },
+                    sf_end,
+                )
             }
             // [2] Change of value
             2 => {
@@ -131,10 +128,13 @@ impl NotificationParameters {
                     return Err(Error::decoding(sf_pos, "ChangeOfValue: truncated flags"));
                 }
                 let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                Ok(Self::ChangeOfValue {
-                    new_value,
-                    status_flags,
-                })
+                finish_variant(
+                    Self::ChangeOfValue {
+                        new_value,
+                        status_flags,
+                    },
+                    sf_end,
+                )
             }
             // [5] Out of range
             5 => {
@@ -170,13 +170,15 @@ impl NotificationParameters {
                     return Err(Error::decoding(p, "OutOfRange: truncated exceeded_limit"));
                 }
                 let exceeded_limit = primitives::decode_real(&data[p..end])?;
-                let _ = (pos, end);
-                Ok(Self::OutOfRange {
-                    exceeding_value,
-                    status_flags,
-                    deadband,
-                    exceeded_limit,
-                })
+                finish_variant(
+                    Self::OutOfRange {
+                        exceeding_value,
+                        status_flags,
+                        deadband,
+                        exceeded_limit,
+                    },
+                    end,
+                )
             }
             // [10] Buffer ready
             10 => {
@@ -201,13 +203,16 @@ impl NotificationParameters {
                 let (previous_notification, pos) =
                     decode_context_u32(data, pos, 1, "BufferReady previous-notification")?;
                 // [2] current-notification
-                let (current_notification, _) =
+                let (current_notification, end) =
                     decode_context_u32(data, pos, 2, "BufferReady current-notification")?;
-                Ok(Self::BufferReady {
-                    buffer_property,
-                    previous_notification,
-                    current_notification,
-                })
+                finish_variant(
+                    Self::BufferReady {
+                        buffer_property,
+                        previous_notification,
+                        current_notification,
+                    },
+                    end,
+                )
             }
             // [11] Unsigned range
             11 => {
@@ -241,12 +246,14 @@ impl NotificationParameters {
                     ));
                 }
                 let exceeded_limit = primitives::decode_unsigned(&data[p..end])?;
-                let _ = (pos, end);
-                Ok(Self::UnsignedRange {
-                    exceeding_value,
-                    status_flags,
-                    exceeded_limit,
-                })
+                finish_variant(
+                    Self::UnsignedRange {
+                        exceeding_value,
+                        status_flags,
+                        exceeded_limit,
+                    },
+                    end,
+                )
             }
             // [0] Change of bitstring
             0 => {
@@ -269,10 +276,13 @@ impl NotificationParameters {
                     ));
                 }
                 let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                Ok(Self::ChangeOfBitstring {
-                    referenced_bitstring: (unused, bits),
-                    status_flags,
-                })
+                finish_variant(
+                    Self::ChangeOfBitstring {
+                        referenced_bitstring: (unused, bits),
+                        status_flags,
+                    },
+                    sf_end,
+                )
             }
             // [3] Command failure
             3 => {
@@ -297,18 +307,21 @@ impl NotificationParameters {
                 if !t.is_opening || t.number != 2 {
                     return Err(Error::decoding(pos, "CommandFailure: expected opening [2]"));
                 }
-                let (feedback_value, _after) = extract_trailing_raw_context(
+                let (feedback_value, after) = extract_trailing_raw_context(
                     data,
                     p,
                     2,
                     variant_body_end,
                     "CommandFailure feedback-value",
                 )?;
-                Ok(Self::CommandFailure {
-                    command_value,
-                    status_flags,
-                    feedback_value,
-                })
+                finish_variant(
+                    Self::CommandFailure {
+                        command_value,
+                        status_flags,
+                        feedback_value,
+                    },
+                    after,
+                )
             }
             // [4] Floating limit
             4 => {
@@ -350,13 +363,15 @@ impl NotificationParameters {
                     return Err(Error::decoding(p, "FloatingLimit: truncated error_limit"));
                 }
                 let error_limit = primitives::decode_real(&data[p..end])?;
-                let _ = (pos, end);
-                Ok(Self::FloatingLimit {
-                    reference_value,
-                    status_flags,
-                    setpoint_value,
-                    error_limit,
-                })
+                finish_variant(
+                    Self::FloatingLimit {
+                        reference_value,
+                        status_flags,
+                        setpoint_value,
+                        error_limit,
+                    },
+                    end,
+                )
             }
             // [8] Change of life safety
             8 => {
@@ -381,19 +396,15 @@ impl NotificationParameters {
                 let status_flags = bits >> 4;
                 let (operation_expected, pos) =
                     decode_context_u32(data, pos, 3, "ChangeOfLifeSafety operation-expected")?;
-                let (closing, _) = tags::decode_tag(data, pos)?;
-                if !closing.is_closing_tag(8) {
-                    return Err(Error::decoding(
-                        pos,
-                        "ChangeOfLifeSafety expected closing tag 8",
-                    ));
-                }
-                Ok(Self::ChangeOfLifeSafety {
-                    new_state,
-                    new_mode,
-                    status_flags,
-                    operation_expected,
-                })
+                finish_variant(
+                    Self::ChangeOfLifeSafety {
+                        new_state,
+                        new_mode,
+                        status_flags,
+                        operation_expected,
+                    },
+                    pos,
+                )
             }
             // [9] Extended
             9 => {
@@ -408,18 +419,21 @@ impl NotificationParameters {
                 if !t.is_opening_tag(2) {
                     return Err(Error::decoding(pos, "Extended: expected opening [2]"));
                 }
-                let (parameters, _after) = extract_trailing_raw_context(
+                let (parameters, after) = extract_trailing_raw_context(
                     data,
                     p,
                     2,
                     variant_body_end,
                     "Extended parameters",
                 )?;
-                Ok(Self::Extended {
-                    vendor_id,
-                    extended_event_type,
-                    parameters,
-                })
+                finish_variant(
+                    Self::Extended {
+                        vendor_id,
+                        extended_event_type,
+                        parameters,
+                    },
+                    after,
+                )
             }
             // [13] Access event
             13 => {
@@ -467,21 +481,24 @@ impl NotificationParameters {
                         "AccessEvent: expected opening [5] for authentication-factor",
                     ));
                 }
-                let (authentication_factor, _after) = extract_trailing_raw_context(
+                let (authentication_factor, after) = extract_trailing_raw_context(
                     data,
                     p,
                     5,
                     variant_body_end,
                     "AccessEvent authentication-factor",
                 )?;
-                Ok(Self::AccessEvent {
-                    access_event,
-                    status_flags,
-                    access_event_tag,
-                    access_event_time,
-                    access_credential,
-                    authentication_factor,
-                })
+                finish_variant(
+                    Self::AccessEvent {
+                        access_event,
+                        status_flags,
+                        access_event_tag,
+                        access_event_time,
+                        access_credential,
+                        authentication_factor,
+                    },
+                    after,
+                )
             }
             // [14] Double out of range
             14 => {
@@ -523,13 +540,15 @@ impl NotificationParameters {
                     ));
                 }
                 let exceeded_limit = primitives::decode_double(&data[p..end])?;
-                let _ = (pos, end);
-                Ok(Self::DoubleOutOfRange {
-                    exceeding_value,
-                    status_flags,
-                    deadband,
-                    exceeded_limit,
-                })
+                finish_variant(
+                    Self::DoubleOutOfRange {
+                        exceeding_value,
+                        status_flags,
+                        deadband,
+                        exceeded_limit,
+                    },
+                    end,
+                )
             }
             // [15] Signed out of range
             15 => {
@@ -571,13 +590,15 @@ impl NotificationParameters {
                     ));
                 }
                 let exceeded_limit = primitives::decode_signed(&data[p..end])?;
-                let _ = (pos, end);
-                Ok(Self::SignedOutOfRange {
-                    exceeding_value,
-                    status_flags,
-                    deadband,
-                    exceeded_limit,
-                })
+                finish_variant(
+                    Self::SignedOutOfRange {
+                        exceeding_value,
+                        status_flags,
+                        deadband,
+                        exceeded_limit,
+                    },
+                    end,
+                )
             }
             // [16] Unsigned out of range
             16 => {
@@ -622,13 +643,15 @@ impl NotificationParameters {
                     ));
                 }
                 let exceeded_limit = primitives::decode_unsigned(&data[p..end])?;
-                let _ = (pos, end);
-                Ok(Self::UnsignedOutOfRange {
-                    exceeding_value,
-                    status_flags,
-                    deadband,
-                    exceeded_limit,
-                })
+                finish_variant(
+                    Self::UnsignedOutOfRange {
+                        exceeding_value,
+                        status_flags,
+                        deadband,
+                        exceeded_limit,
+                    },
+                    end,
+                )
             }
             // [17] Change of characterstring
             17 => {
@@ -657,7 +680,7 @@ impl NotificationParameters {
                 let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
                 pos = sf_end;
                 // [2] alarm-value
-                let (opt_data, _new_pos) = tags::decode_optional_context(data, pos, 2)?;
+                let (opt_data, new_pos) = tags::decode_optional_context(data, pos, 2)?;
                 let alarm_value = match opt_data {
                     Some(content) => primitives::decode_character_string(content)?,
                     None => {
@@ -667,11 +690,14 @@ impl NotificationParameters {
                         ))
                     }
                 };
-                Ok(Self::ChangeOfCharacterstring {
-                    changed_value,
-                    status_flags,
-                    alarm_value,
-                })
+                finish_variant(
+                    Self::ChangeOfCharacterstring {
+                        changed_value,
+                        status_flags,
+                        alarm_value,
+                    },
+                    new_pos,
+                )
             }
             // [18] Change of status flags
             18 => {
@@ -696,10 +722,13 @@ impl NotificationParameters {
                     ));
                 }
                 let referenced_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                Ok(Self::ChangeOfStatusFlags {
-                    present_value,
-                    referenced_flags,
-                })
+                finish_variant(
+                    Self::ChangeOfStatusFlags {
+                        present_value,
+                        referenced_flags,
+                    },
+                    sf_end,
+                )
             }
             // [19] Change of reliability
             19 => {
@@ -717,23 +746,26 @@ impl NotificationParameters {
                         "ChangeOfReliability: expected opening [2]",
                     ));
                 }
-                let (property_values, _after) = extract_trailing_raw_context(
+                let (property_values, after) = extract_trailing_raw_context(
                     data,
                     p,
                     2,
                     variant_body_end,
                     "ChangeOfReliability property-values",
                 )?;
-                Ok(Self::ChangeOfReliability {
-                    reliability,
-                    status_flags,
-                    property_values,
-                })
+                finish_variant(
+                    Self::ChangeOfReliability {
+                        reliability,
+                        status_flags,
+                        property_values,
+                    },
+                    after,
+                )
             }
             // [20] None
-            20 => Ok(Self::NoneParams),
+            20 => finish_variant(Self::NoneParams, inner_start),
             // [21] Change of discrete value
-            21 => decode_change_of_discrete_value(data, inner_start),
+            21 => decode_change_of_discrete_value(data, inner_start, variant_body_end),
             // [22] Change of timer
             22 => decode_change_of_timer(data, inner_start, variant_body_end),
             other => Err(Error::decoding(

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
@@ -1,15 +1,17 @@
 use super::decode_helpers::{
-    closing_tag_start, decode_context_status_flags, decode_context_u16,
-    extract_trailing_raw_context, finish_variant as check_variant_end,
+    closing_tag_start, decode_context_status_flags, decode_context_u16, decode_context_value,
+    finish_variant as check_variant_end,
 };
 use super::decode_timer::{decode_change_of_discrete_value, decode_change_of_timer};
 use super::*;
 use crate::common::{decode_context, decode_context_u32};
 
 impl NotificationParameters {
-    /// Decode one notification-parameter choice ending at the end of `data`.
+    /// Decode one notification-parameter choice, with an optional enclosing `[12]` close.
     pub fn decode(data: &[u8], offset: usize) -> Result<Self, Error> {
-        Self::decode_impl(data, offset, data.len())
+        let end = closing_tag_start(data, data.len(), 12, "NotificationParameters event-values")
+            .unwrap_or(data.len());
+        Self::decode_impl(data, offset, end)
     }
 
     pub(crate) fn decode_bounded(data: &[u8], offset: usize, end: usize) -> Result<Self, Error> {
@@ -65,18 +67,14 @@ impl NotificationParameters {
                 }
                 pos = cp;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(sf_pos, "ChangeOfState: truncated flags"));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "ChangeOfState status-flags")?;
                 finish_variant(
                     Self::ChangeOfState {
                         new_state,
                         status_flags,
                     },
-                    sf_end,
+                    pos,
                 )
             }
             // [2] Change of value
@@ -92,28 +90,36 @@ impl NotificationParameters {
                 }
                 pos = p;
                 // Peek CHOICE tag
-                let (choice_tag, choice_pos) = tags::decode_tag(data, pos)?;
-                let new_value = if choice_tag.number == 0 {
-                    // [0] changed-bits
-                    let end = choice_pos + choice_tag.length as usize;
-                    if end > data.len() {
-                        return Err(Error::decoding(choice_pos, "ChangeOfValue: truncated bits"));
+                let (choice_tag, _) = tags::decode_tag(data, pos)?;
+                let new_value = match choice_tag.number {
+                    0 if choice_tag.is_context(0) => {
+                        let ((unused_bits, data), end) = decode_context_value(
+                            data,
+                            pos,
+                            0,
+                            "ChangeOfValue changed-bits",
+                            primitives::decode_bit_string,
+                        )?;
+                        pos = end;
+                        ChangeOfValueChoice::ChangedBits { unused_bits, data }
                     }
-                    let (unused, bits) = primitives::decode_bit_string(&data[choice_pos..end])?;
-                    pos = end;
-                    ChangeOfValueChoice::ChangedBits {
-                        unused_bits: unused,
-                        data: bits,
+                    1 if choice_tag.is_context(1) => {
+                        let (value, end) = decode_context_value(
+                            data,
+                            pos,
+                            1,
+                            "ChangeOfValue changed-value",
+                            primitives::decode_real,
+                        )?;
+                        pos = end;
+                        ChangeOfValueChoice::ChangedValue(value)
                     }
-                } else {
-                    // [1] changed-value (Real)
-                    let end = choice_pos + choice_tag.length as usize;
-                    if end > data.len() {
-                        return Err(Error::decoding(choice_pos, "ChangeOfValue: truncated real"));
+                    _ => {
+                        return Err(Error::decoding(
+                            pos,
+                            "ChangeOfValue: expected context choice [0] or [1]",
+                        ));
                     }
-                    let v = primitives::decode_real(&data[choice_pos..end])?;
-                    pos = end;
-                    ChangeOfValueChoice::ChangedValue(v)
                 };
                 // Closing tag [0]
                 let (ct, cp) = tags::decode_tag(data, pos)?;
@@ -122,54 +128,45 @@ impl NotificationParameters {
                 }
                 pos = cp;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(sf_pos, "ChangeOfValue: truncated flags"));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "ChangeOfValue status-flags")?;
                 finish_variant(
                     Self::ChangeOfValue {
                         new_value,
                         status_flags,
                     },
-                    sf_end,
+                    pos,
                 )
             }
             // [5] Out of range
             5 => {
-                let mut pos = inner_start;
                 // [0] exceeding-value
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "OutOfRange: truncated exceeding_value"));
-                }
-                let exceeding_value = primitives::decode_real(&data[p..end])?;
-                pos = end;
+                let (exceeding_value, pos) = decode_context_value(
+                    data,
+                    inner_start,
+                    0,
+                    "OutOfRange exceeding-value",
+                    primitives::decode_real,
+                )?;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(sf_pos, "OutOfRange: truncated flags"));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "OutOfRange status-flags")?;
                 // [2] deadband
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "OutOfRange: truncated deadband"));
-                }
-                let deadband = primitives::decode_real(&data[p..end])?;
-                pos = end;
+                let (deadband, pos) = decode_context_value(
+                    data,
+                    pos,
+                    2,
+                    "OutOfRange deadband",
+                    primitives::decode_real,
+                )?;
                 // [3] exceeded-limit
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "OutOfRange: truncated exceeded_limit"));
-                }
-                let exceeded_limit = primitives::decode_real(&data[p..end])?;
+                let (exceeded_limit, pos) = decode_context_value(
+                    data,
+                    pos,
+                    3,
+                    "OutOfRange exceeded-limit",
+                    primitives::decode_real,
+                )?;
                 finish_variant(
                     Self::OutOfRange {
                         exceeding_value,
@@ -177,7 +174,7 @@ impl NotificationParameters {
                         deadband,
                         exceeded_limit,
                     },
-                    end,
+                    pos,
                 )
             }
             // [10] Buffer ready
@@ -216,72 +213,53 @@ impl NotificationParameters {
             }
             // [11] Unsigned range
             11 => {
-                let mut pos = inner_start;
                 // [0] exceeding-value
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "UnsignedRange: truncated exceeding_value",
-                    ));
-                }
-                let exceeding_value = primitives::decode_unsigned(&data[p..end])?;
-                pos = end;
+                let (exceeding_value, pos) = decode_context_value(
+                    data,
+                    inner_start,
+                    0,
+                    "UnsignedRange exceeding-value",
+                    primitives::decode_unsigned,
+                )?;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(sf_pos, "UnsignedRange: truncated flags"));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "UnsignedRange status-flags")?;
                 // [2] exceeded-limit
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "UnsignedRange: truncated exceeded_limit",
-                    ));
-                }
-                let exceeded_limit = primitives::decode_unsigned(&data[p..end])?;
+                let (exceeded_limit, pos) = decode_context_value(
+                    data,
+                    pos,
+                    2,
+                    "UnsignedRange exceeded-limit",
+                    primitives::decode_unsigned,
+                )?;
                 finish_variant(
                     Self::UnsignedRange {
                         exceeding_value,
                         status_flags,
                         exceeded_limit,
                     },
-                    end,
+                    pos,
                 )
             }
             // [0] Change of bitstring
             0 => {
-                let mut pos = inner_start;
                 // [0] referenced-bitstring
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "ChangeOfBitstring: truncated bitstring"));
-                }
-                let (unused, bits) = primitives::decode_bit_string(&data[p..end])?;
-                pos = end;
+                let ((unused, bits), pos) = decode_context_value(
+                    data,
+                    inner_start,
+                    0,
+                    "ChangeOfBitstring referenced-bitstring",
+                    primitives::decode_bit_string,
+                )?;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(
-                        sf_pos,
-                        "ChangeOfBitstring: truncated flags",
-                    ));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "ChangeOfBitstring status-flags")?;
                 finish_variant(
                     Self::ChangeOfBitstring {
                         referenced_bitstring: (unused, bits),
                         status_flags,
                     },
-                    sf_end,
+                    pos,
                 )
             }
             // [3] Command failure
@@ -295,25 +273,14 @@ impl NotificationParameters {
                 let (command_value, after) = extract_raw_context(data, p, 0)?;
                 pos = after;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(sf_pos, "CommandFailure: truncated flags"));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "CommandFailure status-flags")?;
                 // [2] feedback-value — opening/closing, raw
                 let (t, p) = tags::decode_tag(data, pos)?;
                 if !t.is_opening || t.number != 2 {
                     return Err(Error::decoding(pos, "CommandFailure: expected opening [2]"));
                 }
-                let (feedback_value, after) = extract_trailing_raw_context(
-                    data,
-                    p,
-                    2,
-                    variant_body_end,
-                    "CommandFailure feedback-value",
-                )?;
+                let (feedback_value, after) = extract_raw_context(data, p, 2)?;
                 finish_variant(
                     Self::CommandFailure {
                         command_value,
@@ -325,44 +292,33 @@ impl NotificationParameters {
             }
             // [4] Floating limit
             4 => {
-                let mut pos = inner_start;
                 // [0] reference-value
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "FloatingLimit: truncated reference_value",
-                    ));
-                }
-                let reference_value = primitives::decode_real(&data[p..end])?;
-                pos = end;
+                let (reference_value, pos) = decode_context_value(
+                    data,
+                    inner_start,
+                    0,
+                    "FloatingLimit reference-value",
+                    primitives::decode_real,
+                )?;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(sf_pos, "FloatingLimit: truncated flags"));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "FloatingLimit status-flags")?;
                 // [2] setpoint-value
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "FloatingLimit: truncated setpoint_value",
-                    ));
-                }
-                let setpoint_value = primitives::decode_real(&data[p..end])?;
-                pos = end;
+                let (setpoint_value, pos) = decode_context_value(
+                    data,
+                    pos,
+                    2,
+                    "FloatingLimit setpoint-value",
+                    primitives::decode_real,
+                )?;
                 // [3] error-limit
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "FloatingLimit: truncated error_limit"));
-                }
-                let error_limit = primitives::decode_real(&data[p..end])?;
+                let (error_limit, pos) = decode_context_value(
+                    data,
+                    pos,
+                    3,
+                    "FloatingLimit error-limit",
+                    primitives::decode_real,
+                )?;
                 finish_variant(
                     Self::FloatingLimit {
                         reference_value,
@@ -370,7 +326,7 @@ impl NotificationParameters {
                         setpoint_value,
                         error_limit,
                     },
-                    end,
+                    pos,
                 )
             }
             // [8] Change of life safety
@@ -419,13 +375,7 @@ impl NotificationParameters {
                 if !t.is_opening_tag(2) {
                     return Err(Error::decoding(pos, "Extended: expected opening [2]"));
                 }
-                let (parameters, after) = extract_trailing_raw_context(
-                    data,
-                    p,
-                    2,
-                    variant_body_end,
-                    "Extended parameters",
-                )?;
+                let (parameters, after) = extract_raw_context(data, p, 2)?;
                 finish_variant(
                     Self::Extended {
                         vendor_id,
@@ -481,13 +431,7 @@ impl NotificationParameters {
                         "AccessEvent: expected opening [5] for authentication-factor",
                     ));
                 }
-                let (authentication_factor, after) = extract_trailing_raw_context(
-                    data,
-                    p,
-                    5,
-                    variant_body_end,
-                    "AccessEvent authentication-factor",
-                )?;
+                let (authentication_factor, after) = extract_raw_context(data, p, 5)?;
                 finish_variant(
                     Self::AccessEvent {
                         access_event,
@@ -502,44 +446,33 @@ impl NotificationParameters {
             }
             // [14] Double out of range
             14 => {
-                let mut pos = inner_start;
                 // [0] exceeding-value
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "DoubleOutOfRange: truncated exceeding_value",
-                    ));
-                }
-                let exceeding_value = primitives::decode_double(&data[p..end])?;
-                pos = end;
+                let (exceeding_value, pos) = decode_context_value(
+                    data,
+                    inner_start,
+                    0,
+                    "DoubleOutOfRange exceeding-value",
+                    primitives::decode_double,
+                )?;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(sf_pos, "DoubleOutOfRange: truncated flags"));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "DoubleOutOfRange status-flags")?;
                 // [2] deadband
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "DoubleOutOfRange: truncated deadband"));
-                }
-                let deadband = primitives::decode_double(&data[p..end])?;
-                pos = end;
+                let (deadband, pos) = decode_context_value(
+                    data,
+                    pos,
+                    2,
+                    "DoubleOutOfRange deadband",
+                    primitives::decode_double,
+                )?;
                 // [3] exceeded-limit
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "DoubleOutOfRange: truncated exceeded_limit",
-                    ));
-                }
-                let exceeded_limit = primitives::decode_double(&data[p..end])?;
+                let (exceeded_limit, pos) = decode_context_value(
+                    data,
+                    pos,
+                    3,
+                    "DoubleOutOfRange exceeded-limit",
+                    primitives::decode_double,
+                )?;
                 finish_variant(
                     Self::DoubleOutOfRange {
                         exceeding_value,
@@ -547,49 +480,38 @@ impl NotificationParameters {
                         deadband,
                         exceeded_limit,
                     },
-                    end,
+                    pos,
                 )
             }
             // [15] Signed out of range
             15 => {
-                let mut pos = inner_start;
                 // [0] exceeding-value
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "SignedOutOfRange: truncated exceeding_value",
-                    ));
-                }
-                let exceeding_value = primitives::decode_signed(&data[p..end])?;
-                pos = end;
+                let (exceeding_value, pos) = decode_context_value(
+                    data,
+                    inner_start,
+                    0,
+                    "SignedOutOfRange exceeding-value",
+                    primitives::decode_signed,
+                )?;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(sf_pos, "SignedOutOfRange: truncated flags"));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "SignedOutOfRange status-flags")?;
                 // [2] deadband
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "SignedOutOfRange: truncated deadband"));
-                }
-                let deadband = primitives::decode_unsigned(&data[p..end])?;
-                pos = end;
+                let (deadband, pos) = decode_context_value(
+                    data,
+                    pos,
+                    2,
+                    "SignedOutOfRange deadband",
+                    primitives::decode_unsigned,
+                )?;
                 // [3] exceeded-limit
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "SignedOutOfRange: truncated exceeded_limit",
-                    ));
-                }
-                let exceeded_limit = primitives::decode_signed(&data[p..end])?;
+                let (exceeded_limit, pos) = decode_context_value(
+                    data,
+                    pos,
+                    3,
+                    "SignedOutOfRange exceeded-limit",
+                    primitives::decode_signed,
+                )?;
                 finish_variant(
                     Self::SignedOutOfRange {
                         exceeding_value,
@@ -597,52 +519,38 @@ impl NotificationParameters {
                         deadband,
                         exceeded_limit,
                     },
-                    end,
+                    pos,
                 )
             }
             // [16] Unsigned out of range
             16 => {
-                let mut pos = inner_start;
                 // [0] exceeding-value
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "UnsignedOutOfRange: truncated exceeding_value",
-                    ));
-                }
-                let exceeding_value = primitives::decode_unsigned(&data[p..end])?;
-                pos = end;
+                let (exceeding_value, pos) = decode_context_value(
+                    data,
+                    inner_start,
+                    0,
+                    "UnsignedOutOfRange exceeding-value",
+                    primitives::decode_unsigned,
+                )?;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(
-                        sf_pos,
-                        "UnsignedOutOfRange: truncated flags",
-                    ));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "UnsignedOutOfRange status-flags")?;
                 // [2] deadband
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "UnsignedOutOfRange: truncated deadband"));
-                }
-                let deadband = primitives::decode_unsigned(&data[p..end])?;
-                pos = end;
+                let (deadband, pos) = decode_context_value(
+                    data,
+                    pos,
+                    2,
+                    "UnsignedOutOfRange deadband",
+                    primitives::decode_unsigned,
+                )?;
                 // [3] exceeded-limit
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "UnsignedOutOfRange: truncated exceeded_limit",
-                    ));
-                }
-                let exceeded_limit = primitives::decode_unsigned(&data[p..end])?;
+                let (exceeded_limit, pos) = decode_context_value(
+                    data,
+                    pos,
+                    3,
+                    "UnsignedOutOfRange exceeded-limit",
+                    primitives::decode_unsigned,
+                )?;
                 finish_variant(
                     Self::UnsignedOutOfRange {
                         exceeding_value,
@@ -650,7 +558,7 @@ impl NotificationParameters {
                         deadband,
                         exceeded_limit,
                     },
-                    end,
+                    pos,
                 )
             }
             // [17] Change of characterstring
@@ -669,16 +577,12 @@ impl NotificationParameters {
                 };
                 pos = new_pos;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(
-                        sf_pos,
-                        "ChangeOfCharacterstring: truncated flags",
-                    ));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) = decode_context_status_flags(
+                    data,
+                    pos,
+                    1,
+                    "ChangeOfCharacterstring status-flags",
+                )?;
                 // [2] alarm-value
                 let (opt_data, new_pos) = tags::decode_optional_context(data, pos, 2)?;
                 let alarm_value = match opt_data {
@@ -713,21 +617,18 @@ impl NotificationParameters {
                 let (present_value, after) = extract_raw_context(data, p, 0)?;
                 pos = after;
                 // [1] referenced-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(
-                        sf_pos,
-                        "ChangeOfStatusFlags: truncated flags",
-                    ));
-                }
-                let referenced_flags = decode_status_flags(&data[sf_pos..sf_end]);
+                let (referenced_flags, pos) = decode_context_status_flags(
+                    data,
+                    pos,
+                    1,
+                    "ChangeOfStatusFlags referenced-flags",
+                )?;
                 finish_variant(
                     Self::ChangeOfStatusFlags {
                         present_value,
                         referenced_flags,
                     },
-                    sf_end,
+                    pos,
                 )
             }
             // [19] Change of reliability
@@ -746,13 +647,7 @@ impl NotificationParameters {
                         "ChangeOfReliability: expected opening [2]",
                     ));
                 }
-                let (property_values, after) = extract_trailing_raw_context(
-                    data,
-                    p,
-                    2,
-                    variant_body_end,
-                    "ChangeOfReliability property-values",
-                )?;
+                let (property_values, after) = extract_raw_context(data, p, 2)?;
                 finish_variant(
                     Self::ChangeOfReliability {
                         reliability,

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
@@ -1,3 +1,7 @@
+use super::decode_helpers::{
+    closing_tag_start, decode_context_status_flags, decode_context_u16,
+    extract_trailing_raw_context,
+};
 use super::decode_timer::{decode_change_of_discrete_value, decode_change_of_timer};
 use super::*;
 use crate::common::{decode_context, decode_context_u32};
@@ -6,6 +10,20 @@ impl NotificationParameters {
     /// Decode notification parameters from a position just past the opening
     /// tag of the eventValues wrapper.
     pub fn decode(data: &[u8], offset: usize) -> Result<Self, Error> {
+        Self::decode_impl(data, offset, None)
+    }
+
+    pub(crate) fn decode_bounded(data: &[u8], offset: usize, end: usize) -> Result<Self, Error> {
+        Self::decode_impl(data, offset, Some(end))
+    }
+
+    fn decode_impl(data: &[u8], offset: usize, end: Option<usize>) -> Result<Self, Error> {
+        let data = match end {
+            Some(end) => data.get(..end).ok_or_else(|| {
+                Error::decoding(end, "NotificationParameters boundary exceeds input")
+            })?,
+            None => data,
+        };
         // Peek the inner opening tag to determine the variant
         if offset >= data.len() {
             return Err(Error::decoding(
@@ -21,6 +39,16 @@ impl NotificationParameters {
             ));
         }
         let variant_tag = inner_tag.number;
+        let variant_body_end = end
+            .map(|_| {
+                closing_tag_start(
+                    data,
+                    data.len(),
+                    variant_tag,
+                    "NotificationParameters variant",
+                )
+            })
+            .transpose()?;
 
         match variant_tag {
             // [1] Change of state
@@ -170,27 +198,11 @@ impl NotificationParameters {
                 }
                 pos = cp;
                 // [1] previous-notification
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "BufferReady: truncated previous_notification",
-                    ));
-                }
-                let previous_notification = primitives::decode_unsigned(&data[p..end])? as u32;
-                pos = end;
+                let (previous_notification, pos) =
+                    decode_context_u32(data, pos, 1, "BufferReady previous-notification")?;
                 // [2] current-notification
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "BufferReady: truncated current_notification",
-                    ));
-                }
-                let current_notification = primitives::decode_unsigned(&data[p..end])? as u32;
-                let _ = (pos, end);
+                let (current_notification, _) =
+                    decode_context_u32(data, pos, 2, "BufferReady current-notification")?;
                 Ok(Self::BufferReady {
                     buffer_property,
                     previous_notification,
@@ -285,7 +297,13 @@ impl NotificationParameters {
                 if !t.is_opening || t.number != 2 {
                     return Err(Error::decoding(pos, "CommandFailure: expected opening [2]"));
                 }
-                let (feedback_value, _after) = extract_raw_context(data, p, 2)?;
+                let (feedback_value, _after) = extract_trailing_raw_context(
+                    data,
+                    p,
+                    2,
+                    variant_body_end,
+                    "CommandFailure feedback-value",
+                )?;
                 Ok(Self::CommandFailure {
                     command_value,
                     status_flags,
@@ -379,32 +397,24 @@ impl NotificationParameters {
             }
             // [9] Extended
             9 => {
-                let mut pos = inner_start;
                 // [0] vendor-id
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "Extended: truncated vendor_id"));
-                }
-                let vendor_id = primitives::decode_unsigned(&data[p..end])? as u16;
-                pos = end;
+                let (vendor_id, pos) =
+                    decode_context_u16(data, inner_start, 0, "Extended vendor-id")?;
                 // [1] extended-event-type
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "Extended: truncated extended_event_type",
-                    ));
-                }
-                let extended_event_type = primitives::decode_unsigned(&data[p..end])? as u32;
-                pos = end;
+                let (extended_event_type, pos) =
+                    decode_context_u32(data, pos, 1, "Extended extended-event-type")?;
                 // [2] parameters — opening/closing, raw
                 let (t, p) = tags::decode_tag(data, pos)?;
-                if !t.is_opening || t.number != 2 {
+                if !t.is_opening_tag(2) {
                     return Err(Error::decoding(pos, "Extended: expected opening [2]"));
                 }
-                let (parameters, _after) = extract_raw_context(data, p, 2)?;
+                let (parameters, _after) = extract_trailing_raw_context(
+                    data,
+                    p,
+                    2,
+                    variant_body_end,
+                    "Extended parameters",
+                )?;
                 Ok(Self::Extended {
                     vendor_id,
                     extended_event_type,
@@ -413,34 +423,15 @@ impl NotificationParameters {
             }
             // [13] Access event
             13 => {
-                let mut pos = inner_start;
                 // [0] access-event
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(p, "AccessEvent: truncated access_event"));
-                }
-                let access_event = primitives::decode_unsigned(&data[p..end])? as u32;
-                pos = end;
+                let (access_event, pos) =
+                    decode_context_u32(data, inner_start, 0, "AccessEvent access-event")?;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(sf_pos, "AccessEvent: truncated flags"));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "AccessEvent status-flags")?;
                 // [2] access-event-tag
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "AccessEvent: truncated access_event_tag",
-                    ));
-                }
-                let access_event_tag = primitives::decode_unsigned(&data[p..end])? as u32;
-                pos = end;
+                let (access_event_tag, mut pos) =
+                    decode_context_u32(data, pos, 2, "AccessEvent access-event-tag")?;
                 // [3] access-event-time: BACnetTimeStamp (DateTime)
                 let (ts, new_pos) = primitives::decode_timestamp(data, pos, 3)?;
                 pos = new_pos;
@@ -470,13 +461,19 @@ impl NotificationParameters {
                 pos = cp;
                 // [5] authentication-factor — opening/closing, raw
                 let (t, p) = tags::decode_tag(data, pos)?;
-                if !t.is_opening || t.number != 5 {
+                if !t.is_opening_tag(5) {
                     return Err(Error::decoding(
                         pos,
                         "AccessEvent: expected opening [5] for authentication-factor",
                     ));
                 }
-                let (authentication_factor, _after) = extract_raw_context(data, p, 5)?;
+                let (authentication_factor, _after) = extract_trailing_raw_context(
+                    data,
+                    p,
+                    5,
+                    variant_body_end,
+                    "AccessEvent authentication-factor",
+                )?;
                 Ok(Self::AccessEvent {
                     access_event,
                     status_flags,
@@ -706,38 +703,27 @@ impl NotificationParameters {
             }
             // [19] Change of reliability
             19 => {
-                let mut pos = inner_start;
                 // [0] reliability
-                let (t, p) = tags::decode_tag(data, pos)?;
-                let end = p + t.length as usize;
-                if end > data.len() {
-                    return Err(Error::decoding(
-                        p,
-                        "ChangeOfReliability: truncated reliability",
-                    ));
-                }
-                let reliability = primitives::decode_unsigned(&data[p..end])? as u32;
-                pos = end;
+                let (reliability, pos) =
+                    decode_context_u32(data, inner_start, 0, "ChangeOfReliability reliability")?;
                 // [1] status-flags
-                let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-                let sf_end = sf_pos + sf_tag.length as usize;
-                if sf_end > data.len() {
-                    return Err(Error::decoding(
-                        sf_pos,
-                        "ChangeOfReliability: truncated flags",
-                    ));
-                }
-                let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-                pos = sf_end;
+                let (status_flags, pos) =
+                    decode_context_status_flags(data, pos, 1, "ChangeOfReliability status-flags")?;
                 // [2] property-values — opening/closing, raw
                 let (t, p) = tags::decode_tag(data, pos)?;
-                if !t.is_opening || t.number != 2 {
+                if !t.is_opening_tag(2) {
                     return Err(Error::decoding(
                         pos,
                         "ChangeOfReliability: expected opening [2]",
                     ));
                 }
-                let (property_values, _after) = extract_raw_context(data, p, 2)?;
+                let (property_values, _after) = extract_trailing_raw_context(
+                    data,
+                    p,
+                    2,
+                    variant_body_end,
+                    "ChangeOfReliability property-values",
+                )?;
                 Ok(Self::ChangeOfReliability {
                     reliability,
                     status_flags,
@@ -749,7 +735,7 @@ impl NotificationParameters {
             // [21] Change of discrete value
             21 => decode_change_of_discrete_value(data, inner_start),
             // [22] Change of timer
-            22 => decode_change_of_timer(data, inner_start),
+            22 => decode_change_of_timer(data, inner_start, variant_body_end),
             other => Err(Error::decoding(
                 offset,
                 format!("NotificationParameters variant [{other}] unknown"),

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode_helpers.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode_helpers.rs
@@ -36,21 +36,15 @@ pub(super) fn closing_tag_start(
     Ok(start)
 }
 
-pub(super) fn extract_trailing_raw_context(
+pub(super) fn decode_context_value<T>(
     data: &[u8],
-    start: usize,
-    tag_number: u8,
-    variant_body_end: usize,
+    offset: usize,
+    expected_tag: u8,
     field: &str,
-) -> Result<(Vec<u8>, usize), Error> {
-    let closing = closing_tag_start(data, variant_body_end, tag_number, field)?;
-    if closing < start {
-        return Err(Error::decoding(
-            start,
-            format!("{field} has invalid bounds"),
-        ));
-    }
-    Ok((data[start..closing].to_vec(), variant_body_end))
+    decode: impl FnOnce(&[u8]) -> Result<T, Error>,
+) -> Result<(T, usize), Error> {
+    let (content, end) = decode_context(data, offset, expected_tag, field)?;
+    Ok((decode(content)?, end))
 }
 
 pub(super) fn decode_context_u16(

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode_helpers.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode_helpers.rs
@@ -1,0 +1,77 @@
+use super::*;
+use crate::common::decode_context;
+
+pub(super) fn closing_tag_start(
+    data: &[u8],
+    end: usize,
+    tag_number: u8,
+    field: &str,
+) -> Result<usize, Error> {
+    let width = if tag_number > 14 { 2 } else { 1 };
+    let start = end
+        .checked_sub(width)
+        .ok_or_else(|| Error::decoding(end, format!("{field} missing closing tag")))?;
+    let (tag, next) = tags::decode_tag(data, start)?;
+    if !tag.is_closing_tag(tag_number) || next != end {
+        return Err(Error::decoding(
+            start,
+            format!("{field} expected closing tag {tag_number}"),
+        ));
+    }
+    Ok(start)
+}
+
+pub(super) fn extract_trailing_raw_context(
+    data: &[u8],
+    start: usize,
+    tag_number: u8,
+    variant_body_end: Option<usize>,
+    field: &str,
+) -> Result<(Vec<u8>, usize), Error> {
+    let Some(end) = variant_body_end else {
+        return extract_raw_context(data, start, tag_number);
+    };
+    let closing = closing_tag_start(data, end, tag_number, field)?;
+    if closing < start {
+        return Err(Error::decoding(
+            start,
+            format!("{field} has invalid bounds"),
+        ));
+    }
+    Ok((data[start..closing].to_vec(), end))
+}
+
+pub(super) fn decode_context_u16(
+    data: &[u8],
+    offset: usize,
+    expected_tag: u8,
+    field: &str,
+) -> Result<(u16, usize), Error> {
+    let (content, end) = decode_context(data, offset, expected_tag, field)?;
+    let value = primitives::decode_unsigned(content)?;
+    let value = u16::try_from(value)
+        .map_err(|_| Error::decoding(offset, format!("{field} exceeds u16")))?;
+    Ok((value, end))
+}
+
+pub(super) fn decode_context_status_flags(
+    data: &[u8],
+    offset: usize,
+    expected_tag: u8,
+    field: &str,
+) -> Result<(u8, usize), Error> {
+    let (content, end) = decode_context(data, offset, expected_tag, field)?;
+    let [4, bits] = content else {
+        return Err(Error::decoding(
+            offset,
+            format!("{field} must contain four bits"),
+        ));
+    };
+    if bits & 0x0f != 0 {
+        return Err(Error::decoding(
+            offset,
+            format!("{field} must have zero padding"),
+        ));
+    }
+    Ok((bits >> 4, end))
+}

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode_helpers.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode_helpers.rs
@@ -1,6 +1,21 @@
 use super::*;
 use crate::common::decode_context;
 
+pub(super) fn finish_variant(
+    value: NotificationParameters,
+    consumed: usize,
+    body_end: usize,
+    variant_tag: u8,
+) -> Result<NotificationParameters, Error> {
+    if consumed != body_end {
+        return Err(Error::decoding(
+            consumed,
+            format!("NotificationParameters variant {variant_tag} has unexpected fields"),
+        ));
+    }
+    Ok(value)
+}
+
 pub(super) fn closing_tag_start(
     data: &[u8],
     end: usize,
@@ -25,20 +40,17 @@ pub(super) fn extract_trailing_raw_context(
     data: &[u8],
     start: usize,
     tag_number: u8,
-    variant_body_end: Option<usize>,
+    variant_body_end: usize,
     field: &str,
 ) -> Result<(Vec<u8>, usize), Error> {
-    let Some(end) = variant_body_end else {
-        return extract_raw_context(data, start, tag_number);
-    };
-    let closing = closing_tag_start(data, end, tag_number, field)?;
+    let closing = closing_tag_start(data, variant_body_end, tag_number, field)?;
     if closing < start {
         return Err(Error::decoding(
             start,
             format!("{field} has invalid bounds"),
         ));
     }
-    Ok((data[start..closing].to_vec(), end))
+    Ok((data[start..closing].to_vec(), variant_body_end))
 }
 
 pub(super) fn decode_context_u16(

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode_timer.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode_timer.rs
@@ -1,5 +1,6 @@
+use super::decode_helpers::decode_context_status_flags;
 use super::*;
-use crate::common::{decode_context, decode_context_u32};
+use crate::common::decode_context_u32;
 
 fn decode_date_time(
     data: &[u8],
@@ -51,32 +52,16 @@ fn decode_date_time(
     Ok(((date, time), next))
 }
 
-fn decode_timer_status_flags(data: &[u8], offset: usize) -> Result<(u8, usize), Error> {
-    let (content, end) = decode_context(data, offset, 1, "ChangeOfTimer status-flags")?;
-    let [4, bits] = content else {
-        return Err(Error::decoding(
-            offset,
-            "ChangeOfTimer status-flags must contain four bits",
-        ));
-    };
-    if bits & 0x0f != 0 {
-        return Err(Error::decoding(
-            offset,
-            "ChangeOfTimer status-flags must have zero padding",
-        ));
-    }
-    Ok((bits >> 4, end))
-}
-
 pub(super) fn decode_change_of_timer(
     data: &[u8],
     inner_start: usize,
-    variant_body_end: Option<usize>,
+    variant_body_end: usize,
 ) -> Result<NotificationParameters, Error> {
     // [0] new-state
     let (new_state, pos) = decode_context_u32(data, inner_start, 0, "ChangeOfTimer new-state")?;
     // [1] status-flags
-    let (status_flags, pos) = decode_timer_status_flags(data, pos)?;
+    let (status_flags, pos) =
+        decode_context_status_flags(data, pos, 1, "ChangeOfTimer status-flags")?;
     // [2] update-time: BACnetDateTime — opening/closing [2]
     let (update_time, pos) = decode_date_time(data, pos, 2, "ChangeOfTimer update-time")?;
     // [3] last-state-change
@@ -86,7 +71,7 @@ pub(super) fn decode_change_of_timer(
     let (initial_timeout, pos) = decode_context_u32(data, pos, 4, "ChangeOfTimer initial-timeout")?;
     // [5] expiration-time: BACnetDateTime — opening/closing [5]
     let (expiration_time, pos) = decode_date_time(data, pos, 5, "ChangeOfTimer expiration-time")?;
-    if variant_body_end.is_some_and(|end| pos != end) {
+    if pos != variant_body_end {
         return Err(Error::decoding(
             pos,
             "ChangeOfTimer unexpected fields before closing tag 22",
@@ -105,6 +90,7 @@ pub(super) fn decode_change_of_timer(
 pub(super) fn decode_change_of_discrete_value(
     data: &[u8],
     inner_start: usize,
+    variant_body_end: usize,
 ) -> Result<NotificationParameters, Error> {
     let mut pos = inner_start;
     // [0] new-value — opening/closing, raw
@@ -118,15 +104,14 @@ pub(super) fn decode_change_of_discrete_value(
     let (new_value, after) = extract_raw_context(data, p, 0)?;
     pos = after;
     // [1] status-flags
-    let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-    let sf_end = sf_pos + sf_tag.length as usize;
-    if sf_end > data.len() {
+    let (status_flags, pos) =
+        decode_context_status_flags(data, pos, 1, "ChangeOfDiscreteValue status-flags")?;
+    if pos != variant_body_end {
         return Err(Error::decoding(
-            sf_pos,
-            "ChangeOfDiscreteValue: truncated flags",
+            pos,
+            "ChangeOfDiscreteValue unexpected fields before closing tag 21",
         ));
     }
-    let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
     Ok(NotificationParameters::ChangeOfDiscreteValue {
         new_value,
         status_flags,

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode_timer.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode_timer.rs
@@ -1,116 +1,97 @@
 use super::*;
+use crate::common::{decode_context, decode_context_u32};
+
+fn decode_date_time(
+    data: &[u8],
+    offset: usize,
+    context_tag: u8,
+    field: &str,
+) -> Result<((Date, Time), usize), Error> {
+    let (opening, mut pos) = tags::decode_tag(data, offset)?;
+    if !opening.is_opening_tag(context_tag) {
+        return Err(Error::decoding(
+            offset,
+            format!("{field} expected opening tag {context_tag}"),
+        ));
+    }
+
+    let (date_tag, content_start) = tags::decode_tag(data, pos)?;
+    if date_tag.class != tags::TagClass::Application || date_tag.number != tags::app_tag::DATE {
+        return Err(Error::decoding(pos, format!("{field} expected Date")));
+    }
+    let content_end = content_start
+        .checked_add(date_tag.length as usize)
+        .ok_or_else(|| Error::decoding(content_start, format!("{field} Date length overflow")))?;
+    let date = Date::decode(
+        data.get(content_start..content_end)
+            .ok_or_else(|| Error::decoding(content_start, format!("{field} truncated Date")))?,
+    )?;
+    pos = content_end;
+
+    let (time_tag, content_start) = tags::decode_tag(data, pos)?;
+    if time_tag.class != tags::TagClass::Application || time_tag.number != tags::app_tag::TIME {
+        return Err(Error::decoding(pos, format!("{field} expected Time")));
+    }
+    let content_end = content_start
+        .checked_add(time_tag.length as usize)
+        .ok_or_else(|| Error::decoding(content_start, format!("{field} Time length overflow")))?;
+    let time = Time::decode(
+        data.get(content_start..content_end)
+            .ok_or_else(|| Error::decoding(content_start, format!("{field} truncated Time")))?,
+    )?;
+    pos = content_end;
+
+    let (closing, next) = tags::decode_tag(data, pos)?;
+    if !closing.is_closing_tag(context_tag) {
+        return Err(Error::decoding(
+            pos,
+            format!("{field} expected closing tag {context_tag}"),
+        ));
+    }
+    Ok(((date, time), next))
+}
+
+fn decode_timer_status_flags(data: &[u8], offset: usize) -> Result<(u8, usize), Error> {
+    let (content, end) = decode_context(data, offset, 1, "ChangeOfTimer status-flags")?;
+    let [4, bits] = content else {
+        return Err(Error::decoding(
+            offset,
+            "ChangeOfTimer status-flags must contain four bits",
+        ));
+    };
+    if bits & 0x0f != 0 {
+        return Err(Error::decoding(
+            offset,
+            "ChangeOfTimer status-flags must have zero padding",
+        ));
+    }
+    Ok((bits >> 4, end))
+}
 
 pub(super) fn decode_change_of_timer(
     data: &[u8],
     inner_start: usize,
+    variant_body_end: Option<usize>,
 ) -> Result<NotificationParameters, Error> {
-    let mut pos = inner_start;
     // [0] new-state
-    let (t, p) = tags::decode_tag(data, pos)?;
-    let end = p + t.length as usize;
-    if end > data.len() {
-        return Err(Error::decoding(p, "ChangeOfTimer: truncated new_state"));
-    }
-    let new_state = primitives::decode_unsigned(&data[p..end])? as u32;
-    pos = end;
+    let (new_state, pos) = decode_context_u32(data, inner_start, 0, "ChangeOfTimer new-state")?;
     // [1] status-flags
-    let (sf_tag, sf_pos) = tags::decode_tag(data, pos)?;
-    let sf_end = sf_pos + sf_tag.length as usize;
-    if sf_end > data.len() {
-        return Err(Error::decoding(sf_pos, "ChangeOfTimer: truncated flags"));
-    }
-    let status_flags = decode_status_flags(&data[sf_pos..sf_end]);
-    pos = sf_end;
+    let (status_flags, pos) = decode_timer_status_flags(data, pos)?;
     // [2] update-time: BACnetDateTime — opening/closing [2]
-    let (t, p) = tags::decode_tag(data, pos)?;
-    if !t.is_opening || t.number != 2 {
-        return Err(Error::decoding(
-            pos,
-            "ChangeOfTimer: expected opening [2] for update-time",
-        ));
-    }
-    pos = p;
-    // Application-tagged Date
-    let (d_tag, d_pos) = tags::decode_tag(data, pos)?;
-    let d_end = d_pos + d_tag.length as usize;
-    if d_end > data.len() {
-        return Err(Error::decoding(
-            d_pos,
-            "ChangeOfTimer: truncated update date",
-        ));
-    }
-    let update_date = Date::decode(&data[d_pos..d_end])?;
-    pos = d_end;
-    // Application-tagged Time
-    let (t_tag, t_pos) = tags::decode_tag(data, pos)?;
-    let t_end = t_pos + t_tag.length as usize;
-    if t_end > data.len() {
-        return Err(Error::decoding(
-            t_pos,
-            "ChangeOfTimer: truncated update time",
-        ));
-    }
-    let update_time_val = Time::decode(&data[t_pos..t_end])?;
-    pos = t_end;
-    // Closing tag [2]
-    let (ct, cp) = tags::decode_tag(data, pos)?;
-    if !ct.is_closing || ct.number != 2 {
-        return Err(Error::decoding(pos, "ChangeOfTimer: expected closing [2]"));
-    }
-    pos = cp;
-    let update_time = (update_date, update_time_val);
+    let (update_time, pos) = decode_date_time(data, pos, 2, "ChangeOfTimer update-time")?;
     // [3] last-state-change
-    let (t, p) = tags::decode_tag(data, pos)?;
-    let end = p + t.length as usize;
-    if end > data.len() {
-        return Err(Error::decoding(
-            p,
-            "ChangeOfTimer: truncated last_state_change",
-        ));
-    }
-    let last_state_change = primitives::decode_unsigned(&data[p..end])? as u32;
-    pos = end;
+    let (last_state_change, pos) =
+        decode_context_u32(data, pos, 3, "ChangeOfTimer last-state-change")?;
     // [4] initial-timeout
-    let (t, p) = tags::decode_tag(data, pos)?;
-    let end = p + t.length as usize;
-    if end > data.len() {
-        return Err(Error::decoding(
-            p,
-            "ChangeOfTimer: truncated initial_timeout",
-        ));
-    }
-    let initial_timeout = primitives::decode_unsigned(&data[p..end])? as u32;
-    pos = end;
+    let (initial_timeout, pos) = decode_context_u32(data, pos, 4, "ChangeOfTimer initial-timeout")?;
     // [5] expiration-time: BACnetDateTime — opening/closing [5]
-    let (t, p) = tags::decode_tag(data, pos)?;
-    if !t.is_opening || t.number != 5 {
+    let (expiration_time, pos) = decode_date_time(data, pos, 5, "ChangeOfTimer expiration-time")?;
+    if variant_body_end.is_some_and(|end| pos != end) {
         return Err(Error::decoding(
             pos,
-            "ChangeOfTimer: expected opening [5] for expiration-time",
+            "ChangeOfTimer unexpected fields before closing tag 22",
         ));
     }
-    pos = p;
-    let (d_tag, d_pos) = tags::decode_tag(data, pos)?;
-    let d_end = d_pos + d_tag.length as usize;
-    if d_end > data.len() {
-        return Err(Error::decoding(
-            d_pos,
-            "ChangeOfTimer: truncated expiration date",
-        ));
-    }
-    let exp_date = Date::decode(&data[d_pos..d_end])?;
-    pos = d_end;
-    let (t_tag, t_pos) = tags::decode_tag(data, pos)?;
-    let t_end = t_pos + t_tag.length as usize;
-    if t_end > data.len() {
-        return Err(Error::decoding(
-            t_pos,
-            "ChangeOfTimer: truncated expiration time",
-        ));
-    }
-    let exp_time = Time::decode(&data[t_pos..t_end])?;
-    let _ = (pos, t_end);
-    let expiration_time = (exp_date, exp_time);
     Ok(NotificationParameters::ChangeOfTimer {
         new_state,
         status_flags,

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/mod.rs
@@ -1,6 +1,5 @@
 use super::property_states::{
-    decode_device_obj_prop_ref, decode_property_states, decode_status_flags,
-    encode_property_states, extract_raw_context,
+    decode_device_obj_prop_ref, decode_property_states, encode_property_states, extract_raw_context,
 };
 use super::*;
 
@@ -31,7 +30,7 @@ pub enum NotificationParameters {
         new_value: ChangeOfValueChoice,
         status_flags: u8,
     },
-    /// [3] Command failure.
+    /// [3] Command failure. Value byte vectors contain encoded BACnet TLVs.
     CommandFailure {
         command_value: Vec<u8>,
         status_flags: u8,
@@ -58,7 +57,7 @@ pub enum NotificationParameters {
         status_flags: u8,
         operation_expected: u32,
     },
-    /// [9] Extended (vendor-defined).
+    /// [9] Extended (vendor-defined). `parameters` contains encoded BACnet TLVs.
     Extended {
         vendor_id: u16,
         extended_event_type: u32,
@@ -76,7 +75,7 @@ pub enum NotificationParameters {
         status_flags: u8,
         exceeded_limit: u64,
     },
-    /// [13] Access event.
+    /// [13] Access event. `authentication_factor` contains encoded BACnet TLVs.
     AccessEvent {
         access_event: u32,
         status_flags: u8,
@@ -112,12 +111,12 @@ pub enum NotificationParameters {
         status_flags: u8,
         alarm_value: String,
     },
-    /// [18] Change of status flags.
+    /// [18] Change of status flags. `present_value` contains encoded BACnet TLVs.
     ChangeOfStatusFlags {
         present_value: Vec<u8>,
         referenced_flags: u8,
     },
-    /// [19] Change of reliability.
+    /// [19] Change of reliability. `property_values` contains encoded BACnet TLVs.
     ChangeOfReliability {
         reliability: u32,
         status_flags: u8,
@@ -125,7 +124,7 @@ pub enum NotificationParameters {
     },
     /// [20] None.
     NoneParams,
-    /// [21] Change of discrete value.
+    /// [21] Change of discrete value. `new_value` contains encoded BACnet TLVs.
     ChangeOfDiscreteValue {
         new_value: Vec<u8>,
         status_flags: u8,

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/mod.rs
@@ -5,6 +5,7 @@ use super::property_states::{
 use super::*;
 
 mod decode;
+mod decode_helpers;
 mod decode_timer;
 mod encode;
 

--- a/crates/bacnet-services/src/alarm_event/property_states.rs
+++ b/crates/bacnet-services/src/alarm_event/property_states.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::common::{decode_context, decode_context_u32};
 
 /// Encode a BACnetPropertyStates value.
 pub(super) fn encode_property_states(buf: &mut BytesMut, state: &BACnetPropertyStates) {
@@ -177,42 +178,23 @@ pub(super) fn decode_device_obj_prop_ref(
     pos: &mut usize,
 ) -> Result<BACnetDeviceObjectPropertyReference, Error> {
     // [0] objectIdentifier
-    let (t, p) = tags::decode_tag(data, *pos)?;
-    let end = p + t.length as usize;
-    if end > data.len() {
-        return Err(Error::decoding(
-            p,
-            "DeviceObjectPropertyRef: truncated objectIdentifier",
-        ));
-    }
-    let object_identifier = ObjectIdentifier::decode(&data[p..end])?;
+    let (content, end) = decode_context(data, *pos, 0, "DeviceObjectPropertyRef objectIdentifier")?;
+    let object_identifier = ObjectIdentifier::decode(content)?;
     *pos = end;
 
     // [1] propertyIdentifier
-    let (t, p) = tags::decode_tag(data, *pos)?;
-    let end = p + t.length as usize;
-    if end > data.len() {
-        return Err(Error::decoding(
-            p,
-            "DeviceObjectPropertyRef: truncated propertyIdentifier",
-        ));
-    }
-    let property_identifier = primitives::decode_unsigned(&data[p..end])? as u32;
+    let (property_identifier, end) =
+        decode_context_u32(data, *pos, 1, "DeviceObjectPropertyRef propertyIdentifier")?;
     *pos = end;
 
     // [2] propertyArrayIndex — optional
     let mut property_array_index = None;
     if *pos < data.len() {
-        let (peek, peek_pos) = tags::decode_tag(data, *pos)?;
+        let (peek, _) = tags::decode_tag(data, *pos)?;
         if peek.is_context(2) {
-            let end = peek_pos + peek.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(
-                    peek_pos,
-                    "DeviceObjectPropertyRef: truncated propertyArrayIndex",
-                ));
-            }
-            property_array_index = Some(primitives::decode_unsigned(&data[peek_pos..end])? as u32);
+            let (value, end) =
+                decode_context_u32(data, *pos, 2, "DeviceObjectPropertyRef propertyArrayIndex")?;
+            property_array_index = Some(value);
             *pos = end;
         }
     }
@@ -220,16 +202,11 @@ pub(super) fn decode_device_obj_prop_ref(
     // [3] deviceIdentifier — optional
     let mut device_identifier = None;
     if *pos < data.len() {
-        let (peek, peek_pos) = tags::decode_tag(data, *pos)?;
+        let (peek, _) = tags::decode_tag(data, *pos)?;
         if peek.is_context(3) {
-            let end = peek_pos + peek.length as usize;
-            if end > data.len() {
-                return Err(Error::decoding(
-                    peek_pos,
-                    "DeviceObjectPropertyRef: truncated deviceIdentifier",
-                ));
-            }
-            device_identifier = Some(ObjectIdentifier::decode(&data[peek_pos..end])?);
+            let (content, end) =
+                decode_context(data, *pos, 3, "DeviceObjectPropertyRef deviceIdentifier")?;
+            device_identifier = Some(ObjectIdentifier::decode(content)?);
             *pos = end;
         }
     }

--- a/crates/bacnet-services/src/alarm_event/property_states.rs
+++ b/crates/bacnet-services/src/alarm_event/property_states.rs
@@ -219,35 +219,64 @@ pub(super) fn decode_device_obj_prop_ref(
     })
 }
 
-/// Extract raw bytes between an opening and its matching closing context tag.
-///
-/// `start` is the position just past the opening tag. The closing tag byte for
-/// context tags 0–14 is `(tag_number << 4) | 0x0F`. This scans byte-by-byte to
-/// find the matching close without parsing inner content as BACnet tags.
+/// Extract an encoded BACnet value sequence from a constructed context field.
 pub(super) fn extract_raw_context(
     data: &[u8],
     start: usize,
     tag_number: u8,
 ) -> Result<(Vec<u8>, usize), Error> {
-    // For context tags < 15 the opening/closing bytes are single-byte:
-    //   opening = (tag << 4) | 0x0E, closing = (tag << 4) | 0x0F
-    let open_byte = (tag_number << 4) | 0x0E;
-    let close_byte = (tag_number << 4) | 0x0F;
-    let mut depth: usize = 1;
+    let mut stack = [0; tags::MAX_CONTEXT_NESTING_DEPTH];
+    stack[0] = tag_number;
+    let mut depth = 1;
     let mut pos = start;
+
     while pos < data.len() {
-        let b = data[pos];
-        if b == open_byte {
+        let tag_start = pos;
+        let (tag, content_start) = tags::decode_tag(data, pos)?;
+        if tag.is_opening {
+            if depth == stack.len() {
+                return Err(Error::decoding(
+                    pos,
+                    format!(
+                        "context tag nesting depth exceeds maximum ({})",
+                        tags::MAX_CONTEXT_NESTING_DEPTH
+                    ),
+                ));
+            }
+            stack[depth] = tag.number;
             depth += 1;
-        } else if b == close_byte {
+            pos = content_start;
+        } else if tag.is_closing {
+            if tag.number != stack[depth - 1] {
+                return Err(Error::decoding(
+                    pos,
+                    format!(
+                        "closing tag {} does not match opening tag {}",
+                        tag.number,
+                        stack[depth - 1]
+                    ),
+                ));
+            }
             depth -= 1;
             if depth == 0 {
-                let raw = data[start..pos].to_vec();
-                return Ok((raw, pos + 1)); // past closing tag byte
+                return Ok((data[start..tag_start].to_vec(), content_start));
+            }
+            pos = content_start;
+        } else if tag.class == tags::TagClass::Application && tag.number == tags::app_tag::BOOLEAN {
+            pos = content_start;
+        } else {
+            pos = content_start
+                .checked_add(tag.length as usize)
+                .ok_or_else(|| Error::decoding(content_start, "tag length overflow"))?;
+            if pos > data.len() {
+                return Err(Error::decoding(
+                    content_start,
+                    format!("tag data overflows buffer: need {} bytes", tag.length),
+                ));
             }
         }
-        pos += 1;
     }
+
     Err(Error::decoding(
         start,
         format!("extract_raw_context: missing closing tag [{tag_number}]"),

--- a/crates/bacnet-services/src/alarm_event/tests/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/mod.rs
@@ -5,5 +5,6 @@ mod event_notification_decode;
 mod get_event_information_decode;
 mod get_event_information_timestamps;
 mod notification_parameters;
+mod notification_parameters_boundaries;
 mod notification_parameters_life_safety;
 mod service_round_trip;

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters.rs
@@ -353,7 +353,7 @@ fn notification_params_extended_round_trip() {
     let params = NotificationParameters::Extended {
         vendor_id: 42,
         extended_event_type: 7,
-        parameters: vec![0x01, 0x02, 0x03],
+        parameters: vec![0x63, 0x01, 0x02, 0x03],
     };
     let req = make_event_req(Some(params));
     let mut buf = BytesMut::new();
@@ -368,7 +368,7 @@ fn notification_params_extended_round_trip() {
         } => {
             assert_eq!(vendor_id, 42);
             assert_eq!(extended_event_type, 7);
-            assert_eq!(parameters, vec![0x01, 0x02, 0x03]);
+            assert_eq!(parameters, vec![0x63, 0x01, 0x02, 0x03]);
         }
         other => panic!("expected Extended, got {:?}", other),
     }
@@ -401,7 +401,7 @@ fn notification_params_access_event_round_trip() {
             },
         ),
         access_credential: cred.clone(),
-        authentication_factor: vec![0xAB, 0xCD],
+        authentication_factor: vec![0x62, 0xAB, 0xCD],
     };
     let req = make_event_req(Some(params));
     let mut buf = BytesMut::new();
@@ -423,7 +423,7 @@ fn notification_params_access_event_round_trip() {
             assert_eq!(access_event_time.0.year, 124);
             assert_eq!(access_event_time.1.hour, 10);
             assert_eq!(access_credential, cred);
-            assert_eq!(authentication_factor, vec![0xAB, 0xCD]);
+            assert_eq!(authentication_factor, vec![0x62, 0xAB, 0xCD]);
         }
         other => panic!("expected AccessEvent, got {:?}", other),
     }

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters_boundaries.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters_boundaries.rs
@@ -1,0 +1,393 @@
+use super::*;
+
+fn raw_context_value(buf: &mut BytesMut, tag_number: u8, value: &[u8]) {
+    tags::encode_tag(buf, tag_number, tags::TagClass::Context, value.len() as u32);
+    buf.extend_from_slice(value);
+}
+
+fn raw_buffer_ready(values: [&[u8]; 4], field_tags: [u8; 4]) -> BytesMut {
+    let mut buf = BytesMut::new();
+    tags::encode_opening_tag(&mut buf, 10);
+    tags::encode_opening_tag(&mut buf, 0);
+    let object = ObjectIdentifier::new(ObjectType::TREND_LOG, 1).unwrap();
+    primitives::encode_ctx_object_id(&mut buf, 0, &object);
+    raw_context_value(&mut buf, field_tags[0], values[0]);
+    raw_context_value(&mut buf, field_tags[1], values[1]);
+    tags::encode_closing_tag(&mut buf, 0);
+    raw_context_value(&mut buf, field_tags[2], values[2]);
+    raw_context_value(&mut buf, field_tags[3], values[3]);
+    tags::encode_closing_tag(&mut buf, 10);
+    buf
+}
+
+fn raw_extended(values: [&[u8]; 2], field_tags: [u8; 2]) -> BytesMut {
+    let mut buf = BytesMut::new();
+    tags::encode_opening_tag(&mut buf, 9);
+    raw_context_value(&mut buf, field_tags[0], values[0]);
+    raw_context_value(&mut buf, field_tags[1], values[1]);
+    tags::encode_opening_tag(&mut buf, 2);
+    tags::encode_closing_tag(&mut buf, 2);
+    tags::encode_closing_tag(&mut buf, 9);
+    buf
+}
+
+fn test_date_time() -> (Date, Time) {
+    (
+        Date {
+            year: 124,
+            month: 6,
+            day: 15,
+            day_of_week: 3,
+        },
+        Time {
+            hour: 10,
+            minute: 30,
+            second: 0,
+            hundredths: 0,
+        },
+    )
+}
+
+fn encode_device_property_reference(buf: &mut BytesMut) {
+    tags::encode_opening_tag(buf, 4);
+    let object = ObjectIdentifier::new(ObjectType::ACCESS_CREDENTIAL, 1).unwrap();
+    primitives::encode_ctx_object_id(buf, 0, &object);
+    primitives::encode_ctx_unsigned(buf, 1, 85);
+    tags::encode_closing_tag(buf, 4);
+}
+
+fn raw_access_event(values: [&[u8]; 2], field_tags: [u8; 2], flags: &[u8]) -> BytesMut {
+    let mut buf = BytesMut::new();
+    tags::encode_opening_tag(&mut buf, 13);
+    raw_context_value(&mut buf, field_tags[0], values[0]);
+    raw_context_value(&mut buf, 1, flags);
+    raw_context_value(&mut buf, field_tags[1], values[1]);
+    primitives::encode_timestamp(
+        &mut buf,
+        3,
+        &BACnetTimeStamp::DateTime {
+            date: test_date_time().0,
+            time: test_date_time().1,
+        },
+    )
+    .unwrap();
+    encode_device_property_reference(&mut buf);
+    tags::encode_opening_tag(&mut buf, 5);
+    tags::encode_closing_tag(&mut buf, 5);
+    tags::encode_closing_tag(&mut buf, 13);
+    buf
+}
+
+fn raw_change_of_reliability(value: &[u8], field_tag: u8, flags: &[u8]) -> BytesMut {
+    let mut buf = BytesMut::new();
+    tags::encode_opening_tag(&mut buf, 19);
+    raw_context_value(&mut buf, field_tag, value);
+    raw_context_value(&mut buf, 1, flags);
+    tags::encode_opening_tag(&mut buf, 2);
+    tags::encode_closing_tag(&mut buf, 2);
+    tags::encode_closing_tag(&mut buf, 19);
+    buf
+}
+
+fn raw_change_of_timer(values: [&[u8]; 3], field_tags: [u8; 3], flags: &[u8]) -> BytesMut {
+    let mut buf = BytesMut::new();
+    tags::encode_opening_tag(&mut buf, 22);
+    raw_context_value(&mut buf, field_tags[0], values[0]);
+    raw_context_value(&mut buf, 1, flags);
+    tags::encode_opening_tag(&mut buf, 2);
+    primitives::encode_app_date(&mut buf, &test_date_time().0);
+    primitives::encode_app_time(&mut buf, &test_date_time().1);
+    tags::encode_closing_tag(&mut buf, 2);
+    raw_context_value(&mut buf, field_tags[1], values[1]);
+    raw_context_value(&mut buf, field_tags[2], values[2]);
+    tags::encode_opening_tag(&mut buf, 5);
+    primitives::encode_app_date(&mut buf, &test_date_time().0);
+    primitives::encode_app_time(&mut buf, &test_date_time().1);
+    tags::encode_closing_tag(&mut buf, 5);
+    tags::encode_closing_tag(&mut buf, 22);
+    buf
+}
+
+fn decode_variant(data: &[u8]) -> Result<NotificationParameters, Error> {
+    NotificationParameters::decode(data, 0)
+}
+
+fn event_request(event_values: NotificationParameters) -> EventNotificationRequest {
+    EventNotificationRequest {
+        process_identifier: 1,
+        initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap(),
+        event_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 3).unwrap(),
+        timestamp: BACnetTimeStamp::SequenceNumber(7),
+        notification_class: 1,
+        priority: 1,
+        event_type: 1,
+        message_text: None,
+        notify_type: 0,
+        ack_required: true,
+        from_state: 0,
+        to_state: 1,
+        event_values: Some(event_values),
+    }
+}
+
+fn encode_event(event_values: NotificationParameters) -> BytesMut {
+    let mut encoded = BytesMut::new();
+    event_request(event_values).encode(&mut encoded).unwrap();
+    encoded
+}
+
+fn access_event(authentication_factor: Vec<u8>) -> NotificationParameters {
+    NotificationParameters::AccessEvent {
+        access_event: 5,
+        status_flags: 0b1000,
+        access_event_tag: 10,
+        access_event_time: test_date_time(),
+        access_credential: BACnetDeviceObjectPropertyReference::new_local(
+            ObjectIdentifier::new(ObjectType::ACCESS_CREDENTIAL, 1).unwrap(),
+            85,
+        ),
+        authentication_factor,
+    }
+}
+
+#[test]
+fn notification_parameter_values_reject_overflow_aliases() {
+    let too_wide_u32 = [1, 0, 0, 0, 0];
+    let too_wide_u16 = [1, 0, 0];
+    let u64_max = [0xff; 8];
+
+    for value in [too_wide_u32.as_slice(), u64_max.as_slice()] {
+        for field in 0..4 {
+            let mut values = [&[1][..], &[2], &[3], &[4]];
+            values[field] = value;
+            assert!(decode_variant(&raw_buffer_ready(values, [1, 2, 1, 2])).is_err());
+        }
+
+        assert!(decode_variant(&raw_extended([&[1], value], [0, 1])).is_err());
+        for field in 0..2 {
+            let mut values = [&[1][..], &[2]];
+            values[field] = value;
+            assert!(decode_variant(&raw_access_event(values, [0, 2], &[4, 0x80])).is_err());
+        }
+        assert!(decode_variant(&raw_change_of_reliability(value, 0, &[4, 0x80])).is_err());
+        for field in 0..3 {
+            let mut values = [&[1][..], &[2], &[3]];
+            values[field] = value;
+            assert!(decode_variant(&raw_change_of_timer(values, [0, 3, 4], &[4, 0x80],)).is_err());
+        }
+    }
+
+    for value in [too_wide_u16.as_slice(), u64_max.as_slice()] {
+        assert!(decode_variant(&raw_extended([value, &[1]], [0, 1])).is_err());
+    }
+}
+
+#[test]
+fn notification_parameter_values_accept_fitting_leading_zero() {
+    let max_u32 = [0, 0xff, 0xff, 0xff, 0xff];
+    let max_u16 = [0, 0xff, 0xff];
+
+    let buffer = decode_variant(&raw_buffer_ready([max_u32.as_slice(); 4], [1, 2, 1, 2])).unwrap();
+    let NotificationParameters::BufferReady {
+        buffer_property,
+        previous_notification,
+        current_notification,
+    } = buffer
+    else {
+        panic!("expected BufferReady");
+    };
+    assert_eq!(buffer_property.property_identifier, u32::MAX);
+    assert_eq!(buffer_property.property_array_index, Some(u32::MAX));
+    assert_eq!(previous_notification, u32::MAX);
+    assert_eq!(current_notification, u32::MAX);
+
+    assert!(matches!(
+        decode_variant(&raw_extended(
+            [max_u16.as_slice(), max_u32.as_slice()],
+            [0, 1]
+        )),
+        Ok(NotificationParameters::Extended {
+            vendor_id: u16::MAX,
+            extended_event_type: u32::MAX,
+            ..
+        })
+    ));
+    assert!(matches!(
+        decode_variant(&raw_access_event(
+            [max_u32.as_slice(); 2],
+            [0, 2],
+            &[4, 0x80]
+        )),
+        Ok(NotificationParameters::AccessEvent {
+            access_event: u32::MAX,
+            access_event_tag: u32::MAX,
+            ..
+        })
+    ));
+    assert!(matches!(
+        decode_variant(&raw_change_of_reliability(
+            max_u32.as_slice(),
+            0,
+            &[4, 0x80]
+        )),
+        Ok(NotificationParameters::ChangeOfReliability {
+            reliability: u32::MAX,
+            ..
+        })
+    ));
+    assert!(matches!(
+        decode_variant(&raw_change_of_timer(
+            [max_u32.as_slice(); 3],
+            [0, 3, 4],
+            &[4, 0x80]
+        )),
+        Ok(NotificationParameters::ChangeOfTimer {
+            new_state: u32::MAX,
+            last_state_change: u32::MAX,
+            initial_timeout: u32::MAX,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn notification_parameter_fields_require_owned_tags_and_status_flags() {
+    for field in 0..4 {
+        let mut tags = [1, 2, 1, 2];
+        tags[field] = 7;
+        assert!(decode_variant(&raw_buffer_ready([&[1], &[2], &[3], &[4]], tags)).is_err());
+    }
+    for field in 0..2 {
+        let mut tags = [0, 1];
+        tags[field] = 7;
+        assert!(decode_variant(&raw_extended([&[1], &[2]], tags)).is_err());
+
+        let mut tags = [0, 2];
+        tags[field] = 7;
+        assert!(decode_variant(&raw_access_event([&[1], &[2]], tags, &[4, 0x80])).is_err());
+    }
+    for field in 0..3 {
+        let mut tags = [0, 3, 4];
+        tags[field] = 7;
+        assert!(
+            decode_variant(&raw_change_of_timer([&[1], &[2], &[3]], tags, &[4, 0x80],)).is_err()
+        );
+    }
+    assert!(decode_variant(&raw_change_of_reliability(&[1], 7, &[4, 0x80])).is_err());
+
+    for flags in [&[][..], &[3, 0x80], &[4, 0x81]] {
+        assert!(decode_variant(&raw_access_event([&[1], &[2]], [0, 2], flags)).is_err());
+        assert!(decode_variant(&raw_change_of_reliability(&[1], 0, flags)).is_err());
+        assert!(
+            decode_variant(&raw_change_of_timer([&[1], &[2], &[3]], [0, 3, 4], flags,)).is_err()
+        );
+    }
+
+    let mut application_vendor = raw_extended([&[1], &[2]], [0, 1]);
+    application_vendor[1] &= !0x08;
+    assert!(decode_variant(&application_vendor).is_err());
+
+    let mut wrong_object_tag = raw_buffer_ready([&[1], &[2], &[3], &[4]], [1, 2, 1, 2]);
+    wrong_object_tag[2] = 0x3c;
+    assert!(decode_variant(&wrong_object_tag).is_err());
+
+    let mut wrong_timer_date = raw_change_of_timer([&[1], &[2], &[3]], [0, 3, 4], &[4, 0x80]);
+    let date_tag = wrong_timer_date
+        .iter()
+        .position(|byte| *byte == 0xa4)
+        .unwrap();
+    wrong_timer_date[date_tag] = 0xb4;
+    assert!(decode_variant(&wrong_timer_date).is_err());
+}
+
+#[test]
+fn event_notification_preserves_trailing_opaque_payload_bytes() {
+    let variants = [
+        NotificationParameters::CommandFailure {
+            command_value: vec![0x01],
+            status_flags: 0b1000,
+            feedback_value: vec![0x2e, 0x2f, 0xcf, 0x3f],
+        },
+        NotificationParameters::Extended {
+            vendor_id: 42,
+            extended_event_type: 7,
+            parameters: vec![0x2e, 0x2f, 0xcf, 0x9f],
+        },
+        access_event(vec![0x5e, 0x5f, 0xcf, 0xdf]),
+        NotificationParameters::ChangeOfReliability {
+            reliability: 7,
+            status_flags: 0b1000,
+            property_values: vec![0x2e, 0x2f, 0xcf, 0xff],
+        },
+    ];
+
+    for expected in variants {
+        let encoded = encode_event(expected.clone());
+        let decoded = EventNotificationRequest::decode(&encoded).unwrap();
+        assert_eq!(decoded.event_values, Some(expected));
+    }
+}
+
+#[test]
+fn event_notification_requires_exact_event_values_suffix() {
+    let variants = [
+        NotificationParameters::BufferReady {
+            buffer_property: BACnetDeviceObjectPropertyReference::new_local(
+                ObjectIdentifier::new(ObjectType::TREND_LOG, 1).unwrap(),
+                131,
+            ),
+            previous_notification: 1,
+            current_notification: 2,
+        },
+        NotificationParameters::Extended {
+            vendor_id: 42,
+            extended_event_type: 7,
+            parameters: vec![0x01, 0x02],
+        },
+        access_event(vec![0xab, 0xcd]),
+        NotificationParameters::ChangeOfTimer {
+            new_state: 1,
+            status_flags: 0b1000,
+            update_time: test_date_time(),
+            last_state_change: 2,
+            initial_timeout: 3,
+            expiration_time: test_date_time(),
+        },
+    ];
+
+    for variant in variants {
+        let encoded = encode_event(variant);
+
+        let mut missing_outer = encoded.clone();
+        missing_outer.truncate(missing_outer.len() - 1);
+        assert!(EventNotificationRequest::decode(&missing_outer).is_err());
+
+        let mut wrong_outer = encoded.clone();
+        *wrong_outer.last_mut().unwrap() = 0xbf;
+        assert!(EventNotificationRequest::decode(&wrong_outer).is_err());
+
+        let mut trailing = encoded.clone();
+        primitives::encode_ctx_unsigned(&mut trailing, 13, 1);
+        assert!(EventNotificationRequest::decode(&trailing).is_err());
+
+        let mut sibling = encoded.clone();
+        sibling.truncate(sibling.len() - 1);
+        primitives::encode_ctx_unsigned(&mut sibling, 13, 1);
+        tags::encode_closing_tag(&mut sibling, 12);
+        assert!(EventNotificationRequest::decode(&sibling).is_err());
+
+        let mut fake_final_outer = encoded.clone();
+        primitives::encode_ctx_unsigned(&mut fake_final_outer, 13, 1);
+        tags::encode_closing_tag(&mut fake_final_outer, 12);
+        assert!(EventNotificationRequest::decode(&fake_final_outer).is_err());
+
+        let mut wrong_variant_close = encoded;
+        let close_number_index = wrong_variant_close.len() - 2;
+        if wrong_variant_close[close_number_index] == 22 {
+            wrong_variant_close[close_number_index] = 21;
+        } else {
+            wrong_variant_close[close_number_index] = 0x7f;
+        }
+        assert!(EventNotificationRequest::decode(&wrong_variant_close).is_err());
+    }
+}

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters_boundaries.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters_boundaries.rs
@@ -391,3 +391,51 @@ fn event_notification_requires_exact_event_values_suffix() {
         assert!(EventNotificationRequest::decode(&wrong_variant_close).is_err());
     }
 }
+
+#[test]
+fn notification_parameters_require_exact_variant_consumption() {
+    let buffer_ready = NotificationParameters::BufferReady {
+        buffer_property: BACnetDeviceObjectPropertyReference::new_local(
+            ObjectIdentifier::new(ObjectType::TREND_LOG, 1).unwrap(),
+            131,
+        ),
+        previous_notification: 1,
+        current_notification: 2,
+    };
+
+    let mut same_tag_sibling = encode_event(buffer_ready.clone());
+    same_tag_sibling.truncate(same_tag_sibling.len() - 1);
+    buffer_ready.encode(&mut same_tag_sibling).unwrap();
+    tags::encode_closing_tag(&mut same_tag_sibling, 12);
+    assert!(EventNotificationRequest::decode(&same_tag_sibling).is_err());
+
+    let mut extra_inner_field = encode_event(buffer_ready);
+    extra_inner_field.truncate(extra_inner_field.len() - 2);
+    primitives::encode_ctx_unsigned(&mut extra_inner_field, 13, 1);
+    tags::encode_closing_tag(&mut extra_inner_field, 10);
+    tags::encode_closing_tag(&mut extra_inner_field, 12);
+    assert!(EventNotificationRequest::decode(&extra_inner_field).is_err());
+
+    let mut close_in_field_content = raw_buffer_ready([&[1], &[2], &[3], &[0, 0xaf]], [1, 2, 1, 2]);
+    close_in_field_content.truncate(close_in_field_content.len() - 1);
+    assert!(decode_variant(&close_in_field_content).is_err());
+
+    let mut missing_discrete_status = BytesMut::new();
+    tags::encode_opening_tag(&mut missing_discrete_status, 21);
+    tags::encode_opening_tag(&mut missing_discrete_status, 0);
+    tags::encode_closing_tag(&mut missing_discrete_status, 0);
+    tags::encode_closing_tag(&mut missing_discrete_status, 21);
+    assert!(decode_variant(&missing_discrete_status).is_err());
+}
+
+#[test]
+fn public_notification_parameter_decode_preserves_opaque_delimiters() {
+    let expected = NotificationParameters::Extended {
+        vendor_id: 42,
+        extended_event_type: 7,
+        parameters: vec![0x61, 0x2f, 0x9f, 0xcf],
+    };
+    let mut encoded = BytesMut::new();
+    expected.encode(&mut encoded).unwrap();
+    assert_eq!(decode_variant(&encoded).unwrap(), expected);
+}

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters_boundaries.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters_boundaries.rs
@@ -5,6 +5,12 @@ fn raw_context_value(buf: &mut BytesMut, tag_number: u8, value: &[u8]) {
     buf.extend_from_slice(value);
 }
 
+fn encoded_octet_string(value: &[u8]) -> Vec<u8> {
+    let mut encoded = BytesMut::new();
+    primitives::encode_app_octet_string(&mut encoded, value);
+    encoded.to_vec()
+}
+
 fn raw_buffer_ready(values: [&[u8]; 4], field_tags: [u8; 4]) -> BytesMut {
     let mut buf = BytesMut::new();
     tags::encode_opening_tag(&mut buf, 10);
@@ -304,20 +310,20 @@ fn notification_parameter_fields_require_owned_tags_and_status_flags() {
 fn event_notification_preserves_trailing_opaque_payload_bytes() {
     let variants = [
         NotificationParameters::CommandFailure {
-            command_value: vec![0x01],
+            command_value: encoded_octet_string(&[0x01]),
             status_flags: 0b1000,
-            feedback_value: vec![0x2e, 0x2f, 0xcf, 0x3f],
+            feedback_value: encoded_octet_string(&[0x2e, 0x2f, 0xcf, 0x3f]),
         },
         NotificationParameters::Extended {
             vendor_id: 42,
             extended_event_type: 7,
-            parameters: vec![0x2e, 0x2f, 0xcf, 0x9f],
+            parameters: encoded_octet_string(&[0x2e, 0x2f, 0xcf, 0x9f]),
         },
-        access_event(vec![0x5e, 0x5f, 0xcf, 0xdf]),
+        access_event(encoded_octet_string(&[0x5e, 0x5f, 0xcf, 0xdf])),
         NotificationParameters::ChangeOfReliability {
             reliability: 7,
             status_flags: 0b1000,
-            property_values: vec![0x2e, 0x2f, 0xcf, 0xff],
+            property_values: encoded_octet_string(&[0x2e, 0x2f, 0xcf, 0xff]),
         },
     ];
 
@@ -342,9 +348,9 @@ fn event_notification_requires_exact_event_values_suffix() {
         NotificationParameters::Extended {
             vendor_id: 42,
             extended_event_type: 7,
-            parameters: vec![0x01, 0x02],
+            parameters: encoded_octet_string(&[0x01, 0x02]),
         },
-        access_event(vec![0xab, 0xcd]),
+        access_event(encoded_octet_string(&[0xab, 0xcd])),
         NotificationParameters::ChangeOfTimer {
             new_state: 1,
             status_flags: 0b1000,
@@ -433,9 +439,199 @@ fn public_notification_parameter_decode_preserves_opaque_delimiters() {
     let expected = NotificationParameters::Extended {
         vendor_id: 42,
         extended_event_type: 7,
-        parameters: vec![0x61, 0x2f, 0x9f, 0xcf],
+        parameters: encoded_octet_string(&[0x2f, 0x9f, 0xcf]),
     };
     let mut encoded = BytesMut::new();
     expected.encode(&mut encoded).unwrap();
     assert_eq!(decode_variant(&encoded).unwrap(), expected);
+}
+
+#[test]
+fn raw_fields_reject_same_tag_siblings_and_truncated_close_aliases() {
+    let raw = encoded_octet_string(&[0x2f, 0x9f, 0xcf]);
+    let variants = [
+        NotificationParameters::CommandFailure {
+            command_value: raw.clone(),
+            status_flags: 0b1000,
+            feedback_value: raw.clone(),
+        },
+        NotificationParameters::Extended {
+            vendor_id: 42,
+            extended_event_type: 7,
+            parameters: raw.clone(),
+        },
+        access_event(raw.clone()),
+        NotificationParameters::ChangeOfReliability {
+            reliability: 7,
+            status_flags: 0b1000,
+            property_values: raw,
+        },
+    ];
+
+    for variant in variants {
+        let mut siblings = encode_event(variant.clone());
+        siblings.truncate(siblings.len() - 1);
+        variant.encode(&mut siblings).unwrap();
+        tags::encode_closing_tag(&mut siblings, 12);
+        assert!(EventNotificationRequest::decode(&siblings).is_err());
+    }
+
+    let mut truncated = encode_event(NotificationParameters::Extended {
+        vendor_id: 42,
+        extended_event_type: 7,
+        parameters: encoded_octet_string(&[0x2f, 0x9f, 0xcf]),
+    });
+    truncated.truncate(truncated.len() - 3);
+    assert!(EventNotificationRequest::decode(&truncated).is_err());
+}
+
+#[test]
+fn non_trailing_raw_fields_preserve_delimiters_inside_values() {
+    let raw = encoded_octet_string(&[0x0e, 0x0f, 0x1e, 0x1f]);
+    let variants = [
+        NotificationParameters::CommandFailure {
+            command_value: raw.clone(),
+            status_flags: 0b1000,
+            feedback_value: raw.clone(),
+        },
+        NotificationParameters::ChangeOfStatusFlags {
+            present_value: raw.clone(),
+            referenced_flags: 0b1000,
+        },
+        NotificationParameters::ChangeOfDiscreteValue {
+            new_value: raw,
+            status_flags: 0b1000,
+        },
+    ];
+
+    for expected in variants {
+        let decoded = EventNotificationRequest::decode(&encode_event(expected.clone())).unwrap();
+        assert_eq!(decoded.event_values, Some(expected));
+    }
+}
+
+#[test]
+fn public_notification_parameter_decode_accepts_event_values_close() {
+    let expected = NotificationParameters::Extended {
+        vendor_id: 42,
+        extended_event_type: 7,
+        parameters: encoded_octet_string(&[0xcf]),
+    };
+    let mut wrapped = BytesMut::new();
+    tags::encode_opening_tag(&mut wrapped, 12);
+    expected.encode(&mut wrapped).unwrap();
+    tags::encode_closing_tag(&mut wrapped, 12);
+    assert_eq!(
+        NotificationParameters::decode(&wrapped, 1).unwrap(),
+        expected
+    );
+}
+
+#[test]
+fn raw_fields_require_encoded_bacnet_values() {
+    let invalid = NotificationParameters::Extended {
+        vendor_id: 42,
+        extended_event_type: 7,
+        parameters: vec![0x9f],
+    };
+    let mut encoded = BytesMut::new();
+    invalid.encode(&mut encoded).unwrap();
+    assert!(decode_variant(&encoded).is_err());
+}
+
+#[test]
+fn primitive_notification_fields_require_their_context_tags() {
+    let variants = [
+        (
+            NotificationParameters::ChangeOfBitstring {
+                referenced_bitstring: (0, vec![0x80]),
+                status_flags: 0b1000,
+            },
+            2,
+        ),
+        (
+            NotificationParameters::FloatingLimit {
+                reference_value: 1.0,
+                status_flags: 0b1000,
+                setpoint_value: 2.0,
+                error_limit: 3.0,
+            },
+            4,
+        ),
+        (
+            NotificationParameters::OutOfRange {
+                exceeding_value: 1.0,
+                status_flags: 0b1000,
+                deadband: 2.0,
+                exceeded_limit: 3.0,
+            },
+            4,
+        ),
+        (
+            NotificationParameters::UnsignedRange {
+                exceeding_value: 1,
+                status_flags: 0b1000,
+                exceeded_limit: 2,
+            },
+            3,
+        ),
+        (
+            NotificationParameters::DoubleOutOfRange {
+                exceeding_value: 1.0,
+                status_flags: 0b1000,
+                deadband: 2.0,
+                exceeded_limit: 3.0,
+            },
+            4,
+        ),
+        (
+            NotificationParameters::SignedOutOfRange {
+                exceeding_value: -1,
+                status_flags: 0b1000,
+                deadband: 2,
+                exceeded_limit: -3,
+            },
+            4,
+        ),
+        (
+            NotificationParameters::UnsignedOutOfRange {
+                exceeding_value: 1,
+                status_flags: 0b1000,
+                deadband: 2,
+                exceeded_limit: 3,
+            },
+            4,
+        ),
+        (
+            NotificationParameters::ChangeOfCharacterstring {
+                changed_value: "changed".into(),
+                status_flags: 0b1000,
+                alarm_value: "alarm".into(),
+            },
+            3,
+        ),
+        (
+            NotificationParameters::ChangeOfLifeSafety {
+                new_state: 1,
+                new_mode: 2,
+                status_flags: 0b1000,
+                operation_expected: 3,
+            },
+            4,
+        ),
+    ];
+
+    for (variant, field_count) in variants {
+        let mut encoded = BytesMut::new();
+        variant.encode(&mut encoded).unwrap();
+        let (_, mut field_start) = tags::decode_tag(&encoded, 0).unwrap();
+        for expected_tag in 0..field_count {
+            let (field, content_start) = tags::decode_tag(&encoded, field_start).unwrap();
+            assert!(field.is_context(expected_tag));
+            let mut wrong_tag = encoded.clone();
+            wrong_tag[field_start] = 0x70 | (wrong_tag[field_start] & 0x0f);
+            assert!(decode_variant(&wrong_tag).is_err());
+            field_start = content_start + field.length as usize;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- anchor the final EventNotification `[12]` close at the end of the request and require one matching NotificationParameters variant immediately before it
- traverse raw NotificationParameters fields as encoded BACnet TLV sequences, preserving tag-like content octets while rejecting malformed nesting, same-tag siblings, and truncated close aliases
- preserve the public decoder contract for callers that pass the enclosing event-values `[12]` close
- require exact context tags and four-bit StatusFlags across the affected variants
- replace 11 unchecked `u32` narrowings and one `u16` narrowing with exact context decoding and checked conversion
- validate ChangeOfTimer DateTime fields and exact variant consumption

## Scope

Closes #349 and advances #309. The direct unchecked-cast inventory falls from 38 to 26.

This PR preserves the public NotificationParameters variants and encoder wire shapes. Raw `Vec<u8>` fields now explicitly contain encoded BACnet TLV sequences; their values remain byte-preserving. The separate model migration for AccessEvent, ChangeOfTimer, complex event type `[6]`, and the omitted choice `[20]` is tracked in #351. BACnetPropertyStates remains in #346 and audit service models remain in #345.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test -p bacnet-services --locked`
- `cargo test -p bacnet-server event_notification --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`