### PR TITLE
Fix GetEnrollmentSummary wire types and filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GetEnrollmentSummary now uses its Clause 13.11 service-specific Event State
+  Filter values (`OFFNORMAL`, `FAULT`, `NORMAL`, `ALL`, and `ACTIVE`) instead
+  of interpreting them as `EventState`; omission correctly defaults to `ALL`,
+  and undefined filter values are rejected before encoding or handler
+  evaluation (#358). The request's Notification Class filter and the ACK's
+  optional Notification Class now use the full `u32` BACnet Unsigned model.
+  ACK decoding preserves absent versus explicit zero and re-encoding no longer
+  inserts a zero field that was absent on the wire (#176). This retypes the
+  public Rust request/ACK fields and replaces the Python method's `EventState`
+  parameter with `EnrollmentSummaryEventStateFilter`; Python results expose an
+  omitted Notification Class as `None`.
+
 - Test-only server dispatch truth-chain constants are now compiled and
   re-exported only for tests, removing their three non-test unused-code
   warnings while preserving the PICS services-supported cross-check (#359).

--- a/crates/bacnet-server/src/handlers/alarm_event/get_enrollment_summary.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/get_enrollment_summary.rs
@@ -16,6 +16,7 @@ pub fn handle_get_enrollment_summary(
     use bacnet_services::enrollment_summary::{
         EnrollmentSummaryEntry, GetEnrollmentSummaryAck, GetEnrollmentSummaryRequest,
     };
+    use bacnet_types::enums::EnrollmentSummaryEventStateFilter;
 
     let request = GetEnrollmentSummaryRequest::decode(service_data)?;
 
@@ -41,17 +42,32 @@ pub fn handle_get_enrollment_summary(
             })
             .unwrap_or(0);
 
-        if let Some(filter_state) = request.event_state_filter {
-            if event_state != filter_state.to_raw() {
-                continue;
+        let event_state_matches = match request.event_state_filter {
+            None => true,
+            Some(filter) if filter == EnrollmentSummaryEventStateFilter::ALL => true,
+            Some(filter) if filter == EnrollmentSummaryEventStateFilter::ACTIVE => {
+                event_state != bacnet_types::enums::EventState::NORMAL.to_raw()
             }
+            Some(filter) if filter == EnrollmentSummaryEventStateFilter::OFFNORMAL => {
+                event_state == bacnet_types::enums::EventState::OFFNORMAL.to_raw()
+            }
+            Some(filter) if filter == EnrollmentSummaryEventStateFilter::FAULT => {
+                event_state == bacnet_types::enums::EventState::FAULT.to_raw()
+            }
+            Some(filter) if filter == EnrollmentSummaryEventStateFilter::NORMAL => {
+                event_state == bacnet_types::enums::EventState::NORMAL.to_raw()
+            }
+            Some(_) => false,
+        };
+        if !event_state_matches {
+            continue;
         }
 
         let notification_class = object
             .read_property(PropertyIdentifier::NOTIFICATION_CLASS, None)
             .ok()
             .and_then(|v| match v {
-                PropertyValue::Unsigned(n) => Some(n as u16),
+                PropertyValue::Unsigned(n) => u32::try_from(n).ok(),
                 _ => None,
             })
             .unwrap_or(0);
@@ -66,7 +82,7 @@ pub fn handle_get_enrollment_summary(
             // Look up priority from the notification class object for the current event state
             let priority = ObjectIdentifier::new(
                 bacnet_types::enums::ObjectType::NOTIFICATION_CLASS,
-                notification_class as u32,
+                notification_class,
             )
             .ok()
             .and_then(|nc_oid| db.get(&nc_oid))
@@ -86,16 +102,12 @@ pub fn handle_get_enrollment_summary(
             }
         }
 
-        if event_state == 0 && request.event_state_filter.is_none() {
-            continue;
-        }
-
         entries.push(EnrollmentSummaryEntry {
             object_identifier: oid,
             event_type: bacnet_types::enums::EventType::CHANGE_OF_STATE,
             event_state: bacnet_types::enums::EventState::from_raw(event_state),
             priority: 0,
-            notification_class,
+            notification_class: Some(notification_class),
         });
     }
 

--- a/crates/bacnet-server/src/handlers/tests/enrollment_summary_filters.rs
+++ b/crates/bacnet-server/src/handlers/tests/enrollment_summary_filters.rs
@@ -1,0 +1,115 @@
+//! GetEnrollmentSummary Event State Filter semantics (Clause 13.11.1.1).
+
+use super::*;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_services::enrollment_summary::{GetEnrollmentSummaryAck, GetEnrollmentSummaryRequest};
+use bacnet_types::enums::EnrollmentSummaryEventStateFilter;
+
+struct EnrollmentAtState {
+    oid: ObjectIdentifier,
+    event_state: EventState,
+}
+
+impl BACnetObject for EnrollmentAtState {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "EnrollmentAtState"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        match property {
+            p if p == PropertyIdentifier::EVENT_STATE => {
+                Ok(PropertyValue::Enumerated(self.event_state.to_raw()))
+            }
+            p if p == PropertyIdentifier::EVENT_DETECTION_ENABLE => {
+                Ok(PropertyValue::Boolean(true))
+            }
+            p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(7)),
+            _ => Err(Error::Protocol {
+                class: bacnet_types::enums::ErrorClass::PROPERTY.to_raw() as u32,
+                code: bacnet_types::enums::ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            }),
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: bacnet_types::enums::ErrorClass::PROPERTY.to_raw() as u32,
+            code: bacnet_types::enums::ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> std::borrow::Cow<'static, [PropertyIdentifier]> {
+        static PROPERTIES: &[PropertyIdentifier] = &[
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+        ];
+        std::borrow::Cow::Borrowed(PROPERTIES)
+    }
+}
+
+fn entry_count(actual: EventState, filter_raw: Option<u32>) -> usize {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(EnrollmentAtState {
+        oid: ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap(),
+        event_state: actual,
+    }))
+    .unwrap();
+
+    let request = GetEnrollmentSummaryRequest {
+        acknowledgment_filter: 0,
+        enrollment_filter: None,
+        event_state_filter: filter_raw.map(EnrollmentSummaryEventStateFilter::from_raw),
+        event_type_filter: None,
+        priority_filter: None,
+        notification_class_filter: None,
+    };
+    let mut request_bytes = BytesMut::new();
+    request.encode(&mut request_bytes);
+    let mut response = BytesMut::new();
+    handle_get_enrollment_summary(&db, &request_bytes, &mut response).unwrap();
+    let ack = GetEnrollmentSummaryAck::decode(&response).unwrap();
+    assert!(ack
+        .entries
+        .iter()
+        .all(|entry| entry.notification_class == Some(7)));
+    ack.entries.len()
+}
+
+#[test]
+fn event_state_filter_values_have_service_specific_meanings() {
+    assert_eq!(entry_count(EventState::OFFNORMAL, Some(0)), 1);
+    assert_eq!(entry_count(EventState::NORMAL, Some(0)), 0);
+
+    assert_eq!(entry_count(EventState::FAULT, Some(1)), 1);
+
+    assert_eq!(entry_count(EventState::NORMAL, Some(2)), 1);
+    assert_eq!(entry_count(EventState::OFFNORMAL, Some(2)), 0);
+
+    assert_eq!(entry_count(EventState::NORMAL, Some(3)), 1);
+    assert_eq!(entry_count(EventState::HIGH_LIMIT, Some(3)), 1);
+
+    assert_eq!(entry_count(EventState::FAULT, Some(4)), 1);
+    assert_eq!(entry_count(EventState::HIGH_LIMIT, Some(4)), 1);
+    assert_eq!(entry_count(EventState::NORMAL, Some(4)), 0);
+}
+
+#[test]
+fn omitted_event_state_filter_defaults_to_all() {
+    assert_eq!(entry_count(EventState::NORMAL, None), 1);
+    assert_eq!(entry_count(EventState::HIGH_LIMIT, None), 1);
+}

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -38,6 +38,7 @@ mod array_index_gating;
 mod async_dcc;
 mod detection_enable_summary;
 mod device_event;
+mod enrollment_summary_filters;
 mod framed_properties;
 mod life_safety_operation;
 mod multi_element_writes;

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -644,12 +644,18 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             }
         }
     }
