### PR TITLE
fix(objects): type Escalator operation direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     up-reduced-speed / down-rated-speed / down-reduced-speed): the
     Escalator object's `operation_direction` (477) now resolves and
     displays by name instead of falling through to `ResolvedEnum::Unknown`.
-    The object still stores a raw `u32`; retyping is follow-up work.
+    The object stores the value as the typed enum and accepts all six named
+    values plus Clause 23.1 proprietary extensions (1024..=65535), refusing
+    reserved undefined values (6..=1023) and anything above the enumeration
+    maximum with PROPERTY / VALUE_OUT_OF_RANGE (#284).
   - New `BinaryLightingPV` (off / on / warn / warn-off / warn-relinquish /
     stop) and `LightingTransition` (none / fade / ramp); `transition` (385)
     now resolves. No resolve arm exists for `BinaryLightingPV` — it types
@@ -86,6 +89,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the intrinsic detectors (in-memory only).
 
 ### Fixed
+
+- The Escalator object's `operation_direction` (477) is now stored as the
+  typed `EscalatorOperationDirection` (default UNKNOWN) instead of a raw
+  `u32` with an invented 0=unknown/1=up/2=down/3=stopped comment mapping
+  (#284). Write validation now matches the Clause 21 production: all six
+  named values are accepted — including DOWN_RATED_SPEED (4) and
+  DOWN_REDUCED_SPEED (5), which the old `> 3` guard rejected — and
+  Clause 23.1 proprietary extensions (1024..=65535) are preserved as raw
+  values. Reserved undefined values (6..=1023) and values above the
+  enumeration maximum are refused with PROPERTY / VALUE_OUT_OF_RANGE;
+  non-Enumerated inputs with PROPERTY / INVALID_DATA_TYPE. Failed writes
+  leave the prior value unchanged. No wire-format or service-model change.
 
 - The bundled server now enforces a File object's declared
   `File_Access_Method` when executing AtomicReadFile and AtomicWriteFile

--- a/crates/bacnet-objects/src/elevator.rs
+++ b/crates/bacnet-objects/src/elevator.rs
@@ -4,7 +4,7 @@
 //! - EscalatorObject (type 58): represents an escalator
 //! - LiftObject (type 59): represents a single lift/elevator car
 
-use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{EscalatorOperationDirection, ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;
@@ -186,11 +186,9 @@ pub struct EscalatorObject {
     energy_meter_ref: Vec<u8>,
     /// Power mode (Boolean).
     power_mode: bool,
-    /// Operation direction (BACnetEscalatorOperationDirection, Clause 21):
-    /// 0=unknown, 1=stopped, 2=up-rated-speed, 3=up-reduced-speed,
-    /// 4=down-rated-speed, 5=down-reduced-speed. Retyping this raw `u32` to
-    /// the enum is tracked in #284.
-    operation_direction: u32,
+    /// Operation direction (BACnetEscalatorOperationDirection, Clause 21);
+    /// proprietary extensions (Clause 23.1) are preserved as raw values.
+    operation_direction: EscalatorOperationDirection,
     status_flags: StatusFlags,
     out_of_service: bool,
     reliability: u32,
@@ -209,7 +207,7 @@ impl EscalatorObject {
             energy_meter: 0.0,
             energy_meter_ref: Vec::new(),
             power_mode: false,
-            operation_direction: 0, // unknown
+            operation_direction: EscalatorOperationDirection::UNKNOWN,
             status_flags: StatusFlags::empty(),
             out_of_service: false,
             reliability: 0,
@@ -257,7 +255,7 @@ impl BACnetObject for EscalatorObject {
             }
             p if p == PropertyIdentifier::POWER_MODE => Ok(PropertyValue::Boolean(self.power_mode)),
             p if p == PropertyIdentifier::OPERATION_DIRECTION => {
-                Ok(PropertyValue::Enumerated(self.operation_direction))
+                Ok(PropertyValue::Enumerated(self.operation_direction.to_raw()))
             }
             _ => Err(common::unknown_property_error()),
         }
@@ -292,10 +290,19 @@ impl BACnetObject for EscalatorObject {
             }
             p if p == PropertyIdentifier::OPERATION_DIRECTION => {
                 if let PropertyValue::Enumerated(v) = value {
-                    if v > 3 {
+                    // Accept the six named values of the Clause 21
+                    // BACnetEscalatorOperationDirection production plus
+                    // proprietary extensions (Clause 23.1: 1024..=65535);
+                    // 6..=1023 is reserved and undefined in the 2020
+                    // production. Validate before mutating so a refused
+                    // write leaves the prior value intact.
+                    let named = EscalatorOperationDirection::ALL_NAMED
+                        .iter()
+                        .any(|&(_, value)| value.to_raw() == v);
+                    if !(named || (1024..=65535).contains(&v)) {
                         return Err(common::value_out_of_range_error());
                     }
-                    self.operation_direction = v;
+                    self.operation_direction = EscalatorOperationDirection::from_raw(v);
                     Ok(())
                 } else {
                     Err(common::invalid_data_type_error())

--- a/crates/bacnet-objects/src/elevator/tests.rs
+++ b/crates/bacnet-objects/src/elevator/tests.rs
@@ -1,4 +1,65 @@
 use super::*;
+use bacnet_types::enums::{ErrorClass, ErrorCode, EscalatorOperationDirection};
+
+/// Operation_Direction is writable for simulation while Out_Of_Service is
+/// true (Clause 12.60); write-domain tests run with OOS enabled.
+fn oos_escalator() -> EscalatorObject {
+    let mut esc = EscalatorObject::new(1, "ESC-1").unwrap();
+    esc.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    esc
+}
+
+fn assert_value_out_of_range(result: Result<(), Error>, context: &str) {
+    match result.expect_err(&format!("{context}: write must be refused")) {
+        Error::Protocol { class, code } => {
+            assert_eq!(
+                class,
+                ErrorClass::PROPERTY.to_raw() as u32,
+                "{context}: wrong error class"
+            );
+            assert_eq!(
+                code,
+                ErrorCode::VALUE_OUT_OF_RANGE.to_raw() as u32,
+                "{context}: wrong error code"
+            );
+        }
+        other => panic!("{context}: expected PROPERTY/VALUE_OUT_OF_RANGE, got {other:?}"),
+    }
+}
+
+fn assert_invalid_data_type(result: Result<(), Error>, context: &str) {
+    match result.expect_err(&format!("{context}: write must be refused")) {
+        Error::Protocol { class, code } => {
+            assert_eq!(
+                class,
+                ErrorClass::PROPERTY.to_raw() as u32,
+                "{context}: wrong error class"
+            );
+            assert_eq!(
+                code,
+                ErrorCode::INVALID_DATA_TYPE.to_raw() as u32,
+                "{context}: wrong error code"
+            );
+        }
+        other => panic!("{context}: expected PROPERTY/INVALID_DATA_TYPE, got {other:?}"),
+    }
+}
+
+fn read_direction(esc: &EscalatorObject) -> u32 {
+    match esc
+        .read_property(PropertyIdentifier::OPERATION_DIRECTION, None)
+        .unwrap()
+    {
+        PropertyValue::Enumerated(raw) => raw,
+        other => panic!("expected Enumerated readback, got {other:?}"),
+    }
+}
 
 // --- ElevatorGroupObject ---
 
@@ -136,6 +197,191 @@ fn escalator_property_list() {
     assert!(list.contains(&PropertyIdentifier::POWER_MODE));
     assert!(list.contains(&PropertyIdentifier::OPERATION_DIRECTION));
     assert!(list.contains(&PropertyIdentifier::STATUS_FLAGS));
+}
+
+// --- Operation_Direction typed behavior (#284) ---
+
+#[test]
+fn escalator_operation_direction_field_is_typed_and_defaults_to_unknown() {
+    let esc = EscalatorObject::new(1, "ESC-1").unwrap();
+    assert_eq!(
+        esc.operation_direction,
+        EscalatorOperationDirection::UNKNOWN
+    );
+}
+
+#[test]
+fn escalator_operation_direction_default_readback_is_enumerated_zero() {
+    let esc = EscalatorObject::new(1, "ESC-1").unwrap();
+    assert_eq!(
+        esc.read_property(PropertyIdentifier::OPERATION_DIRECTION, None)
+            .unwrap(),
+        PropertyValue::Enumerated(0)
+    );
+}
+
+#[test]
+fn escalator_all_named_directions_round_trip_with_oos() {
+    let mut esc = oos_escalator();
+    let mut last_raw = 0;
+    for &(name, value) in EscalatorOperationDirection::ALL_NAMED {
+        esc.write_property(
+            PropertyIdentifier::OPERATION_DIRECTION,
+            None,
+            PropertyValue::Enumerated(value.to_raw()),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("named direction {name} must be accepted: {e:?}"));
+        assert_eq!(read_direction(&esc), value.to_raw(), "{name} round-trip");
+        last_raw = value.to_raw();
+    }
+    assert_eq!(
+        last_raw,
+        EscalatorOperationDirection::DOWN_REDUCED_SPEED.to_raw()
+    );
+}
+
+#[test]
+fn escalator_down_directions_are_accepted() {
+    for raw in [
+        EscalatorOperationDirection::DOWN_RATED_SPEED.to_raw(),
+        EscalatorOperationDirection::DOWN_REDUCED_SPEED.to_raw(),
+    ] {
+        let mut esc = oos_escalator();
+        esc.write_property(
+            PropertyIdentifier::OPERATION_DIRECTION,
+            None,
+            PropertyValue::Enumerated(raw),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("raw {raw} must be accepted: {e:?}"));
+        assert_eq!(read_direction(&esc), raw);
+    }
+}
+
+// --- Proprietary boundaries (Clause 23.1 / Table 23-1) ---
+
+#[test]
+fn escalator_proprietary_direction_values_round_trip() {
+    for raw in [1024u32, 65535] {
+        let mut esc = oos_escalator();
+        esc.write_property(
+            PropertyIdentifier::OPERATION_DIRECTION,
+            None,
+            PropertyValue::Enumerated(raw),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("proprietary raw {raw} must be accepted: {e:?}"));
+        assert_eq!(read_direction(&esc), raw, "raw {raw} must not normalize");
+    }
+}
+
+// --- Invalid boundaries ---
+
+#[test]
+fn escalator_reserved_direction_values_rejected() {
+    for raw in [6u32, 1023] {
+        let mut esc = oos_escalator();
+        assert_value_out_of_range(
+            esc.write_property(
+                PropertyIdentifier::OPERATION_DIRECTION,
+                None,
+                PropertyValue::Enumerated(raw),
+                None,
+            ),
+            &format!("reserved raw {raw}"),
+        );
+    }
+}
+
+#[test]
+fn escalator_above_maximum_direction_values_rejected() {
+    for raw in [65536u32, u32::MAX] {
+        let mut esc = oos_escalator();
+        assert_value_out_of_range(
+            esc.write_property(
+                PropertyIdentifier::OPERATION_DIRECTION,
+                None,
+                PropertyValue::Enumerated(raw),
+                None,
+            ),
+            &format!("above-maximum raw {raw}"),
+        );
+    }
+}
+
+#[test]
+fn escalator_operation_direction_wrong_datatype_rejected() {
+    let mut esc = oos_escalator();
+    assert_invalid_data_type(
+        esc.write_property(
+            PropertyIdentifier::OPERATION_DIRECTION,
+            None,
+            PropertyValue::Unsigned(4),
+            None,
+        ),
+        "Unsigned instead of Enumerated",
+    );
+}
+
+// --- Atomicity ---
+
+#[test]
+fn escalator_failed_writes_leave_prior_direction_unchanged() {
+    let mut esc = oos_escalator();
+    let prior = EscalatorOperationDirection::UP_RATED_SPEED.to_raw();
+    esc.write_property(
+        PropertyIdentifier::OPERATION_DIRECTION,
+        None,
+        PropertyValue::Enumerated(prior),
+        None,
+    )
+    .unwrap();
+
+    assert_value_out_of_range(
+        esc.write_property(
+            PropertyIdentifier::OPERATION_DIRECTION,
+            None,
+            PropertyValue::Enumerated(6),
+            None,
+        ),
+        "reserved 6",
+    );
+    assert_eq!(
+        read_direction(&esc),
+        prior,
+        "value changed after reserved rejection"
+    );
+
+    assert_value_out_of_range(
+        esc.write_property(
+            PropertyIdentifier::OPERATION_DIRECTION,
+            None,
+            PropertyValue::Enumerated(u32::MAX),
+            None,
+        ),
+        "above maximum",
+    );
+    assert_eq!(
+        read_direction(&esc),
+        prior,
+        "value changed after above-maximum rejection"
+    );
+
+    assert_invalid_data_type(
+        esc.write_property(
+            PropertyIdentifier::OPERATION_DIRECTION,
+            None,
+            PropertyValue::Unsigned(4),
+            None,
+        ),
+        "wrong datatype",
+    );
+    assert_eq!(
+        read_direction(&esc),
+        prior,
+        "value changed after datatype rejection"
+    );
 }
 
 // --- LiftObject ---


### PR DESCRIPTION
Closes #284

## Summary

`EscalatorObject::operation_direction` was a raw `u32` with an invented comment mapping (0=unknown, 1=up, 2=down, 3=stopped) that contradicts the Clause 21 `BACnetEscalatorOperationDirection` production, and the write arm's `> 3` guard rejected the standard values DOWN_RATED_SPEED (4) and DOWN_REDUCED_SPEED (5). The field is now typed as `EscalatorOperationDirection` (default UNKNOWN) and write validation matches the Standard's enumeration domain. No wire-format, codec, service-model, or property-identifier change.

## Standard anchors

- **Clause 12.60 / Table 12-78** — Operation_Direction is `BACnetEscalatorOperationDirection`, writable for simulation while Out_Of_Service is true.
- **Clause 21** — named values: UNKNOWN(0), STOPPED(1), UP_RATED_SPEED(2), UP_REDUCED_SPEED(3), DOWN_RATED_SPEED(4), DOWN_REDUCED_SPEED(5).
- **Clause 23.1 / Table 23-1** — 0..=1023 reserved for ASHRAE; proprietary extensions may extend through 65535.

## Behavior matrix

| Raw value | Result |
|---|---|
| 0..=5 (ALL_NAMED) | accept and preserve |
| 6..=1023 | reject: PROPERTY / VALUE_OUT_OF_RANGE (undefined/reserved in the 2020 production) |
| 1024..=65535 | accept and preserve as proprietary (never normalized) |
| >65535 | reject: PROPERTY / VALUE_OUT_OF_RANGE |
| non-Enumerated input | reject: PROPERTY / INVALID_DATA_TYPE |

Validation runs before mutation; every refused write leaves the prior value unchanged. Readback remains `PropertyValue::Enumerated(raw)` — the network-facing property is unchanged.

## Files changed

- `crates/bacnet-objects/src/elevator.rs` — typed field, UNKNOWN default, semantic write-domain predicate derived from `ALL_NAMED`
- `crates/bacnet-objects/src/elevator/tests.rs` — typed default, ALL_NAMED round-trip under OOS, explicit 4/5 acceptance, proprietary 1024/65535 round-trip, reserved/above-maximum/wrong-datatype rejections with exact class+code, atomicity
- `CHANGELOG.md` — Tranche-Q entry reconciled (no longer says raw u32); #284 Fixed entry

## Red evidence (base 5af90100199013a544770f521eafcdcf2721b6f3)

`RUSTFLAGS=-Awarnings cargo test -q -p bacnet-objects escalator --locked` → 10 passed, 3 failed:

- `escalator_down_directions_are_accepted` → raw 4 rejected with Protocol { class: 2, code: 37 }
- `escalator_all_named_directions_round_trip_with_oos` → DOWN_RATED_SPEED rejected (class 2, code 37)
- `escalator_proprietary_direction_values_round_trip` → raw 1024 rejected (class 2, code 37)

Source inspection at base confirms `operation_direction: u32` storage (`elevator.rs:193`) and the `v > 3` guard (`elevator.rs:295`). The rejection-boundary tests pass at base trivially (the old guard also refused those values); the acceptance tests are the discriminators.

## Green verification (head 8a2b6fa682c0c2471a1634a1bbb6eca3dca79f8c)

- `RUSTFLAGS=-Awarnings cargo test -q -p bacnet-objects escalator --locked` — 14 passed
- `RUSTFLAGS=-Awarnings cargo test -q -p bacnet-objects --locked` — 1017 passed
- `cargo fmt --all -- --check` — pass
- `RUSTFLAGS=-Awarnings cargo clippy -q --workspace --exclude rusty-bacnet --all-targets --locked` — pass (no diagnostics in changed files)
- workspace suite with features (serde, ipv6, sc-tls, serial, ethernet) — 3156 passed, 0 failed, 2 ignored (pre-existing loopback-gated)
- `RUSTFLAGS=-Awarnings cargo check -q -p rusty-bacnet --tests --locked` — pass
- `check-file-size.sh`, `check-no-secrets.sh`, `generate-conformance-docs.py --check`, `git diff --check` — pass

## Compatibility

- No public Rust API change to wire models or service dispatch; the private field type changed within the crate.
- No Python/CLI change.
- Wire behavior: readback encoding unchanged; writes of 4/5 and proprietary 1024..=65535 now succeed where they previously returned Error(-); reserved/oversized values were and still are refused.
- Changelog makes no Escalator object/profile/BIBB conformance claim; no PICS or conformance-ledger change.

## Non-goals honored

Escalator_Mode retyping/domain discrepancy untouched; in-service/OOS ownership unchanged (writes remain accepted regardless of OOS — current behavior preserved, not endorsed); no macro changes, no repo-wide enum migration, no benchmark. Post-#395 File backlog items are unrelated and untouched.

No benchmark: constant-time validation on an unmeasured path.