### PR TITLE
fix(client): bound routed confirmed requests by the routed peer's Max APDU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Routed confirmed requests honor the routed peer's advertised
+  `Max APDU Length Accepted` (#362). The routed path computed the maximum
+  transmittable length from local configuration and the transport alone,
+  so a routed peer advertising 128 octets was sent requests bounded only
+  by the transport — 1471 octets after the routed NPDU header on a
+  1476-octet link — while Clause 5.2.1.2(c) binds the remote peer's limit
+  with no exemption for destinations reached through a router. The Local
+  and Routed length checks are now one shared block in which only the
+  device-table lookup differs — routed peers resolve through the new
+  `DeviceTable::get_by_network_address`, since a routed entry's
+  `mac_address` holds the router it was heard through and cannot identify
+  the peer. The peer's limit governs in both directions: it now sets the
+  transmit bound even when it exceeds the client's own configured
+  (receive) maximum, exactly as the Local path has always treated a
+  discovered peer. Duplicate rows at one SNET/SADR resolve to the
+  freshest `last_seen`. The shared block also names the routed peer as
+  the binding term when its limit falls below the 50-octet
+  MinimumMessageSize floor, and threads the peer's recorded
+  `Max_Segments_Accepted` through the routed segmentation path (Clause
+  5.2.1.3(b)) — structural for now, as no production path records that
+  value from a peer.
+
 - Alert Enrollment now enforces the Clause 13.2.2.1 disabled-state
   conditions (#205). The object now exposes the Table 12-61
   `Event_State` and `Acked_Transitions` properties, resets both when

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -787,6 +787,8 @@ mod device_events_tests;
 mod peer_max_apdu_tests;
 #[cfg(test)]
 mod response_correlation_tests;
+#[cfg(test)]
+mod routed_max_apdu_tests;
 #[cfg(all(test, feature = "sc-tls"))]
 mod sc_builder_tests;
 #[cfg(test)]

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -179,56 +179,42 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let unsegmented_apdu_size = 4 + service_data.len();
         let target_transport_max_apdu = self.target_transport_max_apdu_length(target);
 
-        match target {
-            ConfirmedTarget::Local { mac } => {
-                let (remote_max_apdu, remote_max_segments, advertised) = {
-                    let dt = self.device_table.lock().await;
-                    let device = dt.get_by_mac(mac);
-                    let max_apdu = device
-                        .map(|d| u16::try_from(d.max_apdu_length).unwrap_or(u16::MAX))
-                        .unwrap_or(self.config.max_apdu_length);
-                    let max_seg = device.and_then(|d| d.max_segments_accepted);
-                    let advertised = if device.is_some() {
-                        LengthBoundedBy::DiscoveredPeer(max_apdu)
-                    } else {
-                        LengthBoundedBy::LocalConfig(max_apdu)
-                    };
-                    (max_apdu.min(target_transport_max_apdu), max_seg, advertised)
-                };
-                check_transmittable_length(advertised, target_transport_max_apdu)?;
-                if unsegmented_apdu_size > remote_max_apdu as usize {
-                    return self
-                        .segmented_confirmed_request(
-                            target,
-                            service_choice,
-                            service_data,
-                            remote_max_apdu,
-                            remote_max_segments,
-                        )
-                        .await;
-                }
-            }
-            ConfirmedTarget::Routed { .. } => {
-                let remote_max_apdu = self.config.max_apdu_length.min(target_transport_max_apdu);
-                // Deliberately the local configuration, not a peer value: this
-                // branch never consults the device table, so a routed peer's
-                // own advertised limit is still unenforced. Tracked separately.
-                check_transmittable_length(
-                    LengthBoundedBy::LocalConfig(self.config.max_apdu_length),
-                    target_transport_max_apdu,
-                )?;
-                if unsegmented_apdu_size > remote_max_apdu as usize {
-                    return self
-                        .segmented_confirmed_request(
-                            target,
-                            service_choice,
-                            service_data,
-                            remote_max_apdu,
-                            None,
-                        )
-                        .await;
-                }
-            }
+        let (remote_max_apdu, remote_max_segments, advertised) = {
+            let dt = self.device_table.lock().await;
+            // A routed peer is recorded under the router's MAC, so only the
+            // SNET/SADR of the NPDU that carried its I-Am identifies it
+            // (Clause 5.2.1.2 term (c) binds the peer's Max APDU Length
+            // Accepted regardless of how the peer is reached).
+            let device = match target {
+                ConfirmedTarget::Local { mac } => dt.get_by_mac(mac),
+                ConfirmedTarget::Routed {
+                    dest_network,
+                    dest_mac,
+                    ..
+                } => dt.get_by_network_address(dest_network, dest_mac),
+            };
+            let max_apdu = device
+                .map(|d| u16::try_from(d.max_apdu_length).unwrap_or(u16::MAX))
+                .unwrap_or(self.config.max_apdu_length);
+            let max_seg = device.and_then(|d| d.max_segments_accepted);
+            let advertised = if device.is_some() {
+                LengthBoundedBy::DiscoveredPeer(max_apdu)
+            } else {
+                LengthBoundedBy::LocalConfig(max_apdu)
+            };
+            (max_apdu.min(target_transport_max_apdu), max_seg, advertised)
+        };
+        check_transmittable_length(advertised, target_transport_max_apdu)?;
+        if unsegmented_apdu_size > remote_max_apdu as usize {
+            return self
+                .segmented_confirmed_request(
+                    target,
+                    service_choice,
+                    service_data,
+                    remote_max_apdu,
+                    remote_max_segments,
+                )
+                .await;
         }
 
         let advertised_max_apdu = self.advertised_max_apdu_length_for_target(target)?;

--- a/crates/bacnet-client/src/client/routed_max_apdu_tests.rs
+++ b/crates/bacnet-client/src/client/routed_max_apdu_tests.rs
@@ -1,0 +1,211 @@
+//! The routed peer's advertised Max APDU Length Accepted bounds the request.
+//!
+//! Clause 5.2.1.2 term (c) binds the remote peer's limit with no exemption
+//! for a destination reached through a router, and the client records that
+//! limit from the I-Am's 'Max APDU Length Accepted' parameter, keyed by the
+//! SNET/SADR of the NPDU that carried it — so a routed request must honor it
+//! exactly as a local request does (issue #362).
+//!
+//! Split from `tests.rs`, which is at the 700-LOC cap.
+
+use std::time::Instant;
+
+use bacnet_encoding::apdu::{self, Apdu, SegmentAck as SegmentAckPdu, SimpleAck};
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::enums::{ConfirmedServiceChoice, ObjectType, Segmentation};
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+use tokio::time::{timeout, Duration};
+
+use crate::discovery::DiscoveredDevice;
+
+use super::tests::send_routed_response;
+use super::BACnetClient;
+
+fn routed_peer(
+    max_apdu_length: u32,
+    router_mac: &[u8],
+    network: u16,
+    mac: &[u8],
+) -> DiscoveredDevice {
+    DiscoveredDevice {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 3003).unwrap(),
+        mac_address: MacAddr::from_slice(router_mac),
+        max_apdu_length,
+        segmentation_supported: Segmentation::BOTH,
+        max_segments_accepted: None,
+        vendor_id: 42,
+        last_seen: Instant::now(),
+        source_network: Some(network),
+        source_address: Some(MacAddr::from_slice(mac)),
+    }
+}
+
+/// A routed peer advertising 128 on a 1476-octet transport forces
+/// segmentation at 128 rather than the request going out whole.
+#[tokio::test]
+async fn routed_confirmed_request_honors_discovered_peer_max_apdu() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03];
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+    let mut router_rx = router_transport.start().await.unwrap();
+
+    // Local config and transport both allow 1476, so only the routed peer's
+    // discovered limit of 128 can force segmentation of a 204-octet APDU.
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .max_apdu_length(1476)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(routed_peer(
+        128,
+        &router_mac,
+        remote_network,
+        &remote_mac,
+    ));
+
+    let service_data: Vec<u8> = (0..200u16).map(|i| i as u8).collect();
+    let expected_data = service_data.clone();
+    let router_mac_for_request = router_mac.clone();
+    let remote_mac_for_request = remote_mac.clone();
+
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request_routed(
+                &router_mac_for_request,
+                remote_network,
+                &remote_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let mut all_service_data = Vec::new();
+    let invoke_id = loop {
+        let received = timeout(Duration::from_secs(2), router_rx.recv())
+            .await
+            .expect("router timed out waiting for routed segment")
+            .expect("router channel closed");
+
+        let npdu = decode_npdu(received.npdu).unwrap();
+        assert!(
+            npdu.payload.len() <= 128,
+            "APDU of {} octets exceeds the peer's advertised limit of 128",
+            npdu.payload.len()
+        );
+
+        let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+        let Apdu::ConfirmedRequest(req) = decoded else {
+            panic!("Expected ConfirmedRequest, got {:?}", decoded);
+        };
+        assert!(
+            req.segmented,
+            "request must segment at the routed peer's limit of 128, not go out whole"
+        );
+        let seq = req.sequence_number.unwrap();
+        all_service_data.extend_from_slice(&req.service_request);
+
+        let seg_ack = Apdu::SegmentAck(SegmentAckPdu {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id: req.invoke_id,
+            sequence_number: seq,
+            actual_window_size: 1,
+        });
+        send_routed_response(
+            &router_transport,
+            &client_mac,
+            remote_network,
+            &remote_mac,
+            seg_ack,
+        )
+        .await;
+
+        if !req.more_follows {
+            break req.invoke_id;
+        }
+    };
+
+    assert_eq!(all_service_data, expected_data);
+
+    let ack = Apdu::SimpleAck(SimpleAck {
+        invoke_id,
+        service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+    });
+    send_routed_response(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        ack,
+    )
+    .await;
+
+    let result = request_task.await.unwrap();
+    assert!(result.unwrap().is_empty());
+    router_transport.stop().await.unwrap();
+}
+
+/// A routed peer advertising less than MinimumMessageSize is rejected with the
+/// peer named as the binding term, and nothing goes on the wire.
+#[tokio::test]
+async fn routed_confirmed_request_rejects_subminimum_peer_limit() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03];
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac, router_mac.clone());
+    let mut router_rx = router_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(routed_peer(
+        3,
+        &router_mac,
+        remote_network,
+        &remote_mac,
+    ));
+
+    let err = client
+        .confirmed_request_routed(
+            &router_mac,
+            remote_network,
+            &remote_mac,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            &[0x01],
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("peer's advertised Max APDU Length Accepted of 3"),
+        "the routed peer is the binding term, got: {err}"
+    );
+
+    assert!(
+        timeout(Duration::from_millis(50), router_rx.recv())
+            .await
+            .is_err(),
+        "no frame may reach the router for a rejected request"
+    );
+
+    client.stop().await.unwrap();
+    router_transport.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/tests.rs
+++ b/crates/bacnet-client/src/client/tests.rs
@@ -84,7 +84,7 @@ async fn assert_sc_socket_closed_after_drop(ws_hub: &LoopbackWebSocket, context:
     );
 }
 
