### PR TITLE
fix(server): correlate routed acknowledgments so confirmed notifications reach remote recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Confirmed event notifications reach remote-network recipients (#375). The
+  #186 fix delivered the unconfirmed half and left confirmed recipients
+  skipped, because the server TSM keyed the pending acknowledgment by the
+  target's MAC while a routed recipient's ack arrives from whichever router
+  delivers it — a MAC unknowable when the send goes out on Clause 6.5.3's
+  broadcast DA. The transaction is now keyed by routed identity (DNET/DADR)
+  with an empty local half, inbound correlation tries the exact key, then
+  the router-unknown routed key, then the legacy wildcard, and a hit that
+  carries a routed identity teaches a bounded router cache — Clause 6.5.3
+  method 4, "noting the SA associated with any subsequent responses from
+  the remote device" — so the next confirmed send to that network unicasts
+  to the learned router (first attempt only; a retry after silence falls
+  back to the always-correct broadcast DA in case the router is gone).
+  Confirmed recipients at broadcast addresses stay skipped: that
+  restriction is Clause 6.3's, not a TSM limitation.
+
 - Server-side segmented request reassembly is bounded by the sequence-number
   space instead of silently corrupting past it (#364). The reassembly total
   came from the last wire sequence number plus one — but Clause 20.1.2.7

--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -130,14 +130,12 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             Apdu::SimpleAck(sa) => {
                 let mut tsm = server_tsm.lock().await;
                 let peer = MacAddr::from_slice(source_mac);
-                if !tsm.record_result(
+                tsm.record_result_correlated(
                     &peer,
                     received.source_network.as_ref(),
                     sa.invoke_id,
                     CovAckResult::Ack,
-                ) {
-                    tsm.record_result(&MacAddr::new(), None, sa.invoke_id, CovAckResult::Ack);
-                }
+                );
                 debug!(
                     invoke_id = sa.invoke_id,
                     "SimpleAck received for outgoing confirmed notification"
@@ -146,14 +144,12 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             Apdu::Error(err) => {
                 let mut tsm = server_tsm.lock().await;
                 let peer = MacAddr::from_slice(source_mac);
-                if !tsm.record_result(
+                tsm.record_result_correlated(
                     &peer,
                     received.source_network.as_ref(),
                     err.invoke_id,
                     CovAckResult::Error,
-                ) {
-                    tsm.record_result(&MacAddr::new(), None, err.invoke_id, CovAckResult::Error);
-                }
+                );
                 debug!(
                     invoke_id = err.invoke_id,
                     error_class = err.error_class.to_raw(),
@@ -164,14 +160,12 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             Apdu::Reject(rej) => {
                 let mut tsm = server_tsm.lock().await;
                 let peer = MacAddr::from_slice(source_mac);
-                if !tsm.record_result(
+                tsm.record_result_correlated(
                     &peer,
                     received.source_network.as_ref(),
                     rej.invoke_id,
                     CovAckResult::Error,
-                ) {
-                    tsm.record_result(&MacAddr::new(), None, rej.invoke_id, CovAckResult::Error);
-                }
+                );
                 debug!(
                     invoke_id = rej.invoke_id,
                     "Reject received for outgoing confirmed notification"
@@ -192,14 +186,12 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
                 let mut tsm = server_tsm.lock().await;
                 let peer = MacAddr::from_slice(source_mac);
-                if !tsm.record_result(
+                tsm.record_result_correlated(
                     &peer,
                     received.source_network.as_ref(),
                     abort.invoke_id,
                     CovAckResult::Error,
-                ) {
-                    tsm.record_result(&MacAddr::new(), None, abort.invoke_id, CovAckResult::Error);
-                }
+                );
                 debug!(
                     invoke_id = abort.invoke_id,
                     routed_segmented,

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -1,0 +1,436 @@
+//! Confirmed event notifications to remote-network recipients (#375).
+//!
+//! Clause 6.3 permits a confirmed PDU on a broadcast link DA when the
+//! DNET/DADR restricts the destination to one device, and Clause 6.5.3 names
+//! the broadcast DA as the send form while "the address of the router is
+//! initially unknown". What used to block this was correlation: the ack
+//! arrives from whichever router delivers it, so the transaction is keyed by
+//! routed identity with an empty local half, and the router's MAC is learned
+//! from the ack per Clause 6.5.3 method 4 ("noting the SA associated with any
+//! subsequent responses from the remote device").
+//!
+//! The tests drive the real distribution path over a recording transport and
+//! feed acks through the same correlation entry point the dispatch loop uses.
+
+use super::event_notifications_tests::local_broadcast_destination;
+use super::event_recipient_routing_tests::{address_recipient, destination_for};
+use super::*;
+use bacnet_objects::analog::AnalogInputObject;
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_objects::event::EventStateChange;
+use bacnet_objects::notification_class::NotificationClass;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::constructed::BACnetDestination;
+use bacnet_types::enums::{EventState, EventType};
+use bytes::Bytes;
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
+use tokio::sync::mpsc;
+
+#[derive(Clone, Default)]
+struct RecordingTransport {
+    broadcasts: StdArc<StdMutex<Vec<Bytes>>>,
+    unicasts: StdArc<StdMutex<Vec<(Vec<u8>, Bytes)>>>,
+}
+
+impl TransportPort for RecordingTransport {
+    async fn start(
+        &mut self,
+    ) -> Result<mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+        let (_tx, rx) = mpsc::channel(1);
+        Ok(rx)
+    }
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
+        self.unicasts
+            .lock()
+            .unwrap()
+            .push((mac.to_vec(), Bytes::copy_from_slice(npdu)));
+        Ok(())
+    }
+    async fn send_broadcast(&self, npdu: &[u8]) -> Result<(), Error> {
+        self.broadcasts
+            .lock()
+            .unwrap()
+            .push(Bytes::copy_from_slice(npdu));
+        Ok(())
+    }
+    fn local_mac(&self) -> &[u8] {
+        &[127, 0, 0, 1, 0xBA, 0xC0]
+    }
+}
+
+/// A live distribution fixture: the same database, network and TSM across
+/// multiple distributions, so router learning is observable between them.
+struct Harness {
+    db: Arc<RwLock<ObjectDatabase>>,
+    network: Arc<NetworkLayer<RecordingTransport>>,
+    server_tsm: Arc<Mutex<ServerTsm>>,
+    comm_state: Arc<AtomicU8>,
+    broadcasts: StdArc<StdMutex<Vec<Bytes>>>,
+    unicasts: StdArc<StdMutex<Vec<(Vec<u8>, Bytes)>>>,
+    retry_timeout_ms: u64,
+}
+
+impl Harness {
+    async fn new(destinations: Vec<BACnetDestination>, retry_timeout_ms: u64) -> Self {
+        let transport = RecordingTransport::default();
+        let broadcasts = StdArc::clone(&transport.broadcasts);
+        let unicasts = StdArc::clone(&transport.unicasts);
+        let network = Arc::new(NetworkLayer::new(transport));
+        let comm_state = Arc::new(AtomicU8::new(0));
+        let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+
+        let mut db = ObjectDatabase::new();
+        let mut nc = NotificationClass::new(0, "NC-0").unwrap();
+        nc.priority = [255, 255, 255];
+        for destination in destinations {
+            nc.add_destination(destination);
+        }
+        db.add(Box::new(nc)).unwrap();
+        db.add(Box::new(
+            DeviceObject::new(DeviceConfig {
+                instance: 1,
+                name: "Dev".into(),
+                ..DeviceConfig::default()
+            })
+            .unwrap(),
+        ))
+        .unwrap();
+        let mut ai = AnalogInputObject::new(1, "AI-1", 0).unwrap();
+        ai.write_property(
+            PropertyIdentifier::NOTIFY_TYPE,
+            None,
+            PropertyValue::Enumerated(NotifyType::ALARM.to_raw()),
+            None,
+        )
+        .unwrap();
+        db.add(Box::new(ai)).unwrap();
+
+        Self {
+            db: Arc::new(RwLock::new(db)),
+            network,
+            server_tsm,
+            comm_state,
+            broadcasts,
+            unicasts,
+            retry_timeout_ms,
+        }
+    }
+
+    async fn distribute(&self) {
+        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+        BACnetServer::<RecordingTransport>::build_and_send_event_notification(
+            &self.db,
+            &self.network,
+            &self.comm_state,
+            &self.server_tsm,
+            &oid,
+            (
+                EventStateChange {
+                    from: EventState::NORMAL,
+                    to: EventState::HIGH_LIMIT,
+                },
+                EventType::OUT_OF_RANGE,
+            ),
+            self.retry_timeout_ms,
+        )
+        .await;
+        // The confirmed path spawns its send; yield until it reaches the
+        // transport.
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    fn broadcast_frames(&self) -> Vec<Bytes> {
+        self.broadcasts.lock().unwrap().clone()
+    }
+
+    fn unicast_frames(&self) -> Vec<(Vec<u8>, Bytes)> {
+        self.unicasts.lock().unwrap().clone()
+    }
+
+    /// Deliver an ack the way the dispatch loop would: through the tiered
+    /// correlation, carrying the delivering router's MAC and the recipient's
+    /// routed identity.
+    async fn ack_routed(
+        &self,
+        router_mac: &[u8],
+        network: u16,
+        dadr: &[u8],
+        invoke_id: u8,
+    ) -> bool {
+        let hit = self.server_tsm.lock().await.record_result_correlated(
+            &MacAddr::from_slice(router_mac),
+            Some(&NpduAddress {
+                network,
+                mac_address: MacAddr::from_slice(dadr),
+            }),
+            invoke_id,
+            CovAckResult::Ack,
+        );
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+        hit
+    }
+}
+
+/// Decode a captured frame into its NPDU and the confirmed request inside.
+fn decode_confirmed(frame: &Bytes) -> (bacnet_encoding::npdu::Npdu, ConfirmedRequestPdu) {
+    let npdu = bacnet_encoding::npdu::decode_npdu(frame.clone()).expect("decode NPDU");
+    match apdu::decode_apdu(npdu.payload.clone()).expect("decode APDU") {
+        Apdu::ConfirmedRequest(req) => (npdu, req),
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    }
+}
+
+const ROUTER_A: &[u8] = &[10, 0, 0, 1, 0xBA, 0xC0];
+const RECIPIENT: &[u8] = &[0x0A; 6];
+
+/// #375's headline: a confirmed notification to a remote recipient goes out
+/// as a routed NPDU on the broadcast DA (Clause 6.5.3 unknown-router form)
+/// with 'data_expecting_reply' set, and the routed-identity ack completes the
+/// transaction — no retries, no duplicate deliveries.
+#[tokio::test]
+async fn confirmed_remote_recipient_delivers_and_correlates() {
+    let harness = Harness::new(
+        vec![destination_for(address_recipient(1000, RECIPIENT), true)],
+        150,
+    )
+    .await;
+    harness.distribute().await;
+
+    let broadcasts = harness.broadcast_frames();
+    assert_eq!(broadcasts.len(), 1, "one routed send on the broadcast DA");
+    assert!(harness.unicast_frames().is_empty());
+    let (npdu, req) = decode_confirmed(&broadcasts[0]);
+    assert!(npdu.expecting_reply, "a confirmed send expects its ack");
+    let destination = npdu.destination.expect("routed NPDU names the recipient");
+    assert_eq!(destination.network, 1000);
+    assert_eq!(destination.mac_address.as_ref() as &[u8], RECIPIENT);
+    assert_eq!(
+        req.service_choice,
+        ConfirmedServiceChoice::CONFIRMED_EVENT_NOTIFICATION
+    );
+
+    assert!(
+        harness
+            .ack_routed(ROUTER_A, 1000, RECIPIENT, req.invoke_id)
+            .await,
+        "the routed-identity ack must find the transaction"
+    );
+
+    // Past the retry timeout: an unacknowledged transaction would have
+    // retried by now.
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    assert_eq!(
+        harness.broadcast_frames().len(),
+        1,
+        "an acknowledged notification must not retry"
+    );
+}
+
+/// The issue's discrimination note: a single transaction cannot tell routed
+/// keying from the legacy wildcard fallback, so two concurrent routed
+/// recipients must correlate independently — acking one leaves the other
+/// retrying.
+#[tokio::test]
+async fn two_routed_recipients_correlate_independently() {
+    let harness = Harness::new(
+        vec![
+            destination_for(address_recipient(1000, RECIPIENT), true),
+            destination_for(address_recipient(2000, &[0x0B; 6]), true),
+        ],
+        200,
+    )
+    .await;
+    harness.distribute().await;
+
+    let initial = harness.broadcast_frames();
+    assert_eq!(initial.len(), 2, "both recipients get their send");
+    let by_net: Vec<(u16, u8)> = initial
+        .iter()
+        .map(|f| {
+            let (npdu, req) = decode_confirmed(f);
+            (npdu.destination.unwrap().network, req.invoke_id)
+        })
+        .collect();
+    let invoke_2000 = by_net.iter().find(|(n, _)| *n == 2000).unwrap().1;
+
+    assert!(
+        harness
+            .ack_routed(ROUTER_A, 2000, &[0x0B; 6], invoke_2000)
+            .await
+    );
+
+    // Past one retry timeout: the unacknowledged 1000-network transaction
+    // retries; the acknowledged 2000-network one must not.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let after = harness.broadcast_frames();
+    let retries_1000 = after
+        .iter()
+        .skip(2)
+        .filter(|f| decode_confirmed(f).0.destination.unwrap().network == 1000)
+        .count();
+    let retries_2000 = after
+        .iter()
+        .skip(2)
+        .filter(|f| decode_confirmed(f).0.destination.unwrap().network == 2000)
+        .count();
+    assert!(retries_1000 >= 1, "the unacked recipient keeps retrying");
+    assert_eq!(retries_2000, 0, "the acked recipient must not retry");
+}
+
+/// An ack naming a different routed identity must not complete the
+/// transaction — the tiers are exact lookups, not a wildcard.
+#[tokio::test]
+async fn ack_with_wrong_routed_identity_does_not_complete() {
+    let harness = Harness::new(
+        vec![destination_for(address_recipient(1000, RECIPIENT), true)],
+        60_000,
+    )
+    .await;
+    harness.distribute().await;
+    let (_, req) = decode_confirmed(&harness.broadcast_frames()[0]);
+
+    assert!(
+        !harness
+            .ack_routed(ROUTER_A, 2000, RECIPIENT, req.invoke_id)
+            .await,
+        "wrong DNET must miss"
+    );
+    assert!(
+        !harness
+            .ack_routed(ROUTER_A, 1000, &[0x0C; 6], req.invoke_id)
+            .await,
+        "wrong DADR must miss"
+    );
+    assert!(
+        harness
+            .ack_routed(ROUTER_A, 1000, RECIPIENT, req.invoke_id)
+            .await,
+        "the true identity still completes"
+    );
+}
+
+/// Clause 6.5.3 method 4: the ack's source MAC is the router for that DNET,
+/// so the next confirmed notification to the same network unicasts to it —
+/// carrying the same DNET/DADR NPDU — instead of broadcasting.
+#[tokio::test]
+async fn learned_router_unicasts_the_next_notification() {
+    let harness = Harness::new(
+        vec![destination_for(address_recipient(1000, RECIPIENT), true)],
+        150,
+    )
+    .await;
+    harness.distribute().await;
+    let (_, req) = decode_confirmed(&harness.broadcast_frames()[0]);
+    assert!(
+        harness
+            .ack_routed(ROUTER_A, 1000, RECIPIENT, req.invoke_id)
+            .await
+    );
+
+    harness.distribute().await;
+    let unicasts = harness.unicast_frames();
+    assert_eq!(
+        unicasts.len(),
+        1,
+        "the second notification unicasts to the learned router"
+    );
+    let (router_mac, frame) = &unicasts[0];
+    assert_eq!(router_mac.as_slice(), ROUTER_A);
+    let (npdu, req2) = decode_confirmed(frame);
+    assert!(npdu.expecting_reply);
+    let destination = npdu.destination.unwrap();
+    assert_eq!(destination.network, 1000);
+    assert_eq!(destination.mac_address.as_ref() as &[u8], RECIPIENT);
+
+    // Cleanup so the retry task ends promptly.
+    let _ = harness
+        .ack_routed(ROUTER_A, 1000, RECIPIENT, req2.invoke_id)
+        .await;
+}
+
+/// A learned router can vanish: the first attempt unicasts to it, and the
+/// retry after silence falls back to the always-correct broadcast DA.
+#[tokio::test]
+async fn retry_after_silent_router_falls_back_to_broadcast() {
+    let harness = Harness::new(
+        vec![destination_for(address_recipient(1000, RECIPIENT), true)],
+        150,
+    )
+    .await;
+    harness.distribute().await;
+    let (_, req) = decode_confirmed(&harness.broadcast_frames()[0]);
+    assert!(
+        harness
+            .ack_routed(ROUTER_A, 1000, RECIPIENT, req.invoke_id)
+            .await
+    );
+
+    // Second notification: attempt 0 unicasts to the learned router, which
+    // stays silent; the retry must arrive as a broadcast-DA frame.
+    harness.distribute().await;
+    assert_eq!(harness.unicast_frames().len(), 1);
+    let broadcasts_before = harness.broadcast_frames().len();
+    tokio::time::sleep(Duration::from_millis(400)).await;
+    let broadcasts = harness.broadcast_frames();
+    assert!(
+        broadcasts.len() > broadcasts_before,
+        "the retry falls back to the broadcast DA"
+    );
+    let (npdu, req2) = decode_confirmed(broadcasts.last().unwrap());
+    let destination = npdu.destination.unwrap();
+    assert_eq!(destination.network, 1000);
+    assert_eq!(
+        req2.invoke_id,
+        decode_confirmed(&harness.unicast_frames()[0].1).1.invoke_id
+    );
+
+    let _ = harness
+        .ack_routed(ROUTER_A, 1000, RECIPIENT, req2.invoke_id)
+        .await;
+}
+
+/// A local-unicast confirmed recipient still works exactly as before — the
+/// route split must not disturb the existing path.
+#[tokio::test]
+async fn local_unicast_confirmed_recipient_still_unicasts() {
+    let target = [192, 168, 1, 50, 0xBA, 0xC0];
+    let harness = Harness::new(
+        vec![BACnetDestination {
+            recipient: address_recipient(0, &target),
+            issue_confirmed_notifications: true,
+            ..local_broadcast_destination()
+        }],
+        60_000,
+    )
+    .await;
+    harness.distribute().await;
+
+    let unicasts = harness.unicast_frames();
+    assert_eq!(unicasts.len(), 1);
+    assert_eq!(unicasts[0].0.as_slice(), &target);
+    let (npdu, req) = decode_confirmed(&unicasts[0].1);
+    assert!(npdu.expecting_reply);
+    assert!(npdu.destination.is_none(), "a local unicast is not routed");
+    assert!(harness.broadcast_frames().is_empty());
+
+    // Complete it the way the dispatch loop would for a local peer.
+    let hit = self_ack_local(&harness, &target, req.invoke_id).await;
+    assert!(hit, "the local exact key still correlates");
+}
+
+async fn self_ack_local(harness: &Harness, mac: &[u8], invoke_id: u8) -> bool {
+    harness.server_tsm.lock().await.record_result_correlated(
+        &MacAddr::from_slice(mac),
+        None,
+        invoke_id,
+        CovAckResult::Ack,
+    )
+}

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -104,12 +104,12 @@ impl RecipientRoute {
     /// broadcast MAC, which `resolve` folds into `LocalBroadcast` via the
     /// transport's own knowledge of its spelling.
     ///
-    /// `RemoteUnicast` is excluded for a different reason: Clause 6.3 permits
-    /// sending it confirmed (the DNET/DADR restricts the destination to one
-    /// device), but the server TSM cannot yet correlate an acknowledgment
-    /// that arrives through a router (#375).
+    /// `RemoteUnicast` is admitted: Clause 6.3 permits sending it confirmed
+    /// (the DNET/DADR restricts the destination to one device), and the
+    /// server TSM correlates the acknowledgment by routed identity even when
+    /// it arrives through a router whose MAC was unknown at send time (#375).
     fn permits_confirmed(&self) -> bool {
-        matches!(self, Self::LocalUnicast(_))
+        matches!(self, Self::LocalUnicast(_) | Self::RemoteUnicast { .. })
     }
 
     /// Whether this destination can be sent to at all, logging why not when it
@@ -369,24 +369,12 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             // Downgrading to unconfirmed would drop the acknowledgment the
             // recipient was configured to require, so both cases are skips.
             if *confirmed && !route.permits_confirmed() {
-                match &route {
-                    // Clause 6.3 permits sending this (the DNET/DADR restricts
-                    // the destination to one device), but the server TSM
-                    // cannot yet correlate an acknowledgment that arrives
-                    // through a router. Tracked by #375.
-                    RecipientRoute::RemoteUnicast { network, .. } => warn!(
-                        notification_class,
-                        network,
-                        "Recipient requests confirmed notifications on a remote network; \
-                         routed acknowledgment correlation is unimplemented (#375), skipping"
-                    ),
-                    // Clause 6.3 restricts broadcast to Unconfirmed-Request-PDUs.
-                    _ => warn!(
-                        notification_class,
-                        "Recipient requests confirmed notifications at a broadcast address; \
-                         Clause 6.3 permits only unconfirmed PDUs there, skipping"
-                    ),
-                }
+                // Clause 6.3 restricts broadcast to Unconfirmed-Request-PDUs.
+                warn!(
+                    notification_class,
+                    "Recipient requests confirmed notifications at a broadcast address; \
+                     Clause 6.3 permits only unconfirmed PDUs there, skipping"
+                );
                 continue;
             }
 
@@ -402,20 +390,37 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let service_bytes = service_buf.freeze();
 
             if *confirmed {
-                // `permits_confirmed` above admits only `LocalUnicast`. If
-                // that predicate ever widens without this arm learning the
-                // new route, fail loudly instead of dropping the
-                // notification with no diagnostic.
-                let RecipientRoute::LocalUnicast(target_mac) = &route else {
-                    warn!(
-                        notification_class,
-                        "Confirmed notification reached the send path on a \
-                         non-unicast route; dropping"
-                    );
-                    continue;
+                // `permits_confirmed` above admits exactly these two route
+                // shapes. If that predicate ever widens without this arm
+                // learning the new route, fail loudly instead of dropping
+                // the notification with no diagnostic.
+                //
+                // A remote recipient's transaction is keyed by routed
+                // identity with an empty local half: the ack will arrive
+                // from whichever router delivers it, and that MAC is
+                // unknowable when the send goes out via the Clause 6.5.3
+                // broadcast DA (#375).
+                let (peer_key, remote): (TsmPeer, Option<(u16, MacAddr)>) = match &route {
+                    RecipientRoute::LocalUnicast(target_mac) => ((target_mac.clone(), None), None),
+                    RecipientRoute::RemoteUnicast { network, mac } => (
+                        (
+                            MacAddr::new(),
+                            Some(NpduAddress {
+                                network: *network,
+                                mac_address: mac.clone(),
+                            }),
+                        ),
+                        Some((*network, mac.clone())),
+                    ),
+                    _ => {
+                        warn!(
+                            notification_class,
+                            "Confirmed notification reached the send path on a \
+                             non-unicast route; dropping"
+                        );
+                        continue;
+                    }
                 };
-                let target_mac = target_mac.clone();
-                let peer_key = (target_mac.clone(), None);
                 let (id, result_rx) = match {
                     let mut tsm = server_tsm.lock().await;
                     tsm.allocate(peer_key.clone())
@@ -451,9 +456,54 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     let mut pending_rx: Option<oneshot::Receiver<CovAckResult>> = Some(result_rx);
 
                     for attempt in 0..=apdu_retries {
-                        let send_result = network
-                            .send_apdu(&buf, &target_mac, true, network_priority)
-                            .await;
+                        let send_result = match &remote {
+                            None => {
+                                // Local unicast: the peer key's MAC half is
+                                // the destination.
+                                network
+                                    .send_apdu(&buf, &peer_key.0, true, network_priority)
+                                    .await
+                            }
+                            Some((dnet, dadr)) => {
+                                // Clause 6.5.3 method 4: the first attempt
+                                // may unicast to a router learned from an
+                                // earlier response; a retry after silence
+                                // falls back to the broadcast DA in case
+                                // that router is gone. With nothing learned,
+                                // every attempt uses the broadcast form the
+                                // clause prescribes for an unknown router.
+                                let router = if attempt == 0 {
+                                    tsm.lock().await.cached_router(*dnet)
+                                } else {
+                                    None
+                                };
+                                match router {
+                                    Some(router_mac) => {
+                                        network
+                                            .send_apdu_routed(
+                                                &buf,
+                                                *dnet,
+                                                dadr,
+                                                &router_mac,
+                                                true,
+                                                network_priority,
+                                            )
+                                            .await
+                                    }
+                                    None => {
+                                        network
+                                            .send_apdu_routed_via_local_broadcast(
+                                                &buf,
+                                                *dnet,
+                                                dadr,
+                                                true,
+                                                network_priority,
+                                            )
+                                            .await
+                                    }
+                                }
+                            }
+                        };
 
                         if let Err(e) = send_result {
                             warn!(error = %e, attempt, "Confirmed EventNotification send failed");

--- a/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
@@ -276,20 +276,6 @@ async fn remote_unicast_recipient_routes_via_broadcast_link_da() {
     );
 }
 
-/// #186/#375: a *confirmed* recipient on a remote network is spec-legal to
-/// send (Clause 6.3's single-device parenthetical) but the server TSM cannot
-/// correlate a routed acknowledgment yet, so it is skipped rather than sent
-/// and mis-retried into duplicate deliveries.
-#[tokio::test]
-async fn confirmed_remote_unicast_recipient_is_skipped() {
-    let mac = [0x0A, 0x00, 0x00, 0x64, 0xBA, 0xC0];
-    let (broadcasts, unicasts) =
-        distribute_to(vec![destination_for(address_recipient(1000, &mac), true)]).await;
-
-    assert!(broadcasts.is_empty());
-    assert!(unicasts.is_empty());
-}
-
 /// #360: a confirmed recipient spelled with the data link's *literal*
 /// broadcast MAC is the same unsatisfiable ask as the zero-length form —
 /// Clause 6.3 permits only unconfirmed PDUs at a broadcast — and must be

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -115,13 +115,24 @@ pub struct ServerTsm {
     /// Oneshot senders keyed by peer MAC and invoke ID. When a result arrives
     /// from the dispatch loop, we send it directly — no polling needed.
     pending: HashMap<TsmKey, oneshot::Sender<CovAckResult>>,
+    /// Router MACs learned per remote network, Clause 6.5.3 method 4: "using
+    /// the local broadcast MAC address in the initial transmission to a device
+    /// on a remote DNET and noting the SA associated with any subsequent
+    /// responses from the remote device" (#375). Consulted so later confirmed
+    /// sends to that DNET can unicast to the router instead of broadcasting.
+    routers: HashMap<u16, MacAddr>,
 }
+
+/// Cap on learned router entries; a full cache just means later networks keep
+/// using the (always-correct) broadcast form of Clause 6.5.3.
+const MAX_LEARNED_ROUTERS: usize = 64;
 
 impl ServerTsm {
     fn new() -> Self {
         Self {
             next_invoke_id: 0,
             pending: HashMap::new(),
+            routers: HashMap::new(),
         }
     }
 
@@ -173,6 +184,57 @@ impl ServerTsm {
     fn remove(&mut self, peer: &TsmPeer, invoke_id: u8) {
         self.pending
             .remove(&(peer.0.clone(), peer.1.clone(), invoke_id));
+    }
+
+    /// Correlate an inbound response with the transaction awaiting it (#375).
+    ///
+    /// Three key shapes are tried, most specific first:
+    /// 1. exactly as the sender registered it — the immediate MAC plus any
+    ///    routed identity;
+    /// 2. the router-unknown form — an empty local half with the routed
+    ///    identity, used when the request went out via the Clause 6.5.3
+    ///    broadcast DA and the delivering router's MAC was unknowable at
+    ///    registration;
+    /// 3. the legacy wildcard `(empty, None)`, which nothing registers today
+    ///    but which older callers may still expect.
+    ///
+    /// A hit that carries a routed identity also teaches the router cache:
+    /// the response's immediate MAC is "the SA associated with [a] subsequent
+    /// response from the remote device" (Clause 6.5.3 method 4).
+    fn record_result_correlated(
+        &mut self,
+        source_mac: &MacAddr,
+        source_network: Option<&NpduAddress>,
+        invoke_id: u8,
+        result: CovAckResult,
+    ) -> bool {
+        let hit = self.record_result(source_mac, source_network, invoke_id, result)
+            || (source_network.is_some()
+                && self.record_result(&MacAddr::new(), source_network, invoke_id, result))
+            || self.record_result(&MacAddr::new(), None, invoke_id, result);
+        if hit {
+            if let Some(address) = source_network {
+                self.learn_router(address.network, source_mac);
+            }
+        }
+        hit
+    }
+
+    /// Cache `router` as the way to reach `network`, bounded by
+    /// [`MAX_LEARNED_ROUTERS`].
+    fn learn_router(&mut self, network: u16, router: &MacAddr) {
+        if router.is_empty() {
+            return;
+        }
+        if self.routers.len() >= MAX_LEARNED_ROUTERS && !self.routers.contains_key(&network) {
+            return;
+        }
+        self.routers.insert(network, router.clone());
+    }
+
+    /// The learned router MAC for `network`, if any.
+    fn cached_router(&self, network: u16) -> Option<MacAddr> {
+        self.routers.get(&network).cloned()
     }
 }
 
@@ -843,6 +905,8 @@ mod segmentation;
 mod cov_notifications_tests;
 #[cfg(test)]
 mod dcc_event_detection_tests;
+#[cfg(test)]
+mod event_confirmed_routing_tests;
 #[cfg(test)]
 mod event_enable_distribution_tests;
 #[cfg(test)]


### PR DESCRIPTION
Closes #375.

Completes the remote-recipient notification story #186 started: confirmed event notifications now reach recipients on remote networks. Grounded against the live `_spec/` extraction (Clause 6.5.3's unknown-router send form at ~4981-4982; method 4's router-learning text verified verbatim at ~4984-4990; Clause 6.3's single-device parenthetical at ~4657-4659).

## What blocked it

Not the spec — the TSM. The pending ack was keyed by the target's MAC, but a routed recipient's SimpleAck arrives from *whichever router delivers it*, with the recipient's identity in SNET/SADR. That MAC is unknowable when the send goes out on the Clause 6.5.3 broadcast DA, so the ack could never correlate, the notification would mis-retry into up to four duplicate deliveries, and the previous PRs honestly skipped the send instead (#376's `permits_confirmed`).

## The fix

- **Routed peer key**: a remote recipient's transaction registers under `(empty local half, Some(NpduAddress{DNET, DADR}), invoke)`.
- **Tiered correlation** (`ServerTsm::record_result_correlated`, now the single entry point for all four dispatch arms): exact key → router-unknown routed key → the legacy `(empty, None)` wildcard (which nothing registers today; kept for parity). Wrong-identity acks miss — the tiers are exact lookups, not a scan.
- **Router learning, Clause 6.5.3 method 4**: any routed hit teaches a bounded (64-network) cache that the ack's source MAC is the router for that DNET. The next confirmed send to that network unicasts to the learned router on its **first attempt only**; a retry after silence falls back to the always-correct broadcast DA (self-healing against a vanished router), and with nothing learned every attempt uses the broadcast form the clause prescribes.
- **`permits_confirmed` admits `RemoteUnicast`**; the confirmed send path carries `expecting_reply = TRUE` through both routed forms. Broadcast-shaped confirmed recipients stay skipped — that is Clause 6.3's own restriction, not a TSM limitation.

## Tests

Six new, on a live fixture that keeps db/network/TSM across distributions (so learning is observable) and feeds acks through the same correlation entry point the dispatch loop uses:

- Delivery + correlation: routed NPDU on the broadcast DA, `data_expecting_reply` bit and DNET/DADR asserted byte-for-byte, and no retry after the ack.
- **Two concurrent routed recipients correlate independently** — the issue's own discrimination note: a single transaction cannot distinguish routed keying from the wildcard fallback; acking one leaves the other retrying.
- Wrong-DNET and wrong-DADR acks must **not** complete the transaction.
- Router learned from an ack → the next notification unicasts to it, still carrying the DNET/DADR NPDU.
- Learned router goes silent → first attempt unicast, retry arrives on the broadcast DA with the same invoke ID.
- Local-unicast confirmed recipient unchanged (regression guard).

Discrimination: five of six fail at dev `3540593` (the recipient was skipped, so no frames exist to assert on; `record_result_correlated` shimmed to `record_result` there so the file compiles); the guard passes by design. The #376-era `confirmed_remote_unicast_recipient_is_skipped` pinned the behavior this PR removes and is superseded by the new module.

Gates: workspace 3,001 passed / 0 failed, clippy clean, fmt clean, 700-LOC cap clean, `cargo check -p rusty-bacnet --tests` clean — from a `cargo clean` slate.

## Notes

- COV subscriptions register under the subscriber's *immediate* MAC (the router that delivered the SubscribeCOV), so a routed COV ack via a *different* redundant router still misses tier 1 and — because the registered key has a non-empty local half — tier 2 as well. Pre-existing, adjacent to #384's keying-convention note; not expanded here.
- The invoke-ID space point from grounding: allocation is global across peers, so tier-3's invoke-only wildcard cannot misdeliver among concurrent transactions today; the tiers exist to keep that true when keys, not luck, are doing the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