-    /// Convert an Error into an Error APDU.
-    fn error_apdu_from_error(
+    /// Convert an error into its protocol response APDU.
+    pub(super) fn error_apdu_from_error(
         invoke_id: u8,
         service_choice: ConfirmedServiceChoice,
         error: &Error,
     ) -> Apdu {
+        if let Error::Reject { reason } = error {
+            return Apdu::Reject(RejectPdu {
+                invoke_id,
+                reject_reason: RejectReason::from_raw(*reason),
+            });
+        }
         let (class, code) = match error {
             Error::Protocol { class, code } => (*class, *code),
             _ => (

--- a/crates/bacnet-server/src/server/tests.rs
+++ b/crates/bacnet-server/src/server/tests.rs
@@ -424,6 +424,24 @@ fn seg_key_distinguishes_routed_sources_behind_same_router() {
     assert_ne!(key_a, key_b);
 }
 
+#[test]
+fn service_reject_error_preserves_reason_on_wire_response() {
+    let response = BACnetServer::<BipTransport>::error_apdu_from_error(
+        0x31,
+        ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY,
+        &Error::Reject {
+            reason: RejectReason::UNDEFINED_ENUMERATION.to_raw(),
+        },
+    );
+    assert_eq!(
+        response,
+        Apdu::Reject(RejectPdu {
+            invoke_id: 0x31,
+            reject_reason: RejectReason::UNDEFINED_ENUMERATION,
+        })
+    );
+}
+
 #[tokio::test]
 async fn reply_tx_response_preserves_routed_npdu_destination() {
     use bacnet_encoding::apdu::decode_apdu;

--- a/crates/bacnet-services/src/enrollment_summary.rs
+++ b/crates/bacnet-services/src/enrollment_summary.rs
@@ -1,8 +1,8 @@
-//! GetEnrollmentSummary service per ASHRAE 135-2020 Clause 13.8.
+//! GetEnrollmentSummary service per ASHRAE 135-2020 Clause 13.11.
 
 use bacnet_encoding::primitives;
 use bacnet_encoding::tags;
-use bacnet_types::enums::{EventState, EventType};
+use bacnet_types::enums::{EnrollmentSummaryEventStateFilter, EventState, EventType};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bytes::BytesMut;
@@ -44,13 +44,13 @@ pub struct GetEnrollmentSummaryRequest {
     /// [1] enrollmentFilter (optional) — BACnetRecipientProcess.
     pub enrollment_filter: Option<RecipientProcess>,
     /// [2] eventStateFilter (optional).
-    pub event_state_filter: Option<EventState>,
+    pub event_state_filter: Option<EnrollmentSummaryEventStateFilter>,
     /// [3] eventTypeFilter (optional).
     pub event_type_filter: Option<EventType>,
     /// [4] priorityFilter { [0] minPriority, [1] maxPriority } (optional).
     pub priority_filter: Option<PriorityFilter>,
     /// [5] notificationClassFilter (optional).
-    pub notification_class_filter: Option<u16>,
+    pub notification_class_filter: Option<u32>,
 }
 
 impl GetEnrollmentSummaryRequest {
@@ -58,7 +58,8 @@ impl GetEnrollmentSummaryRequest {
     ///
     /// # Panics
     ///
-    /// Panics if an enrollment filter has no device.
+    /// Panics if an enrollment filter has no device or an event-state filter
+    /// contains a value outside the service-defined enumeration.
     pub fn encode(&self, buf: &mut BytesMut) {
         self.try_encode(buf)
             .expect("invalid GetEnrollmentSummary request");
@@ -73,6 +74,13 @@ impl GetEnrollmentSummaryRequest {
         {
             return Err(Error::Encoding(
                 "EnrollmentSummary enrollmentFilter requires a device".into(),
+            ));
+        }
+        if self.event_state_filter.is_some_and(|filter| {
+            filter.to_raw() > EnrollmentSummaryEventStateFilter::ACTIVE.to_raw()
+        }) {
+            return Err(Error::Encoding(
+                "EnrollmentSummary eventStateFilter is an undefined enumeration".into(),
             ));
         }
         // [0] acknowledgmentFilter
@@ -211,9 +219,15 @@ impl GetEnrollmentSummaryRequest {
         let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 2)?;
         if let Some(content) = opt_data {
             let value = primitives::decode_unsigned(content)?;
-            event_state_filter = Some(EventState::from_raw(u32::try_from(value).map_err(
-                |_| Error::decoding(offset, "EnrollmentSummary eventStateFilter exceeds u32"),
-            )?));
+            let value = u32::try_from(value).map_err(|_| {
+                Error::decoding(offset, "EnrollmentSummary eventStateFilter exceeds u32")
+            })?;
+            if value > EnrollmentSummaryEventStateFilter::ACTIVE.to_raw() {
+                return Err(Error::Reject {
+                    reason: bacnet_types::enums::RejectReason::UNDEFINED_ENUMERATION.to_raw(),
+                });
+            }
+            event_state_filter = Some(EnrollmentSummaryEventStateFilter::from_raw(value));
             offset = new_offset;
         }
 
@@ -300,10 +314,10 @@ impl GetEnrollmentSummaryRequest {
             let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 5)?;
             if let Some(content) = opt_data {
                 let value = primitives::decode_unsigned(content)?;
-                notification_class_filter = Some(u16::try_from(value).map_err(|_| {
+                notification_class_filter = Some(u32::try_from(value).map_err(|_| {
                     Error::decoding(
                         offset,
-                        "EnrollmentSummary notificationClassFilter exceeds u16",
+                        "EnrollmentSummary notificationClassFilter exceeds u32",
                     )
                 })?);
                 offset = new_offset;
@@ -338,8 +352,8 @@ pub struct EnrollmentSummaryEntry {
     pub event_type: EventType,
     pub event_state: EventState,
     pub priority: u8,
-    /// Zero when the optional notification-class member is absent.
-    pub notification_class: u16,
+    /// Optional notification-class member.
+    pub notification_class: Option<u32>,
 }
 
 /// GetEnrollmentSummary-ACK: a sequence of summary entries.
@@ -355,7 +369,9 @@ impl GetEnrollmentSummaryAck {
             primitives::encode_app_enumerated(buf, entry.event_type.to_raw());
             primitives::encode_app_enumerated(buf, entry.event_state.to_raw());
             primitives::encode_app_unsigned(buf, entry.priority as u64);
-            primitives::encode_app_unsigned(buf, entry.notification_class as u64);
+            if let Some(notification_class) = entry.notification_class {
+                primitives::encode_app_unsigned(buf, notification_class as u64);
+            }
         }
     }
 
@@ -452,7 +468,7 @@ impl GetEnrollmentSummaryAck {
             offset = end;
 
             // notificationClass (app unsigned, optional)
-            let mut notification_class = 0;
+            let mut notification_class = None;
             if offset < data.len() {
                 let (tag, pos) = tags::decode_tag(data, offset)?;
                 if is_application_tag(&tag, data[offset], tags::app_tag::UNSIGNED) {
@@ -464,9 +480,9 @@ impl GetEnrollmentSummaryAck {
                         ));
                     }
                     let value = primitives::decode_unsigned(&data[pos..end])?;
-                    notification_class = u16::try_from(value).map_err(|_| {
-                        Error::decoding(pos, "EnrollmentSummaryAck notificationClass exceeds u16")
-                    })?;
+                    notification_class = Some(u32::try_from(value).map_err(|_| {
+                        Error::decoding(pos, "EnrollmentSummaryAck notificationClass exceeds u32")
+                    })?);
                     offset = end;
                 }
             }
@@ -498,7 +514,7 @@ mod tests {
         let req = GetEnrollmentSummaryRequest {
             acknowledgment_filter: 0, // all
             enrollment_filter: None,
-            event_state_filter: Some(EventState::OFFNORMAL),
+            event_state_filter: Some(EnrollmentSummaryEventStateFilter::OFFNORMAL),
             event_type_filter: None,
             priority_filter: Some(PriorityFilter {
                 min_priority: 1,
@@ -537,14 +553,14 @@ mod tests {
                     event_type: EventType::OUT_OF_RANGE,
                     event_state: EventState::HIGH_LIMIT,
                     priority: 3,
-                    notification_class: 10,
+                    notification_class: Some(10),
                 },
                 EnrollmentSummaryEntry {
                     object_identifier: ObjectIdentifier::new(ObjectType::BINARY_INPUT, 5).unwrap(),
                     event_type: EventType::CHANGE_OF_STATE,
                     event_state: EventState::NORMAL,
                     priority: 7,
-                    notification_class: 20,
+                    notification_class: Some(20),
                 },
             ],
         };
@@ -577,7 +593,7 @@ mod tests {
         let req = GetEnrollmentSummaryRequest {
             acknowledgment_filter: 0,
             enrollment_filter: None,
-            event_state_filter: Some(EventState::FAULT),
+            event_state_filter: Some(EnrollmentSummaryEventStateFilter::FAULT),
             event_type_filter: None,
             priority_filter: None,
             notification_class_filter: None,
@@ -600,7 +616,7 @@ mod tests {
                 event_type: EventType::OUT_OF_RANGE,
                 event_state: EventState::HIGH_LIMIT,
                 priority: 3,
-                notification_class: 10,
+                notification_class: Some(10),
             }],
         };
         let mut buf = BytesMut::new();
@@ -616,7 +632,7 @@ mod tests {
                 event_type: EventType::OUT_OF_RANGE,
                 event_state: EventState::HIGH_LIMIT,
                 priority: 3,
-                notification_class: 10,
+                notification_class: Some(10),
             }],
         };
         let mut buf = BytesMut::new();

--- a/crates/bacnet-services/src/enrollment_summary.rs
+++ b/crates/bacnet-services/src/enrollment_summary.rs
@@ -218,13 +218,24 @@ impl GetEnrollmentSummaryRequest {
         let mut event_state_filter = None;
         let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 2)?;
         if let Some(content) = opt_data {
-            let value = primitives::decode_unsigned(content)?;
-            if value > u64::from(EnrollmentSummaryEventStateFilter::ACTIVE.to_raw()) {
+            let value = match content {
+                [value] => u32::from(*value),
+                [] | [0, ..] => {
+                    return Err(Error::Reject {
+                        reason: bacnet_types::enums::RejectReason::INVALID_DATA_ENCODING.to_raw(),
+                    });
+                }
+                _ => {
+                    return Err(Error::Reject {
+                        reason: bacnet_types::enums::RejectReason::UNDEFINED_ENUMERATION.to_raw(),
+                    });
+                }
+            };
+            if value > EnrollmentSummaryEventStateFilter::ACTIVE.to_raw() {
                 return Err(Error::Reject {
                     reason: bacnet_types::enums::RejectReason::UNDEFINED_ENUMERATION.to_raw(),
                 });
             }
-            let value = u32::try_from(value).expect("event-state filter was validated to 0..=4");
             event_state_filter = Some(EnrollmentSummaryEventStateFilter::from_raw(value));
             offset = new_offset;
         }

--- a/crates/bacnet-services/src/enrollment_summary.rs
+++ b/crates/bacnet-services/src/enrollment_summary.rs
@@ -219,14 +219,12 @@ impl GetEnrollmentSummaryRequest {
         let (opt_data, new_offset) = tags::decode_optional_context(data, offset, 2)?;
         if let Some(content) = opt_data {
             let value = primitives::decode_unsigned(content)?;
-            let value = u32::try_from(value).map_err(|_| {
-                Error::decoding(offset, "EnrollmentSummary eventStateFilter exceeds u32")
-            })?;
-            if value > EnrollmentSummaryEventStateFilter::ACTIVE.to_raw() {
+            if value > u64::from(EnrollmentSummaryEventStateFilter::ACTIVE.to_raw()) {
                 return Err(Error::Reject {
                     reason: bacnet_types::enums::RejectReason::UNDEFINED_ENUMERATION.to_raw(),
                 });
             }
+            let value = u32::try_from(value).expect("event-state filter was validated to 0..=4");
             event_state_filter = Some(EnrollmentSummaryEventStateFilter::from_raw(value));
             offset = new_offset;
         }

--- a/crates/bacnet-services/src/enrollment_summary_width_tests.rs
+++ b/crates/bacnet-services/src/enrollment_summary_width_tests.rs
@@ -59,10 +59,16 @@ fn field_offsets(data: &[u8], count: usize) -> Vec<usize> {
 fn request_values_must_fit_public_field_widths() {
     let max_u32 = [0, 0xFF, 0xFF, 0xFF, 0xFF];
     let max_u8 = [0, 0xFF];
-    let max_u16 = [0, 0xFF, 0xFF];
+    let max_filter = [4];
     let decoded = GetEnrollmentSummaryRequest::decode(&raw_request(
         [
-            &max_u32, &max_u32, &max_u32, &max_u32, &max_u8, &max_u8, &max_u16,
+            &max_u32,
+            &max_u32,
+            &max_filter,
+            &max_u32,
+            &max_u8,
+            &max_u8,
+            &max_u32,
         ],
         true,
     ))
@@ -72,24 +78,25 @@ fn request_values_must_fit_public_field_widths() {
         decoded.enrollment_filter.unwrap().process_identifier,
         u32::MAX
     );
-    assert_eq!(decoded.event_state_filter.unwrap().to_raw(), u32::MAX);
+    assert_eq!(
+        decoded.event_state_filter,
+        Some(EnrollmentSummaryEventStateFilter::ACTIVE)
+    );
     assert_eq!(decoded.event_type_filter.unwrap().to_raw(), u32::MAX);
     assert_eq!(decoded.priority_filter.unwrap().min_priority, u8::MAX);
-    assert_eq!(decoded.notification_class_filter, Some(u16::MAX));
+    assert_eq!(decoded.notification_class_filter, Some(u32::MAX));
 
     let zero = [0];
     let base = [&zero[..]; 7];
     let overflow_u32 = (u32::MAX as u64 + 1).to_be_bytes();
     let overflow_u8 = [1, 0];
-    let overflow_u16 = [1, 0, 0];
     for (field, overflow) in [
         (0, &overflow_u32[..]),
         (1, &overflow_u32[..]),
-        (2, &overflow_u32[..]),
         (3, &overflow_u32[..]),
         (4, &overflow_u8[..]),
         (5, &overflow_u8[..]),
-        (6, &overflow_u16[..]),
+        (6, &overflow_u32[..]),
     ] {
         let mut fields = base;
         fields[field] = overflow;
@@ -188,24 +195,22 @@ fn request_try_encode_rejects_unrepresentable_filters_without_writing() {
 fn ack_values_must_fit_public_field_widths() {
     let max_u32 = [0, 0xFF, 0xFF, 0xFF, 0xFF];
     let max_u8 = [0, 0xFF];
-    let max_u16 = [0, 0xFF, 0xFF];
     let decoded =
-        GetEnrollmentSummaryAck::decode(&raw_ack([&max_u32, &max_u32, &max_u8, &max_u16])).unwrap();
+        GetEnrollmentSummaryAck::decode(&raw_ack([&max_u32, &max_u32, &max_u8, &max_u32])).unwrap();
     assert_eq!(decoded.entries[0].event_type.to_raw(), u32::MAX);
     assert_eq!(decoded.entries[0].event_state.to_raw(), u32::MAX);
     assert_eq!(decoded.entries[0].priority, u8::MAX);
-    assert_eq!(decoded.entries[0].notification_class, u16::MAX);
+    assert_eq!(decoded.entries[0].notification_class, Some(u32::MAX));
 
     let zero = [0];
     let base = [&zero[..]; 4];
     let overflow_u32 = (u32::MAX as u64 + 1).to_be_bytes();
     let overflow_u8 = [1, 0];
-    let overflow_u16 = [1, 0, 0];
     for (field, overflow) in [
         (0, &overflow_u32[..]),
         (1, &overflow_u32[..]),
         (2, &overflow_u8[..]),
-        (3, &overflow_u16[..]),
+        (3, &overflow_u32[..]),
     ] {
         let mut fields = base;
         fields[field] = overflow;
@@ -227,7 +232,14 @@ fn ack_accepts_omitted_notification_class_between_entries() {
     let without_notification = &encoded[..notification_offset];
 
     let decoded = GetEnrollmentSummaryAck::decode(without_notification).unwrap();
-    assert_eq!(decoded.entries[0].notification_class, 0);
+    assert_eq!(decoded.entries[0].notification_class, None);
+    let mut reencoded = BytesMut::new();
+    decoded.encode(&mut reencoded);
+    assert_eq!(
+        reencoded.as_ref(),
+        without_notification,
+        "decoding and re-encoding must preserve an omitted notification class"
+    );
 
     let mut repeated = BytesMut::from(without_notification);
     repeated.extend_from_slice(without_notification);
@@ -236,7 +248,122 @@ fn ack_accepts_omitted_notification_class_between_entries() {
     assert!(decoded
         .entries
         .iter()
-        .all(|entry| entry.notification_class == 0));
+        .all(|entry| entry.notification_class.is_none()));
+}
+
+#[test]
+fn ack_preserves_absent_present_zero_and_mixed_notification_classes() {
+    let entries = vec![
+        EnrollmentSummaryEntry {
+            object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+            event_type: EventType::CHANGE_OF_STATE,
+            event_state: EventState::NORMAL,
+            priority: 1,
+            notification_class: None,
+        },
+        EnrollmentSummaryEntry {
+            object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 2).unwrap(),
+            event_type: EventType::CHANGE_OF_STATE,
+            event_state: EventState::FAULT,
+            priority: 2,
+            notification_class: Some(0),
+        },
+        EnrollmentSummaryEntry {
+            object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 3).unwrap(),
+            event_type: EventType::CHANGE_OF_STATE,
+            event_state: EventState::OFFNORMAL,
+            priority: u8::MAX,
+            notification_class: Some(u32::MAX),
+        },
+        EnrollmentSummaryEntry {
+            object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 4).unwrap(),
+            event_type: EventType::CHANGE_OF_STATE,
+            event_state: EventState::NORMAL,
+            priority: 4,
+            notification_class: None,
+        },
+    ];
+    let ack = GetEnrollmentSummaryAck { entries };
+    let mut encoded = BytesMut::new();
+    ack.encode(&mut encoded);
+
+    assert_eq!(GetEnrollmentSummaryAck::decode(&encoded).unwrap(), ack);
+}
+
+#[test]
+fn ack_enforces_decoded_entry_cap() {
+    let zero = [0];
+    let entry_with_notification = raw_ack([&zero; 4]);
+    let notification_offset = field_offsets(&entry_with_notification, 5)[4];
+    let entry = &entry_with_notification[..notification_offset];
+    let mut encoded = BytesMut::with_capacity(entry.len() * (MAX_DECODED_ITEMS + 1));
+    for _ in 0..MAX_DECODED_ITEMS {
+        encoded.extend_from_slice(entry);
+    }
+    assert_eq!(
+        GetEnrollmentSummaryAck::decode(&encoded)
+            .unwrap()
+            .entries
+            .len(),
+        MAX_DECODED_ITEMS
+    );
+    encoded.extend_from_slice(entry);
+    assert!(GetEnrollmentSummaryAck::decode(&encoded).is_err());
+}
+
+#[test]
+fn request_event_state_filter_uses_service_defined_values() {
+    for (raw, expected) in [
+        (0, EnrollmentSummaryEventStateFilter::OFFNORMAL),
+        (1, EnrollmentSummaryEventStateFilter::FAULT),
+        (2, EnrollmentSummaryEventStateFilter::NORMAL),
+        (3, EnrollmentSummaryEventStateFilter::ALL),
+        (4, EnrollmentSummaryEventStateFilter::ACTIVE),
+    ] {
+        let mut encoded = BytesMut::new();
+        primitives::encode_ctx_enumerated(&mut encoded, 0, 0);
+        primitives::encode_ctx_enumerated(&mut encoded, 2, raw);
+        assert_eq!(encoded.as_ref(), &[0x09, 0, 0x29, raw as u8]);
+        assert_eq!(
+            GetEnrollmentSummaryRequest::decode(&encoded)
+                .unwrap()
+                .event_state_filter,
+            Some(expected)
+        );
+    }
+}
+
+#[test]
+fn request_rejects_undefined_event_state_filter() {
+    for raw in [5, u32::MAX] {
+        let mut encoded = BytesMut::new();
+        primitives::encode_ctx_enumerated(&mut encoded, 0, 0);
+        primitives::encode_ctx_enumerated(&mut encoded, 2, raw);
+        assert!(matches!(
+            GetEnrollmentSummaryRequest::decode(&encoded),
+            Err(Error::Reject { reason })
+                if reason == bacnet_types::enums::RejectReason::UNDEFINED_ENUMERATION.to_raw()
+        ));
+    }
+
+    let request = GetEnrollmentSummaryRequest {
+        acknowledgment_filter: 0,
+        enrollment_filter: None,
+        event_state_filter: Some(EnrollmentSummaryEventStateFilter::from_raw(5)),
+        event_type_filter: None,
+        priority_filter: None,
+        notification_class_filter: None,
+    };
+    let mut output = BytesMut::new();
+    assert!(request.try_encode(&mut output).is_err());
+    assert!(output.is_empty());
+
+    let request = GetEnrollmentSummaryRequest {
+        event_state_filter: Some(EnrollmentSummaryEventStateFilter::from_raw(u32::MAX)),
+        ..request
+    };
+    assert!(request.try_encode(&mut output).is_err());
+    assert!(output.is_empty());
 }
 
 #[test]

--- a/crates/bacnet-services/src/enrollment_summary_width_tests.rs
+++ b/crates/bacnet-services/src/enrollment_summary_width_tests.rs
@@ -345,6 +345,12 @@ fn request_rejects_undefined_event_state_filter() {
                 if reason == bacnet_types::enums::RejectReason::UNDEFINED_ENUMERATION.to_raw()
         ));
     }
+    let above_u32 = [0x09, 0, 0x2D, 0x05, 1, 0, 0, 0, 0];
+    assert!(matches!(
+        GetEnrollmentSummaryRequest::decode(&above_u32),
+        Err(Error::Reject { reason })
+            if reason == bacnet_types::enums::RejectReason::UNDEFINED_ENUMERATION.to_raw()
+    ));
 
     let request = GetEnrollmentSummaryRequest {
         acknowledgment_filter: 0,

--- a/crates/bacnet-services/src/enrollment_summary_width_tests.rs
+++ b/crates/bacnet-services/src/enrollment_summary_width_tests.rs
@@ -351,6 +351,25 @@ fn request_rejects_undefined_event_state_filter() {
         Err(Error::Reject { reason })
             if reason == bacnet_types::enums::RejectReason::UNDEFINED_ENUMERATION.to_raw()
     ));
+    let above_u64 = [0x09, 0, 0x2D, 0x09, 1, 0, 0, 0, 0, 0, 0, 0, 0];
+    assert!(matches!(
+        GetEnrollmentSummaryRequest::decode(&above_u64),
+        Err(Error::Reject { reason })
+            if reason == bacnet_types::enums::RejectReason::UNDEFINED_ENUMERATION.to_raw()
+    ));
+
+    for noncanonical in [[0x09, 0, 0x28, 0, 0], [0x09, 0, 0x2A, 0, 4]] {
+        let encoded = if noncanonical[2] == 0x28 {
+            &noncanonical[..3]
+        } else {
+            &noncanonical[..]
+        };
+        assert!(matches!(
+            GetEnrollmentSummaryRequest::decode(encoded),
+            Err(Error::Reject { reason })
+                if reason == bacnet_types::enums::RejectReason::INVALID_DATA_ENCODING.to_raw()
+        ));
+    }
 
     let request = GetEnrollmentSummaryRequest {
         acknowledgment_filter: 0,

--- a/crates/bacnet-types/src/enums/misc.rs
+++ b/crates/bacnet-types/src/enums/misc.rs
@@ -96,12 +96,23 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
-    /// BACnet acknowledgment filter for GetEnrollmentSummary (Clause 13.7.1).
+    /// BACnet acknowledgment filter for GetEnrollmentSummary (Clause 13.11.1.1).
     pub struct AcknowledgmentFilter(u32);
 
     const ALL = 0;
     const ACKED = 1;
     const NOT_ACKED = 2;
+}
+
+bacnet_enum! {
+    /// Event-state filter for GetEnrollmentSummary (Clause 13.11.1.1).
+    pub struct EnrollmentSummaryEventStateFilter(u32);
+
+    const OFFNORMAL = 0;
+    const FAULT = 1;
+    const NORMAL = 2;
+    const ALL = 3;
+    const ACTIVE = 4;
 }
 
 bacnet_enum! {

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -502,6 +502,23 @@ class EventState:
     def __hash__(self) -> int: ...
 
 
+class EnrollmentSummaryEventStateFilter:
+    """GetEnrollmentSummary event-state filter (Clause 13.11.1.1)."""
+
+    OFFNORMAL: EnrollmentSummaryEventStateFilter
+    FAULT: EnrollmentSummaryEventStateFilter
+    NORMAL: EnrollmentSummaryEventStateFilter
+    ALL: EnrollmentSummaryEventStateFilter
+    ACTIVE: EnrollmentSummaryEventStateFilter
+
+    @staticmethod
+    def from_raw(value: int) -> EnrollmentSummaryEventStateFilter: ...
+    def to_raw(self) -> int: ...
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+    def __hash__(self) -> int: ...
+
+
 class EventType:
     """BACnet event type enumeration (Clause 12.12.6)."""
 
@@ -1185,7 +1202,7 @@ class BACnetClient:
         self,
         address: str,
         acknowledgment_filter: int = 0,
-        event_state_filter: Optional[EventState] = None,
+        event_state_filter: Optional[EnrollmentSummaryEventStateFilter] = None,
         event_type_filter: Optional[EventType] = None,
         min_priority: Optional[int] = None,
         max_priority: Optional[int] = None,
@@ -1194,7 +1211,8 @@ class BACnetClient:
         """Get enrollment summary from a remote device.
 
         Returns ``[{"object_id": ObjectIdentifier, "event_type": EventType,
-        "event_state": EventState, "priority": int, "notification_class": int}, ...]``.
+        "event_state": EventState, "priority": int,
+        "notification_class": Optional[int]}, ...]``.
         """
         ...
 

--- a/crates/rusty-bacnet/src/client/client_methods/enrollment_alarm_covmulti_who_writegroup.rs
+++ b/crates/rusty-bacnet/src/client/client_methods/enrollment_alarm_covmulti_who_writegroup.rs
@@ -17,11 +17,11 @@ impl BACnetClient {
         py: Python<'py>,
         address: String,
         acknowledgment_filter: u32,
-        event_state_filter: Option<PyEventState>,
+        event_state_filter: Option<PyEnrollmentSummaryEventStateFilter>,
         event_type_filter: Option<PyEventType>,
         min_priority: Option<u8>,
         max_priority: Option<u8>,
-        notification_class_filter: Option<u16>,
+        notification_class_filter: Option<u32>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let inner = self.inner.clone();
         let es = event_state_filter.map(|e| e.to_rust());
@@ -51,7 +51,7 @@ impl BACnetClient {
                 notification_class_filter,
             };
             let mut buf = BytesMut::new();
-            req.encode(&mut buf);
+            req.try_encode(&mut buf).map_err(to_py_err)?;
             let resp = c
                 .confirmed_request(&mac, ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY, &buf)
                 .await

--- a/crates/rusty-bacnet/src/client/mod.rs
+++ b/crates/rusty-bacnet/src/client/mod.rs
@@ -43,9 +43,9 @@ use bacnet_types::enums::{ConfirmedServiceChoice, UnconfirmedServiceChoice};
 use crate::errors::to_py_err;
 use crate::types::{
     parse_address, py_to_rpm_specs, py_to_wpm_specs, rpm_ack_to_py, PyCovNotificationIterator,
-    PyDiscoveredDevice, PyEnableDisable, PyEventState, PyEventType, PyLifeSafetyOperation,
-    PyMessagePriority, PyObjectIdentifier, PyObjectType, PyPropertyIdentifier, PyPropertyValue,
-    PyReinitializedState,
+    PyDiscoveredDevice, PyEnableDisable, PyEnrollmentSummaryEventStateFilter, PyEventState,
+    PyEventType, PyLifeSafetyOperation, PyMessagePriority, PyObjectIdentifier, PyObjectType,
+    PyPropertyIdentifier, PyPropertyValue, PyReinitializedState,
 };
 
 /// Async BACnet client for reading/writing properties on remote devices.

--- a/crates/rusty-bacnet/src/types/enums.rs
+++ b/crates/rusty-bacnet/src/types/enums.rs
@@ -97,6 +97,12 @@ py_bacnet_enum!(
     u32
 );
 py_bacnet_enum!("EventState", PyEventState, bacnet_enums::EventState, u32);
+py_bacnet_enum!(
+    "EnrollmentSummaryEventStateFilter",
+    PyEnrollmentSummaryEventStateFilter,
+    bacnet_enums::EnrollmentSummaryEventStateFilter,
+    u32
+);
 py_bacnet_enum!("EventType", PyEventType, bacnet_enums::EventType, u32);
 py_bacnet_enum!(
     "MessagePriority",

--- a/crates/rusty-bacnet/src/types/mod.rs
+++ b/crates/rusty-bacnet/src/types/mod.rs
@@ -71,6 +71,11 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyEventState>()?;
     PyEventState::register_constants(&m.getattr("EventState")?)?;
 
+    m.add_class::<PyEnrollmentSummaryEventStateFilter>()?;
+    PyEnrollmentSummaryEventStateFilter::register_constants(
+        &m.getattr("EnrollmentSummaryEventStateFilter")?,
+    )?;
+
     m.add_class::<PyEventType>()?;
     PyEventType::register_constants(&m.getattr("EventType")?)?;
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -844,21 +844,25 @@ Get a summary of all active alarms on a device.
 raw = await client.get_alarm_summary("192.168.1.100:47808")
 ```
 
-#### `get_enrollment_summary(address, acknowledgment_filter, event_state_filter=None, event_type_filter=None, min_priority=None, max_priority=None, notification_class_filter=None) -> bytes`
+#### `get_enrollment_summary(address, acknowledgment_filter, event_state_filter=None, event_type_filter=None, min_priority=None, max_priority=None, notification_class_filter=None) -> list[dict]`
 
 Get enrollment summary with filters.
 
 ```python
-from rusty_bacnet import EventState, EventType
+from rusty_bacnet import EnrollmentSummaryEventStateFilter
 
-raw = await client.get_enrollment_summary(
+summaries = await client.get_enrollment_summary(
     "192.168.1.100:47808",
     acknowledgment_filter=0,                        # 0=all, 1=acked, 2=not-acked
-    event_state_filter=EventState.OFFNORMAL,
+    event_state_filter=EnrollmentSummaryEventStateFilter.OFFNORMAL,
     min_priority=0,
     max_priority=255,
 )
 ```
+
+Each result dictionary contains `object_id`, `event_type`, `event_state`,
+`priority`, and `notification_class`. The notification class is `None` when
+the peer omits that optional ACK member; an explicit class zero remains `0`.
 
 ---
 


### PR DESCRIPTION
## Summary

- add the dedicated Clause 13.11 GetEnrollmentSummary event-state filter model and apply OFFNORMAL, FAULT, NORMAL, ALL, ACTIVE, and omitted-as-ALL semantics
- preserve the optional ACK Notification Class as `Option<u32>`, including the distinction between absent and explicit zero, and widen the request filter to `u32`
- classify malformed and undefined event-state filter wire shapes before handler evaluation, and preserve the resulting Reject reason through server dispatch
- migrate the Python wrapper, type stub, and API documentation to the dedicated filter and optional notification-class result

Closes #176.
Closes #358.

## Standard anchors

- ASHRAE 135-2020 Clauses 13.11, 13.11.1.1.3, and 13.11.1.2.1.5, plus Table 13-15: GetEnrollmentSummary procedure; event-state filter meanings and omitted-as-ALL behavior; and optional ACK Notification Class
- Clause 21: GetEnrollmentSummary request and ACK productions; the ACK Notification Class is BACnet `Unsigned OPTIONAL`
- Clause 23.1 and Table 23-1: the inline event-state filter enumeration is not extensible
- Clause 18.9: undefined canonical filter values map to `UNDEFINED_ENUMERATION`; invalid empty or nonminimal encodings map to `INVALID_DATA_ENCODING`
- Clauses 20.2.4 and 20.2.11: BACnet Unsigned and Enumerated encoding

## Changed files

- `crates/bacnet-types/src/enums/misc.rs`: add `EnrollmentSummaryEventStateFilter` and correct the adjacent acknowledgment-filter clause reference
- `crates/bacnet-services/src/enrollment_summary.rs`: correct Clause 13.11 docs; migrate request/ACK fields; classify the non-extensible filter independently of implementation integer width; preserve optional ACK presence
- `crates/bacnet-services/src/enrollment_summary_width_tests.rs`: golden filter vectors; undefined and invalid-data wire failures, including values wider than `u64`; `u32` boundaries; mixed optional fields; exact round trips; and 10,000/10,001 entry cap coverage
- `crates/bacnet-server/src/handlers/alarm_event/get_enrollment_summary.rs`: implement the five filter predicates, omitted-as-ALL, checked Notification Class conversion, and optional ACK output
- `crates/bacnet-server/src/handlers/tests/enrollment_summary_filters.rs`, `crates/bacnet-server/src/handlers/tests/mod.rs`: focused handler matrix
- `crates/bacnet-server/src/server/requests/mod.rs`, `crates/bacnet-server/src/server/tests.rs`: preserve service Reject reasons in the response APDU
- `crates/rusty-bacnet/src/types/enums.rs`, `crates/rusty-bacnet/src/types/mod.rs`, `crates/rusty-bacnet/src/client/mod.rs`, `crates/rusty-bacnet/src/client/client_methods/enrollment_alarm_covmulti_who_writegroup.rs`: Python wrapper registration and fallible request encoding
- `crates/rusty-bacnet/rusty_bacnet.pyi`, `docs/python-api.md`: public Python signature/result migration and example
- `CHANGELOG.md`: compatibility-visible behavior and API migration

The final base-to-head inventory is 15 files, 448 insertions, and 63 deletions.

## Red evidence

Before implementation:

- `cargo test -q -p bacnet-services ack_accepts_omitted_notification_class_between_entries --locked` failed because decode/re-encode inserted an application Unsigned zero into an ACK that omitted Notification Class
- `cargo test -q -p bacnet-server enrollment_summary_filters --locked` failed both the service-specific numeric filter matrix and omitted-as-ALL behavior

Review-driven malformed-wire cases then exposed implementation-width classification gaps. The predecessor heads returned a generic decode error for canonical `2^32` and greater-than-`u64` filters. The final `request_rejects_undefined_event_state_filter` coverage pins those as `UNDEFINED_ENUMERATION`, while zero-length and redundant-leading-zero encodings are pinned as `INVALID_DATA_ENCODING`.

## Green verification

- `cargo test -q -p bacnet-types --locked` — passed
- `cargo test -q -p bacnet-services --locked` — 458 passed
- `cargo test -q -p bacnet-server --locked` — 465 passed with loopback socket permission
- `cargo check -q -p rusty-bacnet --tests --locked` — passed
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked` — passed; existing repository warnings remain
- `RUSTFLAGS=-Awarnings cargo clippy -q -p rusty-bacnet --all-targets --locked` — passed
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls,bacnet-transport/serial,bacnet-transport/ethernet -q` — CI-equivalent workspace suite passed
- `cargo fmt --all --check` — passed
- `.github/scripts/check-file-size.sh` — passed
- `.github/scripts/check-no-secrets.sh` — passed
- `git diff --check` — passed
- hosted CI run `32353393379` at the exact head passed Ubuntu tests, Clippy, Rustfmt, file-size, and no-secret checks; policy/release jobs were conditionally skipped

No benchmark is warranted: this is a bounded wire-model and predicate correction without a performance claim or measured-hotspot change.

## Compatibility and migration

This intentionally changes public pre-1.0 source types:

- Rust `GetEnrollmentSummaryRequest.event_state_filter`: `Option<EventState>` to `Option<EnrollmentSummaryEventStateFilter>`
- Rust `notification_class_filter`: `Option<u16>` to `Option<u32>`
- Rust `EnrollmentSummaryEntry.notification_class`: `u16` zero sentinel to `Option<u32>`
- Python `get_enrollment_summary(..., event_state_filter=...)` now requires `EnrollmentSummaryEventStateFilter`; omitted ACK Notification Class is returned as `None` and explicit zero remains `0`

`GetEnrollmentSummaryRequest::try_encode` is the fallible path for dynamic or untrusted input. Existing `encode` retains its signature but panics for a missing enrollment-filter device or an undefined service event-state filter; validation occurs before buffer mutation. Python now uses `try_encode` and returns an exception rather than panicking.

Wire behavior changes only where the prior model was incorrect: standard filter values 0, 2, 3, and 4 gain their defined meanings; noncanonical empty or leading-zero event-state-filter ENUMERATED encodings produce `Reject(INVALID_DATA_ENCODING)`; every canonically encoded numeric value outside 0..=4, including values wider than `u64`, produces `Reject(UNDEFINED_ENUMERATION)`; and omitted ACK Notification Class stays omitted. No README, PICS, BIBB, service-support, dependency, feature, or CI claim changes.

Mixed old/new deployments can interpret explicit event-state filter values differently because the old implementation used the wrong enum. Coordinate upgrades or avoid that filter during a rolling transition. Unfiltered calls remain wire-compatible.

## Deliberate limits and follow-ups

- #131 still owns the broader handler procedure: candidate-object scope, acknowledgment/enrollment/event-type filters, derived event type, and transition-specific priority behavior
- the server continues to emit a Notification Class for its current built-in projection; this PR fixes wire presence semantics for received and constructed models without inventing missing-object policy
- this service enforces canonical width for its event-state filter locally; the shared primitive decoder remains permissive for fitting leading-zero Unsigned/Enumerated encodings at other call sites, whose broader hardening remains separate
- no supported local Python 3.11-3.13 runtime was available for an import smoke; the Rust/PyO3 binding target and manual stub were compiled/updated explicitly. A supported-version wheel import smoke remains a publication gate, not a merge gate

## Immutable-head review evidence

All decisions below apply to exact head `b245d92273ce8f101d54bb53b11c48375c465e01` against base `7cedbca3dd3097b1b595b9133b21210bcb89a00b`.

- **Sol/xhigh correctness and safety — READY.** The final review found the event-filter classifier exhaustive and allocation-free: canonical values 0..=4 succeed, all canonical out-of-range widths map to `UNDEFINED_ENUMERATION`, and empty/leading-zero forms map to `INVALID_DATA_ENCODING`. The dedicated model, handler predicates, optional field, server Reject propagation, and Python migration have no remaining blocker.
- **Standards — READY.** Clauses 13.11, 18.9, 20.2.11, 21, and 23.1 were traced against the local 135-2020 Standard. The prior greater-than-`u32` and greater-than-`u64` findings are closed by byte-shape classification and exact vectors.
- **Test verification — READY.** The final two-file delta passed 21/21 focused tests, 458/458 service tests, service clippy, formatting, and diff checks. Hosted run `32353393379` is fully green and the PR merge state is CLEAN.
- **Release readiness — READY WITH RISKS.** Publish this source-breaking pre-1.0 change as the next minor, coordinate mixed-version filter usage, and require a supported Python wheel smoke before publication. Rollback is a full PR revert/version pin with no data cleanup.
- **Packaging — READY.** The 15-file inventory, exact clause anchors, issue closures, compatibility guidance, red/green evidence, #131 boundary, limitations, and no-benchmark/no-support-claim rationale are complete and truthful.
