### PR TITLE
fix(client): correlate responses with the request awaiting them

### DIFF
--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -1,4 +1,26 @@
 use super::*;
+use crate::tsm::CompletionOutcome;
+
+/// Report an acknowledgment that named a different confirmed service.
+///
+/// Clauses 20.1.4.2 and 20.1.5.6 both require an acknowledgment's
+/// service-ack-choice to carry "the value of the BACnetConfirmedServiceChoice
+/// corresponding to the service contained in the previous
+/// BACnet-Confirmed-Service-Request that has resulted in this
+/// acknowledgment", so a mismatch means the peer is not answering this
+/// request. The transaction stays pending; nothing else is needed here beyond
+/// making the peer's misbehavior visible.
+fn log_mismatch(outcome: CompletionOutcome, invoke_id: u8, pdu: &str) {
+    if let CompletionOutcome::ServiceChoiceMismatch { expected, observed } = outcome {
+        warn!(
+            invoke_id,
+            pdu,
+            expected = expected.to_raw(),
+            observed = observed.to_raw(),
+            "Ignoring acknowledgment labelled for a different confirmed service"
+        );
+    }
+}
 
 impl<T: TransportPort + 'static> BACnetClient<T> {
     /// Dispatch a received APDU to the appropriate handler.
@@ -15,14 +37,20 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         source_mac: &[u8],
         source_network: &Option<NpduAddress>,
         apdu: Apdu,
