### PR TITLE
fix(server,network,transport): Table 13-6 NPDU priority, remote recipients, broadcast-MAC spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Event notifications carry the Table 13-6 network priority (#187). Every
+  transmit site — confirmed unicast including each retry, and the four
+  unconfirmed sends — hardcoded a Normal-priority NPDU, so a life-safety
+  alarm received no preferential queueing anywhere on the network. Clause
+  13.2.5.4 makes the mapping mandatory ("the Network Priority as defined
+  in Clause 6.2.2 shall be set as a function of the alarm and event
+  priority as defined in Table 13-6"): 00–63 is a Life Safety message,
+  64–127 Critical Equipment, 128–191 Urgent, 192–255 Normal. The
+  priority is now projected once per notification and threaded through
+  all six sends — the four pre-existing unconfirmed paths, the
+  remote-unicast path the #186 fix below introduces, and the confirmed
+  path. The mapping is scoped to event notifications, as the Standard
+  scopes it — COV notifications carry no priority parameter at all and
+  are unchanged. Tests assert the encoded NPDU control octet at every
+  band boundary, not the APDU field, which was always correct.
+
+- Notifications to a remote-network unicast recipient are delivered
+  instead of skipped (#186). What remained of the issue after the #357
+  rework was the remote-unicast arm: with no router table in this
+  non-routing device it resolved to an unresolved route and was dropped
+  with a warning — but Clause 6.5.3 prescribes exactly this situation's
+  send form: the NPDU names the recipient via DNET/DADR and the link DA
+  "shall be ... the appropriate broadcast DA if the address of the
+  router is initially unknown". The new
+  `NetworkLayer::send_apdu_routed_via_local_broadcast` implements that
+  form, and Clause 6.3's broadcast restriction does not bite because its
+  own parenthetical permits a broadcast MAC "when the network layer
+  address restricts the destination to a single device". Confirmed
+  notifications to remote recipients remain skipped — sending them would
+  mis-retry into duplicate deliveries until the server TSM can correlate
+  a routed acknowledgment (#375) — and the skip now says so instead of
+  claiming no route exists.
+
+- A recipient spelled with the data link's literal broadcast MAC resolves
+  as the broadcast it is (#360). A broadcast destination has two
+  spellings — the zero-length MAC of Clause 21's `BACnetAddress`
+  production and the medium's literal form named by Clause 6.3
+  (`X'FFFFFFFFFFFF'` on Ethernet, `X'FF'` on MS/TP, the subnet's
+  all-ones-host address on B/IP) — but only the first was recognized, so
+  a confirmed notification could still be unicast to a broadcast address
+  and burn its retries against Clause 5.4.5.1's silent receiver-side
+  discard. The new `TransportPort::is_broadcast_mac` lets each transport
+  report its own spelling (BIP consults its configured broadcast IP
+  together with its UDP port, the two components of Clause J.1.2's B/IP
+  broadcast address; MS/TP `X'FF'`; Ethernet all-ones; SC the Local
+  Broadcast VMAC; B/IPv6 the Clause U.4 multicast groups), and recipient
+  resolution folds a matching MAC on network 0 into the same broadcast
+  route as the zero-length form. The check is scoped to network 0
+  because that is where the MAC names an address on this port's own
+  link — a remote recipient's DADR is spelled in the remote network's
+  medium, about which this port's broadcast spelling proves nothing.
+
 - Replies to a routed peer retrace the request's path (#366). Every
   SegmentACK and Abort the client sends while receiving a segmented
   ComplexACK — the per-window and negative (gap) SegmentACKs, the

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -344,26 +344,34 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
         priority: NetworkPriority,
         data_attributes: &[DataAttribute],
     ) -> Result<(), Error> {
-        let npdu = Npdu {
-            is_network_message: false,
-            expecting_reply,
-            priority,
-            destination: Some(NpduAddress {
-                network: dest_network,
-                mac_address: MacAddr::from_slice(dest_mac),
-            }),
-            source: None,
-            hop_count: 255,
-            payload: Bytes::copy_from_slice(apdu),
-            ..Npdu::default()
-        };
-
-        let mut buf = BytesMut::with_capacity(8 + dest_mac.len() + apdu.len());
-        encode_npdu(&mut buf, &npdu)?;
-
+        let buf =
+            Self::encode_routed_npdu_buf(apdu, dest_network, dest_mac, expecting_reply, priority)?;
         self.transport
             .send_unicast_with_data_attributes(&buf, router_mac, data_attributes)
             .await
+    }
+
+    /// Send a routed APDU with a broadcast link DA, for when the next-hop
+    /// router's MAC is unknown.
+    ///
+    /// Clause 6.5.3: the data link DA "shall be the MAC address of the BACnet
+    /// router corresponding to the DNET parameter or the appropriate
+    /// broadcast DA if the address of the router is initially unknown". The
+    /// NPDU still addresses one device via DNET/DADR, which is why Clause
+    /// 6.3's broadcast restriction does not bite: "a MAC layer multicast or
+    /// broadcast address may be used for other PDU types when the network
+    /// layer address restricts the destination to a single device".
+    pub async fn send_apdu_routed_via_local_broadcast(
+        &self,
+        apdu: &[u8],
+        dest_network: u16,
+        dest_mac: &[u8],
+        expecting_reply: bool,
+        priority: NetworkPriority,
+    ) -> Result<(), Error> {
+        let buf =
+            Self::encode_routed_npdu_buf(apdu, dest_network, dest_mac, expecting_reply, priority)?;
+        self.transport.send_broadcast(&buf).await
     }
 
     /// Access the underlying transport.
@@ -377,6 +385,33 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     /// Get the transport's local MAC address.
     pub fn local_mac(&self) -> &[u8] {
         self.transport.local_mac()
+    }
+
+    /// Encode an APDU into an NPDU whose destination is `dest_network` /
+    /// `dest_mac`, ready for whichever link send the caller chooses.
+    fn encode_routed_npdu_buf(
+        apdu: &[u8],
+        dest_network: u16,
+        dest_mac: &[u8],
+        expecting_reply: bool,
+        priority: NetworkPriority,
+    ) -> Result<BytesMut, Error> {
+        let npdu = Npdu {
+            is_network_message: false,
+            expecting_reply,
+            priority,
+            destination: Some(NpduAddress {
+                network: dest_network,
+                mac_address: MacAddr::from_slice(dest_mac),
+            }),
+            source: None,
+            hop_count: 255,
+            payload: Bytes::copy_from_slice(apdu),
+            ..Npdu::default()
+        };
+        let mut buf = BytesMut::with_capacity(8 + dest_mac.len() + apdu.len());
+        encode_npdu(&mut buf, &npdu)?;
+        Ok(buf)
     }
 
     /// Stop the network layer and underlying transport.

--- a/crates/bacnet-server/src/server/event_network_priority_tests.rs
+++ b/crates/bacnet-server/src/server/event_network_priority_tests.rs
@@ -1,0 +1,125 @@
+//! Table 13-6's event-priority → NPDU-priority projection (issue #187).
+//!
+//! Clause 13.2.5.4: "the Network Priority as defined in Clause 6.2.2 shall be
+//! set as a function of the alarm and event priority as defined in Table
+//! 13-6." The assertion target is the encoded NPDU control octet, not the
+//! notification's APDU `priority` field — the APDU field was always right;
+//! the NPDU bits were always Normal.
+//!
+//! Split from `event_notifications_tests.rs`, which is near the 700-LOC cap.
+
+use super::event_notifications::network_priority_for_event;
+use super::event_recipient_routing_tests::{
+    address_recipient, destination_for, distribute_with_priority,
+};
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_types::enums::NetworkPriority;
+use bytes::Bytes;
+
+/// Every band edge of Table 13-6, both ends.
+#[test]
+fn table_13_6_band_boundaries() {
+    for (event_priority, expected) in [
+        (0u8, NetworkPriority::LIFE_SAFETY),
+        (63, NetworkPriority::LIFE_SAFETY),
+        (64, NetworkPriority::CRITICAL_EQUIPMENT),
+        (127, NetworkPriority::CRITICAL_EQUIPMENT),
+        (128, NetworkPriority::URGENT),
+        (191, NetworkPriority::URGENT),
+        (192, NetworkPriority::NORMAL),
+        (255, NetworkPriority::NORMAL),
+    ] {
+        assert_eq!(
+            network_priority_for_event(event_priority),
+            expected,
+            "event priority {event_priority}"
+        );
+    }
+}
+
+fn npdu_priority(frame: &Bytes) -> NetworkPriority {
+    decode_npdu(frame.clone()).expect("decode NPDU").priority
+}
+
+/// An unconfirmed notification's NPDU carries the projected priority, at
+/// both edges of every Table 13-6 band.
+#[tokio::test]
+async fn unconfirmed_notification_npdu_carries_projected_priority() {
+    for (event_priority, expected) in [
+        (0u8, NetworkPriority::LIFE_SAFETY),
+        (63, NetworkPriority::LIFE_SAFETY),
+        (64, NetworkPriority::CRITICAL_EQUIPMENT),
+        (127, NetworkPriority::CRITICAL_EQUIPMENT),
+        (128, NetworkPriority::URGENT),
+        (191, NetworkPriority::URGENT),
+        (192, NetworkPriority::NORMAL),
+        (255, NetworkPriority::NORMAL),
+    ] {
+        let (broadcasts, unicasts) = distribute_with_priority(
+            [event_priority; 3],
+            vec![destination_for(address_recipient(0, &[]), false)],
+        )
+        .await;
+
+        assert_eq!(broadcasts.len(), 1, "event priority {event_priority}");
+        assert!(unicasts.is_empty());
+        assert_eq!(
+            npdu_priority(&broadcasts[0]),
+            expected,
+            "event priority {event_priority}"
+        );
+    }
+}
+
+/// The confirmed path — including its retry loop's send site — carries the
+/// projected priority too.
+#[tokio::test]
+async fn confirmed_notification_npdu_carries_projected_priority() {
+    let mac = [0x0A, 0x00, 0x00, 0x64, 0xBA, 0xC0];
+    let (broadcasts, unicasts) = distribute_with_priority(
+        [0; 3],
+        vec![destination_for(address_recipient(0, &mac), true)],
+    )
+    .await;
+
+    assert!(broadcasts.is_empty());
+    assert_eq!(unicasts.len(), 1, "confirmed unicast goes out");
+    assert_eq!(unicasts[0].0, mac);
+    assert_eq!(npdu_priority(&unicasts[0].1), NetworkPriority::LIFE_SAFETY);
+}
+
+/// Every unconfirmed route shape carries the projected priority — each send
+/// site is a separate call, and any one of them can regress alone.
+#[tokio::test]
+async fn every_unconfirmed_route_carries_projected_priority() {
+    let remote_mac = [0x0A, 0x00, 0x00, 0x64, 0xBA, 0xC0];
+    let recipients = [
+        address_recipient(0, &[]),
+        address_recipient(1000, &[]),
+        address_recipient(65535, &[]),
+        address_recipient(1000, &remote_mac),
+    ];
+    for recipient in recipients {
+        let (broadcasts, unicasts) =
+            distribute_with_priority([0; 3], vec![destination_for(recipient.clone(), false)]).await;
+
+        assert_eq!(broadcasts.len(), 1, "route {recipient:?} goes out");
+        assert!(unicasts.is_empty());
+        assert_eq!(
+            npdu_priority(&broadcasts[0]),
+            NetworkPriority::LIFE_SAFETY,
+            "route {recipient:?}"
+        );
+    }
+
+    // The local-unicast site sends on the unicast path instead.
+    let local_mac = [0x0A, 0x00, 0x00, 0x07, 0xBA, 0xC0];
+    let (broadcasts, unicasts) = distribute_with_priority(
+        [0; 3],
+        vec![destination_for(address_recipient(0, &local_mac), false)],
+    )
+    .await;
+    assert!(broadcasts.is_empty());
+    assert_eq!(unicasts.len(), 1);
+    assert_eq!(npdu_priority(&unicasts[0].1), NetworkPriority::LIFE_SAFETY);
+}

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -16,6 +16,21 @@ impl From<(EventStateChange, EventType)> for NotificationTransition {
 /// The DNET reserved for a global broadcast (Clause 6.3).
 const GLOBAL_BROADCAST_NETWORK: u16 = 0xFFFF;
 
+/// Project an alarm/event priority onto the NPDU Network Priority.
+///
+/// Clause 13.2.5.4: "the Network Priority as defined in Clause 6.2.2 shall be
+/// set as a function of the alarm and event priority as defined in Table
+/// 13-6". Lower event priority is more urgent: 00–63 is a Life Safety
+/// message, 64–127 Critical Equipment, 128–191 Urgent, 192–255 Normal.
+pub(super) fn network_priority_for_event(priority: u8) -> NetworkPriority {
+    match priority {
+        0..=63 => NetworkPriority::LIFE_SAFETY,
+        64..=127 => NetworkPriority::CRITICAL_EQUIPMENT,
+        128..=191 => NetworkPriority::URGENT,
+        192..=255 => NetworkPriority::NORMAL,
+    }
+}
+
 /// The network destination a Notification Class recipient resolves to.
 ///
 /// Clause 21's `BACnetAddress` gives a recipient two independent knobs —
@@ -41,28 +56,38 @@ enum RecipientRoute {
     /// to be numbered 65535. `broadcast_to_network` rejects 0xFFFF outright,
     /// so routing it as one would drop the notification.
     GlobalBroadcast,
-    /// A unicast MAC on a remote network. Delivering it needs the MAC of a
-    /// next-hop router, and no router table is reachable from the server, so
-    /// the destination cannot be resolved. Tracked by #186.
-    UnresolvedRoute(u16),
+    /// A unicast MAC on a remote network. The NPDU names the recipient via
+    /// DNET/DADR; with no router table in this non-routing device, the link
+    /// DA is the local broadcast, exactly as Clause 6.5.3 prescribes when
+    /// "the address of the router is initially unknown".
+    RemoteUnicast { network: u16, mac: MacAddr },
+    /// A unicast MAC alongside network 65535, which is self-contradictory: a
+    /// global broadcast requires DLEN zero.
+    ContradictoryGlobal,
     /// A device-instance recipient. Resolving it needs a device-to-address
     /// binding this device does not maintain. Tracked by #125.
     UnresolvedDevice(ObjectIdentifier),
 }
 
 impl RecipientRoute {
-    fn resolve(recipient: &BACnetRecipient) -> Self {
+    fn resolve(recipient: &BACnetRecipient, is_link_broadcast: impl Fn(&[u8]) -> bool) -> Self {
         match recipient {
             BACnetRecipient::Device(oid) => Self::UnresolvedDevice(*oid),
             BACnetRecipient::Address(addr) => {
                 match (addr.network_number, addr.mac_address.is_empty()) {
                     (0, true) => Self::LocalBroadcast,
+                    // The data-link spelling of a broadcast (#360): Clause 6.3
+                    // names the medium's literal broadcast MAC alongside the
+                    // zero-length form, and both name the same destination.
+                    (0, false) if is_link_broadcast(&addr.mac_address) => Self::LocalBroadcast,
                     (0, false) => Self::LocalUnicast(addr.mac_address.clone()),
                     (GLOBAL_BROADCAST_NETWORK, true) => Self::GlobalBroadcast,
                     (net, true) => Self::RemoteBroadcast(net),
-                    // Includes a MAC alongside network 65535, which is
-                    // self-contradictory: a broadcast requires DLEN zero.
-                    (net, false) => Self::UnresolvedRoute(net),
+                    (GLOBAL_BROADCAST_NETWORK, false) => Self::ContradictoryGlobal,
+                    (net, false) => Self::RemoteUnicast {
+                        network: net,
+                        mac: addr.mac_address.clone(),
+                    },
                 }
             }
         }
@@ -74,31 +99,36 @@ impl RecipientRoute {
     /// may be transmitted using a multicast or broadcast network layer address".
     /// A confirmed notification also has nowhere to return its SimpleACK from.
     ///
-    /// This recognizes only the *network-layer* spelling of a broadcast, the
-    /// zero-length `mac-address`. A recipient carrying its data link's literal
-    /// broadcast MAC — `X'FFFFFFFFFFFF'` on Ethernet, an all-ones host portion
-    /// on BACnet/IP, `X'FF'` on MS/TP — reads as `LocalUnicast` here and is
-    /// still sent confirmed. Recognizing those needs the transport's broadcast
-    /// address, which this layer does not have. Tracked by #360.
+    /// Both spellings of a broadcast land here as non-unicast routes: the
+    /// zero-length `mac-address` (Clause 21), and the data link's literal
+    /// broadcast MAC, which `resolve` folds into `LocalBroadcast` via the
+    /// transport's own knowledge of its spelling.
+    ///
+    /// `RemoteUnicast` is excluded for a different reason: Clause 6.3 permits
+    /// sending it confirmed (the DNET/DADR restricts the destination to one
+    /// device), but the server TSM cannot yet correlate an acknowledgment
+    /// that arrives through a router (#375).
     fn permits_confirmed(&self) -> bool {
         matches!(self, Self::LocalUnicast(_))
     }
 
     /// Whether this destination can be sent to at all, logging why not when it
     /// cannot. The two failures are reported separately because they are
-    /// separate operator problems: an unreachable network is a routing
-    /// configuration gap, while an unbound device instance is a recipient this
-    /// device cannot address at all.
+    /// separate operator problems: a self-contradictory address is a
+    /// configuration error, while an unbound device instance is a recipient
+    /// this device cannot address at all.
     fn is_deliverable(&self, notification_class: u32) -> bool {
         match self {
             Self::LocalUnicast(_)
             | Self::LocalBroadcast
             | Self::RemoteBroadcast(_)
-            | Self::GlobalBroadcast => true,
-            Self::UnresolvedRoute(network) => {
+            | Self::GlobalBroadcast
+            | Self::RemoteUnicast { .. } => true,
+            Self::ContradictoryGlobal => {
                 warn!(
                     notification_class,
-                    network, "Skipping recipient: no known route to its network"
+                    "Skipping recipient: network 65535 with a unicast MAC is \
+                     self-contradictory (a global broadcast requires DLEN zero)"
                 );
                 false
             }
@@ -310,6 +340,9 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         };
 
         let notification_class = notification.notification_class;
+        // Clause 13.2.5.4 sets the NPDU priority from the notification's
+        // event priority, on every send of this notification — retries too.
+        let network_priority = network_priority_for_event(notification.priority);
 
         // Clause 13.2.5: "notifications are distributed to the notification-
         // clients specified by the Recipient_List input". The Recipient_List is
@@ -326,21 +359,34 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         }
 
         for (recipient, process_id, confirmed) in &recipients {
-            let route = RecipientRoute::resolve(recipient);
+            let route =
+                RecipientRoute::resolve(recipient, |mac| network.transport().is_broadcast_mac(mac));
 
             if !route.is_deliverable(notification_class) {
                 continue;
             }
 
-            // Clause 6.3 restricts broadcast to Unconfirmed-Request-PDUs.
             // Downgrading to unconfirmed would drop the acknowledgment the
-            // recipient was configured to require, so this is a skip.
+            // recipient was configured to require, so both cases are skips.
             if *confirmed && !route.permits_confirmed() {
-                warn!(
-                    notification_class,
-                    "Recipient requests confirmed notifications at a broadcast address; \
-                     Clause 6.3 permits only unconfirmed PDUs there, skipping"
-                );
+                match &route {
+                    // Clause 6.3 permits sending this (the DNET/DADR restricts
+                    // the destination to one device), but the server TSM
+                    // cannot yet correlate an acknowledgment that arrives
+                    // through a router. Tracked by #375.
+                    RecipientRoute::RemoteUnicast { network, .. } => warn!(
+                        notification_class,
+                        network,
+                        "Recipient requests confirmed notifications on a remote network; \
+                         routed acknowledgment correlation is unimplemented (#375), skipping"
+                    ),
+                    // Clause 6.3 restricts broadcast to Unconfirmed-Request-PDUs.
+                    _ => warn!(
+                        notification_class,
+                        "Recipient requests confirmed notifications at a broadcast address; \
+                         Clause 6.3 permits only unconfirmed PDUs there, skipping"
+                    ),
+                }
                 continue;
             }
 
@@ -356,8 +402,16 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let service_bytes = service_buf.freeze();
 
             if *confirmed {
-                // `permits_confirmed` above admits only `LocalUnicast`.
+                // `permits_confirmed` above admits only `LocalUnicast`. If
+                // that predicate ever widens without this arm learning the
+                // new route, fail loudly instead of dropping the
+                // notification with no diagnostic.
                 let RecipientRoute::LocalUnicast(target_mac) = &route else {
+                    warn!(
+                        notification_class,
+                        "Confirmed notification reached the send path on a \
+                         non-unicast route; dropping"
+                    );
                     continue;
                 };
                 let target_mac = target_mac.clone();
@@ -398,7 +452,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
                     for attempt in 0..=apdu_retries {
                         let send_result = network
-                            .send_apdu(&buf, &target_mac, true, NetworkPriority::NORMAL)
+                            .send_apdu(&buf, &target_mac, true, network_priority)
                             .await;
 
                         if let Err(e) = send_result {
@@ -463,20 +517,16 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
                 let send_result = match &route {
                     RecipientRoute::LocalUnicast(mac) => {
-                        network
-                            .send_apdu(&buf, mac, false, NetworkPriority::NORMAL)
-                            .await
+                        network.send_apdu(&buf, mac, false, network_priority).await
                     }
                     RecipientRoute::LocalBroadcast => {
-                        network
-                            .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
-                            .await
+                        network.broadcast_apdu(&buf, false, network_priority).await
                     }
                     // Carries DNET with DLEN zero, so routers forward it
                     // onto the remote network as a broadcast there.
                     RecipientRoute::RemoteBroadcast(net) => {
                         network
-                            .broadcast_to_network(&buf, *net, false, NetworkPriority::NORMAL)
+                            .broadcast_to_network(&buf, *net, false, network_priority)
                             .await
                     }
                     // Carries DNET 0xFFFF, which routers forward to every
@@ -484,11 +534,25 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     // DNET, so it needs its own send.
                     RecipientRoute::GlobalBroadcast => {
                         network
-                            .broadcast_global_apdu(&buf, false, NetworkPriority::NORMAL)
+                            .broadcast_global_apdu(&buf, false, network_priority)
+                            .await
+                    }
+                    // DNET/DADR name the recipient; the link DA is the local
+                    // broadcast because this non-routing device keeps no
+                    // router table (Clause 6.5.3's unknown-router form).
+                    RecipientRoute::RemoteUnicast { network: net, mac } => {
+                        network
+                            .send_apdu_routed_via_local_broadcast(
+                                &buf,
+                                *net,
+                                mac,
+                                false,
+                                network_priority,
+                            )
                             .await
                     }
                     // Filtered out by `RecipientRoute::is_deliverable` above.
-                    RecipientRoute::UnresolvedRoute(_) | RecipientRoute::UnresolvedDevice(_) => {
+                    RecipientRoute::ContradictoryGlobal | RecipientRoute::UnresolvedDevice(_) => {
                         continue
                     }
                 };

--- a/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
@@ -59,11 +59,18 @@ impl TransportPort for RoutingTransport {
     fn local_mac(&self) -> &[u8] {
         &[127, 0, 0, 1, 0xBA, 0xC0]
     }
+    fn is_broadcast_mac(&self, mac: &[u8]) -> bool {
+        mac == LITERAL_BROADCAST_MAC
+    }
 }
+
+/// This test link's literal broadcast MAC — the data-link spelling of a
+/// broadcast (#360), as distinct from the zero-length network-layer form.
+pub(super) const LITERAL_BROADCAST_MAC: &[u8] = &[255, 255, 255, 255, 0xBA, 0xC0];
 
 /// A destination carrying `recipient`, active on every day at every time for
 /// every transition, so only the address shape under test decides the outcome.
-fn destination_for(recipient: BACnetRecipient, confirmed: bool) -> BACnetDestination {
+pub(super) fn destination_for(recipient: BACnetRecipient, confirmed: bool) -> BACnetDestination {
     BACnetDestination {
         recipient,
         issue_confirmed_notifications: confirmed,
@@ -71,7 +78,7 @@ fn destination_for(recipient: BACnetRecipient, confirmed: bool) -> BACnetDestina
     }
 }
 
-fn address_recipient(network_number: u16, mac: &[u8]) -> BACnetRecipient {
+pub(super) fn address_recipient(network_number: u16, mac: &[u8]) -> BACnetRecipient {
     BACnetRecipient::Address(BACnetAddress {
         network_number,
         mac_address: MacAddr::from_slice(mac),
@@ -83,6 +90,15 @@ fn address_recipient(network_number: u16, mac: &[u8]) -> BACnetRecipient {
 async fn distribute_to(
     destinations: Vec<BACnetDestination>,
 ) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
+    distribute_with_priority([255, 255, 255], destinations).await
+}
+
+/// [`distribute_to`] with the Notification Class's per-transition Priority
+/// array set, for tests that pin the Table 13-6 NPDU-priority projection.
+pub(super) async fn distribute_with_priority(
+    priority: [u8; 3],
+    destinations: Vec<BACnetDestination>,
+) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
     let transport = RoutingTransport::default();
     let broadcasts = StdArc::clone(&transport.broadcasts);
     let unicasts = StdArc::clone(&transport.unicasts);
@@ -92,6 +108,7 @@ async fn distribute_to(
 
     let mut db = ObjectDatabase::new();
     let mut nc = NotificationClass::new(0, "NC-0").unwrap();
+    nc.priority = priority;
     for destination in destinations {
         nc.add_destination(destination);
     }
@@ -148,9 +165,10 @@ async fn distribute_to(
 
 /// The NPDU destination (DNET/DADR) of a captured frame, or `None` when the
 /// destination specifier bit is clear.
-fn npdu_destination(frame: &Bytes) -> Option<(u16, usize)> {
+pub(super) fn npdu_destination(frame: &Bytes) -> Option<(u16, Vec<u8>)> {
     let npdu = bacnet_encoding::npdu::decode_npdu(frame.clone()).expect("decode NPDU");
-    npdu.destination.map(|d| (d.network, d.mac_address.len()))
+    npdu.destination
+        .map(|d| (d.network, d.mac_address.to_vec()))
 }
 
 /// #185: Clause 12.21 requires a device whose `Recipient_List` is not writable
@@ -193,7 +211,7 @@ async fn zero_length_mac_on_remote_network_broadcasts_with_dnet() {
     assert!(unicasts.is_empty());
     assert_eq!(
         npdu_destination(&broadcasts[0]),
-        Some((1000, 0)),
+        Some((1000, vec![])),
         "DNET names the remote network and DLEN is zero"
     );
 }
@@ -215,7 +233,7 @@ async fn zero_length_mac_on_network_65535_is_a_global_broadcast() {
     assert!(unicasts.is_empty());
     assert_eq!(
         npdu_destination(&broadcasts[0]),
-        Some((0xFFFF, 0)),
+        Some((0xFFFF, vec![])),
         "DNET is the global broadcast address and DLEN is zero"
     );
 }
@@ -232,23 +250,78 @@ async fn global_broadcast_network_with_a_mac_is_skipped() {
     assert!(unicasts.is_empty());
 }
 
-/// #186: a unicast MAC on a remote network needs a next-hop router, and no
-/// router table is reachable from the server. The recipient is skipped.
+/// #186: a unicast MAC on a remote network goes out as a routed NPDU whose
+/// DNET/DADR name the recipient, sent with a broadcast link DA — Clause
+/// 6.5.3's form for when "the address of the router is initially unknown"
+/// (this non-routing device keeps no router table).
 ///
-/// The point of the test is the second assertion. Sending it as a plain local
-/// unicast — the previous behavior, which discarded `network_number` entirely —
-/// delivers the alarm to whichever device holds that MAC on the *local* link.
+/// The unicast assertion still matters most: the pre-#357 behavior discarded
+/// `network_number` entirely and delivered the alarm to whichever device held
+/// that MAC on the *local* link.
 #[tokio::test]
-async fn remote_unicast_recipient_is_skipped_not_sent_locally() {
+async fn remote_unicast_recipient_routes_via_broadcast_link_da() {
     let mac = [0x0A, 0x00, 0x00, 0x64, 0xBA, 0xC0];
     let (broadcasts, unicasts) =
         distribute_to(vec![destination_for(address_recipient(1000, &mac), false)]).await;
 
-    assert!(broadcasts.is_empty(), "must not fall back to a broadcast");
     assert!(
         unicasts.is_empty(),
         "must not deliver a remote recipient to that MAC on the local link"
     );
+    assert_eq!(broadcasts.len(), 1, "one routed frame on the broadcast DA");
+    assert_eq!(
+        npdu_destination(&broadcasts[0]),
+        Some((1000, mac.to_vec())),
+        "DNET names the remote network and DADR carries the recipient's MAC"
+    );
+}
+
+/// #186/#375: a *confirmed* recipient on a remote network is spec-legal to
+/// send (Clause 6.3's single-device parenthetical) but the server TSM cannot
+/// correlate a routed acknowledgment yet, so it is skipped rather than sent
+/// and mis-retried into duplicate deliveries.
+#[tokio::test]
+async fn confirmed_remote_unicast_recipient_is_skipped() {
+    let mac = [0x0A, 0x00, 0x00, 0x64, 0xBA, 0xC0];
+    let (broadcasts, unicasts) =
+        distribute_to(vec![destination_for(address_recipient(1000, &mac), true)]).await;
+
+    assert!(broadcasts.is_empty());
+    assert!(unicasts.is_empty());
+}
+
+/// #360: a confirmed recipient spelled with the data link's *literal*
+/// broadcast MAC is the same unsatisfiable ask as the zero-length form —
+/// Clause 6.3 permits only unconfirmed PDUs at a broadcast — and must be
+/// skipped, not unicast to the broadcast address.
+#[tokio::test]
+async fn confirmed_recipient_at_literal_broadcast_mac_is_skipped() {
+    let (broadcasts, unicasts) = distribute_to(vec![destination_for(
+        address_recipient(0, LITERAL_BROADCAST_MAC),
+        true,
+    )])
+    .await;
+
+    assert!(
+        unicasts.is_empty(),
+        "a literal broadcast MAC must not be offered to a confirmed unicast send"
+    );
+    assert!(broadcasts.is_empty(), "and must not be broadcast confirmed");
+}
+
+/// #360, the deliverable half: an *unconfirmed* recipient at the literal
+/// broadcast MAC resolves to the same broadcast route as the zero-length
+/// spelling.
+#[tokio::test]
+async fn unconfirmed_recipient_at_literal_broadcast_mac_broadcasts() {
+    let (broadcasts, unicasts) = distribute_to(vec![destination_for(
+        address_recipient(0, LITERAL_BROADCAST_MAC),
+        false,
+    )])
+    .await;
+
+    assert_eq!(broadcasts.len(), 1, "delivered via the broadcast path");
+    assert!(unicasts.is_empty());
 }
 
 /// #125: a device-instance recipient needs a device-to-address binding this

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -783,6 +783,8 @@ mod event_enable_distribution_tests;
 #[cfg(test)]
 mod event_enrollment_task_tests;
 #[cfg(test)]
+mod event_network_priority_tests;
+#[cfg(test)]
 mod event_notifications_tests;
 #[cfg(test)]
 mod event_recipient_routing_tests;

--- a/crates/bacnet-transport/src/any.rs
+++ b/crates/bacnet-transport/src/any.rs
@@ -213,6 +213,20 @@ impl<S: SerialPort + 'static> TransportPort for AnyTransport<S> {
             Self::Loopback(t) => t.max_apdu_length(),
         }
     }
+
+    fn is_broadcast_mac(&self, mac: &[u8]) -> bool {
+        match self {
+            Self::Bip(t) => t.is_broadcast_mac(mac),
+            Self::Mstp(t) => t.is_broadcast_mac(mac),
+            #[cfg(feature = "ipv6")]
+            Self::Bip6(t) => t.is_broadcast_mac(mac),
+            #[cfg(all(feature = "ethernet", target_os = "linux"))]
+            Self::Ethernet(t) => t.is_broadcast_mac(mac),
+            #[cfg(feature = "sc-tls")]
+            Self::Sc(t) => t.is_broadcast_mac(mac),
+            Self::Loopback(t) => t.is_broadcast_mac(mac),
+        }
+    }
 }
 
 impl<S: SerialPort> From<BipTransport> for AnyTransport<S> {

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -613,6 +613,16 @@ impl TransportPort for BipTransport {
     fn local_mac(&self) -> &[u8] {
         &self.local_mac
     }
+
+    fn is_broadcast_mac(&self, mac: &[u8]) -> bool {
+        // Clause J.1.2's B/IP broadcast address is the configured broadcast
+        // IP ("all 1's in the host portion") together with this port's UDP
+        // port — a broadcast IP at a different port belongs to a different
+        // B/IP network and must not be folded into this link's broadcast.
+        mac.len() == 6
+            && mac[..4] == self.broadcast_address.octets()
+            && mac[4..] == self.port.to_be_bytes()
+    }
 }
 
 impl Drop for BipTransport {

--- a/crates/bacnet-transport/src/bip/tests.rs
+++ b/crates/bacnet-transport/src/bip/tests.rs
@@ -801,3 +801,17 @@ async fn start_fails_on_nonlocal_interface() {
         "expected Error::Transport, got: {err:?}"
     );
 }
+
+/// #360: Clause J.1.2's B/IP broadcast address is the configured broadcast
+/// IP together with this port's UDP port — a broadcast IP at a different
+/// port is a different B/IP network, and the limited broadcast is not this
+/// link's spelling unless it is the configured one.
+#[test]
+fn is_broadcast_mac_requires_configured_ip_and_port() {
+    let transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0xBAC0, Ipv4Addr::new(192, 168, 1, 255));
+    assert!(transport.is_broadcast_mac(&[192, 168, 1, 255, 0xBA, 0xC0]));
+    assert!(!transport.is_broadcast_mac(&[192, 168, 1, 255, 0xBA, 0xC1]));
+    assert!(!transport.is_broadcast_mac(&[255, 255, 255, 255, 0xBA, 0xC0]));
+    assert!(!transport.is_broadcast_mac(&[192, 168, 1, 7, 0xBA, 0xC0]));
+    assert!(!transport.is_broadcast_mac(&[192, 168, 1, 255]));
+}

--- a/crates/bacnet-transport/src/bip6/port.rs
+++ b/crates/bacnet-transport/src/bip6/port.rs
@@ -732,4 +732,20 @@ impl TransportPort for Bip6Transport {
     fn local_mac(&self) -> &[u8] {
         &self.local_mac
     }
+
+    fn is_broadcast_mac(&self, mac: &[u8]) -> bool {
+        // A B/IPv6 MAC is 16 address octets + 2 port octets. The broadcast
+        // spelling is any of the well-known BACnet multicast groups
+        // (Clause U.4); the port octets do not decide broadcast-ness.
+        if mac.len() != 18 {
+            return false;
+        }
+        [
+            BACNET_IPV6_MULTICAST_LINK_LOCAL,
+            BACNET_IPV6_MULTICAST_SITE_LOCAL,
+            BACNET_IPV6_MULTICAST_ORG_LOCAL,
+        ]
+        .iter()
+        .any(|group| mac[..16] == group.octets())
+    }
 }

--- a/crates/bacnet-transport/src/ethernet/mod.rs
+++ b/crates/bacnet-transport/src/ethernet/mod.rs
@@ -803,6 +803,10 @@ mod transport {
             &self.local_mac
         }
 
+        fn is_broadcast_mac(&self, mac: &[u8]) -> bool {
+            mac == ETHERNET_BROADCAST
+        }
+
         fn max_apdu_length(&self) -> u16 {
             1476
         }

--- a/crates/bacnet-transport/src/mstp/port.rs
+++ b/crates/bacnet-transport/src/mstp/port.rs
@@ -428,6 +428,10 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
     fn max_apdu_length(&self) -> u16 {
         480
     }
+
+    fn is_broadcast_mac(&self, mac: &[u8]) -> bool {
+        mac == [BROADCAST_MAC]
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/bacnet-transport/src/mstp/tests.rs
+++ b/crates/bacnet-transport/src/mstp/tests.rs
@@ -810,3 +810,19 @@ fn t_slot_stored_on_master_node() {
     let node = MasterNode::new(config).unwrap();
     assert_eq!(node.t_slot_ms, 10);
 }
+
+/// #360: X'FF' is the MS/TP broadcast spelling; anything else is a station.
+#[test]
+fn is_broadcast_mac_is_xff() {
+    let (serial_a, _serial_b) = LoopbackSerial::pair();
+    let config = MstpConfig {
+        this_station: 42,
+        max_master: 127,
+        max_info_frames: 1,
+        baud_rate: 9600,
+    };
+    let transport = MstpTransport::new(serial_a, config);
+    assert!(transport.is_broadcast_mac(&[0xFF]));
+    assert!(!transport.is_broadcast_mac(&[42]));
+    assert!(!transport.is_broadcast_mac(&[0xFF, 0xFF]));
+}

--- a/crates/bacnet-transport/src/port.rs
+++ b/crates/bacnet-transport/src/port.rs
@@ -130,4 +130,18 @@ pub trait TransportPort: Send + Sync {
     fn max_apdu_length(&self) -> u16 {
         1476
     }
+
+    /// Whether `mac` is this data link's broadcast address.
+    ///
+    /// A destination can spell a broadcast two ways: the network-layer form
+    /// (a zero-length MAC) or the medium's literal broadcast MAC — Clause 6.3
+    /// names `X'FFFFFFFFFFFF'` for Ethernet, `X'FF'` for MS/TP, an IP address
+    /// with all ones in the host portion for BACnet/IP. Only the transport
+    /// knows its own literal spelling, so senders that must not unicast to a
+    /// broadcast (Clause 6.3 restricts broadcast to Unconfirmed-Request-PDUs)
+    /// ask here. The default recognizes nothing, which leaves such a MAC
+    /// treated as a unicast.
+    fn is_broadcast_mac(&self, _mac: &[u8]) -> bool {
+        false
+    }
 }

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -774,6 +774,10 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
     fn max_apdu_length(&self) -> u16 {
         self.effective_max_apdu_length.load(Ordering::Relaxed)
     }
+
+    fn is_broadcast_mac(&self, mac: &[u8]) -> bool {
+        mac == BROADCAST_VMAC
+    }
 }
 
 impl<W: WebSocketPort> Drop for ScTransport<W> {


### PR DESCRIPTION
Closes #187. Closes #186. Closes #360.

The three-issue notification cluster from PR #357's reviews, grounded against a fresh extraction of the `_spec/` PDF. All three live in the same sender (`event_notifications.rs`); the grounding materially re-scoped two of them.

## #187 — Table 13-6 network priority (was: every NPDU at Normal)

Clause 13.2.5.4 (verbatim, line 41757): "the Network Priority as defined in Clause 6.2.2 shall be set as a function of the alarm and event priority as defined in Table 13-6." Table 13-6 verified verbatim (lines 41760–41765): 00–63 Life Safety, 64–127 Critical Equipment, 128–191 Urgent, 192–255 Normal. A `network_priority_for_event` projection now feeds **all six sends**: the four pre-existing unconfirmed paths, the remote-unicast path the #186 fix introduces, and confirmed unicast including every retry.

Scope confirmed by grounding: the mapping attaches only to event notifications — ConfirmedCOVNotification/UnconfirmedCOVNotification carry **no priority parameter at all** (Table 13-10), and nothing in the Standard assigns a network priority to non-notification traffic — so COV sends are deliberately untouched.

Tests assert the **encoded NPDU control octet** at all eight band edges plus the confirmed path, not the APDU field (which was always right). Mutation-verified: neutralizing the projection input fails both NPDU-level tests while the pure unit test survives, and reverting the five unconfirmed sends to `NORMAL` fails both NPDU-level tests.

## #186 — remote-network unicast recipients (re-scoped by grounding)

What remained after #357 was the remote-unicast arm: it resolved to `UnresolvedRoute` and skipped with "no known route to its network." The issue's suggested `RouterTable::lookup` direction turned out to be both un-plumbable (no server owns a RouterTable; the non-routing `NetworkLayer` drops I-Am-Router-To-Network) and **unnecessary**: Clause 6.5.3 (lines 4981–4982) prescribes the exact form for an unknown router — the link DA "shall be the MAC address of the BACnet router corresponding to the DNET parameter **or the appropriate broadcast DA if the address of the router is initially unknown**" — and the skip itself was non-conformant, silently dropping traffic the Standard says shall be transmitted. Route discovery (Who-Is-Router-To-Network, 6.6.3.2) is MAY for an originating device, so none is required.

The new `NetworkLayer::send_apdu_routed_via_local_broadcast` (shares the routed-NPDU encoder with the unicast form) sends DNET/DADR-addressed NPDUs on the broadcast DA. Clause 6.3's broadcast restriction does not bite: its full sentence carries a parenthetical the issue text had dropped — "a MAC layer multicast or broadcast address may be used for other PDU types **when the network layer address restricts the destination to a single device**" (lines 4657–4659).

**Confirmed** notifications to remote recipients stay skipped, with an honest reason: the server TSM registers acks under `(target_mac, None)` while a routed ack arrives from an unpredictable router MAC — sending anyway would mis-retry into up to four duplicate deliveries. Filed as #375 with the fix shape (routed peer keys, learn the router from the first ack per 6.5.3 method 4).

## #360 — the data-link spelling of a broadcast

New `TransportPort::is_broadcast_mac` (default: recognize nothing) with per-transport implementations: BIP matches its **configured** broadcast IP together with its **UDP port** — the two components of Clause J.1.2's B/IP broadcast address ("all 1's in the host portion" plus the B/IP UDP port; a broadcast IP at a different port belongs to a different B/IP network and must not be folded into this link's broadcast) — MS/TP `X'FF'`, Ethernet all-ones, SC the Local Broadcast VMAC, B/IPv6 the three Clause U.4 `FF0X::BAC0` multicast groups, `AnyTransport` delegates. Recipient resolution folds a matching MAC **on network 0 only** into `LocalBroadcast`. The network-0 scope is where the check is meaningful, not just permitted: a remote recipient's DADR is spelled in the remote network's medium, about which this port's broadcast spelling proves nothing — and a broadcast link DA under a unicast DNET/DADR is legal per the Clause 6.3 parenthetical (it's the #186 mechanism). A confirmed recipient at the literal broadcast MAC is now skipped like the zero-length spelling; an unconfirmed one is delivered via the broadcast path.

Grounding confirmed write-time rejection is not an option: Clause 12.21 (line 18871) forbids restricting `Recipient_List` values, so send-time is the only interception point.

## Tests

- 8-boundary projection unit test + NPDU-octet tests for unconfirmed (all eight boundaries, NPDU-decoded) and confirmed paths, plus a per-route sweep asserting every unconfirmed route shape carries the projected priority (`event_network_priority_tests.rs`, new file).
- Remote unicast: routed frame on the broadcast DA with `DNET=1000` and the recipient's 6-byte DADR asserted byte-for-byte, and **no local unicast** (the original mis-delivery). Confirmed-remote skip pinned.
- Literal-broadcast-MAC: confirmed skipped, unconfirmed broadcast, via a transport-double override.
- BIP `is_broadcast_mac` (configured broadcast at the port's own UDP port matches; same IP at another port and the limited broadcast 255.255.255.255 do not; wrong length) and MS/TP (`X'FF'`, non-broadcast, wrong length) unit tests — MS/TP is testable everywhere (`LoopbackSerial` is unconditional; only `mstp_serial` is feature-gated).
- Discrimination: the three behavior-changing tests verified to fail against dev `66f31de` in a detached worktree; #187 verified by mutation (vacuous-projection input; five-site NORMAL revert) per the standing memory rule.
- `layer.rs` sits at 698/700 after the shared-encoder refactor; all files pass the CI cap.

## Review

Two parallel Opus lanes reviewed the branch: an adversarial code review (approve — 3 minor, 3 nit) and a spec-accuracy review against a live extraction (request changes — 1 blocking, plus minor cites). All findings applied:

- **BIP broadcast must include the UDP port** (both lanes converged, spec lane blocking-adjacent): the first cut matched the broadcast IP at *any* port on the theory that port octets don't decide broadcast-ness. J.1.2 defines the B/IP broadcast address as broadcast IP **and** UDP port; a recipient at `192.168.1.255:47809` seen from a `:47808` server is another B/IP network's broadcast, not ours, and was being redirected onto our local broadcast. Impl + test rewritten to require the port match.
- **B/IPv6 cite** (spec lane, blocking): the multicast-group comment cited U.3.1; the groups are defined in Clause U.4. Fixed.
- `permits_confirmed` doc now states the RemoteUnicast exclusion is the #375 TSM limitation, not a Clause 6.3 prohibition; the confirmed-path let-else now warns instead of silently dropping; `npdu_destination` in the test harness returns the DADR bytes so the routed test pins the full address, not just the DNET; the NPDU-octet test covers all eight band boundaries instead of four; commit/CHANGELOG/PR wording corrected (five→six sends; J.1.2 port; zero-length spelling attributed to Clause 21's `BACnetAddress`, literal spelling to Clause 6.3; network-0 scoping rationale stated as the remote-medium argument).

## Notes

- The conformance ledger needs no regeneration: no row claims Clause 13.2.5.4 or routed distribution (verified by the sweep).
- Issues' page cites were off by two in three places (p648→646, p884→885, p71→69); clause numbers and text all verified correct against heading text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
