### PR TITLE
fix(client): refuse a peer max APDU below MinimumMessageSize

### DIFF
--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -755,6 +755,8 @@ mod cov_renewal_tests;
 mod cov_tests;
 #[cfg(test)]
 mod device_events_tests;
+#[cfg(test)]
+mod peer_max_apdu_tests;
 #[cfg(all(test, feature = "sc-tls"))]
 mod sc_builder_tests;
 #[cfg(test)]

--- a/crates/bacnet-client/src/client/peer_max_apdu_tests.rs
+++ b/crates/bacnet-client/src/client/peer_max_apdu_tests.rs
@@ -1,0 +1,181 @@
+//! What the client does with a peer that advertises an impossible APDU size.
+//!
+//! I-Am carries `Max APDU Length Accepted` as an Unsigned octet count rather
+//! than the four-bit code of Clause 20.1.2.5, so a peer can put any value on
+//! the wire — including values below the 50-octet MinimumMessageSize that
+//! Clause 12.11.18 and Clause 5.2.1.2(c) both require.
+//!
+//! Split from `tests.rs`, which is at the 700-LOC cap.
+
+use std::time::Instant;
+
+use bacnet_encoding::apdu::{self, encode_apdu, Apdu, SimpleAck};
+use bacnet_network::layer::{NetworkLayer, ReceivedApdu};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_types::enums::{ConfirmedServiceChoice, NetworkPriority, ObjectType, Segmentation};
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+use bytes::BytesMut;
+use tokio::time::{timeout, Duration};
+
+use crate::discovery::DiscoveredDevice;
+
+use super::BACnetClient;
+
+/// Build a client whose device table holds one peer advertising
+/// `max_apdu_length`, plus the remote end of the loopback pair.
+async fn client_with_peer_advertising(
+    max_apdu_length: u32,
+) -> (
+    BACnetClient<LoopbackTransport>,
+    Vec<u8>,
+    NetworkLayer<LoopbackTransport>,
+    tokio::sync::mpsc::Receiver<ReceivedApdu>,
+) {
+    let client_mac = vec![0x01];
+    let remote_mac = vec![0x02];
+    let (client_transport, remote_transport) =
+        LoopbackTransport::pair(client_mac, remote_mac.clone());
+    let mut remote_network = NetworkLayer::new(remote_transport);
+    let remote_rx = remote_network.start().await.unwrap();
+    let client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(DiscoveredDevice {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 2003).unwrap(),
+        mac_address: MacAddr::from_slice(&remote_mac),
+        max_apdu_length,
+        segmentation_supported: Segmentation::NONE,
+        max_segments_accepted: None,
+        vendor_id: 42,
+        last_seen: Instant::now(),
+        source_network: None,
+        source_address: None,
+    });
+
+    (client, remote_mac, remote_network, remote_rx)
+}
+
+/// A peer advertising less than MinimumMessageSize gets no frame at all.
+///
+/// The empty-payload case is the one that used to escape. A four-octet
+/// unsegmented APDU looks too large for a limit of 0..3, so the client fell
+/// through to segmentation, where `max_segment_payload` yields a capacity of
+/// zero and `split_payload` returned one empty segment anyway — producing a
+/// six-octet segmented Confirmed-Request, larger still than the limit that
+/// triggered segmentation in the first place.
+#[tokio::test]
+async fn confirmed_request_to_peer_below_minimum_message_size_sends_nothing() {
+    for advertised in [0u32, 1, 2, 3, 4, 6, 49] {
+        let (mut client, remote_mac, mut remote_network, mut remote_rx) =
+            client_with_peer_advertising(advertised).await;
+
+        let result = client
+            .confirmed_request(&remote_mac, ConfirmedServiceChoice::READ_PROPERTY, &[])
+            .await;
+
+        let err = result.expect_err(&format!(
+            "advertised max APDU {advertised} is below MinimumMessageSize and must be refused"
+        ));
+        assert!(
+            err.to_string().contains("minimum"),
+            "error should name the 50-octet minimum, got: {err}"
+        );
+
+        // Nothing may reach the wire, not even a segment.
+        assert!(
+            timeout(Duration::from_millis(50), remote_rx.recv())
+                .await
+                .is_err(),
+            "advertised max APDU {advertised} must produce no outbound frame"
+        );
+
+        remote_network.stop().await.unwrap();
+        client.stop().await.unwrap();
+    }
+}
+
+/// A non-empty payload is refused too.
+///
+/// This one was never broken: `split_payload` already rejected a non-empty
+/// payload at zero capacity, which is exactly why the empty-payload shortcut
+/// above it was the hole. The test pins that the new floor check refuses the
+/// same case *earlier* — before segmentation is attempted at all — rather than
+/// changing whether it is refused.
+#[tokio::test]
+async fn nonempty_request_to_peer_below_minimum_message_size_sends_nothing() {
+    let (mut client, remote_mac, mut remote_network, mut remote_rx) =
+        client_with_peer_advertising(3).await;
+
+    let result = client
+        .confirmed_request(
+            &remote_mac,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            &[0x01, 0x02, 0x03],
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a non-conformant limit refuses any payload"
+    );
+    assert!(
+        timeout(Duration::from_millis(50), remote_rx.recv())
+            .await
+            .is_err(),
+        "no outbound frame"
+    );
+
+    remote_network.stop().await.unwrap();
+    client.stop().await.unwrap();
+}
+
+/// The boundary: exactly MinimumMessageSize still transacts, unsegmented.
+///
+/// Pairs with the refusal tests deliberately — a guard stuck permanently
+/// closed would satisfy those alone.
+#[tokio::test]
+async fn confirmed_request_at_minimum_message_size_is_sent_unsegmented() {
+    let (mut client, remote_mac, mut remote_network, mut remote_rx) =
+        client_with_peer_advertising(50).await;
+
+    let responder = tokio::spawn(async move {
+        let received = timeout(Duration::from_secs(1), remote_rx.recv())
+            .await
+            .expect("remote timed out")
+            .expect("remote channel closed");
+        let Apdu::ConfirmedRequest(req) = apdu::decode_apdu(received.apdu).unwrap() else {
+            panic!("expected ConfirmedRequest");
+        };
+        assert!(
+            !req.segmented,
+            "an empty request fits MinimumMessageSize unsegmented"
+        );
+
+        let ack = Apdu::SimpleAck(SimpleAck {
+            invoke_id: req.invoke_id,
+            service_choice: req.service_choice,
+        });
+        let mut buf = BytesMut::new();
+        encode_apdu(&mut buf, &ack).unwrap();
+        remote_network
+            .send_apdu(&buf, &received.source_mac, false, NetworkPriority::NORMAL)
+            .await
+            .unwrap();
+        remote_network.stop().await.unwrap();
+    });
+
+    let result = client
+        .confirmed_request(&remote_mac, ConfirmedServiceChoice::READ_PROPERTY, &[])
+        .await;
+
+    assert!(
+        result.expect("50 octets is a conformant limit").is_empty(),
+        "SimpleAck carries no service data"
+    );
+    responder.await.unwrap();
+    client.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/peer_max_apdu_tests.rs
+++ b/crates/bacnet-client/src/client/peer_max_apdu_tests.rs
@@ -59,17 +59,22 @@ async fn client_with_peer_advertising(
     (client, remote_mac, remote_network, remote_rx)
 }
 
-/// A peer advertising less than MinimumMessageSize gets no frame at all.
+/// The defect: an advertised limit too small to hold even the four-octet
+/// unsegmented APDU put a *larger* frame on the wire.
 ///
-/// The empty-payload case is the one that used to escape. A four-octet
-/// unsegmented APDU looks too large for a limit of 0..3, so the client fell
+/// A four-octet APDU looks too large for a limit of 0..3, so the client fell
 /// through to segmentation, where `max_segment_payload` yields a capacity of
 /// zero and `split_payload` returned one empty segment anyway — producing a
 /// six-octet segmented Confirmed-Request, larger still than the limit that
-/// triggered segmentation in the first place.
+/// triggered segmentation in the first place. Against `dev` these values put
+/// `[0a 05 00 00 01 0c]` on the wire.
+///
+/// The no-frame assertion comes first deliberately: asserting on the error text
+/// first would make the test fail on wording rather than on the oversize frame
+/// it exists to catch.
 #[tokio::test]
-async fn confirmed_request_to_peer_below_minimum_message_size_sends_nothing() {
-    for advertised in [0u32, 1, 2, 3, 4, 6, 49] {
+async fn peer_max_apdu_too_small_for_an_unsegmented_apdu_sends_nothing() {
+    for advertised in [0u32, 1, 2, 3] {
         let (mut client, remote_mac, mut remote_network, mut remote_rx) =
             client_with_peer_advertising(advertised).await;
 
@@ -77,20 +82,51 @@ async fn confirmed_request_to_peer_below_minimum_message_size_sends_nothing() {
             .confirmed_request(&remote_mac, ConfirmedServiceChoice::READ_PROPERTY, &[])
             .await;
 
-        let err = result.expect_err(&format!(
-            "advertised max APDU {advertised} is below MinimumMessageSize and must be refused"
-        ));
-        assert!(
-            err.to_string().contains("minimum"),
-            "error should name the 50-octet minimum, got: {err}"
-        );
-
-        // Nothing may reach the wire, not even a segment.
         assert!(
             timeout(Duration::from_millis(50), remote_rx.recv())
                 .await
                 .is_err(),
             "advertised max APDU {advertised} must produce no outbound frame"
+        );
+        let err = result.expect_err(&format!(
+            "advertised max APDU {advertised} is below MinimumMessageSize and must be refused"
+        ));
+        assert!(
+            err.to_string().contains("MinimumMessageSize"),
+            "error should name MinimumMessageSize, got: {err}"
+        );
+
+        remote_network.stop().await.unwrap();
+        client.stop().await.unwrap();
+    }
+}
+
+/// A deliberate behavior change, not the defect.
+///
+/// 4 through 49 are large enough to carry the four-octet unsegmented APDU, so
+/// they never emitted an oversize frame — `dev` sent a conforming
+/// `[02 05 00 0c]`. They are refused now because Clause 12.11.18 and Clause
+/// 5.2.1.2(c) both put the floor at 50, so the peer is advertising a value it
+/// is not permitted to advertise and its real capacity is unknowable.
+#[tokio::test]
+async fn peer_max_apdu_below_the_floor_but_above_the_apdu_size_is_also_refused() {
+    for advertised in [4u32, 6, 49] {
+        let (mut client, remote_mac, mut remote_network, mut remote_rx) =
+            client_with_peer_advertising(advertised).await;
+
+        let result = client
+            .confirmed_request(&remote_mac, ConfirmedServiceChoice::READ_PROPERTY, &[])
+            .await;
+
+        assert!(
+            timeout(Duration::from_millis(50), remote_rx.recv())
+                .await
+                .is_err(),
+            "advertised max APDU {advertised} must produce no outbound frame"
+        );
+        assert!(
+            result.is_err(),
+            "advertised max APDU {advertised} is below the 50-octet floor"
         );
 
         remote_network.stop().await.unwrap();

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -1,38 +1,126 @@
 use super::*;
+use bacnet_encoding::apdu::MINIMUM_MESSAGE_SIZE;
 
-/// MinimumMessageSize: the smallest APDU any BACnet device accepts.
+/// Which term of Clause 5.2.1.2's minimum bound the transmittable length down.
 ///
-/// Clause 20.1.2.5 spells the max-APDU-length-accepted field's lowest code,
-/// `B'0000'`, as "Up to MinimumMessageSize (50 octets)", and Clause 12.11.18
-/// requires `Max_APDU_Length_Accepted` to be "greater than or equal to 50".
-const MINIMUM_MESSAGE_SIZE: u16 = 50;
+/// Named separately so the error blames the right one. The checked value is a
+/// minimum over several terms, and the peer is only sometimes the binding one:
+/// BACnet/SC recomputes its own limit from the hub's Connect-Accept, so a
+/// transport can fall below the floor while the peer is perfectly conformant.
+enum LengthBoundedBy {
+    /// A length advertised by a discovered peer, from I-Am.
+    DiscoveredPeer(u16),
+    /// This client's own configured maximum.
+    LocalConfig(u16),
+    /// The data link, after any routed NPDU header.
+    Transport(u16),
+}
 
-/// Reject a maximum transmittable length that no conformant peer could accept.
+impl core::fmt::Display for LengthBoundedBy {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::DiscoveredPeer(v) => {
+                write!(f, "the peer's advertised Max APDU Length Accepted of {v}")
+            }
+            Self::LocalConfig(v) => write!(f, "this client's configured maximum of {v}"),
+            Self::Transport(v) => write!(f, "the transport's limit of {v}"),
+        }
+    }
+}
+
+/// Reject a maximum transmittable length no conformant device could accept.
 ///
 /// Clause 5.2.1.2 derives this length as the smallest of the local capability,
 /// the internetwork limit, and "(c) the maximum APDU size accepted by the
 /// remote peer device, which must be at least 50 octets". Below that floor no
-/// conformant APDU can be formed at all.
+/// conformant APDU can be formed at all. Clause 20.1.2.5 gives the same number
+/// a name, spelling the lowest max-APDU-length-accepted code `B'0000'` as "Up
+/// to MinimumMessageSize (50 octets)".
 ///
 /// The check is a floor, not membership of the six values Clause 20.1.2.5
 /// encodes. A discovered peer's length comes from I-Am's `Max APDU Length
-/// Accepted`, which is an Unsigned octet count rather than the four-bit code,
-/// and Clause 5.2.1.2 notes the true value "may be larger than indicated in
-/// this parameter" — so 600 or 1500 are legitimate and must not be rejected.
+/// Accepted`, an Unsigned octet count rather than the four-bit code, and
+/// Clause 20.1.2.5 notes the true value "may be larger than indicated in this
+/// parameter" — so 600 and 1500 are legitimate and must not be rejected.
 ///
-/// Failing here rather than clamping up to 50 keeps the client from inventing
-/// a capability the peer never claimed: a device advertising less than 50 is
-/// already non-conformant, and a typed error names that, where a silent clamp
+/// Failing rather than clamping up to 50 keeps the client from inventing a
+/// capability the peer never claimed: a device advertising less than 50 is
+/// already non-conformant, and a typed error names that where a silent clamp
 /// would send it frames it said it cannot hold.
-fn check_transmittable_length(max_apdu: u16) -> Result<(), Error> {
-    if max_apdu < MINIMUM_MESSAGE_SIZE {
-        return Err(Error::Segmentation(format!(
-            "maximum transmittable length {max_apdu} is below the {MINIMUM_MESSAGE_SIZE}-octet \
-             minimum every BACnet device accepts (Clause 5.2.1.2); the peer's advertised \
-             Max APDU Length Accepted is non-conformant"
-        )));
+fn check_transmittable_length(peer_or_local: LengthBoundedBy, transport: u16) -> Result<(), Error> {
+    let advertised = match peer_or_local {
+        LengthBoundedBy::DiscoveredPeer(v) | LengthBoundedBy::LocalConfig(v) => v,
+        LengthBoundedBy::Transport(v) => v,
+    };
+    let combined = advertised.min(transport);
+    if combined >= MINIMUM_MESSAGE_SIZE {
+        return Ok(());
     }
-    Ok(())
+    let binding = if transport < advertised {
+        LengthBoundedBy::Transport(transport)
+    } else {
+        peer_or_local
+    };
+    Err(Error::Encoding(format!(
+        "maximum transmittable length {combined} is below the {MINIMUM_MESSAGE_SIZE}-octet \
+         MinimumMessageSize every BACnet device accepts (Clause 5.2.1.2); the binding limit is \
+         {binding}"
+    )))
+}
+
+#[cfg(test)]
+mod transmittable_length_tests {
+    use super::{check_transmittable_length, LengthBoundedBy};
+
+    #[test]
+    fn conformant_lengths_pass() {
+        for advertised in [50u16, 128, 206, 480, 1024, 1476] {
+            assert!(
+                check_transmittable_length(LengthBoundedBy::DiscoveredPeer(advertised), 1476)
+                    .is_ok(),
+                "{advertised} is at or above MinimumMessageSize"
+            );
+        }
+    }
+
+    /// I-Am carries an Unsigned octet count, not the four-bit code, and Clause
+    /// 20.1.2.5 says the true value "may be larger than indicated in this
+    /// parameter" — so values outside the six encodings are legitimate.
+    #[test]
+    fn lengths_outside_the_encoded_set_are_not_rejected() {
+        for advertised in [51u16, 600, 1500, u16::MAX] {
+            assert!(
+                check_transmittable_length(LengthBoundedBy::DiscoveredPeer(advertised), u16::MAX)
+                    .is_ok(),
+                "{advertised} is conformant even though it is not one of the six encodings"
+            );
+        }
+    }
+
+    /// The error must blame whichever term actually bound the minimum. The peer
+    /// is only sometimes that term: BACnet/SC recomputes its own limit from the
+    /// hub's Connect-Accept, so a transport can fall below the floor while the
+    /// peer is entirely conformant.
+    #[test]
+    fn the_error_names_the_binding_term() {
+        let peer_bound =
+            check_transmittable_length(LengthBoundedBy::DiscoveredPeer(3), 1476).unwrap_err();
+        assert!(
+            peer_bound.to_string().contains("peer's advertised"),
+            "peer is the binding term here, got: {peer_bound}"
+        );
+
+        let transport_bound =
+            check_transmittable_length(LengthBoundedBy::DiscoveredPeer(1476), 48).unwrap_err();
+        assert!(
+            transport_bound.to_string().contains("transport's limit"),
+            "transport is the binding term here and the peer is conformant, got: {transport_bound}"
+        );
+        assert!(
+            !transport_bound.to_string().contains("peer's advertised"),
+            "must not blame a conformant peer for the transport's limit"
+        );
+    }
 }
 
 impl<T: TransportPort + 'static> BACnetClient<T> {
@@ -93,16 +181,21 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 
         match target {
             ConfirmedTarget::Local { mac } => {
-                let (remote_max_apdu, remote_max_segments) = {
+                let (remote_max_apdu, remote_max_segments, advertised) = {
                     let dt = self.device_table.lock().await;
                     let device = dt.get_by_mac(mac);
                     let max_apdu = device
                         .map(|d| u16::try_from(d.max_apdu_length).unwrap_or(u16::MAX))
                         .unwrap_or(self.config.max_apdu_length);
                     let max_seg = device.and_then(|d| d.max_segments_accepted);
-                    (max_apdu.min(target_transport_max_apdu), max_seg)
+                    let advertised = if device.is_some() {
+                        LengthBoundedBy::DiscoveredPeer(max_apdu)
+                    } else {
+                        LengthBoundedBy::LocalConfig(max_apdu)
+                    };
+                    (max_apdu.min(target_transport_max_apdu), max_seg, advertised)
                 };
-                check_transmittable_length(remote_max_apdu)?;
+                check_transmittable_length(advertised, target_transport_max_apdu)?;
                 if unsegmented_apdu_size > remote_max_apdu as usize {
                     return self
                         .segmented_confirmed_request(
@@ -117,7 +210,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             }
             ConfirmedTarget::Routed { .. } => {
                 let remote_max_apdu = self.config.max_apdu_length.min(target_transport_max_apdu);
-                check_transmittable_length(remote_max_apdu)?;
+                // Deliberately the local configuration, not a peer value: this
+                // branch never consults the device table, so a routed peer's
+                // own advertised limit is still unenforced. Tracked separately.
+                check_transmittable_length(
+                    LengthBoundedBy::LocalConfig(self.config.max_apdu_length),
+                    target_transport_max_apdu,
+                )?;
                 if unsegmented_apdu_size > remote_max_apdu as usize {
                     return self
                         .segmented_confirmed_request(

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -1,5 +1,40 @@
 use super::*;
 
+/// MinimumMessageSize: the smallest APDU any BACnet device accepts.
+///
+/// Clause 20.1.2.5 spells the max-APDU-length-accepted field's lowest code,
+/// `B'0000'`, as "Up to MinimumMessageSize (50 octets)", and Clause 12.11.18
+/// requires `Max_APDU_Length_Accepted` to be "greater than or equal to 50".
+const MINIMUM_MESSAGE_SIZE: u16 = 50;
+
+/// Reject a maximum transmittable length that no conformant peer could accept.
+///
+/// Clause 5.2.1.2 derives this length as the smallest of the local capability,
+/// the internetwork limit, and "(c) the maximum APDU size accepted by the
+/// remote peer device, which must be at least 50 octets". Below that floor no
+/// conformant APDU can be formed at all.
+///
+/// The check is a floor, not membership of the six values Clause 20.1.2.5
+/// encodes. A discovered peer's length comes from I-Am's `Max APDU Length
+/// Accepted`, which is an Unsigned octet count rather than the four-bit code,
+/// and Clause 5.2.1.2 notes the true value "may be larger than indicated in
+/// this parameter" — so 600 or 1500 are legitimate and must not be rejected.
+///
+/// Failing here rather than clamping up to 50 keeps the client from inventing
+/// a capability the peer never claimed: a device advertising less than 50 is
+/// already non-conformant, and a typed error names that, where a silent clamp
+/// would send it frames it said it cannot hold.
+fn check_transmittable_length(max_apdu: u16) -> Result<(), Error> {
+    if max_apdu < MINIMUM_MESSAGE_SIZE {
+        return Err(Error::Segmentation(format!(
+            "maximum transmittable length {max_apdu} is below the {MINIMUM_MESSAGE_SIZE}-octet \
+             minimum every BACnet device accepts (Clause 5.2.1.2); the peer's advertised \
+             Max APDU Length Accepted is non-conformant"
+        )));
+    }
+    Ok(())
+}
+
 impl<T: TransportPort + 'static> BACnetClient<T> {
     /// Send a confirmed request and wait for the response.
     ///
@@ -67,6 +102,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     let max_seg = device.and_then(|d| d.max_segments_accepted);
                     (max_apdu.min(target_transport_max_apdu), max_seg)
                 };
+                check_transmittable_length(remote_max_apdu)?;
                 if unsegmented_apdu_size > remote_max_apdu as usize {
                     return self
                         .segmented_confirmed_request(
@@ -81,6 +117,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             }
             ConfirmedTarget::Routed { .. } => {
                 let remote_max_apdu = self.config.max_apdu_length.min(target_transport_max_apdu);
+                check_transmittable_length(remote_max_apdu)?;
                 if unsegmented_apdu_size > remote_max_apdu as usize {
                     return self
                         .segmented_confirmed_request(

--- a/crates/bacnet-encoding/src/apdu/mod.rs
+++ b/crates/bacnet-encoding/src/apdu/mod.rs
@@ -60,8 +60,17 @@ fn decode_max_segments(value: u8) -> Option<u8> {
 // Max-APDU-length encoding
 // ---------------------------------------------------------------------------
 
+/// MinimumMessageSize: the smallest APDU any BACnet device accepts.
+///
+/// Clause 20.1.2.5 spells the lowest max-APDU-length-accepted code, `B'0000'`,
+/// as "Up to MinimumMessageSize (50 octets)"; Clause 12.11.18 requires
+/// `Max_APDU_Length_Accepted` to be "greater than or equal to 50"; and Clause
+/// 5.2.1.2 requires the size accepted by a remote peer to be "at least 50
+/// octets".
+pub const MINIMUM_MESSAGE_SIZE: u16 = 50;
+
 /// Decoded max-APDU-length values indexed by the 4-bit field.
-const MAX_APDU_DECODE: [u16; 6] = [50, 128, 206, 480, 1024, 1476];
+const MAX_APDU_DECODE: [u16; 6] = [MINIMUM_MESSAGE_SIZE, 128, 206, 480, 1024, 1476];
 
 /// Return true when `value` is one of the BACnet max-APDU-length encodings
 /// defined by ASHRAE 135-2020 Clause 20.1.2.5.

--- a/crates/bacnet-encoding/src/segmentation.rs
+++ b/crates/bacnet-encoding/src/segmentation.rs
@@ -32,15 +32,19 @@ pub fn max_segment_payload(max_apdu_length: u16, pdu_type: SegmentedPduType) -> 
 
 /// Split a payload into segments of at most `max_segment_size` bytes.
 ///
-/// Always returns at least one segment (possibly empty).
+/// Returns at least one segment (possibly empty) whenever `max_segment_size`
+/// leaves room for one. A zero segment size is an error even for an empty
+/// payload: a segment still costs its PDU header, so a peer whose maximum APDU
+/// cannot hold that header cannot receive a segment at all. Returning a single
+/// empty segment there produced a frame larger than the peer had advertised.
 pub fn split_payload(payload: &[u8], max_segment_size: usize) -> Result<Vec<Bytes>, Error> {
-    if payload.is_empty() {
-        return Ok(vec![Bytes::new()]);
-    }
     if max_segment_size == 0 {
         return Err(Error::Segmentation(
-            "non-empty payload cannot be segmented with max segment size 0".into(),
+            "payload cannot be segmented with max segment size 0".into(),
         ));
+    }
+    if payload.is_empty() {
+        return Ok(vec![Bytes::new()]);
     }
     let segments: Vec<Bytes> = payload
         .chunks(max_segment_size)
@@ -189,6 +193,16 @@ mod tests {
         let segments = split_payload(&[], 100).unwrap();
         assert_eq!(segments.len(), 1);
         assert!(segments[0].is_empty());
+    }
+
+    /// An empty payload is still a segment, and a segment still costs a PDU
+    /// header, so zero capacity cannot carry one. This used to return a single
+    /// empty segment because the empty-payload shortcut ran before the
+    /// zero-size check — which let the client emit a six-octet segmented
+    /// Confirmed-Request to a peer whose advertised maximum was smaller.
+    #[test]
+    fn split_empty_payload_zero_segment_size_errors() {
+        assert!(split_payload(&[], 0).is_err());
     }
 
     #[test]


### PR DESCRIPTION
A discovered device can advertise a maximum APDU length of 0..49. For a confirmed request with **empty service data** the client saw the four-octet unsegmented APDU as too large, switched to segmentation, computed a segment payload capacity of zero, and sent a **six-octet** segmented Confirmed-Request anyway — larger than the limit that caused the switch.

## Two holes, both closed

**1. The peer's value had no floor.** `requests.rs` took `d.max_apdu_length` from the device table verbatim. The only existing clamp — `cap_max_apdu_to_transport` against `VALID_MAX_APDU_LENGTHS` (`client/mod.rs:49,691`) — guards the client's **own** advertised value and never the peer's. That asymmetry is the bug: peer-controlled input reached a size calculation that local config could not.

Clause 5.2.1.2 (extracted Standard line 2054) derives the maximum transmittable length as the smallest of three values, including:

> (c) the maximum APDU size accepted by the remote peer device, **which must be at least 50 octets**.

Below that, no conformant APDU can be formed at all. Both target branches now check it.

**2. `split_payload` returned a segment at zero capacity.** The `payload.is_empty()` shortcut ran *before* the `max_segment_size == 0` check, so an empty payload yielded `Ok(vec![Bytes::new()])` regardless. A segment still costs its PDU header, so zero capacity cannot carry one. The checks are now in the other order.

Non-empty payloads were already rejected there — which is exactly why the empty-payload shortcut above them was the hole.

## A floor, not the six-value set

This deliberately does **not** reuse `is_valid_max_apdu_length`. I-Am carries `Max APDU Length Accepted` as an **Unsigned octet count**, not the four-bit code of Clause 20.1.2.5 — and Clause 20.1.2.5 notes the true value "may be larger than indicated in this parameter" (line 52653). So 600 and 1500 are legitimate advertisements and must not be rejected. Only the 50-octet floor from Clause 12.11.18 ("shall be greater than or equal to 50", line 14693) applies.

Reusing the six-value set here would have been a plausible-looking regression.

## Why refuse rather than clamp to 50

Both are spec-defensible, since a sub-50 advertisement is already non-conformant. Refusing keeps the client from inventing a capability the peer never claimed: a typed error names the misconfiguration, where a silent clamp would send the device frames it said it cannot hold. Flagging the alternative explicitly in case you prefer reachability over strictness.

## Server is unaffected

Its `client_max_apdu` comes from the four-bit header field via `decode_max_apdu`, which maps through `MAX_APDU_DECODE` and whose lowest value is 50. Reserved codes already error. The hole is reachable only through the client's discovered-device path.

## Tests

New module `peer_max_apdu_tests.rs` — `client/tests.rs` is at **698 of the 700-LOC cap**.

Verified against `dev` in a throwaway worktree:

| test | on `dev` | what it pins |
|---|---|---|
| `peer_max_apdu_too_small_for_an_unsegmented_apdu_sends_nothing` | **FAILED** | the defect — 0..3 emitted a six-octet frame on `dev`; now a typed error and **no outbound frame** |
| `peer_max_apdu_below_the_floor_but_above_the_apdu_size_is_also_refused` | ok | 4, 6, 49 were never defective; a deliberate new refusal under the 50-octet floor |
| `nonempty_request_to_peer_below_minimum_message_size_sends_nothing` | ok | never broken; pins that the same case is now refused *earlier*, before segmentation |
| `confirmed_request_at_minimum_message_size_is_sent_unsegmented` | ok | boundary — exactly 50 still transacts unsegmented |

One of three discriminates, which is the honest number: the other two guard behavior that must not change. A guard stuck permanently closed would satisfy the refusal tests alone, so the boundary test is deliberately paired with them.

Also `split_empty_payload_zero_segment_size_errors` at the encoding layer.

## Verification

`cargo test --workspace --exclude rusty-bacnet` 34 suites green · clippy 0 errors · fmt clean · file-size cap OK.

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)
