### PR TITLE
fix(client): route SegmentACKs and Aborts back along the request's path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Replies to a routed peer retrace the request's path (#366). Every
+  SegmentACK and Abort the client sends while receiving a segmented
+  ComplexACK — the per-window and negative (gap) SegmentACKs, the
+  SEGMENTATION_NOT_SUPPORTED and BUFFER_OVERFLOW Aborts, the Abort for
+  an unsolicited segmented ComplexACK, the INVALID_APDU_IN_THIS_STATE
+  Aborts from the four-state SegmentACK dispatch, and the reaper's
+  TSM_TIMEOUT Abort — was unicast to the immediate source MAC with no
+  DNET/DADR, so a router had no reason to forward it and a routed peer's
+  segment timer simply expired. The duty is compositional in the
+  Standard: Clause 5.4 identifies a transaction by the peer's
+  BACnetAddress (network number plus MAC), Clause 6.5.1 makes an absent
+  DNET an assertion that the destination is local, Clause 6.5.2.1 has a
+  router deliver such an NPDU to its own application entity rather than
+  forward it, and Clause 6.5.3 prefers that a device "note the SA
+  associated with the original request and reuse that SA in the
+  response". All reply sites now go through one shared `send_reply_apdu`
+  helper that carries the inbound SNET/SADR back as DNET/DADR (the
+  pattern the confirmed-COV response path already used and now shares),
+  and `SegmentedReceiveState` records the peer's routed identity
+  alongside the reply MAC so deferred Aborts (reassembly overflow,
+  session reaping) route too.
+
 - Routed confirmed requests honor the routed peer's advertised
   `Max APDU Length Accepted` (#362). The routed path computed the maximum
   transmittable length from local configuration and the transport alone,

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -287,11 +287,18 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // still lingers belongs to a send that is already finished.
                 if let Some(state) = seg_state.remove(&key) {
                     debug!(invoke_id, "Aborting reassembly on an unexpected SegmentAck");
+                    // The stored identity, not this PDU's source. A key match
+                    // already forces the inbound SNET/SADR to equal the
+                    // stored pair (the key is derived from it), but the
+                    // immediate MAC can diverge — a second router to the same
+                    // peer — and reading both from the state keeps the
+                    // (reply_mac, reply_network) pair consistent.
                     Self::abort_reassembly(
                         tsm,
                         network,
                         &tsm_mac,
                         &state.reply_mac,
+                        &state.reply_network,
                         invoke_id,
                         bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
                     )
@@ -349,6 +356,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 Self::send_client_abort(
                     network,
                     source_mac,
+                    source_network,
                     invoke_id,
                     bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
                 )
@@ -382,14 +390,32 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             warn!(error = %e, "Failed to encode response for COV notification");
             return;
         }
-        let send_result = match source_network {
+        if let Err(e) = Self::send_reply_apdu(network, &buf, source_mac, source_network).await {
+            warn!(error = %e, "Failed to send response for COV notification");
+        }
+    }
+
+    /// Send a reply back along the path its trigger arrived on.
+    ///
+    /// A PDU from a routed peer carries the peer's SNET/SADR; the reply must
+    /// carry that pair as DNET/DADR, unicast to the router that delivered the
+    /// original, or the router treats it as locally addressed and never
+    /// forwards it. Every PDU answering an inbound one goes through here so
+    /// no reply site can drop the routing half of the address again.
+    pub(super) async fn send_reply_apdu(
+        network: &Arc<NetworkLayer<T>>,
+        buf: &[u8],
+        reply_mac: &[u8],
+        reply_network: &Option<NpduAddress>,
+    ) -> Result<(), Error> {
+        match reply_network {
             Some(address) if !address.mac_address.is_empty() => {
                 network
                     .send_apdu_routed(
-                        &buf,
+                        buf,
                         address.network,
                         &address.mac_address,
-                        source_mac,
+                        reply_mac,
                         false,
                         NetworkPriority::NORMAL,
                     )
@@ -397,12 +423,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             }
             _ => {
                 network
-                    .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
+                    .send_apdu(buf, reply_mac, false, NetworkPriority::NORMAL)
                     .await
             }
-        };
-        if let Err(e) = send_result {
-            warn!(error = %e, "Failed to send response for COV notification");
         }
     }
 }

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -118,9 +118,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     warn!(error = %e, "Failed to encode segmented receive timeout Abort");
                                     continue;
                                 }
