### PR TITLE
Fix conservative Max Segments Accepted encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Confirmed-Request `max-segments-accepted` no longer maps every non-rung
+  client capacity to `B'111'` ("greater than 64"). Capacities 0 and 1 now fail
+  client startup and direct APDU encoding; finite values through 64 round down
+  to the nearest Clause 20.1.2.4 rung, so the wire header and local segmented
+  response limit never exceed the configured capacity (#365).
+
 - Confirmed event notifications reach remote-network recipients (#375). The
   #186 fix delivered the unconfirmed half and left confirmed recipients
   skipped, because the server TSM keyed the pending acknowledgment by the

--- a/crates/bacnet-client/src/client/builder_options.rs
+++ b/crates/bacnet-client/src/client/builder_options.rs
@@ -8,6 +8,9 @@ impl<T: TransportPort + 'static> ClientBuilder<T> {
     }
 
     /// Set the maximum number of APDU segments this client accepts.
+    ///
+    /// Values 0 and 1 fail at build time. Other finite non-rung values are
+    /// conservatively rounded down in Confirmed-Request headers.
     pub fn max_segments(mut self, max_segments: Option<u8>) -> Self {
         self.config.max_segments = max_segments;
         self
@@ -45,6 +48,9 @@ impl BipClientBuilder {
     }
 
     /// Set the maximum number of APDU segments this client accepts.
+    ///
+    /// Values 0 and 1 fail at build time. Other finite non-rung values are
+    /// conservatively rounded down in Confirmed-Request headers.
     pub fn max_segments(mut self, max_segments: Option<u8>) -> Self {
         self.config.max_segments = max_segments;
         self
@@ -83,6 +89,9 @@ impl Bip6ClientBuilder {
     }
 
     /// Set the maximum number of APDU segments this client accepts.
+    ///
+    /// Values 0 and 1 fail at build time. Other finite non-rung values are
+    /// conservatively rounded down in Confirmed-Request headers.
     pub fn max_segments(mut self, max_segments: Option<u8>) -> Self {
         self.config.max_segments = max_segments;
         self
@@ -121,6 +130,9 @@ impl ScClientBuilder {
     }
 
     /// Set the maximum number of APDU segments this client accepts.
+    ///
+    /// Values 0 and 1 fail at build time. Other finite non-rung values are
+    /// conservatively rounded down in Confirmed-Request headers.
     pub fn max_segments(mut self, max_segments: Option<u8>) -> Self {
         self.config.max_segments = max_segments;
         self

--- a/crates/bacnet-client/src/client/builder_options_tests.rs
+++ b/crates/bacnet-client/src/client/builder_options_tests.rs
@@ -54,3 +54,26 @@ async fn builder_rejects_invalid_proposed_window_size() {
 
     assert!(result.is_err());
 }
+
+#[tokio::test]
+async fn builder_rejects_max_segments_below_protocol_minimum() {
+    for invalid in [0, 1] {
+        let (transport, _peer_transport) = LoopbackTransport::pair(vec![0x10], vec![0x11]);
+        let result = BACnetClient::generic_builder()
+            .transport(transport)
+            .max_segments(Some(invalid))
+            .build()
+            .await;
+
+        match result {
+            Err(Error::Encoding(message)) => {
+                assert!(message.contains("max-segments-accepted"));
+            }
+            Err(other) => panic!("expected encoding error, got {other}"),
+            Ok(mut client) => {
+                client.stop().await.unwrap();
+                panic!("max_segments={invalid} must be rejected");
+            }
+        }
+    }
+}

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -30,6 +30,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         options: ClientOptions,
     ) -> Result<Self, Error> {
         validate_max_apdu_length(config.max_apdu_length)?;
+        validate_max_segments(config.max_segments)?;
         config.max_apdu_length =
             cap_max_apdu_to_transport(config.max_apdu_length, transport.max_apdu_length())?;
         if !(1..=127).contains(&config.proposed_window_size) {

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -17,7 +17,7 @@ use tokio::time::{timeout, Duration};
 use tracing::{debug, warn};
 
 use bacnet_encoding::apdu::{
-    self, encode_apdu, validate_max_apdu_length, AbortPdu, Apdu,
+    self, encode_apdu, validate_max_apdu_length, validate_max_segments, AbortPdu, Apdu,
     ConfirmedRequest as ConfirmedRequestPdu, RejectPdu, SegmentAck as SegmentAckPdu, SimpleAck,
 };
 use bacnet_encoding::npdu::NpduAddress;
@@ -83,7 +83,10 @@ pub struct ClientConfig {
     pub apdu_retries: u8,
     /// Maximum APDU length this client accepts.
     pub max_apdu_length: u16,
-    /// Maximum segments this client accepts (None = unspecified).
+    /// Maximum segments this client accepts (`None` = unspecified).
+    ///
+    /// Values 0 and 1 are invalid. Finite values between the BACnet wire
+    /// encodings are conservatively rounded down (for example, 5 advertises 4).
     pub max_segments: Option<u8>,
     /// Whether this client accepts segmented responses.
     pub segmented_response_accepted: bool,

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -642,6 +642,7 @@ impl ScClientBuilder {
     ) -> Result<BACnetClient<bacnet_transport::sc::ScTransport<W>>, Error> {
         self.validate_identity()?;
         self.options.validate()?;
+        validate_max_segments(self.config.max_segments)?;
         let transport = self.sc_transport(ws);
         BACnetClient::start_with_options(self.config, transport, self.options).await
     }
@@ -655,6 +656,7 @@ impl ScClientBuilder {
     > {
         self.validate_identity()?;
         self.options.validate()?;
+        validate_max_segments(self.config.max_segments)?;
         let tls_config =
             self.tls_config.as_ref().cloned().ok_or_else(|| {
                 Error::Encoding("SC client builder: tls_config is required".into())

--- a/crates/bacnet-client/src/client/response_correlation_tests.rs
+++ b/crates/bacnet-client/src/client/response_correlation_tests.rs
@@ -637,13 +637,20 @@ async fn segment_257_aborts_with_buffer_overflow() {
 }
 
 #[tokio::test]
-async fn advertised_max_segments_bounds_reassembly() {
+async fn non_rung_max_segments_rounds_down_in_header_and_bounds_reassembly() {
     let mut config = config();
-    // B'010' — Clause 20.1.2.4 "4 segments accepted".
-    config.max_segments = Some(4);
+    // Five has no Clause 20.1.2.4 encoding. Conservatively advertise the
+    // B'010' rung (four) and enforce the same receive bound locally.
+    config.max_segments = Some(5);
     let mut link =
         PeerLink::issuing(config, ConfirmedServiceChoice::READ_PROPERTY, vec![0x01]).await;
-    let invoke_id = link.request_invoke_id().await;
+    let invoke_id = match link.recv("initial request").await {
+        Apdu::ConfirmedRequest(req) => {
+            assert_eq!(req.max_segments, Some(4));
+            req.invoke_id
+        }
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    };
 
     feed_segments(
         &mut link,

--- a/crates/bacnet-client/src/client/sc_builder_tests.rs
+++ b/crates/bacnet-client/src/client/sc_builder_tests.rs
@@ -83,6 +83,21 @@ async fn sc_client_builder_rejects_reserved_vmac_before_connect() {
     }
 }
 
+#[tokio::test]
+async fn sc_client_builder_rejects_invalid_max_segments_before_connect() {
+    let result = BACnetClient::sc_builder()
+        .vmac([0x22, 0x01, 0x02, 0x03, 0x04, 0x05])
+        .device_uuid([0xAB; 16])
+        .max_segments(Some(1))
+        .build()
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(Error::Encoding(message)) if message.contains("max-segments-accepted")
+    ));
+}
+
 #[test]
 fn sc_client_builder_rejects_broadcast_vmac_and_zero_device_uuid() {
     let broadcast = BACnetClient::sc_builder()

--- a/crates/bacnet-encoding/src/apdu/mod.rs
+++ b/crates/bacnet-encoding/src/apdu/mod.rs
@@ -37,18 +37,37 @@ const MAX_SEGMENTS_DECODE: [Option<u8>; 8] = [
     Some(255), // 7 = >64 segments accepted
 ];
 
-/// Encode a max-segments value to a 3-bit field.
-fn encode_max_segments(value: Option<u8>) -> u8 {
+/// Validate a configured maximum segment count for a Confirmed-Request header.
+///
+/// Clause 20.1.2.4 has no encoding for a finite capacity below two segments.
+/// To decline segmented responses, set `segmented-response-accepted = false`
+/// and use `None` rather than `Some(1)`.
+pub fn validate_max_segments(value: Option<u8>) -> Result<(), Error> {
     match value {
-        None => 0,
-        Some(2) => 1,
-        Some(4) => 2,
-        Some(8) => 3,
-        Some(16) => 4,
-        Some(32) => 5,
-        Some(64) => 6,
-        Some(_) => 7, // >64
+        Some(value @ 0..=1) => Err(Error::Encoding(format!(
+            "invalid max-segments-accepted {value}; expected 2..=255 or unspecified"
+        ))),
+        _ => Ok(()),
     }
+}
+
+/// Encode a max-segments value to a 3-bit field.
+///
+/// Finite counts that fall between the Clause 20.1.2.4 rungs are rounded down
+/// so the wire header never promises more receive capacity than configured.
+fn encode_max_segments(value: Option<u8>) -> Result<u8, Error> {
+    validate_max_segments(value)?;
+    Ok(match value {
+        None => 0,
+        Some(2..=3) => 1,
+        Some(4..=7) => 2,
+        Some(8..=15) => 3,
+        Some(16..=31) => 4,
+        Some(32..=63) => 5,
+        Some(64) => 6,
+        Some(65..=u8::MAX) => 7, // >64
+        Some(0..=1) => unreachable!("validated above"),
+    })
 }
 
 /// Decode a 3-bit max-segments field.
@@ -67,8 +86,11 @@ fn decode_max_segments(value: u8) -> Option<u8> {
 /// `configured` directly: a value such as `Some(100)` encodes as B'111', so the
 /// peer was told "Greater than 64 segments accepted", not "100". Answering
 /// from the configured number would claim a promise that was never sent.
+/// Invalid finite capacities below two yield `None`; APDU encoding and client
+/// startup reject those values through [`validate_max_segments`].
 pub fn advertised_max_segments(configured: Option<u8>) -> Option<u8> {
-    match decode_max_segments(encode_max_segments(configured)) {
+    let encoded = encode_max_segments(configured).ok()?;
+    match decode_max_segments(encoded) {
         // The B'111' sentinel — "Greater than 64 segments accepted", which is
         // open-ended rather than a bound.
         Some(255) => None,
@@ -263,6 +285,9 @@ pub fn encode_apdu(buf: &mut BytesMut, apdu: &Apdu) -> Result<(), Error> {
 }
 
 fn encode_confirmed_request(buf: &mut BytesMut, pdu: &ConfirmedRequest) -> Result<(), Error> {
+    let max_segments = encode_max_segments(pdu.max_segments)?;
+    let max_apdu = encode_max_apdu(pdu.max_apdu_length)?;
+
     let mut byte0 = PduType::CONFIRMED_REQUEST.to_raw() << 4;
     if pdu.segmented {
         byte0 |= 0x08;
@@ -275,8 +300,7 @@ fn encode_confirmed_request(buf: &mut BytesMut, pdu: &ConfirmedRequest) -> Resul
     }
     buf.put_u8(byte0);
 
-    let byte1 =
-        (encode_max_segments(pdu.max_segments) << 4) | encode_max_apdu(pdu.max_apdu_length)?;
+    let byte1 = (max_segments << 4) | max_apdu;
     buf.put_u8(byte1);
 
     buf.put_u8(pdu.invoke_id);

--- a/crates/bacnet-encoding/src/apdu/tests.rs
+++ b/crates/bacnet-encoding/src/apdu/tests.rs
@@ -10,17 +10,93 @@ fn encode_to_vec(apdu: &Apdu) -> Vec<u8> {
 
 #[test]
 fn max_segments_round_trip() {
-    assert_eq!(decode_max_segments(encode_max_segments(None)), None);
-    assert_eq!(decode_max_segments(encode_max_segments(Some(2))), Some(2));
-    assert_eq!(decode_max_segments(encode_max_segments(Some(4))), Some(4));
-    assert_eq!(decode_max_segments(encode_max_segments(Some(8))), Some(8));
-    assert_eq!(decode_max_segments(encode_max_segments(Some(16))), Some(16));
-    assert_eq!(decode_max_segments(encode_max_segments(Some(32))), Some(32));
-    assert_eq!(decode_max_segments(encode_max_segments(Some(64))), Some(64));
     assert_eq!(
-        decode_max_segments(encode_max_segments(Some(100))),
+        decode_max_segments(encode_max_segments(None).unwrap()),
+        None
+    );
+    assert_eq!(
+        decode_max_segments(encode_max_segments(Some(2)).unwrap()),
+        Some(2)
+    );
+    assert_eq!(
+        decode_max_segments(encode_max_segments(Some(4)).unwrap()),
+        Some(4)
+    );
+    assert_eq!(
+        decode_max_segments(encode_max_segments(Some(8)).unwrap()),
+        Some(8)
+    );
+    assert_eq!(
+        decode_max_segments(encode_max_segments(Some(16)).unwrap()),
+        Some(16)
+    );
+    assert_eq!(
+        decode_max_segments(encode_max_segments(Some(32)).unwrap()),
+        Some(32)
+    );
+    assert_eq!(
+        decode_max_segments(encode_max_segments(Some(64)).unwrap()),
+        Some(64)
+    );
+    assert_eq!(
+        decode_max_segments(encode_max_segments(Some(100)).unwrap()),
         Some(255)
     );
+}
+
+#[test]
+fn max_segments_non_rungs_round_down_without_over_advertising() {
+    for (configured, advertised) in [(3, 2), (5, 4), (7, 4), (9, 8), (17, 16), (33, 32), (63, 32)] {
+        assert_eq!(
+            decode_max_segments(encode_max_segments(Some(configured)).unwrap()),
+            Some(advertised),
+            "configured maximum {configured} must not advertise a larger finite capacity"
+        );
+    }
+}
+
+#[test]
+fn greater_than_64_code_is_only_used_for_true_greater_than_64_values() {
+    for configured in 2..=64 {
+        let encoded = encode_max_segments(Some(configured)).unwrap();
+        assert_ne!(
+            encoded, 7,
+            "{configured} must not encode as greater than 64"
+        );
+        assert!(
+            decode_max_segments(encoded).unwrap() <= configured,
+            "the encoded rung must not exceed the configured capacity"
+        );
+    }
+
+    for configured in 65..=u8::MAX {
+        assert_eq!(encode_max_segments(Some(configured)).unwrap(), 7);
+    }
+}
+
+#[test]
+fn confirmed_request_rejects_max_segments_below_protocol_minimum() {
+    for invalid in [0, 1] {
+        let pdu = Apdu::ConfirmedRequest(ConfirmedRequest {
+            segmented: false,
+            more_follows: false,
+            segmented_response_accepted: true,
+            max_segments: Some(invalid),
+            max_apdu_length: 1476,
+            invoke_id: 1,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+            service_request: Bytes::new(),
+        });
+
+        let mut buf = BytesMut::new();
+        assert!(
+            encode_apdu(&mut buf, &pdu).is_err(),
+            "max-segments-accepted={invalid} must not be encoded as greater than 64"
+        );
+        assert!(buf.is_empty(), "validation must precede output mutation");
+    }
 }
 
 #[test]

--- a/crates/bacnet-server/src/server/segmentation_tests/control_limits.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/control_limits.rs
@@ -1,6 +1,57 @@
 use super::*;
 
 #[tokio::test]
+async fn non_rung_request_header_conservatively_bounds_server_response() {
+    let request = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: true,
+        max_segments: Some(5),
+        max_apdu_length: 50,
+        invoke_id: 0x49,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+        service_request: Bytes::new(),
+    });
+    let mut encoded = BytesMut::new();
+    encode_apdu(&mut encoded, &request).unwrap();
+    let client_max_segments = match decode_apdu(encoded.freeze()).unwrap() {
+        Apdu::ConfirmedRequest(request) => {
+            assert_eq!(request.max_segments, Some(4));
+            request.max_segments
+        }
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    };
+
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let source_mac = test_mac(9);
+
+    BACnetServer::<RecordingTransport>::send_segmented_complex_ack(
+        &network,
+        &seg_ack_senders,
+        &seg_send_permits,
+        source_mac.as_slice(),
+        None,
+        0x49,
+        ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+        &[0xA5; 256],
+        50,
+        client_max_segments,
+    )
+    .await;
+
+    assert_eq!(sent_count(&sent), 1);
+    assert_eq!(abort_reason(&sent, 0), AbortReason::BUFFER_OVERFLOW);
+    assert!(seg_ack_senders.lock().await.is_empty());
+}
+
+#[tokio::test]
 async fn client_abort_routed_by_dispatch_terminates_segmented_complex_ack() {
     let sent = StdArc::new(StdMutex::new(Vec::new()));
     let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(


### PR DESCRIPTION
## Summary

- reject finite max-segments-accepted values 0 and 1 at client startup and at the APDU encoder safety boundary
- round finite non-rung capacities through 64 down to the nearest Clause 20.1.2.4 encoding while preserving B111 only for true capacities above 64
- prove the normalized request header controls both client reassembly and server segmented-response limits
- validate BACnet/SC configuration before TLS/WebSocket connection work
- document the behavior change in the client builders and changelog

Closes #365.

## Standard and scope

Clause 20.1.2.4 defines only unspecified, 2, 4, 8, 16, 32, 64, and greater-than-64 wire classes. Clause 5.2.1.3 makes the requester header an input to the responding server segmentation decision. The implementation treats ClientConfig.max_segments as a numeric receive-capacity input and projects finite values through 64 conservatively onto that wire ladder.

The Device Max_Segments_Accepted property in Clause 12.11.20 is an exact Unsigned value, not the three-bit request-header ladder. This PR therefore does not add a new Device or Server configuration field and does not absorb the separate mode-derived Device default defect currently entangled in #379. The server surface covered here is its existing enforcement of the decoded request header.

## Behavior

- None remains B000, unspecified.
- Some(0) and Some(1) return an encoding/configuration error.
- 2..=3 advertise 2.
- 4..=7 advertise 4.
- 8..=15 advertise 8.
- 16..=31 advertise 16.
- 32..=63 advertise 32.
- 64 advertises 64.
- 65..=255 advertise B111, greater than 64.

All four client builders retain their existing fluent signatures. Validation converges in BACnetClient::start_with_options before transport startup. The BACnet/SC production builder also validates before TLS configuration lookup and WebSocket connection. Direct public ConfirmedRequest construction is independently protected by encode_apdu.

## Files changed

- CHANGELOG.md — records the intentional wire/configuration behavior change.
- crates/bacnet-encoding/src/apdu/mod.rs — adds shared validation, conservative rung encoding, and pre-mutation Confirmed-Request checks.
- crates/bacnet-encoding/src/apdu/tests.rs — covers invalid values, representative non-rungs, and exhaustive 2..=255 invariants.
- crates/bacnet-client/src/client/mod.rs — documents ClientConfig and validates both BACnet/SC build paths before connection work.
- crates/bacnet-client/src/client/lifecycle.rs — applies shared validation before generic transport startup.
- crates/bacnet-client/src/client/builder_options.rs — documents the contract on generic, B/IP, B/IP6, and BACnet/SC builders.
- crates/bacnet-client/src/client/builder_options_tests.rs — proves 0/1 startup rejection.
- crates/bacnet-client/src/client/response_correlation_tests.rs — proves header normalization and the matching local reassembly cap.
- crates/bacnet-client/src/client/sc_builder_tests.rs — proves invalid SC configuration fails before TLS/connect prerequisites.
- crates/bacnet-server/src/server/segmentation_tests/control_limits.rs — proves the decoded conservative header bounds responder segmentation.

## Test-first evidence

Before implementation, the new discriminating tests failed because Some(3) and Some(5) decoded as the 255 sentinel, Some(0) and Some(1) encoded successfully, and client startup accepted both invalid values.

After implementation:

- exhaustive 2..=255 encoder invariants prove no 2..=64 value emits B111 and no finite rung exceeds configured capacity
- direct APDU tests prove 0 and 1 fail before output-buffer mutation
- builder tests prove 0 and 1 fail during startup validation
- loopback client coverage proves Some(5) emits four and the fifth response segment triggers BUFFER_OVERFLOW
- server coverage round-trips the non-rung request header and proves an oversized response is aborted before a segmented sender is registered
- BACnet/SC coverage proves invalid configuration wins before TLS configuration lookup or connection work

## Verification

- cargo fmt --all -- --check
- cargo test -p bacnet-encoding --locked
- cargo test -p bacnet-client --locked
- cargo test -p bacnet-client --features sc-tls --locked
- cargo test -p bacnet-server non_rung_request_header_conservatively_bounds_server_response --locked
- cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked
- cargo test --workspace --exclude rusty-bacnet --locked
- cargo check -p rusty-bacnet --tests --locked
- git diff --check

All commands pass locally. Existing repository warnings remain unchanged. Hosted rustfmt, Clippy, Ubuntu tests, file-size, and secret scanning pass at 5010f0fd29dc50f522b8f6051f6d6073624c86e7.

## Immutable-head review

The first review at 5182f7898947a014a5c49ad769132fd6f447b51a found that the production BACnet/SC builder could attempt TLS/WebSocket connection before reaching shared validation. Commit 5010f0f moves validation before connection work and adds a discriminating sc-tls regression.

At final head 5010f0fd29dc50f522b8f6051f6d6073624c86e7:

- BACnet safety/interoperability reviewer on gpt-5.6-sol with xhigh reasoning: READY, no remaining findings.
- BACnet Standard reference reviewer: READY; Clause 20.1.2.3/.4, 5.2.1.3, 5.4.5.3, and the Device-property boundary are consistent.
- Correctness/API reviewer: READY; range coverage, buffer ordering, all builders, and direct APDU callers are sound.
- Independent test verifier: READY; focused, all-feature client, full workspace, format, lint, and hosted gates pass.

Residual bounded follow-ups are unchanged existing work: B111 carries no exact finite upper bound; server response segmentation still materializes chunks before its peer-limit/permit checks; and the exact Device property/default contract remains in #379.

## Compatibility and claims

This intentionally changes wire bytes for finite non-rung values through 64 and makes 0/1 fail instead of falsely advertising greater than 64. Exact rungs, None, and true greater-than-64 configurations retain their existing wire values. No public configuration struct fields were added or removed. A new validation helper is public so all client startup paths share the encoder contract.

No README, PICS, BIBB, object-support, or conformance-ledger claim changes are made. No benchmark is warranted for this constant-time table projection.