### PR TITLE
fix(server,client): bind segmented transfers to their sequence space and their transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Server-side segmented request reassembly is bounded by the sequence-number
+  space instead of silently corrupting past it (#364). The reassembly total
+  came from the last wire sequence number plus one — but Clause 20.1.2.7
+  makes that number modulo 256, so a 260-segment request "reassembled" as
+  its own last four segments and was decoded as the peer's request with no
+  error anywhere. Worse, the wrapped segment 256 arrives as another
+  `seq == 0` and the open path ran before the live-session check, so it
+  silently replaced the session. The session is now consulted first, the
+  total is a monotonic accepted-segment count, and the 257th in-order
+  segment ends the transfer with a `'server' = TRUE` BUFFER_OVERFLOW Abort —
+  Clause 5.4.5.2 has no overflow transition, so its generic `SendAbort`
+  escape (reason a local matter) carries Clause 18.10's closest reason.
+  Exactly 256 segments still reassemble, byte-exact. The companion defect is
+  fixed the same way: a segment the receiver cannot store used to be dropped
+  with only a warning, leaving the session dangling and the peer waiting out
+  its own timer; it now ends the session with the same Abort. A duplicate
+  segment 0 mid-session — a retransmission after a lost ack — now draws the
+  out-of-order negative SegmentAck instead of resetting the session.
+
+- A client-side reassembly session now lives exactly as long as its
+  transaction (#367). The peer ending a transaction with an Abort, Error or
+  Reject — or the caller giving up on timeout — completed the TSM entry but
+  left the reassembly session in place, and the client kept acking segments
+  of a transaction that no longer existed, indefinitely. Sessions are now
+  removed where transactions end: the Abort arm removes the session per
+  Clause 5.4.4.4 `AbortPDU_Received` (no reply PDU — and only for
+  `'server' = TRUE`, so an echoed copy of this client's own Abort cannot
+  tear down a healthy reassembly); the Error and Reject arms mid-reassembly
+  follow `UnexpectedPDU_Received`, whose list names both PDUs — as do a
+  SimpleAck and an unsegmented ComplexAck arriving mid-reassembly, which
+  previously completed the transaction as if they answered it and left the
+  session dangling; all four now abort the reassembly the same way. The
+  peer gets an Abort, the caller gets INVALID_APDU_IN_THIS_STATE rather
+  than the misdirected PDU's content, and an ordinary
+  SimpleAck/ComplexAck/Error/Reject with no session in flight still
+  surfaces as itself. The caller-timeout route has no arm to hook, so
+  the pending-transaction gate now runs per segment instead of only at
+  session open (also moved ahead of the session-count cap, so a non-pending
+  segment draws the Clause 5.4.4.1 Abort even with every slot full).
+
+- A stale SegmentAck no longer kills a healthy segmented request (#368). A
+  SegmentAck whose sequence number was at or past the request's segment
+  count — most ordinarily a duplicated ack from an earlier transfer aliased
+  onto an immediately-reused invoke ID — was a fatal error checked before
+  the window filter could see it. Clause 5.4.4.2 `DuplicateACK_Received`
+  prescribes the opposite: "restart SegmentTimer and enter the
+  SEGMENTED_REQUEST state to await an acknowledgment" — discard and keep
+  waiting. The check is gone; out-of-range acks, positive and negative
+  alike, now fall through to the in-window filter and are discarded like
+  any other stale ack. In the same path, negative acks now take Clause
+  5.4.4.2's ack transitions literally, which never branch on the
+  'negative-ack' flag: either flavor names the last segment the peer
+  accepted and the sender continues after it. The old reading mapped a NAK
+  to "resend from here", which discarded a NAK naming the last segment of
+  the current window (the transfer stalled into a timeout) and treated
+  first-window NAK 0 as "resend segment 0" — making a lost first ack
+  unrecoverable, since the retransmitted segment 0 draws NAK(0) from the
+  peer's live session and the loop never advances.
+
+- The server honors its segmentation advertisement in both directions
+  instead of reassembling or segmenting regardless (#381). A device whose
+  configuration advertises NO_SEGMENTATION or SEGMENTED_TRANSMIT reassembled
+  inbound segmented requests anyway; it now sends the Clause 5.4.5.1
+  `ConfirmedSegmentedReceivedNotSupported` Abort. Symmetrically, a device
+  advertising NO_SEGMENTATION or SEGMENTED_RECEIVE transmitted segmented
+  ComplexACKs anyway; an oversized response now draws the Clause 5.4.5.3
+  `CannotSendSegmentedComplexACK` case (a) Abort. **Behavior change for
+  default configurations**: `ServerConfig::default()` advertises
+  NO_SEGMENTATION, so a default-configured server now refuses segmented
+  traffic in both directions where it previously (wrongly) accepted and
+  produced it — set `segmentation_supported` (a new builder method on the
+  generic, BIP and SC builders) to `BOTH` to restore the old behavior
+  honestly. A peer's own Abort now also ends the server-side reassembly
+  session per Clause 5.4.5.2 `AbortPDU_Received` — as a side effect that
+  still lets the PDU reach dispatch, which routes segmented-send
+  cancellation (#377).
+
 - Event notifications carry the Table 13-6 network priority (#187). Every
   transmit site — confirmed unicast including each retry, and the four
   unconfirmed sends — hardcoded a Normal-priority NPDU, so a life-safety

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -42,6 +42,29 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let tsm_mac = response_tsm_mac(source_mac, source_network);
         match apdu {
             Apdu::SimpleAck(ack) => {
+                // Mid-reassembly, a SimpleACK is in Clause 5.4.4.4
+                // UnexpectedPDU_Received's list, exactly like the Error and
+                // Reject arms below — the segmented response under
+                // reassembly IS this transaction's acknowledgment, so a
+                // second one is not answering it. Checked before the TSM
+                // lock: `abort_reassembly` takes that lock itself (#367).
+                if let Some(state) = seg_state.remove(&(tsm_mac.clone(), ack.invoke_id)) {
+                    debug!(
+                        invoke_id = ack.invoke_id,
+                        "Aborting reassembly on a SimpleAck"
+                    );
+                    Self::abort_reassembly(
+                        tsm,
+                        network,
+                        &tsm_mac,
+                        &state.reply_mac,
+                        &state.reply_network,
+                        ack.invoke_id,
+                        bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                    )
+                    .await;
+                    return;
+                }
                 debug!(invoke_id = ack.invoke_id, "Received SimpleAck");
                 let mut tsm = tsm.lock().await;
                 let outcome = tsm.complete_transaction(
@@ -65,6 +88,27 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     )
                     .await;
                 } else {
+                    // "BACnet-ComplexACK-PDU with 'segmented-message' =
+                    // FALSE" is in the same Clause 5.4.4.4
+                    // UnexpectedPDU_Received list: the transaction's answer
+                    // is the segmented ComplexACK already under reassembly.
+                    if let Some(state) = seg_state.remove(&(tsm_mac.clone(), ack.invoke_id)) {
+                        debug!(
+                            invoke_id = ack.invoke_id,
+                            "Aborting reassembly on an unsegmented ComplexAck"
+                        );
+                        Self::abort_reassembly(
+                            tsm,
+                            network,
+                            &tsm_mac,
+                            &state.reply_mac,
+                            &state.reply_network,
+                            ack.invoke_id,
+                            bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                        )
+                        .await;
+                        return;
+                    }
                     debug!(invoke_id = ack.invoke_id, "Received ComplexAck");
                     let mut tsm = tsm.lock().await;
                     let outcome = tsm.complete_transaction(
@@ -79,6 +123,33 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 }
             }
             Apdu::Error(err) => {
+                // Mid-reassembly, an Error PDU is Clause 5.4.4.4
+                // UnexpectedPDU_Received — "BACnet-Error-PDU" is in its list —
+                // so the local surface is an ABORT.indication with
+                // INVALID_APDU_IN_THIS_STATE, not the error content (#367).
+                // Checked before the TSM lock below: `abort_reassembly` takes
+                // that lock itself, and tokio's Mutex is not reentrant. Keyed
+                // on `seg_state` only — an Error answering an *outgoing*
+                // segmented request can be legitimate (5.4.4.2 surfaces it
+                // once SentAllSegments is TRUE, a flag this client does not
+                // track), so a `seg_ack_senders` entry must not divert here.
+                if let Some(state) = seg_state.remove(&(tsm_mac.clone(), err.invoke_id)) {
+                    debug!(
+                        invoke_id = err.invoke_id,
+                        "Aborting reassembly on an Error PDU"
+                    );
+                    Self::abort_reassembly(
+                        tsm,
+                        network,
+                        &tsm_mac,
+                        &state.reply_mac,
+                        &state.reply_network,
+                        err.invoke_id,
+                        bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                    )
+                    .await;
+                    return;
+                }
                 debug!(invoke_id = err.invoke_id, "Received Error PDU");
                 let mut tsm = tsm.lock().await;
                 // Correlated by invoke ID alone. Unlike 20.1.4.2 and 20.1.5.6,
@@ -99,6 +170,26 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 );
             }
             Apdu::Reject(rej) => {
+                // Same Clause 5.4.4.4 UnexpectedPDU_Received diversion as the
+                // Error arm above ("BACnet-Reject-PDU" is in the same list),
+                // with the same lock-ordering constraint (#367).
+                if let Some(state) = seg_state.remove(&(tsm_mac.clone(), rej.invoke_id)) {
+                    debug!(
+                        invoke_id = rej.invoke_id,
+                        "Aborting reassembly on a Reject PDU"
+                    );
+                    Self::abort_reassembly(
+                        tsm,
+                        network,
+                        &tsm_mac,
+                        &state.reply_mac,
+                        &state.reply_network,
+                        rej.invoke_id,
+                        bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                    )
+                    .await;
+                    return;
+                }
                 debug!(invoke_id = rej.invoke_id, "Received Reject PDU");
                 let mut tsm = tsm.lock().await;
                 // Carries no service choice (Clause 20.1.8); invoke ID is the
@@ -125,6 +216,19 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     );
                     return;
                 }
+                // Clause 5.4.4.4 AbortPDU_Received: "send ABORT.indication to
+                // the local application program; and enter the IDLE state" —
+                // ending the reassembly session is the IDLE half, and no
+                // reply PDU is prescribed (#367). This removal must stay
+                // below the server=FALSE guard above, or an echoed copy of
+                // this client's own Abort would tear down a healthy
+                // reassembly. Behaviorally redundant with the per-segment
+                // pending gate in `handle_segmented_complex_ack` — a later
+                // segment would find no transaction and clear the session
+                // anyway — so no test can pin this line alone; it is kept so
+                // the slot frees at the Abort, not at the peer's next move
+                // or the reaper.
+                seg_state.remove(&(tsm_mac.clone(), abt.invoke_id));
                 debug!(invoke_id = abt.invoke_id, "Received Abort PDU");
                 let mut tsm = tsm.lock().await;
                 // Carries no service choice (Clause 20.1.9).

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -802,6 +802,8 @@ mod sc_max_apdu_tests;
 #[cfg(test)]
 mod segmentation_retransmit_tests;
 #[cfg(test)]
+mod segmented_receive_lifecycle_tests;
+#[cfg(test)]
 mod tests;
 
 impl<T: TransportPort + 'static> BACnetClient<T> {

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -142,41 +142,37 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             return;
         }
 
-        const MAX_CONCURRENT_SEG_SESSIONS: usize = 64;
-        if !seg_state.contains_key(&key) && seg_state.len() >= MAX_CONCURRENT_SEG_SESSIONS {
-            warn!(
-                invoke_id = ack.invoke_id,
-                sessions = seg_state.len(),
-                "Max concurrent segmented sessions reached, dropping segment"
-            );
-            return;
-        }
-
-        // Only a request this client actually issued may open a reassembly
-        // session. Without this, an unsolicited peer can occupy all 64 slots
-        // with invoke IDs nobody is waiting on and starve real responses until
-        // the reaper runs. Clause 5.4.4.1's IDLE state has no transition into
-        // SEGMENTED_CONF: it is entered only from SEGMENTED_REQUEST (5.4.4.2)
-        // or AWAIT_CONFIRMATION (5.4.4.3), both of which mean this device has
-        // a request outstanding.
+        // A reassembly session lives exactly as long as its transaction, so
+        // the TSM is consulted for EVERY segment, not only at session open.
+        // Clause 5.4's SEGMENTED_CONF is a state of the transaction itself:
+        // once the transaction ends — peer Abort/Error/Reject, or the caller
+        // cancelling on timeout — this device is in IDLE for that invoke ID,
+        // and 5.4.4.1 UnexpectedSegmentInfoReceived names this exact PDU as
+        // "an unexpected PDU indicating the existence of an active server
+        // TSM", prescribing an answer, not silence: "transmit a
+        // BACnet-Abort-PDU with 'server' = FALSE and 'abort-reason' =
+        // INVALID_APDU_IN_THIS_STATE and enter the IDLE state." A session
+        // whose transaction is gone is removed here rather than lingering to
+        // ack segments nobody is waiting on (#367). The per-open version of
+        // this gate also kept an unsolicited peer from occupying all 64
+        // session slots; requiring it per-segment keeps that property.
+        //
+        // Residual, deliberate: `release_invoke_id` drops a peer's allocator
+        // once every ID is free, so the caller's next request to this peer
+        // reuses the same invoke ID and a stale segment stream can alias
+        // onto the new pending transaction. This gate removes the orphaned
+        // session; it cannot tell that aliased stream from a genuine one.
         //
         // Bind the guard so its scope is obvious: it must not be held across
         // the send below, and an `if let` here would extend it silently.
         let transaction_pending = {
-            seg_state.contains_key(&key)
-                || tsm
-                    .lock()
-                    .await
-                    .expected_service_choice(&tsm_mac, ack.invoke_id)
-                    .is_some()
+            tsm.lock()
+                .await
+                .expected_service_choice(&tsm_mac, ack.invoke_id)
+                .is_some()
         };
         if !transaction_pending {
-            // Clause 5.4.4.1 UnexpectedSegmentInfoReceived names this exact
-            // PDU — "an unexpected PDU indicating the existence of an active
-            // server TSM (BACnet-ComplexACK-PDU with 'segmented-message' =
-            // TRUE ...)" — and prescribes an answer, not silence: "transmit a
-            // BACnet-Abort-PDU with 'server' = FALSE and 'abort-reason' =
-            // INVALID_APDU_IN_THIS_STATE and enter the IDLE state."
+            seg_state.remove(&key);
             debug!(
                 invoke_id = ack.invoke_id,
                 "Aborting segmented ComplexAck for a transaction that is not pending"
@@ -189,6 +185,18 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
             )
             .await;
+            return;
+        }
+
+        // Below the pending gate: a non-pending segment must draw the 5.4.4.1
+        // Abort above even when every session slot is occupied.
+        const MAX_CONCURRENT_SEG_SESSIONS: usize = 64;
+        if !seg_state.contains_key(&key) && seg_state.len() >= MAX_CONCURRENT_SEG_SESSIONS {
+            warn!(
+                invoke_id = ack.invoke_id,
+                sessions = seg_state.len(),
+                "Max concurrent segmented sessions reached, dropping segment"
+            );
             return;
         }
 
@@ -410,6 +418,11 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let mut window_size = self.config.proposed_window_size.max(1) as usize;
         let mut next_seq: usize = 0;
         let mut neg_ack_retries: u32 = 0;
+        // A local livelock bound with no counterpart in Clause 5.4.4.2, which
+        // bounds SEGMENTED_REQUEST only by SegmentTimer/Nretry and resets
+        // SegmentRetryCount on every in-window ack. Ten in-window NAKs in a
+        // row means a peer that keeps asking for the same window; cutting the
+        // transfer off is a local matter, like every bounded resource here.
         const MAX_NEG_ACK_RETRIES: u32 = 10;
 
         let result = async {
@@ -450,23 +463,35 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         match timeout(timeout_duration, seg_ack_rx.recv()).await {
                             Ok(Some(ack)) => {
                                 let ack_seq = ack.sequence_number as usize;
-                                if ack_seq >= total_segments {
-                                    return Err(Error::Segmentation(format!(
-                                        "SegmentAck sequence {} out of range (total {})",
-                                        ack_seq, total_segments
-                                    )));
-                                }
 
-                                let ack_in_current_window = if ack.negative_ack {
-                                    let resend_seq = if ack_seq == 0 && window_start == 0 {
-                                        0
-                                    } else {
-                                        ack_seq + 1
-                                    };
-                                    resend_seq >= window_start && resend_seq < window_end
-                                } else {
-                                    ack_seq >= window_start && ack_seq < window_end
-                                };
+                                // The sole gate on an inbound SegmentACK,
+                                // standing in for Clause 5.4.2.1's
+                                // InWindow(seqA, seqB). The 5.4.4.2 ack
+                                // transitions apply it without regard to the
+                                // 'negative-ack' flag: either flavor names
+                                // the last segment the peer accepted, and
+                                // either advances this side past it — a NAK
+                                // differs only in asking again for what
+                                // follows. (A NAK spelled as "resend from
+                                // here" has no source in 5.4.4.2; treating
+                                // sequence 0 that way made a lost first ack
+                                // unrecoverable: the retransmitted segment 0
+                                // draws NAK(0) from a live session, and
+                                // "resend segment 0" loops it forever.)
+                                // A sequence number outside the window —
+                                // including one at or past this request's
+                                // segment count, e.g. a duplicated ack from
+                                // an earlier transfer aliased onto a reused
+                                // invoke ID — is 5.4.4.2
+                                // DuplicateACK_Received: "restart
+                                // SegmentTimer and enter the
+                                // SEGMENTED_REQUEST state to await an
+                                // acknowledgment" — discard and keep
+                                // waiting, never a failure (#368). The
+                                // `continue` below re-enters the timeout
+                                // call, which is the SegmentTimer restart.
+                                let ack_in_current_window =
+                                    ack_seq >= window_start && ack_seq < window_end;
 
                                 if !ack_in_current_window {
                                     debug!(
@@ -535,6 +560,12 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 
                 window_size = ack.actual_window_size.max(1) as usize;
 
+                // Clause 5.4.4.2 gives positive and negative acks the same
+                // effect on the window: 'sequence-number' is the last segment
+                // the peer accepted, and this side continues from the one
+                // after it. The NAK counter is the only difference — a local
+                // livelock bound on a peer that keeps re-asking for the same
+                // window.
                 let ack_seq = ack.sequence_number as usize;
                 if ack.negative_ack {
                     neg_ack_retries += 1;
@@ -543,20 +574,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                             "too many negative SegmentAck retransmissions".into(),
                         ));
                     }
-                    // A first-window negative SegmentACK with sequence 0 is
-                    // ambiguous: it can mean segment 0 was the last accepted
-                    // segment, or that no segment has been accepted yet. Later
-                    // NAK 0 frames are stale for this window and are ignored
-                    // before reaching this branch.
-                    next_seq = if ack_seq == 0 && window_start == 0 {
-                        0
-                    } else {
-                        ack_seq + 1
-                    };
                 } else {
                     neg_ack_retries = 0;
-                    next_seq = ack_seq + 1;
                 }
+                next_seq = ack_seq + 1;
             }
 
             timeout(timeout_duration, rx)

--- a/crates/bacnet-client/src/client/segmentation_retransmit_tests.rs
+++ b/crates/bacnet-client/src/client/segmentation_retransmit_tests.rs
@@ -38,8 +38,13 @@ async fn recv_confirmed_segment(
     req
 }
 
+/// Clause 5.4.4.2's ack transitions never branch on the 'negative-ack'
+/// flag: NAK(0) names segment 0 as the last one accepted, so the client
+/// continues from segment 1. (The old reading — "resend from 0" — made a
+/// lost first ack unrecoverable: the retransmitted segment 0 draws NAK(0)
+/// from the peer's live session, and resending 0 loops forever.)
 #[tokio::test]
-async fn segmented_request_retransmits_segment_zero_after_negative_ack_zero() {
+async fn negative_ack_zero_advances_past_the_acknowledged_segment() {
     let client_mac = vec![0x01];
     let server_mac = vec![0x02];
     let (client_transport, mut server_transport) =
@@ -99,10 +104,10 @@ async fn segmented_request_retransmits_segment_zero_after_negative_ack_zero() {
     )
     .await;
 
-    for expected_seq in [0, 1] {
+    for expected_seq in [1, 2] {
         let received = timeout(Duration::from_secs(2), server_rx.recv())
             .await
-            .expect("server timed out waiting for retransmitted window segment")
+            .expect("server timed out waiting for the resumed window segment")
             .expect("server channel closed");
         let npdu = decode_npdu(received.npdu).unwrap();
         let decoded = apdu::decode_apdu(npdu.payload).unwrap();
@@ -120,44 +125,11 @@ async fn segmented_request_retransmits_segment_zero_after_negative_ack_zero() {
             negative_ack: false,
             sent_by_server: true,
             invoke_id,
-            sequence_number: 1,
+            sequence_number: 2,
             actual_window_size: 1,
         }),
     )
     .await;
-
-    loop {
-        let received = timeout(Duration::from_secs(2), server_rx.recv())
-            .await
-            .expect("server timed out waiting for remaining segment")
-            .expect("server channel closed");
-        let npdu = decode_npdu(received.npdu).unwrap();
-        let decoded = apdu::decode_apdu(npdu.payload).unwrap();
-        let Apdu::ConfirmedRequest(req) = decoded else {
-            panic!("Expected ConfirmedRequest, got {:?}", decoded);
-        };
-        assert_eq!(req.invoke_id, invoke_id);
-        let seq = req.sequence_number.unwrap();
-        assert!(seq >= 2);
-        let more_follows = req.more_follows;
-
-        send_local_response(
-            &server_transport,
-            &client_mac,
-            Apdu::SegmentAck(SegmentAck {
-                negative_ack: false,
-                sent_by_server: true,
-                invoke_id,
-                sequence_number: seq,
-                actual_window_size: 1,
-            }),
-        )
-        .await;
-
-        if !more_follows {
-            break;
-        }
-    }
 
     send_local_response(
         &server_transport,
@@ -298,4 +270,455 @@ async fn segmented_request_ignores_stale_negative_ack_zero_after_progress() {
     let result = request_task.await.unwrap();
     assert!(result.unwrap().is_empty());
     server_transport.stop().await.unwrap();
+}
+
+/// The peer stays quiet for `ms` — no retransmission, no new segment. Used
+/// after a stale ack that must be discarded without advancing anything.
+async fn expect_quiet(rx: &mut mpsc::Receiver<ReceivedNpdu>, ms: u64, context: &str) {
+    if let Ok(Some(received)) = timeout(Duration::from_millis(ms), rx.recv()).await {
+        let npdu = decode_npdu(received.npdu).unwrap();
+        let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+        panic!("{context}: expected no traffic, got {decoded:?}");
+    }
+}
+
+/// Common harness for the stale-SegmentAck tests (#368): a 100-byte payload
+/// at max-APDU 50 makes exactly three segments (44 + 44 + 12), window 2.
+async fn start_three_segment_request(
+    payload_len: usize,
+) -> (
+    tokio::task::JoinHandle<Result<bytes::Bytes, bacnet_types::error::Error>>,
+    LoopbackTransport,
+    mpsc::Receiver<ReceivedNpdu>,
+    Vec<u8>,
+    Vec<u8>,
+) {
+    let client_mac = vec![0x01];
+    let server_mac = vec![0x02];
+    let (client_transport, mut server_transport) =
+        LoopbackTransport::pair(client_mac.clone(), server_mac.clone());
+    let server_rx = server_transport.start().await.unwrap();
+
+    let config = ClientConfig {
+        apdu_timeout_ms: 2000,
+        apdu_retries: 0,
+        max_apdu_length: 50,
+        proposed_window_size: 2,
+        ..ClientConfig::default()
+    };
+    let mut client = BACnetClient::start(config, client_transport).await.unwrap();
+
+    let request_server_mac = server_mac.clone();
+    let service_data: Vec<u8> = (0..payload_len).map(|i| i as u8).collect();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request(
+                &request_server_mac,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+    (
+        request_task,
+        server_transport,
+        server_rx,
+        client_mac,
+        server_mac,
+    )
+}
+
+/// #368: a SegmentAck whose sequence number is at or past this request's
+/// segment count — a duplicated ack from an earlier transfer aliased onto a
+/// reused invoke ID — is Clause 5.4.4.2 DuplicateACK_Received: discard and
+/// keep waiting. Before the fix it failed the whole request with
+/// "sequence out of range".
+#[tokio::test]
+async fn stale_out_of_range_positive_ack_is_discarded() {
+    let (task, server_transport, mut rx, client_mac, _server_mac) =
+        start_three_segment_request(100).await;
+
+    let mut invoke_id = 0;
+    for expected_seq in [0, 1] {
+        let req = recv_confirmed_segment(&mut rx, "first window").await;
+        assert_eq!(req.sequence_number, Some(expected_seq));
+        invoke_id = req.invoke_id;
+    }
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 19,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    expect_quiet(&mut rx, 250, "after the out-of-range positive ack").await;
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 1,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    let req = recv_confirmed_segment(&mut rx, "final segment").await;
+    assert_eq!(req.sequence_number, Some(2));
+    assert!(!req.more_follows);
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 2,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+    task.await
+        .unwrap()
+        .expect("a stale out-of-range ack must not fail the request");
+}
+
+/// #368's companion: the stale ack in its negative flavor — before the fix it
+/// hit the same fatal range check before the window filter could discard it.
+#[tokio::test]
+async fn stale_out_of_range_negative_ack_is_discarded() {
+    let (task, server_transport, mut rx, client_mac, _server_mac) =
+        start_three_segment_request(100).await;
+
+    let mut invoke_id = 0;
+    for expected_seq in [0, 1] {
+        let req = recv_confirmed_segment(&mut rx, "first window").await;
+        assert_eq!(req.sequence_number, Some(expected_seq));
+        invoke_id = req.invoke_id;
+    }
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: true,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 19,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    expect_quiet(&mut rx, 250, "after the out-of-range negative ack").await;
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 1,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    let req = recv_confirmed_segment(&mut rx, "final segment").await;
+    assert_eq!(req.sequence_number, Some(2));
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 2,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+    task.await
+        .unwrap()
+        .expect("a stale out-of-range negative ack must not fail the request");
+}
+
+/// After #368's fix the window filter is the ONLY gate on an inbound
+/// SegmentAck, so its in-range-but-out-of-window discard is pinned here: a
+/// stale ack for sequence 0 while the send window is [2, 4) must not rewind
+/// `next_seq` (which would replay segment 1 and corrupt the strict sequence
+/// the peer asserts). Passed before the fix too — this is the
+/// vacuity guard the removal leans on.
+#[tokio::test]
+async fn stale_in_range_out_of_window_ack_is_discarded() {
+    // 260 bytes at max-APDU 50 → six segments (5 × 44 + 40), window 2.
+    let (task, server_transport, mut rx, client_mac, _server_mac) =
+        start_three_segment_request(260).await;
+
+    let mut invoke_id = 0;
+    for expected_seq in [0, 1] {
+        let req = recv_confirmed_segment(&mut rx, "window [0,2)").await;
+        assert_eq!(req.sequence_number, Some(expected_seq));
+        invoke_id = req.invoke_id;
+    }
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 1,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+
+    for expected_seq in [2, 3] {
+        let req = recv_confirmed_segment(&mut rx, "window [2,4)").await;
+        assert_eq!(req.sequence_number, Some(expected_seq));
+    }
+    // In range (0 < 6), out of window: must be discarded, not rewind to 1.
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 0,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    expect_quiet(&mut rx, 250, "after the out-of-window ack").await;
+
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 3,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    for expected_seq in [4, 5] {
+        let req = recv_confirmed_segment(&mut rx, "window [4,6)").await;
+        assert_eq!(req.sequence_number, Some(expected_seq));
+        if expected_seq == 5 {
+            assert!(!req.more_follows);
+        }
+    }
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 5,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+    task.await
+        .unwrap()
+        .expect("an out-of-window ack must not corrupt the transfer");
+}
+
+/// The lost-first-ack recovery loop, end to end: the client's ack for
+/// segment 0 goes missing, the client retransmits segment 0 on timeout, and
+/// the peer — whose session is live and has already accepted segment 0 —
+/// answers with NAK(0), exactly what this repo's server sends for a
+/// duplicate. Per Clause 5.4.4.2 the client must advance to segment 1; the
+/// old "resend from 0" reading looped NAK(0) → segment 0 forever until the
+/// NAK bound failed the transfer.
+#[tokio::test]
+async fn lost_first_ack_recovers_via_negative_ack_zero() {
+    let client_mac = vec![0x01];
+    let server_mac = vec![0x02];
+    let (client_transport, mut server_transport) =
+        LoopbackTransport::pair(client_mac.clone(), server_mac.clone());
+    let mut server_rx = server_transport.start().await.unwrap();
+
+    let config = ClientConfig {
+        apdu_timeout_ms: 300,
+        apdu_retries: 2,
+        max_apdu_length: 50,
+        proposed_window_size: 1,
+        ..ClientConfig::default()
+    };
+    let mut client = BACnetClient::start(config, client_transport).await.unwrap();
+
+    let request_server_mac = server_mac.clone();
+    let service_data: Vec<u8> = (0u8..100).collect();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request(
+                &request_server_mac,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    // Segment 0 arrives; the peer "loses" its ack by sending nothing.
+    let req = recv_confirmed_segment(&mut server_rx, "initial segment 0").await;
+    assert_eq!(req.sequence_number, Some(0));
+    let invoke_id = req.invoke_id;
+
+    // The client's SegmentTimer fires and retransmits segment 0; the peer's
+    // live session treats it as a duplicate and NAKs naming sequence 0.
+    let req = recv_confirmed_segment(&mut server_rx, "retransmitted segment 0").await;
+    assert_eq!(req.sequence_number, Some(0));
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: true,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 0,
+            actual_window_size: 1,
+        }),
+    )
+    .await;
+
+    // Recovery: the next segment must be 1, not another 0.
+    let mut seq = 1u8;
+    loop {
+        let req = recv_confirmed_segment(&mut server_rx, "post-recovery segment").await;
+        assert_eq!(req.sequence_number, Some(seq), "transfer must advance");
+        let more = req.more_follows;
+        send_local_response(
+            &server_transport,
+            &client_mac,
+            Apdu::SegmentAck(SegmentAck {
+                negative_ack: false,
+                sent_by_server: true,
+                invoke_id,
+                sequence_number: seq,
+                actual_window_size: 1,
+            }),
+        )
+        .await;
+        if !more {
+            break;
+        }
+        seq += 1;
+    }
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+    request_task
+        .await
+        .unwrap()
+        .expect("a lost first ack must be recoverable");
+}
+
+/// A NAK naming the last segment of the current window means "I have the
+/// whole window, continue" — Clause 5.4.2.1's InWindow accepts it, and the
+/// client must advance to the next window rather than discard it and stall
+/// into a timeout.
+#[tokio::test]
+async fn negative_ack_naming_last_of_window_advances_the_window() {
+    let (task, server_transport, mut rx, client_mac, _server_mac) =
+        start_three_segment_request(100).await;
+
+    let mut invoke_id = 0;
+    for expected_seq in [0, 1] {
+        let req = recv_confirmed_segment(&mut rx, "window [0,2)").await;
+        assert_eq!(req.sequence_number, Some(expected_seq));
+        invoke_id = req.invoke_id;
+    }
+    // NAK(1): sequence 1 is the last segment of the [0,2) window.
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: true,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 1,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+
+    let req = recv_confirmed_segment(&mut rx, "the window must advance to 2").await;
+    assert_eq!(req.sequence_number, Some(2));
+    assert!(!req.more_follows);
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 2,
+            actual_window_size: 2,
+        }),
+    )
+    .await;
+    send_local_response(
+        &server_transport,
+        &client_mac,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+    task.await
+        .unwrap()
+        .expect("a NAK naming the window's last segment must advance, not stall");
 }

--- a/crates/bacnet-client/src/client/segmented_receive_lifecycle_tests.rs
+++ b/crates/bacnet-client/src/client/segmented_receive_lifecycle_tests.rs
@@ -1,0 +1,432 @@
+//! A reassembly session lives exactly as long as its transaction (#367).
+//!
+//! Clause 5.4.4.4 SEGMENTED_CONF ends by AbortPDU_Received (peer Abort with
+//! 'server' = TRUE), by UnexpectedPDU_Received (Error and Reject PDUs are in
+//! its list), or locally — and every ending is "enter the IDLE state", where
+//! 5.4.4.1 answers further segments with Abort INVALID_APDU_IN_THIS_STATE.
+//! Before #367's fix, none of those endings removed the `seg_state` entry, so
+//! the client kept acking segments of a transaction that no longer existed.
+//!
+//! The tests run a real client over a loopback pair; the test plays the
+//! server. Wall-clock discipline: each test finishes well inside the 4 s
+//! reassembly reaper, and the caller-timeout test asserts the Abort reason so
+//! a reaper eviction (TSM_TIMEOUT) cannot satisfy it for the wrong cause.
+
+use bacnet_encoding::apdu::{self, encode_apdu, AbortPdu, Apdu, ComplexAck, ErrorPdu, RejectPdu};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_types::enums::{
+    AbortReason, ConfirmedServiceChoice, ErrorClass, ErrorCode, RejectReason,
+};
+use bacnet_types::error::Error;
+use bytes::{Bytes, BytesMut};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Duration};
+
+use super::{BACnetClient, ClientConfig};
+
+const CLIENT_MAC: &[u8] = &[0x01];
+const SERVER_MAC: &[u8] = &[0x02];
+
+async fn send_to_client<T: TransportPort>(transport: &T, apdu: &Apdu) {
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, apdu).expect("valid APDU encoding");
+    let npdu = Npdu {
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu).unwrap();
+    transport.send_unicast(&npdu_buf, CLIENT_MAC).await.unwrap();
+}
+
+async fn recv_apdu(rx: &mut mpsc::Receiver<ReceivedNpdu>, context: &str) -> Apdu {
+    let received = timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{context}: timed out waiting for a PDU"))
+        .unwrap_or_else(|| panic!("{context}: channel closed"));
+    let npdu = decode_npdu(received.npdu).unwrap();
+    apdu::decode_apdu(npdu.payload).unwrap()
+}
+
+fn response_segment(invoke_id: u8, seq: u8, more_follows: bool, data: &[u8]) -> Apdu {
+    Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows,
+        invoke_id,
+        sequence_number: Some(seq),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::copy_from_slice(data),
+    })
+}
+
+/// Start a client, issue a ReadProperty, and hand back the peer side with the
+/// request's invoke ID already consumed from the stream.
+async fn start_reassembly(
+    config: ClientConfig,
+) -> (
+    JoinHandle<(BACnetClient<LoopbackTransport>, Result<Bytes, Error>)>,
+    LoopbackTransport,
+    mpsc::Receiver<ReceivedNpdu>,
+    u8,
+) {
+    let (client_transport, mut server_transport) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), SERVER_MAC.to_vec());
+    let mut server_rx = server_transport.start().await.unwrap();
+    let mut client = BACnetClient::start(config, client_transport).await.unwrap();
+
+    // The client rides along in the task's return value: several tests need
+    // it alive (and its dispatch loop running) after the caller has already
+    // returned, so it is stopped by the test, never by the task.
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request(
+                SERVER_MAC,
+                ConfirmedServiceChoice::READ_PROPERTY,
+                &[0x0C; 8],
+            )
+            .await;
+        (client, result)
+    });
+
+    let invoke_id = match recv_apdu(&mut server_rx, "the ReadProperty request").await {
+        Apdu::ConfirmedRequest(req) => {
+            assert!(!req.segmented);
+            req.invoke_id
+        }
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    };
+    (request_task, server_transport, server_rx, invoke_id)
+}
+
+async fn expect_segment_ack(rx: &mut mpsc::Receiver<ReceivedNpdu>, invoke_id: u8, seq: u8) {
+    match recv_apdu(rx, &format!("ack for response segment {seq}")).await {
+        Apdu::SegmentAck(ack) => {
+            assert!(!ack.negative_ack);
+            assert!(!ack.sent_by_server, "a client's SegmentAck is server=FALSE");
+            assert_eq!(ack.invoke_id, invoke_id);
+            assert_eq!(ack.sequence_number, seq);
+        }
+        other => panic!("expected SegmentAck for segment {seq}, got {other:?}"),
+    }
+}
+
+async fn expect_client_abort(rx: &mut mpsc::Receiver<ReceivedNpdu>, invoke_id: u8, context: &str) {
+    match recv_apdu(rx, context).await {
+        Apdu::Abort(abort) => {
+            assert!(
+                !abort.sent_by_server,
+                "{context}: a client's Abort is server=FALSE"
+            );
+            assert_eq!(abort.invoke_id, invoke_id, "{context}");
+            assert_eq!(
+                abort.abort_reason,
+                AbortReason::INVALID_APDU_IN_THIS_STATE,
+                "{context}"
+            );
+        }
+        other => panic!("{context}: expected Abort, got {other:?}"),
+    }
+}
+
+/// #367's failure case: the peer Aborts mid-reassembly, then keeps sending.
+/// The session must die with the transaction — a further segment draws the
+/// 5.4.4.1 Abort, never a SegmentAck.
+#[tokio::test]
+async fn peer_abort_ends_the_reassembly_session() {
+    let (task, server, mut rx, invoke_id) = start_reassembly(ClientConfig::default()).await;
+
+    send_to_client(&server, &response_segment(invoke_id, 0, true, &[0x01; 8])).await;
+    expect_segment_ack(&mut rx, invoke_id, 0).await;
+
+    send_to_client(
+        &server,
+        &Apdu::Abort(AbortPdu {
+            sent_by_server: true,
+            invoke_id,
+            abort_reason: AbortReason::BUFFER_OVERFLOW,
+        }),
+    )
+    .await;
+
+    send_to_client(&server, &response_segment(invoke_id, 1, true, &[0x02; 8])).await;
+    expect_client_abort(&mut rx, invoke_id, "a segment after the peer's Abort").await;
+
+    let (mut client, result) = timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap();
+    match result {
+        Err(Error::Abort { reason }) => {
+            assert_eq!(reason, AbortReason::BUFFER_OVERFLOW.to_raw())
+        }
+        other => panic!("expected Err(Abort), got {other:?}"),
+    }
+    client.stop().await.unwrap();
+}
+
+/// An Error PDU mid-reassembly is Clause 5.4.4.4 UnexpectedPDU_Received: the
+/// peer gets an Abort, the caller gets the ABORT.indication — not the error
+/// content — and the session ends.
+#[tokio::test]
+async fn error_pdu_mid_reassembly_aborts_the_transfer() {
+    let (task, server, mut rx, invoke_id) = start_reassembly(ClientConfig::default()).await;
+
+    send_to_client(&server, &response_segment(invoke_id, 0, true, &[0x01; 8])).await;
+    expect_segment_ack(&mut rx, invoke_id, 0).await;
+
+    send_to_client(
+        &server,
+        &Apdu::Error(ErrorPdu {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+            error_class: ErrorClass::DEVICE,
+            error_code: ErrorCode::OPERATIONAL_PROBLEM,
+            error_data: Bytes::new(),
+        }),
+    )
+    .await;
+    expect_client_abort(&mut rx, invoke_id, "the Error PDU mid-reassembly").await;
+
+    let (mut client, result) = timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap();
+    match result {
+        Err(Error::Abort { reason }) => {
+            assert_eq!(reason, AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw())
+        }
+        other => panic!("expected Err(Abort), got {other:?}"),
+    }
+    client.stop().await.unwrap();
+}
+
+/// A Reject PDU mid-reassembly takes the same UnexpectedPDU_Received path as
+/// an Error — a separate arm in dispatch, so a separate test.
+#[tokio::test]
+async fn reject_pdu_mid_reassembly_aborts_the_transfer() {
+    let (task, server, mut rx, invoke_id) = start_reassembly(ClientConfig::default()).await;
+
+    send_to_client(&server, &response_segment(invoke_id, 0, true, &[0x01; 8])).await;
+    expect_segment_ack(&mut rx, invoke_id, 0).await;
+
+    send_to_client(
+        &server,
+        &Apdu::Reject(RejectPdu {
+            invoke_id,
+            reject_reason: RejectReason::UNRECOGNIZED_SERVICE,
+        }),
+    )
+    .await;
+    expect_client_abort(&mut rx, invoke_id, "the Reject PDU mid-reassembly").await;
+
+    let (mut client, result) = timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap();
+    match result {
+        Err(Error::Abort { reason }) => {
+            assert_eq!(reason, AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw())
+        }
+        other => panic!("expected Err(Abort), got {other:?}"),
+    }
+    client.stop().await.unwrap();
+}
+
+/// The guard order inside the Abort arm: an Abort with 'server' = FALSE — an
+/// echo of this client's own — must NOT tear down the reassembly. Clause
+/// 5.4.4.4 AbortPDU_Received fires only for 'server' = TRUE.
+#[tokio::test]
+async fn echoed_client_abort_does_not_end_the_session() {
+    let (task, server, mut rx, invoke_id) = start_reassembly(ClientConfig::default()).await;
+
+    send_to_client(&server, &response_segment(invoke_id, 0, true, &[0x01; 8])).await;
+    expect_segment_ack(&mut rx, invoke_id, 0).await;
+
+    send_to_client(
+        &server,
+        &Apdu::Abort(AbortPdu {
+            sent_by_server: false,
+            invoke_id,
+            abort_reason: AbortReason::OTHER,
+        }),
+    )
+    .await;
+
+    send_to_client(&server, &response_segment(invoke_id, 1, false, &[0x02; 8])).await;
+    expect_segment_ack(&mut rx, invoke_id, 1).await;
+
+    let (mut client, result) = timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap();
+    let payload = result.expect("the transfer must survive an echoed client Abort");
+    assert_eq!(&payload[..], &[[0x01u8; 8].as_slice(), &[0x02; 8]].concat());
+    client.stop().await.unwrap();
+}
+
+/// The diversion is keyed on a live reassembly session ONLY: an ordinary
+/// Error or Reject answering an unsegmented exchange must still surface as
+/// itself. Guards against the diversion going unconditional.
+#[tokio::test]
+async fn error_and_reject_without_a_session_surface_as_themselves() {
+    let (task, server, _rx, invoke_id) = start_reassembly(ClientConfig::default()).await;
+    send_to_client(
+        &server,
+        &Apdu::Error(ErrorPdu {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+            error_class: ErrorClass::PROPERTY,
+            error_code: ErrorCode::UNKNOWN_PROPERTY,
+            error_data: Bytes::new(),
+        }),
+    )
+    .await;
+    let (mut client, result) = timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap();
+    match result {
+        Err(Error::Protocol { class, code }) => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(code, ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32);
+        }
+        other => panic!("expected Err(Protocol), got {other:?}"),
+    }
+    client.stop().await.unwrap();
+
+    let (task, server, _rx, invoke_id) = start_reassembly(ClientConfig::default()).await;
+    send_to_client(
+        &server,
+        &Apdu::Reject(RejectPdu {
+            invoke_id,
+            reject_reason: RejectReason::BUFFER_OVERFLOW,
+        }),
+    )
+    .await;
+    let (mut client, result) = timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap();
+    match result {
+        Err(Error::Reject { reason }) => {
+            assert_eq!(reason, RejectReason::BUFFER_OVERFLOW.to_raw())
+        }
+        other => panic!("expected Err(Reject), got {other:?}"),
+    }
+    client.stop().await.unwrap();
+}
+
+/// The caller giving up is the fourth way a transaction ends. After
+/// `cancel_transaction`, the next segment must find no pending transaction
+/// and draw the 5.4.4.1 Abort. The reason assertion matters: a reaper
+/// eviction would answer TSM_TIMEOUT, and the whole test stays far under the
+/// reaper's 4 s so only the transaction gate can produce this Abort.
+#[tokio::test]
+async fn caller_timeout_ends_the_reassembly_session() {
+    let config = ClientConfig {
+        apdu_timeout_ms: 300,
+        apdu_retries: 0,
+        ..ClientConfig::default()
+    };
+    let (task, server, mut rx, invoke_id) = start_reassembly(config).await;
+
+    send_to_client(&server, &response_segment(invoke_id, 0, true, &[0x01; 8])).await;
+    expect_segment_ack(&mut rx, invoke_id, 0).await;
+
+    // Past the caller's 300 ms timeout; it cancels the transaction. The
+    // client itself stays up — the session must be ended by the transaction
+    // gate, not by the client shutting down.
+    let (mut client, result) = timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap();
+    match result {
+        Err(Error::Timeout(_)) => {}
+        other => panic!("expected Err(Timeout), got {other:?}"),
+    }
+
+    send_to_client(&server, &response_segment(invoke_id, 1, true, &[0x02; 8])).await;
+    expect_client_abort(&mut rx, invoke_id, "a segment after the caller timed out").await;
+    client.stop().await.unwrap();
+}
+
+/// A SimpleAck mid-reassembly is in the same Clause 5.4.4.4
+/// UnexpectedPDU_Received list as Error and Reject: the segmented ComplexACK
+/// under reassembly IS this transaction's answer, so a second answer aborts
+/// the transfer rather than completing it.
+#[tokio::test]
+async fn simple_ack_mid_reassembly_aborts_the_transfer() {
+    let (task, server, mut rx, invoke_id) = start_reassembly(ClientConfig::default()).await;
+
+    send_to_client(&server, &response_segment(invoke_id, 0, true, &[0x01; 8])).await;
+    expect_segment_ack(&mut rx, invoke_id, 0).await;
+
+    send_to_client(
+        &server,
+        &Apdu::SimpleAck(bacnet_encoding::apdu::SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        }),
+    )
+    .await;
+    expect_client_abort(&mut rx, invoke_id, "the SimpleAck mid-reassembly").await;
+
+    let (mut client, result) = timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap();
+    match result {
+        Err(Error::Abort { reason }) => {
+            assert_eq!(reason, AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw())
+        }
+        other => panic!("expected Err(Abort), got {other:?}"),
+    }
+    client.stop().await.unwrap();
+}
+
+/// "BACnet-ComplexACK-PDU with 'segmented-message' = FALSE" is also in the
+/// Clause 5.4.4.4 UnexpectedPDU_Received list — it must not complete the
+/// transaction with its own content while segments are outstanding.
+#[tokio::test]
+async fn unsegmented_complex_ack_mid_reassembly_aborts_the_transfer() {
+    let (task, server, mut rx, invoke_id) = start_reassembly(ClientConfig::default()).await;
+
+    send_to_client(&server, &response_segment(invoke_id, 0, true, &[0x01; 8])).await;
+    expect_segment_ack(&mut rx, invoke_id, 0).await;
+
+    send_to_client(
+        &server,
+        &Apdu::ComplexAck(ComplexAck {
+            segmented: false,
+            more_follows: false,
+            invoke_id,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+            service_ack: Bytes::from_static(&[0xEE; 4]),
+        }),
+    )
+    .await;
+    expect_client_abort(
+        &mut rx,
+        invoke_id,
+        "the unsegmented ComplexAck mid-reassembly",
+    )
+    .await;
+
+    let (mut client, result) = timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap();
+    match result {
+        Err(Error::Abort { reason }) => {
+            assert_eq!(reason, AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw())
+        }
+        other => panic!("expected Err(Abort), got {other:?}"),
+    }
+    client.stop().await.unwrap();
+}