-                                let _ = network_dispatch
-                                    .send_apdu(&buf, &state.reply_mac, false, NetworkPriority::NORMAL)
-                                    .await;
+                                let _ = Self::send_reply_apdu(
+                                    &network_dispatch,
+                                    &buf,
+                                    &state.reply_mac,
+                                    &state.reply_network,
+                                )
+                                .await;
                             }
                         }
 

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -334,6 +334,10 @@ struct SegmentedReceiveState {
     receiver: SegmentReceiver,
     /// Immediate MAC used to send SegmentAck/Abort PDUs.
     reply_mac: MacAddr,
+    /// The peer's SNET/SADR when the segments arrive through a router; the
+    /// reply's DNET/DADR, or the router takes the reply for itself instead
+    /// of forwarding it (Clause 6.5.2.1).
+    reply_network: Option<NpduAddress>,
     /// Next expected sequence number (for gap detection).
     expected_next_seq: u8,
     /// Timestamp of last received segment (for reaping stale sessions).
@@ -789,6 +793,8 @@ mod peer_max_apdu_tests;
 mod response_correlation_tests;
 #[cfg(test)]
 mod routed_max_apdu_tests;
+#[cfg(test)]
+mod routed_reply_tests;
 #[cfg(all(test, feature = "sc-tls"))]
 mod sc_builder_tests;
 #[cfg(test)]

--- a/crates/bacnet-client/src/client/routed_reply_tests.rs
+++ b/crates/bacnet-client/src/client/routed_reply_tests.rs
@@ -1,0 +1,429 @@
+//! Replies to a routed peer must retrace the request's path (issue #366).
+//!
+//! A segmented ComplexACK from a peer behind a router arrives with the peer's
+//! SNET/SADR in the NPDU. Every PDU the client sends back — SegmentACKs and
+//! Aborts — must carry that pair as DNET/DADR, unicast to the router, or the
+//! router treats the reply as locally addressed and the peer never sees it.
+//!
+//! Split from `tests.rs`, which is at the 700-LOC cap.
+
+use bacnet_encoding::apdu::{self, Apdu, ComplexAck, SegmentAck as SegmentAckPdu, SimpleAck};
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::enums::{AbortReason, ConfirmedServiceChoice};
+use bytes::Bytes;
+use tokio::time::{timeout, Duration};
+
+use super::tests::send_routed_response;
+use super::{BACnetClient, SEG_RECEIVER_TIMEOUT};
+
+/// Every SegmentACK for a router-mediated segmented ComplexACK carries the
+/// peer's network and address as DNET/DADR, and the exchange completes.
+#[tokio::test]
+async fn routed_segmented_complex_ack_replies_carry_dnet_dadr() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03];
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+    let mut router_rx = router_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    let router_mac_for_request = router_mac.clone();
+    let remote_mac_for_request = remote_mac.clone();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request_routed(
+                &router_mac_for_request,
+                remote_network,
+                &remote_mac_for_request,
+                ConfirmedServiceChoice::READ_PROPERTY,
+                &[0x01],
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let received = timeout(Duration::from_secs(2), router_rx.recv())
+        .await
+        .expect("router timed out waiting for the request")
+        .expect("router channel closed");
+    let npdu = decode_npdu(received.npdu).unwrap();
+    let Apdu::ConfirmedRequest(req) = apdu::decode_apdu(npdu.payload).unwrap() else {
+        panic!("expected ConfirmedRequest");
+    };
+    let invoke_id = req.invoke_id;
+
+    let segments: Vec<Bytes> = vec![
+        Bytes::from_static(&[0xAA, 0x01]),
+        Bytes::from_static(&[0xBB, 0x02]),
+        Bytes::from_static(&[0xCC]),
+    ];
+
+    for (i, seg) in segments.iter().enumerate() {
+        let is_last = i == segments.len() - 1;
+        let ack = Apdu::ComplexAck(ComplexAck {
+            segmented: true,
+            more_follows: !is_last,
+            invoke_id,
+            sequence_number: Some(i as u8),
+            proposed_window_size: Some(1),
+            service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+            service_ack: seg.clone(),
+        });
+        send_routed_response(
+            &router_transport,
+            &client_mac,
+            remote_network,
+            &remote_mac,
+            ack,
+        )
+        .await;
+
+        let reply = timeout(Duration::from_secs(2), router_rx.recv())
+            .await
+            .expect("router timed out waiting for a SegmentAck")
+            .expect("router channel closed");
+        let reply_npdu = decode_npdu(reply.npdu).unwrap();
+        let destination = reply_npdu
+            .destination
+            .expect("SegmentAck for a routed peer must carry DNET/DADR");
+        assert_eq!(destination.network, remote_network);
+        assert_eq!(&destination.mac_address[..], &remote_mac[..]);
+
+        let Apdu::SegmentAck(sa) = apdu::decode_apdu(reply_npdu.payload).unwrap() else {
+            panic!("expected SegmentAck");
+        };
+        assert_eq!(sa.invoke_id, invoke_id);
+        assert_eq!(sa.sequence_number, i as u8);
+        assert!(!sa.negative_ack);
+        assert!(!sa.sent_by_server);
+    }
+
+    let result = request_task.await.unwrap().unwrap();
+    assert_eq!(result, vec![0xAA, 0x01, 0xBB, 0x02, 0xCC]);
+    router_transport.stop().await.unwrap();
+}
+
+/// Killing a live routed reassembly with a spurious server SegmentACK sends
+/// an Abort that carries the peer's SNET/SADR. This exercises the
+/// stored-state read at the dispatch site, but cannot distinguish it from the
+/// inbound pair: a session-key match forces the two to be equal (the key is
+/// derived from the SNET/SADR), so only `reply_mac` can genuinely diverge.
+#[tokio::test]
+async fn routed_reassembly_abort_carries_dnet_dadr() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03];
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+    let mut router_rx = router_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    let router_mac_for_request = router_mac.clone();
+    let remote_mac_for_request = remote_mac.clone();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request_routed(
+                &router_mac_for_request,
+                remote_network,
+                &remote_mac_for_request,
+                ConfirmedServiceChoice::READ_PROPERTY,
+                &[0x01],
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let received = timeout(Duration::from_secs(2), router_rx.recv())
+        .await
+        .expect("router timed out waiting for the request")
+        .expect("router channel closed");
+    let npdu = decode_npdu(received.npdu).unwrap();
+    let Apdu::ConfirmedRequest(req) = apdu::decode_apdu(npdu.payload).unwrap() else {
+        panic!("expected ConfirmedRequest");
+    };
+    let invoke_id = req.invoke_id;
+
+    // Open a reassembly session with segment 0, and consume its SegmentAck.
+    let segment_zero = Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows: true,
+        invoke_id,
+        sequence_number: Some(0),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(&[0xAA]),
+    });
+    send_routed_response(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        segment_zero,
+    )
+    .await;
+    let seg_ack = timeout(Duration::from_secs(2), router_rx.recv())
+        .await
+        .expect("router timed out waiting for the SegmentAck")
+        .expect("router channel closed");
+    let seg_ack_npdu = decode_npdu(seg_ack.npdu).unwrap();
+    assert!(matches!(
+        apdu::decode_apdu(seg_ack_npdu.payload).unwrap(),
+        Apdu::SegmentAck(_)
+    ));
+
+    // A server SegmentACK does not belong in SEGMENTED_CONF (Clause 5.4.4.4).
+    let spurious = Apdu::SegmentAck(SegmentAckPdu {
+        negative_ack: false,
+        sent_by_server: true,
+        invoke_id,
+        sequence_number: 0,
+        actual_window_size: 1,
+    });
+    send_routed_response(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        spurious,
+    )
+    .await;
+
+    let reply = timeout(Duration::from_secs(2), router_rx.recv())
+        .await
+        .expect("router timed out waiting for the Abort")
+        .expect("router channel closed");
+    let reply_npdu = decode_npdu(reply.npdu).unwrap();
+    let destination = reply_npdu
+        .destination
+        .expect("Abort from stored session state must carry DNET/DADR");
+    assert_eq!(destination.network, remote_network);
+    assert_eq!(&destination.mac_address[..], &remote_mac[..]);
+
+    let Apdu::Abort(abort) = apdu::decode_apdu(reply_npdu.payload).unwrap() else {
+        panic!("expected Abort");
+    };
+    assert_eq!(abort.invoke_id, invoke_id);
+    assert!(!abort.sent_by_server);
+    assert_eq!(abort.abort_reason, AbortReason::INVALID_APDU_IN_THIS_STATE);
+
+    let result = request_task.await.unwrap();
+    assert!(
+        matches!(result, Err(super::Error::Abort { .. })),
+        "the caller must observe the abort, got {result:?}"
+    );
+    router_transport.stop().await.unwrap();
+}
+
+/// The reaper's TSM_TIMEOUT Abort routes from stored state alone. This is
+/// the one reply site with no inbound PDU in scope — the trigger is a timer —
+/// so `SegmentedReceiveState.reply_network` is the only source of the peer's
+/// SNET/SADR, and this test is what requires the field to exist.
+#[tokio::test]
+async fn reaped_routed_session_abort_carries_dnet_dadr() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03];
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+    let mut router_rx = router_transport.start().await.unwrap();
+
+    // The request must outlive the reaper wait so the exchange can still
+    // finish cleanly after the stale session is reaped.
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(8000)
+        .build()
+        .await
+        .unwrap();
+
+    let router_mac_for_request = router_mac.clone();
+    let remote_mac_for_request = remote_mac.clone();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request_routed(
+                &router_mac_for_request,
+                remote_network,
+                &remote_mac_for_request,
+                ConfirmedServiceChoice::READ_PROPERTY,
+                &[0x01],
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let received = timeout(Duration::from_secs(2), router_rx.recv())
+        .await
+        .expect("router timed out waiting for the request")
+        .expect("router channel closed");
+    let npdu = decode_npdu(received.npdu).unwrap();
+    let Apdu::ConfirmedRequest(req) = apdu::decode_apdu(npdu.payload).unwrap() else {
+        panic!("expected ConfirmedRequest");
+    };
+    let invoke_id = req.invoke_id;
+
+    // Open a reassembly session, then let it go stale.
+    let segment_zero = Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows: true,
+        invoke_id,
+        sequence_number: Some(0),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(&[0xAA]),
+    });
+    send_routed_response(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        segment_zero,
+    )
+    .await;
+    let seg_ack = timeout(Duration::from_secs(2), router_rx.recv())
+        .await
+        .expect("router timed out waiting for the SegmentAck")
+        .expect("router channel closed");
+    assert!(matches!(
+        apdu::decode_apdu(decode_npdu(seg_ack.npdu).unwrap().payload).unwrap(),
+        Apdu::SegmentAck(_)
+    ));
+
+    tokio::time::sleep(SEG_RECEIVER_TIMEOUT + Duration::from_millis(200)).await;
+
+    // The reaper runs on inbound traffic; an ack for an unknown invoke ID
+    // drives it without provoking any reply of its own.
+    let reaper_trigger = Apdu::SimpleAck(SimpleAck {
+        invoke_id: invoke_id.wrapping_add(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+    });
+    send_routed_response(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        reaper_trigger,
+    )
+    .await;
+
+    let reply = timeout(Duration::from_secs(2), router_rx.recv())
+        .await
+        .expect("router timed out waiting for the reaper Abort")
+        .expect("router channel closed");
+    let reply_npdu = decode_npdu(reply.npdu).unwrap();
+    let destination = reply_npdu
+        .destination
+        .expect("the reaper's Abort must carry DNET/DADR");
+    assert_eq!(destination.network, remote_network);
+    assert_eq!(&destination.mac_address[..], &remote_mac[..]);
+
+    let Apdu::Abort(abort) = apdu::decode_apdu(reply_npdu.payload).unwrap() else {
+        panic!("expected Abort");
+    };
+    assert_eq!(abort.invoke_id, invoke_id);
+    assert!(!abort.sent_by_server);
+    assert_eq!(abort.abort_reason, AbortReason::TSM_TIMEOUT);
+
+    // The transaction itself survives the reap; answer it so the exchange
+    // ends cleanly instead of timing out.
+    let response = Apdu::ComplexAck(ComplexAck {
+        segmented: false,
+        more_follows: false,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(&[0xFF]),
+    });
+    send_routed_response(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        response,
+    )
+    .await;
+
+    let result = request_task.await.unwrap().unwrap();
+    assert_eq!(result, vec![0xFF]);
+    router_transport.stop().await.unwrap();
+}
+
+/// An unsolicited routed segmented ComplexACK earns an Abort that retraces
+/// the path — Clause 5.4.4.1's answer, addressed so the peer can hear it.
+#[tokio::test]
+async fn routed_unsolicited_segmented_ack_abort_carries_dnet_dadr() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03];
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac);
+    let mut router_rx = router_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    let unsolicited = Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows: true,
+        invoke_id: 42,
+        sequence_number: Some(0),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(&[0xEE]),
+    });
+    send_routed_response(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        unsolicited,
+    )
+    .await;
+
+    let reply = timeout(Duration::from_secs(2), router_rx.recv())
+        .await
+        .expect("router timed out waiting for the Abort")
+        .expect("router channel closed");
+    let reply_npdu = decode_npdu(reply.npdu).unwrap();
+    let destination = reply_npdu
+        .destination
+        .expect("Abort for a routed peer must carry DNET/DADR");
+    assert_eq!(destination.network, remote_network);
+    assert_eq!(&destination.mac_address[..], &remote_mac[..]);
+
+    let Apdu::Abort(abort) = apdu::decode_apdu(reply_npdu.payload).unwrap() else {
+        panic!("expected Abort");
+    };
+    assert_eq!(abort.invoke_id, 42);
+    assert!(!abort.sent_by_server);
+    assert_eq!(abort.abort_reason, AbortReason::INVALID_APDU_IN_THIS_STATE);
+
+    client.stop().await.unwrap();
+    router_transport.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -48,6 +48,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     pub(super) async fn send_client_abort(
         network: &Arc<NetworkLayer<T>>,
         reply_mac: &[u8],
+        reply_network: &Option<NpduAddress>,
         invoke_id: u8,
         abort_reason: bacnet_types::enums::AbortReason,
     ) {
@@ -61,10 +62,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             warn!(error = %e, reason = abort_reason.to_raw(), "Failed to encode Abort");
             return;
         }
