### PR TITLE
fix(client): safely answer unsupported confirmed requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,22 +89,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Client-mode responders now return `Reject(UNRECOGNIZED_SERVICE)` for
   complete unicast ConfirmedRequest APDUs without a handler (#374), preserve
-  routed reply addressing, use the immediate MS/TP reply channel when one is
-  present, reject malformed confirmed COV payloads before delivery (including
-  an empty required parameter list), and return a server-side
+  routed reply addressing, send ready MS/TP responses immediately (or
+  `ReplyPostponed` with transmission margin before `T_reply_delay`), classify
+  malformed confirmed COV payloads with the applicable Clause 18.9 Reject
+  reason before delivery, and return a server-side
   `SEGMENTATION_NOT_SUPPORTED` Abort when inbound request reassembly is
   unavailable. Confirmed multicast and broadcast deliveries remain silent as
   required by the responding TSM. B/IP and B/IP6 now obtain the actual UDP
   destination from packet metadata and fail closed on missing, truncated, or
-  mismatched metadata; B/IP6 Original-Unicast also requires the local
-  Destination-VMAC before learning the sender, and outbound B/IP6 unicast now
-  fails explicitly until the destination VMAC has been learned instead of
-  emitting a guaranteed-to-be-discarded reserved VMAC. To retain
+  mismatched metadata; oversized Windows datagrams are dropped without stopping
+  reception. B/IP6 unicast data and address-resolution acknowledgements also
+  require the local Destination-VMAC before learning the sender. Its VMAC table
+  is bounded, preserves a unique learned link-local scope, fails closed when
+  scopes are ambiguous, and deterministically replaces stale endpoint mappings.
+  Annex U Forwarded-NPDU now uses the standard single-VMAC wire layout, exposes
+  the original 18-byte B/IPv6 source, and learns it for follow-up unicast.
+  Outbound unicast fails explicitly until the destination VMAC has been learned
+  instead of guessing from an IP endpoint; automatic outbound Address-Resolution
+  remains a follow-up. To retain
   group-delivery provenance after frame decoding, the public `ReceivedNpdu` and
   `ReceivedApdu` envelopes gain `link_layer_group` and `is_group` fields;
   downstream custom transports or exhaustive struct literals must initialize
-  the new fields. Windows builds gain a direct `windows-sys` dependency for
-  `WSARecvMsg` destination metadata.
+  the new fields. The public Forwarded-NPDU payload decoder now returns the
+  original B/IPv6 address and NPDU because the original VMAC is already in the
+  BVLC6 header. Windows builds gain a direct `windows-sys` dependency for
+  `WSARecvMsg` destination metadata; unsupported OS targets reject B/IP startup
+  when safe destination metadata cannot be obtained.
 
 - Confirmed-Request `max-segments-accepted` no longer maps every non-rung
   client capacity to `B'111'` ("greater than 64"). Capacities 0 and 1 now fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,18 +97,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unavailable. Confirmed multicast and broadcast deliveries remain silent as
   required by the responding TSM. B/IP and B/IP6 now obtain the actual UDP
   destination from packet metadata and fail closed on missing, truncated, or
-  mismatched metadata while preserving wildcard binds; oversized Windows
-  datagrams are dropped without stopping reception. B/IP6 unicast data and
+  mismatched metadata while preserving wildcard binds. B/IP management
+  messages require actual unicast delivery, and oversized datagrams plus
+  transient Windows UDP reset errors are dropped without stopping reception.
+  B/IP6 unicast data and
   address-resolution acknowledgements also require the local Destination-VMAC
   before learning the sender. Its 4,096-entry VMAC table preserves a unique
   learned link-local scope, fails closed when scopes are ambiguous, and
   deterministically replaces stale endpoint mappings. Device instance zero's
-  VMAC remains valid. Annex U fixed-size messages reject surplus bytes;
+  VMAC remains valid; out-of-range instances fail startup. Unconfigured nodes
+  draw Random Device Instance VMACs from OS randomness, probe the configured
+  multicast scope, and fail startup rather than use a configured or random VMAC
+  with a detected collision. The public `generate_random_vmac` helper is
+  consequently fallible. Annex U fixed-size messages reject surplus bytes;
   Address-Resolution and Virtual-Address-Resolution use their specified
   multicast and unicast paths. Forwarded-NPDU now uses the standard single-VMAC
   wire layout, accepts only multicast delivery or the configured non-link-local
-  foreign-device BBMD, exposes the original 18-byte B/IPv6 source, and learns a validated,
-  non-link-local origin for follow-up unicast. Outbound unicast fails explicitly
+  foreign-device BBMD, exposes the original 18-byte B/IPv6 source, and learns
+  only a validated, nonzero-port, non-multicast, non-unspecified, non-link-local
+  origin for follow-up unicast. Outbound unicast fails explicitly
   until the destination VMAC has been learned instead of guessing from an IP
   endpoint; automatic outbound VMAC discovery remains a follow-up. To retain
   group-delivery provenance after frame decoding, the public `ReceivedNpdu` and
@@ -117,8 +124,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the new fields. The public Forwarded-NPDU payload decoder now returns the
   original B/IPv6 address and NPDU because the original VMAC is already in the
   BVLC6 header. Windows builds gain a direct `windows-sys` dependency for
-  `WSARecvMsg` destination metadata; unsupported OS targets reject B/IP startup
-  when safe destination metadata cannot be obtained.
+  `WSARecvMsg` destination metadata. Interface enumeration is compiled only on
+  targets whose libc exposes `getifaddrs`; unsupported OS targets still compile
+  and reject B/IP startup when safe destination metadata cannot be obtained.
 
 - Confirmed-Request `max-segments-accepted` no longer maps every non-rung
   client capacity to `B'111'` ("greater than 64"). Capacities 0 and 1 now fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,13 +89,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Client-mode responders now return `Reject(UNRECOGNIZED_SERVICE)` for
   complete unicast ConfirmedRequest APDUs without a handler (#374), preserve
-  routed reply addressing, reject malformed confirmed COV payloads before
-  delivery, and return a server-side `SEGMENTATION_NOT_SUPPORTED` Abort when
-  inbound request reassembly is unavailable. Confirmed broadcasts remain
-  silent as required by the responding TSM. To retain that distinction after
-  frame decoding, the public `ReceivedNpdu` and `ReceivedApdu` envelopes gain
-  `link_layer_broadcast` and `is_broadcast` fields; downstream custom
-  transports or exhaustive struct literals must initialize the new fields.
+  routed reply addressing, use the immediate MS/TP reply channel when one is
+  present, reject malformed confirmed COV payloads before delivery (including
+  an empty required parameter list), and return a server-side
+  `SEGMENTATION_NOT_SUPPORTED` Abort when inbound request reassembly is
+  unavailable. Confirmed multicast and broadcast deliveries remain silent as
+  required by the responding TSM. B/IP and B/IP6 now obtain the actual UDP
+  destination from packet metadata and fail closed on missing, truncated, or
+  mismatched metadata; B/IP6 Original-Unicast also requires the local
+  Destination-VMAC before learning the sender, and outbound B/IP6 unicast now
+  fails explicitly until the destination VMAC has been learned instead of
+  emitting a guaranteed-to-be-discarded reserved VMAC. To retain
+  group-delivery provenance after frame decoding, the public `ReceivedNpdu` and
+  `ReceivedApdu` envelopes gain `link_layer_group` and `is_group` fields;
+  downstream custom transports or exhaustive struct literals must initialize
+  the new fields. Windows builds gain a direct `windows-sys` dependency for
+  `WSARecvMsg` destination metadata.
 
 - Confirmed-Request `max-segments-accepted` no longer maps every non-rung
   client capacity to `B'111'` ("greater than 64"). Capacities 0 and 1 now fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Client-mode responders now return `Reject(UNRECOGNIZED_SERVICE)` for
+  complete unicast ConfirmedRequest APDUs without a handler (#374), preserve
+  routed reply addressing, reject malformed confirmed COV payloads before
+  delivery, and return a server-side `SEGMENTATION_NOT_SUPPORTED` Abort when
+  inbound request reassembly is unavailable. Confirmed broadcasts remain
+  silent as required by the responding TSM. To retain that distinction after
+  frame decoding, the public `ReceivedNpdu` and `ReceivedApdu` envelopes gain
+  `link_layer_broadcast` and `is_broadcast` fields; downstream custom
+  transports or exhaustive struct literals must initialize the new fields.
+
 - Confirmed-Request `max-segments-accepted` no longer maps every non-rung
   client capacity to `B'111'` ("greater than 64"). Capacities 0 and 1 now fail
   client startup and direct APDU encoding; finite values through 64 round down

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,16 +97,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unavailable. Confirmed multicast and broadcast deliveries remain silent as
   required by the responding TSM. B/IP and B/IP6 now obtain the actual UDP
   destination from packet metadata and fail closed on missing, truncated, or
-  mismatched metadata; oversized Windows datagrams are dropped without stopping
-  reception. B/IP6 unicast data and address-resolution acknowledgements also
-  require the local Destination-VMAC before learning the sender. Its VMAC table
-  is bounded, preserves a unique learned link-local scope, fails closed when
-  scopes are ambiguous, and deterministically replaces stale endpoint mappings.
-  Annex U Forwarded-NPDU now uses the standard single-VMAC wire layout, exposes
-  the original 18-byte B/IPv6 source, and learns it for follow-up unicast.
-  Outbound unicast fails explicitly until the destination VMAC has been learned
-  instead of guessing from an IP endpoint; automatic outbound Address-Resolution
-  remains a follow-up. To retain
+  mismatched metadata while preserving wildcard binds; oversized Windows
+  datagrams are dropped without stopping reception. B/IP6 unicast data and
+  address-resolution acknowledgements also require the local Destination-VMAC
+  before learning the sender. Its 4,096-entry VMAC table preserves a unique
+  learned link-local scope, fails closed when scopes are ambiguous, and
+  deterministically replaces stale endpoint mappings. Device instance zero's
+  VMAC remains valid. Annex U fixed-size messages reject surplus bytes;
+  Address-Resolution and Virtual-Address-Resolution use their specified
+  multicast and unicast paths. Forwarded-NPDU now uses the standard single-VMAC
+  wire layout, accepts only multicast delivery or the configured non-link-local
+  foreign-device BBMD, exposes the original 18-byte B/IPv6 source, and learns a validated,
+  non-link-local origin for follow-up unicast. Outbound unicast fails explicitly
+  until the destination VMAC has been learned instead of guessing from an IP
+  endpoint; automatic outbound VMAC discovery remains a follow-up. To retain
   group-delivery provenance after frame decoding, the public `ReceivedNpdu` and
   `ReceivedApdu` envelopes gain `link_layer_group` and `is_group` fields;
   downstream custom transports or exhaustive struct literals must initialize
@@ -1146,7 +1150,7 @@ Deep-dive review of all five transport implementations (BIP, BIPv6, BACnet/SC, E
 
 #### BACnet/IPv6 — VMAC & Address Resolution (Annex U)
 - **Fixed** Virtual-Address-Resolution wire format — was 10 bytes with duplicate VMAC payload, now 7 bytes per Clause U.2.7
-- **Fixed** Virtual-Address-Resolution-ACK — now accepts and encodes requester's destination VMAC (10 bytes per Clause U.2.7A)
+- **Fixed** Virtual-Address-Resolution-ACK — now accepts and encodes requester's destination VMAC (10 bytes per Clause U.2.8)
 - **Fixed** `send_unicast` derived destination VMAC from IPv6 address bytes — now uses VMAC address table reverse lookup per Clause U.5
 - **Fixed** decoder only extracted destination VMAC for OriginalUnicast — now also extracts for AddressResolution, AddressResolutionAck, VirtualAddressResolutionAck
 - **Fixed** `derive_vmac_from_device_instance` did not mask to 22 bits per Clause H.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,19 +105,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   before learning the sender. Its 4,096-entry VMAC table preserves a unique
   learned link-local scope, fails closed when scopes are ambiguous, and
   deterministically replaces stale endpoint mappings. Device instance zero's
-  VMAC remains valid; out-of-range instances fail startup. Unconfigured nodes
-  draw Random Device Instance VMACs from OS randomness, probe the configured
-  multicast scope, and fail startup rather than use a configured or random VMAC
-  with a detected collision. The public `generate_random_vmac` helper is
+  VMAC remains valid; out-of-range instances fail startup. Directly connected,
+  unconfigured nodes draw Random Device Instance VMACs from OS randomness,
+  probe the configured multicast scope, answer peer probes during startup, and
+  fail atomically on probe errors or collisions. Random-identity foreign-device
+  startup is rejected until BBMD-assisted resolution is implemented. The public
+  `generate_random_vmac` helper is
   consequently fallible. Annex U fixed-size messages reject surplus bytes;
   Address-Resolution and Virtual-Address-Resolution use their specified
   multicast and unicast paths. Forwarded-NPDU now uses the standard single-VMAC
   wire layout, accepts only multicast delivery or the configured non-link-local
   foreign-device BBMD, exposes the original 18-byte B/IPv6 source, and learns
-  only a validated, nonzero-port, non-multicast, non-unspecified, non-link-local
-  origin for follow-up unicast. Outbound unicast fails explicitly
-  until the destination VMAC has been learned instead of guessing from an IP
-  endpoint; automatic outbound VMAC discovery remains a follow-up. To retain
+  only a validated, nonzero-port, non-multicast, non-unspecified, non-loopback,
+  non-IPv4-mapped, non-link-local origin for follow-up unicast. Outbound unicast
+  fails explicitly until the destination VMAC has been learned instead of
+  guessing from an IP endpoint; automatic outbound VMAC discovery remains a
+  follow-up. To retain
   group-delivery provenance after frame decoding, the public `ReceivedNpdu` and
   `ReceivedApdu` envelopes gain `link_layer_group` and `is_group` fields;
   downstream custom transports or exhaustive struct literals must initialize

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,7 @@ dependencies = [
  "tokio-serial",
  "tokio-tungstenite",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/bacnet-client/src/client/confirmed_request_dispatch_tests.rs
+++ b/crates/bacnet-client/src/client/confirmed_request_dispatch_tests.rs
@@ -1,0 +1,328 @@
+//! Responding-client behavior for inbound ConfirmedRequest APDUs (issue #374).
+
+use super::*;
+use bacnet_encoding::apdu::{decode_apdu, ConfirmedRequest};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_types::enums::AbortReason;
+
+fn confirmed_request(
+    invoke_id: u8,
+    service_choice: ConfirmedServiceChoice,
+    segmented: bool,
+    service_request: Bytes,
+) -> Apdu {
+    Apdu::ConfirmedRequest(ConfirmedRequest {
+        segmented,
+        more_follows: segmented,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 480,
+        invoke_id,
+        sequence_number: segmented.then_some(0),
+        proposed_window_size: segmented.then_some(1),
+        service_choice,
+        service_request,
+    })
+}
+
+fn encode_inbound(apdu: Apdu, source_network: Option<NpduAddress>) -> BytesMut {
+    encode_inbound_with_destination(apdu, source_network, None)
+}
+
+fn encode_inbound_with_destination(
+    apdu: Apdu,
+    source_network: Option<NpduAddress>,
+    destination: Option<NpduAddress>,
+) -> BytesMut {
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &apdu).unwrap();
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(
+        &mut npdu_buf,
+        &Npdu {
+            source: source_network,
+            destination,
+            payload: apdu_buf.freeze(),
+            ..Npdu::default()
+        },
+    )
+    .unwrap();
+    npdu_buf
+}
+
+async fn receive_response(
+    peer_rx: &mut mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>,
+) -> (Npdu, Apdu) {
+    let received = timeout(Duration::from_secs(2), peer_rx.recv())
+        .await
+        .expect("peer timed out waiting for response")
+        .expect("peer channel closed");
+    let npdu = decode_npdu(received.npdu).unwrap();
+    let apdu = decode_apdu(npdu.payload.clone()).unwrap();
+    (npdu, apdu)
+}
+
+fn assert_unrecognized_reject(apdu: Apdu, invoke_id: u8) {
+    let Apdu::Reject(reject) = apdu else {
+        panic!("expected Reject");
+    };
+    assert_eq!(reject.invoke_id, invoke_id);
+    assert_eq!(reject.reject_reason, RejectReason::UNRECOGNIZED_SERVICE);
+}
+
+#[tokio::test]
+async fn unsupported_local_confirmed_request_receives_reject() {
+    let client_mac = vec![0x01];
+    let peer_mac = vec![0x02];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac);
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    let request = encode_inbound(
+        confirmed_request(
+            0x31,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            false,
+            Bytes::new(),
+        ),
+        None,
+    );
+    peer_transport
+        .send_unicast(&request, &client_mac)
+        .await
+        .unwrap();
+
+    let (npdu, apdu) = receive_response(&mut peer_rx).await;
+    assert!(npdu.destination.is_none());
+    assert_unrecognized_reject(apdu, 0x31);
+
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn unsupported_routed_confirmed_request_receives_routed_reject() {
+    let client_mac = vec![0x11];
+    let router_mac = vec![0x12];
+    let remote = NpduAddress {
+        network: 200,
+        mac_address: MacAddr::from_slice(&[0x13, 0x14]),
+    };
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac);
+    let mut router_rx = router_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    let request = encode_inbound(
+        confirmed_request(
+            0x32,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            false,
+            Bytes::new(),
+        ),
+        Some(remote.clone()),
+    );
+    router_transport
+        .send_unicast(&request, &client_mac)
+        .await
+        .unwrap();
+
+    let (npdu, apdu) = receive_response(&mut router_rx).await;
+    assert_eq!(npdu.destination, Some(remote));
+    assert_unrecognized_reject(apdu, 0x32);
+
+    client.stop().await.unwrap();
+    router_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn unknown_confirmed_service_receives_unrecognized_service_reject() {
+    let client_mac = vec![0x21];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), vec![0x22]);
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    let request = encode_inbound(
+        confirmed_request(
+            0x33,
+            ConfirmedServiceChoice::from_raw(0xFE),
+            false,
+            Bytes::new(),
+        ),
+        None,
+    );
+    peer_transport
+        .send_unicast(&request, &client_mac)
+        .await
+        .unwrap();
+
+    let (_, apdu) = receive_response(&mut peer_rx).await;
+    assert_unrecognized_reject(apdu, 0x33);
+
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn segmented_confirmed_request_is_aborted_by_responding_client() {
+    let client_mac = vec![0x31];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), vec![0x32]);
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    let request = encode_inbound(
+        confirmed_request(
+            0x34,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            true,
+            Bytes::from_static(&[0x0c]),
+        ),
+        None,
+    );
+    peer_transport
+        .send_unicast(&request, &client_mac)
+        .await
+        .unwrap();
+
+    let (_, apdu) = receive_response(&mut peer_rx).await;
+    let Apdu::Abort(abort) = apdu else {
+        panic!("expected Abort");
+    };
+    assert!(abort.sent_by_server);
+    assert_eq!(abort.invoke_id, 0x34);
+    assert_eq!(abort.abort_reason, AbortReason::SEGMENTATION_NOT_SUPPORTED);
+
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn malformed_confirmed_cov_receives_reject_without_delivery() {
+    let client_mac = vec![0x41];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), vec![0x42]);
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+    let mut cov_rx = client.cov_notifications();
+
+    let request = encode_inbound(
+        confirmed_request(
+            0x35,
+            ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION,
+            false,
+            Bytes::new(),
+        ),
+        None,
+    );
+    peer_transport
+        .send_unicast(&request, &client_mac)
+        .await
+        .unwrap();
+
+    let (_, apdu) = receive_response(&mut peer_rx).await;
+    let Apdu::Reject(reject) = apdu else {
+        panic!("expected Reject");
+    };
+    assert_eq!(reject.invoke_id, 0x35);
+    assert_eq!(reject.reject_reason, RejectReason::OTHER);
+    assert!(timeout(Duration::from_millis(100), cov_rx.recv())
+        .await
+        .is_err());
+
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn unsupported_confirmed_broadcast_remains_silent() {
+    let client_mac = vec![0x51];
+    let (client_transport, mut peer_transport) = LoopbackTransport::pair(client_mac, vec![0x52]);
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    let request = encode_inbound(
+        confirmed_request(
+            0x36,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            false,
+            Bytes::new(),
+        ),
+        None,
+    );
+    peer_transport.send_broadcast(&request).await.unwrap();
+
+    assert!(timeout(Duration::from_millis(100), peer_rx.recv())
+        .await
+        .is_err());
+
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn global_broadcast_confirmed_request_remains_silent() {
+    let client_mac = vec![0x61];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), vec![0x62]);
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    let request = encode_inbound_with_destination(
+        confirmed_request(
+            0x37,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            false,
+            Bytes::new(),
+        ),
+        None,
+        Some(NpduAddress {
+            network: 0xFFFF,
+            mac_address: MacAddr::new(),
+        }),
+    );
+    // A BBMD can distribute a global broadcast in a unicast data-link frame;
+    // the NPDU destination still makes the ConfirmedRequest a broadcast.
+    peer_transport
+        .send_unicast(&request, &client_mac)
+        .await
+        .unwrap();
+
+    assert!(timeout(Duration::from_millis(100), peer_rx.recv())
+        .await
+        .is_err());
+
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/confirmed_request_dispatch_tests.rs
+++ b/crates/bacnet-client/src/client/confirmed_request_dispatch_tests.rs
@@ -298,6 +298,50 @@ async fn malformed_confirmed_cov_receives_reject_without_delivery() {
 }
 
 #[tokio::test]
+async fn partial_confirmed_cov_reports_missing_required_parameter() {
+    let client_mac = vec![0x43];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), vec![0x44]);
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+    let mut cov_rx = client.cov_notifications();
+
+    let request = encode_inbound(
+        confirmed_request(
+            0x39,
+            ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION,
+            false,
+            Bytes::from_static(&[0x09, 0x01]),
+        ),
+        None,
+    );
+    peer_transport
+        .send_unicast(&request, &client_mac)
+        .await
+        .unwrap();
+
+    let (_, apdu) = receive_response(&mut peer_rx).await;
+    let Apdu::Reject(reject) = apdu else {
+        panic!("expected Reject");
+    };
+    assert_eq!(reject.invoke_id, 0x39);
+    assert_eq!(
+        reject.reject_reason,
+        RejectReason::MISSING_REQUIRED_PARAMETER
+    );
+    assert!(timeout(Duration::from_millis(100), cov_rx.recv())
+        .await
+        .is_err());
+
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn unsupported_confirmed_group_delivery_remains_silent() {
     let client_mac = vec![0x51];
     let (client_transport, mut peer_transport) = LoopbackTransport::pair(client_mac, vec![0x52]);

--- a/crates/bacnet-client/src/client/confirmed_request_dispatch_tests.rs
+++ b/crates/bacnet-client/src/client/confirmed_request_dispatch_tests.rs
@@ -4,7 +4,44 @@ use super::*;
 use bacnet_encoding::apdu::{decode_apdu, ConfirmedRequest};
 use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
 use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
 use bacnet_types::enums::AbortReason;
+
+struct ImmediateReplyTransport {
+    local_mac: MacAddr,
+    inbound_rx: Option<mpsc::Receiver<ReceivedNpdu>>,
+    fallback_sends: Arc<Mutex<Vec<Bytes>>>,
+}
+
+impl TransportPort for ImmediateReplyTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        Ok(self.inbound_rx.take().expect("transport started once"))
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        self.fallback_sends
+            .lock()
+            .await
+            .push(Bytes::copy_from_slice(npdu));
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, npdu: &[u8]) -> Result<(), Error> {
+        self.fallback_sends
+            .lock()
+            .await
+            .push(Bytes::copy_from_slice(npdu));
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &self.local_mac
+    }
+}
 
 fn confirmed_request(
     invoke_id: u8,
@@ -248,7 +285,10 @@ async fn malformed_confirmed_cov_receives_reject_without_delivery() {
         panic!("expected Reject");
     };
     assert_eq!(reject.invoke_id, 0x35);
-    assert_eq!(reject.reject_reason, RejectReason::OTHER);
+    assert_eq!(
+        reject.reject_reason,
+        RejectReason::MISSING_REQUIRED_PARAMETER
+    );
     assert!(timeout(Duration::from_millis(100), cov_rx.recv())
         .await
         .is_err());
@@ -258,7 +298,7 @@ async fn malformed_confirmed_cov_receives_reject_without_delivery() {
 }
 
 #[tokio::test]
-async fn unsupported_confirmed_broadcast_remains_silent() {
+async fn unsupported_confirmed_group_delivery_remains_silent() {
     let client_mac = vec![0x51];
     let (client_transport, mut peer_transport) = LoopbackTransport::pair(client_mac, vec![0x52]);
     let mut peer_rx = peer_transport.start().await.unwrap();
@@ -285,6 +325,60 @@ async fn unsupported_confirmed_broadcast_remains_silent() {
 
     client.stop().await.unwrap();
     peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn unsupported_confirmed_request_uses_immediate_reply_channel() {
+    let local_mac = MacAddr::from_slice(&[0x71]);
+    let router_mac = MacAddr::from_slice(&[0x72]);
+    let remote = NpduAddress {
+        network: 300,
+        mac_address: MacAddr::from_slice(&[0x73, 0x74]),
+    };
+    let (inbound_tx, inbound_rx) = mpsc::channel(1);
+    let fallback_sends = Arc::new(Mutex::new(Vec::new()));
+    let transport = ImmediateReplyTransport {
+        local_mac,
+        inbound_rx: Some(inbound_rx),
+        fallback_sends: Arc::clone(&fallback_sends),
+    };
+    let mut client = BACnetClient::generic_builder()
+        .transport(transport)
+        .build()
+        .await
+        .unwrap();
+    let request = encode_inbound(
+        confirmed_request(
+            0x38,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            false,
+            Bytes::new(),
+        ),
+        Some(remote.clone()),
+    );
+    let (reply_tx, reply_rx) = oneshot::channel();
+
+    inbound_tx
+        .send(ReceivedNpdu {
+            npdu: request.freeze(),
+            source_mac: router_mac,
+            link_layer_group: false,
+            data_attributes: Vec::new(),
+            reply_tx: Some(reply_tx),
+        })
+        .await
+        .unwrap();
+
+    let reply = timeout(Duration::from_secs(2), reply_rx)
+        .await
+        .expect("timed out waiting for immediate response")
+        .expect("immediate response channel closed");
+    let npdu = decode_npdu(reply).unwrap();
+    assert_eq!(npdu.destination, Some(remote));
+    assert_unrecognized_reject(decode_apdu(npdu.payload).unwrap(), 0x38);
+    assert!(fallback_sends.lock().await.is_empty());
+
+    client.stop().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/bacnet-client/src/client/confirmed_request_dispatch_tests.rs
+++ b/crates/bacnet-client/src/client/confirmed_request_dispatch_tests.rs
@@ -342,6 +342,47 @@ async fn partial_confirmed_cov_reports_missing_required_parameter() {
 }
 
 #[tokio::test]
+async fn invalid_confirmed_cov_representation_reports_invalid_data_encoding() {
+    let client_mac = vec![0x45];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), vec![0x46]);
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+    let mut cov_rx = client.cov_notifications();
+
+    let request = encode_inbound(
+        confirmed_request(
+            0x3A,
+            ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION,
+            false,
+            Bytes::from_static(&[0x09, 0x01, 0x1B, 0x01, 0x02, 0x03]),
+        ),
+        None,
+    );
+    peer_transport
+        .send_unicast(&request, &client_mac)
+        .await
+        .unwrap();
+
+    let (_, apdu) = receive_response(&mut peer_rx).await;
+    let Apdu::Reject(reject) = apdu else {
+        panic!("expected Reject");
+    };
+    assert_eq!(reject.invoke_id, 0x3A);
+    assert_eq!(reject.reject_reason, RejectReason::INVALID_DATA_ENCODING);
+    assert!(timeout(Duration::from_millis(100), cov_rx.recv())
+        .await
+        .is_err());
+
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn unsupported_confirmed_group_delivery_remains_silent() {
     let client_mac = vec![0x51];
     let (client_transport, mut peer_transport) = LoopbackTransport::pair(client_mac, vec![0x52]);

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -36,7 +36,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         seg_ack_senders: &Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
         source_mac: &[u8],
         source_network: &Option<NpduAddress>,
-        is_broadcast: bool,
+        is_group: bool,
+        reply_tx: Option<oneshot::Sender<Bytes>>,
         apdu: Apdu,
         limits: ResponseLimits,
     ) {
@@ -243,11 +244,11 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 );
             }
             Apdu::ConfirmedRequest(req) => {
-                if is_broadcast {
+                if is_group {
                     debug!(
                         invoke_id = req.invoke_id,
                         service = req.service_choice.to_raw(),
-                        "Ignoring broadcast ConfirmedRequest"
+                        "Ignoring group-addressed ConfirmedRequest"
                     );
                     return;
                 }
@@ -256,6 +257,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         network,
                         source_mac,
                         source_network,
+                        reply_tx,
                         req.invoke_id,
                         bacnet_types::enums::AbortReason::SEGMENTATION_NOT_SUPPORTED,
                     )
@@ -284,17 +286,24 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                 req.invoke_id,
                                 req.service_choice,
                                 response,
+                                reply_tx,
                             )
                             .await;
                         }
                         Err(e) => {
                             warn!(error = %e, "Failed to decode ConfirmedCOVNotification");
+                            let reject_reason = if req.service_request.is_empty() {
+                                RejectReason::MISSING_REQUIRED_PARAMETER
+                            } else {
+                                RejectReason::OTHER
+                            };
                             Self::send_confirmed_request_reject(
                                 network,
                                 source_mac,
                                 source_network,
+                                reply_tx,
                                 req.invoke_id,
-                                RejectReason::OTHER,
+                                reject_reason,
                             )
                             .await;
                         }
@@ -308,6 +317,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         network,
                         source_mac,
                         source_network,
+                        reply_tx,
                         req.invoke_id,
                         RejectReason::UNRECOGNIZED_SERVICE,
                     )
@@ -509,6 +519,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         network: &Arc<NetworkLayer<T>>,
         source_mac: &[u8],
         source_network: &Option<NpduAddress>,
+        reply_tx: Option<oneshot::Sender<Bytes>>,
         invoke_id: u8,
         reject_reason: RejectReason,
     ) {
@@ -521,7 +532,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             warn!(error = %e, reason = reject_reason.to_raw(), "Failed to encode Reject");
             return;
         }
-        if let Err(e) = Self::send_reply_apdu(network, &buf, source_mac, source_network).await {
+        if let Err(e) =
+            Self::send_received_reply_apdu(network, &buf, source_mac, source_network, reply_tx)
+                .await
+        {
             warn!(error = %e, reason = reject_reason.to_raw(), "Failed to send Reject");
         }
     }
@@ -530,6 +544,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         network: &Arc<NetworkLayer<T>>,
         source_mac: &[u8],
         source_network: &Option<NpduAddress>,
+        reply_tx: Option<oneshot::Sender<Bytes>>,
         invoke_id: u8,
         abort_reason: bacnet_types::enums::AbortReason,
     ) {
@@ -543,7 +558,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             warn!(error = %e, reason = abort_reason.to_raw(), "Failed to encode server Abort");
             return;
         }
-        if let Err(e) = Self::send_reply_apdu(network, &buf, source_mac, source_network).await {
+        if let Err(e) =
+            Self::send_received_reply_apdu(network, &buf, source_mac, source_network, reply_tx)
+                .await
+        {
             warn!(error = %e, reason = abort_reason.to_raw(), "Failed to send server Abort");
         }
     }
@@ -555,6 +573,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         invoke_id: u8,
         service_choice: ConfirmedServiceChoice,
         response: ConfirmedCOVNotificationResponse,
+        reply_tx: Option<oneshot::Sender<Bytes>>,
     ) {
         let apdu = match response {
             ConfirmedCOVNotificationResponse::Ack => Apdu::SimpleAck(SimpleAck {
@@ -573,9 +592,44 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             warn!(error = %e, "Failed to encode response for COV notification");
             return;
         }
-        if let Err(e) = Self::send_reply_apdu(network, &buf, source_mac, source_network).await {
+        if let Err(e) =
+            Self::send_received_reply_apdu(network, &buf, source_mac, source_network, reply_tx)
+                .await
+        {
             warn!(error = %e, "Failed to send response for COV notification");
         }
+    }
+
+    async fn send_received_reply_apdu(
+        network: &Arc<NetworkLayer<T>>,
+        buf: &[u8],
+        reply_mac: &[u8],
+        reply_network: &Option<NpduAddress>,
+        reply_tx: Option<oneshot::Sender<Bytes>>,
+    ) -> Result<(), Error> {
+        if let Some(reply_tx) = reply_tx {
+            let apdu = Bytes::copy_from_slice(buf);
+            let mut npdu_buf = BytesMut::with_capacity(8 + apdu.len());
+            encode_npdu(
+                &mut npdu_buf,
+                &Npdu {
+                    is_network_message: false,
+                    expecting_reply: false,
+                    priority: NetworkPriority::NORMAL,
+                    destination: reply_network
+                        .clone()
+                        .filter(|address| !address.mac_address.is_empty()),
+                    source: None,
+                    payload: apdu,
+                    ..Npdu::default()
+                },
+            )?;
+            if reply_tx.send(npdu_buf.freeze()).is_ok() {
+                return Ok(());
+            }
+        }
+
+        Self::send_reply_apdu(network, buf, reply_mac, reply_network).await
     }
 
     /// Send a reply back along the path its trigger arrived on.

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -36,6 +36,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         seg_ack_senders: &Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
         source_mac: &[u8],
         source_network: &Option<NpduAddress>,
+        is_broadcast: bool,
         apdu: Apdu,
         limits: ResponseLimits,
     ) {
@@ -242,6 +243,25 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 );
             }
             Apdu::ConfirmedRequest(req) => {
+                if is_broadcast {
+                    debug!(
+                        invoke_id = req.invoke_id,
+                        service = req.service_choice.to_raw(),
+                        "Ignoring broadcast ConfirmedRequest"
+                    );
+                    return;
+                }
+                if req.segmented {
+                    Self::send_server_abort(
+                        network,
+                        source_mac,
+                        source_network,
+                        req.invoke_id,
+                        bacnet_types::enums::AbortReason::SEGMENTATION_NOT_SUPPORTED,
+                    )
+                    .await;
+                    return;
+                }
                 if req.service_choice == ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION {
                     match COVNotificationRequest::decode(&req.service_request) {
                         Ok(notification) => {
@@ -269,13 +289,29 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         }
                         Err(e) => {
                             warn!(error = %e, "Failed to decode ConfirmedCOVNotification");
+                            Self::send_confirmed_request_reject(
+                                network,
+                                source_mac,
+                                source_network,
+                                req.invoke_id,
+                                RejectReason::OTHER,
+                            )
+                            .await;
                         }
                     }
                 } else {
                     debug!(
                         service = req.service_choice.to_raw(),
-                        "Ignoring ConfirmedRequest (client mode)"
+                        "Rejecting unsupported ConfirmedRequest (client mode)"
                     );
+                    Self::send_confirmed_request_reject(
+                        network,
+                        source_mac,
+                        source_network,
+                        req.invoke_id,
+                        RejectReason::UNRECOGNIZED_SERVICE,
+                    )
+                    .await;
                 }
             }
             Apdu::UnconfirmedRequest(req) => {
@@ -466,6 +502,49 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 )
                 .await;
             }
+        }
+    }
+
+    async fn send_confirmed_request_reject(
+        network: &Arc<NetworkLayer<T>>,
+        source_mac: &[u8],
+        source_network: &Option<NpduAddress>,
+        invoke_id: u8,
+        reject_reason: RejectReason,
+    ) {
+        let reject = Apdu::Reject(RejectPdu {
+            invoke_id,
+            reject_reason,
+        });
+        let mut buf = BytesMut::with_capacity(3);
+        if let Err(e) = encode_apdu(&mut buf, &reject) {
+            warn!(error = %e, reason = reject_reason.to_raw(), "Failed to encode Reject");
+            return;
+        }
+        if let Err(e) = Self::send_reply_apdu(network, &buf, source_mac, source_network).await {
+            warn!(error = %e, reason = reject_reason.to_raw(), "Failed to send Reject");
+        }
+    }
+
+    async fn send_server_abort(
+        network: &Arc<NetworkLayer<T>>,
+        source_mac: &[u8],
+        source_network: &Option<NpduAddress>,
+        invoke_id: u8,
+        abort_reason: bacnet_types::enums::AbortReason,
+    ) {
+        let abort = Apdu::Abort(AbortPdu {
+            sent_by_server: true,
+            invoke_id,
+            abort_reason,
+        });
+        let mut buf = BytesMut::with_capacity(3);
+        if let Err(e) = encode_apdu(&mut buf, &abort) {
+            warn!(error = %e, reason = abort_reason.to_raw(), "Failed to encode server Abort");
+            return;
+        }
+        if let Err(e) = Self::send_reply_apdu(network, &buf, source_mac, source_network).await {
+            warn!(error = %e, reason = abort_reason.to_raw(), "Failed to send server Abort");
         }
     }
 

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -265,7 +265,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     return;
                 }
                 if req.service_choice == ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION {
-                    match COVNotificationRequest::decode(&req.service_request) {
+                    match COVNotificationRequest::decode_detailed(&req.service_request) {
                         Ok(notification) => {
                             debug!(
                                 object = ?notification.monitored_object_identifier,
@@ -291,12 +291,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                             .await;
                         }
                         Err(e) => {
+                            let reject_reason = e.reject_reason();
+                            let e = e.into_error();
                             warn!(error = %e, "Failed to decode ConfirmedCOVNotification");
-                            let reject_reason = if req.service_request.is_empty() {
-                                RejectReason::MISSING_REQUIRED_PARAMETER
-                            } else {
-                                RejectReason::OTHER
-                            };
                             Self::send_confirmed_request_reject(
                                 network,
                                 source_mac,

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -142,6 +142,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     &seg_ack_senders_dispatch,
                                     &received.source_mac,
                                     &received.source_network,
+                                    received.is_broadcast,
                                     decoded,
                                     response_limits,
                                 )

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -142,7 +142,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     &seg_ack_senders_dispatch,
                                     &received.source_mac,
                                     &received.source_network,
-                                    received.is_broadcast,
+                                    received.is_group,
+                                    received.reply_tx,
                                     decoded,
                                     response_limits,
                                 )

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use bytes::{Bytes, BytesMut};
-use tokio::sync::{broadcast, mpsc, Mutex};
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
 use tokio::time::{timeout, Duration};
 use tracing::{debug, warn};
@@ -20,7 +20,7 @@ use bacnet_encoding::apdu::{
     self, encode_apdu, validate_max_apdu_length, validate_max_segments, AbortPdu, Apdu,
     ConfirmedRequest as ConfirmedRequestPdu, RejectPdu, SegmentAck as SegmentAckPdu, SimpleAck,
 };
-use bacnet_encoding::npdu::NpduAddress;
+use bacnet_encoding::npdu::{encode_npdu, Npdu, NpduAddress};
 use bacnet_network::layer::NetworkLayer;
 use bacnet_services::cov::COVNotificationRequest;
 use bacnet_transport::bip::BipTransport;

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -785,6 +785,8 @@ pub use cov_renewal::{
 #[cfg(test)]
 mod builder_options_tests;
 #[cfg(test)]
+mod confirmed_request_dispatch_tests;
+#[cfg(test)]
 mod cov_notification_tests;
 #[cfg(test)]
 mod cov_renewal_tests;

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -23,11 +23,11 @@ pub struct ReceivedApdu {
     pub source_mac: MacAddr,
     /// Source network address if the APDU was routed (NPDU had source field).
     pub source_network: Option<NpduAddress>,
-    /// Whether the APDU's effective BACnet destination was a broadcast.
+    /// Whether the APDU's effective BACnet destination was multicast or broadcast.
     ///
     /// A specific DNET/DADR remains a unicast even when a router used a
-    /// broadcast data-link destination to reach that remote device.
-    pub is_broadcast: bool,
+    /// group data-link destination to reach that remote device.
+    pub is_group: bool,
     /// Data-link attributes associated with the NPDU, if the transport supplied any.
     pub data_attributes: Vec<DataAttribute>,
     /// Optional reply channel for MS/TP DataExpectingReply flows.
@@ -41,7 +41,7 @@ impl Clone for ReceivedApdu {
             apdu: self.apdu.clone(),
             source_mac: self.source_mac.clone(),
             source_network: self.source_network.clone(),
-            is_broadcast: self.is_broadcast,
+            is_group: self.is_group,
             data_attributes: self.data_attributes.clone(),
             reply_tx: None,
         }
@@ -54,19 +54,16 @@ impl std::fmt::Debug for ReceivedApdu {
             .field("apdu", &self.apdu)
             .field("source_mac", &self.source_mac)
             .field("source_network", &self.source_network)
-            .field("is_broadcast", &self.is_broadcast)
+            .field("is_group", &self.is_group)
             .field("data_attributes", &self.data_attributes)
             .field("reply_tx", &self.reply_tx.as_ref().map(|_| "Some(...)"))
             .finish()
     }
 }
 
-pub(crate) fn is_broadcast_delivery(
-    link_layer_broadcast: bool,
-    destination: Option<&NpduAddress>,
-) -> bool {
+pub(crate) fn is_group_delivery(link_layer_group: bool, destination: Option<&NpduAddress>) -> bool {
     match destination {
-        None => link_layer_broadcast,
+        None => link_layer_group,
         Some(destination) => destination.network == 0xFFFF || destination.mac_address.is_empty(),
     }
 }
@@ -124,16 +121,14 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
                         }
 
                         let source_network = npdu.source.clone();
-                        let is_broadcast = is_broadcast_delivery(
-                            received.link_layer_broadcast,
-                            npdu.destination.as_ref(),
-                        );
+                        let is_group =
+                            is_group_delivery(received.link_layer_group, npdu.destination.as_ref());
 
                         let apdu = ReceivedApdu {
                             apdu: npdu.payload,
                             source_mac: received.source_mac,
                             source_network,
-                            is_broadcast,
+                            is_group,
                             data_attributes: received.data_attributes,
                             reply_tx: received.reply_tx,
                         };

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -23,6 +23,11 @@ pub struct ReceivedApdu {
     pub source_mac: MacAddr,
     /// Source network address if the APDU was routed (NPDU had source field).
     pub source_network: Option<NpduAddress>,
+    /// Whether the APDU's effective BACnet destination was a broadcast.
+    ///
+    /// A specific DNET/DADR remains a unicast even when a router used a
+    /// broadcast data-link destination to reach that remote device.
+    pub is_broadcast: bool,
     /// Data-link attributes associated with the NPDU, if the transport supplied any.
     pub data_attributes: Vec<DataAttribute>,
     /// Optional reply channel for MS/TP DataExpectingReply flows.
@@ -36,6 +41,7 @@ impl Clone for ReceivedApdu {
             apdu: self.apdu.clone(),
             source_mac: self.source_mac.clone(),
             source_network: self.source_network.clone(),
+            is_broadcast: self.is_broadcast,
             data_attributes: self.data_attributes.clone(),
             reply_tx: None,
         }
@@ -48,9 +54,20 @@ impl std::fmt::Debug for ReceivedApdu {
             .field("apdu", &self.apdu)
             .field("source_mac", &self.source_mac)
             .field("source_network", &self.source_network)
+            .field("is_broadcast", &self.is_broadcast)
             .field("data_attributes", &self.data_attributes)
             .field("reply_tx", &self.reply_tx.as_ref().map(|_| "Some(...)"))
             .finish()
+    }
+}
+
+pub(crate) fn is_broadcast_delivery(
+    link_layer_broadcast: bool,
+    destination: Option<&NpduAddress>,
+) -> bool {
+    match destination {
+        None => link_layer_broadcast,
+        Some(destination) => destination.network == 0xFFFF || destination.mac_address.is_empty(),
     }
 }
 
@@ -107,11 +124,16 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
                         }
 
                         let source_network = npdu.source.clone();
+                        let is_broadcast = is_broadcast_delivery(
+                            received.link_layer_broadcast,
+                            npdu.destination.as_ref(),
+                        );
 
                         let apdu = ReceivedApdu {
                             apdu: npdu.payload,
                             source_mac: received.source_mac,
                             source_network,
+                            is_broadcast,
                             data_attributes: received.data_attributes,
                             reply_tx: received.reply_tx,
                         };
@@ -511,42 +533,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn send_receive_apdu_unicast() {
-        let transport_a = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
-        let transport_b = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
-
-        let mut net_a = NetworkLayer::new(transport_a);
-        let mut net_b = NetworkLayer::new(transport_b);
-
-        let _rx_a = net_a.start().await.unwrap();
-        let mut rx_b = net_b.start().await.unwrap();
-
-        let test_apdu = vec![0x10, 0x08];
-
-        net_a
-            .send_apdu(
-                &test_apdu,
-                net_b.local_mac(),
-                false,
-                NetworkPriority::NORMAL,
-            )
-            .await
-            .unwrap();
-
-        let received = timeout(Duration::from_secs(2), rx_b.recv())
-            .await
-            .expect("Timed out waiting for APDU")
-            .expect("Channel closed");
-
-        assert_eq!(received.apdu, test_apdu);
-        assert_eq!(received.source_mac.as_slice(), net_a.local_mac());
-        assert!(received.source_network.is_none());
-
-        net_a.stop().await.unwrap();
-        net_b.stop().await.unwrap();
-    }
-
-    #[tokio::test]
     async fn sc_data_options_reach_received_apdu_data_attributes() {
         let (ws_client, ws_hub) = LoopbackWebSocket::pair();
         let hub_vmac = [0x10; 6];
@@ -853,3 +839,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "layer_delivery_tests.rs"]
+mod delivery_tests;

--- a/crates/bacnet-network/src/layer_delivery_tests.rs
+++ b/crates/bacnet-network/src/layer_delivery_tests.rs
@@ -1,0 +1,63 @@
+use super::*;
+use bacnet_transport::bip::BipTransport;
+use std::net::Ipv4Addr;
+use tokio::time::{timeout, Duration};
+
+#[test]
+fn effective_broadcast_respects_npdu_destination_precedence() {
+    let remote_unicast = NpduAddress {
+        network: 200,
+        mac_address: MacAddr::from_slice(&[0x11]),
+    };
+    let remote_broadcast = NpduAddress {
+        network: 200,
+        mac_address: MacAddr::new(),
+    };
+    let global_broadcast = NpduAddress {
+        network: 0xFFFF,
+        mac_address: MacAddr::new(),
+    };
+
+    assert!(!is_broadcast_delivery(false, None));
+    assert!(is_broadcast_delivery(true, None));
+    assert!(!is_broadcast_delivery(false, Some(&remote_unicast)));
+    assert!(!is_broadcast_delivery(true, Some(&remote_unicast)));
+    assert!(is_broadcast_delivery(false, Some(&remote_broadcast)));
+    assert!(is_broadcast_delivery(false, Some(&global_broadcast)));
+}
+
+#[tokio::test]
+async fn send_receive_apdu_unicast_is_not_marked_broadcast() {
+    let transport_a = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let transport_b = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+
+    let mut net_a = NetworkLayer::new(transport_a);
+    let mut net_b = NetworkLayer::new(transport_b);
+
+    let _rx_a = net_a.start().await.unwrap();
+    let mut rx_b = net_b.start().await.unwrap();
+    let test_apdu = vec![0x10, 0x08];
+
+    net_a
+        .send_apdu(
+            &test_apdu,
+            net_b.local_mac(),
+            false,
+            NetworkPriority::NORMAL,
+        )
+        .await
+        .unwrap();
+
+    let received = timeout(Duration::from_secs(2), rx_b.recv())
+        .await
+        .expect("Timed out waiting for APDU")
+        .expect("Channel closed");
+
+    assert_eq!(received.apdu, test_apdu);
+    assert_eq!(received.source_mac.as_slice(), net_a.local_mac());
+    assert!(received.source_network.is_none());
+    assert!(!received.is_broadcast);
+
+    net_a.stop().await.unwrap();
+    net_b.stop().await.unwrap();
+}

--- a/crates/bacnet-network/src/layer_delivery_tests.rs
+++ b/crates/bacnet-network/src/layer_delivery_tests.rs
@@ -4,7 +4,7 @@ use std::net::Ipv4Addr;
 use tokio::time::{timeout, Duration};
 
 #[test]
-fn effective_broadcast_respects_npdu_destination_precedence() {
+fn effective_group_delivery_respects_npdu_destination_precedence() {
     let remote_unicast = NpduAddress {
         network: 200,
         mac_address: MacAddr::from_slice(&[0x11]),
@@ -18,16 +18,16 @@ fn effective_broadcast_respects_npdu_destination_precedence() {
         mac_address: MacAddr::new(),
     };
 
-    assert!(!is_broadcast_delivery(false, None));
-    assert!(is_broadcast_delivery(true, None));
-    assert!(!is_broadcast_delivery(false, Some(&remote_unicast)));
-    assert!(!is_broadcast_delivery(true, Some(&remote_unicast)));
-    assert!(is_broadcast_delivery(false, Some(&remote_broadcast)));
-    assert!(is_broadcast_delivery(false, Some(&global_broadcast)));
+    assert!(!is_group_delivery(false, None));
+    assert!(is_group_delivery(true, None));
+    assert!(!is_group_delivery(false, Some(&remote_unicast)));
+    assert!(!is_group_delivery(true, Some(&remote_unicast)));
+    assert!(is_group_delivery(false, Some(&remote_broadcast)));
+    assert!(is_group_delivery(false, Some(&global_broadcast)));
 }
 
 #[tokio::test]
-async fn send_receive_apdu_unicast_is_not_marked_broadcast() {
+async fn send_receive_apdu_unicast_is_not_marked_as_group_delivery() {
     let transport_a = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     let transport_b = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
 
@@ -56,7 +56,7 @@ async fn send_receive_apdu_unicast_is_not_marked_broadcast() {
     assert_eq!(received.apdu, test_apdu);
     assert_eq!(received.source_mac.as_slice(), net_a.local_mac());
     assert!(received.source_network.is_none());
-    assert!(!received.is_broadcast);
+    assert!(!received.is_group);
 
     net_a.stop().await.unwrap();
     net_b.stop().await.unwrap();

--- a/crates/bacnet-network/src/router/mod.rs
+++ b/crates/bacnet-network/src/router/mod.rs
@@ -23,7 +23,7 @@ use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
-use crate::layer::ReceivedApdu;
+use crate::layer::{is_broadcast_delivery, ReceivedApdu};
 use crate::router_table::{ReachabilityStatus, RouterTable};
 
 mod control_messages;
@@ -267,6 +267,7 @@ impl BACnetRouter {
                                         apdu: npdu.payload,
                                         source_mac: received.source_mac,
                                         source_network: npdu.source,
+                                        is_broadcast: true,
                                         data_attributes: received.data_attributes,
                                         reply_tx: received.reply_tx,
                                     };
@@ -320,6 +321,7 @@ impl BACnetRouter {
                                                 apdu: npdu.payload,
                                                 source_mac: received.source_mac,
                                                 source_network: npdu.source,
+                                                is_broadcast: false,
                                                 data_attributes: received.data_attributes,
                                                 reply_tx: received.reply_tx,
                                             };
@@ -332,6 +334,7 @@ impl BACnetRouter {
                                                     apdu: npdu.payload.clone(),
                                                     source_mac: received.source_mac.clone(),
                                                     source_network: npdu.source.clone(),
+                                                    is_broadcast: true,
                                                     data_attributes: received
                                                         .data_attributes
                                                         .clone(),
@@ -374,6 +377,10 @@ impl BACnetRouter {
                                     apdu: npdu.payload,
                                     source_mac: received.source_mac,
                                     source_network: npdu.source,
+                                    is_broadcast: is_broadcast_delivery(
+                                        received.link_layer_broadcast,
+                                        None,
+                                    ),
                                     data_attributes: received.data_attributes,
                                     reply_tx: received.reply_tx,
                                 };

--- a/crates/bacnet-network/src/router/mod.rs
+++ b/crates/bacnet-network/src/router/mod.rs
@@ -23,7 +23,7 @@ use tokio::sync::{mpsc, Mutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
-use crate::layer::{is_broadcast_delivery, ReceivedApdu};
+use crate::layer::{is_group_delivery, ReceivedApdu};
 use crate::router_table::{ReachabilityStatus, RouterTable};
 
 mod control_messages;
@@ -267,7 +267,7 @@ impl BACnetRouter {
                                         apdu: npdu.payload,
                                         source_mac: received.source_mac,
                                         source_network: npdu.source,
-                                        is_broadcast: true,
+                                        is_group: true,
                                         data_attributes: received.data_attributes,
                                         reply_tx: received.reply_tx,
                                     };
@@ -321,7 +321,7 @@ impl BACnetRouter {
                                                 apdu: npdu.payload,
                                                 source_mac: received.source_mac,
                                                 source_network: npdu.source,
-                                                is_broadcast: false,
+                                                is_group: false,
                                                 data_attributes: received.data_attributes,
                                                 reply_tx: received.reply_tx,
                                             };
@@ -334,7 +334,7 @@ impl BACnetRouter {
                                                     apdu: npdu.payload.clone(),
                                                     source_mac: received.source_mac.clone(),
                                                     source_network: npdu.source.clone(),
-                                                    is_broadcast: true,
+                                                    is_group: true,
                                                     data_attributes: received
                                                         .data_attributes
                                                         .clone(),
@@ -377,10 +377,7 @@ impl BACnetRouter {
                                     apdu: npdu.payload,
                                     source_mac: received.source_mac,
                                     source_network: npdu.source,
-                                    is_broadcast: is_broadcast_delivery(
-                                        received.link_layer_broadcast,
-                                        None,
-                                    ),
+                                    is_group: is_group_delivery(received.link_layer_group, None),
                                     data_attributes: received.data_attributes,
                                     reply_tx: received.reply_tx,
                                 };

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -401,7 +401,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 	                                                            apdu: bytes::Bytes::new(),
 	                                                            source_mac: bacnet_types::MacAddr::new(),
 	                                                            source_network: None,
-	                                                            is_broadcast: false,
+	                                                            is_group: false,
 	                                                            data_attributes: Vec::new(),
 	                                                            reply_tx: None,
 	                                                        }
@@ -447,7 +447,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                         apdu: bytes::Bytes::new(),
                                         source_mac: bacnet_types::MacAddr::new(),
                                         source_network: None,
-                                        is_broadcast: false,
+                                        is_group: false,
                                         data_attributes: Vec::new(),
                                         reply_tx: None,
                                     }

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -401,6 +401,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 	                                                            apdu: bytes::Bytes::new(),
 	                                                            source_mac: bacnet_types::MacAddr::new(),
 	                                                            source_network: None,
+	                                                            is_broadcast: false,
 	                                                            data_attributes: Vec::new(),
 	                                                            reply_tx: None,
 	                                                        }
@@ -446,6 +447,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                         apdu: bytes::Bytes::new(),
                                         source_mac: bacnet_types::MacAddr::new(),
                                         source_network: None,
+                                        is_broadcast: false,
                                         data_attributes: Vec::new(),
                                         reply_tx: None,
                                     }

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -292,6 +292,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
             apdu: Bytes::new(),
             source_mac: source_mac.clone(),
             source_network,
+            is_broadcast: false,
             data_attributes: Vec::new(),
             reply_tx: None,
         },

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -292,7 +292,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
             apdu: Bytes::new(),
             source_mac: source_mac.clone(),
             source_network,
-            is_broadcast: false,
+            is_group: false,
             data_attributes: Vec::new(),
             reply_tx: None,
         },

--- a/crates/bacnet-services/src/cov.rs
+++ b/crates/bacnet-services/src/cov.rs
@@ -327,6 +327,12 @@ impl COVNotificationRequest {
             values.push(pv);
             offset = new_offset;
         }
+        if values.is_empty() {
+            return Err(Error::decoding(
+                offset,
+                "COVNotification list-of-values must contain at least one value",
+            ));
+        }
         if offset != data.len() {
             return Err(Error::decoding(offset, "COVNotification has trailing data"));
         }
@@ -470,6 +476,22 @@ mod tests {
     #[test]
     fn test_decode_cov_notification_empty_input() {
         assert!(COVNotificationRequest::decode(&[]).is_err());
+    }
+
+    #[test]
+    fn test_decode_cov_notification_rejects_empty_list_of_values() {
+        let req = COVNotificationRequest {
+            subscriber_process_identifier: 1,
+            initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap(),
+            monitored_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1)
+                .unwrap(),
+            time_remaining: 60,
+            list_of_values: Vec::new(),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+
+        assert!(COVNotificationRequest::decode(&buf).is_err());
     }
 
     #[test]

--- a/crates/bacnet-services/src/cov.rs
+++ b/crates/bacnet-services/src/cov.rs
@@ -2,7 +2,7 @@
 
 use bacnet_encoding::primitives;
 use bacnet_encoding::tags;
-use bacnet_types::enums::PropertyIdentifier;
+use bacnet_types::enums::{PropertyIdentifier, RejectReason};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
@@ -11,6 +11,8 @@ use crate::common::{
     decode_context, decode_context_bool, decode_context_u32, BACnetPropertyValue,
     PropertyReference, MAX_DECODED_ITEMS,
 };
+
+pub use crate::cov_decode::COVNotificationDecodeError;
 
 // ---------------------------------------------------------------------------
 // SubscribeCOVRequest
@@ -272,78 +274,7 @@ impl COVNotificationRequest {
     }
 
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        let mut offset = 0;
-
-        // [0] subscriber-process-identifier
-        let (subscriber_process_identifier, end) =
-            decode_context_u32(data, offset, 0, "COVNotification process-id")?;
-        offset = end;
-
-        // [1] initiating-device-identifier
-        let (content, end) = decode_context(data, offset, 1, "COVNotification device-id")?;
-        let initiating_device_identifier = ObjectIdentifier::decode(content)?;
-        offset = end;
-
-        // [2] monitored-object-identifier
-        let (content, end) = decode_context(data, offset, 2, "COVNotification monitored-id")?;
-        let monitored_object_identifier = ObjectIdentifier::decode(content)?;
-        offset = end;
-
-        // [3] time-remaining
-        let (time_remaining, end) =
-            decode_context_u32(data, offset, 3, "COVNotification time-remaining")?;
-        offset = end;
-
-        // [4] list-of-values (opening tag 4)
-        let (tag, tag_end) = tags::decode_tag(data, offset)?;
-        if !tag.is_opening_tag(4) {
-            return Err(Error::decoding(
-                offset,
-                "COVNotification expected opening tag 4",
-            ));
-        }
-        offset = tag_end;
-
-        let mut values = Vec::new();
-        loop {
-            if offset >= data.len() {
-                return Err(Error::decoding(
-                    offset,
-                    "COVNotification missing closing tag 4",
-                ));
-            }
-            if values.len() >= MAX_DECODED_ITEMS {
-                return Err(Error::decoding(
-                    offset,
-                    "COVNotification values exceeds max",
-                ));
-            }
-            let (tag, tag_end) = tags::decode_tag(data, offset)?;
-            if tag.is_closing_tag(4) {
-                offset = tag_end;
-                break;
-            }
-            let (pv, new_offset) = BACnetPropertyValue::decode_in_list(data, offset, 4)?;
-            values.push(pv);
-            offset = new_offset;
-        }
-        if values.is_empty() {
-            return Err(Error::decoding(
-                offset,
-                "COVNotification list-of-values must contain at least one value",
-            ));
-        }
-        if offset != data.len() {
-            return Err(Error::decoding(offset, "COVNotification has trailing data"));
-        }
-
-        Ok(Self {
-            subscriber_process_identifier,
-            initiating_device_identifier,
-            monitored_object_identifier,
-            time_remaining,
-            list_of_values: values,
-        })
+        Self::decode_detailed(data).map_err(COVNotificationDecodeError::into_error)
     }
 }
 
@@ -476,6 +407,39 @@ mod tests {
     #[test]
     fn test_decode_cov_notification_empty_input() {
         assert!(COVNotificationRequest::decode(&[]).is_err());
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&[])
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::MISSING_REQUIRED_PARAMETER
+        );
+    }
+
+    #[test]
+    fn test_decode_cov_notification_classifies_missing_and_invalid_tags() {
+        // A valid [0] process identifier followed by EOF is still missing a
+        // later mandatory service argument.
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&[0x09, 0x01])
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::MISSING_REQUIRED_PARAMETER
+        );
+        // Context [7] cannot begin this service request.
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&[0x79, 0x01])
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::INVALID_TAG
+        );
+        // RejectReason has no invalid-data-encoding value; a present
+        // ObjectIdentifier with an invalid wire width is OTHER syntax.
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&[0x09, 0x01, 0x1B, 0x01, 0x02, 0x03])
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::OTHER
+        );
     }
 
     #[test]
@@ -491,7 +455,84 @@ mod tests {
         let mut buf = BytesMut::new();
         req.encode(&mut buf);
 
-        assert!(COVNotificationRequest::decode(&buf).is_err());
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&buf)
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::PARAMETER_OUT_OF_RANGE
+        );
+    }
+
+    #[test]
+    fn test_decode_cov_notification_enforces_value_cap() {
+        let value = BACnetPropertyValue {
+            property_identifier: PropertyIdentifier::PRESENT_VALUE,
+            property_array_index: None,
+            value: vec![0x21, 0x01],
+            priority: None,
+        };
+        let mut req = COVNotificationRequest {
+            subscriber_process_identifier: 1,
+            initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap(),
+            monitored_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1)
+                .unwrap(),
+            time_remaining: 60,
+            list_of_values: vec![value.clone(); MAX_DECODED_ITEMS],
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&buf)
+                .unwrap()
+                .list_of_values
+                .len(),
+            MAX_DECODED_ITEMS
+        );
+
+        req.list_of_values.push(value);
+        buf.clear();
+        req.encode(&mut buf);
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&buf)
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::BUFFER_OVERFLOW
+        );
+    }
+
+    #[test]
+    fn test_decode_cov_notification_classifies_trailing_arguments() {
+        let req = COVNotificationRequest {
+            subscriber_process_identifier: 1,
+            initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap(),
+            monitored_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1)
+                .unwrap(),
+            time_remaining: 60,
+            list_of_values: vec![BACnetPropertyValue {
+                property_identifier: PropertyIdentifier::PRESENT_VALUE,
+                property_array_index: None,
+                value: vec![0x44, 0x42, 0x90, 0x00, 0x00],
+                priority: None,
+            }],
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        buf.extend_from_slice(&[0x59, 0x01]);
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&buf)
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::TOO_MANY_ARGUMENTS
+        );
+
+        buf.truncate(buf.len() - 2);
+        buf.extend_from_slice(&[0xFF]);
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&buf)
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::INVALID_TAG
+        );
     }
 
     #[test]

--- a/crates/bacnet-services/src/cov.rs
+++ b/crates/bacnet-services/src/cov.rs
@@ -432,13 +432,20 @@ mod tests {
                 .reject_reason(),
             RejectReason::INVALID_TAG
         );
-        // RejectReason has no invalid-data-encoding value; a present
-        // ObjectIdentifier with an invalid wire width is OTHER syntax.
+        // A present ObjectIdentifier with an invalid wire width has invalid
+        // data encoding rather than a missing argument.
         assert_eq!(
             COVNotificationRequest::decode_detailed(&[0x09, 0x01, 0x1B, 0x01, 0x02, 0x03])
                 .unwrap_err()
                 .reject_reason(),
-            RejectReason::OTHER
+            RejectReason::INVALID_DATA_ENCODING
+        );
+        // Unsigned values use the smallest possible encoding.
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&[0x0A, 0x00, 0x01])
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::INVALID_DATA_ENCODING
         );
     }
 
@@ -460,6 +467,34 @@ mod tests {
                 .unwrap_err()
                 .reject_reason(),
             RejectReason::PARAMETER_OUT_OF_RANGE
+        );
+    }
+
+    #[test]
+    fn test_decode_cov_notification_classifies_nested_invalid_tag() {
+        let req = COVNotificationRequest {
+            subscriber_process_identifier: 1,
+            initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap(),
+            monitored_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1)
+                .unwrap(),
+            time_remaining: 60,
+            list_of_values: vec![BACnetPropertyValue {
+                property_identifier: PropertyIdentifier::PRESENT_VALUE,
+                property_array_index: None,
+                value: vec![0x21, 0x01],
+                priority: None,
+            }],
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let list_start = buf.iter().position(|byte| *byte == 0x4E).unwrap();
+        buf[list_start + 1] = 0x79;
+
+        assert_eq!(
+            COVNotificationRequest::decode_detailed(&buf)
+                .unwrap_err()
+                .reject_reason(),
+            RejectReason::INVALID_TAG
         );
     }
 

--- a/crates/bacnet-services/src/cov_decode.rs
+++ b/crates/bacnet-services/src/cov_decode.rs
@@ -70,13 +70,13 @@ fn decode_required_context<'a>(
     let end = pos.checked_add(tag.length as usize).ok_or_else(|| {
         failure(
             Error::decoding(pos, format!("{field} length overflow")),
-            RejectReason::OTHER,
+            RejectReason::INVALID_DATA_ENCODING,
         )
     })?;
     if end > data.len() {
         return Err(failure(
             Error::decoding(pos, format!("{field} has invalid data encoding")),
-            RejectReason::OTHER,
+            RejectReason::INVALID_DATA_ENCODING,
         ));
     }
     Ok((&data[pos..end], end))
@@ -89,8 +89,14 @@ fn decode_required_u32(
     field: &str,
 ) -> COVDecodeResult<(u32, usize)> {
     let (content, end) = decode_required_context(data, offset, expected_tag, field)?;
+    if content.len() > 1 && content.first() == Some(&0) {
+        return Err(failure(
+            Error::decoding(offset, format!("{field} is not minimally encoded")),
+            RejectReason::INVALID_DATA_ENCODING,
+        ));
+    }
     let value = primitives::decode_unsigned(content)
-        .map_err(|error| failure(error, RejectReason::OTHER))?;
+        .map_err(|error| failure(error, RejectReason::INVALID_DATA_ENCODING))?;
     let value = u32::try_from(value).map_err(|_| {
         failure(
             Error::decoding(offset, format!("{field} exceeds u32")),
@@ -104,8 +110,10 @@ fn property_value_reject_reason(error: &Error) -> RejectReason {
     match error {
         Error::InvalidTag(_) => RejectReason::INVALID_TAG,
         Error::OutOfRange(_) => RejectReason::PARAMETER_OUT_OF_RANGE,
+        Error::BufferTooShort { .. } => RejectReason::INVALID_DATA_ENCODING,
         Error::Decoding { message, .. }
-            if message.contains("expected opening tag")
+            if message.contains("expected context tag")
+                || message.contains("expected opening tag")
                 || message.contains("expected closing tag") =>
         {
             RejectReason::INVALID_TAG
@@ -113,6 +121,7 @@ fn property_value_reject_reason(error: &Error) -> RejectReason {
         Error::Decoding { message, .. } if message.contains("out of range") => {
             RejectReason::PARAMETER_OUT_OF_RANGE
         }
+        Error::Decoding { .. } => RejectReason::INVALID_DATA_ENCODING,
         _ => RejectReason::OTHER,
     }
 }
@@ -129,13 +138,13 @@ impl COVNotificationRequest {
 
         let (content, end) = decode_required_context(data, offset, 1, "COVNotification device-id")?;
         let initiating_device_identifier = ObjectIdentifier::decode(content)
-            .map_err(|error| failure(error, RejectReason::OTHER))?;
+            .map_err(|error| failure(error, RejectReason::INVALID_DATA_ENCODING))?;
         offset = end;
 
         let (content, end) =
             decode_required_context(data, offset, 2, "COVNotification monitored-id")?;
         let monitored_object_identifier = ObjectIdentifier::decode(content)
-            .map_err(|error| failure(error, RejectReason::OTHER))?;
+            .map_err(|error| failure(error, RejectReason::INVALID_DATA_ENCODING))?;
         offset = end;
 
         let (time_remaining, end) =

--- a/crates/bacnet-services/src/cov_decode.rs
+++ b/crates/bacnet-services/src/cov_decode.rs
@@ -1,0 +1,219 @@
+//! Detailed confirmed-COV decoding and Reject classification.
+
+use bacnet_encoding::{primitives, tags};
+use bacnet_types::enums::RejectReason;
+use bacnet_types::error::Error;
+use bacnet_types::primitives::ObjectIdentifier;
+
+use crate::common::{BACnetPropertyValue, MAX_DECODED_ITEMS};
+use crate::cov::COVNotificationRequest;
+
+/// Structured failure returned when decoding a confirmed COV notification.
+///
+/// Confirmed-service responders need the Clause 18.9 Reject reason in
+/// addition to the ordinary decoder error retained by
+/// [`COVNotificationRequest::decode`].
+#[derive(Debug)]
+pub struct COVNotificationDecodeError {
+    error: Error,
+    reject_reason: RejectReason,
+}
+
+impl COVNotificationDecodeError {
+    fn new(error: Error, reject_reason: RejectReason) -> Self {
+        Self {
+            error,
+            reject_reason,
+        }
+    }
+
+    /// Reject reason appropriate for this confirmed-service syntax failure.
+    pub fn reject_reason(&self) -> RejectReason {
+        self.reject_reason
+    }
+
+    /// Recover the ordinary decoder error used by the compatibility API.
+    pub fn into_error(self) -> Error {
+        self.error
+    }
+}
+
+type COVDecodeResult<T> = Result<T, COVNotificationDecodeError>;
+
+fn failure(error: Error, reject_reason: RejectReason) -> COVNotificationDecodeError {
+    COVNotificationDecodeError::new(error, reject_reason)
+}
+
+fn decode_required_context<'a>(
+    data: &'a [u8],
+    offset: usize,
+    expected_tag: u8,
+    field: &str,
+) -> COVDecodeResult<(&'a [u8], usize)> {
+    if offset >= data.len() {
+        return Err(failure(
+            Error::decoding(offset, format!("{field} is missing")),
+            RejectReason::MISSING_REQUIRED_PARAMETER,
+        ));
+    }
+    let (tag, pos) = tags::decode_tag(data, offset)
+        .map_err(|error| failure(error, RejectReason::INVALID_TAG))?;
+    if !tag.is_context(expected_tag) {
+        return Err(failure(
+            Error::decoding(
+                offset,
+                format!("{field} expected context tag {expected_tag}"),
+            ),
+            RejectReason::INVALID_TAG,
+        ));
+    }
+    let end = pos.checked_add(tag.length as usize).ok_or_else(|| {
+        failure(
+            Error::decoding(pos, format!("{field} length overflow")),
+            RejectReason::OTHER,
+        )
+    })?;
+    if end > data.len() {
+        return Err(failure(
+            Error::decoding(pos, format!("{field} has invalid data encoding")),
+            RejectReason::OTHER,
+        ));
+    }
+    Ok((&data[pos..end], end))
+}
+
+fn decode_required_u32(
+    data: &[u8],
+    offset: usize,
+    expected_tag: u8,
+    field: &str,
+) -> COVDecodeResult<(u32, usize)> {
+    let (content, end) = decode_required_context(data, offset, expected_tag, field)?;
+    let value = primitives::decode_unsigned(content)
+        .map_err(|error| failure(error, RejectReason::OTHER))?;
+    let value = u32::try_from(value).map_err(|_| {
+        failure(
+            Error::decoding(offset, format!("{field} exceeds u32")),
+            RejectReason::PARAMETER_OUT_OF_RANGE,
+        )
+    })?;
+    Ok((value, end))
+}
+
+fn property_value_reject_reason(error: &Error) -> RejectReason {
+    match error {
+        Error::InvalidTag(_) => RejectReason::INVALID_TAG,
+        Error::OutOfRange(_) => RejectReason::PARAMETER_OUT_OF_RANGE,
+        Error::Decoding { message, .. }
+            if message.contains("expected opening tag")
+                || message.contains("expected closing tag") =>
+        {
+            RejectReason::INVALID_TAG
+        }
+        Error::Decoding { message, .. } if message.contains("out of range") => {
+            RejectReason::PARAMETER_OUT_OF_RANGE
+        }
+        _ => RejectReason::OTHER,
+    }
+}
+
+impl COVNotificationRequest {
+    /// Decode a confirmed COV notification and retain its Clause 18.9 Reject
+    /// classification if the service parameters are malformed.
+    pub fn decode_detailed(data: &[u8]) -> COVDecodeResult<Self> {
+        let mut offset = 0;
+
+        let (subscriber_process_identifier, end) =
+            decode_required_u32(data, offset, 0, "COVNotification process-id")?;
+        offset = end;
+
+        let (content, end) = decode_required_context(data, offset, 1, "COVNotification device-id")?;
+        let initiating_device_identifier = ObjectIdentifier::decode(content)
+            .map_err(|error| failure(error, RejectReason::OTHER))?;
+        offset = end;
+
+        let (content, end) =
+            decode_required_context(data, offset, 2, "COVNotification monitored-id")?;
+        let monitored_object_identifier = ObjectIdentifier::decode(content)
+            .map_err(|error| failure(error, RejectReason::OTHER))?;
+        offset = end;
+
+        let (time_remaining, end) =
+            decode_required_u32(data, offset, 3, "COVNotification time-remaining")?;
+        offset = end;
+
+        if offset >= data.len() {
+            return Err(failure(
+                Error::decoding(offset, "COVNotification list-of-values is missing"),
+                RejectReason::MISSING_REQUIRED_PARAMETER,
+            ));
+        }
+        let (tag, tag_end) = tags::decode_tag(data, offset)
+            .map_err(|error| failure(error, RejectReason::INVALID_TAG))?;
+        if !tag.is_opening_tag(4) {
+            return Err(failure(
+                Error::decoding(offset, "COVNotification expected opening tag 4"),
+                RejectReason::INVALID_TAG,
+            ));
+        }
+        offset = tag_end;
+
+        let mut values = Vec::new();
+        loop {
+            if offset >= data.len() {
+                return Err(failure(
+                    Error::decoding(offset, "COVNotification missing closing tag 4"),
+                    RejectReason::INVALID_TAG,
+                ));
+            }
+            let (tag, tag_end) = tags::decode_tag(data, offset)
+                .map_err(|error| failure(error, RejectReason::INVALID_TAG))?;
+            if tag.is_closing_tag(4) {
+                offset = tag_end;
+                break;
+            }
+            if values.len() >= MAX_DECODED_ITEMS {
+                return Err(failure(
+                    Error::decoding(offset, "COVNotification values exceeds max"),
+                    RejectReason::BUFFER_OVERFLOW,
+                ));
+            }
+            let (pv, new_offset) =
+                BACnetPropertyValue::decode_in_list(data, offset, 4).map_err(|error| {
+                    let reject_reason = property_value_reject_reason(&error);
+                    failure(error, reject_reason)
+                })?;
+            values.push(pv);
+            offset = new_offset;
+        }
+        if values.is_empty() {
+            return Err(failure(
+                Error::decoding(
+                    offset,
+                    "COVNotification list-of-values must contain at least one value",
+                ),
+                RejectReason::PARAMETER_OUT_OF_RANGE,
+            ));
+        }
+        if offset != data.len() {
+            let reject_reason = match tags::decode_tag(data, offset) {
+                Ok((tag, _)) if !tag.is_opening && !tag.is_closing => {
+                    RejectReason::TOO_MANY_ARGUMENTS
+                }
+                _ => RejectReason::INVALID_TAG,
+            };
+            return Err(failure(
+                Error::decoding(offset, "COVNotification has trailing data"),
+                reject_reason,
+            ));
+        }
+
+        Ok(Self {
+            subscriber_process_identifier,
+            initiating_device_identifier,
+            monitored_object_identifier,
+            time_remaining,
+            list_of_values: values,
+        })
+    }
+}

--- a/crates/bacnet-services/src/cov_width_tests.rs
+++ b/crates/bacnet-services/src/cov_width_tests.rs
@@ -67,7 +67,7 @@ fn cov_notification(process_id: &[u8], time_remaining: &[u8]) -> BytesMut {
 }
 
 #[test]
-fn cov_unsigned_fields_accept_u32_max_with_leading_zero() {
+fn subscribe_cov_unsigned_fields_accept_u32_max_with_leading_zero() {
     let decoded = SubscribeCOVRequest::decode(&subscribe_cov(
         MAX_WITH_LEADING_ZERO,
         Some(MAX_WITH_LEADING_ZERO),
@@ -87,14 +87,19 @@ fn cov_unsigned_fields_accept_u32_max_with_leading_zero() {
     assert_eq!(decoded.lifetime, Some(u32::MAX));
     assert_eq!(decoded.monitored_property_identifier.to_raw(), u32::MAX);
     assert_eq!(decoded.monitored_property_array_index, Some(u32::MAX));
+}
 
-    let decoded = COVNotificationRequest::decode(&cov_notification(
+#[test]
+fn confirmed_cov_rejects_nonminimal_unsigned_encoding() {
+    let error = COVNotificationRequest::decode_detailed(&cov_notification(
         MAX_WITH_LEADING_ZERO,
         MAX_WITH_LEADING_ZERO,
     ))
-    .unwrap();
-    assert_eq!(decoded.subscriber_process_identifier, u32::MAX);
-    assert_eq!(decoded.time_remaining, u32::MAX);
+    .unwrap_err();
+    assert_eq!(
+        error.reject_reason(),
+        bacnet_types::enums::RejectReason::INVALID_DATA_ENCODING
+    );
 }
 
 #[test]

--- a/crates/bacnet-services/src/lib.rs
+++ b/crates/bacnet-services/src/lib.rs
@@ -10,6 +10,7 @@ pub mod alarm_summary;
 pub mod audit;
 pub mod common;
 pub mod cov;
+mod cov_decode;
 pub mod cov_multiple;
 pub mod device_mgmt;
 pub mod enrollment_summary;

--- a/crates/bacnet-transport/Cargo.toml
+++ b/crates/bacnet-transport/Cargo.toml
@@ -25,6 +25,13 @@ gpiocdev = { version = "0.8", optional = true }
 libc = { workspace = true }
 getrandom = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+    "Win32_Foundation",
+    "Win32_Networking_WinSock",
+    "Win32_System_IO",
+] }
+
 [features]
 default = []
 ipv6 = []

--- a/crates/bacnet-transport/Cargo.toml
+++ b/crates/bacnet-transport/Cargo.toml
@@ -42,6 +42,7 @@ ethernet = []
 
 [dev-dependencies]
 rcgen.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 
 [lints]
 workspace = true

--- a/crates/bacnet-transport/src/bip/dbtn_tests.rs
+++ b/crates/bacnet-transport/src/bip/dbtn_tests.rs
@@ -94,7 +94,7 @@ async fn dbtn_registered_foreign_device_fans_out_without_origin_echo() {
         received.source_mac.as_slice(),
         &encode_bip_mac(sender.0, sender.1)
     );
-    assert!(received.link_layer_broadcast);
+    assert!(received.link_layer_group);
 
     for (label, socket) in [
         ("local broadcast", &local_broadcast_sink),

--- a/crates/bacnet-transport/src/bip/dbtn_tests.rs
+++ b/crates/bacnet-transport/src/bip/dbtn_tests.rs
@@ -94,6 +94,7 @@ async fn dbtn_registered_foreign_device_fans_out_without_origin_echo() {
         received.source_mac.as_slice(),
         &encode_bip_mac(sender.0, sender.1)
     );
+    assert!(received.link_layer_broadcast);
 
     for (label, socket) in [
         ("local broadcast", &local_broadcast_sink),

--- a/crates/bacnet-transport/src/bip/forwarded_tests.rs
+++ b/crates/bacnet-transport/src/bip/forwarded_tests.rs
@@ -85,7 +85,7 @@ async fn forwarded_npdu_from_bdt_peer_uses_originating_source_mac() {
         received.source_mac.as_slice(),
         &encode_bip_mac(origin.0, origin.1)
     );
-    assert!(received.link_layer_broadcast);
+    assert!(received.link_layer_group);
 
     let local_frame = recv_bvll(&local_broadcast_sink).await;
     assert_eq!(local_frame.function, BvlcFunction::FORWARDED_NPDU);

--- a/crates/bacnet-transport/src/bip/forwarded_tests.rs
+++ b/crates/bacnet-transport/src/bip/forwarded_tests.rs
@@ -85,6 +85,7 @@ async fn forwarded_npdu_from_bdt_peer_uses_originating_source_mac() {
         received.source_mac.as_slice(),
         &encode_bip_mac(origin.0, origin.1)
     );
+    assert!(received.link_layer_broadcast);
 
     let local_frame = recv_bvll(&local_broadcast_sink).await;
     assert_eq!(local_frame.function, BvlcFunction::FORWARDED_NPDU);

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -24,26 +24,28 @@ pub(super) fn original_destination_matches(
     wildcard_bind: bool,
     os_group_delivery: Option<bool>,
 ) -> bool {
+    let local_unicast = match destination {
+        IpAddr::V4(ip) if wildcard_bind => {
+            ip != configured_broadcast
+                && ip != Ipv4Addr::BROADCAST
+                && !ip.is_multicast()
+                && (local_unicast_ips.contains(&ip)
+                    || (cfg!(windows) && os_group_delivery == Some(false)))
+        }
+        IpAddr::V4(ip) => ip == local_ip,
+        IpAddr::V6(_) => false,
+    } && os_group_delivery != Some(true);
+    let broadcast = matches!(destination, IpAddr::V4(ip) if ip == configured_broadcast || ip == Ipv4Addr::BROADCAST)
+        && os_group_delivery != Some(false);
+
     match function {
-        f if f == BvlcFunction::ORIGINAL_UNICAST_NPDU => {
-            let ip_matches = match destination {
-                IpAddr::V4(ip) if wildcard_bind => {
-                    ip != configured_broadcast
-                        && ip != Ipv4Addr::BROADCAST
-                        && !ip.is_multicast()
-                        && (local_unicast_ips.contains(&ip)
-                            || (cfg!(windows) && os_group_delivery == Some(false)))
-                }
-                IpAddr::V4(ip) => ip == local_ip,
-                IpAddr::V6(_) => false,
-            };
-            ip_matches && os_group_delivery != Some(true)
-        }
-        f if f == BvlcFunction::ORIGINAL_BROADCAST_NPDU => {
-            matches!(destination, IpAddr::V4(ip) if ip == configured_broadcast || ip == Ipv4Addr::BROADCAST)
-                && os_group_delivery != Some(false)
-        }
-        _ => true,
+        f if f == BvlcFunction::ORIGINAL_UNICAST_NPDU => local_unicast,
+        f if f == BvlcFunction::ORIGINAL_BROADCAST_NPDU => broadcast,
+        // A Forwarded-NPDU may arrive by direct unicast or by a configured
+        // directed/limited broadcast. All BVLL management requests and
+        // responses are point-to-point and must arrive as actual unicast.
+        f if f == BvlcFunction::FORWARDED_NPDU => local_unicast || broadcast,
+        _ => local_unicast,
     }
 }
 

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -1,4 +1,4 @@
-use std::net::{Ipv4Addr, SocketAddrV4};
+use std::net::{IpAddr, Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 
 use bytes::BytesMut;
@@ -14,6 +14,25 @@ use crate::bvll::{self, encode_bip_mac, encode_bvll, encode_bvll_forwarded};
 use crate::port::ReceivedNpdu;
 
 use super::{decode_bvlc_result_code, PendingBvlcResponse};
+
+pub(super) fn original_destination_matches(
+    function: BvlcFunction,
+    destination: IpAddr,
+    local_ip: Ipv4Addr,
+    configured_broadcast: Ipv4Addr,
+    os_group_delivery: Option<bool>,
+) -> bool {
+    match function {
+        f if f == BvlcFunction::ORIGINAL_UNICAST_NPDU => {
+            destination == IpAddr::V4(local_ip) && os_group_delivery != Some(true)
+        }
+        f if f == BvlcFunction::ORIGINAL_BROADCAST_NPDU => {
+            matches!(destination, IpAddr::V4(ip) if ip == configured_broadcast || ip == Ipv4Addr::BROADCAST)
+                && os_group_delivery != Some(false)
+        }
+        _ => true,
+    }
+}
 
 /// Send a Register-Foreign-Device message to a BBMD.
 pub(super) async fn send_register_foreign_device(
@@ -84,7 +103,7 @@ pub(super) async fn handle_bvll_message(
                 .try_send(ReceivedNpdu {
                     npdu: msg.payload.clone(),
                     source_mac,
-                    link_layer_broadcast: false,
+                    link_layer_group: false,
                     data_attributes: Vec::new(),
                     reply_tx: None,
                 })
@@ -105,7 +124,7 @@ pub(super) async fn handle_bvll_message(
                 .try_send(ReceivedNpdu {
                     npdu: msg.payload.clone(),
                     source_mac,
-                    link_layer_broadcast: true,
+                    link_layer_group: true,
                     data_attributes: Vec::new(),
                     reply_tx: None,
                 })
@@ -160,7 +179,7 @@ pub(super) async fn handle_bvll_message(
                     .try_send(ReceivedNpdu {
                         npdu: msg.payload.clone(),
                         source_mac,
-                        link_layer_broadcast: true,
+                        link_layer_group: true,
                         data_attributes: Vec::new(),
                         reply_tx: None,
                     })
@@ -200,7 +219,7 @@ pub(super) async fn handle_bvll_message(
                     .try_send(ReceivedNpdu {
                         npdu: msg.payload.clone(),
                         source_mac,
-                        link_layer_broadcast: true,
+                        link_layer_group: true,
                         data_attributes: Vec::new(),
                         reply_tx: None,
                     })
@@ -240,7 +259,7 @@ pub(super) async fn handle_bvll_message(
                     .try_send(ReceivedNpdu {
                         npdu: msg.payload.clone(),
                         source_mac,
-                        link_layer_broadcast: true,
+                        link_layer_group: true,
                         data_attributes: Vec::new(),
                         reply_tx: None,
                     })

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -84,6 +84,7 @@ pub(super) async fn handle_bvll_message(
                 .try_send(ReceivedNpdu {
                     npdu: msg.payload.clone(),
                     source_mac,
+                    link_layer_broadcast: false,
                     data_attributes: Vec::new(),
                     reply_tx: None,
                 })
@@ -104,6 +105,7 @@ pub(super) async fn handle_bvll_message(
                 .try_send(ReceivedNpdu {
                     npdu: msg.payload.clone(),
                     source_mac,
+                    link_layer_broadcast: true,
                     data_attributes: Vec::new(),
                     reply_tx: None,
                 })
@@ -158,6 +160,7 @@ pub(super) async fn handle_bvll_message(
                     .try_send(ReceivedNpdu {
                         npdu: msg.payload.clone(),
                         source_mac,
+                        link_layer_broadcast: true,
                         data_attributes: Vec::new(),
                         reply_tx: None,
                     })
@@ -197,6 +200,7 @@ pub(super) async fn handle_bvll_message(
                     .try_send(ReceivedNpdu {
                         npdu: msg.payload.clone(),
                         source_mac,
+                        link_layer_broadcast: true,
                         data_attributes: Vec::new(),
                         reply_tx: None,
                     })
@@ -236,6 +240,7 @@ pub(super) async fn handle_bvll_message(
                     .try_send(ReceivedNpdu {
                         npdu: msg.payload.clone(),
                         source_mac,
+                        link_layer_broadcast: true,
                         data_attributes: Vec::new(),
                         reply_tx: None,
                     })

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -20,11 +20,24 @@ pub(super) fn original_destination_matches(
     destination: IpAddr,
     local_ip: Ipv4Addr,
     configured_broadcast: Ipv4Addr,
+    local_unicast_ips: &[Ipv4Addr],
+    wildcard_bind: bool,
     os_group_delivery: Option<bool>,
 ) -> bool {
     match function {
         f if f == BvlcFunction::ORIGINAL_UNICAST_NPDU => {
-            destination == IpAddr::V4(local_ip) && os_group_delivery != Some(true)
+            let ip_matches = match destination {
+                IpAddr::V4(ip) if wildcard_bind => {
+                    ip != configured_broadcast
+                        && ip != Ipv4Addr::BROADCAST
+                        && !ip.is_multicast()
+                        && (local_unicast_ips.contains(&ip)
+                            || (cfg!(windows) && os_group_delivery == Some(false)))
+                }
+                IpAddr::V4(ip) => ip == local_ip,
+                IpAddr::V6(_) => false,
+            };
+            ip_matches && os_group_delivery != Some(true)
         }
         f if f == BvlcFunction::ORIGINAL_BROADCAST_NPDU => {
             matches!(destination, IpAddr::V4(ip) if ip == configured_broadcast || ip == Ipv4Addr::BROADCAST)

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -443,11 +443,24 @@ impl TransportPort for BipTransport {
         let std_socket: std::net::UdpSocket = socket2.into();
         let socket = UdpSocket::from_std(std_socket).map_err(Error::Transport)?;
 
-        let local_ip = if self.interface.is_unspecified() {
+        let wildcard_bind = self.interface.is_unspecified();
+        let local_ip = if wildcard_bind {
             resolve_local_ip().unwrap_or(Ipv4Addr::LOCALHOST)
         } else {
             self.interface
         };
+        let local_unicast_ips = if wildcard_bind {
+            crate::local_addresses::ipv4()
+        } else {
+            vec![local_ip]
+        };
+        #[cfg(unix)]
+        if wildcard_bind && local_unicast_ips.is_empty() {
+            return Err(Error::Transport(std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                "could not enumerate local IPv4 addresses for wildcard ingress",
+            )));
+        }
 
         let local_port = socket.local_addr().map_err(Error::Transport)?.port();
         self.port = local_port;
@@ -522,6 +535,8 @@ impl TransportPort for BipTransport {
                                     received.destination,
                                     local_ip,
                                     recv_ctx.broadcast_addr,
+                                    &local_unicast_ips,
+                                    wildcard_bind,
                                     received.os_group_delivery,
                                 ) {
                                     debug!(

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -17,11 +17,15 @@ use tracing::{debug, warn};
 use crate::bbmd::{self, BbmdState, BdtEntry, FdtEntryWire};
 use crate::bvll::{decode_bip_mac, decode_bvll, encode_bip_mac, encode_bvll, BvllMessage};
 use crate::port::{ReceivedNpdu, TransportPort};
+use crate::udp_metadata::{DestinationReceiver, IpVersion};
 use bacnet_types::enums::{BvlcFunction, BvlcResultCode};
 use bacnet_types::error::Error;
 
 mod io;
-use io::{handle_bvll_message, resolve_local_ip, send_register_foreign_device, RecvContext};
+use io::{
+    handle_bvll_message, original_destination_matches, resolve_local_ip,
+    send_register_foreign_device, RecvContext,
+};
 
 /// Default BACnet/IP port (0xBAC0 = 47808).
 pub const DEFAULT_BACNET_PORT: u16 = 0xBAC0;
@@ -433,6 +437,9 @@ impl TransportPort for BipTransport {
         let bind_addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, self.port);
         socket2.bind(&bind_addr.into()).map_err(Error::Transport)?;
 
+        let destination_receiver =
+            DestinationReceiver::configure(&socket2, IpVersion::V4).map_err(Error::Transport)?;
+
         let std_socket: std::net::UdpSocket = socket2.into();
         let socket = UdpSocket::from_std(std_socket).map_err(Error::Transport)?;
 
@@ -502,16 +509,34 @@ impl TransportPort for BipTransport {
         let recv_task = tokio::spawn(async move {
             let mut recv_buf = vec![0u8; 2048];
             loop {
-                match recv_ctx.socket.recv_from(&mut recv_buf).await {
-                    Ok((len, addr)) => {
-                        let data = &recv_buf[..len];
+                match destination_receiver
+                    .recv_from(&recv_ctx.socket, &mut recv_buf)
+                    .await
+                {
+                    Ok(received) => {
+                        let data = &recv_buf[..received.len];
                         match decode_bvll(data) {
                             Ok(msg) => {
-                                let sender_addr = if let std::net::SocketAddr::V4(v4) = addr {
-                                    (v4.ip().octets(), v4.port())
-                                } else {
+                                if !original_destination_matches(
+                                    msg.function,
+                                    received.destination,
+                                    local_ip,
+                                    recv_ctx.broadcast_addr,
+                                    received.os_group_delivery,
+                                ) {
+                                    debug!(
+                                        function = msg.function.to_raw(),
+                                        destination = %received.destination,
+                                        "Dropping BVLL/IP destination mismatch"
+                                    );
                                     continue;
-                                };
+                                }
+                                let sender_addr =
+                                    if let std::net::SocketAddr::V4(v4) = received.peer {
+                                        (v4.ip().octets(), v4.port())
+                                    } else {
+                                        continue;
+                                    };
 
                                 handle_bvll_message(&msg, sender_addr, &recv_ctx).await;
                             }
@@ -519,6 +544,9 @@ impl TransportPort for BipTransport {
                                 warn!(error = %e, "Failed to decode BVLL frame");
                             }
                         }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                        debug!(error = %e, "Dropping UDP datagram with invalid destination metadata");
                     }
                     Err(e) => {
                         warn!(error = %e, "UDP recv error");

--- a/crates/bacnet-transport/src/bip/original_tests.rs
+++ b/crates/bacnet-transport/src/bip/original_tests.rs
@@ -62,6 +62,56 @@ fn original_function_must_match_actual_ipv4_destination() {
         true,
         Some(true),
     ));
+
+    for function in [
+        BvlcFunction::BVLC_RESULT,
+        BvlcFunction::WRITE_BROADCAST_DISTRIBUTION_TABLE,
+        BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE,
+        BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK,
+        BvlcFunction::REGISTER_FOREIGN_DEVICE,
+        BvlcFunction::READ_FOREIGN_DEVICE_TABLE,
+        BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK,
+        BvlcFunction::DELETE_FOREIGN_DEVICE_TABLE_ENTRY,
+        BvlcFunction::DISTRIBUTE_BROADCAST_TO_NETWORK,
+    ] {
+        assert!(original_destination_matches(
+            function,
+            local.into(),
+            local,
+            broadcast,
+            &[local],
+            false,
+            None,
+        ));
+        assert!(!original_destination_matches(
+            function,
+            broadcast.into(),
+            local,
+            broadcast,
+            &[local],
+            false,
+            Some(true),
+        ));
+    }
+
+    assert!(original_destination_matches(
+        BvlcFunction::FORWARDED_NPDU,
+        local.into(),
+        local,
+        broadcast,
+        &[local],
+        false,
+        None,
+    ));
+    assert!(original_destination_matches(
+        BvlcFunction::FORWARDED_NPDU,
+        broadcast.into(),
+        local,
+        broadcast,
+        &[local],
+        false,
+        Some(true),
+    ));
 }
 
 async fn recv_bvll(socket: &UdpSocket) -> BvllMessage {

--- a/crates/bacnet-transport/src/bip/original_tests.rs
+++ b/crates/bacnet-transport/src/bip/original_tests.rs
@@ -2,6 +2,41 @@ use super::*;
 use bytes::Bytes;
 use tokio::time::{timeout, Duration};
 
+#[test]
+fn original_function_must_match_actual_ipv4_destination() {
+    let local = Ipv4Addr::new(192, 0, 2, 10);
+    let broadcast = Ipv4Addr::new(192, 0, 2, 255);
+
+    assert!(original_destination_matches(
+        BvlcFunction::ORIGINAL_UNICAST_NPDU,
+        local.into(),
+        local,
+        broadcast,
+        None,
+    ));
+    assert!(!original_destination_matches(
+        BvlcFunction::ORIGINAL_UNICAST_NPDU,
+        broadcast.into(),
+        local,
+        broadcast,
+        None,
+    ));
+    assert!(!original_destination_matches(
+        BvlcFunction::ORIGINAL_BROADCAST_NPDU,
+        local.into(),
+        local,
+        broadcast,
+        None,
+    ));
+    assert!(original_destination_matches(
+        BvlcFunction::ORIGINAL_BROADCAST_NPDU,
+        broadcast.into(),
+        local,
+        broadcast,
+        None,
+    ));
+}
+
 async fn recv_bvll(socket: &UdpSocket) -> BvllMessage {
     let mut recv_buf = [0u8; 2048];
     let (len, _addr) = timeout(Duration::from_secs(2), socket.recv_from(&mut recv_buf))
@@ -50,7 +85,7 @@ async fn original_unicast_npdu_uses_udp_sender_source_mac_and_ignores_self() {
         received.source_mac.as_slice(),
         &encode_bip_mac(sender.0, sender.1)
     );
-    assert!(!received.link_layer_broadcast);
+    assert!(!received.link_layer_group);
 
     handle_bvll_message(&msg, (Ipv4Addr::LOCALHOST.octets(), local_port), &ctx).await;
     assert!(
@@ -125,7 +160,7 @@ async fn original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo
         received.source_mac.as_slice(),
         &encode_bip_mac(sender.0, sender.1)
     );
-    assert!(received.link_layer_broadcast);
+    assert!(received.link_layer_group);
 
     for (label, socket) in [
         ("BDT peer", &bdt_peer_sink),

--- a/crates/bacnet-transport/src/bip/original_tests.rs
+++ b/crates/bacnet-transport/src/bip/original_tests.rs
@@ -50,6 +50,7 @@ async fn original_unicast_npdu_uses_udp_sender_source_mac_and_ignores_self() {
         received.source_mac.as_slice(),
         &encode_bip_mac(sender.0, sender.1)
     );
+    assert!(!received.link_layer_broadcast);
 
     handle_bvll_message(&msg, (Ipv4Addr::LOCALHOST.octets(), local_port), &ctx).await;
     assert!(
@@ -124,6 +125,7 @@ async fn original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo
         received.source_mac.as_slice(),
         &encode_bip_mac(sender.0, sender.1)
     );
+    assert!(received.link_layer_broadcast);
 
     for (label, socket) in [
         ("BDT peer", &bdt_peer_sink),

--- a/crates/bacnet-transport/src/bip/original_tests.rs
+++ b/crates/bacnet-transport/src/bip/original_tests.rs
@@ -12,6 +12,8 @@ fn original_function_must_match_actual_ipv4_destination() {
         local.into(),
         local,
         broadcast,
+        &[local],
+        false,
         None,
     ));
     assert!(!original_destination_matches(
@@ -19,6 +21,8 @@ fn original_function_must_match_actual_ipv4_destination() {
         broadcast.into(),
         local,
         broadcast,
+        &[local],
+        false,
         None,
     ));
     assert!(!original_destination_matches(
@@ -26,6 +30,8 @@ fn original_function_must_match_actual_ipv4_destination() {
         local.into(),
         local,
         broadcast,
+        &[local],
+        false,
         None,
     ));
     assert!(original_destination_matches(
@@ -33,7 +39,28 @@ fn original_function_must_match_actual_ipv4_destination() {
         broadcast.into(),
         local,
         broadcast,
+        &[local],
+        false,
         None,
+    ));
+
+    assert!(original_destination_matches(
+        BvlcFunction::ORIGINAL_UNICAST_NPDU,
+        Ipv4Addr::new(192, 0, 2, 11).into(),
+        local,
+        broadcast,
+        &[local, Ipv4Addr::new(192, 0, 2, 11)],
+        true,
+        None,
+    ));
+    assert!(!original_destination_matches(
+        BvlcFunction::ORIGINAL_UNICAST_NPDU,
+        broadcast.into(),
+        local,
+        broadcast,
+        &[local],
+        true,
+        Some(true),
     ));
 }
 

--- a/crates/bacnet-transport/src/bip6/frame.rs
+++ b/crates/bacnet-transport/src/bip6/frame.rs
@@ -71,10 +71,29 @@ pub fn decode_bvlc6(data: &[u8]) -> Result<Bvlc6Frame, Error> {
     if length < BVLC6_HEADER_LENGTH {
         return Err(Error::decoding(2, "BVLC6 length less than header size"));
     }
-    if length > data.len() {
+    if length != data.len() {
         return Err(Error::decoding(
             2,
-            format!("BVLC6 length {} exceeds data length {}", length, data.len()),
+            format!(
+                "BVLC6 length {} does not match datagram length {}",
+                length,
+                data.len()
+            ),
+        ));
+    }
+
+    let fixed_length = match function {
+        Bvlc6Function::VirtualAddressResolution => Some(BVLC6_HEADER_LENGTH),
+        Bvlc6Function::AddressResolution
+        | Bvlc6Function::AddressResolutionAck
+        | Bvlc6Function::VirtualAddressResolutionAck => Some(BVLC6_UNICAST_HEADER_LENGTH),
+        Bvlc6Function::ForwardedAddressResolution => Some(28),
+        _ => None,
+    };
+    if fixed_length.is_some_and(|expected| length != expected) {
+        return Err(Error::decoding(
+            2,
+            format!("BVLC6 function has invalid fixed length {length}"),
         ));
     }
 
@@ -86,6 +105,7 @@ pub fn decode_bvlc6(data: &[u8]) -> Result<Bvlc6Frame, Error> {
         function,
         Bvlc6Function::OriginalUnicast
             | Bvlc6Function::AddressResolution
+            | Bvlc6Function::ForwardedAddressResolution
             | Bvlc6Function::AddressResolutionAck
             | Bvlc6Function::VirtualAddressResolutionAck
     );
@@ -163,7 +183,7 @@ pub fn encode_virtual_address_resolution(source_vmac: &Bip6Vmac) -> BytesMut {
 
 /// Encode a BVLC-IPv6 Virtual-Address-Resolution-Ack frame (10 bytes).
 ///
-/// Per spec Clause U.2.7A: includes the requester's VMAC as destination.
+/// Per spec Clause U.2.8: includes the requester's VMAC as destination.
 /// type(1) + function(1) + length(2) + source_vmac(3) + dest_vmac(3) = 10.
 pub fn encode_virtual_address_resolution_ack(
     source_vmac: &Bip6Vmac,
@@ -193,7 +213,7 @@ pub fn encode_address_resolution(source_vmac: &Bip6Vmac, target_vmac: &Bip6Vmac)
 
 /// Encode a BVLC-IPv6 Address-Resolution-Ack frame (10 bytes).
 ///
-/// Per spec Clause U.2.5: includes the requester's VMAC as destination.
+/// Per spec Clause U.2.6: includes the requester's VMAC as destination.
 pub fn encode_address_resolution_ack(source_vmac: &Bip6Vmac, dest_vmac: &Bip6Vmac) -> BytesMut {
     let mut buf = BytesMut::with_capacity(BVLC6_UNICAST_HEADER_LENGTH);
     buf.put_u8(BVLC6_TYPE);

--- a/crates/bacnet-transport/src/bip6/frame.rs
+++ b/crates/bacnet-transport/src/bip6/frame.rs
@@ -8,6 +8,21 @@ use super::{
     BVLC6_UNICAST_HEADER_LENGTH,
 };
 
+pub(super) fn destination_vmac_matches(
+    function: Bvlc6Function,
+    destination_vmac: Option<Bip6Vmac>,
+    local_vmac: Bip6Vmac,
+) -> bool {
+    match function {
+        Bvlc6Function::OriginalUnicast
+        | Bvlc6Function::AddressResolutionAck
+        | Bvlc6Function::VirtualAddressResolutionAck => destination_vmac == Some(local_vmac),
+        // Address-Resolution uses this field as a broadcast Target-VMAC;
+        // its handler separately decides whether the target is local.
+        _ => true,
+    }
+}
+
 /// Encode a BVLC-IPv6 frame into a buffer.
 pub fn encode_bvlc6(
     buf: &mut BytesMut,
@@ -191,29 +206,26 @@ pub fn encode_address_resolution_ack(source_vmac: &Bip6Vmac, dest_vmac: &Bip6Vma
 
 /// Extract the NPDU from a ForwardedNpdu payload.
 ///
-/// ForwardedNpdu payload layout:
-///   Original-Source-Virtual-Address(3) + Original-Source-B/IPv6-Address(18) + NPDU.
-/// Returns the originating VMAC, originating B/IPv6 address, and NPDU bytes.
-pub fn decode_forwarded_npdu_payload(
-    payload: &[u8],
-) -> Result<(Bip6Vmac, SocketAddrV6, &[u8]), Error> {
-    if payload.len() < 21 {
+/// The BVLC6 header's Source-Virtual-Address is the original source VMAC.
+/// The payload layout is therefore:
+///   Original-Source-B/IPv6-Address(18) + NPDU.
+/// Returns the originating B/IPv6 address and NPDU bytes.
+pub fn decode_forwarded_npdu_payload(payload: &[u8]) -> Result<(SocketAddrV6, &[u8]), Error> {
+    if payload.len() < 18 {
         return Err(Error::decoding(
             0,
             format!(
-                "ForwardedNpdu payload too short: need at least 21 bytes, have {}",
+                "ForwardedNpdu payload too short: need at least 18 bytes, have {}",
                 payload.len()
             ),
         ));
     }
-    let mut originating_vmac = [0u8; 3];
-    originating_vmac.copy_from_slice(&payload[..3]);
 
     let mut ipv6_bytes = [0u8; 16];
-    ipv6_bytes.copy_from_slice(&payload[3..19]);
+    ipv6_bytes.copy_from_slice(&payload[..16]);
     let ipv6_addr = Ipv6Addr::from(ipv6_bytes);
-    let port = u16::from_be_bytes([payload[19], payload[20]]);
+    let port = u16::from_be_bytes([payload[16], payload[17]]);
     let source_addr = SocketAddrV6::new(ipv6_addr, port, 0, 0);
 
-    Ok((originating_vmac, source_addr, &payload[21..]))
+    Ok((source_addr, &payload[18..]))
 }

--- a/crates/bacnet-transport/src/bip6/frame.rs
+++ b/crates/bacnet-transport/src/bip6/frame.rs
@@ -83,6 +83,8 @@ pub fn decode_bvlc6(data: &[u8]) -> Result<Bvlc6Frame, Error> {
     }
 
     let fixed_length = match function {
+        Bvlc6Function::Result | Bvlc6Function::RegisterForeignDevice => Some(9),
+        Bvlc6Function::DeleteForeignDeviceEntry => Some(25),
         Bvlc6Function::VirtualAddressResolution => Some(BVLC6_HEADER_LENGTH),
         Bvlc6Function::AddressResolution
         | Bvlc6Function::AddressResolutionAck
@@ -231,11 +233,13 @@ pub fn encode_address_resolution_ack(source_vmac: &Bip6Vmac, dest_vmac: &Bip6Vma
 ///   Original-Source-B/IPv6-Address(18) + NPDU.
 /// Returns the originating B/IPv6 address and NPDU bytes.
 pub fn decode_forwarded_npdu_payload(payload: &[u8]) -> Result<(SocketAddrV6, &[u8]), Error> {
-    if payload.len() < 18 {
+    const ADDRESS_LENGTH: usize = 18;
+    const MIN_NPDU_LENGTH: usize = 2;
+    if payload.len() < ADDRESS_LENGTH + MIN_NPDU_LENGTH {
         return Err(Error::decoding(
             0,
             format!(
-                "ForwardedNpdu payload too short: need at least 18 bytes, have {}",
+                "ForwardedNpdu payload too short: need an 18-byte address and BACnet NPDU, have {} bytes",
                 payload.len()
             ),
         ));
@@ -247,5 +251,5 @@ pub fn decode_forwarded_npdu_payload(payload: &[u8]) -> Result<(SocketAddrV6, &[
     let port = u16::from_be_bytes([payload[16], payload[17]]);
     let source_addr = SocketAddrV6::new(ipv6_addr, port, 0, 0);
 
-    Ok((source_addr, &payload[18..]))
+    Ok((source_addr, &payload[ADDRESS_LENGTH..]))
 }

--- a/crates/bacnet-transport/src/bip6/ingress.rs
+++ b/crates/bacnet-transport/src/bip6/ingress.rs
@@ -21,6 +21,8 @@ pub(super) fn forwarded_source_is_usable(source: SocketAddrV6) -> bool {
     source.port() != 0
         && !ip.is_unspecified()
         && !ip.is_multicast()
+        && !ip.is_loopback()
+        && ip.to_ipv4().is_none()
         // A Forwarded-NPDU carries no IPv6 scope ID. Synthesizing the BBMD's
         // ingress scope for a link-local origin can target the wrong link.
         && !ip.is_unicast_link_local()

--- a/crates/bacnet-transport/src/bip6/ingress.rs
+++ b/crates/bacnet-transport/src/bip6/ingress.rs
@@ -1,0 +1,111 @@
+//! BACnet/IPv6 ingress provenance checks.
+
+use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+
+use super::{
+    Bip6Vmac, Bvlc6Function, BACNET_IPV6_MULTICAST_LINK_LOCAL, BACNET_IPV6_MULTICAST_ORG_LOCAL,
+    BACNET_IPV6_MULTICAST_SITE_LOCAL,
+};
+
+fn is_bacnet_ipv6_multicast(destination: Ipv6Addr) -> bool {
+    matches!(
+        destination,
+        BACNET_IPV6_MULTICAST_LINK_LOCAL
+            | BACNET_IPV6_MULTICAST_SITE_LOCAL
+            | BACNET_IPV6_MULTICAST_ORG_LOCAL
+    )
+}
+
+pub(super) fn is_local_unicast_delivery(
+    destination: IpAddr,
+    destination_vmac: Option<Bip6Vmac>,
+    local_ip: Ipv6Addr,
+    local_vmac: Bip6Vmac,
+    local_unicast_ips: &[Ipv6Addr],
+    wildcard_bind: bool,
+    os_group_delivery: Option<bool>,
+) -> bool {
+    let ip_matches = match destination {
+        IpAddr::V6(ip) if wildcard_bind => {
+            !ip.is_multicast()
+                && (local_unicast_ips.contains(&ip)
+                    || (cfg!(windows) && os_group_delivery == Some(false)))
+        }
+        IpAddr::V6(ip) => ip == local_ip,
+        IpAddr::V4(_) => false,
+    };
+    ip_matches && destination_vmac == Some(local_vmac) && os_group_delivery != Some(true)
+}
+
+pub(super) fn original_destination_matches(
+    function: Bvlc6Function,
+    destination: IpAddr,
+    destination_vmac: Option<Bip6Vmac>,
+    local_ip: Ipv6Addr,
+    local_vmac: Bip6Vmac,
+    local_unicast_ips: &[Ipv6Addr],
+    wildcard_bind: bool,
+    os_group_delivery: Option<bool>,
+) -> bool {
+    match function {
+        Bvlc6Function::OriginalUnicast
+        | Bvlc6Function::AddressResolutionAck
+        | Bvlc6Function::VirtualAddressResolutionAck => is_local_unicast_delivery(
+            destination,
+            destination_vmac,
+            local_ip,
+            local_vmac,
+            local_unicast_ips,
+            wildcard_bind,
+            os_group_delivery,
+        ),
+        Bvlc6Function::VirtualAddressResolution => {
+            let ip_matches = match destination {
+                IpAddr::V6(ip) if wildcard_bind => {
+                    !ip.is_multicast()
+                        && (local_unicast_ips.contains(&ip)
+                            || (cfg!(windows) && os_group_delivery == Some(false)))
+                }
+                IpAddr::V6(ip) => ip == local_ip,
+                IpAddr::V4(_) => false,
+            };
+            ip_matches && os_group_delivery != Some(true)
+        }
+        Bvlc6Function::OriginalBroadcast | Bvlc6Function::AddressResolution => {
+            matches!(destination, IpAddr::V6(ip) if is_bacnet_ipv6_multicast(ip))
+                && os_group_delivery != Some(false)
+        }
+        // Forwarded-Address-Resolution is not implemented. Drop it before
+        // learning or any other state mutation.
+        Bvlc6Function::ForwardedAddressResolution => false,
+        _ => true,
+    }
+}
+
+pub(super) fn forwarded_npdu_is_trusted(
+    peer: SocketAddr,
+    destination: IpAddr,
+    os_group_delivery: Option<bool>,
+    local_ip: Ipv6Addr,
+    local_unicast_ips: &[Ipv6Addr],
+    wildcard_bind: bool,
+    foreign_bbmd: Option<(Ipv6Addr, u16)>,
+) -> bool {
+    if let Some((bbmd_ip, bbmd_port)) = foreign_bbmd {
+        let peer_matches = !bbmd_ip.is_unicast_link_local()
+            && matches!(peer, SocketAddr::V6(peer) if *peer.ip() == bbmd_ip && peer.port() == bbmd_port);
+        let destination_matches = match destination {
+            IpAddr::V6(ip) if wildcard_bind => {
+                !ip.is_multicast()
+                    && (local_unicast_ips.contains(&ip)
+                        || (cfg!(windows) && os_group_delivery == Some(false)))
+            }
+            IpAddr::V6(ip) => ip == local_ip,
+            IpAddr::V4(_) => false,
+        };
+        peer_matches && destination_matches && os_group_delivery != Some(true)
+    } else {
+        matches!(destination, IpAddr::V6(ip) if is_bacnet_ipv6_multicast(ip))
+            && os_group_delivery != Some(false)
+    }
+}

--- a/crates/bacnet-transport/src/bip6/ingress.rs
+++ b/crates/bacnet-transport/src/bip6/ingress.rs
@@ -1,6 +1,6 @@
 //! BACnet/IPv6 ingress provenance checks.
 
-use std::net::{IpAddr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv6Addr, SocketAddr, SocketAddrV6};
 
 use super::{
     Bip6Vmac, Bvlc6Function, BACNET_IPV6_MULTICAST_LINK_LOCAL, BACNET_IPV6_MULTICAST_ORG_LOCAL,
@@ -14,6 +14,16 @@ fn is_bacnet_ipv6_multicast(destination: Ipv6Addr) -> bool {
             | BACNET_IPV6_MULTICAST_SITE_LOCAL
             | BACNET_IPV6_MULTICAST_ORG_LOCAL
     )
+}
+
+pub(super) fn forwarded_source_is_usable(source: SocketAddrV6) -> bool {
+    let ip = source.ip();
+    source.port() != 0
+        && !ip.is_unspecified()
+        && !ip.is_multicast()
+        // A Forwarded-NPDU carries no IPv6 scope ID. Synthesizing the BBMD's
+        // ingress scope for a link-local origin can target the wrong link.
+        && !ip.is_unicast_link_local()
 }
 
 pub(super) fn is_local_unicast_delivery(

--- a/crates/bacnet-transport/src/bip6/mod.rs
+++ b/crates/bacnet-transport/src/bip6/mod.rs
@@ -106,14 +106,17 @@ pub struct Bvlc6Frame {
 
 mod frame;
 pub use frame::*;
+mod ingress;
 mod port;
 mod vmac_table;
 pub use port::{
-    decode_bip6_mac, encode_bip6_mac, generate_random_vmac, Bip6BroadcastScope,
-    Bip6ForeignDeviceConfig, Bip6Transport, BACNET_IPV6_MULTICAST,
-    BACNET_IPV6_MULTICAST_LINK_LOCAL, BACNET_IPV6_MULTICAST_ORG_LOCAL,
+    decode_bip6_mac, encode_bip6_mac, Bip6BroadcastScope, Bip6ForeignDeviceConfig, Bip6Transport,
+    BACNET_IPV6_MULTICAST, BACNET_IPV6_MULTICAST_LINK_LOCAL, BACNET_IPV6_MULTICAST_ORG_LOCAL,
     BACNET_IPV6_MULTICAST_SITE_LOCAL, DEFAULT_BACNET6_PORT,
 };
+pub use vmac_table::generate_random_vmac;
 
+#[cfg(test)]
+mod safety_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-transport/src/bip6/mod.rs
+++ b/crates/bacnet-transport/src/bip6/mod.rs
@@ -107,6 +107,7 @@ pub struct Bvlc6Frame {
 mod frame;
 pub use frame::*;
 mod port;
+mod vmac_table;
 pub use port::{
     decode_bip6_mac, encode_bip6_mac, generate_random_vmac, Bip6BroadcastScope,
     Bip6ForeignDeviceConfig, Bip6Transport, BACNET_IPV6_MULTICAST,

--- a/crates/bacnet-transport/src/bip6/mod.rs
+++ b/crates/bacnet-transport/src/bip6/mod.rs
@@ -17,7 +17,7 @@ pub const BVLC6_HEADER_LENGTH: usize = 7;
 /// BVLC-IPv6 unicast header length: type(1) + function(1) + length(2) + source-vmac(3) + dest-vmac(3).
 pub const BVLC6_UNICAST_HEADER_LENGTH: usize = 10;
 
-/// Maximum number of VMAC collision resolution retries before giving up (Annex U.5).
+/// Maximum number of random VMAC regenerations before startup fails (Annex U.5/H.7.2).
 pub const MAX_VMAC_RETRIES: u32 = 3;
 
 /// BVLC-IPv6 function codes per Annex U.
@@ -120,3 +120,5 @@ pub use vmac_table::generate_random_vmac;
 mod safety_tests;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod vmac_generation_tests;

--- a/crates/bacnet-transport/src/bip6/port.rs
+++ b/crates/bacnet-transport/src/bip6/port.rs
@@ -1,5 +1,4 @@
 use std::collections::hash_map::RandomState;
-use std::collections::HashMap;
 use std::hash::{BuildHasher, Hasher};
 use std::net::{IpAddr, Ipv6Addr, SocketAddrV6};
 use std::sync::Arc;
@@ -16,6 +15,8 @@ use tracing::{debug, warn};
 use crate::port::{ReceivedNpdu, TransportPort};
 use crate::udp_metadata::{DestinationReceiver, IpVersion};
 
+use super::frame::destination_vmac_matches;
+use super::vmac_table::VmacTable;
 use super::{
     decode_bvlc6, decode_forwarded_npdu_payload, encode_address_resolution_ack, encode_bvlc6,
     encode_bvlc6_original_broadcast, encode_bvlc6_original_unicast,
@@ -71,7 +72,9 @@ pub(super) fn original_destination_matches(
     os_group_delivery: Option<bool>,
 ) -> bool {
     match function {
-        Bvlc6Function::OriginalUnicast => is_local_unicast_delivery(
+        Bvlc6Function::OriginalUnicast
+        | Bvlc6Function::AddressResolutionAck
+        | Bvlc6Function::VirtualAddressResolutionAck => is_local_unicast_delivery(
             destination,
             destination_vmac,
             local_ip,
@@ -109,41 +112,6 @@ pub fn decode_bip6_mac(mac: &[u8]) -> Result<(Ipv6Addr, u16), Error> {
     let ip = Ipv6Addr::from(ip_bytes);
     let port = u16::from_be_bytes([mac[16], mac[17]]);
     Ok((ip, port))
-}
-
-/// VMAC-to-address mapping table per Clause U.5.
-/// Updated from incoming frames (learn-on-receive) and AR exchanges.
-#[derive(Debug, Clone)]
-pub(super) struct VmacTable {
-    entries: Arc<tokio::sync::RwLock<HashMap<Bip6Vmac, SocketAddrV6>>>,
-}
-
-impl VmacTable {
-    fn new() -> Self {
-        Self {
-            entries: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
-        }
-    }
-
-    /// Learn a VMAC-to-address mapping from an incoming frame.
-    pub(super) async fn learn(&self, vmac: Bip6Vmac, addr: SocketAddrV6) {
-        self.entries.write().await.insert(vmac, addr);
-    }
-
-    /// Look up the B/IPv6 address for a VMAC.
-    #[allow(dead_code)] // used by AR exchange (future)
-    async fn lookup(&self, vmac: &Bip6Vmac) -> Option<SocketAddrV6> {
-        self.entries.read().await.get(vmac).copied()
-    }
-
-    /// Reverse lookup: find the VMAC for a B/IPv6 address.
-    async fn lookup_by_addr(&self, addr: &SocketAddrV6) -> Option<Bip6Vmac> {
-        let entries = self.entries.read().await;
-        entries
-            .iter()
-            .find(|(_, a)| *a == addr)
-            .map(|(vmac, _)| *vmac)
-    }
 }
 
 /// BACnet/IPv6 transport over UDP (Annex U).
@@ -525,6 +493,18 @@ impl TransportPort for Bip6Transport {
                         let data = &recv_buf[..received.len];
                         match decode_bvlc6(data) {
                             Ok(frame) => {
+                                if !destination_vmac_matches(
+                                    frame.function,
+                                    frame.destination_vmac,
+                                    source_vmac_copy,
+                                ) {
+                                    debug!(
+                                        function = frame.function.to_byte(),
+                                        destination_vmac = ?frame.destination_vmac,
+                                        "Dropping BVLC6 message addressed to another VMAC"
+                                    );
+                                    continue;
+                                }
                                 if !original_destination_matches(
                                     frame.function,
                                     received.destination,
@@ -540,8 +520,12 @@ impl TransportPort for Bip6Transport {
                                     );
                                     continue;
                                 }
-                                // Learn-on-receive: update VMAC table from every frame
-                                if frame.source_vmac != [0; 3] {
+                                // Forwarded-NPDU's source VMAC identifies the original
+                                // node, not the forwarding BBMD. Its original address is
+                                // learned from the function payload below.
+                                if frame.function != Bvlc6Function::ForwardedNpdu
+                                    && frame.source_vmac != [0; 3]
+                                {
                                     if let std::net::SocketAddr::V6(v6) = received.peer {
                                         vmac_table_clone.learn(frame.source_vmac, v6).await;
                                     }
@@ -581,18 +565,36 @@ impl TransportPort for Bip6Transport {
 
                                     Bvlc6Function::ForwardedNpdu => {
                                         match decode_forwarded_npdu_payload(&frame.payload) {
-                                            Ok((originating_vmac, _source_addr, npdu_bytes)) => {
+                                            Ok((mut source_addr, npdu_bytes)) => {
                                                 if npdu_bytes.is_empty() {
                                                     debug!(
                                                     "ForwardedNpdu with no NPDU payload, ignoring"
                                                 );
                                                     continue;
                                                 }
+                                                // A forwarded link-local address has no wire scope;
+                                                // use the forwarding BBMD's ingress interface hint.
+                                                if source_addr.ip().is_unicast_link_local()
+                                                    && source_addr.scope_id() == 0
+                                                {
+                                                    if let std::net::SocketAddr::V6(peer) =
+                                                        received.peer
+                                                    {
+                                                        source_addr.set_scope_id(peer.scope_id());
+                                                    }
+                                                }
+                                                vmac_table_clone
+                                                    .learn(frame.source_vmac, source_addr)
+                                                    .await;
+                                                let source_mac = encode_bip6_mac(
+                                                    *source_addr.ip(),
+                                                    source_addr.port(),
+                                                );
                                                 if tx
                                                     .try_send(ReceivedNpdu {
                                                         npdu: Bytes::copy_from_slice(npdu_bytes),
                                                         source_mac: MacAddr::from_slice(
-                                                            &originating_vmac,
+                                                            &source_mac,
                                                         ),
                                                         link_layer_group: true,
                                                         data_attributes: Vec::new(),
@@ -762,21 +764,21 @@ impl TransportPort for Bip6Transport {
         })?;
 
         let (ip, port) = decode_bip6_mac(mac)?;
-        let dest = SocketAddrV6::new(ip, port, 0, 0);
-
         let mut buf = BytesMut::with_capacity(BVLC6_UNICAST_HEADER_LENGTH + npdu.len());
-        let source_vmac = self.source_vmac;
-        // Original-Unicast requires the destination's actual VMAC. Sending
-        // the reserved unknown VMAC would guarantee a conforming peer drops
-        // the frame, so fail before emission until an inbound frame has
-        // populated the Clause U.5 table.
-        let dest_vmac = self.vmac_table.lookup_by_addr(&dest).await.ok_or_else(|| {
-            Error::Transport(std::io::Error::new(
-                std::io::ErrorKind::AddrNotAvailable,
-                "BIP6 destination VMAC is unknown; receive a frame from the peer first",
-            ))
-        })?;
-        encode_bvlc6_original_unicast(&mut buf, &source_vmac, &dest_vmac, npdu)?;
+        // Original-Unicast requires the destination's actual VMAC. The
+        // network MAC contains only IPv6+port, so use the latest learned
+        // mapping both for that VMAC and for the exact scoped endpoint.
+        let (dest_vmac, dest) =
+            self.vmac_table
+                .resolve_by_addr(ip, port)
+                .await
+                .ok_or_else(|| {
+                    Error::Transport(std::io::Error::new(
+                        std::io::ErrorKind::AddrNotAvailable,
+                        "BIP6 destination VMAC is unknown; receive a frame from the peer first",
+                    ))
+                })?;
+        encode_bvlc6_original_unicast(&mut buf, &self.source_vmac, &dest_vmac, npdu)?;
 
         socket.send_to(&buf, dest).await.map_err(Error::Transport)?;
 

--- a/crates/bacnet-transport/src/bip6/port.rs
+++ b/crates/bacnet-transport/src/bip6/port.rs
@@ -151,6 +151,10 @@ impl Bip6Transport {
     }
 
     /// Configure this transport as a foreign device.
+    ///
+    /// A foreign device must also have a configured Device instance. Random
+    /// VMAC startup is rejected until BBMD-assisted collision resolution is
+    /// implemented.
     /// Must be called before `start()`.
     pub fn register_as_foreign_device(&mut self, config: Bip6ForeignDeviceConfig) {
         self.foreign_device = Some(config);
@@ -201,64 +205,6 @@ fn resolve_local_ipv6() -> Option<Ipv6Addr> {
     }
 }
 
-/// Best-effort resolution of IPv6 interface index for the given address.
-/// Returns `None` if the interface cannot be determined.
-#[allow(unsafe_code)]
-fn resolve_interface_index(addr: &Ipv6Addr) -> Option<u32> {
-    #[cfg(unix)]
-    {
-        use std::ffi::CStr;
-
-        /// RAII guard for `getifaddrs` that calls `freeifaddrs` on drop.
-        struct IfAddrsGuard(*mut libc::ifaddrs);
-        impl Drop for IfAddrsGuard {
-            fn drop(&mut self) {
-                // SAFETY: `self.0` was returned by `getifaddrs` and stored without modification;
-                // `freeifaddrs` is the matching deallocator and is called exactly once on drop.
-                unsafe { libc::freeifaddrs(self.0) }
-            }
-        }
-
-        // SAFETY: this block performs the `getifaddrs`/walk/family-dispatch dance. The
-        // returned linked list is owned by `_guard` (calls `freeifaddrs` on drop). All
-        // pointer dereferences of `cursor`/`ifa.ifa_addr` are gated on null checks; address
-        // family bytes are read after confirming `family == AF_INET6`. `CStr::from_ptr`
-        // requires NUL-terminated strings, which the kernel guarantees for `ifa_name`.
-        unsafe {
-            let mut ifaddrs: *mut libc::ifaddrs = std::ptr::null_mut();
-            if libc::getifaddrs(&mut ifaddrs) != 0 {
-                return None;
-            }
-            let _guard = IfAddrsGuard(ifaddrs);
-            let mut cursor = ifaddrs;
-            while !cursor.is_null() {
-                let ifa = &*cursor;
-                if !ifa.ifa_addr.is_null() {
-                    let family = (*ifa.ifa_addr).sa_family as i32;
-                    if family == libc::AF_INET6 {
-                        let sockaddr6 = &*(ifa.ifa_addr as *const libc::sockaddr_in6);
-                        let ifa_ip = Ipv6Addr::from(sockaddr6.sin6_addr.s6_addr);
-                        if ifa_ip == *addr {
-                            let name = CStr::from_ptr(ifa.ifa_name);
-                            let idx = libc::if_nametoindex(name.as_ptr());
-                            if idx != 0 {
-                                return Some(idx);
-                            }
-                        }
-                    }
-                }
-                cursor = ifa.ifa_next;
-            }
-            None
-        }
-    }
-    #[cfg(not(unix))]
-    {
-        let _ = addr;
-        None
-    }
-}
-
 impl TransportPort for Bip6Transport {
     async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
         if self.recv_task.is_some() {
@@ -271,6 +217,12 @@ impl TransportPort for Bip6Transport {
             return Err(Error::Encoding(
                 "BACnet Device instance must be in 0..=4194303".to_string(),
             ));
+        }
+        if self.foreign_device.is_some() && self.device_instance.is_none() {
+            return Err(Error::Transport(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "BIP6 foreign devices require a configured Device instance until BBMD-assisted random-VMAC resolution is implemented",
+            )));
         }
 
         let wildcard_bind = self.interface.is_unspecified();
@@ -332,40 +284,41 @@ impl TransportPort for Bip6Transport {
             generate_random_vmac()?
         };
 
-        let if_index = if local_ip.is_loopback() {
-            0u32
-        } else {
-            resolve_interface_index(&local_ip).unwrap_or_else(|| {
+        let if_index =
+            crate::local_addresses::ipv6_interface_index(&local_ip).unwrap_or_else(|| {
                 warn!("Could not resolve interface index for {local_ip}, using OS default (0)");
                 0u32
-            })
-        };
+            });
+        let collision_probe_required = self.device_instance.is_none();
+        let collision_group = self.broadcast_scope.multicast_addr();
         for group in &[
             BACNET_IPV6_MULTICAST_LINK_LOCAL,
             BACNET_IPV6_MULTICAST_SITE_LOCAL,
             BACNET_IPV6_MULTICAST_ORG_LOCAL,
         ] {
             if let Err(e) = socket.join_multicast_v6(group, if_index) {
+                if collision_probe_required && *group == collision_group {
+                    return Err(Error::Transport(e));
+                }
                 warn!("Could not join IPv6 multicast group {group} on interface {if_index}: {e}");
             }
         }
 
         let socket = Arc::new(socket);
-        self.socket = Some(Arc::clone(&socket));
 
         // VMAC collision detection and resolution
-        {
-            let multicast_dest = SocketAddrV6::new(
-                self.broadcast_scope.multicast_addr(),
-                self.port,
-                0,
-                if_index,
-            );
+        if self.foreign_device.is_none() {
+            let multicast_dest = SocketAddrV6::new(collision_group, self.port, 0, if_index);
             let mut check_buf = vec![0u8; 64];
 
             for attempt in 0..=MAX_VMAC_RETRIES {
                 let ar_msg = encode_address_resolution(&self.source_vmac, &self.source_vmac);
-                let _ = socket.send_to(&ar_msg, multicast_dest).await;
+                if let Err(error) = socket.send_to(&ar_msg, multicast_dest).await {
+                    if collision_probe_required {
+                        return Err(Error::Transport(error));
+                    }
+                    debug!(error = %error, "Configured-VMAC collision probe send failed");
+                }
 
                 let mut collision = false;
                 let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
@@ -378,6 +331,34 @@ impl TransportPort for Bip6Transport {
                     {
                         Ok(Ok(received)) => {
                             if let Ok(frame) = decode_bvlc6(&check_buf[..received.len]) {
+                                let is_self_loop = matches!(
+                                    received.peer,
+                                    std::net::SocketAddr::V6(peer)
+                                        if peer.port() == local_port
+                                            && (*peer.ip() == local_ip
+                                                || local_unicast_ips.contains(peer.ip()))
+                                );
+                                if frame.function == Bvlc6Function::AddressResolution
+                                    && frame.destination_vmac == Some(self.source_vmac)
+                                    && matches!(received.destination, std::net::IpAddr::V6(ip) if ip == collision_group)
+                                    && received.os_group_delivery != Some(false)
+                                    && !is_self_loop
+                                {
+                                    let ack = encode_address_resolution_ack(
+                                        &self.source_vmac,
+                                        &frame.source_vmac,
+                                    );
+                                    if let Err(error) = socket.send_to(&ack, received.peer).await {
+                                        if collision_probe_required {
+                                            return Err(Error::Transport(error));
+                                        }
+                                        debug!(error = %error, "Configured-VMAC AR-Ack send failed");
+                                    }
+                                    if frame.source_vmac == self.source_vmac {
+                                        collision = true;
+                                        break;
+                                    }
+                                }
                                 // AR-ACK from another node using our VMAC.
                                 if frame.function == Bvlc6Function::AddressResolutionAck
                                     && frame.source_vmac == self.source_vmac
@@ -401,7 +382,10 @@ impl TransportPort for Bip6Transport {
                             continue;
                         }
                         Ok(Err(e)) => {
-                            debug!(error = %e, "Error during VMAC collision check");
+                            if collision_probe_required {
+                                return Err(Error::Transport(e));
+                            }
+                            debug!(error = %e, "Configured-VMAC collision probe receive failed");
                             break;
                         }
                         Err(_) => break, // timeout elapsed — no collision
@@ -709,6 +693,7 @@ impl TransportPort for Bip6Transport {
         });
 
         self.recv_task = Some(recv_task);
+        self.socket = Some(Arc::clone(&socket));
 
         // Start foreign device registration if configured
         if let Some(fd) = &self.foreign_device {

--- a/crates/bacnet-transport/src/bip6/port.rs
+++ b/crates/bacnet-transport/src/bip6/port.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::hash::{BuildHasher, Hasher};
-use std::net::{Ipv6Addr, SocketAddrV6};
+use std::net::{IpAddr, Ipv6Addr, SocketAddrV6};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -14,6 +14,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
 use crate::port::{ReceivedNpdu, TransportPort};
+use crate::udp_metadata::{DestinationReceiver, IpVersion};
 
 use super::{
     decode_bvlc6, decode_forwarded_npdu_payload, encode_address_resolution_ack, encode_bvlc6,
@@ -39,6 +40,51 @@ pub const BACNET_IPV6_MULTICAST: Ipv6Addr = BACNET_IPV6_MULTICAST_LINK_LOCAL;
 
 /// Default BACnet/IPv6 port (same as BIP: 0xBAC0 = 47808).
 pub const DEFAULT_BACNET6_PORT: u16 = 0xBAC0;
+
+fn is_bacnet_ipv6_multicast(destination: Ipv6Addr) -> bool {
+    matches!(
+        destination,
+        BACNET_IPV6_MULTICAST_LINK_LOCAL
+            | BACNET_IPV6_MULTICAST_SITE_LOCAL
+            | BACNET_IPV6_MULTICAST_ORG_LOCAL
+    )
+}
+
+fn is_local_unicast_delivery(
+    destination: IpAddr,
+    destination_vmac: Option<Bip6Vmac>,
+    local_ip: Ipv6Addr,
+    local_vmac: Bip6Vmac,
+    os_group_delivery: Option<bool>,
+) -> bool {
+    destination == IpAddr::V6(local_ip)
+        && destination_vmac == Some(local_vmac)
+        && os_group_delivery != Some(true)
+}
+
+pub(super) fn original_destination_matches(
+    function: Bvlc6Function,
+    destination: IpAddr,
+    destination_vmac: Option<Bip6Vmac>,
+    local_ip: Ipv6Addr,
+    local_vmac: Bip6Vmac,
+    os_group_delivery: Option<bool>,
+) -> bool {
+    match function {
+        Bvlc6Function::OriginalUnicast => is_local_unicast_delivery(
+            destination,
+            destination_vmac,
+            local_ip,
+            local_vmac,
+            os_group_delivery,
+        ),
+        Bvlc6Function::OriginalBroadcast => {
+            matches!(destination, IpAddr::V6(ip) if is_bacnet_ipv6_multicast(ip))
+                && os_group_delivery != Some(false)
+        }
+        _ => true,
+    }
+}
 
 /// Encode an IPv6 address + port into an 18-byte MAC.
 ///
@@ -68,7 +114,7 @@ pub fn decode_bip6_mac(mac: &[u8]) -> Result<(Ipv6Addr, u16), Error> {
 /// VMAC-to-address mapping table per Clause U.5.
 /// Updated from incoming frames (learn-on-receive) and AR exchanges.
 #[derive(Debug, Clone)]
-struct VmacTable {
+pub(super) struct VmacTable {
     entries: Arc<tokio::sync::RwLock<HashMap<Bip6Vmac, SocketAddrV6>>>,
 }
 
@@ -80,7 +126,7 @@ impl VmacTable {
     }
 
     /// Learn a VMAC-to-address mapping from an incoming frame.
-    async fn learn(&self, vmac: Bip6Vmac, addr: SocketAddrV6) {
+    pub(super) async fn learn(&self, vmac: Bip6Vmac, addr: SocketAddrV6) {
         self.entries.write().await.insert(vmac, addr);
     }
 
@@ -110,7 +156,7 @@ pub struct Bip6Transport {
     pub(super) socket: Option<Arc<UdpSocket>>,
     recv_task: Option<JoinHandle<()>>,
     /// VMAC address table (Clause U.5).
-    vmac_table: VmacTable,
+    pub(super) vmac_table: VmacTable,
     /// Broadcast scope for send_broadcast.
     broadcast_scope: Bip6BroadcastScope,
     /// Foreign device BBMD configuration (optional).
@@ -345,6 +391,9 @@ impl TransportPort for Bip6Transport {
             .bind(&bind_addr.into())
             .map_err(Error::Transport)?;
 
+        let destination_receiver = DestinationReceiver::configure(&socket2_sock, IpVersion::V6)
+            .map_err(Error::Transport)?;
+
         let std_socket: std::net::UdpSocket = socket2_sock.into();
         let socket = UdpSocket::from_std(std_socket).map_err(Error::Transport)?;
 
@@ -400,13 +449,24 @@ impl TransportPort for Bip6Transport {
                 let mut collision = false;
                 let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
                 loop {
-                    match tokio::time::timeout_at(deadline, socket.recv_from(&mut check_buf)).await
+                    match tokio::time::timeout_at(
+                        deadline,
+                        destination_receiver.recv_from(&socket, &mut check_buf),
+                    )
+                    .await
                     {
-                        Ok(Ok((len, _peer))) => {
-                            if let Ok(frame) = decode_bvlc6(&check_buf[..len]) {
+                        Ok(Ok(received)) => {
+                            if let Ok(frame) = decode_bvlc6(&check_buf[..received.len]) {
                                 // VAR-ACK from another node using our VMAC
                                 if frame.function == Bvlc6Function::VirtualAddressResolutionAck
                                     && frame.source_vmac == self.source_vmac
+                                    && is_local_unicast_delivery(
+                                        received.destination,
+                                        frame.destination_vmac,
+                                        local_ip,
+                                        self.source_vmac,
+                                        received.os_group_delivery,
+                                    )
                                 {
                                     collision = true;
                                     break;
@@ -457,14 +517,32 @@ impl TransportPort for Bip6Transport {
         let recv_task = tokio::spawn(async move {
             let mut recv_buf = vec![0u8; 2048];
             loop {
-                match socket_for_recv.recv_from(&mut recv_buf).await {
-                    Ok((len, addr)) => {
-                        let data = &recv_buf[..len];
+                match destination_receiver
+                    .recv_from(&socket_for_recv, &mut recv_buf)
+                    .await
+                {
+                    Ok(received) => {
+                        let data = &recv_buf[..received.len];
                         match decode_bvlc6(data) {
                             Ok(frame) => {
+                                if !original_destination_matches(
+                                    frame.function,
+                                    received.destination,
+                                    frame.destination_vmac,
+                                    local_ip,
+                                    source_vmac_copy,
+                                    received.os_group_delivery,
+                                ) {
+                                    debug!(
+                                        function = frame.function.to_byte(),
+                                        destination = %received.destination,
+                                        "Dropping BVLC6/IP or Destination-VMAC mismatch"
+                                    );
+                                    continue;
+                                }
                                 // Learn-on-receive: update VMAC table from every frame
                                 if frame.source_vmac != [0; 3] {
-                                    if let std::net::SocketAddr::V6(v6) = addr {
+                                    if let std::net::SocketAddr::V6(v6) = received.peer {
                                         vmac_table_clone.learn(frame.source_vmac, v6).await;
                                     }
                                 }
@@ -472,15 +550,15 @@ impl TransportPort for Bip6Transport {
                                 match frame.function {
                                     Bvlc6Function::OriginalUnicast
                                     | Bvlc6Function::OriginalBroadcast => {
-                                        let source_mac = if let std::net::SocketAddr::V6(v6) = addr
-                                        {
-                                            MacAddr::from_slice(&encode_bip6_mac(
-                                                *v6.ip(),
-                                                v6.port(),
-                                            ))
-                                        } else {
-                                            continue;
-                                        };
+                                        let source_mac =
+                                            if let std::net::SocketAddr::V6(v6) = received.peer {
+                                                MacAddr::from_slice(&encode_bip6_mac(
+                                                    *v6.ip(),
+                                                    v6.port(),
+                                                ))
+                                            } else {
+                                                continue;
+                                            };
                                         if source_mac[..] == local_mac[..] {
                                             continue;
                                         }
@@ -488,7 +566,7 @@ impl TransportPort for Bip6Transport {
                                             .try_send(ReceivedNpdu {
                                                 npdu: frame.payload.clone(),
                                                 source_mac,
-                                                link_layer_broadcast: frame.function
+                                                link_layer_group: frame.function
                                                     == Bvlc6Function::OriginalBroadcast,
                                                 data_attributes: Vec::new(),
                                                 reply_tx: None,
@@ -516,7 +594,7 @@ impl TransportPort for Bip6Transport {
                                                         source_mac: MacAddr::from_slice(
                                                             &originating_vmac,
                                                         ),
-                                                        link_layer_broadcast: true,
+                                                        link_layer_group: true,
                                                         data_attributes: Vec::new(),
                                                         reply_tx: None,
                                                     })
@@ -546,7 +624,8 @@ impl TransportPort for Bip6Transport {
                                                 &source_vmac_copy,
                                                 &frame.source_vmac,
                                             );
-                                            let _ = socket_for_recv.send_to(&ack, addr).await;
+                                            let _ =
+                                                socket_for_recv.send_to(&ack, received.peer).await;
                                         }
                                     }
 
@@ -563,7 +642,9 @@ impl TransportPort for Bip6Transport {
                                                     &source_vmac_copy,
                                                     &frame.source_vmac,
                                                 );
-                                                let _ = socket_for_recv.send_to(&ack, addr).await;
+                                                let _ = socket_for_recv
+                                                    .send_to(&ack, received.peer)
+                                                    .await;
                                             }
                                         }
                                     }
@@ -573,7 +654,7 @@ impl TransportPort for Bip6Transport {
                                         // (will be used by VMAC table in future)
                                         debug!(
                                             vmac = ?frame.source_vmac,
-                                            addr = %addr,
+                                                addr = %received.peer,
                                             "Received AR-Ack"
                                         );
                                     }
@@ -619,6 +700,9 @@ impl TransportPort for Bip6Transport {
                                 warn!(error = %e, "Failed to decode BVLC6 frame");
                             }
                         }
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::InvalidData => {
+                        debug!(error = %e, "Dropping UDP datagram with invalid destination metadata");
                     }
                     Err(e) => {
                         warn!(error = %e, "IPv6 UDP recv error");
@@ -682,13 +766,16 @@ impl TransportPort for Bip6Transport {
 
         let mut buf = BytesMut::with_capacity(BVLC6_UNICAST_HEADER_LENGTH + npdu.len());
         let source_vmac = self.source_vmac;
-        // Look up destination VMAC from table (Clause U.5).
-        // Fall back to reverse address lookup, then [0; 3] (unknown).
-        let dest_vmac = self
-            .vmac_table
-            .lookup_by_addr(&dest)
-            .await
-            .unwrap_or([0; 3]);
+        // Original-Unicast requires the destination's actual VMAC. Sending
+        // the reserved unknown VMAC would guarantee a conforming peer drops
+        // the frame, so fail before emission until an inbound frame has
+        // populated the Clause U.5 table.
+        let dest_vmac = self.vmac_table.lookup_by_addr(&dest).await.ok_or_else(|| {
+            Error::Transport(std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                "BIP6 destination VMAC is unknown; receive a frame from the peer first",
+            ))
+        })?;
         encode_bvlc6_original_unicast(&mut buf, &source_vmac, &dest_vmac, npdu)?;
 
         socket.send_to(&buf, dest).await.map_err(Error::Transport)?;

--- a/crates/bacnet-transport/src/bip6/port.rs
+++ b/crates/bacnet-transport/src/bip6/port.rs
@@ -488,6 +488,8 @@ impl TransportPort for Bip6Transport {
                                             .try_send(ReceivedNpdu {
                                                 npdu: frame.payload.clone(),
                                                 source_mac,
+                                                link_layer_broadcast: frame.function
+                                                    == Bvlc6Function::OriginalBroadcast,
                                                 data_attributes: Vec::new(),
                                                 reply_tx: None,
                                             })
@@ -514,6 +516,7 @@ impl TransportPort for Bip6Transport {
                                                         source_mac: MacAddr::from_slice(
                                                             &originating_vmac,
                                                         ),
+                                                        link_layer_broadcast: true,
                                                         data_attributes: Vec::new(),
                                                         reply_tx: None,
                                                     })

--- a/crates/bacnet-transport/src/bip6/port.rs
+++ b/crates/bacnet-transport/src/bip6/port.rs
@@ -1,9 +1,8 @@
-use std::collections::hash_map::RandomState;
-use std::hash::{BuildHasher, Hasher};
-use std::net::{IpAddr, Ipv6Addr, SocketAddrV6};
+use std::net::{Ipv6Addr, SocketAddrV6};
 use std::sync::Arc;
 use std::time::Duration;
 
+use bacnet_encoding::npdu::decode_npdu;
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 use bytes::{Bytes, BytesMut};
@@ -16,12 +15,17 @@ use crate::port::{ReceivedNpdu, TransportPort};
 use crate::udp_metadata::{DestinationReceiver, IpVersion};
 
 use super::frame::destination_vmac_matches;
-use super::vmac_table::VmacTable;
+use super::ingress::{
+    forwarded_npdu_is_trusted, is_local_unicast_delivery, original_destination_matches,
+};
+use super::vmac_table::{
+    derive_vmac_from_addr, derive_vmac_from_device_instance, generate_random_vmac, VmacTable,
+};
 use super::{
-    decode_bvlc6, decode_forwarded_npdu_payload, encode_address_resolution_ack, encode_bvlc6,
-    encode_bvlc6_original_broadcast, encode_bvlc6_original_unicast,
-    encode_virtual_address_resolution, encode_virtual_address_resolution_ack, Bip6Vmac,
-    Bvlc6Function, BVLC6_HEADER_LENGTH, BVLC6_UNICAST_HEADER_LENGTH, MAX_VMAC_RETRIES,
+    decode_bvlc6, decode_forwarded_npdu_payload, encode_address_resolution,
+    encode_address_resolution_ack, encode_bvlc6, encode_bvlc6_original_broadcast,
+    encode_bvlc6_original_unicast, encode_virtual_address_resolution_ack, Bip6Vmac, Bvlc6Function,
+    BVLC6_HEADER_LENGTH, BVLC6_UNICAST_HEADER_LENGTH, MAX_VMAC_RETRIES,
 };
 
 /// BACnet/IPv6 multicast group (link-local): FF02::BAC0.
@@ -41,53 +45,6 @@ pub const BACNET_IPV6_MULTICAST: Ipv6Addr = BACNET_IPV6_MULTICAST_LINK_LOCAL;
 
 /// Default BACnet/IPv6 port (same as BIP: 0xBAC0 = 47808).
 pub const DEFAULT_BACNET6_PORT: u16 = 0xBAC0;
-
-fn is_bacnet_ipv6_multicast(destination: Ipv6Addr) -> bool {
-    matches!(
-        destination,
-        BACNET_IPV6_MULTICAST_LINK_LOCAL
-            | BACNET_IPV6_MULTICAST_SITE_LOCAL
-            | BACNET_IPV6_MULTICAST_ORG_LOCAL
-    )
-}
-
-fn is_local_unicast_delivery(
-    destination: IpAddr,
-    destination_vmac: Option<Bip6Vmac>,
-    local_ip: Ipv6Addr,
-    local_vmac: Bip6Vmac,
-    os_group_delivery: Option<bool>,
-) -> bool {
-    destination == IpAddr::V6(local_ip)
-        && destination_vmac == Some(local_vmac)
-        && os_group_delivery != Some(true)
-}
-
-pub(super) fn original_destination_matches(
-    function: Bvlc6Function,
-    destination: IpAddr,
-    destination_vmac: Option<Bip6Vmac>,
-    local_ip: Ipv6Addr,
-    local_vmac: Bip6Vmac,
-    os_group_delivery: Option<bool>,
-) -> bool {
-    match function {
-        Bvlc6Function::OriginalUnicast
-        | Bvlc6Function::AddressResolutionAck
-        | Bvlc6Function::VirtualAddressResolutionAck => is_local_unicast_delivery(
-            destination,
-            destination_vmac,
-            local_ip,
-            local_vmac,
-            os_group_delivery,
-        ),
-        Bvlc6Function::OriginalBroadcast => {
-            matches!(destination, IpAddr::V6(ip) if is_bacnet_ipv6_multicast(ip))
-                && os_group_delivery != Some(false)
-        }
-        _ => true,
-    }
-}
 
 /// Encode an IPv6 address + port into an 18-byte MAC.
 ///
@@ -201,7 +158,7 @@ impl Bip6Transport {
     }
 }
 
-/// Derive a 3-byte VMAC from the lower 24 bits of a device instance (Annex U.5).
+/// Derive a 3-byte VMAC from a 22-bit device instance (Clause H.7.2).
 /// Send a Register-Foreign-Device message (Clause U.4.5).
 async fn send_register_foreign_device_v6(
     socket: &UdpSocket,
@@ -224,30 +181,6 @@ async fn send_register_foreign_device_v6(
     } else {
         debug!(bbmd = %bbmd_addr, ttl = ttl, "BIP6: sent Register-Foreign-Device");
     }
-}
-
-pub(super) fn derive_vmac_from_device_instance(device_instance: u32) -> Bip6Vmac {
-    // Mask to 22 bits per Clause H.7.2 (BACnet device instances are 22-bit)
-    let masked = device_instance & 0x3FFFFF;
-    let bytes = masked.to_be_bytes(); // [b0, b1, b2, b3]
-    [bytes[1], bytes[2], bytes[3]]
-}
-
-/// Generate a random 3-byte VMAC for collision resolution (Annex U.5).
-pub fn generate_random_vmac() -> Bip6Vmac {
-    let h = RandomState::new().build_hasher().finish().to_ne_bytes();
-    [h[0], h[1], h[2]]
-}
-
-/// Derive a 3-byte VMAC by XOR-folding 16-byte IPv6 + 2-byte port.
-fn derive_vmac_from_addr(addr: &SocketAddrV6) -> Bip6Vmac {
-    let octets = addr.ip().octets();
-    let port_bytes = addr.port().to_be_bytes();
-    let mut vmac = [0u8; 3];
-    for (i, &b) in octets.iter().chain(port_bytes.iter()).enumerate() {
-        vmac[i % 3] ^= b;
-    }
-    vmac
 }
 
 /// Resolve the local IPv6 address by connecting a UDP socket to a link-local
@@ -336,6 +269,7 @@ impl TransportPort for Bip6Transport {
             )));
         }
 
+        let wildcard_bind = self.interface.is_unspecified();
         let socket2_sock = socket2::Socket::new(
             socket2::Domain::IPV6,
             socket2::Type::DGRAM,
@@ -374,6 +308,18 @@ impl TransportPort for Bip6Transport {
         } else {
             self.interface
         };
+        let local_unicast_ips = if wildcard_bind {
+            crate::local_addresses::ipv6()
+        } else {
+            vec![local_ip]
+        };
+        #[cfg(unix)]
+        if wildcard_bind && local_unicast_ips.is_empty() {
+            return Err(Error::Transport(std::io::Error::new(
+                std::io::ErrorKind::AddrNotAvailable,
+                "could not enumerate local IPv6 addresses for wildcard ingress",
+            )));
+        }
         self.local_mac = encode_bip6_mac(local_ip, local_port);
 
         self.source_vmac = if let Some(id) = self.device_instance {
@@ -411,8 +357,8 @@ impl TransportPort for Bip6Transport {
             let mut check_buf = vec![0u8; 64];
 
             for attempt in 0..=MAX_VMAC_RETRIES {
-                let var_msg = encode_virtual_address_resolution(&self.source_vmac);
-                let _ = socket.send_to(&var_msg, multicast_dest).await;
+                let ar_msg = encode_address_resolution(&self.source_vmac, &self.source_vmac);
+                let _ = socket.send_to(&ar_msg, multicast_dest).await;
 
                 let mut collision = false;
                 let deadline = tokio::time::Instant::now() + Duration::from_millis(200);
@@ -425,14 +371,16 @@ impl TransportPort for Bip6Transport {
                     {
                         Ok(Ok(received)) => {
                             if let Ok(frame) = decode_bvlc6(&check_buf[..received.len]) {
-                                // VAR-ACK from another node using our VMAC
-                                if frame.function == Bvlc6Function::VirtualAddressResolutionAck
+                                // AR-ACK from another node using our VMAC.
+                                if frame.function == Bvlc6Function::AddressResolutionAck
                                     && frame.source_vmac == self.source_vmac
                                     && is_local_unicast_delivery(
                                         received.destination,
                                         frame.destination_vmac,
                                         local_ip,
                                         self.source_vmac,
+                                        &local_unicast_ips,
+                                        wildcard_bind,
                                         received.os_group_delivery,
                                     )
                                 {
@@ -440,6 +388,10 @@ impl TransportPort for Bip6Transport {
                                     break;
                                 }
                             }
+                        }
+                        Ok(Err(e)) if e.kind() == std::io::ErrorKind::InvalidData => {
+                            debug!(error = %e, "Error during VMAC collision check");
+                            continue;
                         }
                         Ok(Err(e)) => {
                             debug!(error = %e, "Error during VMAC collision check");
@@ -480,6 +432,10 @@ impl TransportPort for Bip6Transport {
         let local_mac = self.local_mac;
 
         let source_vmac_copy = self.source_vmac;
+        let foreign_bbmd = self
+            .foreign_device
+            .as_ref()
+            .map(|fd| (fd.bbmd_ip, fd.bbmd_port));
         let socket_for_recv = Arc::clone(&socket);
         let vmac_table_clone = self.vmac_table.clone();
         let recv_task = tokio::spawn(async move {
@@ -511,6 +467,8 @@ impl TransportPort for Bip6Transport {
                                     frame.destination_vmac,
                                     local_ip,
                                     source_vmac_copy,
+                                    &local_unicast_ips,
+                                    wildcard_bind,
                                     received.os_group_delivery,
                                 ) {
                                     debug!(
@@ -520,12 +478,36 @@ impl TransportPort for Bip6Transport {
                                     );
                                     continue;
                                 }
+                                if frame.function == Bvlc6Function::ForwardedNpdu
+                                    && !forwarded_npdu_is_trusted(
+                                        received.peer,
+                                        received.destination,
+                                        received.os_group_delivery,
+                                        local_ip,
+                                        &local_unicast_ips,
+                                        wildcard_bind,
+                                        foreign_bbmd,
+                                    )
+                                {
+                                    debug!(
+                                        peer = %received.peer,
+                                        destination = %received.destination,
+                                        "Dropping Forwarded-NPDU from an untrusted path"
+                                    );
+                                    continue;
+                                }
                                 // Forwarded-NPDU's source VMAC identifies the original
                                 // node, not the forwarding BBMD. Its original address is
                                 // learned from the function payload below.
-                                if frame.function != Bvlc6Function::ForwardedNpdu
-                                    && frame.source_vmac != [0; 3]
-                                {
+                                if matches!(
+                                    frame.function,
+                                    Bvlc6Function::OriginalUnicast
+                                        | Bvlc6Function::OriginalBroadcast
+                                        | Bvlc6Function::AddressResolution
+                                        | Bvlc6Function::AddressResolutionAck
+                                        | Bvlc6Function::VirtualAddressResolution
+                                        | Bvlc6Function::VirtualAddressResolutionAck
+                                ) {
                                     if let std::net::SocketAddr::V6(v6) = received.peer {
                                         vmac_table_clone.learn(frame.source_vmac, v6).await;
                                     }
@@ -565,23 +547,27 @@ impl TransportPort for Bip6Transport {
 
                                     Bvlc6Function::ForwardedNpdu => {
                                         match decode_forwarded_npdu_payload(&frame.payload) {
-                                            Ok((mut source_addr, npdu_bytes)) => {
+                                            Ok((source_addr, npdu_bytes)) => {
                                                 if npdu_bytes.is_empty() {
                                                     debug!(
                                                     "ForwardedNpdu with no NPDU payload, ignoring"
                                                 );
                                                     continue;
                                                 }
-                                                // A forwarded link-local address has no wire scope;
-                                                // use the forwarding BBMD's ingress interface hint.
-                                                if source_addr.ip().is_unicast_link_local()
-                                                    && source_addr.scope_id() == 0
+                                                if source_addr.ip().is_unicast_link_local() {
+                                                    debug!(
+                                                        source = %source_addr,
+                                                        "Dropping Forwarded-NPDU with unscoped link-local origin"
+                                                    );
+                                                    continue;
+                                                }
+                                                if decode_npdu(Bytes::copy_from_slice(npdu_bytes))
+                                                    .is_err()
                                                 {
-                                                    if let std::net::SocketAddr::V6(peer) =
-                                                        received.peer
-                                                    {
-                                                        source_addr.set_scope_id(peer.scope_id());
-                                                    }
+                                                    debug!(
+                                                        "Dropping Forwarded-NPDU with malformed NPDU"
+                                                    );
+                                                    continue;
                                                 }
                                                 vmac_table_clone
                                                     .learn(frame.source_vmac, source_addr)
@@ -615,20 +601,13 @@ impl TransportPort for Bip6Transport {
                                     }
 
                                     Bvlc6Function::VirtualAddressResolution => {
-                                        // VAR: sender is checking if anyone else uses their VMAC.
-                                        // If the source VMAC matches ours, respond (collision).
-                                        if frame.source_vmac == source_vmac_copy {
-                                            debug!(
-                                                vmac = ?source_vmac_copy,
-                                                "Received VAR for our VMAC, sending VAR-Ack"
-                                            );
-                                            let ack = encode_virtual_address_resolution_ack(
-                                                &source_vmac_copy,
-                                                &frame.source_vmac,
-                                            );
-                                            let _ =
-                                                socket_for_recv.send_to(&ack, received.peer).await;
-                                        }
+                                        // A node receiving VAR at its unicast B/IPv6 address
+                                        // answers with its own VMAC and the requester's VMAC.
+                                        let ack = encode_virtual_address_resolution_ack(
+                                            &source_vmac_copy,
+                                            &frame.source_vmac,
+                                        );
+                                        let _ = socket_for_recv.send_to(&ack, received.peer).await;
                                     }
 
                                     Bvlc6Function::AddressResolution => {

--- a/crates/bacnet-transport/src/bip6/port.rs
+++ b/crates/bacnet-transport/src/bip6/port.rs
@@ -16,11 +16,10 @@ use crate::udp_metadata::{DestinationReceiver, IpVersion};
 
 use super::frame::destination_vmac_matches;
 use super::ingress::{
-    forwarded_npdu_is_trusted, is_local_unicast_delivery, original_destination_matches,
+    forwarded_npdu_is_trusted, forwarded_source_is_usable, is_local_unicast_delivery,
+    original_destination_matches,
 };
-use super::vmac_table::{
-    derive_vmac_from_addr, derive_vmac_from_device_instance, generate_random_vmac, VmacTable,
-};
+use super::vmac_table::{derive_vmac_from_device_instance, generate_random_vmac, VmacTable};
 use super::{
     decode_bvlc6, decode_forwarded_npdu_payload, encode_address_resolution,
     encode_address_resolution_ack, encode_bvlc6, encode_bvlc6_original_broadcast,
@@ -128,8 +127,8 @@ impl Bip6Transport {
     /// - `interface`: Local IPv6 address to bind (use `::` for all interfaces)
     /// - `port`: UDP port (default 47808 / 0xBAC0)
     /// - `device_instance`: If `Some(id)`, derive the 3-byte VMAC from the
-    ///   lower 22 bits of the device instance (per Clause H.7.2). Otherwise the
-    ///   VMAC is derived from the local IPv6 address + port.
+    ///   valid 22-bit device instance (per Clause H.7.2). Otherwise an
+    ///   OS-random Random Device Instance VMAC is generated at startup.
     pub fn new(interface: Ipv6Addr, port: u16, device_instance: Option<u32>) -> Self {
         Self {
             interface,
@@ -268,6 +267,11 @@ impl TransportPort for Bip6Transport {
                 "BIP6 transport already started",
             )));
         }
+        if self.device_instance.is_some_and(|id| id > 0x3F_FFFF) {
+            return Err(Error::Encoding(
+                "BACnet Device instance must be in 0..=4194303".to_string(),
+            ));
+        }
 
         let wildcard_bind = self.interface.is_unspecified();
         let socket2_sock = socket2::Socket::new(
@@ -325,8 +329,7 @@ impl TransportPort for Bip6Transport {
         self.source_vmac = if let Some(id) = self.device_instance {
             derive_vmac_from_device_instance(id)
         } else {
-            let local_v6 = SocketAddrV6::new(local_ip, local_port, 0, 0);
-            derive_vmac_from_addr(&local_v6)
+            generate_random_vmac()?
         };
 
         let if_index = if local_ip.is_loopback() {
@@ -352,8 +355,12 @@ impl TransportPort for Bip6Transport {
 
         // VMAC collision detection and resolution
         {
-            let multicast_dest =
-                SocketAddrV6::new(BACNET_IPV6_MULTICAST_LINK_LOCAL, self.port, 0, if_index);
+            let multicast_dest = SocketAddrV6::new(
+                self.broadcast_scope.multicast_addr(),
+                self.port,
+                0,
+                if_index,
+            );
             let mut check_buf = vec![0u8; 64];
 
             for attempt in 0..=MAX_VMAC_RETRIES {
@@ -405,9 +412,16 @@ impl TransportPort for Bip6Transport {
                     break;
                 }
 
+                if self.device_instance.is_some() {
+                    return Err(Error::Transport(std::io::Error::new(
+                        std::io::ErrorKind::AddrInUse,
+                        "configured BACnet Device instance VMAC is already in use",
+                    )));
+                }
+
                 if attempt < MAX_VMAC_RETRIES {
                     let old_vmac = self.source_vmac;
-                    self.source_vmac = generate_random_vmac();
+                    self.source_vmac = generate_random_vmac()?;
                     warn!(
                         old_vmac = ?old_vmac,
                         new_vmac = ?self.source_vmac,
@@ -416,11 +430,12 @@ impl TransportPort for Bip6Transport {
                         "BIP6 VMAC collision detected, re-deriving new VMAC"
                     );
                 } else {
-                    warn!(
-                        vmac = ?self.source_vmac,
-                        "BIP6 VMAC collision persists after {MAX_VMAC_RETRIES} retries, \
-                         proceeding with current VMAC"
-                    );
+                    return Err(Error::Transport(std::io::Error::new(
+                        std::io::ErrorKind::AddrInUse,
+                        format!(
+                            "random BIP6 VMAC collision persists after {MAX_VMAC_RETRIES} retries"
+                        ),
+                    )));
                 }
             }
         }
@@ -554,10 +569,10 @@ impl TransportPort for Bip6Transport {
                                                 );
                                                     continue;
                                                 }
-                                                if source_addr.ip().is_unicast_link_local() {
+                                                if !forwarded_source_is_usable(source_addr) {
                                                     debug!(
                                                         source = %source_addr,
-                                                        "Dropping Forwarded-NPDU with unscoped link-local origin"
+                                                        "Dropping Forwarded-NPDU with unusable origin"
                                                     );
                                                     continue;
                                                 }

--- a/crates/bacnet-transport/src/bip6/safety_tests.rs
+++ b/crates/bacnet-transport/src/bip6/safety_tests.rs
@@ -73,7 +73,14 @@ fn forwarded_npdu_origin_must_be_a_usable_unicast_endpoint() {
         SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 47_808, 0, 0),
         SocketAddrV6::new(BACNET_IPV6_MULTICAST_SITE_LOCAL, 47_808, 0, 0),
         SocketAddrV6::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1), 47_808, 0, 4),
-        SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0),
+        SocketAddrV6::new(Ipv6Addr::LOCALHOST, 47_808, 0, 0),
+        SocketAddrV6::new(
+            Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc000, 0x0201),
+            47_808,
+            0,
+            0,
+        ),
+        SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 9), 0, 0, 0),
     ] {
         assert!(!forwarded_source_is_usable(source), "{source}");
     }
@@ -81,7 +88,7 @@ fn forwarded_npdu_origin_must_be_a_usable_unicast_endpoint() {
 
 #[tokio::test]
 async fn device_zero_vmac_is_learned_and_used_for_reply() {
-    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(43));
     let mut rx = transport.start().await.unwrap();
     let (_, transport_port) = decode_bip6_mac(transport.local_mac()).unwrap();
     let destination = SocketAddrV6::new(Ipv6Addr::LOCALHOST, transport_port, 0, 0);
@@ -120,7 +127,7 @@ async fn untrusted_forwarded_npdu_cannot_replace_learned_peer() {
         std::net::SocketAddr::V6(address) => address,
         _ => unreachable!(),
     };
-    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(45));
     transport.register_as_foreign_device(Bip6ForeignDeviceConfig {
         bbmd_ip: *bbmd_addr.ip(),
         bbmd_port: bbmd_addr.port(),

--- a/crates/bacnet-transport/src/bip6/safety_tests.rs
+++ b/crates/bacnet-transport/src/bip6/safety_tests.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use bytes::BytesMut;
 use tokio::net::UdpSocket;
 
-use super::ingress::forwarded_npdu_is_trusted;
+use super::ingress::{forwarded_npdu_is_trusted, forwarded_source_is_usable};
 use super::*;
 use crate::port::TransportPort;
 
@@ -59,6 +59,24 @@ fn forwarded_npdu_requires_multicast_or_configured_bbmd() {
         false,
         Some((link_local, 47_808)),
     ));
+}
+
+#[test]
+fn forwarded_npdu_origin_must_be_a_usable_unicast_endpoint() {
+    assert!(forwarded_source_is_usable(SocketAddrV6::new(
+        Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 9),
+        47_808,
+        0,
+        0,
+    )));
+    for source in [
+        SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, 47_808, 0, 0),
+        SocketAddrV6::new(BACNET_IPV6_MULTICAST_SITE_LOCAL, 47_808, 0, 0),
+        SocketAddrV6::new(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1), 47_808, 0, 4),
+        SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0),
+    ] {
+        assert!(!forwarded_source_is_usable(source), "{source}");
+    }
 }
 
 #[tokio::test]

--- a/crates/bacnet-transport/src/bip6/safety_tests.rs
+++ b/crates/bacnet-transport/src/bip6/safety_tests.rs
@@ -1,0 +1,165 @@
+use std::net::{Ipv6Addr, SocketAddrV6};
+use std::time::Duration;
+
+use bytes::BytesMut;
+use tokio::net::UdpSocket;
+
+use super::ingress::forwarded_npdu_is_trusted;
+use super::*;
+use crate::port::TransportPort;
+
+#[test]
+fn forwarded_npdu_requires_multicast_or_configured_bbmd() {
+    let local_ip = Ipv6Addr::LOCALHOST;
+    let peer = SocketAddrV6::new(local_ip, 47_808, 0, 0);
+
+    assert!(forwarded_npdu_is_trusted(
+        peer.into(),
+        BACNET_IPV6_MULTICAST_LINK_LOCAL.into(),
+        Some(true),
+        local_ip,
+        &[local_ip],
+        false,
+        None,
+    ));
+    assert!(!forwarded_npdu_is_trusted(
+        peer.into(),
+        local_ip.into(),
+        Some(false),
+        local_ip,
+        &[local_ip],
+        false,
+        None,
+    ));
+    assert!(forwarded_npdu_is_trusted(
+        peer.into(),
+        local_ip.into(),
+        Some(false),
+        local_ip,
+        &[local_ip],
+        false,
+        Some((local_ip, 47_808)),
+    ));
+    assert!(!forwarded_npdu_is_trusted(
+        SocketAddrV6::new(local_ip, 47_809, 0, 0).into(),
+        local_ip.into(),
+        Some(false),
+        local_ip,
+        &[local_ip],
+        false,
+        Some((local_ip, 47_808)),
+    ));
+    let link_local = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+    assert!(!forwarded_npdu_is_trusted(
+        SocketAddrV6::new(link_local, 47_808, 0, 4).into(),
+        local_ip.into(),
+        Some(false),
+        local_ip,
+        &[local_ip],
+        false,
+        Some((link_local, 47_808)),
+    ));
+}
+
+#[tokio::test]
+async fn device_zero_vmac_is_learned_and_used_for_reply() {
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    let mut rx = transport.start().await.unwrap();
+    let (_, transport_port) = decode_bip6_mac(transport.local_mac()).unwrap();
+    let destination = SocketAddrV6::new(Ipv6Addr::LOCALHOST, transport_port, 0, 0);
+    let peer = UdpSocket::bind("[::1]:0").await.unwrap();
+    let npdu = [0x01, 0x00, 0x10, 0x08];
+    let mut frame = BytesMut::new();
+    encode_bvlc6_original_unicast(&mut frame, &[0, 0, 0], &transport.source_vmac, &npdu).unwrap();
+    peer.send_to(&frame, destination).await.unwrap();
+
+    let received = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.npdu.as_ref(), npdu);
+    transport
+        .send_unicast(&[0x01, 0x00, 0x10, 0x09], received.source_mac.as_slice())
+        .await
+        .unwrap();
+
+    let mut response = [0u8; 64];
+    let (len, source) = tokio::time::timeout(Duration::from_secs(2), peer.recv_from(&mut response))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(source.port(), transport_port);
+    let response = decode_bvlc6(&response[..len]).unwrap();
+    assert_eq!(response.destination_vmac, Some([0, 0, 0]));
+
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn untrusted_forwarded_npdu_cannot_replace_learned_peer() {
+    let bbmd = UdpSocket::bind("[::1]:0").await.unwrap();
+    let bbmd_addr = match bbmd.local_addr().unwrap() {
+        std::net::SocketAddr::V6(address) => address,
+        _ => unreachable!(),
+    };
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    transport.register_as_foreign_device(Bip6ForeignDeviceConfig {
+        bbmd_ip: *bbmd_addr.ip(),
+        bbmd_port: bbmd_addr.port(),
+        ttl: 60,
+    });
+    let mut rx = transport.start().await.unwrap();
+    let (_, transport_port) = decode_bip6_mac(transport.local_mac()).unwrap();
+    let destination = SocketAddrV6::new(Ipv6Addr::LOCALHOST, transport_port, 0, 0);
+
+    let origin = UdpSocket::bind("[::1]:0").await.unwrap();
+    let origin_addr = match origin.local_addr().unwrap() {
+        std::net::SocketAddr::V6(address) => address,
+        _ => unreachable!(),
+    };
+    let legitimate_vmac = [0x41, 0x10, 0x01];
+    let mut original = BytesMut::new();
+    encode_bvlc6_original_unicast(
+        &mut original,
+        &legitimate_vmac,
+        &transport.source_vmac,
+        &[0x01, 0x00, 0x10, 0x08],
+    )
+    .unwrap();
+    origin.send_to(&original, destination).await.unwrap();
+    let received = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+
+    let attacker = UdpSocket::bind("[::1]:0").await.unwrap();
+    let forged_vmac = [0x41, 0x10, 0x02];
+    let mut forwarded_payload = origin_addr.ip().octets().to_vec();
+    forwarded_payload.extend_from_slice(&origin_addr.port().to_be_bytes());
+    forwarded_payload.extend_from_slice(&[0x01, 0x00, 0x10, 0x09]);
+    let mut forged = BytesMut::new();
+    encode_bvlc6(
+        &mut forged,
+        Bvlc6Function::ForwardedNpdu,
+        &forged_vmac,
+        &forwarded_payload,
+    )
+    .unwrap();
+    attacker.send_to(&forged, destination).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    assert_eq!(transport.vmac_table.lookup(&forged_vmac).await, None);
+
+    transport
+        .send_unicast(&[0x01, 0x00, 0x10, 0x0A], received.source_mac.as_slice())
+        .await
+        .unwrap();
+    let mut reply = [0u8; 64];
+    let (len, _) = tokio::time::timeout(Duration::from_secs(2), origin.recv_from(&mut reply))
+        .await
+        .unwrap()
+        .unwrap();
+    let reply = decode_bvlc6(&reply[..len]).unwrap();
+    assert_eq!(reply.destination_vmac, Some(legitimate_vmac));
+
+    transport.stop().await.unwrap();
+}

--- a/crates/bacnet-transport/src/bip6/tests.rs
+++ b/crates/bacnet-transport/src/bip6/tests.rs
@@ -5,7 +5,7 @@ use bytes::BytesMut;
 use tokio::net::UdpSocket;
 
 use super::ingress::original_destination_matches;
-use super::vmac_table::{derive_vmac_from_addr, derive_vmac_from_device_instance};
+use super::vmac_table::derive_vmac_from_device_instance;
 use super::*;
 use crate::port::TransportPort;
 
@@ -505,6 +505,20 @@ fn fixed_length_bvlc6_frames_reject_surplus_bytes() {
     let ar_len = ar.len() as u16;
     ar[2..4].copy_from_slice(&ar_len.to_be_bytes());
     assert!(decode_bvlc6(&ar).is_err());
+
+    for (function, payload) in [
+        (Bvlc6Function::Result, vec![0; 2]),
+        (Bvlc6Function::RegisterForeignDevice, vec![0; 2]),
+        (Bvlc6Function::DeleteForeignDeviceEntry, vec![0; 18]),
+    ] {
+        let mut frame = BytesMut::new();
+        encode_bvlc6(&mut frame, function, &[1, 2, 3], &payload).unwrap();
+        assert!(decode_bvlc6(&frame).is_ok());
+        frame.extend_from_slice(&[0]);
+        let length = frame.len() as u16;
+        frame[2..4].copy_from_slice(&length.to_be_bytes());
+        assert!(decode_bvlc6(&frame).is_err(), "{function:?}");
+    }
 }
 
 #[test]
@@ -515,12 +529,13 @@ fn bvlc6_declared_length_must_match_datagram() {
 }
 
 #[test]
-fn vmac_from_device_instance_masks_to_22_bits() {
+fn vmac_from_valid_device_instance_uses_all_22_bits() {
     let vmac = derive_vmac_from_device_instance(0x123456);
     assert_eq!(vmac, [0x12, 0x34, 0x56]);
-    // Value > 22 bits — upper bits should be masked off
-    let vmac = derive_vmac_from_device_instance(0xFFFFFFFF);
-    assert_eq!(vmac, [0x3F, 0xFF, 0xFF]);
+    assert_eq!(
+        derive_vmac_from_device_instance(0x3F_FFFF),
+        [0x3F, 0xFF, 0xFF]
+    );
 }
 
 // --- ForwardedNpdu tests ---
@@ -543,17 +558,9 @@ fn decode_forwarded_npdu_extracts_npdu() {
 #[test]
 fn decode_forwarded_npdu_rejects_short_payload() {
     assert!(decode_forwarded_npdu_payload(&[0x01; 17]).is_err());
+    assert!(decode_forwarded_npdu_payload(&[0x01; 18]).is_err());
+    assert!(decode_forwarded_npdu_payload(&[0x01; 19]).is_err());
     assert!(decode_forwarded_npdu_payload(&[]).is_err());
-}
-
-#[test]
-fn decode_forwarded_npdu_vmac_and_addr_only_is_ok() {
-    // Exactly 18 bytes = B/IPv6 address with empty NPDU. The originating
-    // VMAC is carried by the BVLC6 header, not duplicated in the payload.
-    let mut payload = Ipv6Addr::LOCALHOST.octets().to_vec(); // 16 bytes
-    payload.extend_from_slice(&47808u16.to_be_bytes()); // 2 bytes
-    let (_addr, npdu) = decode_forwarded_npdu_payload(&payload).unwrap();
-    assert!(npdu.is_empty());
 }
 
 #[test]
@@ -643,21 +650,41 @@ async fn bip6_forwarded_npdu_delivered() {
     tokio::time::sleep(Duration::from_millis(25)).await;
     assert_eq!(transport.vmac_table.lookup(&malformed_vmac).await, None);
 
-    let link_local_vmac = [0x41, 0x00, 0x02];
-    let mut link_local_payload = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1).octets().to_vec();
-    link_local_payload.extend_from_slice(&origin_addr.port().to_be_bytes());
-    link_local_payload.extend_from_slice(&test_npdu);
-    let mut link_local = BytesMut::new();
-    encode_bvlc6(
-        &mut link_local,
-        Bvlc6Function::ForwardedNpdu,
-        &link_local_vmac,
-        &link_local_payload,
-    )
-    .unwrap();
-    sender.send_to(&link_local, dest).await.unwrap();
+    let invalid_origins = [
+        (
+            [0x41, 0x00, 0x02],
+            SocketAddrV6::new(
+                Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1),
+                origin_addr.port(),
+                0,
+                4,
+            ),
+        ),
+        (
+            [0x41, 0x00, 0x03],
+            SocketAddrV6::new(Ipv6Addr::UNSPECIFIED, origin_addr.port(), 0, 0),
+        ),
+        (
+            [0x41, 0x00, 0x04],
+            SocketAddrV6::new(BACNET_IPV6_MULTICAST_SITE_LOCAL, origin_addr.port(), 0, 0),
+        ),
+        (
+            [0x41, 0x00, 0x05],
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0),
+        ),
+    ];
+    for (vmac, invalid_origin) in invalid_origins {
+        let mut payload = invalid_origin.ip().octets().to_vec();
+        payload.extend_from_slice(&invalid_origin.port().to_be_bytes());
+        payload.extend_from_slice(&test_npdu);
+        let mut frame = BytesMut::new();
+        encode_bvlc6(&mut frame, Bvlc6Function::ForwardedNpdu, &vmac, &payload).unwrap();
+        sender.send_to(&frame, dest).await.unwrap();
+    }
     tokio::time::sleep(Duration::from_millis(25)).await;
-    assert_eq!(transport.vmac_table.lookup(&link_local_vmac).await, None);
+    for (vmac, _) in invalid_origins {
+        assert_eq!(transport.vmac_table.lookup(&vmac).await, None);
+    }
 
     sender.send_to(&buf, dest).await.unwrap();
 
@@ -769,30 +796,4 @@ fn bvlc6_function_codes_match_types_crate() {
         Bvlc6Function::from_byte(0x0B),
         Bvlc6Function::Unknown(0x0B)
     ));
-}
-
-#[test]
-fn generate_random_vmac_produces_3_bytes() {
-    let vmac = generate_random_vmac();
-    assert_eq!(vmac.len(), 3);
-    assert_eq!(vmac[0] & 0xC0, 0x40);
-}
-
-#[test]
-fn address_derived_vmac_uses_random_instance_range() {
-    let address = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 47_808, 0, 0);
-    assert_eq!(derive_vmac_from_addr(&address)[0] & 0xC0, 0x40);
-}
-
-#[test]
-fn generate_random_vmac_is_nondeterministic() {
-    // Generate several VMACs — at least two should differ.
-    let vmacs: Vec<Bip6Vmac> = (0..10).map(|_| generate_random_vmac()).collect();
-    let all_same = vmacs.windows(2).all(|w| w[0] == w[1]);
-    assert!(!all_same, "10 random VMACs should not all be identical");
-}
-
-#[test]
-fn max_vmac_retries_constant() {
-    const { assert!(MAX_VMAC_RETRIES >= 1, "must allow at least one retry") };
 }

--- a/crates/bacnet-transport/src/bip6/tests.rs
+++ b/crates/bacnet-transport/src/bip6/tests.rs
@@ -45,6 +45,121 @@ fn original_function_requires_matching_ip_destination_and_vmac() {
         local_vmac,
         None,
     ));
+    assert!(!original_destination_matches(
+        Bvlc6Function::AddressResolutionAck,
+        BACNET_IPV6_MULTICAST_LINK_LOCAL.into(),
+        Some(local_vmac),
+        local_ip,
+        local_vmac,
+        Some(true),
+    ));
+}
+
+#[tokio::test]
+async fn vmac_table_preserves_scope_and_replaces_address_owner() {
+    let table = super::vmac_table::VmacTable::new();
+    let ip = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+    let first = SocketAddrV6::new(ip, 47808, 0, 4);
+    let replacement = SocketAddrV6::new(ip, 47808, 0, 4);
+
+    table.learn([1, 2, 3], first).await;
+    assert_eq!(
+        table.resolve_by_addr(ip, 47808).await,
+        Some(([1, 2, 3], first))
+    );
+
+    table.learn([4, 5, 6], replacement).await;
+    assert_eq!(table.lookup(&[1, 2, 3]).await, None);
+    assert_eq!(
+        table.resolve_by_addr(ip, 47808).await,
+        Some(([4, 5, 6], replacement))
+    );
+}
+
+#[tokio::test]
+async fn vmac_table_fails_closed_for_ambiguous_scope() {
+    let table = super::vmac_table::VmacTable::new();
+    let ip = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+
+    table
+        .learn([1, 2, 3], SocketAddrV6::new(ip, 47808, 0, 4))
+        .await;
+    table
+        .learn([4, 5, 6], SocketAddrV6::new(ip, 47808, 0, 7))
+        .await;
+
+    assert_eq!(table.resolve_by_addr(ip, 47808).await, None);
+}
+
+#[tokio::test]
+async fn vmac_table_is_bounded() {
+    let table = super::vmac_table::VmacTable::new();
+    for index in 0..super::vmac_table::MAX_VMAC_TABLE_ENTRIES {
+        let vmac = [
+            ((index >> 16) & 0xFF) as u8,
+            ((index >> 8) & 0xFF) as u8,
+            (index & 0xFF) as u8,
+        ];
+        table
+            .learn(
+                vmac,
+                SocketAddrV6::new(Ipv6Addr::LOCALHOST, 10_000 + index as u16, 0, 0),
+            )
+            .await;
+    }
+    table
+        .learn(
+            [0xFE, 0xFE, 0xFE],
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, 9999, 0, 0),
+        )
+        .await;
+
+    assert_eq!(table.len().await, super::vmac_table::MAX_VMAC_TABLE_ENTRIES);
+    assert_eq!(table.lookup(&[0xFE, 0xFE, 0xFE]).await, None);
+}
+
+#[tokio::test]
+async fn wrong_destination_vmac_ack_is_not_learned() {
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    let _rx = transport.start().await.unwrap();
+    let (_, transport_port) = decode_bip6_mac(transport.local_mac()).unwrap();
+    let destination = SocketAddrV6::new(Ipv6Addr::LOCALHOST, transport_port, 0, 0);
+    let sender = UdpSocket::bind("[::1]:0").await.unwrap();
+    let sender_addr = match sender.local_addr().unwrap() {
+        std::net::SocketAddr::V6(address) => address,
+        _ => unreachable!(),
+    };
+    let foreign_destination = [9, 9, 9];
+
+    let ar_source = [1, 2, 3];
+    sender
+        .send_to(
+            &encode_address_resolution_ack(&ar_source, &foreign_destination),
+            destination,
+        )
+        .await
+        .unwrap();
+    let var_source = [4, 5, 6];
+    sender
+        .send_to(
+            &encode_virtual_address_resolution_ack(&var_source, &foreign_destination),
+            destination,
+        )
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    assert_eq!(transport.vmac_table.lookup(&ar_source).await, None);
+    assert_eq!(transport.vmac_table.lookup(&var_source).await, None);
+    assert_eq!(
+        transport
+            .vmac_table
+            .resolve_by_addr(*sender_addr.ip(), sender_addr.port())
+            .await,
+        None
+    );
+
+    transport.stop().await.unwrap();
 }
 
 #[test]
@@ -281,17 +396,14 @@ fn vmac_from_device_instance_masks_to_22_bits() {
 
 #[test]
 fn decode_forwarded_npdu_extracts_npdu() {
-    let originating_vmac: Bip6Vmac = [0xDE, 0xAD, 0x01];
     let source_ip = Ipv6Addr::LOCALHOST;
     let source_port: u16 = 47808;
     let npdu_data = vec![0x01, 0x00, 0xFF, 0xEE];
-    let mut payload = originating_vmac.to_vec();
-    payload.extend_from_slice(&source_ip.octets());
+    let mut payload = source_ip.octets().to_vec();
     payload.extend_from_slice(&source_port.to_be_bytes());
     payload.extend_from_slice(&npdu_data);
 
-    let (vmac, addr, npdu) = decode_forwarded_npdu_payload(&payload).unwrap();
-    assert_eq!(vmac, originating_vmac);
+    let (addr, npdu) = decode_forwarded_npdu_payload(&payload).unwrap();
     assert_eq!(*addr.ip(), source_ip);
     assert_eq!(addr.port(), source_port);
     assert_eq!(npdu, &npdu_data[..]);
@@ -299,31 +411,28 @@ fn decode_forwarded_npdu_extracts_npdu() {
 
 #[test]
 fn decode_forwarded_npdu_rejects_short_payload() {
-    assert!(decode_forwarded_npdu_payload(&[0x01; 20]).is_err());
+    assert!(decode_forwarded_npdu_payload(&[0x01; 17]).is_err());
     assert!(decode_forwarded_npdu_payload(&[]).is_err());
 }
 
 #[test]
 fn decode_forwarded_npdu_vmac_and_addr_only_is_ok() {
-    // Exactly 21 bytes = VMAC + B/IPv6 address with empty NPDU
-    let mut payload = vec![0x01, 0x02, 0x03]; // vmac
-    payload.extend_from_slice(&Ipv6Addr::LOCALHOST.octets()); // 16 bytes
+    // Exactly 18 bytes = B/IPv6 address with empty NPDU. The originating
+    // VMAC is carried by the BVLC6 header, not duplicated in the payload.
+    let mut payload = Ipv6Addr::LOCALHOST.octets().to_vec(); // 16 bytes
     payload.extend_from_slice(&47808u16.to_be_bytes()); // 2 bytes
-    let (vmac, _addr, npdu) = decode_forwarded_npdu_payload(&payload).unwrap();
-    assert_eq!(vmac, [0x01, 0x02, 0x03]);
+    let (_addr, npdu) = decode_forwarded_npdu_payload(&payload).unwrap();
     assert!(npdu.is_empty());
 }
 
 #[test]
 fn forwarded_npdu_encode_decode_round_trip() {
     // Build a full ForwardedNpdu BVLC6 frame and decode it
-    let sender_vmac: Bip6Vmac = [0x10, 0x20, 0x30];
     let originating_vmac: Bip6Vmac = [0xAA, 0xBB, 0xCC];
     let source_ip = Ipv6Addr::LOCALHOST;
     let npdu = vec![0x01, 0x00, 0xDE, 0xAD];
 
-    let mut forwarded_payload = originating_vmac.to_vec();
-    forwarded_payload.extend_from_slice(&source_ip.octets());
+    let mut forwarded_payload = source_ip.octets().to_vec();
     forwarded_payload.extend_from_slice(&47808u16.to_be_bytes());
     forwarded_payload.extend_from_slice(&npdu);
 
@@ -331,17 +440,16 @@ fn forwarded_npdu_encode_decode_round_trip() {
     encode_bvlc6(
         &mut buf,
         Bvlc6Function::ForwardedNpdu,
-        &sender_vmac,
+        &originating_vmac,
         &forwarded_payload,
     )
     .expect("valid BVLC6 encoding");
 
     let frame = decode_bvlc6(&buf).unwrap();
     assert_eq!(frame.function, Bvlc6Function::ForwardedNpdu);
-    assert_eq!(frame.source_vmac, sender_vmac);
+    assert_eq!(frame.source_vmac, originating_vmac);
 
-    let (orig_vmac, addr, extracted_npdu) = decode_forwarded_npdu_payload(&frame.payload).unwrap();
-    assert_eq!(orig_vmac, originating_vmac);
+    let (addr, extracted_npdu) = decode_forwarded_npdu_payload(&frame.payload).unwrap();
     assert_eq!(*addr.ip(), source_ip);
     assert_eq!(extracted_npdu, &npdu[..]);
 }
@@ -353,20 +461,24 @@ async fn bip6_forwarded_npdu_delivered() {
     let mut rx = transport.start().await.unwrap();
 
     // Build a ForwardedNpdu frame from a "BBMD"
-    let bbmd_vmac: Bip6Vmac = [0xBB, 0xBB, 0xBB];
     let originating_vmac: Bip6Vmac = [0xAA, 0xAA, 0xAA];
     let test_npdu = vec![0x01, 0x00, 0xCA, 0xFE];
 
-    let mut forwarded_payload = originating_vmac.to_vec();
-    forwarded_payload.extend_from_slice(&Ipv6Addr::LOCALHOST.octets());
-    forwarded_payload.extend_from_slice(&47808u16.to_be_bytes());
+    let origin = UdpSocket::bind("[::1]:0").await.unwrap();
+    let origin_addr = match origin.local_addr().unwrap() {
+        std::net::SocketAddr::V6(address) => address,
+        _ => unreachable!(),
+    };
+
+    let mut forwarded_payload = origin_addr.ip().octets().to_vec();
+    forwarded_payload.extend_from_slice(&origin_addr.port().to_be_bytes());
     forwarded_payload.extend_from_slice(&test_npdu);
 
     let mut buf = BytesMut::new();
     encode_bvlc6(
         &mut buf,
         Bvlc6Function::ForwardedNpdu,
-        &bbmd_vmac,
+        &originating_vmac,
         &forwarded_payload,
     )
     .expect("valid BVLC6 encoding");
@@ -383,9 +495,27 @@ async fn bip6_forwarded_npdu_delivered() {
         .expect("channel closed");
 
     assert_eq!(received.npdu, test_npdu);
-    // source_mac must be the originating VMAC (3 bytes), not the UDP sender address
-    assert_eq!(received.source_mac.as_slice(), &originating_vmac[..]);
+    assert_eq!(
+        received.source_mac.as_slice(),
+        &encode_bip6_mac(*origin_addr.ip(), origin_addr.port())
+    );
     assert!(received.link_layer_group);
+
+    let reply_npdu = [0x01, 0x00, 0xBE, 0xEF];
+    transport
+        .send_unicast(&reply_npdu, received.source_mac.as_slice())
+        .await
+        .unwrap();
+    let mut reply_buf = [0u8; 64];
+    let (reply_len, _) =
+        tokio::time::timeout(Duration::from_secs(2), origin.recv_from(&mut reply_buf))
+            .await
+            .expect("reply timeout")
+            .unwrap();
+    let reply = decode_bvlc6(&reply_buf[..reply_len]).unwrap();
+    assert_eq!(reply.function, Bvlc6Function::OriginalUnicast);
+    assert_eq!(reply.destination_vmac, Some(originating_vmac));
+    assert_eq!(reply.payload.as_ref(), reply_npdu);
 
     transport.stop().await.unwrap();
 }

--- a/crates/bacnet-transport/src/bip6/tests.rs
+++ b/crates/bacnet-transport/src/bip6/tests.rs
@@ -331,6 +331,7 @@ async fn bip6_forwarded_npdu_delivered() {
     assert_eq!(received.npdu, test_npdu);
     // source_mac must be the originating VMAC (3 bytes), not the UDP sender address
     assert_eq!(received.source_mac.as_slice(), &originating_vmac[..]);
+    assert!(received.link_layer_broadcast);
 
     transport.stop().await.unwrap();
 }

--- a/crates/bacnet-transport/src/bip6/tests.rs
+++ b/crates/bacnet-transport/src/bip6/tests.rs
@@ -231,7 +231,7 @@ async fn vmac_table_does_not_retain_ambiguous_reverse_entries() {
 
 #[tokio::test]
 async fn wrong_destination_vmac_ack_is_not_learned() {
-    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(42));
     let _rx = transport.start().await.unwrap();
     let (_, transport_port) = decode_bip6_mac(transport.local_mac()).unwrap();
     let destination = SocketAddrV6::new(Ipv6Addr::LOCALHOST, transport_port, 0, 0);
@@ -375,7 +375,7 @@ fn bip6_max_apdu_length() {
 
 #[tokio::test]
 async fn bip6_start_stop() {
-    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(1));
     let _rx = transport.start().await.unwrap();
     assert!(transport.socket.is_some());
     assert_eq!(transport.local_mac().len(), 18);
@@ -385,8 +385,8 @@ async fn bip6_start_stop() {
 
 #[tokio::test]
 async fn bip6_unicast_loopback() {
-    let mut transport_a = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
-    let mut transport_b = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    let mut transport_a = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(2));
+    let mut transport_b = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(3));
 
     let _rx_a = transport_a.start().await.unwrap();
     let mut rx_b = transport_b.start().await.unwrap();
@@ -600,7 +600,7 @@ async fn bip6_forwarded_npdu_delivered() {
         std::net::SocketAddr::V6(address) => address,
         _ => unreachable!(),
     };
-    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(44));
     transport.register_as_foreign_device(Bip6ForeignDeviceConfig {
         bbmd_ip: *sender_addr.ip(),
         bbmd_port: sender_addr.port(),
@@ -612,11 +612,8 @@ async fn bip6_forwarded_npdu_delivered() {
     let originating_vmac: Bip6Vmac = [0xAA, 0xAA, 0xAA];
     let test_npdu = vec![0x01, 0x00, 0xCA, 0xFE];
 
-    let origin = UdpSocket::bind("[::1]:0").await.unwrap();
-    let origin_addr = match origin.local_addr().unwrap() {
-        std::net::SocketAddr::V6(address) => address,
-        _ => unreachable!(),
-    };
+    let origin_addr =
+        SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 9), 47_808, 0, 0);
 
     let mut forwarded_payload = origin_addr.ip().octets().to_vec();
     forwarded_payload.extend_from_slice(&origin_addr.port().to_be_bytes());
@@ -670,7 +667,11 @@ async fn bip6_forwarded_npdu_delivered() {
         ),
         (
             [0x41, 0x00, 0x05],
-            SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0),
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, origin_addr.port(), 0, 0),
+        ),
+        (
+            [0x41, 0x00, 0x06],
+            SocketAddrV6::new(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 10), 0, 0, 0),
         ),
     ];
     for (vmac, invalid_origin) in invalid_origins {
@@ -700,21 +701,10 @@ async fn bip6_forwarded_npdu_delivered() {
     );
     assert!(received.link_layer_group);
 
-    let reply_npdu = [0x01, 0x00, 0xBE, 0xEF];
-    transport
-        .send_unicast(&reply_npdu, received.source_mac.as_slice())
-        .await
-        .unwrap();
-    let mut reply_buf = [0u8; 64];
-    let (reply_len, _) =
-        tokio::time::timeout(Duration::from_secs(2), origin.recv_from(&mut reply_buf))
-            .await
-            .expect("reply timeout")
-            .unwrap();
-    let reply = decode_bvlc6(&reply_buf[..reply_len]).unwrap();
-    assert_eq!(reply.function, Bvlc6Function::OriginalUnicast);
-    assert_eq!(reply.destination_vmac, Some(originating_vmac));
-    assert_eq!(reply.payload.as_ref(), reply_npdu);
+    assert_eq!(
+        transport.vmac_table.lookup(&originating_vmac).await,
+        Some(origin_addr)
+    );
 
     transport.stop().await.unwrap();
 }

--- a/crates/bacnet-transport/src/bip6/tests.rs
+++ b/crates/bacnet-transport/src/bip6/tests.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 use bytes::BytesMut;
 use tokio::net::UdpSocket;
 
-use super::port::{derive_vmac_from_device_instance, original_destination_matches};
+use super::ingress::original_destination_matches;
+use super::vmac_table::{derive_vmac_from_addr, derive_vmac_from_device_instance};
 use super::*;
 use crate::port::TransportPort;
 
@@ -19,6 +20,8 @@ fn original_function_requires_matching_ip_destination_and_vmac() {
         Some(local_vmac),
         local_ip,
         local_vmac,
+        &[local_ip],
+        false,
         None,
     ));
     assert!(!original_destination_matches(
@@ -27,6 +30,8 @@ fn original_function_requires_matching_ip_destination_and_vmac() {
         Some(local_vmac),
         local_ip,
         local_vmac,
+        &[local_ip],
+        false,
         None,
     ));
     assert!(!original_destination_matches(
@@ -35,6 +40,8 @@ fn original_function_requires_matching_ip_destination_and_vmac() {
         Some([9, 9, 9]),
         local_ip,
         local_vmac,
+        &[local_ip],
+        false,
         None,
     ));
     assert!(original_destination_matches(
@@ -43,6 +50,8 @@ fn original_function_requires_matching_ip_destination_and_vmac() {
         None,
         local_ip,
         local_vmac,
+        &[local_ip],
+        false,
         None,
     ));
     assert!(!original_destination_matches(
@@ -51,7 +60,80 @@ fn original_function_requires_matching_ip_destination_and_vmac() {
         Some(local_vmac),
         local_ip,
         local_vmac,
+        &[local_ip],
+        false,
         Some(true),
+    ));
+
+    assert!(original_destination_matches(
+        Bvlc6Function::OriginalUnicast,
+        Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 9).into(),
+        Some(local_vmac),
+        local_ip,
+        local_vmac,
+        &[local_ip, Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 9),],
+        true,
+        None,
+    ));
+    assert!(!original_destination_matches(
+        Bvlc6Function::OriginalUnicast,
+        BACNET_IPV6_MULTICAST_LINK_LOCAL.into(),
+        Some(local_vmac),
+        local_ip,
+        local_vmac,
+        &[local_ip],
+        true,
+        Some(true),
+    ));
+    assert!(original_destination_matches(
+        Bvlc6Function::AddressResolution,
+        BACNET_IPV6_MULTICAST_LINK_LOCAL.into(),
+        Some(local_vmac),
+        local_ip,
+        local_vmac,
+        &[local_ip],
+        false,
+        Some(true),
+    ));
+    assert!(!original_destination_matches(
+        Bvlc6Function::AddressResolution,
+        local_ip.into(),
+        Some(local_vmac),
+        local_ip,
+        local_vmac,
+        &[local_ip],
+        false,
+        Some(false),
+    ));
+    assert!(original_destination_matches(
+        Bvlc6Function::VirtualAddressResolution,
+        local_ip.into(),
+        None,
+        local_ip,
+        local_vmac,
+        &[local_ip],
+        false,
+        Some(false),
+    ));
+    assert!(!original_destination_matches(
+        Bvlc6Function::VirtualAddressResolution,
+        BACNET_IPV6_MULTICAST_LINK_LOCAL.into(),
+        None,
+        local_ip,
+        local_vmac,
+        &[local_ip],
+        false,
+        Some(true),
+    ));
+    assert!(!original_destination_matches(
+        Bvlc6Function::ForwardedAddressResolution,
+        local_ip.into(),
+        Some(local_vmac),
+        local_ip,
+        local_vmac,
+        &[local_ip],
+        false,
+        Some(false),
     ));
 }
 
@@ -116,6 +198,35 @@ async fn vmac_table_is_bounded() {
 
     assert_eq!(table.len().await, super::vmac_table::MAX_VMAC_TABLE_ENTRIES);
     assert_eq!(table.lookup(&[0xFE, 0xFE, 0xFE]).await, None);
+
+    table
+        .learn(
+            [0xFD, 0xFD, 0xFD],
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, 10_000, 0, 0),
+        )
+        .await;
+    assert_eq!(table.len().await, super::vmac_table::MAX_VMAC_TABLE_ENTRIES);
+    assert_eq!(table.lookup(&[0, 0, 0]).await, None);
+    assert!(table.lookup(&[0xFD, 0xFD, 0xFD]).await.is_some());
+}
+
+#[tokio::test]
+async fn vmac_table_does_not_retain_ambiguous_reverse_entries() {
+    let table = super::vmac_table::VmacTable::new();
+    let ip = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1);
+
+    for port in 10_000..10_100 {
+        table
+            .learn([1, 2, 3], SocketAddrV6::new(ip, port, 0, 4))
+            .await;
+        table
+            .learn([4, 5, 6], SocketAddrV6::new(ip, port, 0, 7))
+            .await;
+        assert_eq!(table.resolve_by_addr(ip, port).await, None);
+    }
+
+    assert_eq!(table.len().await, 2);
+    assert_eq!(table.resolve_by_addr(ip, 10_000).await, None);
 }
 
 #[tokio::test]
@@ -384,6 +495,26 @@ fn encode_decode_address_resolution_ack() {
 }
 
 #[test]
+fn fixed_length_bvlc6_frames_reject_surplus_bytes() {
+    let mut var = encode_virtual_address_resolution(&[1, 2, 3]);
+    var.extend_from_slice(&[0]);
+    assert!(decode_bvlc6(&var).is_err());
+
+    let mut ar = encode_address_resolution(&[1, 2, 3], &[4, 5, 6]);
+    ar.extend_from_slice(&[0]);
+    let ar_len = ar.len() as u16;
+    ar[2..4].copy_from_slice(&ar_len.to_be_bytes());
+    assert!(decode_bvlc6(&ar).is_err());
+}
+
+#[test]
+fn bvlc6_declared_length_must_match_datagram() {
+    let mut frame = encode_virtual_address_resolution(&[1, 2, 3]);
+    frame[2..4].copy_from_slice(&6u16.to_be_bytes());
+    assert!(decode_bvlc6(&frame).is_err());
+}
+
+#[test]
 fn vmac_from_device_instance_masks_to_22_bits() {
     let vmac = derive_vmac_from_device_instance(0x123456);
     assert_eq!(vmac, [0x12, 0x34, 0x56]);
@@ -456,8 +587,18 @@ fn forwarded_npdu_encode_decode_round_trip() {
 
 #[tokio::test]
 async fn bip6_forwarded_npdu_delivered() {
-    // Verify that a ForwardedNpdu sent to a transport is delivered as a ReceivedNpdu
+    // Verify a foreign device accepts a ForwardedNpdu only from its BBMD.
+    let sender = UdpSocket::bind("[::1]:0").await.unwrap();
+    let sender_addr = match sender.local_addr().unwrap() {
+        std::net::SocketAddr::V6(address) => address,
+        _ => unreachable!(),
+    };
     let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    transport.register_as_foreign_device(Bip6ForeignDeviceConfig {
+        bbmd_ip: *sender_addr.ip(),
+        bbmd_port: sender_addr.port(),
+        ttl: 60,
+    });
     let mut rx = transport.start().await.unwrap();
 
     // Build a ForwardedNpdu frame from a "BBMD"
@@ -483,10 +624,41 @@ async fn bip6_forwarded_npdu_delivered() {
     )
     .expect("valid BVLC6 encoding");
 
-    // Send directly to the transport's bound address using a separate socket
-    let sender = UdpSocket::bind("[::1]:0").await.unwrap();
     let (_, transport_port) = decode_bip6_mac(transport.local_mac()).unwrap();
     let dest = SocketAddrV6::new(Ipv6Addr::LOCALHOST, transport_port, 0, 0);
+
+    let malformed_vmac = [0x41, 0x00, 0x01];
+    let mut malformed_payload = origin_addr.ip().octets().to_vec();
+    malformed_payload.extend_from_slice(&origin_addr.port().to_be_bytes());
+    malformed_payload.push(0);
+    let mut malformed = BytesMut::new();
+    encode_bvlc6(
+        &mut malformed,
+        Bvlc6Function::ForwardedNpdu,
+        &malformed_vmac,
+        &malformed_payload,
+    )
+    .unwrap();
+    sender.send_to(&malformed, dest).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    assert_eq!(transport.vmac_table.lookup(&malformed_vmac).await, None);
+
+    let link_local_vmac = [0x41, 0x00, 0x02];
+    let mut link_local_payload = Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 1).octets().to_vec();
+    link_local_payload.extend_from_slice(&origin_addr.port().to_be_bytes());
+    link_local_payload.extend_from_slice(&test_npdu);
+    let mut link_local = BytesMut::new();
+    encode_bvlc6(
+        &mut link_local,
+        Bvlc6Function::ForwardedNpdu,
+        &link_local_vmac,
+        &link_local_payload,
+    )
+    .unwrap();
+    sender.send_to(&link_local, dest).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    assert_eq!(transport.vmac_table.lookup(&link_local_vmac).await, None);
+
     sender.send_to(&buf, dest).await.unwrap();
 
     let received = tokio::time::timeout(Duration::from_secs(2), rx.recv())
@@ -522,14 +694,13 @@ async fn bip6_forwarded_npdu_delivered() {
 
 #[tokio::test]
 async fn bip6_var_response() {
-    // Verify that receiving a VAR from a node with the same VMAC
-    // causes a VAR-Ack response (collision detection per Clause U.5).
+    // A unicast VAR asks the destination node to disclose its VMAC.
     let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(42));
     let _rx = transport.start().await.unwrap();
     let our_vmac = transport.source_vmac;
+    let requester_vmac = [0x41, 0x22, 0x33];
 
-    // Build a VAR frame from a node claiming our VMAC (collision scenario)
-    let buf = encode_virtual_address_resolution(&our_vmac);
+    let buf = encode_virtual_address_resolution(&requester_vmac);
 
     // Send VAR to the transport
     let checker = UdpSocket::bind("[::1]:0").await.unwrap();
@@ -547,8 +718,7 @@ async fn bip6_var_response() {
             let frame = decode_bvlc6(&resp_buf[..len]).unwrap();
             assert_eq!(frame.function, Bvlc6Function::VirtualAddressResolutionAck);
             assert_eq!(frame.source_vmac, our_vmac);
-            // destination_vmac should be the querier's VMAC (same as ours)
-            assert_eq!(frame.destination_vmac, Some(our_vmac));
+            assert_eq!(frame.destination_vmac, Some(requester_vmac));
         }
         Ok(Err(e)) => panic!("recv error: {e}"),
         Err(_) => panic!("timeout waiting for VAR-Ack response"),
@@ -605,6 +775,13 @@ fn bvlc6_function_codes_match_types_crate() {
 fn generate_random_vmac_produces_3_bytes() {
     let vmac = generate_random_vmac();
     assert_eq!(vmac.len(), 3);
+    assert_eq!(vmac[0] & 0xC0, 0x40);
+}
+
+#[test]
+fn address_derived_vmac_uses_random_instance_range() {
+    let address = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 47_808, 0, 0);
+    assert_eq!(derive_vmac_from_addr(&address)[0] & 0xC0, 0x40);
 }
 
 #[test]

--- a/crates/bacnet-transport/src/bip6/tests.rs
+++ b/crates/bacnet-transport/src/bip6/tests.rs
@@ -4,9 +4,48 @@ use std::time::Duration;
 use bytes::BytesMut;
 use tokio::net::UdpSocket;
 
-use super::port::derive_vmac_from_device_instance;
+use super::port::{derive_vmac_from_device_instance, original_destination_matches};
 use super::*;
 use crate::port::TransportPort;
+
+#[test]
+fn original_function_requires_matching_ip_destination_and_vmac() {
+    let local_ip = Ipv6Addr::LOCALHOST;
+    let local_vmac = [1, 2, 3];
+
+    assert!(original_destination_matches(
+        Bvlc6Function::OriginalUnicast,
+        local_ip.into(),
+        Some(local_vmac),
+        local_ip,
+        local_vmac,
+        None,
+    ));
+    assert!(!original_destination_matches(
+        Bvlc6Function::OriginalUnicast,
+        BACNET_IPV6_MULTICAST_LINK_LOCAL.into(),
+        Some(local_vmac),
+        local_ip,
+        local_vmac,
+        None,
+    ));
+    assert!(!original_destination_matches(
+        Bvlc6Function::OriginalUnicast,
+        local_ip.into(),
+        Some([9, 9, 9]),
+        local_ip,
+        local_vmac,
+        None,
+    ));
+    assert!(original_destination_matches(
+        Bvlc6Function::OriginalBroadcast,
+        BACNET_IPV6_MULTICAST_LINK_LOCAL.into(),
+        None,
+        local_ip,
+        local_vmac,
+        None,
+    ));
+}
 
 #[test]
 fn encode_original_unicast() {
@@ -127,6 +166,21 @@ async fn bip6_unicast_loopback() {
     let mut rx_b = transport_b.start().await.unwrap();
 
     let test_npdu = vec![0x01, 0x00, 0xDE, 0xAD];
+
+    let error = transport_a
+        .send_unicast(&test_npdu, transport_b.local_mac())
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("destination VMAC is unknown"));
+
+    let (peer_ip, peer_port) = decode_bip6_mac(transport_b.local_mac()).unwrap();
+    transport_a
+        .vmac_table
+        .learn(
+            transport_b.source_vmac,
+            SocketAddrV6::new(peer_ip, peer_port, 0, 0),
+        )
+        .await;
 
     transport_a
         .send_unicast(&test_npdu, transport_b.local_mac())
@@ -331,7 +385,7 @@ async fn bip6_forwarded_npdu_delivered() {
     assert_eq!(received.npdu, test_npdu);
     // source_mac must be the originating VMAC (3 bytes), not the UDP sender address
     assert_eq!(received.source_mac.as_slice(), &originating_vmac[..]);
-    assert!(received.link_layer_broadcast);
+    assert!(received.link_layer_group);
 
     transport.stop().await.unwrap();
 }

--- a/crates/bacnet-transport/src/bip6/vmac_generation_tests.rs
+++ b/crates/bacnet-transport/src/bip6/vmac_generation_tests.rs
@@ -1,0 +1,29 @@
+use std::net::Ipv6Addr;
+
+use super::{generate_random_vmac, Bip6Transport, Bip6Vmac, MAX_VMAC_RETRIES};
+use crate::port::TransportPort;
+
+#[test]
+fn generate_random_vmac_produces_3_bytes() {
+    let vmac = generate_random_vmac().unwrap();
+    assert_eq!(vmac.len(), 3);
+    assert_eq!(vmac[0] & 0xC0, 0x40);
+}
+
+#[test]
+fn generate_random_vmac_is_nondeterministic() {
+    let vmacs: Vec<Bip6Vmac> = (0..10).map(|_| generate_random_vmac().unwrap()).collect();
+    let all_same = vmacs.windows(2).all(|window| window[0] == window[1]);
+    assert!(!all_same, "10 random VMACs should not all be identical");
+}
+
+#[tokio::test]
+async fn out_of_range_device_instance_fails_before_bip6_startup() {
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(0x40_0000));
+    assert!(transport.start().await.is_err());
+}
+
+#[test]
+fn max_vmac_retries_constant() {
+    const { assert!(MAX_VMAC_RETRIES >= 1, "must allow at least one retry") };
+}

--- a/crates/bacnet-transport/src/bip6/vmac_generation_tests.rs
+++ b/crates/bacnet-transport/src/bip6/vmac_generation_tests.rs
@@ -1,6 +1,14 @@
-use std::net::Ipv6Addr;
+use std::net::{Ipv6Addr, SocketAddrV6};
+use std::time::Duration;
 
-use super::{generate_random_vmac, Bip6Transport, Bip6Vmac, MAX_VMAC_RETRIES};
+use bacnet_types::error::Error;
+use tokio::net::UdpSocket;
+
+use super::vmac_table::derive_vmac_from_device_instance;
+use super::{
+    encode_address_resolution_ack, generate_random_vmac, Bip6ForeignDeviceConfig, Bip6Transport,
+    Bip6Vmac, MAX_VMAC_RETRIES,
+};
 use crate::port::TransportPort;
 
 #[test]
@@ -21,6 +29,56 @@ fn generate_random_vmac_is_nondeterministic() {
 async fn out_of_range_device_instance_fails_before_bip6_startup() {
     let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, Some(0x40_0000));
     assert!(transport.start().await.is_err());
+}
+
+#[tokio::test]
+async fn random_vmac_foreign_device_fails_before_bip6_startup() {
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, 0, None);
+    transport.register_as_foreign_device(Bip6ForeignDeviceConfig {
+        bbmd_ip: Ipv6Addr::LOCALHOST,
+        bbmd_port: 47_808,
+        ttl: 60,
+    });
+
+    let error = transport.start().await.unwrap_err();
+    assert!(
+        matches!(error, Error::Transport(error) if error.kind() == std::io::ErrorKind::InvalidInput)
+    );
+    assert!(transport.socket.is_none());
+}
+
+#[tokio::test]
+async fn peer_probe_collision_fails_startup_without_publishing_socket() {
+    let reservation = UdpSocket::bind("[::1]:0").await.unwrap();
+    let port = reservation.local_addr().unwrap().port();
+    drop(reservation);
+
+    let device_instance = 0x12_3456;
+    let vmac = derive_vmac_from_device_instance(device_instance);
+    let destination = SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0);
+    let peer = UdpSocket::bind("[::1]:0").await.unwrap();
+    let peer_task = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        let probe = encode_address_resolution_ack(&vmac, &vmac);
+        for _ in 0..20 {
+            let _ = peer.send_to(&probe, destination).await;
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    });
+
+    let mut transport = Bip6Transport::new(Ipv6Addr::LOCALHOST, port, Some(device_instance));
+    let error = transport.start().await.unwrap_err();
+    peer_task.abort();
+    let _ = peer_task.await;
+
+    assert!(
+        matches!(error, Error::Transport(error) if error.kind() == std::io::ErrorKind::AddrInUse)
+    );
+    assert!(transport.socket.is_none());
+    let send_error = transport.send_broadcast(&[0x01, 0x00]).await.unwrap_err();
+    assert!(
+        matches!(send_error, Error::Transport(error) if error.kind() == std::io::ErrorKind::NotConnected)
+    );
 }
 
 #[test]

--- a/crates/bacnet-transport/src/bip6/vmac_table.rs
+++ b/crates/bacnet-transport/src/bip6/vmac_table.rs
@@ -1,0 +1,125 @@
+//! Deterministic BACnet/IPv6 VMAC and scoped-endpoint mappings.
+
+use std::collections::HashMap;
+use std::net::{Ipv6Addr, SocketAddrV6};
+use std::sync::Arc;
+
+use super::Bip6Vmac;
+
+/// Defensive cap for learned on-link VMAC mappings.
+pub(super) const MAX_VMAC_TABLE_ENTRIES: usize = 4096;
+
+/// VMAC-to-address mapping table per Clause U.5.
+/// Updated from incoming frames and address-resolution exchanges.
+#[derive(Debug, Clone)]
+pub(super) struct VmacTable {
+    mappings: Arc<tokio::sync::RwLock<VmacMappings>>,
+}
+
+#[derive(Debug, Default)]
+struct VmacMappings {
+    by_vmac: HashMap<Bip6Vmac, SocketAddrV6>,
+    by_address: HashMap<(Ipv6Addr, u16), AddressMapping>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AddressMapping {
+    Unique(Bip6Vmac, SocketAddrV6),
+    /// The public 18-byte BACnet/IPv6 MAC omits the IPv6 scope ID, so the
+    /// endpoint cannot be selected safely after the same address and port
+    /// have been observed on more than one scoped interface.
+    Ambiguous,
+}
+
+impl VmacTable {
+    pub(super) fn new() -> Self {
+        Self {
+            mappings: Arc::new(tokio::sync::RwLock::new(VmacMappings::default())),
+        }
+    }
+
+    /// Learn the latest VMAC and exact scoped endpoint from an incoming frame.
+    pub(super) async fn learn(&self, vmac: Bip6Vmac, addr: SocketAddrV6) {
+        let key = (*addr.ip(), addr.port());
+        let mut mappings = self.mappings.write().await;
+
+        let updates_known_vmac = mappings.by_vmac.contains_key(&vmac);
+        let updates_known_address = mappings.by_address.contains_key(&key);
+        if !updates_known_vmac
+            && !updates_known_address
+            && mappings.by_vmac.len() >= MAX_VMAC_TABLE_ENTRIES
+        {
+            return;
+        }
+
+        if let Some(old_addr) = mappings.by_vmac.get(&vmac).copied() {
+            let old_key = (*old_addr.ip(), old_addr.port());
+            if old_key != key
+                && mappings
+                    .by_address
+                    .get(&old_key)
+                    .is_some_and(
+                        |mapping| matches!(mapping, AddressMapping::Unique(mapped_vmac, _) if *mapped_vmac == vmac),
+                    )
+            {
+                mappings.by_address.remove(&old_key);
+            }
+        }
+
+        match mappings.by_address.get(&key).copied() {
+            Some(AddressMapping::Unique(_, old_addr)) if old_addr != addr => {
+                mappings.by_address.insert(key, AddressMapping::Ambiguous);
+                if updates_known_vmac || mappings.by_vmac.len() < MAX_VMAC_TABLE_ENTRIES {
+                    mappings.by_vmac.insert(vmac, addr);
+                }
+                return;
+            }
+            Some(AddressMapping::Ambiguous) => {
+                if updates_known_vmac || mappings.by_vmac.len() < MAX_VMAC_TABLE_ENTRIES {
+                    mappings.by_vmac.insert(vmac, addr);
+                }
+                return;
+            }
+            Some(AddressMapping::Unique(old_vmac, _)) if old_vmac != vmac => {
+                mappings.by_vmac.remove(&old_vmac);
+            }
+            _ => {}
+        }
+
+        mappings.by_vmac.insert(vmac, addr);
+        mappings
+            .by_address
+            .insert(key, AddressMapping::Unique(vmac, addr));
+    }
+
+    /// Look up the B/IPv6 address for a VMAC.
+    #[allow(dead_code)] // used by address-resolution handling and tests
+    pub(super) async fn lookup(&self, vmac: &Bip6Vmac) -> Option<SocketAddrV6> {
+        self.mappings.read().await.by_vmac.get(vmac).copied()
+    }
+
+    /// Resolve the public IPv6+port MAC to the latest VMAC and scoped endpoint.
+    ///
+    /// The 18-byte public MAC omits IPv6 scope ID. Returning the exact learned
+    /// endpoint lets link-local replies preserve the ingress interface.
+    pub(super) async fn resolve_by_addr(
+        &self,
+        ip: Ipv6Addr,
+        port: u16,
+    ) -> Option<(Bip6Vmac, SocketAddrV6)> {
+        self.mappings
+            .read()
+            .await
+            .by_address
+            .get(&(ip, port))
+            .and_then(|mapping| match mapping {
+                AddressMapping::Unique(vmac, endpoint) => Some((*vmac, *endpoint)),
+                AddressMapping::Ambiguous => None,
+            })
+    }
+
+    #[cfg(test)]
+    pub(super) async fn len(&self) -> usize {
+        self.mappings.read().await.by_vmac.len()
+    }
+}

--- a/crates/bacnet-transport/src/bip6/vmac_table.rs
+++ b/crates/bacnet-transport/src/bip6/vmac_table.rs
@@ -1,10 +1,10 @@
-//! Deterministic BACnet/IPv6 VMAC and scoped-endpoint mappings.
+//! BACnet/IPv6 VMAC generation and scoped-endpoint mappings.
 
-use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
-use std::hash::{BuildHasher, Hasher};
 use std::net::{Ipv6Addr, SocketAddrV6};
 use std::sync::Arc;
+
+use bacnet_types::error::Error;
 
 use super::Bip6Vmac;
 
@@ -12,29 +12,19 @@ use super::Bip6Vmac;
 pub(super) const MAX_VMAC_TABLE_ENTRIES: usize = 4096;
 
 pub(super) fn derive_vmac_from_device_instance(device_instance: u32) -> Bip6Vmac {
-    let bytes = (device_instance & 0x3F_FFFF).to_be_bytes();
+    debug_assert!(device_instance <= 0x3F_FFFF);
+    let bytes = device_instance.to_be_bytes();
     [bytes[1], bytes[2], bytes[3]]
 }
 
 /// Generate a Random Device Instance VMAC for collision resolution (Clause H.7.2).
-pub fn generate_random_vmac() -> Bip6Vmac {
-    let bytes = RandomState::new().build_hasher().finish().to_ne_bytes();
-    [(bytes[0] & 0x3F) | 0x40, bytes[1], bytes[2]]
-}
-
-pub(super) fn derive_vmac_from_addr(addr: &SocketAddrV6) -> Bip6Vmac {
+pub fn generate_random_vmac() -> Result<Bip6Vmac, Error> {
     let mut vmac = [0u8; 3];
-    for (index, byte) in addr
-        .ip()
-        .octets()
-        .iter()
-        .chain(addr.port().to_be_bytes().iter())
-        .enumerate()
-    {
-        vmac[index % 3] ^= byte;
-    }
+    getrandom::fill(&mut vmac).map_err(|error| {
+        Error::Encoding(format!("failed to generate Random Instance VMAC: {error}"))
+    })?;
     vmac[0] = (vmac[0] & 0x3F) | 0x40;
-    vmac
+    Ok(vmac)
 }
 
 /// VMAC-to-address mapping table per Clause U.5.

--- a/crates/bacnet-transport/src/bip6/vmac_table.rs
+++ b/crates/bacnet-transport/src/bip6/vmac_table.rs
@@ -1,6 +1,8 @@
 //! Deterministic BACnet/IPv6 VMAC and scoped-endpoint mappings.
 
+use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
+use std::hash::{BuildHasher, Hasher};
 use std::net::{Ipv6Addr, SocketAddrV6};
 use std::sync::Arc;
 
@@ -8,6 +10,32 @@ use super::Bip6Vmac;
 
 /// Defensive cap for learned on-link VMAC mappings.
 pub(super) const MAX_VMAC_TABLE_ENTRIES: usize = 4096;
+
+pub(super) fn derive_vmac_from_device_instance(device_instance: u32) -> Bip6Vmac {
+    let bytes = (device_instance & 0x3F_FFFF).to_be_bytes();
+    [bytes[1], bytes[2], bytes[3]]
+}
+
+/// Generate a Random Device Instance VMAC for collision resolution (Clause H.7.2).
+pub fn generate_random_vmac() -> Bip6Vmac {
+    let bytes = RandomState::new().build_hasher().finish().to_ne_bytes();
+    [(bytes[0] & 0x3F) | 0x40, bytes[1], bytes[2]]
+}
+
+pub(super) fn derive_vmac_from_addr(addr: &SocketAddrV6) -> Bip6Vmac {
+    let mut vmac = [0u8; 3];
+    for (index, byte) in addr
+        .ip()
+        .octets()
+        .iter()
+        .chain(addr.port().to_be_bytes().iter())
+        .enumerate()
+    {
+        vmac[index % 3] ^= byte;
+    }
+    vmac[0] = (vmac[0] & 0x3F) | 0x40;
+    vmac
+}
 
 /// VMAC-to-address mapping table per Clause U.5.
 /// Updated from incoming frames and address-resolution exchanges.
@@ -19,16 +47,6 @@ pub(super) struct VmacTable {
 #[derive(Debug, Default)]
 struct VmacMappings {
     by_vmac: HashMap<Bip6Vmac, SocketAddrV6>,
-    by_address: HashMap<(Ipv6Addr, u16), AddressMapping>,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum AddressMapping {
-    Unique(Bip6Vmac, SocketAddrV6),
-    /// The public 18-byte BACnet/IPv6 MAC omits the IPv6 scope ID, so the
-    /// endpoint cannot be selected safely after the same address and port
-    /// have been observed on more than one scoped interface.
-    Ambiguous,
 }
 
 impl VmacTable {
@@ -40,56 +58,26 @@ impl VmacTable {
 
     /// Learn the latest VMAC and exact scoped endpoint from an incoming frame.
     pub(super) async fn learn(&self, vmac: Bip6Vmac, addr: SocketAddrV6) {
-        let key = (*addr.ip(), addr.port());
         let mut mappings = self.mappings.write().await;
 
         let updates_known_vmac = mappings.by_vmac.contains_key(&vmac);
-        let updates_known_address = mappings.by_address.contains_key(&key);
+        // A fully scoped endpoint has one current owner. Replacing it removes
+        // the stale VMAC while still allowing the same public IP+port on
+        // different interfaces to remain ambiguous at lookup time.
+        let old_owner = mappings.by_vmac.iter().find_map(|(mapped_vmac, endpoint)| {
+            (*mapped_vmac != vmac && *endpoint == addr).then_some(*mapped_vmac)
+        });
         if !updates_known_vmac
-            && !updates_known_address
+            && old_owner.is_none()
             && mappings.by_vmac.len() >= MAX_VMAC_TABLE_ENTRIES
         {
             return;
         }
-
-        if let Some(old_addr) = mappings.by_vmac.get(&vmac).copied() {
-            let old_key = (*old_addr.ip(), old_addr.port());
-            if old_key != key
-                && mappings
-                    .by_address
-                    .get(&old_key)
-                    .is_some_and(
-                        |mapping| matches!(mapping, AddressMapping::Unique(mapped_vmac, _) if *mapped_vmac == vmac),
-                    )
-            {
-                mappings.by_address.remove(&old_key);
-            }
-        }
-
-        match mappings.by_address.get(&key).copied() {
-            Some(AddressMapping::Unique(_, old_addr)) if old_addr != addr => {
-                mappings.by_address.insert(key, AddressMapping::Ambiguous);
-                if updates_known_vmac || mappings.by_vmac.len() < MAX_VMAC_TABLE_ENTRIES {
-                    mappings.by_vmac.insert(vmac, addr);
-                }
-                return;
-            }
-            Some(AddressMapping::Ambiguous) => {
-                if updates_known_vmac || mappings.by_vmac.len() < MAX_VMAC_TABLE_ENTRIES {
-                    mappings.by_vmac.insert(vmac, addr);
-                }
-                return;
-            }
-            Some(AddressMapping::Unique(old_vmac, _)) if old_vmac != vmac => {
-                mappings.by_vmac.remove(&old_vmac);
-            }
-            _ => {}
+        if let Some(old_vmac) = old_owner {
+            mappings.by_vmac.remove(&old_vmac);
         }
 
         mappings.by_vmac.insert(vmac, addr);
-        mappings
-            .by_address
-            .insert(key, AddressMapping::Unique(vmac, addr));
     }
 
     /// Look up the B/IPv6 address for a VMAC.
@@ -107,15 +95,17 @@ impl VmacTable {
         ip: Ipv6Addr,
         port: u16,
     ) -> Option<(Bip6Vmac, SocketAddrV6)> {
-        self.mappings
-            .read()
-            .await
-            .by_address
-            .get(&(ip, port))
-            .and_then(|mapping| match mapping {
-                AddressMapping::Unique(vmac, endpoint) => Some((*vmac, *endpoint)),
-                AddressMapping::Ambiguous => None,
-            })
+        let mappings = self.mappings.read().await;
+        let mut matches = mappings
+            .by_vmac
+            .iter()
+            .filter(|(_, endpoint)| *endpoint.ip() == ip && endpoint.port() == port);
+        let (&vmac, &endpoint) = matches.next()?;
+        if matches.next().is_some() {
+            None
+        } else {
+            Some((vmac, endpoint))
+        }
     }
 
     #[cfg(test)]

--- a/crates/bacnet-transport/src/ethernet/mod.rs
+++ b/crates/bacnet-transport/src/ethernet/mod.rs
@@ -6,6 +6,7 @@
 //! Platform: Linux only (AF_PACKET raw sockets). Feature-gated behind `ethernet`.
 
 use bacnet_types::error::Error;
+#[cfg(target_os = "linux")]
 use bacnet_types::MacAddr;
 use bytes::{BufMut, Bytes, BytesMut};
 
@@ -41,6 +42,11 @@ pub const MIN_ETHERNET_PAYLOAD: usize = 46;
 
 /// BACnet broadcast MAC (all 0xFF).
 pub const ETHERNET_BROADCAST: [u8; 6] = [0xFF; 6];
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn is_ethernet_group(destination: &[u8; 6]) -> bool {
+    destination[0] & 0x01 != 0
+}
 
 /// A decoded BACnet Ethernet LLC frame.
 #[derive(Debug, Clone)]
@@ -693,8 +699,7 @@ mod transport {
                                         .try_send(ReceivedNpdu {
                                             npdu: frame.payload.clone(),
                                             source_mac: MacAddr::from(frame.source),
-                                            link_layer_broadcast: frame.destination
-                                                == ETHERNET_BROADCAST,
+                                            link_layer_group: is_ethernet_group(&frame.destination),
                                             data_attributes: Vec::new(),
                                             reply_tx: None,
                                         })

--- a/crates/bacnet-transport/src/ethernet/mod.rs
+++ b/crates/bacnet-transport/src/ethernet/mod.rs
@@ -693,6 +693,8 @@ mod transport {
                                         .try_send(ReceivedNpdu {
                                             npdu: frame.payload.clone(),
                                             source_mac: MacAddr::from(frame.source),
+                                            link_layer_broadcast: frame.destination
+                                                == ETHERNET_BROADCAST,
                                             data_attributes: Vec::new(),
                                             reply_tx: None,
                                         })

--- a/crates/bacnet-transport/src/ethernet/tests.rs
+++ b/crates/bacnet-transport/src/ethernet/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+#[cfg(target_os = "linux")]
 use crate::port::TransportPort;
 
 #[test]
@@ -14,6 +15,13 @@ fn encode_decode_round_trip() {
     assert_eq!(decoded.destination, dst);
     assert_eq!(decoded.source, src);
     assert_eq!(decoded.payload, npdu);
+}
+
+#[test]
+fn ieee_group_bit_covers_multicast_and_broadcast_destinations() {
+    assert!(!is_ethernet_group(&[0x02, 0, 0, 0, 0, 1]));
+    assert!(is_ethernet_group(&[0x01, 0, 0x5e, 0, 0, 1]));
+    assert!(is_ethernet_group(&ETHERNET_BROADCAST));
 }
 
 #[test]

--- a/crates/bacnet-transport/src/lib.rs
+++ b/crates/bacnet-transport/src/lib.rs
@@ -30,3 +30,4 @@ pub mod sc_frame;
 pub mod sc_hub;
 #[cfg(feature = "sc-tls")]
 pub mod sc_tls;
+mod udp_metadata;

--- a/crates/bacnet-transport/src/lib.rs
+++ b/crates/bacnet-transport/src/lib.rs
@@ -18,6 +18,7 @@ pub mod bip6;
 pub mod bvll;
 #[cfg(feature = "ethernet")]
 pub mod ethernet;
+mod local_addresses;
 pub mod loopback;
 pub mod mstp;
 pub mod mstp_frame;

--- a/crates/bacnet-transport/src/local_addresses.rs
+++ b/crates/bacnet-transport/src/local_addresses.rs
@@ -1,0 +1,76 @@
+//! Local interface address discovery for wildcard-bound UDP ingress checks.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn collect() -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
+    struct IfAddrsGuard(*mut libc::ifaddrs);
+
+    impl Drop for IfAddrsGuard {
+        fn drop(&mut self) {
+            // SAFETY: the pointer was returned by `getifaddrs` and this guard
+            // owns the corresponding single `freeifaddrs` call.
+            unsafe { libc::freeifaddrs(self.0) }
+        }
+    }
+
+    let mut head = std::ptr::null_mut();
+    // SAFETY: `getifaddrs` initializes `head` on success. The guarded list is
+    // walked only through non-null nodes and address-family-checked pointers.
+    if unsafe { libc::getifaddrs(&mut head) } != 0 {
+        return (Vec::new(), Vec::new());
+    }
+    let _guard = IfAddrsGuard(head);
+    let mut ipv4 = Vec::new();
+    let mut ipv6 = Vec::new();
+    let mut current = head;
+    while !current.is_null() {
+        // SAFETY: `current` is a node in the live guarded list.
+        let entry = unsafe { &*current };
+        if !entry.ifa_addr.is_null() {
+            // SAFETY: the non-null sockaddr is valid for its reported family.
+            let family = unsafe { (*entry.ifa_addr).sa_family as i32 };
+            if family == libc::AF_INET {
+                // SAFETY: family AF_INET selects the sockaddr_in layout.
+                let address = unsafe { &*(entry.ifa_addr as *const libc::sockaddr_in) };
+                ipv4.push(Ipv4Addr::from(address.sin_addr.s_addr.to_ne_bytes()));
+            } else if family == libc::AF_INET6 {
+                // SAFETY: family AF_INET6 selects the sockaddr_in6 layout.
+                let address = unsafe { &*(entry.ifa_addr as *const libc::sockaddr_in6) };
+                ipv6.push(Ipv6Addr::from(address.sin6_addr.s6_addr));
+            }
+        }
+        current = entry.ifa_next;
+    }
+    ipv4.sort_unstable();
+    ipv4.dedup();
+    ipv6.sort_unstable();
+    ipv6.dedup();
+    (ipv4, ipv6)
+}
+
+#[cfg(not(unix))]
+fn collect() -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
+    (Vec::new(), Vec::new())
+}
+
+pub(crate) fn ipv4() -> Vec<Ipv4Addr> {
+    collect().0
+}
+
+pub(crate) fn ipv6() -> Vec<Ipv6Addr> {
+    collect().1
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn local_addresses_include_loopback_on_unix() {
+        #[cfg(unix)]
+        {
+            assert!(super::ipv4().contains(&std::net::Ipv4Addr::LOCALHOST));
+            assert!(super::ipv6().contains(&std::net::Ipv6Addr::LOCALHOST));
+        }
+    }
+}

--- a/crates/bacnet-transport/src/local_addresses.rs
+++ b/crates/bacnet-transport/src/local_addresses.rs
@@ -2,7 +2,23 @@
 
 use std::net::{Ipv4Addr, Ipv6Addr};
 
-#[cfg(unix)]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "l4re",
+    target_os = "android",
+    target_os = "emscripten",
+    target_vendor = "apple",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "solaris",
+    target_os = "illumos",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "hurd",
+    target_os = "fuchsia",
+))]
 #[allow(unsafe_code)]
 fn collect() -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
     struct IfAddrsGuard(*mut libc::ifaddrs);
@@ -50,7 +66,23 @@ fn collect() -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
     (ipv4, ipv6)
 }
 
-#[cfg(not(unix))]
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "l4re",
+    target_os = "android",
+    target_os = "emscripten",
+    target_vendor = "apple",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "solaris",
+    target_os = "illumos",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "hurd",
+    target_os = "fuchsia",
+)))]
 fn collect() -> (Vec<Ipv4Addr>, Vec<Ipv6Addr>) {
     (Vec::new(), Vec::new())
 }
@@ -66,11 +98,25 @@ pub(crate) fn ipv6() -> Vec<Ipv6Addr> {
 #[cfg(test)]
 mod tests {
     #[test]
-    fn local_addresses_include_loopback_on_unix() {
-        #[cfg(unix)]
-        {
-            assert!(super::ipv4().contains(&std::net::Ipv4Addr::LOCALHOST));
-            assert!(super::ipv6().contains(&std::net::Ipv6Addr::LOCALHOST));
-        }
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "l4re",
+        target_os = "android",
+        target_os = "emscripten",
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "illumos",
+        target_os = "haiku",
+        target_os = "nto",
+        target_os = "hurd",
+        target_os = "fuchsia",
+    ))]
+    fn local_addresses_include_loopback_on_supported_targets() {
+        assert!(super::ipv4().contains(&std::net::Ipv4Addr::LOCALHOST));
+        assert!(super::ipv6().contains(&std::net::Ipv6Addr::LOCALHOST));
     }
 }

--- a/crates/bacnet-transport/src/local_addresses.rs
+++ b/crates/bacnet-transport/src/local_addresses.rs
@@ -95,6 +95,88 @@ pub(crate) fn ipv6() -> Vec<Ipv6Addr> {
     collect().1
 }
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "l4re",
+    target_os = "android",
+    target_os = "emscripten",
+    target_vendor = "apple",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "solaris",
+    target_os = "illumos",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "hurd",
+    target_os = "fuchsia",
+))]
+#[allow(unsafe_code)]
+pub(crate) fn ipv6_interface_index(addr: &Ipv6Addr) -> Option<u32> {
+    use std::ffi::CStr;
+
+    struct IfAddrsGuard(*mut libc::ifaddrs);
+    impl Drop for IfAddrsGuard {
+        fn drop(&mut self) {
+            // SAFETY: this is the matching deallocator for `getifaddrs`.
+            unsafe { libc::freeifaddrs(self.0) }
+        }
+    }
+
+    let mut head = std::ptr::null_mut();
+    // SAFETY: the guarded list and address pointers remain valid through the walk.
+    if unsafe { libc::getifaddrs(&mut head) } != 0 {
+        return None;
+    }
+    let _guard = IfAddrsGuard(head);
+    let mut current = head;
+    while !current.is_null() {
+        // SAFETY: `current` is a node in the live guarded list.
+        let entry = unsafe { &*current };
+        if !entry.ifa_addr.is_null() {
+            // SAFETY: the non-null sockaddr is valid for its reported family.
+            let family = unsafe { (*entry.ifa_addr).sa_family as i32 };
+            if family == libc::AF_INET6 {
+                // SAFETY: family AF_INET6 selects the sockaddr_in6 layout.
+                let address = unsafe { &*(entry.ifa_addr as *const libc::sockaddr_in6) };
+                if Ipv6Addr::from(address.sin6_addr.s6_addr) == *addr {
+                    // SAFETY: the OS provides a NUL-terminated interface name.
+                    let index =
+                        unsafe { libc::if_nametoindex(CStr::from_ptr(entry.ifa_name).as_ptr()) };
+                    if index != 0 {
+                        return Some(index);
+                    }
+                }
+            }
+        }
+        current = entry.ifa_next;
+    }
+    None
+}
+
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "l4re",
+    target_os = "android",
+    target_os = "emscripten",
+    target_vendor = "apple",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "solaris",
+    target_os = "illumos",
+    target_os = "haiku",
+    target_os = "nto",
+    target_os = "hurd",
+    target_os = "fuchsia",
+)))]
+pub(crate) fn ipv6_interface_index(addr: &Ipv6Addr) -> Option<u32> {
+    let _ = addr;
+    None
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/bacnet-transport/src/loopback.rs
+++ b/crates/bacnet-transport/src/loopback.rs
@@ -66,7 +66,7 @@ impl TransportPort for LoopbackTransport {
         let msg = ReceivedNpdu {
             npdu: Bytes::copy_from_slice(npdu),
             source_mac: self.local_mac.clone(),
-            link_layer_broadcast: false,
+            link_layer_group: false,
             data_attributes: Vec::new(),
             reply_tx: None,
         };
@@ -80,7 +80,7 @@ impl TransportPort for LoopbackTransport {
         let msg = ReceivedNpdu {
             npdu: Bytes::copy_from_slice(npdu),
             source_mac: self.local_mac.clone(),
-            link_layer_broadcast: true,
+            link_layer_group: true,
             data_attributes: Vec::new(),
             reply_tx: None,
         };
@@ -109,7 +109,7 @@ mod tests {
         let npdu = rx_b.recv().await.unwrap();
         assert_eq!(&npdu.npdu[..], b"hello");
         assert_eq!(&npdu.source_mac[..], &[0x00, 0x01]);
-        assert!(!npdu.link_layer_broadcast);
+        assert!(!npdu.link_layer_group);
     }
 
     #[tokio::test]
@@ -122,7 +122,7 @@ mod tests {
         let npdu = rx_a.recv().await.unwrap();
         assert_eq!(&npdu.npdu[..], b"world");
         assert_eq!(&npdu.source_mac[..], &[0x00, 0x02]);
-        assert!(!npdu.link_layer_broadcast);
+        assert!(!npdu.link_layer_group);
     }
 
     #[tokio::test]
@@ -134,7 +134,7 @@ mod tests {
         a.send_broadcast(b"bcast").await.unwrap();
         let npdu = rx_b.recv().await.unwrap();
         assert_eq!(&npdu.npdu[..], b"bcast");
-        assert!(npdu.link_layer_broadcast);
+        assert!(npdu.link_layer_group);
     }
 
     #[tokio::test]

--- a/crates/bacnet-transport/src/loopback.rs
+++ b/crates/bacnet-transport/src/loopback.rs
@@ -66,6 +66,7 @@ impl TransportPort for LoopbackTransport {
         let msg = ReceivedNpdu {
             npdu: Bytes::copy_from_slice(npdu),
             source_mac: self.local_mac.clone(),
+            link_layer_broadcast: false,
             data_attributes: Vec::new(),
             reply_tx: None,
         };
@@ -76,7 +77,17 @@ impl TransportPort for LoopbackTransport {
     }
 
     async fn send_broadcast(&self, npdu: &[u8]) -> Result<(), Error> {
-        self.send_unicast(npdu, &[]).await
+        let msg = ReceivedNpdu {
+            npdu: Bytes::copy_from_slice(npdu),
+            source_mac: self.local_mac.clone(),
+            link_layer_broadcast: true,
+            data_attributes: Vec::new(),
+            reply_tx: None,
+        };
+        self.peer_tx
+            .send(msg)
+            .await
+            .map_err(|_| Error::Encoding("loopback peer channel closed".to_string()))
     }
 
     fn local_mac(&self) -> &[u8] {
@@ -98,6 +109,7 @@ mod tests {
         let npdu = rx_b.recv().await.unwrap();
         assert_eq!(&npdu.npdu[..], b"hello");
         assert_eq!(&npdu.source_mac[..], &[0x00, 0x01]);
+        assert!(!npdu.link_layer_broadcast);
     }
 
     #[tokio::test]
@@ -110,6 +122,7 @@ mod tests {
         let npdu = rx_a.recv().await.unwrap();
         assert_eq!(&npdu.npdu[..], b"world");
         assert_eq!(&npdu.source_mac[..], &[0x00, 0x02]);
+        assert!(!npdu.link_layer_broadcast);
     }
 
     #[tokio::test]
@@ -121,6 +134,7 @@ mod tests {
         a.send_broadcast(b"bcast").await.unwrap();
         let npdu = rx_b.recv().await.unwrap();
         assert_eq!(&npdu.npdu[..], b"bcast");
+        assert!(npdu.link_layer_broadcast);
     }
 
     #[tokio::test]

--- a/crates/bacnet-transport/src/mstp/mod.rs
+++ b/crates/bacnet-transport/src/mstp/mod.rs
@@ -246,7 +246,7 @@ impl MasterNode {
                         let _ = npdu_tx.try_send(ReceivedNpdu {
                             npdu: frame.data.clone(),
                             source_mac: MacAddr::from_slice(&[frame.source]),
-                            link_layer_broadcast: false,
+                            link_layer_group: false,
                             data_attributes: Vec::new(),
                             reply_tx: None,
                         });
@@ -260,7 +260,7 @@ impl MasterNode {
                     let _ = npdu_tx.try_send(ReceivedNpdu {
                         npdu: frame.data.clone(),
                         source_mac: MacAddr::from_slice(&[frame.source]),
-                        link_layer_broadcast: frame.destination == BROADCAST_MAC,
+                        link_layer_group: frame.destination == BROADCAST_MAC,
                         data_attributes: Vec::new(),
                         reply_tx: None,
                     });
@@ -276,7 +276,7 @@ impl MasterNode {
                     let _ = npdu_tx.try_send(ReceivedNpdu {
                         npdu: frame.data.clone(),
                         source_mac: MacAddr::from_slice(&[frame.source]),
-                        link_layer_broadcast: false,
+                        link_layer_group: false,
                         data_attributes: Vec::new(),
                         reply_tx: Some(tx),
                     });

--- a/crates/bacnet-transport/src/mstp/mod.rs
+++ b/crates/bacnet-transport/src/mstp/mod.rs
@@ -203,6 +203,12 @@ impl MasterNode {
         match frame.frame_type {
             FrameType::Token => {
                 if frame.destination == self.config.this_station {
+                    // A reply decision owns the node until its bound response
+                    // or ReplyPostponed is sent. Out-of-turn traffic must not
+                    // replace that transaction's state or requester.
+                    if self.pending_reply_source.is_some() {
+                        return None;
+                    }
                     debug!(src = frame.source, "received token");
                     self.sole_master = false;
                     self.state = MasterState::UseToken;
@@ -272,7 +278,7 @@ impl MasterNode {
             }
             FrameType::BACnetDataExpectingReply => {
                 if frame.destination == self.config.this_station {
-                    if self.state == MasterState::AnswerDataRequest {
+                    if self.pending_reply_source.is_some() {
                         return None;
                     }
                     self.state = MasterState::AnswerDataRequest;
@@ -317,10 +323,7 @@ impl MasterNode {
 
     /// Complete AnswerDataRequest with application data or ReplyPostponed.
     pub(crate) fn finish_data_request(&mut self, reply_data: Option<Bytes>) -> Option<MstpFrame> {
-        if self.state != MasterState::AnswerDataRequest {
-            return None;
-        }
-        let destination = self.pending_reply_source.take().unwrap_or(BROADCAST_MAC);
+        let destination = self.pending_reply_source.take()?;
         self.reply_rx = None;
         self.state = MasterState::Idle;
         Some(match reply_data {

--- a/crates/bacnet-transport/src/mstp/mod.rs
+++ b/crates/bacnet-transport/src/mstp/mod.rs
@@ -50,6 +50,9 @@ fn calculate_t_slot_ms(_baud_rate: u32) -> u64 {
 }
 /// Maximum time a node may delay before sending a reply to DataExpectingReply (ms).
 const T_REPLY_DELAY_MS: u64 = 250;
+/// Scheduling/write margin reserved so the first reply octet starts before
+/// the T_reply_delay limit rather than beginning at the limit.
+const T_REPLY_TRANSMIT_MARGIN_MS: u64 = 25;
 /// Minimum silence time (40 bit times) before transmitting after receiving last octet.
 fn calculate_t_turnaround_us(baud_rate: u32) -> u64 {
     40_000_000u64 / baud_rate as u64
@@ -309,6 +312,30 @@ impl MasterNode {
         }
     }
 
+    /// Complete AnswerDataRequest with application data or ReplyPostponed.
+    pub(crate) fn finish_data_request(&mut self, reply_data: Option<Bytes>) -> Option<MstpFrame> {
+        if self.state != MasterState::AnswerDataRequest {
+            return None;
+        }
+        let destination = self.pending_reply_source.take().unwrap_or(BROADCAST_MAC);
+        self.reply_rx = None;
+        self.state = MasterState::Idle;
+        Some(match reply_data {
+            Some(data) => MstpFrame {
+                frame_type: FrameType::BACnetDataNotExpectingReply,
+                destination,
+                source: self.config.this_station,
+                data,
+            },
+            None => MstpFrame {
+                frame_type: FrameType::ReplyPostponed,
+                destination,
+                source: self.config.this_station,
+                data: Bytes::new(),
+            },
+        })
+    }
+
     /// Decide what to send when we have the token. Returns a frame to send.
     pub fn use_token(&mut self) -> MstpFrame {
         // Send queued data if available and under frame limit
@@ -497,5 +524,7 @@ fn next_addr(current: u8, max_master: u8) -> u8 {
 mod port;
 pub use port::{LoopbackSerial, MstpTransport, NoSerial};
 
+#[cfg(test)]
+mod port_timing_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-transport/src/mstp/mod.rs
+++ b/crates/bacnet-transport/src/mstp/mod.rs
@@ -246,6 +246,7 @@ impl MasterNode {
                         let _ = npdu_tx.try_send(ReceivedNpdu {
                             npdu: frame.data.clone(),
                             source_mac: MacAddr::from_slice(&[frame.source]),
+                            link_layer_broadcast: false,
                             data_attributes: Vec::new(),
                             reply_tx: None,
                         });
@@ -259,6 +260,7 @@ impl MasterNode {
                     let _ = npdu_tx.try_send(ReceivedNpdu {
                         npdu: frame.data.clone(),
                         source_mac: MacAddr::from_slice(&[frame.source]),
+                        link_layer_broadcast: frame.destination == BROADCAST_MAC,
                         data_attributes: Vec::new(),
                         reply_tx: None,
                     });
@@ -274,6 +276,7 @@ impl MasterNode {
                     let _ = npdu_tx.try_send(ReceivedNpdu {
                         npdu: frame.data.clone(),
                         source_mac: MacAddr::from_slice(&[frame.source]),
+                        link_layer_broadcast: false,
                         data_attributes: Vec::new(),
                         reply_tx: Some(tx),
                     });

--- a/crates/bacnet-transport/src/mstp/mod.rs
+++ b/crates/bacnet-transport/src/mstp/mod.rs
@@ -55,7 +55,7 @@ const T_REPLY_DELAY_MS: u64 = 250;
 const T_REPLY_TRANSMIT_MARGIN_MS: u64 = 25;
 /// Minimum silence time (40 bit times) before transmitting after receiving last octet.
 fn calculate_t_turnaround_us(baud_rate: u32) -> u64 {
-    40_000_000u64 / baud_rate as u64
+    40_000_000u64.div_ceil(baud_rate as u64)
 }
 /// Number of retries for token pass before declaring token lost.
 const N_RETRY_TOKEN: u8 = 1;
@@ -272,6 +272,9 @@ impl MasterNode {
             }
             FrameType::BACnetDataExpectingReply => {
                 if frame.destination == self.config.this_station {
+                    if self.state == MasterState::AnswerDataRequest {
+                        return None;
+                    }
                     self.state = MasterState::AnswerDataRequest;
                     self.pending_reply_source = Some(frame.source);
                     let (tx, rx) = oneshot::channel();
@@ -526,5 +529,7 @@ pub use port::{LoopbackSerial, MstpTransport, NoSerial};
 
 #[cfg(test)]
 mod port_timing_tests;
+#[cfg(test)]
+mod reply_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-transport/src/mstp/port.rs
+++ b/crates/bacnet-transport/src/mstp/port.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use bacnet_types::error::Error;
 use bytes::{Bytes, BytesMut};
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex};
 use tracing::{debug, warn};
 
 use crate::mstp_frame::{
@@ -13,7 +13,7 @@ use crate::port::{ReceivedNpdu, TransportPort};
 use super::{
     calculate_t_frame_abort_us, calculate_t_turnaround_us, next_addr, MasterNode, MasterState,
     MstpConfig, SerialPort, MSTP_MAX_FRAME_BUF, T_NO_TOKEN_MS, T_REPLY_DELAY_MS,
-    T_REPLY_TIMEOUT_MS, T_USAGE_TIMEOUT_MS,
+    T_REPLY_TIMEOUT_MS, T_REPLY_TRANSMIT_MARGIN_MS, T_USAGE_TIMEOUT_MS,
 };
 
 // ---------------------------------------------------------------------------
@@ -66,6 +66,8 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
         let serial_clone = serial.clone();
         let t_turnaround_us = calculate_t_turnaround_us(self.config.baud_rate);
         let t_frame_abort_us = calculate_t_frame_abort_us(self.config.baud_rate);
+        let reply_decision_delay_ms = T_REPLY_DELAY_MS
+            .saturating_sub(t_turnaround_us.div_ceil(1_000) + T_REPLY_TRANSMIT_MARGIN_MS);
 
         // Receive loop using tokio::select! with timer
         let task = tokio::spawn(async move {
@@ -78,9 +80,42 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
             tokio::pin!(sleep);
 
             let mut encode_buf = BytesMut::with_capacity(1024);
+            let mut pending_reply_rx: Option<oneshot::Receiver<Bytes>> = None;
 
             loop {
                 tokio::select! {
+                    biased;
+                    // A DataExpectingReply application response must wake the
+                    // loop immediately; waiting for T_reply_delay would begin
+                    // transmission after the Standard's deadline.
+                    reply = async {
+                        pending_reply_rx
+                            .as_mut()
+                            .expect("reply branch is guarded")
+                            .await
+                    }, if pending_reply_rx.is_some() => {
+                        pending_reply_rx = None;
+                        let mut node_guard = node.lock().await;
+                        let response = node_guard.finish_data_request(reply.ok());
+                        drop(node_guard);
+
+                        if let Some(response) = response {
+                            encode_buf.clear();
+                            if encode_frame(&mut encode_buf, &response).is_ok() {
+                                tokio::time::sleep(tokio::time::Duration::from_micros(
+                                    t_turnaround_us,
+                                ))
+                                .await;
+                                if let Err(e) = serial_clone.write(&encode_buf).await {
+                                    warn!("MS/TP write error: {}", e);
+                                }
+                            }
+                        }
+                        sleep.as_mut().reset(
+                            tokio::time::Instant::now()
+                                + tokio::time::Duration::from_millis(T_USAGE_TIMEOUT_MS),
+                        );
+                    }
                     // Branch 1: serial data arrives
                     result = serial_clone.read(&mut recv_buf) => {
                         match result {
@@ -142,6 +177,11 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                                     let mut node_guard = node.lock().await;
                                     let response =
                                         node_guard.handle_received_frame(&frame, &npdu_tx);
+                                    if pending_reply_rx.is_none()
+                                        && node_guard.state == MasterState::AnswerDataRequest
+                                    {
+                                        pending_reply_rx = node_guard.reply_rx.take();
+                                    }
                                     let mut pending_writes: Vec<Vec<u8>> = Vec::new();
                                     if let Some(response) = response {
                                         encode_buf.clear();
@@ -194,11 +234,19 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                                         MasterState::NoToken => T_NO_TOKEN_MS,
                                         MasterState::PollForMaster => node_guard.t_slot_ms,
                                         MasterState::WaitForReply => T_REPLY_TIMEOUT_MS,
-                                        MasterState::AnswerDataRequest => T_REPLY_DELAY_MS,
+                                        MasterState::AnswerDataRequest => reply_decision_delay_ms,
                                         MasterState::PassToken => T_USAGE_TIMEOUT_MS,
                                         MasterState::UseToken
                                         | MasterState::DoneWithToken => T_USAGE_TIMEOUT_MS,
                                     };
+                                    let reply_deadline = (node_guard.state
+                                        == MasterState::AnswerDataRequest)
+                                        .then(|| {
+                                            last_byte_time
+                                                + tokio::time::Duration::from_millis(
+                                                    reply_decision_delay_ms,
+                                                )
+                                        });
                                     drop(node_guard);
 
                                     // T_turnaround before transmitting
@@ -216,8 +264,10 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                                     }
 
                                     sleep.as_mut().reset(
-                                        tokio::time::Instant::now()
-                                            + tokio::time::Duration::from_millis(timeout_ms),
+                                        reply_deadline.unwrap_or_else(|| {
+                                            tokio::time::Instant::now()
+                                                + tokio::time::Duration::from_millis(timeout_ms)
+                                        }),
                                     );
                                 }
                                 Err(_) => {
@@ -282,36 +332,21 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                                 T_USAGE_TIMEOUT_MS
                             }
                             MasterState::AnswerDataRequest => {
-                                let dest = node_guard.pending_reply_source.unwrap_or(BROADCAST_MAC);
-                                // Check if the application layer sent a reply via the channel.
-                                let reply_data = node_guard.reply_rx.take().and_then(|mut rx| rx.try_recv().ok());
-                                if let Some(data) = reply_data {
-                                    // Send the reply as DataNotExpectingReply
-                                    let reply_frame = MstpFrame {
-                                        frame_type: FrameType::BACnetDataNotExpectingReply,
-                                        destination: dest,
-                                        source: node_guard.config.this_station,
-                                        data,
-                                    };
+                                // The timer fires early enough to include
+                                // turnaround and scheduling before the first
+                                // octet's T_reply_delay deadline. Prefer a
+                                // response that became ready at the boundary.
+                                let reply_data = pending_reply_rx
+                                    .take()
+                                    .and_then(|mut rx| rx.try_recv().ok());
+                                if let Some(reply_frame) =
+                                    node_guard.finish_data_request(reply_data)
+                                {
                                     encode_buf.clear();
-                                    if let Ok(()) = encode_frame(&mut encode_buf, &reply_frame) {
-                                        pending_writes.push(encode_buf.to_vec());
-                                    }
-                                } else {
-                                    // No reply in time — send ReplyPostponed
-                                    let rp = MstpFrame {
-                                        frame_type: FrameType::ReplyPostponed,
-                                        destination: dest,
-                                        source: node_guard.config.this_station,
-                                        data: Bytes::new(),
-                                    };
-                                    encode_buf.clear();
-                                    if let Ok(()) = encode_frame(&mut encode_buf, &rp) {
+                                    if encode_frame(&mut encode_buf, &reply_frame).is_ok() {
                                         pending_writes.push(encode_buf.to_vec());
                                     }
                                 }
-                                node_guard.pending_reply_source = None;
-                                node_guard.state = MasterState::Idle;
                                 T_USAGE_TIMEOUT_MS
                             }
                             MasterState::PassToken => {

--- a/crates/bacnet-transport/src/mstp/port.rs
+++ b/crates/bacnet-transport/src/mstp/port.rs
@@ -81,6 +81,7 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
 
             let mut encode_buf = BytesMut::with_capacity(1024);
             let mut pending_reply_rx: Option<oneshot::Receiver<Bytes>> = None;
+            let mut pending_reply_deadline: Option<tokio::time::Instant> = None;
 
             loop {
                 tokio::select! {
@@ -95,6 +96,7 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                             .await
                     }, if pending_reply_rx.is_some() => {
                         pending_reply_rx = None;
+                        pending_reply_deadline = None;
                         let mut node_guard = node.lock().await;
                         let response = node_guard.finish_data_request(reply.ok());
                         drop(node_guard);
@@ -177,10 +179,20 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                                     let mut node_guard = node.lock().await;
                                     let response =
                                         node_guard.handle_received_frame(&frame, &npdu_tx);
+                                    let mut started_reply = false;
                                     if pending_reply_rx.is_none()
                                         && node_guard.state == MasterState::AnswerDataRequest
                                     {
                                         pending_reply_rx = node_guard.reply_rx.take();
+                                        started_reply = pending_reply_rx.is_some();
+                                    }
+                                    if started_reply {
+                                        pending_reply_deadline = Some(
+                                            last_byte_time
+                                                + tokio::time::Duration::from_millis(
+                                                    reply_decision_delay_ms,
+                                                ),
+                                        );
                                     }
                                     let mut pending_writes: Vec<Vec<u8>> = Vec::new();
                                     if let Some(response) = response {
@@ -239,14 +251,6 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                                         MasterState::UseToken
                                         | MasterState::DoneWithToken => T_USAGE_TIMEOUT_MS,
                                     };
-                                    let reply_deadline = (node_guard.state
-                                        == MasterState::AnswerDataRequest)
-                                        .then(|| {
-                                            last_byte_time
-                                                + tokio::time::Duration::from_millis(
-                                                    reply_decision_delay_ms,
-                                                )
-                                        });
                                     drop(node_guard);
 
                                     // T_turnaround before transmitting
@@ -264,7 +268,7 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                                     }
 
                                     sleep.as_mut().reset(
-                                        reply_deadline.unwrap_or_else(|| {
+                                        pending_reply_deadline.unwrap_or_else(|| {
                                             tokio::time::Instant::now()
                                                 + tokio::time::Duration::from_millis(timeout_ms)
                                         }),
@@ -284,6 +288,8 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                     () = &mut sleep => {
                         let mut node_guard = node.lock().await;
                         let mut pending_writes: Vec<Vec<u8>> = Vec::new();
+                        let was_answering_data_request =
+                            node_guard.pending_reply_source.is_some();
                         let timeout_ms = match node_guard.state {
                             MasterState::Idle => {
                                 node_guard.state = MasterState::NoToken;
@@ -379,6 +385,9 @@ impl<S: SerialPort> TransportPort for MstpTransport<S> {
                                 T_USAGE_TIMEOUT_MS
                             }
                         };
+                        if was_answering_data_request {
+                            pending_reply_deadline = None;
+                        }
                         drop(node_guard);
 
                         // T_turnaround before transmitting

--- a/crates/bacnet-transport/src/mstp/port_timing_tests.rs
+++ b/crates/bacnet-transport/src/mstp/port_timing_tests.rs
@@ -71,3 +71,37 @@ async fn reply_postponed_starts_before_reply_delay_limit() {
     assert!(started.elapsed() < tokio::time::Duration::from_millis(T_REPLY_DELAY_MS));
     transport.stop().await.unwrap();
 }
+
+#[tokio::test(start_paused = true)]
+async fn second_data_request_does_not_extend_first_reply_deadline() {
+    let (serial_transport, serial_peer) = LoopbackSerial::pair();
+    let mut transport = MstpTransport::new(serial_transport, timing_config());
+    let mut npdu_rx = transport.start().await.unwrap();
+    let mut first = BytesMut::new();
+    encode_frame(&mut first, &expecting_reply_frame()).unwrap();
+    let started = tokio::time::Instant::now();
+    serial_peer.write(&first).await.unwrap();
+
+    let received = npdu_rx.recv().await.unwrap();
+    let _reply_tx = received.reply_tx.unwrap();
+    tokio::time::advance(tokio::time::Duration::from_millis(100)).await;
+
+    let mut second = BytesMut::new();
+    let second_request = MstpFrame {
+        source: 8,
+        data: Bytes::from_static(&[0x01, 0x04, 0x20]),
+        ..expecting_reply_frame()
+    };
+    encode_frame(&mut second, &second_request).unwrap();
+    serial_peer.write(&second).await.unwrap();
+    tokio::task::yield_now().await;
+    assert!(npdu_rx.try_recv().is_err());
+
+    let mut response_buf = [0u8; 64];
+    let response_len = serial_peer.read(&mut response_buf).await.unwrap();
+    let (response, _) = decode_frame(&response_buf[..response_len]).unwrap();
+    assert_eq!(response.frame_type, FrameType::ReplyPostponed);
+    assert_eq!(response.destination, 7);
+    assert!(started.elapsed() < tokio::time::Duration::from_millis(T_REPLY_DELAY_MS));
+    transport.stop().await.unwrap();
+}

--- a/crates/bacnet-transport/src/mstp/port_timing_tests.rs
+++ b/crates/bacnet-transport/src/mstp/port_timing_tests.rs
@@ -1,0 +1,73 @@
+use bytes::{Bytes, BytesMut};
+
+use super::*;
+use crate::mstp_frame::{decode_frame, encode_frame, FrameType, MstpFrame};
+use crate::port::TransportPort;
+
+fn expecting_reply_frame() -> MstpFrame {
+    MstpFrame {
+        frame_type: FrameType::BACnetDataExpectingReply,
+        destination: 3,
+        source: 7,
+        data: Bytes::from_static(&[0x01, 0x04, 0x10]),
+    }
+}
+
+fn timing_config() -> MstpConfig {
+    MstpConfig {
+        this_station: 3,
+        max_master: 127,
+        max_info_frames: 1,
+        baud_rate: 9600,
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn ready_data_reply_does_not_wait_for_reply_delay() {
+    let (serial_transport, serial_peer) = LoopbackSerial::pair();
+    let mut transport = MstpTransport::new(serial_transport, timing_config());
+    let mut npdu_rx = transport.start().await.unwrap();
+    let mut encoded = BytesMut::new();
+    encode_frame(&mut encoded, &expecting_reply_frame()).unwrap();
+    let started = tokio::time::Instant::now();
+    serial_peer.write(&encoded).await.unwrap();
+
+    let received = npdu_rx.recv().await.unwrap();
+    received
+        .reply_tx
+        .unwrap()
+        .send(Bytes::from_static(&[0x01, 0x00, 0x30, 0x01]))
+        .unwrap();
+    let mut response_buf = [0u8; 64];
+    let response_len = serial_peer.read(&mut response_buf).await.unwrap();
+    let (response, _) = decode_frame(&response_buf[..response_len]).unwrap();
+
+    assert_eq!(response.frame_type, FrameType::BACnetDataNotExpectingReply);
+    assert_eq!(response.destination, 7);
+    assert!(started.elapsed() < tokio::time::Duration::from_millis(50));
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn reply_postponed_starts_before_reply_delay_limit() {
+    let (serial_transport, serial_peer) = LoopbackSerial::pair();
+    let mut transport = MstpTransport::new(serial_transport, timing_config());
+    let mut npdu_rx = transport.start().await.unwrap();
+    let mut encoded = BytesMut::new();
+    encode_frame(&mut encoded, &expecting_reply_frame()).unwrap();
+    let started = tokio::time::Instant::now();
+    serial_peer.write(&encoded).await.unwrap();
+
+    // Keep the application sender alive without replying so the deadline,
+    // rather than channel cancellation, selects ReplyPostponed.
+    let received = npdu_rx.recv().await.unwrap();
+    let _reply_tx = received.reply_tx.unwrap();
+    let mut response_buf = [0u8; 64];
+    let response_len = serial_peer.read(&mut response_buf).await.unwrap();
+    let (response, _) = decode_frame(&response_buf[..response_len]).unwrap();
+
+    assert_eq!(response.frame_type, FrameType::ReplyPostponed);
+    assert_eq!(response.destination, 7);
+    assert!(started.elapsed() < tokio::time::Duration::from_millis(T_REPLY_DELAY_MS));
+    transport.stop().await.unwrap();
+}

--- a/crates/bacnet-transport/src/mstp/reply_tests.rs
+++ b/crates/bacnet-transport/src/mstp/reply_tests.rs
@@ -1,0 +1,41 @@
+use bacnet_types::MacAddr;
+use bytes::Bytes;
+use tokio::sync::mpsc;
+
+use super::*;
+
+#[test]
+fn second_data_request_cannot_replace_pending_reply_source() {
+    let (tx, mut rx) = mpsc::channel(16);
+    let config = MstpConfig {
+        this_station: 3,
+        max_master: 127,
+        max_info_frames: 1,
+        baud_rate: 9600,
+    };
+    let mut node = MasterNode::new(config).unwrap();
+    let first = MstpFrame {
+        frame_type: FrameType::BACnetDataExpectingReply,
+        destination: 3,
+        source: 7,
+        data: Bytes::from_static(&[0x01, 0x00, 0x11]),
+    };
+    let second = MstpFrame {
+        source: 8,
+        data: Bytes::from_static(&[0x01, 0x00, 0x22]),
+        ..first.clone()
+    };
+
+    node.handle_received_frame(&first, &tx);
+    node.handle_received_frame(&second, &tx);
+
+    assert_eq!(node.pending_reply_source, Some(7));
+    let received = rx.try_recv().unwrap();
+    assert_eq!(received.source_mac, MacAddr::from_slice(&[7]));
+    assert_eq!(received.npdu, first.data);
+    assert!(rx.try_recv().is_err());
+    let reply = node
+        .finish_data_request(Some(Bytes::from_static(&[0x01, 0x00, 0xAA])))
+        .unwrap();
+    assert_eq!(reply.destination, 7);
+}

--- a/crates/bacnet-transport/src/mstp/reply_tests.rs
+++ b/crates/bacnet-transport/src/mstp/reply_tests.rs
@@ -39,3 +39,45 @@ fn second_data_request_cannot_replace_pending_reply_source() {
         .unwrap();
     assert_eq!(reply.destination, 7);
 }
+
+#[test]
+fn token_cannot_break_pending_reply_ownership() {
+    let (tx, mut rx) = mpsc::channel(16);
+    let config = MstpConfig {
+        this_station: 3,
+        max_master: 127,
+        max_info_frames: 1,
+        baud_rate: 9600,
+    };
+    let mut node = MasterNode::new(config).unwrap();
+    let first = MstpFrame {
+        frame_type: FrameType::BACnetDataExpectingReply,
+        destination: 3,
+        source: 7,
+        data: Bytes::from_static(&[0x01, 0x00, 0x11]),
+    };
+    let token = MstpFrame {
+        frame_type: FrameType::Token,
+        destination: 3,
+        source: 9,
+        data: Bytes::new(),
+    };
+    let second = MstpFrame {
+        source: 8,
+        data: Bytes::from_static(&[0x01, 0x00, 0x22]),
+        ..first.clone()
+    };
+
+    node.handle_received_frame(&first, &tx);
+    node.handle_received_frame(&token, &tx);
+    node.handle_received_frame(&second, &tx);
+
+    assert_eq!(node.state, MasterState::AnswerDataRequest);
+    assert_eq!(node.pending_reply_source, Some(7));
+    assert_eq!(rx.try_recv().unwrap().source_mac, MacAddr::from_slice(&[7]));
+    assert!(rx.try_recv().is_err());
+    let reply = node
+        .finish_data_request(Some(Bytes::from_static(&[0x01, 0x00, 0xAA])))
+        .unwrap();
+    assert_eq!(reply.destination, 7);
+}

--- a/crates/bacnet-transport/src/mstp/tests.rs
+++ b/crates/bacnet-transport/src/mstp/tests.rs
@@ -783,6 +783,12 @@ fn pending_reply_source_stored_on_data_expecting_reply() {
 }
 
 #[test]
+fn t_turnaround_rounds_up_to_full_bit_time() {
+    assert_eq!(calculate_t_turnaround_us(9600), 4167);
+    assert_eq!(calculate_t_turnaround_us(38_400), 1042);
+}
+
+#[test]
 fn t_slot_baud_rate_9600() {
     assert_eq!(calculate_t_slot_ms(9600), 10);
 }

--- a/crates/bacnet-transport/src/mstp/tests.rs
+++ b/crates/bacnet-transport/src/mstp/tests.rs
@@ -128,6 +128,7 @@ fn handle_data_not_expecting_reply_unicast() {
     let received = rx.try_recv().unwrap();
     assert_eq!(received.npdu, npdu_data);
     assert_eq!(received.source_mac.as_slice(), &[0u8]);
+    assert!(!received.link_layer_broadcast);
 }
 
 #[test]
@@ -152,6 +153,7 @@ fn handle_data_not_expecting_reply_broadcast() {
     assert!(node.reply_rx.is_none());
     let received = rx.try_recv().unwrap();
     assert_eq!(received.source_mac.as_slice(), &[5u8]);
+    assert!(received.link_layer_broadcast);
 }
 
 #[test]
@@ -180,6 +182,7 @@ fn handle_data_expecting_reply() {
 
     let received = rx.try_recv().unwrap();
     assert_eq!(received.npdu, vec![0x01, 0x00, 0x30]);
+    assert!(!received.link_layer_broadcast);
 }
 
 #[test]

--- a/crates/bacnet-transport/src/mstp/tests.rs
+++ b/crates/bacnet-transport/src/mstp/tests.rs
@@ -128,7 +128,7 @@ fn handle_data_not_expecting_reply_unicast() {
     let received = rx.try_recv().unwrap();
     assert_eq!(received.npdu, npdu_data);
     assert_eq!(received.source_mac.as_slice(), &[0u8]);
-    assert!(!received.link_layer_broadcast);
+    assert!(!received.link_layer_group);
 }
 
 #[test]
@@ -153,7 +153,7 @@ fn handle_data_not_expecting_reply_broadcast() {
     assert!(node.reply_rx.is_none());
     let received = rx.try_recv().unwrap();
     assert_eq!(received.source_mac.as_slice(), &[5u8]);
-    assert!(received.link_layer_broadcast);
+    assert!(received.link_layer_group);
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn handle_data_expecting_reply() {
 
     let received = rx.try_recv().unwrap();
     assert_eq!(received.npdu, vec![0x01, 0x00, 0x30]);
-    assert!(!received.link_layer_broadcast);
+    assert!(!received.link_layer_group);
 }
 
 #[test]

--- a/crates/bacnet-transport/src/port.rs
+++ b/crates/bacnet-transport/src/port.rs
@@ -31,6 +31,12 @@ pub struct ReceivedNpdu {
     pub npdu: Bytes,
     /// Source MAC address in transport-native format.
     pub source_mac: MacAddr,
+    /// Whether the NPDU arrived using the data link's broadcast destination.
+    ///
+    /// This is ingress provenance, not a conclusion about the NPDU's logical
+    /// destination: routers may legitimately send a routed unicast over a
+    /// broadcast data-link destination.
+    pub link_layer_broadcast: bool,
     /// Optional data attributes carried by the data link.
     pub data_attributes: Vec<DataAttribute>,
     /// Optional reply channel for MS/TP DataExpectingReply frames.
@@ -44,6 +50,7 @@ impl Clone for ReceivedNpdu {
         Self {
             npdu: self.npdu.clone(),
             source_mac: self.source_mac.clone(),
+            link_layer_broadcast: self.link_layer_broadcast,
             data_attributes: self.data_attributes.clone(),
             reply_tx: None, // oneshot::Sender is not Clone; clones lose the reply channel
         }
@@ -55,6 +62,7 @@ impl std::fmt::Debug for ReceivedNpdu {
         f.debug_struct("ReceivedNpdu")
             .field("npdu", &self.npdu)
             .field("source_mac", &self.source_mac)
+            .field("link_layer_broadcast", &self.link_layer_broadcast)
             .field("data_attributes", &self.data_attributes)
             .field("reply_tx", &self.reply_tx.as_ref().map(|_| "Some(Sender)"))
             .finish()

--- a/crates/bacnet-transport/src/port.rs
+++ b/crates/bacnet-transport/src/port.rs
@@ -31,12 +31,12 @@ pub struct ReceivedNpdu {
     pub npdu: Bytes,
     /// Source MAC address in transport-native format.
     pub source_mac: MacAddr,
-    /// Whether the NPDU arrived using the data link's broadcast destination.
+    /// Whether the NPDU arrived using a data-link multicast or broadcast destination.
     ///
     /// This is ingress provenance, not a conclusion about the NPDU's logical
     /// destination: routers may legitimately send a routed unicast over a
-    /// broadcast data-link destination.
-    pub link_layer_broadcast: bool,
+    /// group data-link destination.
+    pub link_layer_group: bool,
     /// Optional data attributes carried by the data link.
     pub data_attributes: Vec<DataAttribute>,
     /// Optional reply channel for MS/TP DataExpectingReply frames.
@@ -50,7 +50,7 @@ impl Clone for ReceivedNpdu {
         Self {
             npdu: self.npdu.clone(),
             source_mac: self.source_mac.clone(),
-            link_layer_broadcast: self.link_layer_broadcast,
+            link_layer_group: self.link_layer_group,
             data_attributes: self.data_attributes.clone(),
             reply_tx: None, // oneshot::Sender is not Clone; clones lose the reply channel
         }
@@ -62,7 +62,7 @@ impl std::fmt::Debug for ReceivedNpdu {
         f.debug_struct("ReceivedNpdu")
             .field("npdu", &self.npdu)
             .field("source_mac", &self.source_mac)
-            .field("link_layer_broadcast", &self.link_layer_broadcast)
+            .field("link_layer_group", &self.link_layer_group)
             .field("data_attributes", &self.data_attributes)
             .field("reply_tx", &self.reply_tx.as_ref().map(|_| "Some(Sender)"))
             .finish()

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -463,7 +463,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                             .try_send(ReceivedNpdu {
                                                 npdu,
                                                 source_mac: MacAddr::from_slice(&source_vmac),
-                                                link_layer_broadcast: msg.destination_vmac
+                                                link_layer_group: msg.destination_vmac
                                                     == Some(BROADCAST_VMAC),
                                                 data_attributes: data_attributes::from_data_options(&msg),
                                                 reply_tx: None,

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -463,6 +463,8 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                             .try_send(ReceivedNpdu {
                                                 npdu,
                                                 source_mac: MacAddr::from_slice(&source_vmac),
+                                                link_layer_broadcast: msg.destination_vmac
+                                                    == Some(BROADCAST_VMAC),
                                                 data_attributes: data_attributes::from_data_options(&msg),
                                                 reply_tx: None,
                                             })

--- a/crates/bacnet-transport/src/sc/tests.rs
+++ b/crates/bacnet-transport/src/sc/tests.rs
@@ -396,6 +396,7 @@ async fn transport_receive_preserves_data_options_as_attributes() {
         .expect("SC NPDU channel closed");
     assert_eq!(received.npdu, msg.payload);
     assert_eq!(received.source_mac.as_slice(), hub_vmac);
+    assert!(!received.link_layer_broadcast);
     assert_eq!(received.data_attributes.len(), 2);
     assert_eq!(received.data_attributes[0].option_type, 1);
     assert!(received.data_attributes[0].must_understand);

--- a/crates/bacnet-transport/src/sc/tests.rs
+++ b/crates/bacnet-transport/src/sc/tests.rs
@@ -396,7 +396,7 @@ async fn transport_receive_preserves_data_options_as_attributes() {
         .expect("SC NPDU channel closed");
     assert_eq!(received.npdu, msg.payload);
     assert_eq!(received.source_mac.as_slice(), hub_vmac);
-    assert!(!received.link_layer_broadcast);
+    assert!(!received.link_layer_group);
     assert_eq!(received.data_attributes.len(), 2);
     assert_eq!(received.data_attributes[0].option_type, 1);
     assert!(received.data_attributes[0].must_understand);

--- a/crates/bacnet-transport/src/udp_metadata.rs
+++ b/crates/bacnet-transport/src/udp_metadata.rs
@@ -15,6 +15,7 @@ pub(crate) enum IpVersion {
     V6,
 }
 
+#[derive(Debug)]
 pub(crate) struct ReceivedDatagram {
     pub len: usize,
     pub peer: SocketAddr,
@@ -131,7 +132,10 @@ impl DestinationReceiver {
             )
         };
         if result == SOCKET_ERROR {
-            return Err(io::Error::from_raw_os_error(unsafe { WSAGetLastError() }));
+            return Err(classify_recv_error(
+                unsafe { WSAGetLastError() },
+                WSAEMSGSIZE,
+            ));
         }
         if message.dwFlags & (MSG_TRUNC | MSG_CTRUNC) != 0 {
             return Err(invalid_metadata("truncated UDP payload or packet metadata"));
@@ -155,10 +159,31 @@ impl DestinationReceiver {
             os_group_delivery: Some(message.dwFlags & (MSG_BCAST | MSG_MCAST) != 0),
         })
     }
+
+    #[cfg(not(any(unix, windows)))]
+    fn try_recv_from(
+        &self,
+        _udp_socket: &UdpSocket,
+        _buf: &mut [u8],
+    ) -> io::Result<ReceivedDatagram> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "UDP destination metadata is unsupported on this platform",
+        ))
+    }
 }
 
 fn invalid_metadata(message: &'static str) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+#[cfg_attr(not(windows), allow(dead_code))]
+fn classify_recv_error(code: i32, message_too_large_code: i32) -> io::Error {
+    if code == message_too_large_code {
+        invalid_metadata("truncated UDP payload")
+    } else {
+        io::Error::from_raw_os_error(code)
+    }
 }
 
 #[cfg(unix)]
@@ -190,6 +215,25 @@ fn configure_packet_info(udp_socket: &Socket, version: IpVersion) -> io::Result<
 #[cfg(all(unix, any(target_os = "linux", target_os = "android")))]
 fn ipv4_packet_info_option() -> io::Result<(libc::c_int, libc::c_int)> {
     Ok((libc::IPPROTO_IP, libc::IP_PKTINFO))
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))
+))]
+unsafe fn unix_ipv4_destination_cmsg(_header: &libc::cmsghdr) -> io::Result<Option<Ipv4Addr>> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "IPv4 destination metadata is unsupported on this platform",
+    ))
 }
 
 #[cfg(all(
@@ -351,6 +395,14 @@ fn configure_packet_info(udp_socket: &Socket, version: IpVersion) -> io::Result<
     }
 }
 
+#[cfg(not(any(unix, windows)))]
+fn configure_packet_info(_udp_socket: &Socket, _version: IpVersion) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "UDP destination metadata is unsupported on this platform",
+    ))
+}
+
 #[cfg(windows)]
 fn windows_recv_msg(
     udp_socket: &Socket,
@@ -502,5 +554,45 @@ mod tests {
         let received = receiver.recv_from(&socket, &mut buf).await.unwrap();
         assert_eq!(&buf[..received.len], b"v6");
         assert_eq!(received.destination, IpAddr::V6(Ipv6Addr::LOCALHOST));
+    }
+
+    #[tokio::test]
+    async fn oversized_datagram_is_dropped_without_stopping_receive() {
+        let socket = Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        socket.set_nonblocking(true).unwrap();
+        let receiver = DestinationReceiver::configure(&socket, IpVersion::V4).unwrap();
+        socket
+            .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+            .unwrap();
+        let socket = UdpSocket::from_std(socket.into()).unwrap();
+        let sender = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        let destination = socket.local_addr().unwrap();
+
+        sender.send_to(&[0xAA; 64], destination).await.unwrap();
+        let mut buf = [0u8; 8];
+        assert_eq!(
+            receiver
+                .recv_from(&socket, &mut buf)
+                .await
+                .unwrap_err()
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+
+        sender.send_to(b"ok", destination).await.unwrap();
+        let received = receiver.recv_from(&socket, &mut buf).await.unwrap();
+        assert_eq!(&buf[..received.len], b"ok");
+    }
+
+    #[test]
+    fn oversized_datagram_error_is_droppable_invalid_data() {
+        assert_eq!(
+            classify_recv_error(10040, 10040).kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            classify_recv_error(12345, 10040).raw_os_error(),
+            Some(12345)
+        );
     }
 }

--- a/crates/bacnet-transport/src/udp_metadata.rs
+++ b/crates/bacnet-transport/src/udp_metadata.rs
@@ -1,0 +1,506 @@
+//! Destination-aware UDP receive support for BACnet/IP transports.
+#![allow(unsafe_code)]
+
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
+
+use socket2::Socket;
+use tokio::io::Interest;
+use tokio::net::UdpSocket;
+
+#[derive(Clone, Copy)]
+pub(crate) enum IpVersion {
+    V4,
+    #[cfg_attr(not(feature = "ipv6"), allow(dead_code))]
+    V6,
+}
+
+pub(crate) struct ReceivedDatagram {
+    pub len: usize,
+    pub peer: SocketAddr,
+    pub destination: IpAddr,
+    pub os_group_delivery: Option<bool>,
+}
+
+pub(crate) struct DestinationReceiver {
+    version: IpVersion,
+    #[cfg(windows)]
+    recv_msg: windows_sys::Win32::Networking::WinSock::LPFN_WSARECVMSG,
+}
+
+impl DestinationReceiver {
+    pub fn configure(socket: &Socket, version: IpVersion) -> io::Result<Self> {
+        configure_packet_info(socket, version)?;
+        Ok(Self {
+            version,
+            #[cfg(windows)]
+            recv_msg: windows_recv_msg(socket)?,
+        })
+    }
+
+    pub async fn recv_from(
+        &self,
+        socket: &UdpSocket,
+        buf: &mut [u8],
+    ) -> io::Result<ReceivedDatagram> {
+        socket
+            .async_io(Interest::READABLE, || self.try_recv_from(socket, buf))
+            .await
+    }
+
+    #[cfg(unix)]
+    fn try_recv_from(
+        &self,
+        udp_socket: &UdpSocket,
+        buf: &mut [u8],
+    ) -> io::Result<ReceivedDatagram> {
+        use std::mem::{size_of, zeroed};
+        use std::os::fd::AsRawFd;
+
+        let mut peer_storage: libc::sockaddr_storage = unsafe { zeroed() };
+        let mut iov = libc::iovec {
+            iov_base: buf.as_mut_ptr().cast(),
+            iov_len: buf.len(),
+        };
+        let mut control = [0usize; 16];
+        let mut message: libc::msghdr = unsafe { zeroed() };
+        message.msg_name = (&mut peer_storage as *mut libc::sockaddr_storage).cast();
+        message.msg_namelen = size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+        message.msg_iov = &mut iov;
+        message.msg_iovlen = 1;
+        message.msg_control = control.as_mut_ptr().cast();
+        message.msg_controllen = size_of::<[usize; 16]>() as _;
+
+        let received = unsafe { libc::recvmsg(udp_socket.as_raw_fd(), &mut message, 0) };
+        if received < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if message.msg_flags & (libc::MSG_TRUNC | libc::MSG_CTRUNC) != 0 {
+            return Err(invalid_metadata("truncated UDP payload or packet metadata"));
+        }
+
+        let peer = unsafe { unix_socket_addr(&peer_storage) }
+            .ok_or_else(|| invalid_metadata("missing or invalid UDP peer address"))?;
+        let destination = unsafe { unix_destination(&message, self.version) }?;
+        Ok(ReceivedDatagram {
+            len: received as usize,
+            peer,
+            destination,
+            os_group_delivery: None,
+        })
+    }
+
+    #[cfg(windows)]
+    fn try_recv_from(
+        &self,
+        udp_socket: &UdpSocket,
+        buf: &mut [u8],
+    ) -> io::Result<ReceivedDatagram> {
+        use std::mem::{size_of, zeroed};
+        use std::os::windows::io::AsRawSocket;
+        use windows_sys::Win32::Networking::WinSock::*;
+
+        let recv_msg = self
+            .recv_msg
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "WSARecvMsg unavailable"))?;
+        let mut peer_storage: SOCKADDR_STORAGE = unsafe { zeroed() };
+        let mut data = WSABUF {
+            len: u32::try_from(buf.len()).unwrap_or(u32::MAX),
+            buf: buf.as_mut_ptr(),
+        };
+        let mut control = [0usize; 16];
+        let mut message = WSAMSG {
+            name: (&mut peer_storage as *mut SOCKADDR_STORAGE).cast(),
+            namelen: size_of::<SOCKADDR_STORAGE>() as i32,
+            lpBuffers: &mut data,
+            dwBufferCount: 1,
+            Control: WSABUF {
+                len: size_of::<[usize; 16]>() as u32,
+                buf: control.as_mut_ptr().cast(),
+            },
+            dwFlags: 0,
+        };
+        let mut received = 0u32;
+        let result = unsafe {
+            recv_msg(
+                udp_socket.as_raw_socket() as SOCKET,
+                &mut message,
+                &mut received,
+                std::ptr::null_mut(),
+                None,
+            )
+        };
+        if result == SOCKET_ERROR {
+            return Err(io::Error::from_raw_os_error(unsafe { WSAGetLastError() }));
+        }
+        if message.dwFlags & (MSG_TRUNC | MSG_CTRUNC) != 0 {
+            return Err(invalid_metadata("truncated UDP payload or packet metadata"));
+        }
+
+        let peer = unsafe { windows_socket_addr(&peer_storage) }
+            .ok_or_else(|| invalid_metadata("missing or invalid UDP peer address"))?;
+        let destination = unsafe {
+            windows_destination(
+                std::slice::from_raw_parts(
+                    control.as_ptr().cast::<u8>(),
+                    message.Control.len as usize,
+                ),
+                self.version,
+            )
+        }?;
+        Ok(ReceivedDatagram {
+            len: received as usize,
+            peer,
+            destination,
+            os_group_delivery: Some(message.dwFlags & (MSG_BCAST | MSG_MCAST) != 0),
+        })
+    }
+}
+
+fn invalid_metadata(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+#[cfg(unix)]
+fn configure_packet_info(udp_socket: &Socket, version: IpVersion) -> io::Result<()> {
+    use std::mem::size_of;
+    use std::os::fd::AsRawFd;
+
+    let enabled: libc::c_int = 1;
+    let (level, option) = match version {
+        IpVersion::V4 => ipv4_packet_info_option()?,
+        IpVersion::V6 => (libc::IPPROTO_IPV6, libc::IPV6_RECVPKTINFO),
+    };
+    let result = unsafe {
+        libc::setsockopt(
+            udp_socket.as_raw_fd(),
+            level,
+            option,
+            (&enabled as *const libc::c_int).cast(),
+            size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(all(unix, any(target_os = "linux", target_os = "android")))]
+fn ipv4_packet_info_option() -> io::Result<(libc::c_int, libc::c_int)> {
+    Ok((libc::IPPROTO_IP, libc::IP_PKTINFO))
+}
+
+#[cfg(all(
+    unix,
+    any(
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )
+))]
+fn ipv4_packet_info_option() -> io::Result<(libc::c_int, libc::c_int)> {
+    Ok((libc::IPPROTO_IP, libc::IP_RECVDSTADDR))
+}
+
+#[cfg(all(
+    unix,
+    not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_vendor = "apple",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))
+))]
+fn ipv4_packet_info_option() -> io::Result<(libc::c_int, libc::c_int)> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "IPv4 destination metadata is unsupported on this platform",
+    ))
+}
+
+#[cfg(unix)]
+unsafe fn unix_socket_addr(storage: &libc::sockaddr_storage) -> Option<SocketAddr> {
+    match storage.ss_family as libc::c_int {
+        libc::AF_INET => {
+            let address = unsafe { &*(storage as *const _ as *const libc::sockaddr_in) };
+            Some(SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::from(address.sin_addr.s_addr.to_ne_bytes()),
+                u16::from_be(address.sin_port),
+            )))
+        }
+        libc::AF_INET6 => {
+            let address = unsafe { &*(storage as *const _ as *const libc::sockaddr_in6) };
+            Some(SocketAddr::V6(SocketAddrV6::new(
+                Ipv6Addr::from(address.sin6_addr.s6_addr),
+                u16::from_be(address.sin6_port),
+                address.sin6_flowinfo,
+                address.sin6_scope_id,
+            )))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(unix)]
+unsafe fn unix_destination(message: &libc::msghdr, version: IpVersion) -> io::Result<IpAddr> {
+    let mut destination = None;
+    let mut header = unsafe { libc::CMSG_FIRSTHDR(message) };
+    while !header.is_null() {
+        let current = unsafe { &*header };
+        let candidate = unsafe { unix_destination_cmsg(current, version) }?;
+        if let Some(candidate) = candidate {
+            if destination.replace(candidate).is_some() {
+                return Err(invalid_metadata("duplicate UDP destination metadata"));
+            }
+        }
+        header = unsafe { libc::CMSG_NXTHDR(message, header) };
+    }
+    destination.ok_or_else(|| invalid_metadata("missing UDP destination metadata"))
+}
+
+#[cfg(unix)]
+unsafe fn unix_destination_cmsg(
+    header: &libc::cmsghdr,
+    version: IpVersion,
+) -> io::Result<Option<IpAddr>> {
+    match version {
+        IpVersion::V4 => unsafe {
+            unix_ipv4_destination_cmsg(header).map(|address| address.map(IpAddr::V4))
+        },
+        IpVersion::V6
+            if header.cmsg_level == libc::IPPROTO_IPV6
+                && header.cmsg_type == libc::IPV6_PKTINFO =>
+        {
+            if !unix_cmsg_has_payload::<libc::in6_pktinfo>(header) {
+                return Err(invalid_metadata("short IPv6 destination metadata"));
+            }
+            let info = unsafe { &*(libc::CMSG_DATA(header) as *const libc::in6_pktinfo) };
+            Ok(Some(IpAddr::V6(Ipv6Addr::from(info.ipi6_addr.s6_addr))))
+        }
+        _ => Ok(None),
+    }
+}
+
+#[cfg(unix)]
+fn unix_cmsg_has_payload<T>(header: &libc::cmsghdr) -> bool {
+    let required = unsafe { libc::CMSG_LEN(std::mem::size_of::<T>() as _) } as usize;
+    header.cmsg_len as usize >= required
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+unsafe fn unix_ipv4_destination_cmsg(header: &libc::cmsghdr) -> io::Result<Option<Ipv4Addr>> {
+    if header.cmsg_level != libc::IPPROTO_IP || header.cmsg_type != libc::IP_PKTINFO {
+        return Ok(None);
+    }
+    if !unix_cmsg_has_payload::<libc::in_pktinfo>(header) {
+        return Err(invalid_metadata("short IPv4 destination metadata"));
+    }
+    let info = unsafe { &*(libc::CMSG_DATA(header) as *const libc::in_pktinfo) };
+    Ok(Some(Ipv4Addr::from(info.ipi_addr.s_addr.to_ne_bytes())))
+}
+
+#[cfg(any(
+    target_vendor = "apple",
+    target_os = "freebsd",
+    target_os = "dragonfly",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+unsafe fn unix_ipv4_destination_cmsg(header: &libc::cmsghdr) -> io::Result<Option<Ipv4Addr>> {
+    if header.cmsg_level != libc::IPPROTO_IP || header.cmsg_type != libc::IP_RECVDSTADDR {
+        return Ok(None);
+    }
+    if !unix_cmsg_has_payload::<libc::in_addr>(header) {
+        return Err(invalid_metadata("short IPv4 destination metadata"));
+    }
+    let address = unsafe { &*(libc::CMSG_DATA(header) as *const libc::in_addr) };
+    Ok(Some(Ipv4Addr::from(address.s_addr.to_ne_bytes())))
+}
+
+#[cfg(windows)]
+fn configure_packet_info(udp_socket: &Socket, version: IpVersion) -> io::Result<()> {
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawSocket;
+    use windows_sys::Win32::Networking::WinSock::*;
+
+    let enabled = 1u32;
+    let (level, option) = match version {
+        IpVersion::V4 => (IPPROTO_IP, IP_PKTINFO),
+        IpVersion::V6 => (IPPROTO_IPV6, IPV6_PKTINFO),
+    };
+    let result = unsafe {
+        setsockopt(
+            udp_socket.as_raw_socket() as SOCKET,
+            level,
+            option,
+            (&enabled as *const u32).cast(),
+            size_of::<u32>() as i32,
+        )
+    };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::from_raw_os_error(unsafe { WSAGetLastError() }))
+    }
+}
+
+#[cfg(windows)]
+fn windows_recv_msg(
+    udp_socket: &Socket,
+) -> io::Result<windows_sys::Win32::Networking::WinSock::LPFN_WSARECVMSG> {
+    use std::mem::size_of;
+    use std::os::windows::io::AsRawSocket;
+    use windows_sys::Win32::Networking::WinSock::*;
+
+    let mut function: LPFN_WSARECVMSG = None;
+    let mut returned = 0u32;
+    let result = unsafe {
+        WSAIoctl(
+            udp_socket.as_raw_socket() as SOCKET,
+            SIO_GET_EXTENSION_FUNCTION_POINTER,
+            (&WSAID_WSARECVMSG as *const windows_sys::core::GUID).cast(),
+            size_of::<windows_sys::core::GUID>() as u32,
+            (&mut function as *mut LPFN_WSARECVMSG).cast(),
+            size_of::<LPFN_WSARECVMSG>() as u32,
+            &mut returned,
+            std::ptr::null_mut(),
+            None,
+        )
+    };
+    if result != 0 {
+        return Err(io::Error::from_raw_os_error(unsafe { WSAGetLastError() }));
+    }
+    function
+        .map(Some)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Unsupported, "WSARecvMsg unavailable"))
+}
+
+#[cfg(windows)]
+unsafe fn windows_socket_addr(
+    storage: &windows_sys::Win32::Networking::WinSock::SOCKADDR_STORAGE,
+) -> Option<SocketAddr> {
+    use windows_sys::Win32::Networking::WinSock::*;
+
+    match storage.ss_family {
+        AF_INET => {
+            let address = unsafe { &*(storage as *const _ as *const SOCKADDR_IN) };
+            let bytes = unsafe { address.sin_addr.S_un.S_addr.to_ne_bytes() };
+            Some(SocketAddr::V4(SocketAddrV4::new(
+                Ipv4Addr::from(bytes),
+                u16::from_be(address.sin_port),
+            )))
+        }
+        AF_INET6 => {
+            let address = unsafe { &*(storage as *const _ as *const SOCKADDR_IN6) };
+            let bytes = unsafe { address.sin6_addr.u.Byte };
+            Some(SocketAddr::V6(SocketAddrV6::new(
+                Ipv6Addr::from(bytes),
+                u16::from_be(address.sin6_port),
+                address.sin6_flowinfo,
+                unsafe { address.Anonymous.sin6_scope_id },
+            )))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(windows)]
+unsafe fn windows_destination(control: &[u8], version: IpVersion) -> io::Result<IpAddr> {
+    use std::mem::size_of;
+    use windows_sys::Win32::Networking::WinSock::*;
+
+    let align = |length: usize| (length + size_of::<usize>() - 1) & !(size_of::<usize>() - 1);
+    let data_offset = align(size_of::<CMSGHDR>());
+    let mut offset = 0usize;
+    let mut destination = None;
+    while offset + size_of::<CMSGHDR>() <= control.len() {
+        let header: CMSGHDR =
+            unsafe { std::ptr::read_unaligned(control.as_ptr().add(offset).cast()) };
+        if header.cmsg_len < data_offset || offset + header.cmsg_len > control.len() {
+            return Err(invalid_metadata("invalid Windows UDP control message"));
+        }
+        let data = unsafe { control.as_ptr().add(offset + data_offset) };
+        let candidate = match version {
+            IpVersion::V4
+                if header.cmsg_level == IPPROTO_IP
+                    && header.cmsg_type == IP_PKTINFO
+                    && header.cmsg_len >= data_offset + size_of::<IN_PKTINFO>() =>
+            {
+                let info: IN_PKTINFO = unsafe { std::ptr::read_unaligned(data.cast()) };
+                let bytes = unsafe { info.ipi_addr.S_un.S_addr.to_ne_bytes() };
+                Some(IpAddr::V4(Ipv4Addr::from(bytes)))
+            }
+            IpVersion::V6
+                if header.cmsg_level == IPPROTO_IPV6
+                    && header.cmsg_type == IPV6_PKTINFO
+                    && header.cmsg_len >= data_offset + size_of::<IN6_PKTINFO>() =>
+            {
+                let info: IN6_PKTINFO = unsafe { std::ptr::read_unaligned(data.cast()) };
+                Some(IpAddr::V6(Ipv6Addr::from(unsafe { info.ipi6_addr.u.Byte })))
+            }
+            _ => None,
+        };
+        if let Some(candidate) = candidate {
+            if destination.replace(candidate).is_some() {
+                return Err(invalid_metadata("duplicate UDP destination metadata"));
+            }
+        }
+        offset = offset.saturating_add(align(header.cmsg_len));
+    }
+    destination.ok_or_else(|| invalid_metadata("missing UDP destination metadata"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn ipv4_loopback_destination_is_reported() {
+        let socket = Socket::new(socket2::Domain::IPV4, socket2::Type::DGRAM, None).unwrap();
+        socket.set_nonblocking(true).unwrap();
+        let receiver = DestinationReceiver::configure(&socket, IpVersion::V4).unwrap();
+        socket
+            .bind(&SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0).into())
+            .unwrap();
+        let socket = UdpSocket::from_std(socket.into()).unwrap();
+        let sender = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+        sender
+            .send_to(b"v4", socket.local_addr().unwrap())
+            .await
+            .unwrap();
+
+        let mut buf = [0u8; 8];
+        let received = receiver.recv_from(&socket, &mut buf).await.unwrap();
+        assert_eq!(&buf[..received.len], b"v4");
+        assert_eq!(received.destination, IpAddr::V4(Ipv4Addr::LOCALHOST));
+    }
+
+    #[tokio::test]
+    async fn ipv6_loopback_destination_is_reported() {
+        let socket = Socket::new(socket2::Domain::IPV6, socket2::Type::DGRAM, None).unwrap();
+        socket.set_only_v6(true).unwrap();
+        socket.set_nonblocking(true).unwrap();
+        let receiver = DestinationReceiver::configure(&socket, IpVersion::V6).unwrap();
+        socket
+            .bind(&SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0).into())
+            .unwrap();
+        let socket = UdpSocket::from_std(socket.into()).unwrap();
+        let sender = UdpSocket::bind((Ipv6Addr::LOCALHOST, 0)).await.unwrap();
+        sender
+            .send_to(b"v6", socket.local_addr().unwrap())
+            .await
+            .unwrap();
+
+        let mut buf = [0u8; 8];
+        let received = receiver.recv_from(&socket, &mut buf).await.unwrap();
+        assert_eq!(&buf[..received.len], b"v6");
+        assert_eq!(received.destination, IpAddr::V6(Ipv6Addr::LOCALHOST));
+    }
+}

--- a/crates/bacnet-transport/src/udp_metadata.rs
+++ b/crates/bacnet-transport/src/udp_metadata.rs
@@ -8,6 +8,47 @@ use socket2::Socket;
 use tokio::io::Interest;
 use tokio::net::UdpSocket;
 
+macro_rules! supported_unix_item {
+    ($item:item) => {
+        #[cfg(any(
+            target_os = "linux",
+            target_os = "l4re",
+            target_os = "android",
+            target_os = "emscripten",
+            target_vendor = "apple",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "solaris",
+            target_os = "illumos",
+            target_os = "nto",
+        ))]
+        $item
+    };
+}
+
+macro_rules! unsupported_udp_metadata_item {
+    ($item:item) => {
+        #[cfg(not(any(
+            windows,
+            target_os = "linux",
+            target_os = "l4re",
+            target_os = "android",
+            target_os = "emscripten",
+            target_vendor = "apple",
+            target_os = "freebsd",
+            target_os = "dragonfly",
+            target_os = "openbsd",
+            target_os = "netbsd",
+            target_os = "solaris",
+            target_os = "illumos",
+            target_os = "nto",
+        )))]
+        $item
+    };
+}
+
 #[derive(Clone, Copy)]
 pub(crate) enum IpVersion {
     V4,
@@ -49,7 +90,7 @@ impl DestinationReceiver {
             .await
     }
 
-    #[cfg(unix)]
+    supported_unix_item! {
     fn try_recv_from(
         &self,
         udp_socket: &UdpSocket,
@@ -89,6 +130,7 @@ impl DestinationReceiver {
             destination,
             os_group_delivery: None,
         })
+    }
     }
 
     #[cfg(windows)]
@@ -134,7 +176,7 @@ impl DestinationReceiver {
         if result == SOCKET_ERROR {
             return Err(classify_recv_error(
                 unsafe { WSAGetLastError() },
-                WSAEMSGSIZE,
+                &[WSAEMSGSIZE, WSAECONNRESET, WSAENETRESET],
             ));
         }
         if message.dwFlags & (MSG_TRUNC | MSG_CTRUNC) != 0 {
@@ -160,7 +202,7 @@ impl DestinationReceiver {
         })
     }
 
-    #[cfg(not(any(unix, windows)))]
+    unsupported_udp_metadata_item! {
     fn try_recv_from(
         &self,
         _udp_socket: &UdpSocket,
@@ -171,6 +213,7 @@ impl DestinationReceiver {
             "UDP destination metadata is unsupported on this platform",
         ))
     }
+    }
 }
 
 fn invalid_metadata(message: &'static str) -> io::Error {
@@ -178,15 +221,15 @@ fn invalid_metadata(message: &'static str) -> io::Error {
 }
 
 #[cfg_attr(not(windows), allow(dead_code))]
-fn classify_recv_error(code: i32, message_too_large_code: i32) -> io::Error {
-    if code == message_too_large_code {
-        invalid_metadata("truncated UDP payload")
+fn classify_recv_error(code: i32, droppable_codes: &[i32]) -> io::Error {
+    if droppable_codes.contains(&code) {
+        invalid_metadata("droppable UDP receive error")
     } else {
         io::Error::from_raw_os_error(code)
     }
 }
 
-#[cfg(unix)]
+supported_unix_item! {
 fn configure_packet_info(udp_socket: &Socket, version: IpVersion) -> io::Result<()> {
     use std::mem::size_of;
     use std::os::fd::AsRawFd;
@@ -211,6 +254,7 @@ fn configure_packet_info(udp_socket: &Socket, version: IpVersion) -> io::Result<
         Err(io::Error::last_os_error())
     }
 }
+}
 
 #[cfg(all(unix, any(target_os = "linux", target_os = "android")))]
 fn ipv4_packet_info_option() -> io::Result<(libc::c_int, libc::c_int)> {
@@ -229,11 +273,13 @@ fn ipv4_packet_info_option() -> io::Result<(libc::c_int, libc::c_int)> {
         target_os = "openbsd"
     ))
 ))]
+supported_unix_item! {
 unsafe fn unix_ipv4_destination_cmsg(_header: &libc::cmsghdr) -> io::Result<Option<Ipv4Addr>> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "IPv4 destination metadata is unsupported on this platform",
     ))
+}
 }
 
 #[cfg(all(
@@ -269,7 +315,7 @@ fn ipv4_packet_info_option() -> io::Result<(libc::c_int, libc::c_int)> {
     ))
 }
 
-#[cfg(unix)]
+supported_unix_item! {
 unsafe fn unix_socket_addr(storage: &libc::sockaddr_storage) -> Option<SocketAddr> {
     match storage.ss_family as libc::c_int {
         libc::AF_INET => {
@@ -291,8 +337,9 @@ unsafe fn unix_socket_addr(storage: &libc::sockaddr_storage) -> Option<SocketAdd
         _ => None,
     }
 }
+}
 
-#[cfg(unix)]
+supported_unix_item! {
 unsafe fn unix_destination(message: &libc::msghdr, version: IpVersion) -> io::Result<IpAddr> {
     let mut destination = None;
     let mut header = unsafe { libc::CMSG_FIRSTHDR(message) };
@@ -308,8 +355,9 @@ unsafe fn unix_destination(message: &libc::msghdr, version: IpVersion) -> io::Re
     }
     destination.ok_or_else(|| invalid_metadata("missing UDP destination metadata"))
 }
+}
 
-#[cfg(unix)]
+supported_unix_item! {
 unsafe fn unix_destination_cmsg(
     header: &libc::cmsghdr,
     version: IpVersion,
@@ -331,11 +379,13 @@ unsafe fn unix_destination_cmsg(
         _ => Ok(None),
     }
 }
+}
 
-#[cfg(unix)]
+supported_unix_item! {
 fn unix_cmsg_has_payload<T>(header: &libc::cmsghdr) -> bool {
     let required = unsafe { libc::CMSG_LEN(std::mem::size_of::<T>() as _) } as usize;
     header.cmsg_len as usize >= required
+}
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -395,12 +445,13 @@ fn configure_packet_info(udp_socket: &Socket, version: IpVersion) -> io::Result<
     }
 }
 
-#[cfg(not(any(unix, windows)))]
+unsupported_udp_metadata_item! {
 fn configure_packet_info(_udp_socket: &Socket, _version: IpVersion) -> io::Result<()> {
     Err(io::Error::new(
         io::ErrorKind::Unsupported,
         "UDP destination metadata is unsupported on this platform",
     ))
+}
 }
 
 #[cfg(windows)]
@@ -585,13 +636,21 @@ mod tests {
     }
 
     #[test]
-    fn oversized_datagram_error_is_droppable_invalid_data() {
+    fn windows_recoverable_receive_errors_are_droppable_invalid_data() {
         assert_eq!(
-            classify_recv_error(10040, 10040).kind(),
+            classify_recv_error(10040, &[10040, 10054, 10052]).kind(),
             io::ErrorKind::InvalidData
         );
         assert_eq!(
-            classify_recv_error(12345, 10040).raw_os_error(),
+            classify_recv_error(10054, &[10040, 10054, 10052]).kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            classify_recv_error(10052, &[10040, 10054, 10052]).kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            classify_recv_error(12345, &[10040, 10054, 10052]).raw_os_error(),
             Some(12345)
         );
     }

--- a/crates/bacnet-types/src/enums/protocol.rs
+++ b/crates/bacnet-types/src/enums/protocol.rs
@@ -280,6 +280,7 @@ bacnet_enum! {
     const TOO_MANY_ARGUMENTS = 7;
     const UNDEFINED_ENUMERATION = 8;
     const UNRECOGNIZED_SERVICE = 9;
+    const INVALID_DATA_ENCODING = 10;
 }
 
 bacnet_enum! {


### PR DESCRIPTION
Closes #374

## Summary

- Return `Reject(UNRECOGNIZED_SERVICE)` for complete, unsegmented, unicast ConfirmedRequest APDUs without a client-mode handler, preserving the invoke ID and routed reply identity.
- Return a server-side `Abort(SEGMENTATION_NOT_SUPPORTED)` for inbound segmented ConfirmedRequests because this client does not implement responder-side request reassembly.
- Keep confirmed multicast, broadcast, and other group deliveries silent while preserving a routed unicast whose data-link next hop happens to be group-addressed.
- Classify malformed ConfirmedCOVNotification bodies before application delivery with the applicable Clause 18.9 Reject reason, including `INVALID_DATA_ENCODING (10)` for malformed or non-minimal parameter representations.
- Use the immediate MS/TP reply channel for DataExpectingReply. Ready responses wake the transport immediately; otherwise ReplyPostponed is scheduled once from the first request's final received octet with turnaround and transmission margin before `T_reply_delay`. Later traffic cannot replace the in-flight source, state, or deadline.
- Validate actual UDP destination metadata before B/IP or B/IP6 application delivery. Wildcard binds accept all enumerated local interface addresses without admitting IPv4 directed broadcasts; B/IP management is unicast-only; and missing, duplicate, truncated, group-mismatched, or unavailable metadata fails closed. Oversized datagrams and recoverable Windows UDP reset errors are dropped without terminating receive.
- Harden B/IP6 ingress and address state: all Table U-1 fixed-frame lengths; function-aware IP and Destination-VMAC gates; valid Device-0 VMAC support; OS-random H.7.2 VMACs and fail-closed direct-network collision handling; a truly bounded 4,096-entry scoped mapping table; and implemented AR/VAR validation and reply behavior.
- Correct Annex U Forwarded-NPDU to the single-VMAC wire layout and original 18-byte source identity. Accept it only on BACnet multicast or from the configured non-link-local foreign-device BBMD, require a valid NPDU and usable unicast origin before learning, and reject link-local, unspecified, multicast, or zero-port origins.

## Standard anchors

- ASHRAE 135-2020 Clause 5.4.5.1: confirmed multicast/broadcast requests are discarded; a responder without segmented-request reception sends a server Abort with `SEGMENTATION_NOT_SUPPORTED`.
- Clauses 6.3 and 6.5.3: routed replies reverse SNET/SADR into DNET/DADR; a group next hop can carry a specific routed-unicast destination.
- Clause 9.5.6.9 and `T_reply_delay`: an MS/TP response or ReplyPostponed begins within the reply-delay limit.
- Clause 13.6 and Table 13-10: ConfirmedCOVNotification parameters are mandatory and list-of-values contains one or more values.
- Clause 18.9 and Clause 21 `BACnetRejectReason`: Reject taxonomy includes `INVALID_DATA_ENCODING (10)` and `UNRECOGNIZED_SERVICE`.
- Clauses 20.1.8 and 20.2: Reject framing and minimal Unsigned encoding.
- Annex J.2.5, J.2.10-J.2.12, J.3, and J.4.5: Forwarded-NPDU, distributed/original broadcast, Original-Unicast, and directed/broadcast delivery behavior.
- Annex U Table U-1; U.2.4, U.2.6-U.2.9; U.3; and U.5: B/IP6 frame layouts, AR/VAR exchanges, unicast Destination-VMAC filtering, Forwarded-NPDU source fields, and VMAC/address learning.
- Clause H.7.2: Device-instance and Random Device Instance VMAC ranges, including valid VMAC `X'000000'` for Device instance 0.

## Behavior matrix

| Input | Result |
| --- | --- |
| Complete local or routed unicast, unsupported or unknown service | `Reject(UNRECOGNIZED_SERVICE)` |
| Missing ConfirmedCOVNotification body or later mandatory field | `Reject(MISSING_REQUIRED_PARAMETER)`, no delivery |
| Invalid COV tag / representation / empty list / extra argument | Typed `INVALID_TAG` / `INVALID_DATA_ENCODING` / `PARAMETER_OUT_OF_RANGE` / `TOO_MANY_ARGUMENTS`, no delivery |
| COV list exceeds `MAX_DECODED_ITEMS` | `Reject(BUFFER_OVERFLOW)`, no delivery |
| Segmented unicast ConfirmedRequest | Server `Abort(SEGMENTATION_NOT_SUPPORTED)` |
| Link, remote, global, or multicast-group ConfirmedRequest | No response |
| Valid ConfirmedCOVNotification | Existing configured ACK/Reject/NoResponse policy |
| B/IP Original-Unicast delivered to an IP group destination | Drop before application delivery |
| B/IP management request/result/ack delivered to an IP group destination | Drop before response or state mutation |
| B/IP6 unicast function with wrong IP destination or Destination-VMAC | Drop before learning/application handling |
| Trusted, conformant B/IP6 Forwarded-NPDU | Group delivery with original 18-byte source; validated origin learned |
| Untrusted, malformed, link-local, loopback, IPv4-mapped, unspecified, multicast, or zero-port Forwarded-NPDU origin | Drop before learning/delivery |
| Direct-network B/IP6 without configured Device instance | Generate an OS-random H.7.2 VMAC; answer peer probes; regenerate on collision; fail startup atomically on probe error or at the bounded retry limit |
| Foreign-device B/IP6 without configured Device instance | Fail startup until BBMD-assisted random-VMAC resolution is implemented |
| Direct-network configured duplicate or out-of-range Device instance | Fail startup without changing identity |
| MS/TP DataExpectingReply | Immediate data response, or ReplyPostponed before `T_reply_delay` |

## Safety and compatibility

`ReceivedNpdu` now records `link_layer_group`, and `ReceivedApdu` records the effective `is_group` result after NPDU decoding. These are public envelope fields in pre-1.0 crates; downstream custom transports and exhaustive struct literals must initialize them. The public Forwarded-NPDU payload decoder now returns the original B/IPv6 address and NPDU because the original VMAC is already in the BVLC6 header. The public `generate_random_vmac` helper now returns `Result<Bip6Vmac, Error>` so entropy failure cannot silently choose an identity. `RejectReason::INVALID_DATA_ENCODING` is a source-compatible associated-constant addition.

Destination metadata is enabled before transport startup and received through Tokio readiness. Unix wildcard binds enumerate local interface addresses only on targets whose libc exposes the required APIs; unsupported targets still compile and fail startup. Windows uses `WSARecvMsg` delivery flags. A platform that cannot provide safe destination metadata fails startup. Windows builds gain a direct `windows-sys 0.61` dependency; Tokio's `test-util` feature is dev-only. Native Windows packet-metadata runtime CI is unavailable, so this head carries Windows cross-compilation and pure error-classification coverage. Unix interface addresses are snapshotted at startup, so later interface changes require transport restart.

B/IP6 outbound unicast reports `AddrNotAvailable` until the destination VMAC has been learned. Automatic outbound Address-Resolution for an unknown destination VMAC, required by U.5, remains unimplemented. Forwarded-Address-Resolution is deliberately dropped before learning because that function is not implemented in this slice. The three fixed BACnet multicast groups are supported; arbitrary configured multicast groups are not. Foreign-device mode currently requires a configured Device instance because BBMD-assisted random-VMAC resolution is not implemented. Link-local foreign-device BBMD configuration and forwarded link-local origins are rejected because the public 18-byte address/configuration lacks an unambiguous scope; loopback and IPv4-mapped forwarded origins are also rejected as unusable remote identities. The VMAC table has a hard 4,096-entry cap and no expiry policy.

The explicit ConfirmedCOVNotification `NoResponse` policy remains intentional. This PR does not add ConfirmedEventNotification handling (#193), responder-side segmented-request reassembly, request rate limiting, or a general syntax classifier for other handled confirmed services.

## Files

- `CHANGELOG.md`, `Cargo.lock`, `crates/bacnet-transport/Cargo.toml`: behavior/compatibility notes, direct Windows dependency, and dev-only Tokio test feature.
- `crates/bacnet-types/src/enums/protocol.rs`: Clause 21 `INVALID_DATA_ENCODING (10)` Reject reason.
- `crates/bacnet-client/src/client/{dispatch.rs,lifecycle.rs,mod.rs,confirmed_request_dispatch_tests.rs}`: group gate, Reject/Abort dispatch, typed COV failures, immediate reply use, and regressions.
- `crates/bacnet-services/src/{cov.rs,cov_decode.rs,cov_width_tests.rs,lib.rs}`: compatible COV API plus detailed Reject taxonomy, minimal encoding, and list bounds.
- `crates/bacnet-network/src/{layer.rs,layer_delivery_tests.rs,router/mod.rs}`: preserve effective group delivery while retaining routed-unicast precedence.
- `crates/bacnet-transport/src/{port.rs,udp_metadata.rs,local_addresses.rs,lib.rs}`: public ingress provenance, bounded interface discovery, and fail-closed Unix/Windows destination-aware receive.
- `crates/bacnet-transport/src/bip/{mod.rs,io.rs,original_tests.rs,dbtn_tests.rs,forwarded_tests.rs}`: validate IPv4 destination/class before BVLL delivery while preserving wildcard binds.
- `crates/bacnet-transport/src/bip6/{frame.rs,ingress.rs,mod.rs,port.rs,vmac_table.rs,tests.rs,safety_tests.rs,vmac_generation_tests.rs}`: exact codecs, random/fail-closed VMAC selection, function-aware provenance, bounded scoped learning, trusted Forwarded-NPDU, and unresolved-unicast failure.
- `crates/bacnet-transport/src/ethernet/{mod.rs,tests.rs}`, `crates/bacnet-transport/src/loopback.rs`, and `crates/bacnet-transport/src/sc/{mod.rs,tests.rs}`: populate group provenance and recognize IEEE group destinations, with transport regressions.
- `crates/bacnet-transport/src/mstp/{mod.rs,port.rs,port_timing_tests.rs,reply_tests.rs,tests.rs}`: immediate/deadline replies, state binding, turnaround rounding, and timing regressions.
- `crates/bacnet-server/src/server/{lifecycle.rs,segmentation_tests/mod.rs}`: preserve the expanded delivery envelope during synthetic reassembly and tests.

## Test evidence

Red before the original implementation:

- `cargo test -p bacnet-client confirmed_request --locked` — response-required cases timed out while broadcast-silence cases passed.

Review blockers reproduced before correction included IP-group Original-Unicast and management delivery, foreign Destination-VMAC learning, malformed COV taxonomy, delayed/cross-peer/deadline-extending MS/TP replies, Windows oversized/reset-error receive termination, deterministic/colliding H.7.2 identity selection, incomplete fixed-frame lengths, link-local scope loss, unusable Forwarded-NPDU origins, unbounded reverse VMAC state, untrusted Forwarded-NPDU poisoning, nonstandard Forwarded-NPDU framing, wildcard-bind narrowing, partially usable failed B/IP6 startup, random-identity foreign-device startup without BBMD-assisted resolution, forwarded loopback redirection, and unsupported-Unix compile failures.

Green locally at `451e4d640c043abec4757048be2cb0b94a017353`:

- `cargo test -q --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls,bacnet-transport/serial,bacnet-transport/ethernet` — 3,101 passed, 0 failed, 2 ignored.
- Focused COV suite: 24 passed; client invalid-encoding wire Reject regression passed.
- `cargo test -q -p bacnet-transport --features ipv6,serial,ethernet --locked` — 388 passed; public API tests 2 passed; one doctest ignored.
- `cargo test -q -p bacnet-transport --features ipv6 bip6:: --locked` — 42 passed, including atomic failed-start and foreign-device/forwarded-origin regressions.
- `cargo test -q -p bacnet-transport udp_metadata --features ipv6 --locked` — 4 passed.
- `cargo check -p bacnet-transport --features ipv6 --target x86_64-pc-windows-gnu --locked`
- `cargo check -p bacnet-transport --features ipv6,serial,ethernet --target x86_64-unknown-linux-gnu --locked`
- `cargo clippy -q --workspace --exclude rusty-bacnet --all-targets --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls,bacnet-transport/serial,bacnet-transport/ethernet`
- `cargo fmt --all --check`, `bash .github/scripts/check-file-size.sh`, `bash .github/scripts/check-no-secrets.sh`, and `git diff --check` pass.

This control-path correctness change does not warrant a performance benchmark. No README, PICS, BIBB, CI, or public support claim is broadened.

## Immutable-head review evidence

All final lanes reviewed immutable head `451e4d640c043abec4757048be2cb0b94a017353` against base `043290400c65be4e4915cc9abbd92ccaa63582a2` and returned READY:

- **Required Sol/xhigh safety/reliability:** READY. Verified fail-closed random-VMAC probing, peer AR handling, atomic startup failure, target-gated interface discovery, forwarded-origin rejection, bounded state, and the documented operational limits; no blocking safety, reliability, or interoperability finding.
- **BACnet standards/reference:** READY. Clause 5/6/9/13/18/20, Annex J, Annex U, and H.7.2 behavior and claims are correctly scoped. Random-identity foreign-device startup safely rejects the unsupported BBMD-assisted resolution variant.
- **Correctness and safety/interop:** READY. The prior partial-socket, forwarded-loopback, VMAC-table, MS/TP ownership/deadline, and reflection blockers are closed; the collision regression passed repeated runs.
- **Independent verification:** READY. Exact detached-head runs passed 6 VMAC tests, 42 B/IP6 tests, 433 full-feature transport tests, 3,101 workspace tests, formatting, file-size, secret scan, base-to-head diff check, full-workspace Clippy, and affected Linux/Windows/Apple checks. Hosted run `32349865477` is green at the exact SHA.
- **Release readiness:** READY with documented risks. Public API migrations require the next pre-1.0 minor; native Windows metadata runtime and unsupported-Unix runtime remain unavailable, while cross-compilation/fallback structure pass.
- **PR packaging:** READY. The 44-file inventory, issue closure, Standard anchors, compatibility notes, limitations, test evidence, and no-benchmark/no-support-claim decisions reconcile.
