### PR TITLE
fix(server): gate dispatch truth constants to tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Test-only server dispatch truth-chain constants are now compiled and
+  re-exported only for tests, removing their three non-test unused-code
+  warnings while preserving the PICS services-supported cross-check (#359).
+
 - Client-mode responders now return `Reject(UNRECOGNIZED_SERVICE)` for
   complete unicast ConfirmedRequest APDUs without a handler (#374), preserve
   routed reply addressing, send ready MS/TP responses immediately (or

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -939,6 +939,7 @@ mod dispatch;
 mod event_notifications;
 mod lifecycle;
 mod requests;
+#[cfg(test)]
 pub(crate) use requests::{EXECUTED_CONFIRMED, EXECUTED_UNCONFIRMED};
 mod responses;
 mod segmentation;

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -1,8 +1,10 @@
 use super::*;
 
 mod unconfirmed;
+#[cfg(test)]
 pub(crate) use unconfirmed::EXECUTED_UNCONFIRMED;
 
+#[cfg(test)]
 /// Every confirmed service choice with an inbound execution arm in
 /// `handle_confirmed_request` below. Keep in lockstep with the `match` —
 /// the `executed_services_match_dispatch_table` test compares this list

--- a/crates/bacnet-server/src/server/requests/unconfirmed.rs
+++ b/crates/bacnet-server/src/server/requests/unconfirmed.rs
@@ -1,10 +1,11 @@
 //! Unconfirmed-service dispatch (Who-Is, Who-Has, time sync, WriteGroup,
-//! UnconfirmedTextMessage) — see [`EXECUTED_UNCONFIRMED`].
+//! UnconfirmedTextMessage) — see `EXECUTED_UNCONFIRMED`.
 //!
 //! Split out of `requests.rs` to keep every file under the 700-LOC cap.
 
 use super::super::*;
 
+#[cfg(test)]
 /// Every unconfirmed service choice with an inbound execution arm in
 /// `handle_unconfirmed_request` below. Keep in lockstep with the dispatch
 /// chain — see `EXECUTED_CONFIRMED` in `requests/mod.rs` for the cross-check


### PR DESCRIPTION
## Summary

- compile the confirmed and unconfirmed dispatch truth-chain constants only in test builds
- gate their internal re-exports at the same boundary
- preserve the PICS services-supported cross-check while removing three non-test unused-code warnings

Closes #359.

## Scope

- `crates/bacnet-server/src/server/requests/mod.rs`: gate `EXECUTED_CONFIRMED` and the unconfirmed re-export
- `crates/bacnet-server/src/server/requests/unconfirmed.rs`: gate `EXECUTED_UNCONFIRMED` and render its cfg(test)-only module-doc reference as plain code
- `crates/bacnet-server/src/server/mod.rs`: gate the test-only server re-export
- `CHANGELOG.md`: record the build-hygiene fix

No runtime dispatch, service advertisement, public API, wire behavior, PICS capability, BIBB, or CI configuration changes.

## Evidence

Red baseline at base `02c98a0c50e4a39baf9b05bbf3cf1b2fa307c98f`:

- `cargo clippy -p bacnet-server --lib --locked --message-format short` produced 62 server-library warnings, including the unused re-export and two dead constants.

Green verification:

- `cargo fmt --all --check`
- `cargo test -q -p bacnet-server executed_services_match_dispatch_table --locked` — 1 passed
- `RUSTFLAGS=-Awarnings cargo test -q -p bacnet-server --locked` — 462 passed
- `cargo clippy -p bacnet-server --lib --locked --message-format short` — 59 pre-existing unrelated warnings; all three `EXECUTED_*` warnings absent
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked --message-format short` — completed successfully; no `EXECUTED_*` warning
- `cargo doc -p bacnet-server --no-deps --document-private-items --locked` — completed; the `EXECUTED_UNCONFIRMED` dangling-link warning is absent, while unrelated pre-existing rustdoc warnings remain
- `git diff --check`

The four initial socket-based test failures under the restricted sandbox were rerun with loopback socket permission and passed; they were environment-only `PermissionDenied` failures.

## Standards and compatibility

This is the W11 build-hygiene item in the active compliance work plan and has no normative BACnet clause. The constants remain available to the crate test build, so the three-way dispatch → `BACnetServicesSupported` → Device/PICS truth-chain assertion is unchanged. The affected items are `pub(crate)` and test-only in purpose; downstream compatibility is unchanged.

## Immutable-head review evidence

All decisions below apply to exact head `52c896444f0c30502b2ea93f202a1fe81df7a755` against base `02c98a0c50e4a39baf9b05bbf3cf1b2fa307c98f`.

- **Sol/xhigh safety and correctness — READY.** The review found that `cfg(test)` made the module-level `EXECUTED_UNCONFIRMED` intra-doc link unavailable to non-test rustdoc. This head renders that private reference as plain code. `cargo doc -p bacnet-server --no-deps --document-private-items --locked`, the PICS truth-chain test, and `git diff --check` pass; no runtime, wire, API, PICS, or reliability behavior changed.
- **Test verification — READY.** The prior dangling-link warning was reproduced and is absent at this head. The focused truth-chain test passed 1/1, the non-test all-feature server check, rustfmt, and base-to-head diff check passed, and hosted CI run `32351212756` passed Ubuntu tests, Clippy, rustfmt, file-size, and no-secret checks. Prior unchanged-code evidence includes 462/462 server tests and removal of the three intended non-test `EXECUTED_*` warnings. Unrelated pre-existing rustdoc warnings remain out of scope.
- **Release readiness — READY.** The sole affected-head delta is documentation-only; no compatibility, migration, rollback, runtime, or public-support impact remains.
- **Packaging — READY.** The four-file inventory, issue #359 closure, red/green evidence, compatibility statement, and non-normative W11 scope are complete and truthful.