-        segmented_response_accepted: bool,
+        limits: ResponseLimits,
     ) {
         let tsm_mac = response_tsm_mac(source_mac, source_network);
         match apdu {
             Apdu::SimpleAck(ack) => {
                 debug!(invoke_id = ack.invoke_id, "Received SimpleAck");
                 let mut tsm = tsm.lock().await;
-                tsm.complete_transaction(&tsm_mac, ack.invoke_id, TsmResponse::SimpleAck);
+                let outcome = tsm.complete_transaction(
+                    &tsm_mac,
+                    ack.invoke_id,
+                    Some(ack.service_choice),
+                    TsmResponse::SimpleAck,
+                );
+                log_mismatch(outcome, ack.invoke_id, "SimpleAck");
             }
             Apdu::ComplexAck(ack) => {
                 if ack.segmented {
@@ -33,27 +61,36 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         source_mac,
                         source_network,
                         ack,
-                        segmented_response_accepted,
+                        limits,
                     )
                     .await;
                 } else {
                     debug!(invoke_id = ack.invoke_id, "Received ComplexAck");
                     let mut tsm = tsm.lock().await;
-                    tsm.complete_transaction(
+                    let outcome = tsm.complete_transaction(
                         &tsm_mac,
                         ack.invoke_id,
+                        Some(ack.service_choice),
                         TsmResponse::ComplexAck {
                             service_data: ack.service_ack,
                         },
                     );
+                    log_mismatch(outcome, ack.invoke_id, "ComplexAck");
                 }
             }
             Apdu::Error(err) => {
                 debug!(invoke_id = err.invoke_id, "Received Error PDU");
                 let mut tsm = tsm.lock().await;
+                // Correlated by invoke ID alone. Clause 20.1.7.2 words the
+                // Error PDU's service choice differently from the ACK clauses
+                // — "the tag value of the BACnet-Error choice" — and Clause 21
+                // defines `BACnet-Error ::= CHOICE { other [127] Error, ... }`,
+                // so a conformant peer may answer any service with choice 127.
+                // Requiring an exact match would reject those.
                 tsm.complete_transaction(
                     &tsm_mac,
                     err.invoke_id,
+                    None,
                     TsmResponse::Error {
                         class: err.error_class.to_raw() as u32,
                         code: err.error_code.to_raw() as u32,
@@ -63,20 +100,37 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             Apdu::Reject(rej) => {
                 debug!(invoke_id = rej.invoke_id, "Received Reject PDU");
                 let mut tsm = tsm.lock().await;
+                // Carries no service choice (Clause 20.1.8); invoke ID is the
+                // only correlation the Standard provides.
                 tsm.complete_transaction(
                     &tsm_mac,
                     rej.invoke_id,
+                    None,
                     TsmResponse::Reject {
                         reason: rej.reject_reason.to_raw(),
                     },
                 );
             }
             Apdu::Abort(abt) => {
+                // Clause 5.4.4.3 AbortPDU_Received fires only for an Abort
+                // "whose 'server' parameter is TRUE". An Abort this client
+                // itself sent — 5.4.4.4 emits them with 'server' = FALSE —
+                // must not, echoed back or spoofed, complete the very
+                // transaction it was trying to abort.
+                if !abt.sent_by_server {
+                    debug!(
+                        invoke_id = abt.invoke_id,
+                        "Ignoring Abort PDU with server=FALSE"
+                    );
+                    return;
+                }
                 debug!(invoke_id = abt.invoke_id, "Received Abort PDU");
                 let mut tsm = tsm.lock().await;
+                // Carries no service choice (Clause 20.1.9).
                 tsm.complete_transaction(
                     &tsm_mac,
                     abt.invoke_id,
+                    None,
                     TsmResponse::Abort {
                         reason: abt.abort_reason.to_raw(),
                     },
@@ -189,6 +243,18 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 }
             }
             Apdu::SegmentAck(sa) => {
+                // Clause 5.4.4.2 gates DuplicateACK_Received, NewACK_Received
+                // and FinalACK_Received on the 'server' parameter being TRUE.
+                // A SegmentACK this client sent while receiving a segmented
+                // response carries server=FALSE and must not be fed back into
+                // its own segmented send.
+                if !sa.sent_by_server {
+                    debug!(
+                        invoke_id = sa.invoke_id,
+                        "Ignoring SegmentAck with server=FALSE"
+                    );
+                    return;
+                }
                 let key = (tsm_mac, sa.invoke_id);
                 let senders = seg_ack_senders.lock().await;
                 if let Some(tx) = senders.get(&key) {

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -263,10 +263,42 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     );
                     return;
                 }
-                // Which state this client is in for `invoke_id` decides the
-                // answer, and Clause 5.4 gives a different one for each.
+                // Which of Clause 5.4's four client states this device is in
+                // for `invoke_id` decides the answer, and each gives a
+                // different one. The predicates below are what distinguishes
+                // them: a `seg_state` entry means a segmented response is
+                // being reassembled, a `seg_ack_senders` entry means a
+                // segmented request is still being sent, and a pending TSM
+                // transaction without either means the send is done.
                 let invoke_id = sa.invoke_id;
                 let key = (tsm_mac.clone(), invoke_id);
+
+                // SEGMENTED_CONF (5.4.4.4) `UnexpectedPDU_Received` lists
+                // "BACnet-SegmentACK-PDU with 'server' = TRUE" among the PDUs
+                // that do not belong in this state, and requires all three of:
+                // "transmit a BACnet-Abort-PDU with 'server' = FALSE; send
+                // ABORT.indication with 'server' = FALSE and 'abort-reason' =
+                // INVALID_APDU_IN_THIS_STATE to the local application program;
+                // and enter the IDLE state."
+                //
+                // Checked first because it is the narrower state: reassembly
+                // only starts once the request has been sent in full, so a
+                // `seg_state` entry means any `seg_ack_senders` entry that
+                // still lingers belongs to a send that is already finished.
+                if let Some(state) = seg_state.remove(&key) {
+                    debug!(invoke_id, "Aborting reassembly on an unexpected SegmentAck");
+                    Self::abort_reassembly(
+                        tsm,
+                        network,
+                        &tsm_mac,
+                        &state.reply_mac,
+                        invoke_id,
+                        bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                    )
+                    .await;
+                    return;
+                }
+
                 let delivered = {
                     let senders = seg_ack_senders.lock().await;
                     match senders.get(&key) {

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -81,12 +81,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             Apdu::Error(err) => {
                 debug!(invoke_id = err.invoke_id, "Received Error PDU");
                 let mut tsm = tsm.lock().await;
-                // Correlated by invoke ID alone. Clause 20.1.7.2 words the
-                // Error PDU's service choice differently from the ACK clauses
-                // — "the tag value of the BACnet-Error choice" — and Clause 21
-                // defines `BACnet-Error ::= CHOICE { other [127] Error, ... }`,
-                // so a conformant peer may answer any service with choice 127.
-                // Requiring an exact match would reject those.
+                // Correlated by invoke ID alone. Unlike 20.1.4.2 and 20.1.5.6,
+                // Clause 20.1.7.2 imposes no correspondence to the requested
+                // service: error-choice is "the tag value of the BACnet-Error
+                // choice", and Clause 21 opens that production with
+                // `other [127] Error`. Nothing in the Standard forbids a peer
+                // from answering through that tag, so an exact-match gate here
+                // would reject conformant responses.
                 tsm.complete_transaction(
                     &tsm_mac,
                     err.invoke_id,
@@ -255,15 +256,33 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     );
                     return;
                 }
-                let key = (tsm_mac, sa.invoke_id);
-                let senders = seg_ack_senders.lock().await;
-                if let Some(tx) = senders.get(&key) {
-                    let _ = tx.try_send(sa);
-                } else {
-                    debug!(
-                        invoke_id = sa.invoke_id,
-                        "Ignoring SegmentAck for unknown transaction"
-                    );
+                let invoke_id = sa.invoke_id;
+                let key = (tsm_mac, invoke_id);
+                let delivered = {
+                    let senders = seg_ack_senders.lock().await;
+                    match senders.get(&key) {
+                        Some(tx) => {
+                            let _ = tx.try_send(sa);
+                            true
+                        }
+                        None => false,
+                    }
+                };
+                if !delivered {
+                    // The other half of Clause 5.4.4.1
+                    // UnexpectedSegmentInfoReceived: a "BACnet-SegmentACK-PDU
+                    // with 'server' = TRUE" for which this device has no
+                    // outstanding segmented send is the same unexpected
+                    // evidence of an active server TSM, and gets the same
+                    // Abort ('server' = FALSE, INVALID_APDU_IN_THIS_STATE).
+                    debug!(invoke_id, "Aborting SegmentAck for unknown transaction");
+                    Self::send_client_abort(
+                        network,
+                        source_mac,
+                        invoke_id,
+                        bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                    )
+                    .await;
                 }
             }
         }

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -256,8 +256,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     );
                     return;
                 }
+                // Which state this client is in for `invoke_id` decides the
+                // answer, and Clause 5.4 gives a different one for each.
                 let invoke_id = sa.invoke_id;
-                let key = (tsm_mac, invoke_id);
+                let key = (tsm_mac.clone(), invoke_id);
                 let delivered = {
                     let senders = seg_ack_senders.lock().await;
                     match senders.get(&key) {
@@ -268,22 +270,50 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         None => false,
                     }
                 };
-                if !delivered {
-                    // The other half of Clause 5.4.4.1
-                    // UnexpectedSegmentInfoReceived: a "BACnet-SegmentACK-PDU
-                    // with 'server' = TRUE" for which this device has no
-                    // outstanding segmented send is the same unexpected
-                    // evidence of an active server TSM, and gets the same
-                    // Abort ('server' = FALSE, INVALID_APDU_IN_THIS_STATE).
-                    debug!(invoke_id, "Aborting SegmentAck for unknown transaction");
-                    Self::send_client_abort(
-                        network,
-                        source_mac,
-                        invoke_id,
-                        bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
-                    )
-                    .await;
+                if delivered {
+                    // SEGMENTED_REQUEST (5.4.4.2): still sending, so this is
+                    // the flow control the send loop is waiting on.
+                    return;
                 }
+
+                // AWAIT_CONFIRMATION (5.4.4.3) `SegmentACK_Received`: a
+                // transaction is outstanding but its send phase is over, so
+                // the Standard is explicit — "discard the PDU as a duplicate,
+                // and re-enter the current state."
+                //
+                // This case is not hypothetical. `release_invoke_id` drops a
+                // peer's allocator once every ID is free, so the next request
+                // to an idle peer reuses invoke ID 0. A duplicated SegmentACK
+                // from a finished segmented transfer therefore lands on a live
+                // unsegmented request — which has no `seg_ack_senders` entry —
+                // and aborting here would kill this client's own healthy
+                // request at the peer.
+                if tsm
+                    .lock()
+                    .await
+                    .expected_service_choice(&tsm_mac, invoke_id)
+                    .is_some()
+                {
+                    debug!(
+                        invoke_id,
+                        "Discarding duplicate SegmentAck for an outstanding transaction"
+                    );
+                    return;
+                }
+
+                // IDLE (5.4.4.1) `UnexpectedSegmentInfoReceived`: nothing is
+                // outstanding, so a "BACnet-SegmentACK-PDU with 'server' =
+                // TRUE" is unexpected evidence of an active server TSM and
+                // earns the Abort ('server' = FALSE,
+                // INVALID_APDU_IN_THIS_STATE).
+                debug!(invoke_id, "Aborting SegmentAck received while idle");
+                Self::send_client_abort(
+                    network,
+                    source_mac,
+                    invoke_id,
+                    bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                )
+                .await;
             }
         }
     }

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -249,6 +249,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // A SegmentACK this client sent while receiving a segmented
                 // response carries server=FALSE and must not be fed back into
                 // its own segmented send.
+                //
+                // This check must stay ahead of the Abort below. A client
+                // emits SegmentACKs with 'server' = FALSE, so if the order
+                // were reversed, two of these clients exchanging a segmented
+                // ConfirmedCOVNotification would answer each other's
+                // SegmentACKs with Aborts indefinitely. Dropping them here is
+                // what keeps the Abort reachable only by a *server's* PDU.
                 if !sa.sent_by_server {
                     debug!(
                         invoke_id = sa.invoke_id,

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -69,7 +69,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let seg_ack_senders: Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let seg_ack_senders_dispatch = Arc::clone(&seg_ack_senders);
-        let segmented_response_accepted = config.segmented_response_accepted;
+        let response_limits = ResponseLimits::from_config(&config);
 
         let dispatch_task = tokio::spawn(async move {
             let mut seg_state: HashMap<SegKey, SegmentedReceiveState> = HashMap::new();
@@ -138,7 +138,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     &received.source_mac,
                                     &received.source_network,
                                     decoded,
-                                    segmented_response_accepted,
+                                    response_limits,
                                 )
                                 .await;
                             }

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -366,6 +366,13 @@ pub struct BACnetClient<T: TransportPort> {
     cov_tx: broadcast::Sender<ReceivedCOVNotification>,
     device_tx: broadcast::Sender<DeviceEvent>,
     dispatch_task: Option<JoinHandle<()>>,
+    /// Channels feeding SegmentACKs to in-flight segmented sends.
+    ///
+    /// Lock invariant: never hold this and [`Self::tsm`] at the same time.
+    /// They are acquired in both orders by design — setup registers the
+    /// transaction and then inserts the sender, while teardown and inbound
+    /// dispatch go the other way — so the pair is deadlock-free only because
+    /// neither is ever held across the other's acquisition.
     seg_ack_senders: Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
     local_mac: MacAddr,
 }

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -315,6 +315,20 @@ pub struct DeviceWriteResult {
     pub result: Result<(), Error>,
 }
 
+/// The receive-side promises this client puts in every confirmed request.
+///
+/// Clause 20.1.2.3 and Clause 20.1.2.4 exist "so that the responding device may
+/// determine how to convey its response", so the same values must bound what
+/// the dispatch loop is willing to take back. Keeping the pair together stops
+/// the two halves from drifting as they are threaded through dispatch.
+#[derive(Debug, Clone, Copy)]
+struct ResponseLimits {
+    /// Clause 20.1.2.3 'segmented-response-accepted'.
+    segmented_response_accepted: bool,
+    /// Most segments this client will hold for one reassembly.
+    max_reassembly_segments: usize,
+}
+
 /// In-progress segmented receive state.
 struct SegmentedReceiveState {
     receiver: SegmentReceiver,
@@ -328,6 +342,13 @@ struct SegmentedReceiveState {
     window_position: u8,
     /// Proposed window size from the server.
     proposed_window_size: u8,
+    /// How many distinct segments have been stored.
+    ///
+    /// Monotonic, and deliberately not derived from `expected_next_seq`, which
+    /// is a `u8` and wraps: Clause 20.1.5.4 makes sequence numbers modulo 256,
+    /// so after 256 segments the counter returns to a slot already occupied.
+    /// This is the only value that can tell 257 segments from 1.
+    accepted_segments: usize,
 }
 
 /// Timeout for idle segmented reassembly sessions.
@@ -757,6 +778,8 @@ mod cov_tests;
 mod device_events_tests;
 #[cfg(test)]
 mod peer_max_apdu_tests;
+#[cfg(test)]
+mod response_correlation_tests;
 #[cfg(all(test, feature = "sc-tls"))]
 mod sc_builder_tests;
 #[cfg(test)]

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -237,7 +237,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             let invoke_id = tsm.allocate_invoke_id(&tsm_mac).ok_or_else(|| {
                 Error::Encoding("all invoke IDs exhausted for destination".into())
             })?;
-            let rx = tsm.register_transaction(tsm_mac.clone(), invoke_id);
+            let rx = tsm.register_transaction(tsm_mac.clone(), invoke_id, service_choice);
             (invoke_id, rx)
         };
 

--- a/crates/bacnet-client/src/client/response_correlation_tests.rs
+++ b/crates/bacnet-client/src/client/response_correlation_tests.rs
@@ -1,0 +1,549 @@
+//! Correlating inbound responses with the request that is actually waiting.
+//!
+//! Two independent ways a peer's PDU can be mistaken for this client's answer:
+//! it can name a different confirmed service (Clause 20.1.4.2 / 20.1.5.6), or it
+//! can carry `'server' = FALSE`, which Clause 5.4.4.2 and 5.4.4.3 use to mark a
+//! PDU as travelling the other way. A third failure needs no misbehaving peer at
+//! all: Clause 20.1.5.4 numbers segments modulo 256, so a long enough response
+//! wraps onto segments already stored.
+
+use bacnet_encoding::apdu::{self, encode_apdu, AbortPdu, Apdu, ComplexAck, SegmentAck, SimpleAck};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_types::enums::{AbortReason, ConfirmedServiceChoice};
+use bacnet_types::error::Error;
+use bytes::{Bytes, BytesMut};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Duration};
+
+use super::{BACnetClient, ClientConfig};
+
+const CLIENT_MAC: [u8; 1] = [0x01];
+const PEER_MAC: [u8; 1] = [0x02];
+
+/// How long "the client stayed quiet" is asserted over.
+///
+/// Comfortably shorter than the 2 s APDU timeout every test here configures, so
+/// a retransmission can never masquerade as the reaction under test.
+const SILENCE_WINDOW: Duration = Duration::from_millis(300);
+
+/// A test config with retries off and a timeout short enough to keep the
+/// deliberately-unanswered cases quick.
+fn config() -> ClientConfig {
+    ClientConfig {
+        apdu_timeout_ms: 2_000,
+        apdu_retries: 0,
+        proposed_window_size: 1,
+        ..ClientConfig::default()
+    }
+}
+
+/// The far end of an in-process link to a running client.
+struct PeerLink {
+    transport: LoopbackTransport,
+    rx: mpsc::Receiver<ReceivedNpdu>,
+    /// Present when the client was started to issue one request.
+    request: Option<JoinHandle<Result<Bytes, Error>>>,
+}
+
+impl PeerLink {
+    /// Start a client that immediately issues one confirmed request.
+    async fn issuing(
+        config: ClientConfig,
+        service_choice: ConfirmedServiceChoice,
+        service_data: Vec<u8>,
+    ) -> Self {
+        let (client_transport, mut transport) =
+            LoopbackTransport::pair(CLIENT_MAC.to_vec(), PEER_MAC.to_vec());
+        let rx = transport.start().await.expect("peer transport starts");
+        let mut client = BACnetClient::start(config, client_transport)
+            .await
+            .expect("client starts");
+
+        let request = tokio::spawn(async move {
+            let result = client
+                .confirmed_request(&PEER_MAC, service_choice, &service_data)
+                .await;
+            client.stop().await.expect("client stops");
+            result
+        });
+
+        Self {
+            transport,
+            rx,
+            request: Some(request),
+        }
+    }
+
+    /// Start a client with nothing outstanding. The returned client must be
+    /// stopped by the caller.
+    async fn idle(config: ClientConfig) -> (Self, BACnetClient<LoopbackTransport>) {
+        let (client_transport, mut transport) =
+            LoopbackTransport::pair(CLIENT_MAC.to_vec(), PEER_MAC.to_vec());
+        let rx = transport.start().await.expect("peer transport starts");
+        let client = BACnetClient::start(config, client_transport)
+            .await
+            .expect("client starts");
+        (
+            Self {
+                transport,
+                rx,
+                request: None,
+            },
+            client,
+        )
+    }
+
+    async fn send(&self, apdu: Apdu) {
+        let mut apdu_buf = BytesMut::new();
+        encode_apdu(&mut apdu_buf, &apdu).expect("valid APDU encoding");
+        let npdu = Npdu {
+            payload: apdu_buf.freeze(),
+            ..Npdu::default()
+        };
+        let mut npdu_buf = BytesMut::new();
+        encode_npdu(&mut npdu_buf, &npdu).expect("valid NPDU encoding");
+        self.transport
+            .send_unicast(&npdu_buf, &CLIENT_MAC)
+            .await
+            .expect("loopback delivers");
+    }
+
+    async fn recv(&mut self, context: &str) -> Apdu {
+        match timeout(Duration::from_secs(5), self.rx.recv()).await {
+            Ok(Some(received)) => {
+                let npdu = decode_npdu(received.npdu).expect("valid NPDU");
+                apdu::decode_apdu(npdu.payload).expect("valid APDU")
+            }
+            Ok(None) => panic!("{context}: {}", self.epitaph().await),
+            Err(_) => panic!("{context}: timed out waiting for an APDU"),
+        }
+    }
+
+    /// Assert the client transmits nothing for [`SILENCE_WINDOW`].
+    ///
+    /// A closed channel is a failure, not silence: a client that shut down
+    /// early is quiet for the wrong reason and would pass the assertion these
+    /// tests are actually making.
+    async fn expect_silence(&mut self, context: &str) {
+        match timeout(SILENCE_WINDOW, self.rx.recv()).await {
+            Err(_) => {}
+            Ok(None) => panic!("{context}: {}", self.epitaph().await),
+            Ok(Some(received)) => {
+                let npdu = decode_npdu(received.npdu).expect("valid NPDU");
+                let decoded = apdu::decode_apdu(npdu.payload).expect("valid APDU");
+                panic!("{context}: expected no transmission, got {decoded:?}");
+            }
+        }
+    }
+
+    /// Why the client stopped, for a failure message.
+    async fn epitaph(&mut self) -> String {
+        match self.request.take() {
+            Some(handle) => format!(
+                "client shut down, its request returned {:?}",
+                handle.await.expect("request task did not panic")
+            ),
+            None => "client shut down".into(),
+        }
+    }
+
+    /// Consume the client's request and return its invoke ID.
+    async fn request_invoke_id(&mut self) -> u8 {
+        match self.recv("initial request").await {
+            Apdu::ConfirmedRequest(req) => req.invoke_id,
+            other => panic!("expected ConfirmedRequest, got {other:?}"),
+        }
+    }
+
+    async fn finish(mut self) -> Result<Bytes, Error> {
+        let result = self
+            .request
+            .take()
+            .expect("link was created with a request")
+            .await
+            .expect("request task did not panic");
+        self.transport.stop().await.expect("peer transport stops");
+        result
+    }
+}
+
+/// Feed `count` in-order segments carrying `[0, 1, 2, ...]`, one byte each,
+/// consuming the SegmentACK the client returns for every one of them.
+///
+/// `terminates` sets `more-follows` FALSE on the last segment. A window size of
+/// 1 keeps the exchange in lockstep, so this works at any length.
+async fn feed_segments(
+    link: &mut PeerLink,
+    invoke_id: u8,
+    service_choice: ConfirmedServiceChoice,
+    count: usize,
+    terminates: bool,
+) {
+    for i in 0..count {
+        let is_last = i == count - 1;
+        link.send(Apdu::ComplexAck(ComplexAck {
+            segmented: true,
+            more_follows: !(is_last && terminates),
+            invoke_id,
+            sequence_number: Some(i as u8),
+            proposed_window_size: Some(1),
+            service_choice,
+            service_ack: Bytes::from(vec![i as u8]),
+        }))
+        .await;
+
+        if is_last && terminates {
+            break;
+        }
+        match link.recv("segment ack").await {
+            Apdu::SegmentAck(ack) => {
+                assert!(!ack.negative_ack, "segment {i} was negatively acked");
+                assert_eq!(
+                    ack.sequence_number, i as u8,
+                    "segment {i} acked out of step"
+                );
+            }
+            other => panic!("segment {i}: expected SegmentAck, got {other:?}"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Service-choice correlation (Clause 20.1.4.2, 20.1.5.6)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn complex_ack_for_a_different_service_does_not_answer_the_request() {
+    let mut link =
+        PeerLink::issuing(config(), ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
+    let invoke_id = link.request_invoke_id().await;
+
+    // Same invoke ID, wrong service-ack-choice: not this transaction's answer.
+    link.send(Apdu::ComplexAck(ComplexAck {
+        segmented: false,
+        more_follows: false,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        service_ack: Bytes::from_static(b"imposter"),
+    }))
+    .await;
+
+    // The transaction must still be pending, so the real answer still lands.
+    link.send(Apdu::ComplexAck(ComplexAck {
+        segmented: false,
+        more_follows: false,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(b"genuine"),
+    }))
+    .await;
+
+    let payload = link.finish().await.expect("request succeeds");
+    assert_eq!(
+        payload.as_ref(),
+        b"genuine",
+        "the mismatched ComplexACK was delivered to the caller"
+    );
+}
+
+#[tokio::test]
+async fn simple_ack_for_a_different_service_does_not_answer_the_request() {
+    let mut link =
+        PeerLink::issuing(config(), ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
+    let invoke_id = link.request_invoke_id().await;
+
+    // A SimpleACK is the wrong shape of answer for READ_PROPERTY as well as
+    // the wrong service, and it carries no data of its own — so the genuine
+    // answer below has to be the ComplexACK to make the difference visible.
+    // Asserting "the result was an empty payload" would hold either way.
+    link.send(Apdu::SimpleAck(SimpleAck {
+        invoke_id,
+        service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+    }))
+    .await;
+    link.send(Apdu::ComplexAck(ComplexAck {
+        segmented: false,
+        more_follows: false,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(b"genuine"),
+    }))
+    .await;
+
+    let payload = link.finish().await.expect("request succeeds");
+    assert_eq!(
+        payload.as_ref(),
+        b"genuine",
+        "the mismatched SimpleACK completed the transaction"
+    );
+}
+
+#[tokio::test]
+async fn reassembled_ack_for_a_different_service_is_discarded() {
+    let mut link =
+        PeerLink::issuing(config(), ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
+    let invoke_id = link.request_invoke_id().await;
+
+    // A complete, well-formed three-segment response — for the wrong service.
+    // It reassembles (the client acks every segment) and is then dropped.
+    feed_segments(
+        &mut link,
+        invoke_id,
+        ConfirmedServiceChoice::ATOMIC_READ_FILE,
+        3,
+        true,
+    )
+    .await;
+
+    link.send(Apdu::ComplexAck(ComplexAck {
+        segmented: false,
+        more_follows: false,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(b"genuine"),
+    }))
+    .await;
+
+    let payload = link.finish().await.expect("request succeeds");
+    assert_eq!(
+        payload.as_ref(),
+        b"genuine",
+        "the reassembled mismatched response reached the caller"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The 'server' parameter (Clause 5.4.4.2, 5.4.4.3)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn abort_with_server_false_does_not_end_the_transaction() {
+    let mut link =
+        PeerLink::issuing(config(), ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
+    let invoke_id = link.request_invoke_id().await;
+
+    // Clause 5.4.4.3 gates every AWAIT_CONFIRMATION abort transition on
+    // 'server' = TRUE; this one is what a *client* emits, echoed back.
+    link.send(Apdu::Abort(AbortPdu {
+        sent_by_server: false,
+        invoke_id,
+        abort_reason: AbortReason::BUFFER_OVERFLOW,
+    }))
+    .await;
+    link.send(Apdu::SimpleAck(SimpleAck {
+        invoke_id,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+    }))
+    .await;
+
+    link.finish()
+        .await
+        .expect("the server=FALSE Abort aborted the transaction");
+}
+
+#[tokio::test]
+async fn segment_ack_with_server_false_does_not_advance_the_send_window() {
+    let mut config = config();
+    // Force segmentation of the outbound request and a two-segment window.
+    config.max_apdu_length = 50;
+    config.proposed_window_size = 2;
+    // Long enough that the second window really does carry two more segments.
+    let service_data: Vec<u8> = (0..260).map(|i| (i % 251) as u8).collect();
+    let mut link =
+        PeerLink::issuing(config, ConfirmedServiceChoice::WRITE_PROPERTY, service_data).await;
+
+    let invoke_id = link.request_invoke_id().await;
+    match link.recv("second segment of initial window").await {
+        Apdu::ConfirmedRequest(req) => assert_eq!(req.sequence_number, Some(1)),
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    }
+
+    // A SegmentACK a *receiver* emits. Clause 5.4.4.2's NewACK_Received
+    // requires 'server' = TRUE, so this must not open the next window.
+    link.send(Apdu::SegmentAck(SegmentAck {
+        negative_ack: false,
+        sent_by_server: false,
+        invoke_id,
+        sequence_number: 1,
+        actual_window_size: 2,
+    }))
+    .await;
+    link.expect_silence("after a server=FALSE SegmentACK").await;
+
+    // The genuine acknowledgment still moves the transfer along.
+    link.send(Apdu::SegmentAck(SegmentAck {
+        negative_ack: false,
+        sent_by_server: true,
+        invoke_id,
+        sequence_number: 1,
+        actual_window_size: 2,
+    }))
+    .await;
+    for expected_seq in [2, 3] {
+        match link.recv("second window").await {
+            Apdu::ConfirmedRequest(req) => {
+                assert_eq!(req.sequence_number, Some(expected_seq));
+            }
+            other => panic!("expected ConfirmedRequest, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn segmented_ack_for_an_unknown_invoke_id_opens_no_session() {
+    let (mut link, mut client) = PeerLink::idle(config()).await;
+
+    // Clause 5.4.4.3 reaches SEGMENTED_CONF only from AWAIT_CONFIRMATION, so a
+    // segment for a transaction nobody issued is not owed a SegmentACK — and
+    // answering it would let a peer occupy reassembly slots at will.
+    link.send(Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows: true,
+        invoke_id: 42,
+        sequence_number: Some(0),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(&[0xAA]),
+    }))
+    .await;
+
+    link.expect_silence("unsolicited segment").await;
+    client.stop().await.expect("client stops");
+    link.transport.stop().await.expect("peer transport stops");
+}
+
+// ---------------------------------------------------------------------------
+// Reassembly capacity (Clause 20.1.5.4, 5.4.4.4, 20.1.2.4)
+// ---------------------------------------------------------------------------
+
+/// The one test here that is meant to pass before the fix as well as after:
+/// 256 segments were always legal, and the new cap must not take them away.
+#[tokio::test]
+async fn exactly_256_segments_reassemble() {
+    let mut link =
+        PeerLink::issuing(config(), ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
+    let invoke_id = link.request_invoke_id().await;
+
+    // 256 fills the modulo-256 sequence space exactly and must still work.
+    feed_segments(
+        &mut link,
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY,
+        256,
+        true,
+    )
+    .await;
+
+    let payload = link.finish().await.expect("request succeeds");
+    let expected: Vec<u8> = (0..=255).collect();
+    assert_eq!(payload.as_ref(), expected.as_slice());
+}
+
+#[tokio::test]
+async fn segment_257_aborts_with_buffer_overflow() {
+    let mut link =
+        PeerLink::issuing(config(), ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
+    let invoke_id = link.request_invoke_id().await;
+
+    // 256 segments, all still promising more.
+    feed_segments(
+        &mut link,
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY,
+        256,
+        false,
+    )
+    .await;
+
+    // The 257th wraps to sequence number 0. Storing it would overwrite the
+    // first segment and silently corrupt the reassembled payload, so Clause
+    // 5.4.4.4 NewSegmentReceived_NoSpace applies instead.
+    link.send(Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows: false,
+        invoke_id,
+        sequence_number: Some(0),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(&[0xFF]),
+    }))
+    .await;
+
+    match link.recv("overflow abort").await {
+        Apdu::Abort(abort) => {
+            assert_eq!(abort.invoke_id, invoke_id);
+            assert!(
+                !abort.sent_by_server,
+                "Clause 5.4.4.4 requires 'server' = FALSE"
+            );
+            assert_eq!(abort.abort_reason, AbortReason::BUFFER_OVERFLOW);
+        }
+        other => panic!("expected Abort, got {other:?}"),
+    }
+
+    match link.finish().await {
+        Err(Error::Abort { reason }) => {
+            assert_eq!(reason, AbortReason::BUFFER_OVERFLOW.to_raw());
+        }
+        other => panic!("expected a BUFFER_OVERFLOW abort, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn advertised_max_segments_bounds_reassembly() {
+    let mut config = config();
+    // B'010' — Clause 20.1.2.4 "4 segments accepted".
+    config.max_segments = Some(4);
+    let mut link =
+        PeerLink::issuing(config, ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
+    let invoke_id = link.request_invoke_id().await;
+
+    feed_segments(
+        &mut link,
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY,
+        4,
+        false,
+    )
+    .await;
+
+    link.send(Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows: false,
+        invoke_id,
+        sequence_number: Some(4),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(&[0xFF]),
+    }))
+    .await;
+
+    match link.recv("overflow abort").await {
+        Apdu::Abort(abort) => assert_eq!(abort.abort_reason, AbortReason::BUFFER_OVERFLOW),
+        other => panic!("expected Abort, got {other:?}"),
+    }
+    assert!(matches!(link.finish().await, Err(Error::Abort { .. })));
+}
+
+#[tokio::test]
+async fn max_segments_above_the_encodable_rungs_advertises_no_bound() {
+    // Clause 20.1.2.4 has no rung for 100; it encodes as B'111', "greater than
+    // 64 segments accepted", which promises the peer nothing. Capping
+    // reassembly at 100 would enforce a limit that was never advertised.
+    assert_eq!(apdu::advertised_max_segments(Some(100)), None);
+    assert_eq!(apdu::advertised_max_segments(None), None);
+    assert_eq!(apdu::advertised_max_segments(Some(255)), None);
+    assert_eq!(apdu::advertised_max_segments(Some(4)), Some(4));
+    assert_eq!(apdu::advertised_max_segments(Some(64)), Some(64));
+}

--- a/crates/bacnet-client/src/client/response_correlation_tests.rs
+++ b/crates/bacnet-client/src/client/response_correlation_tests.rs
@@ -440,6 +440,47 @@ async fn segmented_ack_for_an_unknown_invoke_id_is_aborted_not_reassembled() {
     link.transport.stop().await.expect("peer transport stops");
 }
 
+/// A stale SegmentACK must not abort a live request that reused its invoke ID.
+///
+/// `release_invoke_id` drops a peer's allocator once every ID is free, so the
+/// next request to an idle peer reuses invoke ID 0. A duplicated SegmentACK
+/// from a finished segmented transfer then lands on a live *unsegmented*
+/// request, which has no `seg_ack_senders` entry — and Clause 5.4.4.3
+/// `SegmentACK_Received` says to "discard the PDU as a duplicate", precisely
+/// so that this client does not abort its own healthy request at the peer.
+#[tokio::test]
+async fn segment_ack_during_an_outstanding_request_is_discarded_not_aborted() {
+    let mut link =
+        PeerLink::issuing(config(), ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
+    let invoke_id = link.request_invoke_id().await;
+
+    link.send(Apdu::SegmentAck(SegmentAck {
+        negative_ack: false,
+        sent_by_server: true,
+        invoke_id,
+        sequence_number: 0,
+        actual_window_size: 1,
+    }))
+    .await;
+    link.expect_silence("stale SegmentACK during AWAIT_CONFIRMATION")
+        .await;
+
+    // The request must still be alive and answerable.
+    link.send(Apdu::ComplexAck(ComplexAck {
+        segmented: false,
+        more_follows: false,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(b"genuine"),
+    }))
+    .await;
+
+    let payload = link.finish().await.expect("request survives the stale ack");
+    assert_eq!(payload.as_ref(), b"genuine");
+}
+
 #[tokio::test]
 async fn segment_ack_for_an_unknown_invoke_id_is_aborted() {
     let (mut link, mut client) = PeerLink::idle(config()).await;

--- a/crates/bacnet-client/src/client/response_correlation_tests.rs
+++ b/crates/bacnet-client/src/client/response_correlation_tests.rs
@@ -481,6 +481,56 @@ async fn segment_ack_during_an_outstanding_request_is_discarded_not_aborted() {
     assert_eq!(payload.as_ref(), b"genuine");
 }
 
+/// Mid-reassembly, an unexpected SegmentACK aborts rather than being discarded.
+///
+/// SEGMENTED_CONF and AWAIT_CONFIRMATION both have a transaction outstanding,
+/// so "is a transaction pending" cannot tell them apart — but Clause 5.4.4.4
+/// `UnexpectedPDU_Received` and Clause 5.4.4.3 `SegmentACK_Received` give them
+/// opposite answers. Reassembly in progress is the distinguishing fact.
+#[tokio::test]
+async fn segment_ack_during_reassembly_aborts_the_transaction() {
+    let mut link =
+        PeerLink::issuing(config(), ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
+    let invoke_id = link.request_invoke_id().await;
+
+    // One segment in, so the client is reassembling: SEGMENTED_CONF.
+    feed_segments(
+        &mut link,
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY,
+        1,
+        false,
+    )
+    .await;
+
+    link.send(Apdu::SegmentAck(SegmentAck {
+        negative_ack: false,
+        sent_by_server: true,
+        invoke_id,
+        sequence_number: 0,
+        actual_window_size: 1,
+    }))
+    .await;
+
+    match link.recv("unexpected SegmentACK during reassembly").await {
+        Apdu::Abort(abort) => {
+            assert_eq!(abort.invoke_id, invoke_id);
+            assert!(!abort.sent_by_server);
+            assert_eq!(abort.abort_reason, AbortReason::INVALID_APDU_IN_THIS_STATE);
+        }
+        other => panic!("expected Abort, got {other:?}"),
+    }
+
+    // "send ABORT.indication ... to the local application program": the
+    // caller must be told, not left waiting for a reassembly that is over.
+    match link.finish().await {
+        Err(Error::Abort { reason }) => {
+            assert_eq!(reason, AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw());
+        }
+        other => panic!("expected the caller to be aborted, got {other:?}"),
+    }
+}
+
 #[tokio::test]
 async fn segment_ack_for_an_unknown_invoke_id_is_aborted() {
     let (mut link, mut client) = PeerLink::idle(config()).await;

--- a/crates/bacnet-client/src/client/response_correlation_tests.rs
+++ b/crates/bacnet-client/src/client/response_correlation_tests.rs
@@ -1,11 +1,12 @@
 //! Correlating inbound responses with the request that is actually waiting.
 //!
 //! Two independent ways a peer's PDU can be mistaken for this client's answer:
-//! it can name a different confirmed service (Clause 20.1.4.2 / 20.1.5.6), or it
-//! can carry `'server' = FALSE`, which Clause 5.4.4.2 and 5.4.4.3 use to mark a
-//! PDU as travelling the other way. A third failure needs no misbehaving peer at
-//! all: Clause 20.1.5.4 numbers segments modulo 256, so a long enough response
-//! wraps onto segments already stored.
+//! it can name a different confirmed service (Clause 20.1.4.2 / 20.1.5.6), or
+//! it can carry `'server' = FALSE`, which Clause 20.1.6.2 and 20.1.9.1 define
+//! as marking the sender's role and which Clause 5.4.4.2 and 5.4.4.3 then test
+//! before accepting the PDU. A third failure needs no misbehaving peer at all:
+//! Clause 20.1.5.4 numbers segments modulo 256, so a long enough response wraps
+//! onto segments already stored.
 
 use bacnet_encoding::apdu::{self, encode_apdu, AbortPdu, Apdu, ComplexAck, SegmentAck, SimpleAck};
 use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
@@ -401,12 +402,13 @@ async fn segment_ack_with_server_false_does_not_advance_the_send_window() {
 }
 
 #[tokio::test]
-async fn segmented_ack_for_an_unknown_invoke_id_opens_no_session() {
+async fn segmented_ack_for_an_unknown_invoke_id_is_aborted_not_reassembled() {
     let (mut link, mut client) = PeerLink::idle(config()).await;
 
-    // Clause 5.4.4.3 reaches SEGMENTED_CONF only from AWAIT_CONFIRMATION, so a
-    // segment for a transaction nobody issued is not owed a SegmentACK — and
-    // answering it would let a peer occupy reassembly slots at will.
+    // Clause 5.4.4.1's IDLE state has no transition into SEGMENTED_CONF, so a
+    // segment for a transaction nobody issued must not open a reassembly
+    // session — that is how a peer would occupy every slot at will. What it
+    // gets instead is UnexpectedSegmentInfoReceived's Abort, not silence.
     link.send(Apdu::ComplexAck(ComplexAck {
         segmented: true,
         more_follows: true,
@@ -418,7 +420,50 @@ async fn segmented_ack_for_an_unknown_invoke_id_opens_no_session() {
     }))
     .await;
 
-    link.expect_silence("unsolicited segment").await;
+    match link.recv("unsolicited segment").await {
+        Apdu::Abort(abort) => {
+            assert_eq!(abort.invoke_id, 42);
+            assert!(!abort.sent_by_server, "this client is not the server");
+            assert_eq!(
+                abort.abort_reason,
+                AbortReason::INVALID_APDU_IN_THIS_STATE,
+                "Clause 5.4.4.1 names this reason specifically"
+            );
+        }
+        other => panic!("expected Abort, got {other:?}"),
+    }
+    // And crucially not a SegmentACK, which would mean a session was opened.
+    link.expect_silence("after the unsolicited-segment Abort")
+        .await;
+
+    client.stop().await.expect("client stops");
+    link.transport.stop().await.expect("peer transport stops");
+}
+
+#[tokio::test]
+async fn segment_ack_for_an_unknown_invoke_id_is_aborted() {
+    let (mut link, mut client) = PeerLink::idle(config()).await;
+
+    // The other half of Clause 5.4.4.1 UnexpectedSegmentInfoReceived: a
+    // SegmentACK with 'server' = TRUE that answers no outstanding send.
+    link.send(Apdu::SegmentAck(SegmentAck {
+        negative_ack: false,
+        sent_by_server: true,
+        invoke_id: 7,
+        sequence_number: 0,
+        actual_window_size: 1,
+    }))
+    .await;
+
+    match link.recv("unsolicited SegmentACK").await {
+        Apdu::Abort(abort) => {
+            assert_eq!(abort.invoke_id, 7);
+            assert!(!abort.sent_by_server);
+            assert_eq!(abort.abort_reason, AbortReason::INVALID_APDU_IN_THIS_STATE);
+        }
+        other => panic!("expected Abort, got {other:?}"),
+    }
+
     client.stop().await.expect("client stops");
     link.transport.stop().await.expect("peer transport stops");
 }
@@ -538,7 +583,7 @@ async fn advertised_max_segments_bounds_reassembly() {
 
 #[tokio::test]
 async fn max_segments_above_the_encodable_rungs_advertises_no_bound() {
-    // Clause 20.1.2.4 has no rung for 100; it encodes as B'111', "greater than
+    // Clause 20.1.2.4 has no rung for 100; it encodes as B'111', "Greater than
     // 64 segments accepted", which promises the peer nothing. Capping
     // reassembly at 100 would enforce a limit that was never advertised.
     assert_eq!(apdu::advertised_max_segments(Some(100)), None);

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -1,6 +1,80 @@
 use super::*;
+use crate::tsm::CompletionOutcome;
+use bacnet_encoding::apdu::advertised_max_segments;
+
+/// Size of the sequence-number space, and so the hard reassembly ceiling.
+///
+/// A local storage bound, not a protocol one. Clause 20.1.5.4 makes the
+/// sequence number modulo 256, so a longer response is entirely representable —
+/// this client simply keys its segment store by that `u8` and cannot tell
+/// segment 257 from segment 1. Clause 5.4.4.4 names this exact situation
+/// (`NewSegmentReceived_NoSpace`, "the segment cannot be saved due to local
+/// conditions") and prescribes the Abort below.
+///
+/// Exactly 256 segments reassemble correctly and must keep working; 257 is the
+/// first that would corrupt the payload.
+const SEQUENCE_NUMBER_SPACE: usize = 256;
+
+impl ResponseLimits {
+    /// The receive-side limits `config` puts on the wire.
+    pub(super) fn from_config(config: &ClientConfig) -> Self {
+        // Clause 20.1.2.4: max-segments-accepted "specifies the maximum number
+        // of segments that the device will accept", so a peer that overruns it
+        // is not owed a reassembly this client never promised. Only the rungs
+        // B'001'..B'110' name a number; B'000' and B'111' promise nothing, and
+        // `advertised_max_segments` reports those as `None`.
+        let advertised =
+            advertised_max_segments(config.max_segments).map_or(usize::MAX, usize::from);
+        Self {
+            segmented_response_accepted: config.segmented_response_accepted,
+            max_reassembly_segments: advertised.min(SEQUENCE_NUMBER_SPACE),
+        }
+    }
+}
 
 impl<T: TransportPort + 'static> BACnetClient<T> {
+    /// Abort a reassembly this client has no room to finish.
+    ///
+    /// Clause 5.4.4.4 `NewSegmentReceived_NoSpace`: "transmit a
+    /// BACnet-Abort-PDU with 'server' = FALSE and 'abort-reason' =
+    /// BUFFER_OVERFLOW; send ABORT.indication ...; and enter the IDLE state."
+    /// The local ABORT.indication is the waiting caller, so the transaction is
+    /// completed with the same reason rather than left to time out.
+    async fn abort_reassembly(
+        tsm: &Arc<Mutex<Tsm>>,
+        network: &Arc<NetworkLayer<T>>,
+        tsm_mac: &MacAddr,
+        reply_mac: &MacAddr,
+        invoke_id: u8,
+    ) {
+        let reason = bacnet_types::enums::AbortReason::BUFFER_OVERFLOW;
+        let abort = Apdu::Abort(AbortPdu {
+            sent_by_server: false,
+            invoke_id,
+            abort_reason: reason,
+        });
+        let mut buf = BytesMut::with_capacity(4);
+        match encode_apdu(&mut buf, &abort) {
+            Ok(()) => {
+                if let Err(e) = network
+                    .send_apdu(&buf, reply_mac, false, NetworkPriority::NORMAL)
+                    .await
+                {
+                    warn!(error = %e, "Failed to send buffer-overflow Abort");
+                }
+            }
+            Err(e) => warn!(error = %e, "Failed to encode buffer-overflow Abort"),
+        }
+        tsm.lock().await.complete_transaction(
+            tsm_mac,
+            invoke_id,
+            None,
+            TsmResponse::Abort {
+                reason: reason.to_raw(),
+            },
+        );
+    }
+
     /// Handle a segmented ComplexAck: accumulate segments, send SegmentAcks,
     /// and reassemble when all segments are received.
     pub(super) async fn handle_segmented_complex_ack(
@@ -10,7 +84,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         source_mac: &[u8],
         source_network: &Option<NpduAddress>,
         ack: bacnet_encoding::apdu::ComplexAck,
-        segmented_response_accepted: bool,
+        limits: ResponseLimits,
     ) {
         let seq = ack.sequence_number.unwrap_or(0);
         let tsm_mac = response_tsm_mac(source_mac, source_network);
@@ -24,7 +98,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         );
 
         // If client doesn't support segmented reception, send Abort per Clause 5.4.4.2
-        if !segmented_response_accepted {
+        if !limits.segmented_response_accepted {
             let abort = Apdu::Abort(AbortPdu {
                 sent_by_server: false,
                 invoke_id: ack.invoke_id,
@@ -51,6 +125,27 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             return;
         }
 
+        // Only a request this client actually issued may open a reassembly
+        // session. Without this, an unsolicited peer can occupy all 64 slots
+        // with invoke IDs nobody is waiting on and starve real responses until
+        // the reaper runs. Clause 5.4.4.1's IDLE state has no transition into
+        // SEGMENTED_CONF: it is entered only from SEGMENTED_REQUEST (5.4.4.2)
+        // or AWAIT_CONFIRMATION (5.4.4.3), both of which mean this device has
+        // a request outstanding.
+        if !seg_state.contains_key(&key)
+            && tsm
+                .lock()
+                .await
+                .expected_service_choice(&tsm_mac, ack.invoke_id)
+                .is_none()
+        {
+            debug!(
+                invoke_id = ack.invoke_id,
+                "Ignoring segmented ComplexAck for a transaction that is not pending"
+            );
+            return;
+        }
+
         let proposed_ws = ack.proposed_window_size.unwrap_or(1);
         let state = seg_state
             .entry(key.clone())
@@ -61,6 +156,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 last_activity: Instant::now(),
                 window_position: 0,
                 proposed_window_size: proposed_ws,
+                accepted_segments: 0,
             });
 
         state.last_activity = Instant::now();
@@ -108,10 +204,35 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             return;
         }
 
-        if let Err(e) = state.receiver.receive(seq, ack.service_ack) {
-            warn!(error = %e, "Rejecting oversized segment");
+        // Reached only by an in-order NEW segment: every duplicate and every
+        // out-of-order segment returned above. That placement is the whole
+        // point — Clause 5.4.4.4 requires a duplicate to be discarded, not
+        // treated as an error, so a cap that duplicates could trip would abort
+        // healthy transfers on retransmission.
+        if state.accepted_segments >= limits.max_reassembly_segments {
+            warn!(
+                invoke_id = ack.invoke_id,
+                accepted = state.accepted_segments,
+                limit = limits.max_reassembly_segments,
+                "Segmented response exceeds reassembly capacity, aborting"
+            );
+            let reply_mac = state.reply_mac.clone();
+            seg_state.remove(&key);
+            Self::abort_reassembly(tsm, network, &tsm_mac, &reply_mac, ack.invoke_id).await;
             return;
         }
+
+        if let Err(e) = state.receiver.receive(seq, ack.service_ack) {
+            // Also "the segment cannot be saved due to local conditions", so
+            // Clause 5.4.4.4 wants the same Abort rather than leaving the
+            // caller to time out on a session that can no longer complete.
+            warn!(error = %e, "Rejecting oversized segment");
+            let reply_mac = state.reply_mac.clone();
+            seg_state.remove(&key);
+            Self::abort_reassembly(tsm, network, &tsm_mac, &reply_mac, ack.invoke_id).await;
+            return;
+        }
+        state.accepted_segments += 1;
         state.expected_next_seq = seq.wrapping_add(1);
         state.window_position += 1;
 
@@ -152,13 +273,23 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         "Reassembled segmented ComplexAck"
                     );
                     let mut tsm = tsm.lock().await;
-                    tsm.complete_transaction(
+                    let outcome = tsm.complete_transaction(
                         &tsm_mac,
                         ack.invoke_id,
+                        Some(ack.service_choice),
                         TsmResponse::ComplexAck {
                             service_data: Bytes::from(service_data),
                         },
                     );
+                    if let CompletionOutcome::ServiceChoiceMismatch { expected, observed } = outcome
+                    {
+                        warn!(
+                            invoke_id = ack.invoke_id,
+                            expected = expected.to_raw(),
+                            observed = observed.to_raw(),
+                            "Discarding reassembled ComplexAck labelled for a different service"
+                        );
+                    }
                 }
                 Err(e) => {
                     warn!(error = %e, "Failed to reassemble segmented ComplexAck");
@@ -202,7 +333,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             let invoke_id = tsm.allocate_invoke_id(&tsm_mac).ok_or_else(|| {
                 Error::Encoding("all invoke IDs exhausted for destination".into())
             })?;
-            let rx = tsm.register_transaction(tsm_mac.clone(), invoke_id);
+            let rx = tsm.register_transaction(tsm_mac.clone(), invoke_id, service_choice);
             (invoke_id, rx)
         };
 

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -18,11 +18,18 @@ const SEQUENCE_NUMBER_SPACE: usize = 256;
 impl ResponseLimits {
     /// The receive-side limits `config` puts on the wire.
     pub(super) fn from_config(config: &ClientConfig) -> Self {
-        // Clause 20.1.2.4: max-segments-accepted "specifies the maximum number
-        // of segments that the device will accept", so a peer that overruns it
-        // is not owed a reassembly this client never promised. Only the rungs
-        // B'001'..B'110' name a number; B'000' and B'111' promise nothing, and
-        // `advertised_max_segments` reports those as `None`.
+        // Clause 20.1.2.4 defines max-segments-accepted as "the maximum number
+        // of segments that the device will accept"; Clause 5.2.1.3 makes it
+        // binding, requiring the segment count to be the smallest of the
+        // sender's own limit and "(b) the maximum number of segments accepted
+        // by the remote peer device" — which, for a ComplexACK, is "the 'Max
+        // Segments Accepted' parameter of the BACnet-Confirmed-Request-PDU for
+        // which this is a response". A peer that overruns it is therefore
+        // non-conformant, not merely unusual.
+        //
+        // Only the rungs B'001'..B'110' name a number; B'000' and B'111'
+        // promise nothing, and `advertised_max_segments` reports those as
+        // `None`.
         let advertised =
             advertised_max_segments(config.max_segments).map_or(usize::MAX, usize::from);
         Self {
@@ -33,6 +40,35 @@ impl ResponseLimits {
 }
 
 impl<T: TransportPort + 'static> BACnetClient<T> {
+    /// Transmit an Abort this client originates.
+    ///
+    /// Every Abort a requesting BACnet-user sends carries `'server' = FALSE` —
+    /// Clauses 5.4.4.1, 5.4.4.3 and 5.4.4.4 each spell it out — because the
+    /// flag names the sender's role, not the error.
+    pub(super) async fn send_client_abort(
+        network: &Arc<NetworkLayer<T>>,
+        reply_mac: &[u8],
+        invoke_id: u8,
+        abort_reason: bacnet_types::enums::AbortReason,
+    ) {
+        let abort = Apdu::Abort(AbortPdu {
+            sent_by_server: false,
+            invoke_id,
+            abort_reason,
+        });
+        let mut buf = BytesMut::with_capacity(4);
+        if let Err(e) = encode_apdu(&mut buf, &abort) {
+            warn!(error = %e, reason = abort_reason.to_raw(), "Failed to encode Abort");
+            return;
+        }
+        if let Err(e) = network
+            .send_apdu(&buf, reply_mac, false, NetworkPriority::NORMAL)
+            .await
+        {
+            warn!(error = %e, reason = abort_reason.to_raw(), "Failed to send Abort");
+        }
+    }
+
     /// Abort a reassembly this client has no room to finish.
     ///
     /// Clause 5.4.4.4 `NewSegmentReceived_NoSpace`: "transmit a
@@ -48,23 +84,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         invoke_id: u8,
     ) {
         let reason = bacnet_types::enums::AbortReason::BUFFER_OVERFLOW;
-        let abort = Apdu::Abort(AbortPdu {
-            sent_by_server: false,
-            invoke_id,
-            abort_reason: reason,
-        });
-        let mut buf = BytesMut::with_capacity(4);
-        match encode_apdu(&mut buf, &abort) {
-            Ok(()) => {
-                if let Err(e) = network
-                    .send_apdu(&buf, reply_mac, false, NetworkPriority::NORMAL)
-                    .await
-                {
-                    warn!(error = %e, "Failed to send buffer-overflow Abort");
-                }
-            }
-            Err(e) => warn!(error = %e, "Failed to encode buffer-overflow Abort"),
-        }
+        Self::send_client_abort(network, reply_mac, invoke_id, reason).await;
         tsm.lock().await.complete_transaction(
             tsm_mac,
             invoke_id,
@@ -132,17 +152,35 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         // SEGMENTED_CONF: it is entered only from SEGMENTED_REQUEST (5.4.4.2)
         // or AWAIT_CONFIRMATION (5.4.4.3), both of which mean this device has
         // a request outstanding.
-        if !seg_state.contains_key(&key)
-            && tsm
-                .lock()
-                .await
-                .expected_service_choice(&tsm_mac, ack.invoke_id)
-                .is_none()
-        {
+        //
+        // Bind the guard so its scope is obvious: it must not be held across
+        // the send below, and an `if let` here would extend it silently.
+        let transaction_pending = {
+            seg_state.contains_key(&key)
+                || tsm
+                    .lock()
+                    .await
+                    .expected_service_choice(&tsm_mac, ack.invoke_id)
+                    .is_some()
+        };
+        if !transaction_pending {
+            // Clause 5.4.4.1 UnexpectedSegmentInfoReceived names this exact
+            // PDU — "an unexpected PDU indicating the existence of an active
+            // server TSM (BACnet-ComplexACK-PDU with 'segmented-message' =
+            // TRUE ...)" — and prescribes an answer, not silence: "transmit a
+            // BACnet-Abort-PDU with 'server' = FALSE and 'abort-reason' =
+            // INVALID_APDU_IN_THIS_STATE and enter the IDLE state."
             debug!(
                 invoke_id = ack.invoke_id,
-                "Ignoring segmented ComplexAck for a transaction that is not pending"
+                "Aborting segmented ComplexAck for a transaction that is not pending"
             );
+            Self::send_client_abort(
+                network,
+                source_mac,
+                ack.invoke_id,
+                bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+            )
+            .await;
             return;
         }
 

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -69,21 +69,27 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         }
     }
 
-    /// Abort a reassembly this client has no room to finish.
+    /// Abort a reassembly in progress, telling both the peer and the caller.
     ///
-    /// Clause 5.4.4.4 `NewSegmentReceived_NoSpace`: "transmit a
-    /// BACnet-Abort-PDU with 'server' = FALSE and 'abort-reason' =
-    /// BUFFER_OVERFLOW; send ABORT.indication ...; and enter the IDLE state."
-    /// The local ABORT.indication is the waiting caller, so the transaction is
-    /// completed with the same reason rather than left to time out.
-    async fn abort_reassembly(
+    /// Clause 5.4.4.4 gives this same shape to every way SEGMENTED_CONF can
+    /// end badly — `NewSegmentReceived_NoSpace` for a segment that "cannot be
+    /// saved due to local conditions" and `UnexpectedPDU_Received` for a PDU
+    /// that does not belong in the state. Both "transmit a BACnet-Abort-PDU
+    /// with 'server' = FALSE", "send ABORT.indication ... to the local
+    /// application program", and "enter the IDLE state"; only `abort-reason`
+    /// differs. The local ABORT.indication is the waiting caller, so the
+    /// transaction is completed rather than left to time out.
+    ///
+    /// The caller is responsible for having removed the `seg_state` entry —
+    /// that is the "enter the IDLE state" half.
+    pub(super) async fn abort_reassembly(
         tsm: &Arc<Mutex<Tsm>>,
         network: &Arc<NetworkLayer<T>>,
         tsm_mac: &MacAddr,
         reply_mac: &MacAddr,
         invoke_id: u8,
+        reason: bacnet_types::enums::AbortReason,
     ) {
-        let reason = bacnet_types::enums::AbortReason::BUFFER_OVERFLOW;
         Self::send_client_abort(network, reply_mac, invoke_id, reason).await;
         tsm.lock().await.complete_transaction(
             tsm_mac,
@@ -256,7 +262,15 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             );
             let reply_mac = state.reply_mac.clone();
             seg_state.remove(&key);
-            Self::abort_reassembly(tsm, network, &tsm_mac, &reply_mac, ack.invoke_id).await;
+            Self::abort_reassembly(
+                tsm,
+                network,
+                &tsm_mac,
+                &reply_mac,
+                ack.invoke_id,
+                bacnet_types::enums::AbortReason::BUFFER_OVERFLOW,
+            )
+            .await;
             return;
         }
 
@@ -267,7 +281,15 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             warn!(error = %e, "Rejecting oversized segment");
             let reply_mac = state.reply_mac.clone();
             seg_state.remove(&key);
-            Self::abort_reassembly(tsm, network, &tsm_mac, &reply_mac, ack.invoke_id).await;
+            Self::abort_reassembly(
+                tsm,
+                network,
+                &tsm_mac,
+                &reply_mac,
+                ack.invoke_id,
+                bacnet_types::enums::AbortReason::BUFFER_OVERFLOW,
+            )
+            .await;
             return;
         }
         state.accepted_segments += 1;

--- a/crates/bacnet-client/src/tsm.rs
+++ b/crates/bacnet-client/src/tsm.rs
@@ -3,6 +3,7 @@
 //! Tracks in-flight confirmed requests. Each request gets a unique invoke_id
 //! (0-255) scoped per destination MAC. Responses are delivered via oneshot channels.
 
+use bacnet_types::enums::ConfirmedServiceChoice;
 use bacnet_types::MacAddr;
 use bytes::Bytes;
 use std::collections::HashMap;
@@ -30,7 +31,11 @@ impl Default for TsmConfig {
 }
 
 /// Response types that complete a transaction.
+///
+/// Non-exhaustive: the TSM gains completion reasons as more of Clause 5.4's
+/// state machine is implemented, and those should be additive for callers.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum TsmResponse {
     /// SimpleACK — confirmed service completed with no return data.
     SimpleAck,
@@ -86,14 +91,46 @@ impl InvokeIdAllocator {
 /// Prevents unbounded memory growth from spoofed source addresses.
 const MAX_TSM_DESTINATIONS: usize = 1024;
 
+/// What `complete_transaction` did with a response.
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CompletionOutcome {
+    /// The response matched a pending transaction and was delivered.
+    Delivered,
+    /// No transaction was pending for this source and invoke ID.
+    NoTransaction,
+    /// A transaction was pending, but the response was labelled for a
+    /// different confirmed service. The transaction is left pending and the
+    /// invoke ID stays allocated, so the legitimate response can still arrive.
+    ServiceChoiceMismatch {
+        /// The service the pending request asked for.
+        expected: ConfirmedServiceChoice,
+        /// The service the response claimed to answer.
+        observed: ConfirmedServiceChoice,
+    },
+}
+
+/// A confirmed request awaiting its response.
+struct PendingTransaction {
+    responder: oneshot::Sender<TsmResponse>,
+    /// The service this request asked for. Clause 20.1.4.2 and 20.1.5.6 both
+    /// require an acknowledgment's service-ack-choice to "contain the value of
+    /// the BACnetConfirmedServiceChoice corresponding to the service contained
+    /// in the previous BACnet-Confirmed-Service-Request that has resulted in
+    /// this acknowledgment", so anything else is not this transaction's
+    /// response.
+    expected_service_choice: ConfirmedServiceChoice,
+}
+
 /// Transaction State Machine.
 ///
 /// Tracks pending confirmed requests and correlates responses by
-/// `(destination_mac, invoke_id)`.
+/// `(destination_mac, invoke_id)` and by the confirmed service each request
+/// asked for.
 pub struct Tsm {
     config: TsmConfig,
     allocators: HashMap<MacAddr, InvokeIdAllocator>,
-    pending: HashMap<(MacAddr, u8), oneshot::Sender<TsmResponse>>,
+    pending: HashMap<(MacAddr, u8), PendingTransaction>,
 }
 
 impl Tsm {
@@ -138,10 +175,14 @@ impl Tsm {
 
     /// Register a pending transaction. Returns a receiver that will deliver
     /// the response when it arrives.
+    ///
+    /// `service_choice` is the confirmed service being requested; a response
+    /// labelled for any other service will not complete this transaction.
     pub fn register_transaction(
         &mut self,
         destination_mac: MacAddr,
         invoke_id: u8,
+        service_choice: ConfirmedServiceChoice,
     ) -> oneshot::Receiver<TsmResponse> {
         let (tx, rx) = oneshot::channel();
         debug_assert!(
@@ -151,25 +192,62 @@ impl Tsm {
             "duplicate TSM registration for invoke_id {}",
             invoke_id
         );
-        self.pending.insert((destination_mac, invoke_id), tx);
+        self.pending.insert(
+            (destination_mac, invoke_id),
+            PendingTransaction {
+                responder: tx,
+                expected_service_choice: service_choice,
+            },
+        );
         rx
     }
 
-    /// Deliver a response to a pending transaction. Returns `true` if found.
+    /// The confirmed service a pending transaction is waiting on, if any.
+    ///
+    /// Doubles as the "is a transaction pending" predicate: an inbound
+    /// segmented response for an invoke ID nobody is waiting on should not be
+    /// allocated a reassembly session.
+    pub fn expected_service_choice(
+        &self,
+        source_mac: &[u8],
+        invoke_id: u8,
+    ) -> Option<ConfirmedServiceChoice> {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        self.pending.get(&key).map(|p| p.expected_service_choice)
+    }
+
+    /// Deliver a response to a pending transaction.
+    ///
+    /// `observed_service_choice` is the service the response claims to answer,
+    /// or `None` for PDUs that carry no service choice at all — Reject and
+    /// Abort (Clauses 20.1.8 and 20.1.9), which can only be correlated by
+    /// invoke ID.
+    ///
+    /// A mismatch leaves the transaction pending and the invoke ID allocated.
+    /// Completing it would hand the caller a payload belonging to a different
+    /// service and free the ID for reuse while the real response is still in
+    /// flight.
     pub fn complete_transaction(
         &mut self,
         source_mac: &[u8],
         invoke_id: u8,
+        observed_service_choice: Option<ConfirmedServiceChoice>,
         response: TsmResponse,
-    ) -> bool {
+    ) -> CompletionOutcome {
         let key = (MacAddr::from_slice(source_mac), invoke_id);
-        if let Some(tx) = self.pending.remove(&key) {
-            self.release_invoke_id(source_mac, invoke_id);
-            let _ = tx.send(response);
-            true
-        } else {
-            false
+        let Some(pending) = self.pending.get(&key) else {
+            return CompletionOutcome::NoTransaction;
+        };
+        let expected = pending.expected_service_choice;
+        if let Some(observed) = observed_service_choice {
+            if observed != expected {
+                return CompletionOutcome::ServiceChoiceMismatch { expected, observed };
+            }
         }
+        let pending = self.pending.remove(&key).expect("presence just checked");
+        self.release_invoke_id(source_mac, invoke_id);
+        let _ = pending.responder.send(response);
+        CompletionOutcome::Delivered
     }
 
     /// Cancel a pending transaction. Returns `true` if found.
@@ -287,13 +365,22 @@ mod tests {
         let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
         let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
 
-        let rx = tsm.register_transaction(mac.clone(), invoke_id);
+        let rx = tsm.register_transaction(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
 
         let response = TsmResponse::ComplexAck {
             service_data: Bytes::from_static(&[0xDE, 0xAD]),
         };
-        let completed = tsm.complete_transaction(&mac, invoke_id, response);
-        assert!(completed);
+        let outcome = tsm.complete_transaction(
+            &mac,
+            invoke_id,
+            Some(ConfirmedServiceChoice::READ_PROPERTY),
+            response,
+        );
+        assert_eq!(outcome, CompletionOutcome::Delivered);
 
         let result = rx.await.unwrap();
         match result {
@@ -305,11 +392,91 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn complete_unknown_transaction_returns_false() {
+    async fn mismatched_service_choice_leaves_the_transaction_pending() {
         let mut tsm = Tsm::new(TsmConfig::default());
         let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
-        let completed = tsm.complete_transaction(&mac, 42, TsmResponse::SimpleAck);
-        assert!(!completed);
+        let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+        let rx = tsm.register_transaction(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+
+        let outcome = tsm.complete_transaction(
+            &mac,
+            invoke_id,
+            Some(ConfirmedServiceChoice::WRITE_PROPERTY),
+            TsmResponse::ComplexAck {
+                service_data: Bytes::from_static(&[0xBA, 0xD0]),
+            },
+        );
+        assert_eq!(
+            outcome,
+            CompletionOutcome::ServiceChoiceMismatch {
+                expected: ConfirmedServiceChoice::READ_PROPERTY,
+                observed: ConfirmedServiceChoice::WRITE_PROPERTY,
+            }
+        );
+        assert_eq!(tsm.pending_count(), 1, "transaction must stay pending");
+        assert_eq!(
+            tsm.allocate_invoke_id(&mac),
+            Some(invoke_id.wrapping_add(1)),
+            "the invoke ID must not have been handed back for reuse"
+        );
+
+        // The genuine response still completes it.
+        let outcome = tsm.complete_transaction(
+            &mac,
+            invoke_id,
+            Some(ConfirmedServiceChoice::READ_PROPERTY),
+            TsmResponse::ComplexAck {
+                service_data: Bytes::from_static(&[0xDE, 0xAD]),
+            },
+        );
+        assert_eq!(outcome, CompletionOutcome::Delivered);
+        match rx.await.unwrap() {
+            TsmResponse::ComplexAck { service_data } => {
+                assert_eq!(service_data.as_ref(), &[0xDE, 0xAD]);
+            }
+            other => panic!("expected ComplexAck, got {other:?}"),
+        }
+    }
+
+    /// Reject and Abort carry no service choice (Clauses 20.1.8, 20.1.9), and
+    /// Clause 20.1.7.2 lets an Error PDU answer any service with the
+    /// `BACnet-Error` `other [127]` choice. All three correlate by invoke ID
+    /// alone.
+    #[tokio::test]
+    async fn a_response_without_a_service_choice_completes_any_transaction() {
+        let mut tsm = Tsm::new(TsmConfig::default());
+        let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+        let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+        let rx = tsm.register_transaction(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+
+        let outcome =
+            tsm.complete_transaction(&mac, invoke_id, None, TsmResponse::Reject { reason: 9 });
+        assert_eq!(outcome, CompletionOutcome::Delivered);
+        assert!(matches!(
+            rx.await.unwrap(),
+            TsmResponse::Reject { reason: 9 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn complete_unknown_transaction_reports_no_transaction() {
+        let mut tsm = Tsm::new(TsmConfig::default());
+        let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+        let outcome = tsm.complete_transaction(
+            &mac,
+            42,
+            Some(ConfirmedServiceChoice::READ_PROPERTY),
+            TsmResponse::SimpleAck,
+        );
+        assert_eq!(outcome, CompletionOutcome::NoTransaction);
     }
 
     #[test]
@@ -317,7 +484,11 @@ mod tests {
         let mut tsm = Tsm::new(TsmConfig::default());
         let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
         let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
-        let _rx = tsm.register_transaction(mac.clone(), invoke_id);
+        let _rx = tsm.register_transaction(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
         assert_eq!(tsm.pending_count(), 1);
 
         let cancelled = tsm.cancel_transaction(&mac, invoke_id);

--- a/crates/bacnet-client/src/tsm.rs
+++ b/crates/bacnet-client/src/tsm.rs
@@ -6,6 +6,7 @@
 use bacnet_types::enums::ConfirmedServiceChoice;
 use bacnet_types::MacAddr;
 use bytes::Bytes;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use tokio::sync::oneshot;
 
@@ -235,16 +236,18 @@ impl Tsm {
         response: TsmResponse,
     ) -> CompletionOutcome {
         let key = (MacAddr::from_slice(source_mac), invoke_id);
-        let Some(pending) = self.pending.get(&key) else {
+        let Entry::Occupied(entry) = self.pending.entry(key) else {
             return CompletionOutcome::NoTransaction;
         };
-        let expected = pending.expected_service_choice;
+        let expected = entry.get().expected_service_choice;
         if let Some(observed) = observed_service_choice {
             if observed != expected {
                 return CompletionOutcome::ServiceChoiceMismatch { expected, observed };
             }
         }
-        let pending = self.pending.remove(&key).expect("presence just checked");
+        // Taking the entry ends the borrow of `pending`, so the invoke ID can
+        // be released without a second lookup that would have to be `expect`ed.
+        let pending = entry.remove();
         self.release_invoke_id(source_mac, invoke_id);
         let _ = pending.responder.send(response);
         CompletionOutcome::Delivered

--- a/crates/bacnet-encoding/src/apdu/mod.rs
+++ b/crates/bacnet-encoding/src/apdu/mod.rs
@@ -56,6 +56,25 @@ fn decode_max_segments(value: u8) -> Option<u8> {
     MAX_SEGMENTS_DECODE[(value & 0x07) as usize]
 }
 
+/// The segment count a configured `max-segments-accepted` actually promises a peer.
+///
+/// Clause 20.1.2.4 carries this parameter in three bits, and only B'001'
+/// through B'110' name a number (2, 4, 8, 16, 32, 64). B'000' is "Unspecified
+/// number of segments accepted" and B'111' is "Greater than 64 segments
+/// accepted" — neither tells the peer a limit, so both yield `None`.
+///
+/// This deliberately round-trips through the wire encoding rather than reading
+/// `configured` directly: a value such as `Some(100)` encodes as B'111', so the
+/// peer was told "greater than 64", not "100". Answering from the configured
+/// number would claim a promise that was never sent.
+pub fn advertised_max_segments(configured: Option<u8>) -> Option<u8> {
+    match decode_max_segments(encode_max_segments(configured)) {
+        // The B'111' sentinel — an open-ended "more than 64", not a bound.
+        Some(255) => None,
+        decoded => decoded,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Max-APDU-length encoding
 // ---------------------------------------------------------------------------

--- a/crates/bacnet-encoding/src/apdu/mod.rs
+++ b/crates/bacnet-encoding/src/apdu/mod.rs
@@ -65,11 +65,12 @@ fn decode_max_segments(value: u8) -> Option<u8> {
 ///
 /// This deliberately round-trips through the wire encoding rather than reading
 /// `configured` directly: a value such as `Some(100)` encodes as B'111', so the
-/// peer was told "greater than 64", not "100". Answering from the configured
-/// number would claim a promise that was never sent.
+/// peer was told "Greater than 64 segments accepted", not "100". Answering
+/// from the configured number would claim a promise that was never sent.
 pub fn advertised_max_segments(configured: Option<u8>) -> Option<u8> {
     match decode_max_segments(encode_max_segments(configured)) {
-        // The B'111' sentinel — an open-ended "more than 64", not a bound.
+        // The B'111' sentinel — "Greater than 64 segments accepted", which is
+        // open-ended rather than a bound.
         Some(255) => None,
         decoded => decoded,
     }


### PR DESCRIPTION
Closes #341. Closes #355.

The client TSM matched an inbound response on `(source MAC, invoke ID)` alone. Three distinct ways that lets bytes reach a caller that do not belong to its request.

## 1. Service choice (#341) — hardening

Clauses **20.1.4.2** and **20.1.5.6** both require an acknowledgment's `service-ack-choice` to hold *"the value of the BACnetConfirmedServiceChoice corresponding to the service contained in the previous BACnet-Confirmed-Service-Request that has resulted in this acknowledgment"*. A peer that violates this is non-conformant, so this is **hardening against a broken peer**, not a fix to our own conformance.

`Tsm` now records the service each request asked for and returns `CompletionOutcome::ServiceChoiceMismatch` rather than delivering the payload. A mismatch **leaves the transaction pending and the invoke ID allocated** — completing it would both hand over foreign bytes and free the ID for reuse while the real response is still in flight.

Deliberately *not* gated on service choice:

| PDU | Why |
|---|---|
| Reject | Clause **20.1.8**'s `BACnet-Reject-PDU ::= SEQUENCE` has no service-choice field |
| Abort | Clause **20.1.9**'s `BACnet-Abort-PDU` likewise (it carries `server`, not a service) |
| Error | Clause **20.1.7.2** imposes no correspondence to the request, unlike the two ACK clauses — `error-choice` is *"the tag value of the BACnet-Error choice"*, and Clause 21 opens that production with `other [127] Error`. An exact-match gate would reject responses no clause forbids. |

## 2. The `'server'` parameter — genuine client-side non-conformance

Clause **20.1.6.2** defines the SegmentACK flag as *"TRUE when the SegmentACK PDU is sent by a server ... FALSE when the SegmentACK PDU is sent by a client"*, and **20.1.9.1** says the same for Abort. It marks the sender's role. Clause **5.4.4.3** `AbortPDU_Received` and Clause **5.4.4.2**'s `DuplicateACK_Received` / `NewACK_Received` / `FinalACK_Received` then each fire only for a PDU *"whose 'server' parameter is TRUE"*.

This client emits **both** PDU types with `'server' = FALSE`, so its own PDUs — echoed back or spoofed — ended the transaction they were aborting or advanced its own send window. Both are now gated.

## 3. Reassembly capacity (#355)

Clause **20.1.5.4** numbers segments modulo 256 and the segment store is keyed by that `u8`, so segment 257 **overwrote** segment 0 while `received_count()` stayed pinned at 256. The caller received a payload of mixed head and tail data, `Ok`, with no error raised.

Reassembly is now capped, and an overrun gets the Abort Clause **5.4.4.4** `NewSegmentReceived_NoSpace` prescribes — *"transmit a BACnet-Abort-PDU with 'server' = FALSE and 'abort-reason' = BUFFER_OVERFLOW; send ABORT.indication ...; and enter the IDLE state"* — with the local ABORT.indication delivered to the waiting caller.

The cap is `min(256, advertised)`. Clause **5.2.1.3** is what makes an overrun non-conformant: the segment count must be the smallest of the sender's own limit and *"(b) the maximum number of segments accepted by the remote peer device"*, which for a ComplexACK is *"the 'Max Segments Accepted' parameter of the BACnet-Confirmed-Request-PDU for which this is a response"*.

New `bacnet_encoding::apdu::advertised_max_segments` derives `advertised` by **round-tripping through the wire encoding** rather than reading the configured number: Clause **20.1.2.4** encodes this in three bits and only B'001'–B'110' name a value (2/4/8/16/32/64). B'000' is *"Unspecified number of segments accepted"* and B'111' is *"Greater than 64 segments accepted"* — neither promises a limit, so both report `None`. A configured `Some(100)` encodes as B'111', so the peer was told *"Greater than 64 segments accepted"*, never "100"; capping at 100 would enforce a promise that was never sent.

**Exactly 256 segments still reassemble.** 257 is the first corrupting case.

## 4. Unexpected segmented PDUs are answered per the state they arrive in

A reassembly session may now only be opened when a TSM transaction is pending — otherwise an unsolicited peer can occupy all 64 `MAX_CONCURRENT_SEG_SESSIONS` slots with invoke IDs nobody is waiting on.

The first version of that gate dropped the PDU silently. A spec audit caught that the decision was right but the action was wrong: Clause **5.4.4.1** `UnexpectedSegmentInfoReceived` names this input precisely — *"an unexpected PDU indicating the existence of an active server TSM (BACnet-ComplexACK-PDU with 'segmented-message' = TRUE or BACnet-SegmentACK-PDU with 'server' = TRUE)"* — and prescribes *"transmit a BACnet-Abort-PDU with 'server' = FALSE and 'abort-reason' = INVALID_APDU_IN_THIS_STATE and enter the IDLE state."*

Applying that to **every** unmatched SegmentACK was then too broad, and two rounds of adversarial review were needed to get the state machine right. The arm now dispatches on which of Clause 5.4's **four** client states this device is in:

| State | Distinguishing fact | Clause | Action |
|---|---|---|---|
| SEGMENTED_CONF | a `seg_state` entry — reassembling a response | 5.4.4.4 `UnexpectedPDU_Received` | Abort + `ABORT.indication` + drop session |
| SEGMENTED_REQUEST | a `seg_ack_senders` entry — still sending | 5.4.4.2 | deliver to the send loop |
| AWAIT_CONFIRMATION | transaction pending, send phase over | 5.4.4.3 `SegmentACK_Received` | *"discard the PDU as a duplicate"* |
| IDLE | nothing outstanding | 5.4.4.1 | Abort |

Two of those rows were wrong at some point in this branch, and each has a test that fails against the commit that got it wrong:

- **AWAIT_CONFIRMATION.** `release_invoke_id` drops a peer's allocator once every ID is free, so the **next** request to an idle peer reuses invoke ID 0. A duplicated SegmentACK from a finished segmented transfer lands on a live *unsegmented* request — which never creates a `seg_ack_senders` entry — and aborting there killed this client's own healthy request at the peer.
- **SEGMENTED_CONF.** Both this state and AWAIT_CONFIRMATION have a transaction pending, so `expected_service_choice` cannot separate them, and 5.4.4.4 was silently folded into the discard branch. Clause 5.4.4.4 requires the opposite: Abort, tell the caller, drop the session.

The ordering of the `!sa.sent_by_server` early return ahead of all four is load-bearing and now says so in a comment: a client emits SegmentACKs with `'server' = FALSE`, so reversing it would let two of these clients exchanging a segmented ConfirmedCOVNotification Abort each other indefinitely.

Also folded in: the oversized-segment path — the same *"cannot be saved due to local conditions"* condition — now aborts and drops its session instead of stranding the caller until timeout.

## Correction to the issue text

#355 as filed argued via Clause 5.2.1.3 that exceeding 256 segments is inherently non-conformant. That framing is wrong and I corrected it on the issue: modulo-256 sequence numbers make a longer response perfectly representable. 5.2.1.3(b) is still the operative clause, but for the *advertised* bound, not for 256.

## Breaking changes

Confined to `bacnet_client::tsm`, which neither downstream repo imports (both pin 0.9/0.8):

- `Tsm::register_transaction` takes the requested `ConfirmedServiceChoice`
- `Tsm::complete_transaction` takes the observed choice as `Option<ConfirmedServiceChoice>` and returns `CompletionOutcome` instead of `bool`
- `TsmResponse` and the new `CompletionOutcome` are `#[non_exhaustive]`

### Behavior changes worth knowing about

1. **A mislabelled ACK now costs a timeout instead of a fast wrong answer.** Previously a peer that mislabelled its service choice gave the caller an immediate (incorrect) success. Now the transaction stays pending until `apdu_timeout_ms x (apdu_retries + 1)` elapses — 24 s at defaults — and the request is retransmitted up to 3 more times. For WriteProperty, CreateObject or AtomicWriteFile that means a non-conformant peer may execute the operation up to four times. This is inherent to BACnet's retry model and is the right trade against handing the caller foreign bytes, but it is a real cost of the hardening.
2. **New outbound PDU on an inbound path.** The client now emits an Abort where it previously stayed silent, for an unsolicited segmented ComplexACK, an idle-state SegmentACK, or a SegmentACK arriving mid-reassembly. An attacker spoofing a victim's source address can use this as a 1:1 reflector. Amplification was measured, not assumed — the encoders give Abort = 3 bytes against SegmentACK = 4 and segmented ComplexACK = 6, so the factor is below 1 and it is a reflector, not an amplifier. No loop is constructible either: Clause 5.4.5.1 and 5.4.5.4 both make a `'server' = FALSE` Abort produce an `ABORT.indication` and nothing on the wire. The posture still changes, so it is called out here.
3. **Oversized-segment error type changed.** That path now yields `Err(Abort { reason: 1 })` rather than `Err(Timeout)`. Downstream code matching on the error variant will see the difference.
4. **After a completed transfer**, a retransmitted trailing segment used to draw a bogus negative SegmentACK; it is now discarded or aborted depending on state.
5. **New public API** (additive, not breaking): `Tsm::expected_service_choice`.

## Verification

- `cargo test -p bacnet-client` — **89 passed**, up from 74 (13 integration + 2 TSM unit tests)
- `cargo test --workspace --exclude rusty-bacnet` — all green
- `cargo clippy`, `cargo fmt --all --check`, `check-file-size.sh` — clean
- `cargo check -p rusty-bacnet --tests` and `-p bacnet-cli --all-targets` — layer-7 crates unaffected

**Discrimination tested, three times.** The tests were run against `dev` (`7099f91`) in a throwaway worktree: **9 of 10 fail there**. The two tests added in response to review findings were additionally run against the intermediate commits that contained those defects (`22a2e28` and `b316399`), and each fails there and passes now — so they demonstrably catch the bug they were written for, not just the original one. The one that passes, `exactly_256_segments_reassemble`, is the deliberate regression guard that the new cap does not take away a length that was always legal — its doc comment says so.

That exercise caught a real defect in my own work: `simple_ack_for_a_different_service_does_not_answer_the_request` originally asserted `payload.is_empty()`, which held on `dev` too, because `TsmResponse::SimpleAck` maps to `Ok(Bytes::new())` whether the imposter or the genuine ACK completed it. It now makes the genuine answer a ComplexACK carrying distinguishable bytes.

**Every clause citation was verified against a line number** in `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` (extracted with `pdftotext -layout`). Seven were wrong across two rounds and are fixed: a misquoted `BACnet-Confirmed-Request-PDU` for `BACnet-Confirmed-Service-Request`; an overstated "all 5.4.4.3 transitions"; a claim that SEGMENTED_CONF is reached only from AWAIT_CONFIRMATION when 5.4.4.2 reaches it too, plus a stale copy of that same comment in the test file; `"more than 64"` paraphrased inside quotation marks; an unsupported "may answer any service with choice 127"; and `'server'` semantics attributed to the clauses that test the flag rather than 20.1.6.2/20.1.9.1, which define it.

## Follow-ups filed, not fixed here

- **#364** — `bacnet-server` has a worse form of the same wrap: `final_total = Some(seq as usize + 1)` derives the total from the *wrapped* sequence number, so a 260-segment request reassembles as 4 segments and returns `Ok`.
- **#365** — `encode_max_segments` maps any unencodable value, including `Some(3)`, to B'111' "Greater than 64 segments accepted", so a constrained device advertises the opposite of its limit.
- **#366** — no reply on the segmented-receive path is routed: SegmentACKs and Aborts all go to the immediate MAC with no DNET/DADR, though `source_network` is in hand. Pre-existing; this PR follows the existing convention rather than changing it.
- **#367** — a reassembly session outlives its transaction: the Abort/Error/Reject arms never clear `seg_state`, and because `last_activity` refreshes on every segment the reaper cannot reclaim it. The new gate is deliberately written not to close this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