--- a/crates/bacnet-integration-tests/tests/server.rs
+++ b/crates/bacnet-integration-tests/tests/server.rs
@@ -12,6 +12,7 @@ use bacnet_server::server::BACnetServer;
 use bacnet_transport::bip::BipTransport;
 use bacnet_types::enums::{
     AbortReason, ConfirmedServiceChoice, NetworkPriority, ObjectType, PropertyIdentifier,
+    Segmentation,
 };
 use bacnet_types::primitives::ObjectIdentifier;
 use bacnet_types::MacAddr;
@@ -56,6 +57,13 @@ async fn make_server() -> BACnetServer<BipTransport> {
         .interface(Ipv4Addr::LOCALHOST)
         .port(0) // ephemeral
         .broadcast_address(Ipv4Addr::LOCALHOST)
+        // The segmentation_rx/segmentation_tx suites in this harness
+        // exercise segmented reception and transmission, and the dispatch
+        // loop now enforces the advertisement (Clause 5.4.5.1/5.4.5.3), so
+        // this shared fixture advertises both. The other suites are
+        // indifferent to it beyond the I-Am/Device property now saying
+        // SEGMENTED_BOTH.
+        .segmentation_supported(Segmentation::BOTH)
         .database(db)
         .build()
         .await

--- a/crates/bacnet-integration-tests/tests/server/segmentation_tx.rs
+++ b/crates/bacnet-integration-tests/tests/server/segmentation_tx.rs
@@ -49,6 +49,9 @@ async fn server_segments_large_rpm_response() {
     let mut server = BACnetServer::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
         .port(0)
+        // The transmit side is gated on the advertisement too (Clause
+        // 5.4.5.3 case (a)): segmenting the response requires saying so.
+        .segmentation_supported(Segmentation::BOTH)
         .database(db)
         .build()
         .await

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -80,6 +80,23 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     Ok(decoded) => {
                         let source_mac = received.source_mac.clone();
                         let source_network = received.source_network.clone();
+
+                        // Clause 5.4.5.2 AbortPDU_Received: a peer's Abort
+                        // ('server' = FALSE) ends any reassembly session for
+                        // its transaction. A side effect, not a short
+                        // circuit — the PDU still reaches `dispatch`, whose
+                        // Abort arm cancels in-flight segmented response
+                        // senders and records server-TSM results (#377).
+                        if let Apdu::Abort(ref abt) = decoded {
+                            if !abt.sent_by_server {
+                                seg_receivers.remove(&(
+                                    source_mac.clone(),
+                                    source_network.clone(),
+                                    abt.invoke_id,
+                                ));
+                            }
+                        }
+
                         let mut received = Some(received);
                         let handled = if let Apdu::ConfirmedRequest(ref req) = decoded {
                             if req.segmented {
@@ -87,10 +104,138 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 let key: SegKey =
                                     (source_mac.clone(), source_network.clone(), req.invoke_id);
 
+                                // Clause 5.4.5.1
+                                // ConfirmedSegmentedReceivedNotSupported: a
+                                // device that does not support segmented
+                                // reception answers segment traffic with this
+                                // Abort instead of reassembling — the
+                                // configured Segmentation value is the
+                                // advertisement peers plan transfers around
+                                // (#381).
+                                let receives_segments = config_dispatch.segmentation_supported
+                                    == Segmentation::BOTH
+                                    || config_dispatch.segmentation_supported
+                                        == Segmentation::RECEIVE;
+                                if !receives_segments {
+                                    Self::send_server_abort(
+                                        &network_dispatch,
+                                        &source_mac,
+                                        source_network.as_ref(),
+                                        req.invoke_id,
+                                        AbortReason::SEGMENTATION_NOT_SUPPORTED,
+                                    )
+                                    .await;
+                                    continue;
+                                }
+
                                 let mut ack_to_send: Option<SegmentAckPdu> = None;
                                 let mut final_total: Option<usize> = None;
 
-                                if seq == 0 {
+                                // The live session is consulted before the
+                                // `seq == 0` open path: Clause 20.1.2.7 wraps
+                                // the sequence number modulo 256, so segment
+                                // 256 of a long request arrives as another
+                                // `seq == 0` — treating it as a fresh initial
+                                // segment would silently replace the session
+                                // and reassemble only the tail (#364).
+                                if let Some(state) = seg_receivers.get_mut(&key) {
+                                    // Clause 5.4.5.2 restarts SegmentTimer
+                                    // for accepted, duplicate and
+                                    // out-of-order segments alike, so the
+                                    // refresh precedes the ordering checks.
+                                    state.last_activity = Instant::now();
+                                    if seq != state.expected_seq {
+                                        warn!(
+                                            invoke_id = req.invoke_id,
+                                            expected = state.expected_seq,
+                                            received = seq,
+                                            "Segment gap detected, sending negative SegmentAck"
+                                        );
+                                        ack_to_send = Some(SegmentAckPdu {
+                                            negative_ack: true,
+                                            sent_by_server: true,
+                                            invoke_id: req.invoke_id,
+                                            sequence_number: state.last_acked_seq,
+                                            actual_window_size: state.actual_window_size,
+                                        });
+                                    } else {
+                                        // In-order NEW segment: duplicates
+                                        // and gaps returned above, so a
+                                        // retransmission can never trip the
+                                        // cap (Clause 5.4.5.2
+                                        // DuplicateSegmentReceived requires
+                                        // duplicates be discarded, not
+                                        // punished).
+                                        if state.accepted_segments >= MAX_REQUEST_SEGMENTS {
+                                            // Clause 5.4.5.2 has no overflow
+                                            // transition; SendAbort ('server'
+                                            // = TRUE, reason a local matter)
+                                            // is its one generic escape, and
+                                            // Clause 18.10's BUFFER_OVERFLOW
+                                            // — "a buffer capacity has been
+                                            // exceeded" — is the fit (#364).
+                                            warn!(
+                                                invoke_id = req.invoke_id,
+                                                accepted = state.accepted_segments,
+                                                "Segmented request exceeds reassembly capacity, aborting"
+                                            );
+                                            seg_receivers.remove(&key);
+                                            Self::send_server_abort(
+                                                &network_dispatch,
+                                                &source_mac,
+                                                source_network.as_ref(),
+                                                req.invoke_id,
+                                                AbortReason::BUFFER_OVERFLOW,
+                                            )
+                                            .await;
+                                            continue;
+                                        }
+                                        if let Err(e) =
+                                            state.receiver.receive(seq, req.service_request.clone())
+                                        {
+                                            // An unsaveable segment ends the
+                                            // session the same way — leaving
+                                            // it dangling told the peer
+                                            // nothing while this side could
+                                            // never complete (#364).
+                                            warn!(error = %e, "Rejecting oversized segment");
+                                            seg_receivers.remove(&key);
+                                            Self::send_server_abort(
+                                                &network_dispatch,
+                                                &source_mac,
+                                                source_network.as_ref(),
+                                                req.invoke_id,
+                                                AbortReason::BUFFER_OVERFLOW,
+                                            )
+                                            .await;
+                                            continue;
+                                        }
+                                        state.accepted_segments += 1;
+                                        state.expected_seq = seq.wrapping_add(1);
+                                        state.last_acked_seq = seq;
+                                        state.window_pos += 1;
+                                        let should_ack = !req.more_follows
+                                            || state.window_pos >= state.actual_window_size;
+                                        if should_ack {
+                                            state.window_pos = 0;
+                                            ack_to_send = Some(SegmentAckPdu {
+                                                negative_ack: false,
+                                                sent_by_server: true,
+                                                invoke_id: req.invoke_id,
+                                                sequence_number: seq,
+                                                actual_window_size: state.actual_window_size,
+                                            });
+                                        }
+                                        if !req.more_follows {
+                                            // The count, not `seq + 1`: the
+                                            // wire sequence number is modulo
+                                            // 256 (Clause 20.1.2.7) and says
+                                            // nothing about how many segments
+                                            // were accepted (#364).
+                                            final_total = Some(state.accepted_segments);
+                                        }
+                                    }
+                                } else if seq == 0 {
                                     let proposed_window_size =
                                         req.proposed_window_size.unwrap_or(0);
                                     if !(1..=127).contains(&proposed_window_size) {
@@ -99,40 +244,27 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 	                                            proposed_window_size,
 	                                            "Rejecting segmented request with invalid proposed window size"
 	                                        );
-                                        let abort_pdu = Apdu::Abort(AbortPdu {
-                                            sent_by_server: true,
-                                            invoke_id: req.invoke_id,
-                                            abort_reason: AbortReason::WINDOW_SIZE_OUT_OF_RANGE,
-                                        });
-                                        let mut abort_buf = BytesMut::new();
-                                        encode_apdu(&mut abort_buf, &abort_pdu)
-                                            .expect("valid APDU encoding");
-                                        let _ = Self::send_confirmed_response_apdu(
+                                        Self::send_server_abort(
                                             &network_dispatch,
-                                            &abort_buf,
                                             &source_mac,
                                             source_network.as_ref(),
+                                            req.invoke_id,
+                                            AbortReason::WINDOW_SIZE_OUT_OF_RANGE,
                                         )
                                         .await;
                                         continue;
                                     }
 
-                                    if !seg_receivers.contains_key(&key)
-                                        && seg_receivers.len() >= MAX_SEG_RECEIVERS
-                                    {
-                                        let abort_pdu = Apdu::Abort(AbortPdu {
-                                            sent_by_server: true,
-                                            invoke_id: req.invoke_id,
-                                            abort_reason: AbortReason::BUFFER_OVERFLOW,
-                                        });
-                                        let mut abort_buf = BytesMut::new();
-                                        encode_apdu(&mut abort_buf, &abort_pdu)
-                                            .expect("valid APDU encoding");
-                                        let _ = Self::send_confirmed_response_apdu(
+                                    // This path runs only when no session
+                                    // exists for the key, so the map length
+                                    // is the whole capacity check.
+                                    if seg_receivers.len() >= MAX_SEG_RECEIVERS {
+                                        Self::send_server_abort(
                                             &network_dispatch,
-                                            &abort_buf,
                                             &source_mac,
                                             source_network.as_ref(),
+                                            req.invoke_id,
+                                            AbortReason::BUFFER_OVERFLOW,
                                         )
                                         .await;
                                         continue;
@@ -142,7 +274,19 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                     if let Err(e) =
                                         receiver.receive(seq, req.service_request.clone())
                                     {
+                                        // No session exists to drop on this
+                                        // path; the Abort is what tells the
+                                        // peer instead of leaving it to time
+                                        // out (#364).
                                         warn!(error = %e, "Rejecting oversized segment");
+                                        Self::send_server_abort(
+                                            &network_dispatch,
+                                            &source_mac,
+                                            source_network.as_ref(),
+                                            req.invoke_id,
+                                            AbortReason::BUFFER_OVERFLOW,
+                                        )
+                                        .await;
                                         continue;
                                     }
                                     let actual_window_size = proposed_window_size;
@@ -154,6 +298,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                         last_acked_seq: 0,
                                         window_pos: 1,
                                         actual_window_size,
+                                        accepted_segments: 1,
                                     };
                                     let should_ack =
                                         !req.more_follows || state.window_pos >= actual_window_size;
@@ -171,67 +316,18 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                         final_total = Some(1);
                                     }
                                     seg_receivers.insert(key.clone(), state);
-                                } else if let Some(state) = seg_receivers.get_mut(&key) {
-                                    state.last_activity = Instant::now();
-                                    if seq != state.expected_seq {
-                                        warn!(
-                                            invoke_id = req.invoke_id,
-                                            expected = state.expected_seq,
-                                            received = seq,
-                                            "Segment gap detected, sending negative SegmentAck"
-                                        );
-                                        ack_to_send = Some(SegmentAckPdu {
-                                            negative_ack: true,
-                                            sent_by_server: true,
-                                            invoke_id: req.invoke_id,
-                                            sequence_number: state.last_acked_seq,
-                                            actual_window_size: state.actual_window_size,
-                                        });
-                                    } else {
-                                        if let Err(e) =
-                                            state.receiver.receive(seq, req.service_request.clone())
-                                        {
-                                            warn!(error = %e, "Rejecting oversized segment");
-                                            continue;
-                                        }
-                                        state.expected_seq = seq.wrapping_add(1);
-                                        state.last_acked_seq = seq;
-                                        state.window_pos += 1;
-                                        let should_ack = !req.more_follows
-                                            || state.window_pos >= state.actual_window_size;
-                                        if should_ack {
-                                            state.window_pos = 0;
-                                            ack_to_send = Some(SegmentAckPdu {
-                                                negative_ack: false,
-                                                sent_by_server: true,
-                                                invoke_id: req.invoke_id,
-                                                sequence_number: seq,
-                                                actual_window_size: state.actual_window_size,
-                                            });
-                                        }
-                                        if !req.more_follows {
-                                            final_total = Some(seq as usize + 1);
-                                        }
-                                    }
                                 } else {
                                     warn!(
 	                                        invoke_id = req.invoke_id,
 	                                        seq = seq,
 	                                        "Received non-initial segment without prior segment 0, aborting"
 	                                    );
-                                    let abort_pdu = Apdu::Abort(AbortPdu {
-                                        sent_by_server: true,
-                                        invoke_id: req.invoke_id,
-                                        abort_reason: AbortReason::INVALID_APDU_IN_THIS_STATE,
-                                    });
-                                    let mut abort_buf = BytesMut::new();
-                                    encode_apdu(&mut abort_buf, &abort_pdu)
-                                        .expect("valid APDU encoding");
-                                    let _ = Self::send_confirmed_response_apdu(
+                                    Self::send_server_abort(
                                         &network_dispatch,
-                                        &abort_buf,
                                         &source_mac,
                                         source_network.as_ref(),
+                                        req.invoke_id,
+                                        AbortReason::INVALID_APDU_IN_THIS_STATE,
                                     )
                                     .await;
                                     continue;
@@ -560,6 +656,34 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             intrinsic_reporting_task,
             local_mac,
         })
+    }
+
+    /// Send a `'server' = TRUE` Abort back along the request's path.
+    ///
+    /// Every Abort this dispatch loop originates answers a client's request,
+    /// so the flag is always TRUE — it names the sender's role, not the
+    /// error (Clause 20.1.9.1: "TRUE when the Abort PDU is sent by a
+    /// server").
+    async fn send_server_abort(
+        network: &Arc<NetworkLayer<T>>,
+        source_mac: &MacAddr,
+        source_network: Option<&NpduAddress>,
+        invoke_id: u8,
+        abort_reason: AbortReason,
+    ) {
+        let abort_pdu = Apdu::Abort(AbortPdu {
+            sent_by_server: true,
+            invoke_id,
+            abort_reason,
+        });
+        let mut abort_buf = BytesMut::new();
+        encode_apdu(&mut abort_buf, &abort_pdu).expect("valid APDU encoding");
+        if let Err(e) =
+            Self::send_confirmed_response_apdu(network, &abort_buf, source_mac, source_network)
+                .await
+        {
+            warn!(error = %e, reason = abort_reason.to_raw(), "Failed to send Abort");
+        }
     }
 
     /// Get the server's local MAC address.

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -55,6 +55,21 @@ use crate::handlers;
 /// Maximum number of concurrent segmented reassembly sessions.
 const MAX_SEG_RECEIVERS: usize = 128;
 
+/// Hard per-request reassembly ceiling: the sequence-number space (#364).
+///
+/// A local storage bound, not a protocol one. Clause 20.1.2.7 makes the
+/// request sequence number modulo 256, so a longer request is entirely
+/// representable on the wire — this server simply keys its segment store by
+/// that `u8` and cannot tell segment 256 from segment 0. The Device object
+/// does publish a tighter advertisement — its `Max_Segments_Accepted`
+/// (Clause 12.11) defaults to `Unsigned(65)` — but enforcing it here is
+/// deliberately not done: accepting more segments than advertised is
+/// permissive, not a violation, while the sequence space is the line past
+/// which acceptance silently corrupts. Exactly 256 segments reassemble
+/// correctly and must keep working; 257 is the first that would corrupt the
+/// payload.
+const MAX_REQUEST_SEGMENTS: usize = 256;
+
 /// Maximum number of concurrent segmented response send sessions.
 const MAX_SEG_SENDERS: usize = 128;
 
@@ -182,6 +197,14 @@ pub struct ServerConfig {
     /// Maximum APDU length accepted.
     pub max_apdu_length: u32,
     /// Segmentation support level.
+    ///
+    /// Enforced, not just advertised: the dispatch loop reassembles inbound
+    /// segmented requests only under `BOTH`/`RECEIVE` and transmits
+    /// segmented responses only under `BOTH`/`TRANSMIT` (Clauses 5.4.5.1 and
+    /// 5.4.5.3); anything else draws a SEGMENTATION_NOT_SUPPORTED Abort. The
+    /// default is `NONE`, so a default-configured server refuses segmented
+    /// traffic in both directions — set this to what the device should
+    /// actually honor.
     pub segmentation_supported: Segmentation,
     /// Vendor identifier.
     pub vendor_id: u16,
@@ -345,6 +368,17 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
         self
     }
 
+    /// Set the segmentation support this device advertises and enforces.
+    ///
+    /// The dispatch loop honors the advertisement (Clause 5.4.5.1): inbound
+    /// segmented requests are reassembled only under `BOTH` or `RECEIVE`, and
+    /// draw a SEGMENTATION_NOT_SUPPORTED Abort otherwise. The default is
+    /// `NONE`.
+    pub fn segmentation_supported(mut self, segmentation: Segmentation) -> Self {
+        self.config.segmentation_supported = segmentation;
+        self
+    }
+
     /// Set the vendor identifier (used in IAm responses and protocol operations).
     pub fn vendor_id(mut self, id: u16) -> Self {
         self.config.vendor_id = id;
@@ -422,6 +456,17 @@ impl BipServerBuilder {
     /// (default 10).
     pub fn event_enrollment_interval_secs(mut self, secs: u64) -> Self {
         self.config.event_enrollment_interval_secs = secs;
+        self
+    }
+
+    /// Set the segmentation support this device advertises and enforces.
+    ///
+    /// The dispatch loop honors the advertisement (Clause 5.4.5.1): inbound
+    /// segmented requests are reassembled only under `BOTH` or `RECEIVE`, and
+    /// draw a SEGMENTATION_NOT_SUPPORTED Abort otherwise. The default is
+    /// `NONE`.
+    pub fn segmentation_supported(mut self, segmentation: Segmentation) -> Self {
+        self.config.segmentation_supported = segmentation;
         self
     }
 
@@ -537,6 +582,15 @@ struct SegmentedRequestState {
     last_acked_seq: u8,
     window_pos: u8,
     actual_window_size: u8,
+    /// Monotonic count of segments accepted in order (#364).
+    ///
+    /// The reassembly total. `expected_seq` cannot serve: Clause 20.1.2.7
+    /// makes the sequence number modulo 256, so a 260-segment request ends at
+    /// sequence 3 and `seq + 1` names a four-segment total. This counter also
+    /// carries the overrun cap — acceptance is strictly in order, so it
+    /// reaches [`MAX_REQUEST_SEGMENTS`] exactly when the sequence number is
+    /// about to wrap onto stored segment 0.
+    accepted_segments: usize,
 }
 
 /// BACnet server with APDU dispatch and service handling.
@@ -650,6 +704,17 @@ impl ScServerBuilder {
     /// Set the hub WebSocket URL (e.g. `wss://hub.example.com/bacnet`).
     pub fn hub_url(mut self, url: &str) -> Self {
         self.hub_url = url.to_string();
+        self
+    }
+
+    /// Set the segmentation support this device advertises and enforces.
+    ///
+    /// The dispatch loop honors the advertisement (Clause 5.4.5.1): inbound
+    /// segmented requests are reassembled only under `BOTH` or `RECEIVE`, and
+    /// draw a SEGMENTATION_NOT_SUPPORTED Abort otherwise. The default is
+    /// `NONE`.
+    pub fn segmentation_supported(mut self, segmentation: Segmentation) -> Self {
+        self.config.segmentation_supported = segmentation;
         self
     }
 

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -382,7 +382,16 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             encode_apdu(&mut full_buf, &response).expect("valid APDU encoding");
 
             if full_buf.len() > client_max_apdu as usize {
-                if !client_accepts_segmented {
+                // Clause 5.4.5.3 CannotSendSegmentedComplexACK reads both
+                // sides of the exchange: case (a) — "this device does not
+                // support the transmission of segmented messages" — and case
+                // (b), the client not accepting one. Either way the response
+                // "cannot be sent as one PDU or multiple PDUs" and draws the
+                // same Abort; SendSegmentedComplexACK is available only when
+                // the device supports transmitting segments (#381).
+                let device_transmits_segments = config.segmentation_supported == Segmentation::BOTH
+                    || config.segmentation_supported == Segmentation::TRANSMIT;
+                if !client_accepts_segmented || !device_transmits_segments {
                     let abort = Apdu::Abort(AbortPdu {
                         sent_by_server: true,
                         invoke_id,

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -395,4 +395,5 @@ fn fake_segmented_send_handle(
 
 mod ack_window;
 mod control_limits;
+mod request_reassembly;
 mod routing_overlap;

--- a/crates/bacnet-server/src/server/segmentation_tests/request_reassembly.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/request_reassembly.rs
@@ -1,0 +1,482 @@
+//! Inbound segmented ConfirmedRequest reassembly (#364, #377, #381).
+//!
+//! Clause 20.1.2.7 makes the request sequence number modulo 256, so the wire
+//! can carry a request longer than the sequence space and only the receiver's
+//! bookkeeping stands between that and silent payload corruption. These tests
+//! run the real dispatch loop over a loopback pair, with the test playing the
+//! client in lockstep (window size 1, one ack awaited per segment — also what
+//! keeps the loopback channels from filling).
+//!
+//! Wall-clock discipline: every test must finish well inside the 4 s
+//! reassembly reaper, which would otherwise evict the session mid-test and
+//! satisfy "the session is gone" assertions for the wrong reason.
+
+use super::*;
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_objects::value_types::CharacterStringValueObject;
+use bacnet_services::write_property::WritePropertyRequest;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_types::enums::Segmentation;
+use bacnet_types::primitives::PropertyValue;
+use bytes::BytesMut;
+use tokio::time::timeout;
+
+const SERVER_MAC: &[u8] = &[0x02];
+const CLIENT_MAC: &[u8] = &[0x01];
+const CSV_INSTANCE: u32 = 1;
+
+/// Start a real server on one end of a loopback pair; the test is the client
+/// on the other end. The database holds one CharacterString Value object so a
+/// reassembled WriteProperty has a writable target.
+async fn start_reassembly_server(
+    segmentation: Segmentation,
+) -> (
+    BACnetServer<LoopbackTransport>,
+    LoopbackTransport,
+    mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>,
+) {
+    let (server_transport, mut client_transport) =
+        LoopbackTransport::pair(SERVER_MAC.to_vec(), CLIENT_MAC.to_vec());
+    let client_rx = client_transport.start().await.unwrap();
+
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(
+        CharacterStringValueObject::new(CSV_INSTANCE, "CSV-1").unwrap(),
+    ))
+    .unwrap();
+
+    let config = ServerConfig {
+        segmentation_supported: segmentation,
+        ..ServerConfig::default()
+    };
+    let server = BACnetServer::start(config, db, server_transport)
+        .await
+        .unwrap();
+    (server, client_transport, client_rx)
+}
+
+/// A WriteProperty request whose reassembled form writes `text` to the CSV
+/// object's Present_Value — the payload the segments carry, so a corrupt
+/// reassembly cannot produce a SimpleAck and a correct one must.
+fn write_property_payload(text: &str) -> Vec<u8> {
+    let mut value = BytesMut::new();
+    encode_property_value(
+        &mut value,
+        &PropertyValue::CharacterString(text.to_string()),
+    )
+    .unwrap();
+    let request = WritePropertyRequest {
+        object_identifier: ObjectIdentifier::new(ObjectType::CHARACTERSTRING_VALUE, CSV_INSTANCE)
+            .unwrap(),
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+        property_value: value.to_vec(),
+        priority: None,
+    };
+    let mut buf = BytesMut::new();
+    request.encode(&mut buf);
+    buf.to_vec()
+}
+
+/// Split `payload` into exactly `count` non-empty chunks.
+fn split_into(payload: &[u8], count: usize) -> Vec<Vec<u8>> {
+    assert!(
+        payload.len() >= count,
+        "payload of {} bytes cannot fill {count} non-empty segments",
+        payload.len()
+    );
+    let base = payload.len() / count;
+    let extra = payload.len() % count;
+    let mut chunks = Vec::with_capacity(count);
+    let mut at = 0;
+    for i in 0..count {
+        let len = base + usize::from(i < extra);
+        chunks.push(payload[at..at + len].to_vec());
+        at += len;
+    }
+    chunks
+}
+
+async fn send_apdu(transport: &LoopbackTransport, apdu: &Apdu) {
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, apdu).unwrap();
+    let npdu = Npdu {
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu).unwrap();
+    transport.send_unicast(&npdu_buf, SERVER_MAC).await.unwrap();
+}
+
+async fn send_segment(
+    transport: &LoopbackTransport,
+    invoke_id: u8,
+    seq: u8,
+    more_follows: bool,
+    data: &[u8],
+) {
+    send_apdu(
+        transport,
+        &Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+            segmented: true,
+            more_follows,
+            segmented_response_accepted: true,
+            max_segments: None,
+            max_apdu_length: 1476,
+            invoke_id,
+            sequence_number: Some(seq),
+            proposed_window_size: Some(1),
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+            service_request: Bytes::copy_from_slice(data),
+        }),
+    )
+    .await;
+}
+
+async fn recv_apdu(
+    rx: &mut mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>,
+    context: &str,
+) -> Apdu {
+    let received = timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{context}: timed out waiting for a PDU"))
+        .unwrap_or_else(|| panic!("{context}: channel closed"));
+    let npdu = decode_npdu(received.npdu).unwrap();
+    apdu::decode_apdu(npdu.payload).unwrap()
+}
+
+async fn expect_positive_ack(
+    rx: &mut mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>,
+    invoke_id: u8,
+    seq: u8,
+) {
+    match recv_apdu(rx, &format!("ack for segment {seq}")).await {
+        Apdu::SegmentAck(ack) => {
+            assert!(!ack.negative_ack, "segment {seq}: expected a positive ack");
+            assert!(ack.sent_by_server, "SegmentAck must carry 'server' = TRUE");
+            assert_eq!(ack.invoke_id, invoke_id);
+            assert_eq!(ack.sequence_number, seq);
+        }
+        other => panic!("segment {seq}: expected SegmentAck, got {other:?}"),
+    }
+}
+
+async fn expect_abort(
+    rx: &mut mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>,
+    invoke_id: u8,
+    reason: AbortReason,
+    context: &str,
+) {
+    match recv_apdu(rx, context).await {
+        Apdu::Abort(abort) => {
+            assert!(
+                abort.sent_by_server,
+                "{context}: server Abort must carry 'server' = TRUE"
+            );
+            assert_eq!(abort.invoke_id, invoke_id, "{context}");
+            assert_eq!(abort.abort_reason, reason, "{context}");
+        }
+        other => panic!("{context}: expected Abort, got {other:?}"),
+    }
+}
+
+async fn present_value(server: &BACnetServer<LoopbackTransport>) -> String {
+    let db = server.database().read().await;
+    let oid = ObjectIdentifier::new(ObjectType::CHARACTERSTRING_VALUE, CSV_INSTANCE).unwrap();
+    match db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::PRESENT_VALUE, None)
+        .unwrap()
+    {
+        PropertyValue::CharacterString(s) => s,
+        other => panic!("expected CharacterString present value, got {other:?}"),
+    }
+}
+
+/// #364: exactly 256 segments — the full sequence space — reassemble to the
+/// byte-exact request. Passed before the fix too (`seq + 1` happens to equal
+/// the count when nothing has wrapped); this pins the boundary the cap must
+/// not break.
+#[tokio::test]
+async fn two_hundred_fifty_six_segments_reassemble_byte_exact() {
+    let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+    let text = "x".repeat(300);
+    let chunks = split_into(&write_property_payload(&text), 256);
+
+    for (i, chunk) in chunks.iter().enumerate() {
+        let seq = i as u8;
+        send_segment(&client, 7, seq, i + 1 < chunks.len(), chunk).await;
+        expect_positive_ack(&mut rx, 7, seq).await;
+    }
+    match recv_apdu(&mut rx, "response to the reassembled WriteProperty").await {
+        Apdu::SimpleAck(ack) => assert_eq!(ack.invoke_id, 7),
+        other => panic!("expected SimpleAck, got {other:?}"),
+    }
+    assert_eq!(present_value(&server).await, text);
+}
+
+/// #364: the 257th in-order segment arrives as a wrapped `seq == 0` and must
+/// end the transfer with BUFFER_OVERFLOW — before the fix it silently replaced
+/// the session (the wrapped 0 looked like a fresh initial segment) and the
+/// request "succeeded" as its own tail.
+#[tokio::test]
+async fn segment_past_the_sequence_space_aborts_instead_of_corrupting() {
+    let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+    let text = "y".repeat(310);
+    let chunks = split_into(&write_property_payload(&text), 260);
+
+    for (i, chunk) in chunks.iter().enumerate().take(256) {
+        let seq = i as u8;
+        send_segment(&client, 9, seq, true, chunk).await;
+        expect_positive_ack(&mut rx, 9, seq).await;
+    }
+    // Segment index 256 wraps to sequence 0. In order, new, and one past
+    // capacity.
+    send_segment(&client, 9, 0, true, &chunks[256]).await;
+    expect_abort(
+        &mut rx,
+        9,
+        AbortReason::BUFFER_OVERFLOW,
+        "the 257th segment",
+    )
+    .await;
+    // The session is gone: a follow-up segment finds no state and draws the
+    // no-session Abort rather than an ack.
+    send_segment(&client, 9, 1, true, &chunks[257]).await;
+    expect_abort(
+        &mut rx,
+        9,
+        AbortReason::INVALID_APDU_IN_THIS_STATE,
+        "a segment after the overflow Abort",
+    )
+    .await;
+    assert_eq!(
+        present_value(&server).await,
+        "",
+        "an overlong request must not write anything"
+    );
+}
+
+/// A duplicate segment 0 mid-session is out-of-order traffic for the live
+/// session (Clause 5.4.5.2), not a fresh initial segment — before the fix it
+/// silently reset the session. The transfer must survive it.
+#[tokio::test]
+async fn duplicate_segment_zero_draws_negative_ack_and_transfer_survives() {
+    let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+    let text = "z".repeat(40);
+    let chunks = split_into(&write_property_payload(&text), 3);
+
+    send_segment(&client, 11, 0, true, &chunks[0]).await;
+    expect_positive_ack(&mut rx, 11, 0).await;
+    send_segment(&client, 11, 1, true, &chunks[1]).await;
+    expect_positive_ack(&mut rx, 11, 1).await;
+
+    // A retransmitted segment 0 (as after a lost ack).
+    send_segment(&client, 11, 0, true, &chunks[0]).await;
+    match recv_apdu(&mut rx, "reply to the duplicate segment 0").await {
+        Apdu::SegmentAck(ack) => {
+            assert!(ack.negative_ack, "a duplicate must not be re-acked as new");
+            assert_eq!(ack.sequence_number, 1, "NAK names the last accepted seq");
+        }
+        other => panic!("expected SegmentAck, got {other:?}"),
+    }
+
+    send_segment(&client, 11, 2, false, &chunks[2]).await;
+    expect_positive_ack(&mut rx, 11, 2).await;
+    match recv_apdu(&mut rx, "response after the duplicate").await {
+        Apdu::SimpleAck(ack) => assert_eq!(ack.invoke_id, 11),
+        other => panic!("expected SimpleAck, got {other:?}"),
+    }
+    assert_eq!(present_value(&server).await, text);
+}
+
+/// #364 companion defect: a segment the receiver cannot store used to be
+/// dropped with a warning, leaving the session dangling and the peer waiting.
+/// It must end the session and say so.
+#[tokio::test]
+async fn unsaveable_segment_aborts_and_ends_the_session() {
+    let (_server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+
+    send_segment(&client, 13, 0, true, &[0xAA; 32]).await;
+    expect_positive_ack(&mut rx, 13, 0).await;
+
+    // service_request larger than SegmentReceiver's 1476-byte segment cap.
+    send_segment(&client, 13, 1, true, &[0xBB; 1500]).await;
+    expect_abort(
+        &mut rx,
+        13,
+        AbortReason::BUFFER_OVERFLOW,
+        "an oversized segment",
+    )
+    .await;
+
+    send_segment(&client, 13, 2, true, &[0xCC; 32]).await;
+    expect_abort(
+        &mut rx,
+        13,
+        AbortReason::INVALID_APDU_IN_THIS_STATE,
+        "a segment after the oversized-segment Abort",
+    )
+    .await;
+}
+
+/// #377: a peer's Abort ('server' = FALSE) ends the reassembly session, per
+/// Clause 5.4.5.2 AbortPDU_Received. Before the fix the session survived and
+/// the next segment was acked as if nothing happened.
+#[tokio::test]
+async fn peer_abort_clears_the_reassembly_session() {
+    let (_server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+
+    send_segment(&client, 17, 0, true, &[0x11; 16]).await;
+    expect_positive_ack(&mut rx, 17, 0).await;
+
+    send_apdu(
+        &client,
+        &Apdu::Abort(AbortPdu {
+            sent_by_server: false,
+            invoke_id: 17,
+            abort_reason: AbortReason::OTHER,
+        }),
+    )
+    .await;
+
+    send_segment(&client, 17, 1, true, &[0x22; 16]).await;
+    expect_abort(
+        &mut rx,
+        17,
+        AbortReason::INVALID_APDU_IN_THIS_STATE,
+        "a segment after the peer's Abort",
+    )
+    .await;
+}
+
+/// #381: a device that does not support segmented reception answers segment
+/// traffic with SEGMENTATION_NOT_SUPPORTED (Clause 5.4.5.1) instead of
+/// reassembling. `ServerConfig::default()` advertises NO_SEGMENTATION.
+#[tokio::test]
+async fn default_config_aborts_segmented_requests_as_unsupported() {
+    let (_server, client, mut rx) = start_reassembly_server(Segmentation::NONE).await;
+
+    send_segment(&client, 19, 0, true, &[0x33; 16]).await;
+    expect_abort(
+        &mut rx,
+        19,
+        AbortReason::SEGMENTATION_NOT_SUPPORTED,
+        "segment 0 at a NO_SEGMENTATION device",
+    )
+    .await;
+}
+
+/// SEGMENTED_TRANSMIT can send but not receive; reception draws the same
+/// Clause 5.4.5.1 Abort as NO_SEGMENTATION.
+#[tokio::test]
+async fn transmit_only_config_aborts_segmented_requests_as_unsupported() {
+    let (_server, client, mut rx) = start_reassembly_server(Segmentation::TRANSMIT).await;
+
+    send_segment(&client, 21, 0, true, &[0x44; 16]).await;
+    expect_abort(
+        &mut rx,
+        21,
+        AbortReason::SEGMENTATION_NOT_SUPPORTED,
+        "segment 0 at a SEGMENTED_TRANSMIT device",
+    )
+    .await;
+}
+
+/// The 129th concurrent session is refused with BUFFER_OVERFLOW. Pins the
+/// session-count cap after its guard lost the (now dead) same-key exemption
+/// in the branch reorder.
+#[tokio::test]
+async fn session_count_cap_refuses_the_129th_session() {
+    let (_server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+
+    for invoke_id in 0u8..128 {
+        send_segment(&client, invoke_id, 0, true, &[invoke_id; 8]).await;
+        expect_positive_ack(&mut rx, invoke_id, 0).await;
+    }
+    send_segment(&client, 128, 0, true, &[0x55; 8]).await;
+    expect_abort(
+        &mut rx,
+        128,
+        AbortReason::BUFFER_OVERFLOW,
+        "the 129th concurrent session",
+    )
+    .await;
+}
+
+/// Clause 5.4.5.3 case (a): a device that does not support transmitting
+/// segments must Abort an oversized response rather than segmenting it —
+/// the receive-side #381 gate's mirror. RECEIVE may reassemble but not
+/// transmit; BOTH is the positive control proving the gate keys on the
+/// configured advertisement.
+#[tokio::test]
+async fn transmit_gate_aborts_oversized_response_under_receive_only() {
+    for (segmentation, expects_segmented) in
+        [(Segmentation::RECEIVE, false), (Segmentation::BOTH, true)]
+    {
+        let (server, client, mut rx) = start_reassembly_server(segmentation).await;
+        {
+            let db = server.database();
+            let mut db = db.write().await;
+            let oid =
+                ObjectIdentifier::new(ObjectType::CHARACTERSTRING_VALUE, CSV_INSTANCE).unwrap();
+            db.get_mut(&oid)
+                .unwrap()
+                .write_property(
+                    PropertyIdentifier::PRESENT_VALUE,
+                    None,
+                    PropertyValue::CharacterString("v".repeat(300)),
+                    None,
+                )
+                .unwrap();
+        }
+
+        let mut service_buf = BytesMut::new();
+        bacnet_services::read_property::ReadPropertyRequest {
+            object_identifier: ObjectIdentifier::new(
+                ObjectType::CHARACTERSTRING_VALUE,
+                CSV_INSTANCE,
+            )
+            .unwrap(),
+            property_identifier: PropertyIdentifier::PRESENT_VALUE,
+            property_array_index: None,
+        }
+        .encode(&mut service_buf);
+        send_apdu(
+            &client,
+            &Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+                segmented: false,
+                more_follows: false,
+                segmented_response_accepted: true,
+                max_segments: None,
+                max_apdu_length: 50,
+                invoke_id: 23,
+                sequence_number: None,
+                proposed_window_size: None,
+                service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+                service_request: service_buf.freeze(),
+            }),
+        )
+        .await;
+
+        if expects_segmented {
+            match recv_apdu(&mut rx, "segmented response under BOTH").await {
+                Apdu::ComplexAck(ack) => {
+                    assert!(ack.segmented, "an oversized response must segment");
+                    assert_eq!(ack.sequence_number, Some(0));
+                }
+                other => panic!("expected segmented ComplexAck, got {other:?}"),
+            }
+        } else {
+            expect_abort(
+                &mut rx,
+                23,
+                AbortReason::SEGMENTATION_NOT_SUPPORTED,
+                "an oversized response at a receive-only device",
+            )
+            .await;
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/tests.rs
+++ b/crates/bacnet-server/src/server/tests.rs
@@ -45,6 +45,27 @@ fn event_enrollment_period_passes_through_nonzero() {
 }
 
 #[test]
+fn all_builders_assign_segmentation_supported() {
+    // Same copy-paste hazard as the enrollment test below: the setter targets
+    // one ServerConfig field among look-alikes, and the dispatch loop now
+    // enforces it (Clause 5.4.5.1), so a mis-assignment silently turns
+    // segmented reception off.
+    let generic = BACnetServer::<BipTransport>::generic_builder()
+        .segmentation_supported(Segmentation::RECEIVE);
+    assert_eq!(generic.config.segmentation_supported, Segmentation::RECEIVE);
+
+    let bip =
+        BACnetServer::<BipTransport>::bip_builder().segmentation_supported(Segmentation::BOTH);
+    assert_eq!(bip.config.segmentation_supported, Segmentation::BOTH);
+
+    #[cfg(feature = "sc-tls")]
+    {
+        let sc = BACnetServer::sc_builder().segmentation_supported(Segmentation::RECEIVE);
+        assert_eq!(sc.config.segmentation_supported, Segmentation::RECEIVE);
+    }
+}
+
+#[test]
 fn all_builders_assign_event_enrollment_config() {
     // Six near-identical assignments across three builders. Every neighbouring
     // ServerConfig field is a bool or u64, so a copy-paste targeting the wrong one


### PR DESCRIPTION
Closes #364. Closes #367. Closes #368. Closes #377. Closes #381.

The segmentation-hygiene cluster from PR #363's reviews, grounded against a fresh extraction of the `_spec/` PDF (two Opus lanes verified every design decision against the live clause text before implementation; their corrections are folded in below).

## #364 — server reassembly bounded by the sequence space

The total came from the last wire sequence number plus one, but Clause **20.1.2.7** (not 20.1.5.4 — that is the response direction) makes that number modulo 256, so a 260-segment request "reassembled" as *its own last four segments* and was decoded as the peer's request with no error at any layer. The corruption shape differs from the issue text: the wrapped segment 256 arrives as another `seq == 0`, and the open path ran **before** the live-session check, so it silently replaced the session — the grounding pinned this as "last four segments", not a head/tail mix, and made the branch reorder a hard prerequisite of the cap (without it, the wrapped 0 resets the counter and the cap is dead code).

Now: the live session is consulted first; the total is a monotonic `accepted_segments` count; and the 257th in-order segment ends the transfer with a `'server' = TRUE` **BUFFER_OVERFLOW** Abort. 5.4.5.2 has no overflow transition — `SendAbort` (reason unspecified, a local matter) is its one generic escape, and 18.10's BUFFER_OVERFLOW ("a buffer capacity has been exceeded") is the fit; APDU_TOO_LONG is defined for the local-application direction and does not apply. The cap sits on the in-order-new-segment path only, so retransmitted duplicates can never trip it (5.4.5.2 `DuplicateSegmentReceived`). The cap is a plain 256: `ServerConfig` carries no segment limit and the Device object's `Max_Segments_Accepted` defaults to "more than 64", so no advertisement binds tighter (the issue's `advertised_max_segments` suggestion was a category error — 20.1.2.4 is the *requester's* parameter bounding the response; grounding correction). Companion defect: an unsaveable segment (>1476 B) was dropped with only a warning, leaving the session dangling and the peer waiting; it now ends the session with the same Abort.

## #367 — a client session lives exactly as long as its transaction

All four transaction endings left the reassembly session acking segments nobody was waiting on: peer Abort/Error/Reject completed the TSM entry and returned; caller timeout cancelled it. Now:

- **Abort arm** (5.4.4.4 `AbortPDU_Received`): removes the session, no reply PDU — placed *below* the `server=FALSE` guard, so an echoed copy of this client's own Abort cannot tear down a healthy reassembly (the same PDU-reflection class PR #363 fixed for SegmentAck; pinned by a test).
- **Error and Reject arms** (5.4.4.4 `UnexpectedPDU_Received` — both PDUs are in its list, verified live): mid-reassembly they divert to the existing `abort_reassembly` — the peer gets an Abort, the caller gets INVALID_APDU_IN_THIS_STATE rather than the error content. Placed **before** the arms' TSM lock — `abort_reassembly` takes that lock itself and tokio's Mutex is not reentrant (grounding caught the deadlock). Keyed on `seg_state` only: an Error answering an *outgoing* segmented request can be legitimate once SentAllSegments is TRUE (5.4.4.2), a flag this client does not track, so `seg_ack_senders` must not divert. An ordinary Error/Reject with no session still surfaces as itself (pinned).
- **Caller timeout** has no arm to hook, so the pending-transaction gate now runs **per segment** instead of only at session open, and was moved ahead of the 64-session cap so a non-pending segment draws the 5.4.4.1 Abort even with every slot full (grounding correction). `last_activity` still refreshes on duplicates — 5.4.4.4 `DuplicateSegmentReceived` restarts SegmentTimer, so that half of the issue's suggestion is deliberately not taken.

Acknowledged residuals, each filed: the reaper's own non-conformances (#379: 4 s hardcoded vs Tseg×4, transmits an Abort where the clause is indication-only, never completes the TSM, reaps only on inbound traffic) and the caller's request timer running through reassembly contra 5.4.4.3 stop-RequestTimer (#380). Invoke-ID immediate reuse means a stale segment stream can still alias onto a *new* pending transaction — the gate removes orphans, it cannot tell that stream from a genuine one (the issue's optional quiet-period idea, not taken here).

## #368 — a stale SegmentAck is discarded, not fatal

The `ack_seq >= total_segments → return Err` check ran before the window filter could see the ack. 5.4.4.2 `DuplicateACK_Received` prescribes "restart SegmentTimer and enter the SEGMENTED_REQUEST state to await an acknowledgment" — discard and keep waiting. The check is **deleted**; out-of-range acks, positive and negative alike (the issue's "same fix domain" ask), fall through to the in-window filter and are discarded — the `continue` re-enters the timeout call, which is the SegmentTimer restart. After review (below), negative acks now take 5.4.4.2's ack transitions literally — they never branch on the 'negative-ack' flag, so either flavor names the last accepted segment and the sender continues after it; the filter is one uniform 5.4.2.1 `InWindow` stand-in. MAX_NEG_ACK_RETRIES stays as a documented local livelock bound — 5.4.4.2 has no counterpart (`NewACK_Received` resets SegmentRetryCount on every in-window ack).

## Riders from grounding (#381, #377)

- **#381**: the server reassembled segmented requests unconditionally while `ServerConfig::default()` advertises NO_SEGMENTATION. It now sends the 5.4.5.1 `ConfirmedSegmentedReceivedNotSupported` Abort unless configured `BOTH`/`RECEIVE`. That made a `segmentation_supported` **builder method** necessary (generic, BIP, SC) — without it builder users could never enable reception — and the four pre-existing `segmentation_rx` integration tests now advertise what they exercise.
- **#377**: a peer's Abort (`server=FALSE`) now clears the server-side reassembly session per 5.4.5.2 `AbortPDU_Received` — as a **side effect that still reaches dispatch**, whose Abort arm cancels in-flight segmented response senders and records TSM results (grounding: a `continue` there would have silently broken both; the existing component test `client_abort_routed_by_dispatch_terminates_segmented_complex_ack` covers that arm).

Also filed, not fixed: #378 (Device `Max_Segments_Accepted` = 65 under SEGMENTED_TRANSMIT where Clause 12.11 requires 1).

## Tests

17 new, all through real dispatch loops over `LoopbackTransport::pair`, lockstep (window 1 server-side — also what keeps the loopback channels from filling), every test far inside the 4 s reaper so it cannot satisfy assertions for the wrong reason:

- **Server** (8): 260-segment request → BUFFER_OVERFLOW at the 257th, then INVALID_APDU for the follow-up, and the target property **unchanged** (the payload is a well-formed WriteProperty when whole — the anti-vacuity pairing); exactly-256 → SimpleAck and **byte-exact** value round-trip; duplicate segment-0 mid-session → NAK naming the last accepted seq, transfer survives; oversized segment → abort + session gone; peer Abort → session gone; NO_SEGMENTATION and SEGMENTED_TRANSMIT both → 5.4.5.1 Abort; 129th concurrent session refused.
- **Client** (9): peer Abort / Error / Reject mid-reassembly (each its own arm); echoed `server=FALSE` Abort does NOT end the session; Error/Reject with no session surface as themselves; caller-timeout then segment → INVALID_APDU (reason asserted ≠ TSM_TIMEOUT so the reaper cannot fake it; `apdu_retries=0`, whole test <4 s); stale out-of-range positive and negative acks discarded with a quiet-window assert; in-range-out-of-window ack discarded with the strict per-segment sequence asserted at the peer.

**Discrimination** (detached worktree at dev `3a0bc93`, test files only): 12 behavior-changing tests fail there — 6 server, 4 client-lifecycle, 2 stale-ack — and the 5 that pass are the deliberate regression guards (256-exact, 129-session cap, echoed-abort immunity, no-session passthrough, in-window filter). Builder-assignment test added for the new setter, following the existing copy-paste-hazard pattern.

Full gates: fmt, clippy (`0 errors`), 700-LOC cap, workspace suite 2,991 passed / 0 failed, `cargo check -p rusty-bacnet --tests` clean — from a `cargo clean` slate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review (two Opus lanes, both initially request-changes; all findings applied)

**Adversarial lane** — two probe-confirmed protocol regressions, both fixed by making the client's negative-ack handling spec-literal:

- **Blocking**: with the branch reorder, a retransmitted segment 0 (the ordinary consequence of a lost first ack) draws NAK(0) from the server's live session — and this client's own "NAK 0 in the first window means resend 0" special case looped NAK(0) → segment 0 for 11 rounds to failure. Root cause was the client's non-spec NAK reading, not the reorder: 5.4.4.2's ack transitions never consult 'negative-ack'. The special case is gone; NAK(0) advances to segment 1. Pinned end-to-end by `lost_first_ack_recovers_via_negative_ack_zero` (fails at the reviewed commit).
- **Major**: the "map a NAK to its resend target" window predicate rejected a NAK naming the last segment of the current window (`resend_seq == window_end`), stalling the transfer into a timeout against this repo's own server. Same fix; pinned by `negative_ack_naming_last_of_window_advances_the_window`. The pre-existing `..._retransmits_segment_zero_after_negative_ack_zero` test pinned the old semantics and was rewritten to the spec's (`negative_ack_zero_advances_past_the_acknowledged_segment`).
- **Major**: the 5.4.5.1 advertisement was enforced on receive only — a NO_SEGMENTATION server still *transmitted* segmented ComplexACKs. The transmit side now applies 5.4.5.3 case (a): an oversized response at a device not advertising BOTH/TRANSMIT draws the same SEGMENTATION_NOT_SUPPORTED Abort. Pinned with a RECEIVE-vs-BOTH pair in `transmit_gate_aborts_oversized_response_under_receive_only`.
- **Major**: SimpleAck and unsegmented ComplexAck — the rest of 5.4.4.4 `UnexpectedPDU_Received`'s list — were not diverted mid-reassembly and completed the transaction with misdirected content, leaving a dangling session. Both now abort the reassembly like Error/Reject; two new tests.
- **Minor**: the Abort-arm `seg_state.remove` is behaviorally redundant with the per-segment gate (mutation survives all tests); kept for immediate slot reclamation with a comment saying exactly that, so a future refactor knows what it is and is not load-bearing for.
- **Minor**: the default-config behavior change (NO_SEGMENTATION now *refuses* segmented traffic both ways) is flagged in the CHANGELOG as a behavior change with the builder opt-in named, and in the `segmentation_supported` field doc.

**Spec lane** — `InWindow` is Clause **5.4.2.1** (5.4.2.2 is `DuplicateInWindow`) — fixed in the comment and this body; the `MAX_REQUEST_SEGMENTS` rustdoc no longer claims "no advertisement binds tighter" (the Device object publishes `Unsigned(65)`, which does — enforcement is deliberately declined, and the doc now says that plainly); `send_server_abort`'s 'server'-flag pointer corrected to 20.1.9.1; the shared-fixture comment in the integration harness no longer claims all its tests exercise segmentation; test counts corrected (23 new + 1 rewritten).

Not taken: implementing `DuplicateInWindow`/Ndup duplicate counting on the server (it still NAKs the first duplicate where 5.4.5.2 wants silent discard until Ndup — harmless now that NAKs advance the peer correctly, and chattier-than-spec rather than wrong); filed as a follow-up. The server-side SegKey keys on the immediate MAC where the client keys route-independently — inherited convention divergence, noted for a future issue.

Post-review gates: full workspace 2,996 passed / 0 failed, clippy clean, fmt clean, 700-LOC cap clean; six new discrimination runs fail at the reviewed intermediate commit `610d717`.