-async fn send_routed_response<T: TransportPort>(
+pub(super) async fn send_routed_response<T: TransportPort>(
     transport: &T,
     client_mac: &[u8],
     source_network: u16,

--- a/crates/bacnet-client/src/discovery.rs
+++ b/crates/bacnet-client/src/discovery.rs
@@ -93,6 +93,33 @@ impl DeviceTable {
             .find(|d| d.mac_address.as_slice() == mac)
     }
 
+    /// Look up a routed device by its remote network number and MAC address.
+    ///
+    /// A routed device's `mac_address` holds the router it was heard through,
+    /// which every device behind that router shares; its own identity is the
+    /// SNET/SADR of the NPDU that carried its I-Am, stored as
+    /// `source_network` and `source_address`.
+    ///
+    /// The table is keyed by device instance, so two rows can share one
+    /// SNET/SADR (a re-commissioned instance survives until the stale purge).
+    /// The freshest `last_seen` wins: it holds what the device most recently
+    /// advertised.
+    pub fn get_by_network_address(
+        &self,
+        network: u16,
+        address: &[u8],
+    ) -> Option<&DiscoveredDevice> {
+        self.devices
+            .values()
+            .filter(|d| {
+                d.source_network == Some(network)
+                    && d.source_address
+                        .as_ref()
+                        .is_some_and(|a| a.as_slice() == address)
+            })
+            .max_by_key(|d| d.last_seen)
+    }
+
     /// Clear all entries.
     pub fn clear(&mut self) {
         self.devices.clear();
@@ -219,6 +246,62 @@ mod tests {
         let mut table = DeviceTable::new();
         table.upsert(make_device(1234));
         assert!(table.get_by_mac(&[10, 0, 0, 1, 0xBA, 0xC0]).is_none());
+    }
+
+    fn make_routed_device(instance: u32, network: u16, address: &[u8]) -> DiscoveredDevice {
+        let mut device = make_device(instance);
+        device.source_network = Some(network);
+        device.source_address = Some(MacAddr::from_slice(address));
+        device
+    }
+
+    #[test]
+    fn get_by_network_address_finds_routed_device() {
+        let mut table = DeviceTable::new();
+        table.upsert(make_routed_device(1, 100, &[0x03]));
+        table.upsert(make_routed_device(2, 200, &[0x03]));
+        let dev = table.get_by_network_address(200, &[0x03]).unwrap();
+        assert_eq!(dev.object_identifier.instance_number(), 2);
+    }
+
+    /// A local device whose MAC happens to equal the queried remote address
+    /// lives in a different address space and must not match.
+    #[test]
+    fn get_by_network_address_ignores_local_devices() {
+        let mut table = DeviceTable::new();
+        let mut local = make_device(1);
+        local.mac_address = MacAddr::from_slice(&[0x03]);
+        table.upsert(local);
+        assert!(table.get_by_network_address(100, &[0x03]).is_none());
+    }
+
+    #[test]
+    fn get_by_network_address_requires_both_terms() {
+        let mut table = DeviceTable::new();
+        table.upsert(make_routed_device(1, 100, &[0x03]));
+        assert!(table.get_by_network_address(100, &[0x04]).is_none());
+        assert!(table.get_by_network_address(101, &[0x03]).is_none());
+    }
+
+    /// A re-commissioned device instance leaves two rows at one SNET/SADR
+    /// until the stale purge; the freshest advertisement must win, not an
+    /// arbitrary hash-order pick.
+    #[test]
+    fn get_by_network_address_prefers_freshest_entry() {
+        let mut table = DeviceTable::new();
+        let now = Instant::now();
+        let mut stale = make_routed_device(1, 100, &[0x03]);
+        stale.max_apdu_length = 1476;
+        stale.last_seen = now;
+        let mut fresh = make_routed_device(2, 100, &[0x03]);
+        fresh.max_apdu_length = 128;
+        fresh.last_seen = now + Duration::from_secs(60);
+        table.upsert(stale);
+        table.upsert(fresh);
+
+        let dev = table.get_by_network_address(100, &[0x03]).unwrap();
+        assert_eq!(dev.object_identifier.instance_number(), 2);
+        assert_eq!(dev.max_apdu_length, 128);
     }
 
     #[test]


### PR DESCRIPTION
Closes #362.

## Defect

The `ConfirmedTarget::Routed` branch of `confirmed_request_inner` computed the maximum transmittable length as `config.max_apdu_length.min(transport)`, never consulting the device table — so a routed peer that advertised `Max APDU Length Accepted` of 128 was sent requests bounded only by the transport (1471 octets after the routed NPDU header on a 1476-octet link). The Local branch does consult the table, so the two paths disagreed about whether the peer has a say.

## Spec grounding (live-extracted from the `_spec/` PDF this session)

- Clause 5.2.1.2 (lines 2046–2054): the maximum transmittable length is the smallest of three terms; term (c) is "the maximum APDU size accepted by the remote peer device, which must be at least 50 octets". Nothing in the clause conditions any term on topology — lines 2056–2058 state term (c) by *sender role*, and the routed case appears in the clause only as term (b)'s "any intervening networks", which is cumulative with (c), not a substitute.
- Lines 2058–2061: the value "may be obtained from the 'Max APDU Length Accepted' parameter of an I-Am service request received from the remote device" — and `dispatch.rs` already records that parameter for routed peers, keyed by the SNET/SADR of the NPDU that carried the I-Am.
- (The spec's own line 2061 miscites "Clause 16.9" for Who-Is/I-Am; the correct clause in 135-2020 is 16.10. Not propagated here.)

## Fix

Rather than mirroring the Local branch's logic into the Routed branch, the two branches are collapsed into **one** block in which only the device-table lookup differs by target — Local keys by MAC, Routed by the (network, address) pair via the new `DeviceTable::get_by_network_address`. A routed entry's `mac_address` holds the router it was heard through (shared by every device behind that router), so only the NPDU's SNET/SADR identifies it. With the paths structurally shared, the routed/local disagreement cannot recur. Duplicate rows at one SNET/SADR resolve deterministically to the freshest `last_seen`.

Consequences of the unification, called out explicitly:

- The routed path now runs the `check_transmittable_length` floor with `LengthBoundedBy::DiscoveredPeer` when the peer is discovered, naming the peer as the binding term (the deliberate `LocalConfig` pass and its comment from #361 are removed — the limitation it recorded no longer exists).
- The routed path now threads the peer's recorded `Max_Segments_Accepted` to segmentation (Clause 5.2.1.3(b), previously hardcoded `None`). **Structural for now**: no production path records a `Some` value for that field, since I-Am doesn't carry it.
- Behavior widening, matching Local-branch semantics (documented in the CHANGELOG): when a routed peer *is* discovered, `config.max_apdu_length` no longer caps the transmit size (it is the client's receive window, i.e. what `advertised_max_apdu_length_for_target` encodes in the request header; that function is untouched — `sc_max_apdu_tests.rs:298` still pins it). A client configured at 480 talking to a discovered routed peer advertising 1476 now sends 1476 unsegmented where it previously segmented at 480. This is exactly how the Local branch has always treated a discovered peer.
- When the routed peer is **not** in the device table, behavior is unchanged: fall back to `LocalConfig`, as before (`routed_segmented_request_uses_routed_tsm_key` still covers this).

## Tests

- `routed_confirmed_request_honors_discovered_peer_max_apdu` — routed peer advertising 128 on a 1476-octet transport: asserts every outbound APDU ≤ 128 and segmented, and the exchange completes.
- `routed_confirmed_request_rejects_subminimum_peer_limit` — routed peer advertising 3: typed error naming "the peer's advertised Max APDU Length Accepted of 3", and no frame reaches the router (50 ms recv-timeout idiom from `peer_max_apdu_tests.rs`).
- Both verified to **fail against the unfixed `requests.rs`** — once by stash-discrimination during development, and independently re-verified by the adversarial review lane in its own throwaway worktree.
- `DeviceTable` unit tests: finds by (network, address); a local device whose MAC equals the queried remote address does not match; both terms required; two rows sharing one SNET/SADR resolve to the freshest.
- New tests live in `routed_max_apdu_tests.rs` because `tests.rs` sits at the 700-LOC CI cap.

## Review

Two independent Opus lanes, both **approve**:

- **Adversarial**: verified the Local path is statement-for-statement identical to dev (no local regression), the boundary math has no off-by-one (`unsegmented == limit` stays unsegmented; header is 4 octets unsegmented / 6 segmented), the floor makes `split_payload(0)` unreachable, lock ordering introduces no new pair, and the resolve-then-send race can only degrade to the pre-fix fallback. Findings applied: the widening direction is now documented (CHANGELOG + commit), duplicate SNET/SADR resolution is deterministic (freshest `last_seen`, with test), and the "up to 1476" phrasing corrected to 1471-after-NPDU-header.
- **Spec-accuracy**: every clause citation in the diff, CHANGELOG, and commit verified against the extraction's heading text — all correct. Finding applied: four sites conflated SNET/SADR (NPDU header fields) with I-Am parameters; all reworded, and the bare "Clause 5.2.1.2" comment now cites term (c).

Known-gap follow-ups filed from grounding rather than smuggled in here: #370 (term (b) — intervening-network limits still bounded by local egress only), #371 (`segmentation_supported` not consulted before segmenting), #372 (DeviceTable identity conflation, incl. `get_by_mac` matching routed entries by router MAC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)