### PR TITLE
fix(types): restore no_std compilation; drop orphaned binary tests module

### DIFF
--- a/crates/bacnet-objects/src/binary/tests/mod.rs
+++ b/crates/bacnet-objects/src/binary/tests/mod.rs
@@ -1,3 +1,0 @@
-mod command_failure;
-mod input_output;
-mod value;

--- a/crates/bacnet-types/src/constructed/mod.rs
+++ b/crates/bacnet-types/src/constructed/mod.rs
@@ -5,7 +5,7 @@
 //! All types follow the same `no_std`-compatible pattern used in `primitives.rs`.
 
 #[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 use crate::error::Error;
 use crate::primitives::{Date, ObjectIdentifier, Time};

--- a/crates/bacnet-types/src/enums/mod.rs
+++ b/crates/bacnet-types/src/enums/mod.rs
@@ -5,9 +5,6 @@
 //! without panicking. Every type provides `from_raw` / `to_raw` for
 //! wire-level conversion and a human-readable `Display` impl.
 
-#[cfg(not(feature = "std"))]
-use alloc::format;
-
 // ---------------------------------------------------------------------------
 // Macro to reduce boilerplate for newtype enum wrappers
 // ---------------------------------------------------------------------------

--- a/crates/bacnet-types/src/error.rs
+++ b/crates/bacnet-types/src/error.rs
@@ -5,7 +5,7 @@
 //! and timeouts.
 
 #[cfg(not(feature = "std"))]
-use alloc::string::String;
+use alloc::{format, string::String};
 #[cfg(feature = "std")]
 use std::time::Duration;
 

--- a/crates/bacnet-types/src/primitives.rs
+++ b/crates/bacnet-types/src/primitives.rs
@@ -4,7 +4,7 @@
 //! [`Time`], and the [`PropertyValue`] sum type.
 
 #[cfg(not(feature = "std"))]
-use alloc::{string::String, vec::Vec};
+use alloc::{format, string::String, vec::Vec};
 
 use crate::enums::ObjectType;
 use crate::error::Error;


### PR DESCRIPTION
Two compile-hygiene defects in disjoint crates, no API surface between them.

## `#354` — `bacnet-types` does not compile without `std`

`cargo check -p bacnet-types --no-default-features --locked` failed with 8 errors before any consumer compiled. The crate declares `no_std` (`lib.rs:14`) and pulls in `alloc` (`:17`), but three modules used items that only the std prelude supplies:

| file | missing |
|---|---|
| `error.rs:25-28` | `format!` → `alloc::format` |
| `primitives.rs:155,223,277` | `format!` → `alloc::format` |
| `constructed/mod.rs:551` | `String` → `alloc::string::String` |

`enums/mod.rs:8-9` also imported `alloc::format` that nothing uses — every remaining `format!` under `enums/` is in test or serde-test code.

All four edits are inside `#[cfg(not(feature = "std"))]` blocks, so **the default-feature API is unchanged**.

**Not a regression.** `git show v0.10.1:crates/bacnet-types/src/error.rs` has the same missing import, so the *published* 0.10.1 is broken while `Cargo.toml:10` lists the crate under the crates.io `no-std` category. It rotted unnoticed because `.github/workflows/ci.yml` contains zero `--no-default-features` invocations — the configuration is declared and categorized but compiled nowhere.

`bacnet-types` is the only workspace member with a `std` feature, and no member depends on it with `default-features = false`, so nothing else is affected.

## `#263` — orphaned module file

`crates/bacnet-objects/src/binary/tests/mod.rs` was three `mod` declarations and no test code. `binary/mod.rs` has no `mod tests;`, and all four test files are already reached via `#[path]` attributes (`input.rs:297`, `output.rs:347`, `value.rs:357`, `mod.rs:24`). Deleting it loses nothing; wiring it up instead would have double-declared three modules and still missed `generic_event_properties.rs`, which the orphan never listed.

`binary` was the only orphan — the other nine `*/tests/mod.rs` files in the workspace all have a matching `mod tests;` in their parent.

## Verification

- `cargo check -p bacnet-types` across all four feature combinations (`--no-default-features`, `--no-default-features --features serde`, default, `--features serde`) — all compile, zero unused-import warnings
- `cargo test --workspace --exclude rusty-bacnet` — pass
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked` — clean
- `cargo fmt --all --check` — clean

## Deliberately not in this PR

**No CI change.** `AGENTS.md:16` says not to add CI unsolicited, and `#354` itself asks to verify a dependent crate before adding coverage. Without a gate this will rot again, so it is worth an owner decision: the cheapest guard is adding `--no-default-features` to an existing job rather than a new one.

**Pre-existing warning left alone.** `server/mod.rs:773` re-exports `EXECUTED_CONFIRMED`/`EXECUTED_UNCONFIRMED`, which are only consumed by `pics/tests.rs:775-782` under `#[cfg(test)]`, so the non-test build warns on both. It dates to `ce0ef1e` (#192) and belongs to `bacnet-server`, not to either issue here.

Closes #354
Closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)