-        if let Err(e) = network
-            .send_apdu(&buf, reply_mac, false, NetworkPriority::NORMAL)
-            .await
-        {
+        if let Err(e) = Self::send_reply_apdu(network, &buf, reply_mac, reply_network).await {
             warn!(error = %e, reason = abort_reason.to_raw(), "Failed to send Abort");
         }
     }
@@ -87,10 +85,11 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         network: &Arc<NetworkLayer<T>>,
         tsm_mac: &MacAddr,
         reply_mac: &MacAddr,
+        reply_network: &Option<NpduAddress>,
         invoke_id: u8,
         reason: bacnet_types::enums::AbortReason,
     ) {
-        Self::send_client_abort(network, reply_mac, invoke_id, reason).await;
+        Self::send_client_abort(network, reply_mac, reply_network, invoke_id, reason).await;
         tsm.lock().await.complete_transaction(
             tsm_mac,
             invoke_id,
@@ -123,7 +122,11 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             "Received segmented ComplexAck"
         );
 
-        // If client doesn't support segmented reception, send Abort per Clause 5.4.4.2
+        // A segmented ComplexACK when this device does not support
+        // segmentation is Clause 5.4.4.3's UnexpectedPDU_Received, which
+        // requires an Abort with 'server' = FALSE. The transmitted reason
+        // follows Clause 18.10, which names SEGMENTATION_NOT_SUPPORTED for
+        // exactly this case.
         if !limits.segmented_response_accepted {
             let abort = Apdu::Abort(AbortPdu {
                 sent_by_server: false,
@@ -135,9 +138,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 warn!(error = %e, "Failed to encode segmentation-not-supported Abort");
                 return;
             }
-            let _ = network
-                .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
-                .await;
+            let _ = Self::send_reply_apdu(network, &buf, source_mac, source_network).await;
             return;
         }
 
@@ -183,6 +184,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             Self::send_client_abort(
                 network,
                 source_mac,
+                source_network,
                 ack.invoke_id,
                 bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
             )
@@ -196,6 +198,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             .or_insert_with(|| SegmentedReceiveState {
                 receiver: SegmentReceiver::new(),
                 reply_mac: MacAddr::from_slice(source_mac),
+                reply_network: source_network.clone(),
                 expected_next_seq: 0,
                 last_activity: Instant::now(),
                 window_position: 0,
@@ -239,10 +242,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 warn!(error = %e, "Failed to encode negative SegmentAck");
                 return;
             }
-            if let Err(e) = network
-                .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
-                .await
-            {
+            if let Err(e) = Self::send_reply_apdu(network, &buf, source_mac, source_network).await {
                 warn!(error = %e, "Failed to send SegmentAck");
             }
             return;
@@ -261,12 +261,14 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 "Segmented response exceeds reassembly capacity, aborting"
             );
             let reply_mac = state.reply_mac.clone();
+            let reply_network = state.reply_network.clone();
             seg_state.remove(&key);
             Self::abort_reassembly(
                 tsm,
                 network,
                 &tsm_mac,
                 &reply_mac,
+                &reply_network,
                 ack.invoke_id,
                 bacnet_types::enums::AbortReason::BUFFER_OVERFLOW,
             )
@@ -280,12 +282,14 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             // caller to time out on a session that can no longer complete.
             warn!(error = %e, "Rejecting oversized segment");
             let reply_mac = state.reply_mac.clone();
+            let reply_network = state.reply_network.clone();
             seg_state.remove(&key);
             Self::abort_reassembly(
                 tsm,
                 network,
                 &tsm_mac,
                 &reply_mac,
+                &reply_network,
                 ack.invoke_id,
                 bacnet_types::enums::AbortReason::BUFFER_OVERFLOW,
             )
@@ -313,10 +317,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 warn!(error = %e, "Failed to encode SegmentAck");
                 return;
             }
-            if let Err(e) = network
-                .send_apdu(&buf, source_mac, false, NetworkPriority::NORMAL)
-                .await
-            {
+            if let Err(e) = Self::send_reply_apdu(network, &buf, source_mac, source_network).await {
                 warn!(error = %e, "Failed to send SegmentAck");
             }
         }


### PR DESCRIPTION
Closes #366.

## Defect

When the client receives a segmented ComplexACK from a peer reached through a router, every PDU it sends back goes to the immediate `source_mac` with no DNET/DADR. Per Clause 6.5.1, "the absence of DNET indicates that the destination device resides on the same BACnet network as the device issuing this transmission request" — and per Clause 6.5.2.1 a router delivers such an NPDU to its own application entity; it never forwards it. So the peer's SegmentTimer expires, it retransmits to its retry limit, and the caller sees a bare APDU timeout with no hint routing was the cause.

## Spec grounding (fresh extraction of the `_spec/` PDF)

No single sentence mandates "DNET/DADR = received SNET/SADR" — the duty is compositional, assembled with verbatim quotes:

- **Clause 5.4** (lines 2401–2406): a transaction is identified by the client and server *BACnetAddresses* — network number plus MAC (Clause 21, line 56354) — so for a routed peer the SNET/SADR pair *is* the peer's identity; the router's MAC is only the link-layer SA. SegmentACK (`server`=FALSE) and Abort (`server`=FALSE) are enumerated PDUs of the requesting user inside that same TSM; no alternate addressing path exists for them.
- **Clause 6.5.1** (lines 4922–4926): absent DNET asserts a local destination (quoted above).
- **Clause 6.5.2.1** (lines 4942–4949): a DNET-less NPDU received by a router goes to the router's own application entity.
- **Clause 6.5.3** (lines 4994–4996): "It is preferable that a device note the SA associated with the original request and reuse that SA in the response" — the exact unicast-to-the-delivering-router shape this fix uses.

## Fix

One shared `Self::send_reply_apdu(network, buf, reply_mac, reply_network)` helper encodes "replies retrace the inbound path"; every reply in the crate now goes through it, so no site can drop the routing half of the address again. On the base commit, six physical send calls answered inbound PDUs unrouted — one of them, `send_client_abort`'s body, serves three logical Abort paths — covering the four sites the issue listed **plus two it missed**: the session reaper's TSM_TIMEOUT Abort (`lifecycle.rs`) and the IDLE-state Abort in dispatch's four-state SegmentACK arm (from PR #363). The seventh reply site, the confirmed-COV response, already routed correctly; it now shares the helper (empty-MAC guard preserved).

Where each site gets the pair:

- **Inbound `source_network`** at sites answering the PDU in hand: SEGMENTATION_NOT_SUPPORTED (fires before any session exists), the unsolicited-segmented-ComplexACK Abort, both SegmentACK sends, and the IDLE-state Abort.
- **Stored `SegmentedReceiveState.reply_network`** (new field) at the deferred Aborts: reassembly overflow, oversized segment, unexpected SegmentACK, and the timer-driven reaper. The reaper is what *forces* the field to exist — no inbound PDU is in scope there. Everywhere else, the adversarial lane proved a session-key match pins the stored pair equal to the inbound one (the key is derived injectively from SNET/SADR), so the stored read's other job is keeping `(reply_mac, reply_network)` mutually consistent when a second router carries the same peer.

Also corrects a pre-existing miscitation at the segmentation-not-supported site: the receive-side duty is Clause 5.4.4.3 `UnexpectedPDU_Received` (5.4.4.2 is the send-side state); the transmitted reason follows Clause 18.10's segmentation case.

## Tests (`routed_reply_tests.rs`, new file — `tests.rs` has 2 lines of headroom under the 700-LOC cap)

- `routed_segmented_complex_ack_replies_carry_dnet_dadr` — router-mediated 3-segment ComplexACK; every SegmentACK asserted routed; reassembled result checked.
- `routed_unsolicited_segmented_ack_abort_carries_dnet_dadr` — inbound-parameter Abort path.
- `routed_reassembly_abort_carries_dnet_dadr` — the dispatch stored-state Abort path (doc honest about what it can discriminate, per review).
- `reaped_routed_session_abort_carries_dnet_dadr` — the reaper's TSM_TIMEOUT Abort routed from stored state alone (added after review mutation-testing showed the reaper site had zero coverage: reverting it wholesale left the suite green). Also documents that the reap kills the session but not the transaction, which then completes normally.
- All four verified to **fail against unfixed dev** (`b2719bc`) in a detached worktree with the "must carry DNET/DADR" assertions.
- No prior test covered a routed segmented *response*, so nothing pinned the unrouted reply behavior; on the local path (`source_network = None`) the helper's fallback arm is byte-identical to the old code. Full workspace suite green.

## Review

Two independent Opus lanes, both **approve**, no correctness defect surviving:

- **Adversarial** (with mutation testing in a scratch copy): local path byte-identical to dev at all sites; helper argument order verified by type and value; COV refactor preserves `expecting_reply`/priority/guard. Its sharpest finding was the injectivity argument above, which showed my third test's original name/doc claimed a stored-vs-inbound distinction it cannot detect (renamed, re-documented) and that the reaper site was untested (test added). Both applied.
- **Spec-accuracy**: all four headline citations verified against heading text; caught the `reply_network` field doc misdescribing 6.5.2.1's mechanism ("drops" vs. "takes for itself" — fixed), the pre-existing 5.4.4.2 miscitation (fixed with live verification), and this PR body's original site-count arithmetic and over-broad "every prior test" claim (both corrected above).

Notes out of scope, from grounding: the server crate already has this architecture (`responses.rs`); its helper lacks the empty-MAC guard (latent); the client reaper only ticks on inbound APDUs (adjacent to #367); a ConfirmedRequest for a non-COV service is dropped with no Reject (candidate issue); `LoopbackTransport` ignores the outer unicast MAC, so tests assert routing at the NPDU layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)