### PR TITLE
fix(server): route notification recipients by their BACnetAddress

### DIFF
--- a/crates/bacnet-objects/src/notification_class/mod.rs
+++ b/crates/bacnet-objects/src/notification_class/mod.rs
@@ -443,9 +443,8 @@ pub fn get_notification_recipients(
 ///   was found and its `Recipient_List` decoded; `list` may be empty after
 ///   filtering (no recipient viable right now).
 /// - `None` — a NotificationClass matched but its stored `Recipient_List`
-///   FAILED to decode: the configured recipients are unknown, and
-///   delivering to a decodable prefix (or falling back to the
-///   would notify the wrong set of devices.
+///   FAILED to decode: the configured recipients are unknown, and delivering
+///   to a decodable prefix would notify the wrong set of devices.
 pub fn get_notification_recipients_strict(
     db: &ObjectDatabase,
     notification_class: u32,

--- a/crates/bacnet-objects/src/notification_class/mod.rs
+++ b/crates/bacnet-objects/src/notification_class/mod.rs
@@ -363,9 +363,12 @@ fn find_notification_class(
 /// When no NotificationClass matches the given number (the object's
 /// `Notification_Class` was never configured or points at a missing class),
 /// the spec leaves the projection undefined; we fall back to the BACnet
-/// defaults — `Priority = 255` (lowest) and `Ack_Required = false` — so the
-/// notification is still delivered with a benign priority and no
-/// acknowledgement demand rather than dropped silently.
+/// defaults — `Priority = 255` (lowest) and `Ack_Required = false`.
+///
+/// Those defaults no longer reach the wire on the server's send path. A class
+/// that does not exist also names no recipients, and the sender distributes
+/// nothing when the recipient set is empty, so the fallback survives only for
+/// direct callers of this function.
 pub fn resolve_transition_priority_ack(
     db: &ObjectDatabase,
     notification_class: u32,
@@ -442,7 +445,7 @@ pub fn get_notification_recipients(
 /// - `None` — a NotificationClass matched but its stored `Recipient_List`
 ///   FAILED to decode: the configured recipients are unknown, and
 ///   delivering to a decodable prefix (or falling back to the
-///   no-recipients broadcast path) would notify the wrong set of devices.
+///   would notify the wrong set of devices.
 pub fn get_notification_recipients_strict(
     db: &ObjectDatabase,
     notification_class: u32,

--- a/crates/bacnet-server/src/server/dcc_event_detection_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_event_detection_tests.rs
@@ -97,6 +97,12 @@ async fn dcc_states_preserve_delayed_detection_but_suppress_distribution() {
             .unwrap(),
         ))
         .unwrap();
+        // A recipient that WOULD be broadcast to, so the empty assertion can
+        // only be satisfied by the DCC gate rather than by an unnamed recipient.
+        db.add(Box::new(
+            super::event_notifications_tests::notification_class_0_broadcasting(),
+        ))
+        .unwrap();
 
         let mut server = BACnetServer::start(ServerConfig::default(), db, transport)
             .await

--- a/crates/bacnet-server/src/server/event_enable_distribution_tests.rs
+++ b/crates/bacnet-server/src/server/event_enable_distribution_tests.rs
@@ -126,6 +126,12 @@ impl Fixture {
             .unwrap(),
         ))
         .unwrap();
+        // These objects leave Notification_Class at its default of 0, so class
+        // 0 has to exist and name a recipient for anything to be distributed.
+        db.add(Box::new(
+            super::event_notifications_tests::notification_class_0_broadcasting(),
+        ))
+        .unwrap();
 
         let sent = StdArc::new(StdMutex::new(Vec::new()));
         Self {

--- a/crates/bacnet-server/src/server/event_enrollment_task_tests.rs
+++ b/crates/bacnet-server/src/server/event_enrollment_task_tests.rs
@@ -94,6 +94,14 @@ async fn spawned_task_advances_and_fires_the_time_delay_countdown() {
         .unwrap(),
     ))
     .unwrap();
+    // A recipient that WOULD be broadcast to. The Event Enrollment path has no
+    // send call today, so this changes nothing now — it makes the assertion
+    // below a live tripwire: when #127 gives that path a sender, this test goes
+    // red and asks to be updated instead of quietly staying green.
+    db.add(Box::new(
+        super::event_notifications_tests::notification_class_0_broadcasting(),
+    ))
+    .unwrap();
 
     let config = ServerConfig {
         event_enrollment_interval_secs: 1,

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -20,10 +20,11 @@ const GLOBAL_BROADCAST_NETWORK: u16 = 0xFFFF;
 ///
 /// Clause 21's `BACnetAddress` gives a recipient two independent knobs —
 /// `network-number`, where "A value of 0 indicates the local network", and
-/// `mac-address`, where "A string of length 0 indicates a broadcast". Their
-/// four combinations are four different sends, not one unicast with edge
-/// cases, which is why this is resolved once up front rather than decided at
-/// each send site.
+/// `mac-address`, where "A string of length 0 indicates a broadcast" — and
+/// Clause 6.3 reserves network 65535 for the global broadcast. Their
+/// combinations are distinct sends rather than one unicast with edge cases,
+/// which is why this is resolved once up front rather than decided at each
+/// send site.
 enum RecipientRoute {
     /// Network 0 with an explicit MAC: unicast on the local network.
     LocalUnicast(MacAddr),
@@ -78,7 +79,7 @@ impl RecipientRoute {
     /// broadcast MAC — `X'FFFFFFFFFFFF'` on Ethernet, an all-ones host portion
     /// on BACnet/IP, `X'FF'` on MS/TP — reads as `LocalUnicast` here and is
     /// still sent confirmed. Recognizing those needs the transport's broadcast
-    /// address, which this layer does not have.
+    /// address, which this layer does not have. Tracked by #360.
     fn permits_confirmed(&self) -> bool {
         matches!(self, Self::LocalUnicast(_))
     }

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -1,4 +1,5 @@
 use super::*;
+use bacnet_types::constructed::BACnetRecipient;
 use bacnet_types::enums::EventType;
 
 pub(super) struct NotificationTransition {
@@ -9,6 +10,84 @@ pub(super) struct NotificationTransition {
 impl From<(EventStateChange, EventType)> for NotificationTransition {
     fn from((change, event_type): (EventStateChange, EventType)) -> Self {
         Self { change, event_type }
+    }
+}
+
+/// The network destination a Notification Class recipient resolves to.
+///
+/// Clause 21's `BACnetAddress` gives a recipient two independent knobs —
+/// `network-number`, where "A value of 0 indicates the local network", and
+/// `mac-address`, where "A string of length 0 indicates a broadcast". Their
+/// four combinations are four different sends, not one unicast with edge
+/// cases, which is why this is resolved once up front rather than decided at
+/// each send site.
+enum RecipientRoute {
+    /// Network 0 with an explicit MAC: unicast on the local network.
+    LocalUnicast(MacAddr),
+    /// Network 0 with a zero-length MAC. Clause 12.21 prescribes exactly this
+    /// recipient for a device whose `Recipient_List` is not writable and which
+    /// uses no local Notification Forwarder objects.
+    LocalBroadcast,
+    /// A zero-length MAC on a remote network. Clause 6.3: "DNET shall specify
+    /// the network number of the remote network and DLEN shall be set to zero".
+    RemoteBroadcast(u16),
+    /// A unicast MAC on a remote network. Delivering it needs the MAC of a
+    /// next-hop router, and no router table is reachable from the server, so
+    /// the destination cannot be resolved. Tracked by #186.
+    UnresolvedRoute(u16),
+    /// A device-instance recipient. Resolving it needs a device-to-address
+    /// binding this device does not maintain. Tracked by #125.
+    UnresolvedDevice(ObjectIdentifier),
+}
+
+impl RecipientRoute {
+    fn resolve(recipient: &BACnetRecipient) -> Self {
+        match recipient {
+            BACnetRecipient::Device(oid) => Self::UnresolvedDevice(*oid),
+            BACnetRecipient::Address(addr) => {
+                match (addr.network_number, addr.mac_address.is_empty()) {
+                    (0, true) => Self::LocalBroadcast,
+                    (0, false) => Self::LocalUnicast(addr.mac_address.clone()),
+                    (net, true) => Self::RemoteBroadcast(net),
+                    (net, false) => Self::UnresolvedRoute(net),
+                }
+            }
+        }
+    }
+
+    /// Whether a ConfirmedEventNotification may be sent to this destination.
+    ///
+    /// Clause 6.3: "Of the BACnet APDUs, only the BACnet-Unconfirmed-Request-PDU
+    /// may be transmitted using a multicast or broadcast network layer address".
+    /// A confirmed notification also has nowhere to return its SimpleACK from.
+    fn permits_confirmed(&self) -> bool {
+        matches!(self, Self::LocalUnicast(_))
+    }
+
+    /// Whether this destination can be sent to at all, logging why not when it
+    /// cannot. The two failures are reported separately because they are
+    /// separate operator problems: an unreachable network is a routing
+    /// configuration gap, while an unbound device instance is a recipient this
+    /// device cannot address at all.
+    fn is_deliverable(&self, notification_class: u32) -> bool {
+        match self {
+            Self::LocalUnicast(_) | Self::LocalBroadcast | Self::RemoteBroadcast(_) => true,
+            Self::UnresolvedRoute(network) => {
+                warn!(
+                    notification_class,
+                    network, "Skipping recipient: no known route to its network"
+                );
+                false
+            }
+            Self::UnresolvedDevice(device) => {
+                warn!(
+                    notification_class,
+                    %device,
+                    "Skipping recipient: no address binding for this device instance"
+                );
+                false
+            }
+        }
     }
 }
 
@@ -207,182 +286,187 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             (base_notification, recipients)
         };
 
+        let notification_class = notification.notification_class;
+
+        // Clause 13.2.5: "notifications are distributed to the notification-
+        // clients specified by the Recipient_List input". The Recipient_List is
+        // the destination set, so no matching recipient means no notification
+        // is distributed. Broadcasting instead would invent a destination the
+        // configuration never named, and would leak the alarm to every device
+        // on the link.
         if recipients.is_empty() {
+            debug!(
+                notification_class,
+                "No Recipient_List entry matched this transition; nothing distributed"
+            );
+            return;
+        }
+
+        for (recipient, process_id, confirmed) in &recipients {
+            let route = RecipientRoute::resolve(recipient);
+
+            if !route.is_deliverable(notification_class) {
+                continue;
+            }
+
+            // Clause 6.3 restricts broadcast to Unconfirmed-Request-PDUs.
+            // Downgrading to unconfirmed would drop the acknowledgment the
+            // recipient was configured to require, so this is a skip.
+            if *confirmed && !route.permits_confirmed() {
+                warn!(
+                    notification_class,
+                    "Recipient requests confirmed notifications at a broadcast address; \
+                     Clause 6.3 permits only unconfirmed PDUs there, skipping"
+                );
+                continue;
+            }
+
+            let mut targeted = notification.clone();
+            targeted.process_identifier = *process_id;
+
             let mut service_buf = BytesMut::new();
-            if let Err(e) = notification.encode(&mut service_buf) {
+            if let Err(e) = targeted.encode(&mut service_buf) {
                 warn!(error = %e, "Failed to encode EventNotification");
-                return;
+                continue;
             }
 
-            let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
-                service_choice: UnconfirmedServiceChoice::UNCONFIRMED_EVENT_NOTIFICATION,
-                service_request: service_buf.freeze(),
-            });
+            let service_bytes = service_buf.freeze();
 
-            let mut buf = BytesMut::new();
-            encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
-
-            if let Err(e) = network
-                .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
-                .await
-            {
-                warn!(error = %e, "Failed to broadcast EventNotification");
-            }
-        } else {
-            for (recipient, process_id, confirmed) in &recipients {
-                let mut targeted = notification.clone();
-                targeted.process_identifier = *process_id;
-
-                let mut service_buf = BytesMut::new();
-                if let Err(e) = targeted.encode(&mut service_buf) {
-                    warn!(error = %e, "Failed to encode EventNotification");
+            if *confirmed {
+                // `permits_confirmed` above admits only `LocalUnicast`.
+                let RecipientRoute::LocalUnicast(target_mac) = &route else {
                     continue;
-                }
+                };
+                let target_mac = target_mac.clone();
+                let peer_key = (target_mac.clone(), None);
+                let (id, result_rx) = match {
+                    let mut tsm = server_tsm.lock().await;
+                    tsm.allocate(peer_key.clone())
+                } {
+                    Some(allocated) => allocated,
+                    None => {
+                        warn!("No free invoke ID for confirmed EventNotification");
+                        continue;
+                    }
+                };
 
-                let service_bytes = service_buf.freeze();
+                let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+                    segmented: false,
+                    more_follows: false,
+                    segmented_response_accepted: false,
+                    max_segments: None,
+                    max_apdu_length: 1476,
+                    invoke_id: id,
+                    sequence_number: None,
+                    proposed_window_size: None,
+                    service_choice: ConfirmedServiceChoice::CONFIRMED_EVENT_NOTIFICATION,
+                    service_request: service_bytes,
+                });
 
-                if *confirmed {
-                    let target_mac = match recipient {
-                        bacnet_types::constructed::BACnetRecipient::Address(addr) => {
-                            Some(addr.mac_address.clone())
+                let mut buf = BytesMut::new();
+                encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
+
+                let network = Arc::clone(network);
+                let tsm = Arc::clone(server_tsm);
+                let timeout = Duration::from_millis(retry_timeout_ms);
+                let apdu_retries = DEFAULT_APDU_RETRIES;
+                tokio::spawn(async move {
+                    let mut pending_rx: Option<oneshot::Receiver<CovAckResult>> = Some(result_rx);
+
+                    for attempt in 0..=apdu_retries {
+                        let send_result = network
+                            .send_apdu(&buf, &target_mac, true, NetworkPriority::NORMAL)
+                            .await;
+
+                        if let Err(e) = send_result {
+                            warn!(error = %e, attempt, "Confirmed EventNotification send failed");
+                        } else {
+                            debug!(invoke_id = id, attempt, "Confirmed EventNotification sent");
                         }
-                        bacnet_types::constructed::BACnetRecipient::Device(_) => None,
-                    };
-                    let peer_key = (target_mac.clone().unwrap_or_else(MacAddr::new), None);
-                    let (id, result_rx) = match {
-                        let mut tsm = server_tsm.lock().await;
-                        tsm.allocate(peer_key.clone())
-                    } {
-                        Some(allocated) => allocated,
-                        None => {
-                            warn!("No free invoke ID for confirmed EventNotification");
-                            continue;
+
+                        let rx = pending_rx
+                            .take()
+                            .expect("receiver always set for each attempt");
+                        let result = match tokio::time::timeout(timeout, rx).await {
+                            Ok(Ok(r)) => Ok(r),
+                            Ok(Err(_)) => Err(()),
+                            Err(_) => Err(()),
+                        };
+
+                        if result.is_err() && attempt < apdu_retries {
+                            let new_rx = {
+                                let mut tsm = tsm.lock().await;
+                                tsm.register(peer_key.clone(), id)
+                            };
+                            pending_rx = Some(new_rx);
                         }
-                    };
 
-                    let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
-                        segmented: false,
-                        more_follows: false,
-                        segmented_response_accepted: false,
-                        max_segments: None,
-                        max_apdu_length: 1476,
-                        invoke_id: id,
-                        sequence_number: None,
-                        proposed_window_size: None,
-                        service_choice: ConfirmedServiceChoice::CONFIRMED_EVENT_NOTIFICATION,
-                        service_request: service_bytes,
-                    });
-
-                    let mut buf = BytesMut::new();
-                    encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
-
-                    let network = Arc::clone(network);
-                    let tsm = Arc::clone(server_tsm);
-                    let timeout = Duration::from_millis(retry_timeout_ms);
-                    let apdu_retries = DEFAULT_APDU_RETRIES;
-                    tokio::spawn(async move {
-                        let mut pending_rx: Option<oneshot::Receiver<CovAckResult>> =
-                            Some(result_rx);
-
-                        for attempt in 0..=apdu_retries {
-                            let send_result = if let Some(mac) = target_mac.as_ref() {
-                                network
-                                    .send_apdu(&buf, mac, true, NetworkPriority::NORMAL)
-                                    .await
-                            } else {
-                                network
-                                    .broadcast_apdu(&buf, true, NetworkPriority::NORMAL)
-                                    .await
-                            };
-
-                            if let Err(e) = send_result {
-                                warn!(error = %e, attempt, "Confirmed EventNotification send failed");
-                            } else {
-                                debug!(invoke_id = id, attempt, "Confirmed EventNotification sent");
+                        match result {
+                            Ok(CovAckResult::Ack) => {
+                                debug!(invoke_id = id, "EventNotification acknowledged");
+                                return;
                             }
-
-                            let rx = pending_rx
-                                .take()
-                                .expect("receiver always set for each attempt");
-                            let result = match tokio::time::timeout(timeout, rx).await {
-                                Ok(Ok(r)) => Ok(r),
-                                Ok(Err(_)) => Err(()),
-                                Err(_) => Err(()),
-                            };
-
-                            if result.is_err() && attempt < apdu_retries {
-                                let new_rx = {
-                                    let mut tsm = tsm.lock().await;
-                                    tsm.register(peer_key.clone(), id)
-                                };
-                                pending_rx = Some(new_rx);
+                            Ok(CovAckResult::Error) => {
+                                warn!(invoke_id = id, "EventNotification rejected by recipient");
+                                return;
                             }
-
-                            match result {
-                                Ok(CovAckResult::Ack) => {
-                                    debug!(invoke_id = id, "EventNotification acknowledged");
-                                    return;
-                                }
-                                Ok(CovAckResult::Error) => {
+                            Err(_) => {
+                                if attempt < apdu_retries {
+                                    debug!(
+                                        invoke_id = id,
+                                        attempt, "EventNotification timeout, retrying"
+                                    );
+                                } else {
                                     warn!(
                                         invoke_id = id,
-                                        "EventNotification rejected by recipient"
+                                        "EventNotification failed after {} retries", apdu_retries
                                     );
-                                    return;
                                 }
-                                Err(_) => {
-                                    if attempt < apdu_retries {
-                                        debug!(
-                                            invoke_id = id,
-                                            attempt, "EventNotification timeout, retrying"
-                                        );
-                                    } else {
-                                        warn!(
-                                            invoke_id = id,
-                                            "EventNotification failed after {} retries",
-                                            apdu_retries
-                                        );
-                                    }
-                                }
-                            }
-                        }
-
-                        let mut tsm = tsm.lock().await;
-                        tsm.remove(&peer_key, id);
-                    });
-                } else {
-                    let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
-                        service_choice: UnconfirmedServiceChoice::UNCONFIRMED_EVENT_NOTIFICATION,
-                        service_request: service_bytes,
-                    });
-
-                    let mut buf = BytesMut::new();
-                    encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
-
-                    match recipient {
-                        bacnet_types::constructed::BACnetRecipient::Address(addr) => {
-                            if let Err(e) = network
-                                .send_apdu(&buf, &addr.mac_address, false, NetworkPriority::NORMAL)
-                                .await
-                            {
-                                warn!(
-                                    error = %e,
-                                    "Failed to send unconfirmed EventNotification"
-                                );
-                            }
-                        }
-                        bacnet_types::constructed::BACnetRecipient::Device(_) => {
-                            if let Err(e) = network
-                                .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
-                                .await
-                            {
-                                warn!(
-                                    error = %e,
-                                    "Failed to broadcast unconfirmed EventNotification"
-                                );
                             }
                         }
                     }
+
+                    let mut tsm = tsm.lock().await;
+                    tsm.remove(&peer_key, id);
+                });
+            } else {
+                let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
+                    service_choice: UnconfirmedServiceChoice::UNCONFIRMED_EVENT_NOTIFICATION,
+                    service_request: service_bytes,
+                });
+
+                let mut buf = BytesMut::new();
+                encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
+
+                let send_result = match &route {
+                    RecipientRoute::LocalUnicast(mac) => {
+                        network
+                            .send_apdu(&buf, mac, false, NetworkPriority::NORMAL)
+                            .await
+                    }
+                    RecipientRoute::LocalBroadcast => {
+                        network
+                            .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
+                            .await
+                    }
+                    // Carries DNET with DLEN zero, so routers forward it
+                    // onto the remote network as a broadcast there.
+                    RecipientRoute::RemoteBroadcast(net) => {
+                        network
+                            .broadcast_to_network(&buf, *net, false, NetworkPriority::NORMAL)
+                            .await
+                    }
+                    // Filtered out by `undeliverable_reason` above.
+                    RecipientRoute::UnresolvedRoute(_) | RecipientRoute::UnresolvedDevice(_) => {
+                        continue
+                    }
+                };
+
+                if let Err(e) = send_result {
+                    warn!(
+                        error = %e,
+                        "Failed to send unconfirmed EventNotification"
+                    );
                 }
             }
         }

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -72,6 +72,13 @@ impl RecipientRoute {
     /// Clause 6.3: "Of the BACnet APDUs, only the BACnet-Unconfirmed-Request-PDU
     /// may be transmitted using a multicast or broadcast network layer address".
     /// A confirmed notification also has nowhere to return its SimpleACK from.
+    ///
+    /// This recognizes only the *network-layer* spelling of a broadcast, the
+    /// zero-length `mac-address`. A recipient carrying its data link's literal
+    /// broadcast MAC — `X'FFFFFFFFFFFF'` on Ethernet, an all-ones host portion
+    /// on BACnet/IP, `X'FF'` on MS/TP — reads as `LocalUnicast` here and is
+    /// still sent confirmed. Recognizing those needs the transport's broadcast
+    /// address, which this layer does not have.
     fn permits_confirmed(&self) -> bool {
         matches!(self, Self::LocalUnicast(_))
     }
@@ -108,7 +115,7 @@ impl RecipientRoute {
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Evaluate intrinsic reporting on an object and send event notifications
-    /// to NotificationClass recipients (or broadcast if none configured).
+    /// to the recipients the object's NotificationClass names.
     /// DCC gates network-message initiation (Clause 16.1), not the local
     /// transition actions in Clause 13.2.2.1.4. The outbound sender below
     /// suppresses distribution while communications are disabled.
@@ -165,7 +172,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     }
 
     /// Build an `EventNotificationRequest` for a pre-computed transition and
-    /// send it to NotificationClass recipients (or broadcast if none).
+    /// send it to the recipients the object's NotificationClass names.
     ///
     /// Shared by the per-write path ([`fire_event_notifications`]) and the
     /// periodic `Time_Delay` confirmation path, so both emit identical
@@ -289,7 +296,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     // closed (consistent with the encode-failure branches
                     // below): deliver this notification to NO ONE rather
                     // than to a silently-truncated prefix of the configured
-                    // destinations or the no-recipients broadcast fallback.
+                    // destinations.
                     warn!(
                         notification_class,
                         "Recipient_List failed to decode; skipping event notification delivery"
@@ -479,7 +486,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             .broadcast_global_apdu(&buf, false, NetworkPriority::NORMAL)
                             .await
                     }
-                    // Filtered out by `is_deliverable` above.
+                    // Filtered out by `RecipientRoute::is_deliverable` above.
                     RecipientRoute::UnresolvedRoute(_) | RecipientRoute::UnresolvedDevice(_) => {
                         continue
                     }

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -13,6 +13,9 @@ impl From<(EventStateChange, EventType)> for NotificationTransition {
     }
 }
 
+/// The DNET reserved for a global broadcast (Clause 6.3).
+const GLOBAL_BROADCAST_NETWORK: u16 = 0xFFFF;
+
 /// The network destination a Notification Class recipient resolves to.
 ///
 /// Clause 21's `BACnetAddress` gives a recipient two independent knobs —
@@ -31,6 +34,12 @@ enum RecipientRoute {
     /// A zero-length MAC on a remote network. Clause 6.3: "DNET shall specify
     /// the network number of the remote network and DLEN shall be set to zero".
     RemoteBroadcast(u16),
+    /// A zero-length MAC on network 65535. Clause 6.3: "A global broadcast,
+    /// indicated by a DNET of X'FFFF', is sent to all networks through all
+    /// routers" — a destination of its own, not a remote network that happens
+    /// to be numbered 65535. `broadcast_to_network` rejects 0xFFFF outright,
+    /// so routing it as one would drop the notification.
+    GlobalBroadcast,
     /// A unicast MAC on a remote network. Delivering it needs the MAC of a
     /// next-hop router, and no router table is reachable from the server, so
     /// the destination cannot be resolved. Tracked by #186.
@@ -48,7 +57,10 @@ impl RecipientRoute {
                 match (addr.network_number, addr.mac_address.is_empty()) {
                     (0, true) => Self::LocalBroadcast,
                     (0, false) => Self::LocalUnicast(addr.mac_address.clone()),
+                    (GLOBAL_BROADCAST_NETWORK, true) => Self::GlobalBroadcast,
                     (net, true) => Self::RemoteBroadcast(net),
+                    // Includes a MAC alongside network 65535, which is
+                    // self-contradictory: a broadcast requires DLEN zero.
                     (net, false) => Self::UnresolvedRoute(net),
                 }
             }
@@ -71,7 +83,10 @@ impl RecipientRoute {
     /// device cannot address at all.
     fn is_deliverable(&self, notification_class: u32) -> bool {
         match self {
-            Self::LocalUnicast(_) | Self::LocalBroadcast | Self::RemoteBroadcast(_) => true,
+            Self::LocalUnicast(_)
+            | Self::LocalBroadcast
+            | Self::RemoteBroadcast(_)
+            | Self::GlobalBroadcast => true,
             Self::UnresolvedRoute(network) => {
                 warn!(
                     notification_class,
@@ -456,7 +471,15 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             .broadcast_to_network(&buf, *net, false, NetworkPriority::NORMAL)
                             .await
                     }
-                    // Filtered out by `undeliverable_reason` above.
+                    // Carries DNET 0xFFFF, which routers forward to every
+                    // reachable network. `broadcast_to_network` rejects that
+                    // DNET, so it needs its own send.
+                    RecipientRoute::GlobalBroadcast => {
+                        network
+                            .broadcast_global_apdu(&buf, false, NetworkPriority::NORMAL)
+                            .await
+                    }
+                    // Filtered out by `is_deliverable` above.
                     RecipientRoute::UnresolvedRoute(_) | RecipientRoute::UnresolvedDevice(_) => {
                         continue
                     }

--- a/crates/bacnet-server/src/server/event_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_tests.rs
@@ -124,8 +124,52 @@ fn decode_broadcast_notification(sent: &StdMutex<Vec<Bytes>>) -> EventNotificati
     }
 }
 
-/// Build a server fixture: a Device, a NotificationClass (instance `nc`,
-/// empty recipient list so notifications broadcast) with the given
+/// The `Recipient_List` entry Clause 12.21 prescribes for a device whose list
+/// is not writable: a local broadcast (network 0, zero-length MAC), all days,
+/// the full daily window, process identifier 0, unconfirmed, all transitions.
+///
+/// Notifications reach the recording transport's broadcast wire *because this
+/// entry asks them to*. An empty `Recipient_List` names no notification-clients
+/// and so distributes nothing (Clause 13.2.5).
+pub(super) fn local_broadcast_destination() -> bacnet_types::constructed::BACnetDestination {
+    use bacnet_types::constructed::{BACnetAddress, BACnetDestination, BACnetRecipient};
+    use bacnet_types::primitives::Time;
+    BACnetDestination {
+        valid_days: 0b0111_1111,
+        from_time: Time {
+            hour: 0,
+            minute: 0,
+            second: 0,
+            hundredths: 0,
+        },
+        to_time: Time {
+            hour: 23,
+            minute: 59,
+            second: 59,
+            hundredths: 99,
+        },
+        recipient: BACnetRecipient::Address(BACnetAddress {
+            network_number: 0,
+            mac_address: MacAddr::new(),
+        }),
+        process_identifier: 0,
+        issue_confirmed_notifications: false,
+        transitions: 0b0000_0111,
+    }
+}
+
+/// Notification Class instance 0 — the class an object points at when its
+/// `Notification_Class` property is left at its default — carrying the single
+/// local-broadcast recipient from [`local_broadcast_destination`].
+pub(super) fn notification_class_0_broadcasting(
+) -> bacnet_objects::notification_class::NotificationClass {
+    let mut nc = bacnet_objects::notification_class::NotificationClass::new(0, "NC-0").unwrap();
+    nc.add_destination(local_broadcast_destination());
+    nc
+}
+
+/// Build a server fixture: a Device, a NotificationClass (instance `nc`, whose
+/// recipient list holds the Clause 12.21 local-broadcast entry) with the given
 /// per-transition `priority` / `ack_required`, and an AnalogInput whose
 /// `Notification_Class` points at it with `Notify_Type = ALARM`.
 async fn fixture_with_commanded_nc(
@@ -150,12 +194,13 @@ async fn fixture_with_commanded_nc(
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
 
     let mut db = ObjectDatabase::new();
-    // NotificationClass with the configured per-transition arrays and an
-    // empty recipient list, so the notification is broadcast (not per-recipient).
+    // NotificationClass with the configured per-transition arrays and a single
+    // local-broadcast recipient, so the notification lands on the broadcast wire.
     let mut notification_class =
         bacnet_objects::notification_class::NotificationClass::new(nc, "NC").unwrap();
     notification_class.priority = priority;
     notification_class.ack_required = ack_required;
+    notification_class.add_destination(local_broadcast_destination());
     db.add(Box::new(notification_class)).unwrap();
 
     db.add(Box::new(
@@ -327,10 +372,16 @@ async fn event_notification_projects_normal_priority_from_class() {
     );
 }
 
-/// Missing NotificationClass falls back to Priority 255 and no ack, and
-/// the notification is still delivered (not silently dropped).
+/// A `Notification_Class` naming an object that does not exist distributes
+/// nothing.
+///
+/// Clause 13.2.5 sends notifications "to the notification-clients specified by
+/// the Recipient_List input", and a class that does not exist supplies no such
+/// input. This previously broadcast the notification to the whole link, which
+/// is how a misconfigured `Notification_Class` turned into an alarm every
+/// device on the network received.
 #[tokio::test]
-async fn event_notification_missing_class_falls_back_to_defaults() {
+async fn event_notification_missing_class_distributes_nothing() {
     let sent = StdArc::new(StdMutex::new(Vec::new()));
     let transport = RecordingTransport {
         sent_broadcast: StdArc::clone(&sent),
@@ -385,14 +436,10 @@ async fn event_notification_missing_class_falls_back_to_defaults() {
     )
     .await;
 
-    let notif = decode_broadcast_notification(&sent);
-    assert_eq!(
-        notif.priority, 255,
-        "missing class falls back to lowest priority"
-    );
     assert!(
-        !notif.ack_required,
-        "missing class falls back to no acknowledgement"
+        sent.lock().unwrap().is_empty(),
+        "a Notification_Class that does not exist names no recipients, so \
+         nothing may be distributed"
     );
 }
 
@@ -493,6 +540,10 @@ pub(super) fn db_with_high_limit_transition(
         .unwrap(),
     ))
     .unwrap();
+    // The AnalogInput's Notification_Class defaults to 0, so class 0 has to
+    // exist and name a recipient for anything to be distributed.
+    db.add(Box::new(notification_class_0_broadcasting()))
+        .unwrap();
     Arc::new(tokio::sync::RwLock::new(db))
 }
 
@@ -750,6 +801,8 @@ async fn periodic_time_delay_carries_detector_event_type_to_wire() {
         .unwrap(),
     ))
     .unwrap();
+    db.add(Box::new(notification_class_0_broadcasting()))
+        .unwrap();
     let server = BACnetServer::start(ServerConfig::default(), db, transport)
         .await
         .expect("server should start");

--- a/crates/bacnet-server/src/server/event_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_tests.rs
@@ -710,6 +710,10 @@ async fn event_enable_cleared_suppresses_periodic_time_delay_send() {
         .unwrap(),
     ))
     .unwrap();
+    // A recipient that WOULD be broadcast to, so both assertions below can only
+    // be satisfied by the Event_Enable gate rather than by an unnamed recipient.
+    db.add(Box::new(notification_class_0_broadcasting()))
+        .unwrap();
 
     let server = BACnetServer::start(ServerConfig::default(), db, transport)
         .await

--- a/crates/bacnet-server/src/server/event_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_tests.rs
@@ -69,6 +69,11 @@ async fn dcc_suppresses_periodic_event_send() {
         .unwrap(),
     ))
     .unwrap();
+    // A recipient that WOULD be broadcast to, so the empty assertion below can
+    // only be satisfied by the DCC gate. Without this the test passes because
+    // no recipient was named, and it stays green even with the gate removed.
+    db.add(Box::new(notification_class_0_broadcasting()))
+        .unwrap();
     let db = Arc::new(tokio::sync::RwLock::new(db));
     let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
 
@@ -375,11 +380,16 @@ async fn event_notification_projects_normal_priority_from_class() {
 /// A `Notification_Class` naming an object that does not exist distributes
 /// nothing.
 ///
-/// Clause 13.2.5 sends notifications "to the notification-clients specified by
-/// the Recipient_List input", and a class that does not exist supplies no such
-/// input. This previously broadcast the notification to the whole link, which
-/// is how a misconfigured `Notification_Class` turned into an alarm every
-/// device on the network received.
+/// The Standard does not say what a `Notification_Class` naming a nonexistent
+/// object should do — Clause 13.2.5 governs distribution given a Recipient_List,
+/// and Clause 12 defines the property without a missing-object rule. So this is
+/// a deliberate choice for an undefined configuration, not a mandate.
+///
+/// Silence is the defensible reading: a class that does not exist supplies no
+/// Recipient_List, and 13.2.5 distributes only "to the notification-clients
+/// specified by the Recipient_List input". The alternative was the previous
+/// behavior, where a misconfigured `Notification_Class` broadcast the alarm to
+/// every device on the link.
 #[tokio::test]
 async fn event_notification_missing_class_distributes_nothing() {
     let sent = StdArc::new(StdMutex::new(Vec::new()));

--- a/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
@@ -198,6 +198,40 @@ async fn zero_length_mac_on_remote_network_broadcasts_with_dnet() {
     );
 }
 
+/// Network 65535 with a zero-length MAC is a *global* broadcast, not a remote
+/// network that happens to be numbered 65535. Clause 6.3: "A global broadcast,
+/// indicated by a DNET of X'FFFF', is sent to all networks through all routers."
+///
+/// It needs its own send: `NetworkLayer::broadcast_to_network` rejects 0xFFFF
+/// ("reserved for global broadcasts; use broadcast_global_apdu instead"), so
+/// routing it as an ordinary remote broadcast turns the notification into a
+/// logged send error and delivers nothing.
+#[tokio::test]
+async fn zero_length_mac_on_network_65535_is_a_global_broadcast() {
+    let (broadcasts, unicasts) =
+        distribute_to(vec![destination_for(address_recipient(65535, &[]), false)]).await;
+
+    assert_eq!(broadcasts.len(), 1, "global broadcast goes out");
+    assert!(unicasts.is_empty());
+    assert_eq!(
+        npdu_destination(&broadcasts[0]),
+        Some((0xFFFF, 0)),
+        "DNET is the global broadcast address and DLEN is zero"
+    );
+}
+
+/// Network 65535 with a unicast MAC is self-contradictory — a broadcast
+/// requires DLEN zero — so it is skipped rather than guessed at.
+#[tokio::test]
+async fn global_broadcast_network_with_a_mac_is_skipped() {
+    let mac = [0x0A, 0x00, 0x00, 0x64, 0xBA, 0xC0];
+    let (broadcasts, unicasts) =
+        distribute_to(vec![destination_for(address_recipient(65535, &mac), false)]).await;
+
+    assert!(broadcasts.is_empty());
+    assert!(unicasts.is_empty());
+}
+
 /// #186: a unicast MAC on a remote network needs a next-hop router, and no
 /// router table is reachable from the server. The recipient is skipped.
 ///

--- a/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
@@ -1,0 +1,327 @@
+//! How a `Recipient_List` entry becomes a network destination.
+//!
+//! Clause 21's `BACnetAddress` carries two independent fields — `network-number`
+//! ("A value of 0 indicates the local network") and `mac-address` ("A string of
+//! length 0 indicates a broadcast") — so a recipient names one of four
+//! destinations, not one unicast with edge cases. These tests pin each one, plus
+//! the two that cannot be resolved at all.
+//!
+//! Split from `event_notifications_tests.rs`, which is at the 700-LOC cap.
+
+use super::event_notifications_tests::local_broadcast_destination;
+use super::*;
+use bacnet_objects::analog::AnalogInputObject;
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_objects::event::EventStateChange;
+use bacnet_objects::notification_class::NotificationClass;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::constructed::{BACnetAddress, BACnetDestination, BACnetRecipient};
+use bacnet_types::enums::{EventState, EventType};
+use bytes::Bytes;
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
+use tokio::sync::mpsc;
+
+/// Records broadcasts and unicasts separately, keeping each unicast's target
+/// MAC. The MAC matters: a recipient on a remote network that is delivered as a
+/// local unicast reaches whichever device happens to hold that MAC on this link,
+/// which is the failure this module exists to catch.
+#[derive(Clone, Default)]
+struct RoutingTransport {
+    broadcasts: StdArc<StdMutex<Vec<Bytes>>>,
+    unicasts: StdArc<StdMutex<Vec<(Vec<u8>, Bytes)>>>,
+}
+
+impl TransportPort for RoutingTransport {
+    async fn start(
+        &mut self,
+    ) -> Result<mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+        let (_tx, rx) = mpsc::channel(1);
+        Ok(rx)
+    }
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
+        self.unicasts
+            .lock()
+            .unwrap()
+            .push((mac.to_vec(), Bytes::copy_from_slice(npdu)));
+        Ok(())
+    }
+    async fn send_broadcast(&self, npdu: &[u8]) -> Result<(), Error> {
+        self.broadcasts
+            .lock()
+            .unwrap()
+            .push(Bytes::copy_from_slice(npdu));
+        Ok(())
+    }
+    fn local_mac(&self) -> &[u8] {
+        &[127, 0, 0, 1, 0xBA, 0xC0]
+    }
+}
+
+/// A destination carrying `recipient`, active on every day at every time for
+/// every transition, so only the address shape under test decides the outcome.
+fn destination_for(recipient: BACnetRecipient, confirmed: bool) -> BACnetDestination {
+    BACnetDestination {
+        recipient,
+        issue_confirmed_notifications: confirmed,
+        ..local_broadcast_destination()
+    }
+}
+
+fn address_recipient(network_number: u16, mac: &[u8]) -> BACnetRecipient {
+    BACnetRecipient::Address(BACnetAddress {
+        network_number,
+        mac_address: MacAddr::from_slice(mac),
+    })
+}
+
+/// Fire one TO_OFFNORMAL transition at an AnalogInput whose Notification Class
+/// holds exactly `destinations`, and return what reached the transport.
+async fn distribute_to(
+    destinations: Vec<BACnetDestination>,
+) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
+    let transport = RoutingTransport::default();
+    let broadcasts = StdArc::clone(&transport.broadcasts);
+    let unicasts = StdArc::clone(&transport.unicasts);
+    let network = Arc::new(NetworkLayer::new(transport));
+    let comm_state = Arc::new(AtomicU8::new(0));
+    let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+
+    let mut db = ObjectDatabase::new();
+    let mut nc = NotificationClass::new(0, "NC-0").unwrap();
+    for destination in destinations {
+        nc.add_destination(destination);
+    }
+    db.add(Box::new(nc)).unwrap();
+    db.add(Box::new(
+        DeviceObject::new(DeviceConfig {
+            instance: 1,
+            name: "Dev".into(),
+            ..DeviceConfig::default()
+        })
+        .unwrap(),
+    ))
+    .unwrap();
+    let mut ai = AnalogInputObject::new(1, "AI-1", 0).unwrap();
+    ai.write_property(
+        PropertyIdentifier::NOTIFY_TYPE,
+        None,
+        PropertyValue::Enumerated(NotifyType::ALARM.to_raw()),
+        None,
+    )
+    .unwrap();
+    db.add(Box::new(ai)).unwrap();
+
+    let db = Arc::new(RwLock::new(db));
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    BACnetServer::<RoutingTransport>::build_and_send_event_notification(
+        &db,
+        &network,
+        &comm_state,
+        &server_tsm,
+        &oid,
+        (
+            EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            EventType::OUT_OF_RANGE,
+        ),
+        1000,
+    )
+    .await;
+
+    // The confirmed path spawns its send, so a test that sampled the transport
+    // straight after the await would pass whether or not anything was sent.
+    // Yield until the spawned task has reached its first send.
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+
+    let broadcasts = broadcasts.lock().unwrap().clone();
+    let unicasts = unicasts.lock().unwrap().clone();
+    (broadcasts, unicasts)
+}
+
+/// The NPDU destination (DNET/DADR) of a captured frame, or `None` when the
+/// destination specifier bit is clear.
+fn npdu_destination(frame: &Bytes) -> Option<(u16, usize)> {
+    let npdu = bacnet_encoding::npdu::decode_npdu(frame.clone()).expect("decode NPDU");
+    npdu.destination.map(|d| (d.network, d.mac_address.len()))
+}
+
+/// #185: Clause 12.21 requires a device whose `Recipient_List` is not writable
+/// to ship exactly one entry, "with the Recipient set to a local broadcast".
+/// Clause 21 spells a local broadcast as network 0 with a zero-length MAC.
+///
+/// This previously reached `send_apdu` with an empty MAC, which BACnet/IP
+/// rejects ("BIP MAC must be 6 bytes, got 0"), so the one configuration the
+/// standard prescribes for a whole class of device sent nothing at all.
+#[tokio::test]
+async fn zero_length_mac_on_local_network_broadcasts() {
+    let (broadcasts, unicasts) =
+        distribute_to(vec![destination_for(address_recipient(0, &[]), false)]).await;
+
+    assert_eq!(
+        broadcasts.len(),
+        1,
+        "a zero-length MAC on network 0 is a local broadcast request"
+    );
+    assert!(
+        unicasts.is_empty(),
+        "a zero-length MAC must never be offered to a unicast send"
+    );
+    assert_eq!(
+        npdu_destination(&broadcasts[0]),
+        None,
+        "a local broadcast carries no DNET"
+    );
+}
+
+/// #185/#186: a zero-length MAC on a *remote* network is a remote broadcast.
+/// Clause 6.3: "DNET shall specify the network number of the remote network and
+/// DLEN shall be set to zero."
+#[tokio::test]
+async fn zero_length_mac_on_remote_network_broadcasts_with_dnet() {
+    let (broadcasts, unicasts) =
+        distribute_to(vec![destination_for(address_recipient(1000, &[]), false)]).await;
+
+    assert_eq!(broadcasts.len(), 1, "remote broadcast goes out");
+    assert!(unicasts.is_empty());
+    assert_eq!(
+        npdu_destination(&broadcasts[0]),
+        Some((1000, 0)),
+        "DNET names the remote network and DLEN is zero"
+    );
+}
+
+/// #186: a unicast MAC on a remote network needs a next-hop router, and no
+/// router table is reachable from the server. The recipient is skipped.
+///
+/// The point of the test is the second assertion. Sending it as a plain local
+/// unicast — the previous behavior, which discarded `network_number` entirely —
+/// delivers the alarm to whichever device holds that MAC on the *local* link.
+#[tokio::test]
+async fn remote_unicast_recipient_is_skipped_not_sent_locally() {
+    let mac = [0x0A, 0x00, 0x00, 0x64, 0xBA, 0xC0];
+    let (broadcasts, unicasts) =
+        distribute_to(vec![destination_for(address_recipient(1000, &mac), false)]).await;
+
+    assert!(broadcasts.is_empty(), "must not fall back to a broadcast");
+    assert!(
+        unicasts.is_empty(),
+        "must not deliver a remote recipient to that MAC on the local link"
+    );
+}
+
+/// #125: a device-instance recipient needs a device-to-address binding this
+/// device does not maintain, so it is skipped rather than widened to a
+/// broadcast that reaches every device on the link.
+#[tokio::test]
+async fn device_recipient_is_skipped_not_broadcast() {
+    let device = ObjectIdentifier::new(ObjectType::DEVICE, 99).unwrap();
+    let (broadcasts, unicasts) = distribute_to(vec![destination_for(
+        BACnetRecipient::Device(device),
+        false,
+    )])
+    .await;
+
+    assert!(
+        broadcasts.is_empty(),
+        "a targeted device recipient must not be widened to a broadcast"
+    );
+    assert!(unicasts.is_empty());
+}
+
+/// Clause 6.3: "Of the BACnet APDUs, only the BACnet-Unconfirmed-Request-PDU
+/// may be transmitted using a multicast or broadcast network layer address."
+///
+/// A recipient asking for confirmed notifications at a broadcast address is
+/// unsatisfiable — it is skipped rather than broadcast as a ConfirmedRequest
+/// (which the previous code did for device recipients) or silently downgraded
+/// to unconfirmed (which would drop the acknowledgment it asked for).
+#[tokio::test]
+async fn confirmed_notification_to_a_broadcast_recipient_is_skipped() {
+    let (broadcasts, unicasts) =
+        distribute_to(vec![destination_for(address_recipient(0, &[]), true)]).await;
+
+    assert!(
+        broadcasts.is_empty(),
+        "a ConfirmedRequest may not use a broadcast address"
+    );
+    assert!(unicasts.is_empty());
+}
+
+/// The ordinary case still works: network 0 with a real MAC is a local unicast
+/// addressed to exactly that MAC.
+#[tokio::test]
+async fn local_unicast_recipient_reaches_its_mac() {
+    let mac = [127, 0, 0, 1, 0xBA, 0xC1];
+    let (broadcasts, unicasts) =
+        distribute_to(vec![destination_for(address_recipient(0, &mac), false)]).await;
+
+    assert!(broadcasts.is_empty());
+    assert_eq!(unicasts.len(), 1, "one unicast for one recipient");
+    assert_eq!(unicasts[0].0, mac, "addressed to the configured MAC");
+    assert_eq!(
+        npdu_destination(&unicasts[0].1),
+        None,
+        "a local recipient carries no DNET"
+    );
+}
+
+/// The confirmed path still delivers to a recipient that can actually receive
+/// one. Guards the other side of the Clause 6.3 check: rejecting broadcast
+/// destinations must not reject unicast ones.
+#[tokio::test]
+async fn confirmed_notification_to_a_local_unicast_recipient_is_sent() {
+    let mac = [127, 0, 0, 1, 0xBA, 0xC1];
+    let (broadcasts, unicasts) =
+        distribute_to(vec![destination_for(address_recipient(0, &mac), true)]).await;
+
+    assert!(broadcasts.is_empty());
+    assert_eq!(unicasts.len(), 1, "confirmed notification reaches the wire");
+    assert_eq!(unicasts[0].0, mac);
+}
+
+/// #124: an empty `Recipient_List` names no notification-clients, and Clause
+/// 13.2.5 distributes "to the notification-clients specified by the
+/// Recipient_List input". Broadcasting instead invented a destination the
+/// configuration never named.
+#[tokio::test]
+async fn empty_recipient_list_distributes_nothing() {
+    let (broadcasts, unicasts) = distribute_to(vec![]).await;
+
+    assert!(
+        broadcasts.is_empty(),
+        "an empty Recipient_List is not permission to broadcast"
+    );
+    assert!(unicasts.is_empty());
+}
+
+/// Resolution is per-recipient: one undeliverable entry does not suppress the
+/// deliverable ones alongside it.
+#[tokio::test]
+async fn one_unresolvable_recipient_does_not_suppress_the_others() {
+    let mac = [127, 0, 0, 1, 0xBA, 0xC1];
+    let (broadcasts, unicasts) = distribute_to(vec![
+        destination_for(
+            BACnetRecipient::Device(ObjectIdentifier::new(ObjectType::DEVICE, 99).unwrap()),
+            false,
+        ),
+        destination_for(address_recipient(0, &mac), false),
+        destination_for(address_recipient(0, &[]), false),
+    ])
+    .await;
+
+    assert_eq!(
+        unicasts.len(),
+        1,
+        "the local unicast recipient still gets it"
+    );
+    assert_eq!(unicasts[0].0, mac);
+    assert_eq!(broadcasts.len(), 1, "the broadcast recipient still gets it");
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -785,6 +785,8 @@ mod event_enrollment_task_tests;
 #[cfg(test)]
 mod event_notifications_tests;
 #[cfg(test)]
+mod event_recipient_routing_tests;
+#[cfg(test)]
 mod segmentation_tests;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
The EventNotification sender read a recipient's MAC and nothing else, so three of the four destinations Clause 21 can express came out wrong — including the one the standard *requires* a whole class of device to ship.

## The four destinations

Clause 21 (extracted Standard line 56354) gives `BACnetAddress` two independent fields:

```
BACnetAddress ::= SEQUENCE {
      network-number   Unsigned16,     -- A value of 0 indicates the local network
      mac-address      OCTET STRING    -- A string of length 0 indicates a broadcast
      }
```

Their combinations are four different sends, so this resolves them once up front instead of re-reading a MAC at each send site:

| `network-number` | `mac-address` | now | before |
|---|---|---|---|
| 0 | 6 bytes | `send_apdu` | same |
| 0 | **empty** | `broadcast_apdu` | unicast with an empty MAC |
| N | **empty** | `broadcast_to_network(N)` | unicast with an empty MAC |
| N | 6 bytes | skipped, logged | local unicast to the wrong device |
| **65535** | **empty** | `broadcast_global_apdu` | unicast with an empty MAC |

### The local-broadcast case is the severe one (`#185`)

Clause 12.21 (line 18861) requires that a device whose `Recipient_List` is not writable and which uses no local Notification Forwarder objects ship exactly one entry, "with the Recipient set to a local broadcast". That reached `send_apdu` with a zero-length MAC, which BACnet/IP rejects outright — `decode_bip_mac` raises *"BIP MAC must be 6 bytes, got 0"* — producing a `warn!` and a dropped notification.

**A device configured the way the standard prescribes distributed nothing at all.**

### Remote recipients (`#186`)

`network_number` was decoded correctly by `#126` and then discarded by the sender, so the NPDU went out with the destination specifier bit clear: no DNET, no DLEN, no DADR. A recipient on network 1000 was delivered to whichever device held that MAC on the *local* link.

Remote broadcast now uses `NetworkLayer::broadcast_to_network`, which is exactly the Clause 6.3 form (line 4679): *"DNET shall specify the network number of the remote network and DLEN shall be set to zero."*

Remote **unicast** needs the MAC of a next-hop router. `RouterTable` lives in `BACnetRouter`, which `BACnetServer` does not hold — there is no route resolution reachable from here. So it is skipped and logged rather than misdelivered. That is strictly better than the current behavior but is not a resolution; see the scope note below.

## Two invented broadcasts removed

**Empty `Recipient_List` no longer broadcasts.** Clause 13.2.5 (line 41547) distributes "to the notification-clients specified by the Recipient_List input", and an empty list specifies none. There is no broadcast-on-empty rule anywhere in the Standard.

⚠️ **This is a behavior change.** An object whose `Notification_Class` names a class that does not exist now stays silent instead of alarming every device on the link. `event_notification_missing_class_falls_back_to_defaults` asserted the old behavior and is replaced by `event_notification_missing_class_distributes_nothing`.

**Confirmed notifications to a broadcast address are skipped.** Clause 6.3 (line 4658): *"only the BACnet-Unconfirmed-Request-PDU may be transmitted using a multicast or broadcast network layer address."* Device recipients previously broadcast a **ConfirmedRequest** APDU, which that sentence forbids and which has nowhere to return its SimpleACK from. Skipped rather than downgraded to unconfirmed, since downgrading would silently drop the acknowledgment the recipient was configured to require.

## Scope — what this does and does not close

Only `#185` closes outright. I would rather be explicit than let the others look finished:

| issue | status |
|---|---|
| **#185** | **closed** — both broadcast forms work |
| #186 | remote broadcast works and remote unicast no longer misdelivers; **route resolution still owed** |
| #125 | device recipients are no longer silently widened to a broadcast; **address binding still owed** |
| #124 | the broadcast fallback is gone and destinations are typed at the send site; **the four-way taxonomy at the lookup boundary is still owed** — `get_notification_recipients_strict` still returns `Option<Vec<..>>`, so "class missing", "list empty", and "nothing matched today" remain indistinguishable to the caller. Separating them means changing that public `bacnet-objects` signature, which is a larger change than this one |

## Tests

New module `event_recipient_routing_tests.rs` — `event_notifications_tests.rs` is at **672 of the 700-LOC cap**, so this could not go there.

Eleven tests, one per destination shape plus the two unresolvable ones, the empty list, and a mixed list proving one bad recipient does not suppress its neighbours. The transport records broadcasts and unicasts separately and keeps each unicast's **target MAC**, which is what catches a remote recipient delivered locally.

**Verified they discriminate:** run against `dev` in a throwaway worktree, **9 of 11 fail**. The two that pass are `local_unicast_recipient_reaches_its_mac` and `confirmed_notification_to_a_local_unicast_recipient_is_sent` — the paths this change must not disturb.

One trap worth flagging: the confirmed path `tokio::spawn`s its send, so the first draft of the confirmed test passed **vacuously** on both branches — it sampled the transport before the spawned task ran. `distribute_to` now yields until the send lands, which is what turned that test into a real discriminator.

## Verification

- `cargo test --workspace --exclude rusty-bacnet` — 34 suites green (422 in `bacnet-server`)
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked` — no errors
- `cargo fmt --all --check` — clean
- `bash .github/scripts/check-file-size.sh` — all files within the cap

Refs #124, #125, #186
Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)
