### PR TITLE
fix(client): make device-table address identity route-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   detection-disabled reset clears all three, and restart semantics match
   the intrinsic detectors (in-memory only).
 
+### Added
+
+- `BACnetClient::add_routed_device` with a `RoutedDeviceConfig` (#372):
+  callers that already know a routed peer can register its device instance,
+  immediate-hop router MAC, remote SNET/SADR, advertised Max APDU Length
+  Accepted, segmentation capability, and optional Max Segments Accepted,
+  so requests are sized by the peer's advertised limits instead of silently
+  falling back to local config. Vendor ID defaults to 0 when unknown and
+  empty `router_mac`/`remote_mac` registrations are refused. Rust-only for
+  now; the Python surface is unchanged.
+
 ### Fixed
 
 - DeviceTable address identity no longer conflates routers with routed
@@ -100,20 +111,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   them. Both secondary lookups now select the freshest `last_seen` when
   several rows share an address, replacing nondeterministic hash-order
   picks. `resolve_device`'s two-lock snapshot/coherence boundary is now
-  documented on the method.
-
-### Added
-
-- `BACnetClient::add_routed_device` with a `RoutedDeviceConfig` (#372):
-  callers that already know a routed peer can register its device instance,
-  immediate-hop router MAC, remote SNET/SADR, advertised Max APDU Length
-  Accepted, segmentation capability, and optional Max Segments Accepted,
-  so requests are sized by the peer's advertised limits instead of silently
-  falling back to local config. Vendor ID defaults to 0 when unknown.
-  Rust-only for now; the Python surface is unchanged. Legacy
-  `add_device(instance, mac)` still creates local rows and its metadata
-  defaults are now documented as manual registration values rather than
-  advertised peer capabilities.
+  documented on the method. Legacy `add_device(instance, mac)` still
+  creates local rows and its metadata defaults are documented as manual
+  registration values rather than advertised peer capabilities.
 
 - The Escalator object's `operation_direction` (477) is now stored as the
   typed `EscalatorOperationDirection` (default UNKNOWN) instead of a raw

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- DeviceTable address identity no longer conflates routers with routed
+  peers, and duplicate matches resolve deterministically (#372). A local
+  `get_by_mac` lookup now considers only unambiguously local rows: a routed
+  row's `mac_address` is the immediate-hop router (Clause 6.2.2), never the
+  remote device's identity, so requesting the router's own Device object can
+  no longer pick up a peer's limits from behind it. Rows with partial
+  routing metadata match neither lookup until a complete I-Am refreshes
+  them. Both secondary lookups now select the freshest `last_seen` when
+  several rows share an address, replacing nondeterministic hash-order
+  picks. `resolve_device`'s two-lock snapshot/coherence boundary is now
+  documented on the method.
+
+### Added
+
+- `BACnetClient::add_routed_device` with a `RoutedDeviceConfig` (#372):
+  callers that already know a routed peer can register its device instance,
+  immediate-hop router MAC, remote SNET/SADR, advertised Max APDU Length
+  Accepted, segmentation capability, and optional Max Segments Accepted,
+  so requests are sized by the peer's advertised limits instead of silently
+  falling back to local config. Vendor ID defaults to 0 when unknown.
+  Rust-only for now; the Python surface is unchanged. Legacy
+  `add_device(instance, mac)` still creates local rows and its metadata
+  defaults are now documented as manual registration values rather than
+  advertised peer capabilities.
+
 - The Escalator object's `operation_direction` (477) is now stored as the
   typed `EscalatorOperationDirection` (default UNKNOWN) instead of a raw
   `u32` with an invented 0=unknown/1=up/2=down/3=stopped comment mapping

--- a/crates/bacnet-client/src/client/discovery.rs
+++ b/crates/bacnet-client/src/client/discovery.rs
@@ -1,7 +1,19 @@
 use super::*;
+use bacnet_types::enums::Segmentation;
 
 impl<T: TransportPort + 'static> BACnetClient<T> {
     /// Resolve a device instance to its MAC address and optional routing info.
+    ///
+    /// # Snapshot/coherence contract
+    ///
+    /// This returns an address/routing snapshot taken under one
+    /// [`DeviceTable`] lock; the lock is released before any network I/O.
+    /// The request's later capability lookup (Max APDU/segmentation) takes a
+    /// second lock, so a table update between the two reads can make the
+    /// capability decision observe a newer entry than the address snapshot.
+    /// This is an intentional non-atomic snapshot boundary, not a promise
+    /// that both reads use the same row forever; holding the lock across the
+    /// request would serialize all in-flight requests.
     pub(super) async fn resolve_device(
         &self,
         device_instance: u32,
@@ -122,11 +134,14 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         self.device_table.lock().await.clear();
     }
 
-    /// Manually register a device in the device table.
+    /// Manually register a local device in the device table.
     ///
     /// Useful for adding known devices without requiring WhoIs/IAm exchange.
-    /// Sets default values for max_apdu_length (1476), segmentation (NONE),
-    /// and vendor_id (0) since these are unknown without IAm.
+    /// The metadata defaults below (max_apdu_length 1476, segmentation NONE,
+    /// vendor_id 0) are local/manual registration defaults, **not** values
+    /// learned from an I-Am; requests to this device are bounded by them
+    /// until a real I-Am refreshes the row. The row is unambiguously local:
+    /// routed lookups by SNET/SADR will not match it.
     pub async fn add_device(&self, instance: u32, mac: &[u8]) -> Result<(), Error> {
         let oid = bacnet_types::primitives::ObjectIdentifier::new(
             bacnet_types::enums::ObjectType::DEVICE,
@@ -142,6 +157,38 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             last_seen: std::time::Instant::now(),
             source_network: None,
             source_address: None,
+        };
+        self.device_table.lock().await.upsert(device);
+        Ok(())
+    }
+
+    /// Manually register a routed peer whose address and capabilities are
+    /// already known, without fabricating an I-Am exchange.
+    ///
+    /// `router_mac` is only the immediate transport next hop (Clause 6.2.2);
+    /// the peer's identity is the (`remote_network`, `remote_mac`) SNET/SADR
+    /// pair, which is what [`BACnetClient::confirmed_request_routed`] and the
+    /// device-table routed lookup match against. The supplied Max APDU
+    /// Length Accepted, segmentation capability, and optional Max Segments
+    /// Accepted are treated as advertised peer limits for request sizing.
+    ///
+    /// Vendor ID is recorded as 0 when unknown; this does not affect
+    /// routing or request-size decisions.
+    pub async fn add_routed_device(&self, config: RoutedDeviceConfig) -> Result<(), Error> {
+        let oid = bacnet_types::primitives::ObjectIdentifier::new(
+            bacnet_types::enums::ObjectType::DEVICE,
+            config.instance,
+        )?;
+        let device = DiscoveredDevice {
+            object_identifier: oid,
+            mac_address: MacAddr::from_slice(&config.router_mac),
+            max_apdu_length: config.max_apdu_length,
+            segmentation_supported: config.segmentation_supported,
+            max_segments_accepted: config.max_segments_accepted,
+            vendor_id: 0,
+            last_seen: std::time::Instant::now(),
+            source_network: Some(config.remote_network),
+            source_address: Some(MacAddr::from_slice(&config.remote_mac)),
         };
         self.device_table.lock().await.upsert(device);
         Ok(())

--- a/crates/bacnet-client/src/client/discovery.rs
+++ b/crates/bacnet-client/src/client/discovery.rs
@@ -174,7 +174,22 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     ///
     /// Vendor ID is recorded as 0 when unknown; this does not affect
     /// routing or request-size decisions.
+    ///
+    /// Malformed routing metadata is rejected deliberately: an empty
+    /// `router_mac` or `remote_mac` cannot identify a next hop or a peer, so
+    /// such a registration returns [`Error::Encoding`] and the table is left
+    /// unchanged (an empty SADR could never satisfy a routed lookup).
     pub async fn add_routed_device(&self, config: RoutedDeviceConfig) -> Result<(), Error> {
+        if config.router_mac.is_empty() {
+            return Err(Error::Encoding(
+                "router_mac must not be empty: it is the immediate transport next hop".into(),
+            ));
+        }
+        if config.remote_mac.is_empty() {
+            return Err(Error::Encoding(
+                "remote_mac must not be empty: it is half of the routed peer's identity".into(),
+            ));
+        }
         let oid = bacnet_types::primitives::ObjectIdentifier::new(
             bacnet_types::enums::ObjectType::DEVICE,
             config.instance,

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -33,7 +33,7 @@ use bacnet_types::enums::{
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 
-use crate::discovery::{DeviceTable, DeviceUpsertResult, DiscoveredDevice};
+use crate::discovery::{DeviceTable, DeviceUpsertResult, DiscoveredDevice, RoutedDeviceConfig};
 use crate::segmentation::{max_segment_payload, split_payload, SegmentReceiver, SegmentedPduType};
 use crate::tsm::{Tsm, TsmConfig, TsmResponse};
 

--- a/crates/bacnet-client/src/client/routed_max_apdu_tests.rs
+++ b/crates/bacnet-client/src/client/routed_max_apdu_tests.rs
@@ -19,7 +19,7 @@ use bacnet_types::primitives::ObjectIdentifier;
 use bacnet_types::MacAddr;
 use tokio::time::{timeout, Duration};
 
-use crate::discovery::DiscoveredDevice;
+use crate::discovery::{DiscoveredDevice, RoutedDeviceConfig};
 
 use super::tests::send_routed_response;
 use super::BACnetClient;
@@ -208,4 +208,164 @@ async fn routed_confirmed_request_rejects_subminimum_peer_limit() {
 
     client.stop().await.unwrap();
     router_transport.stop().await.unwrap();
+}
+
+/// A routed peer seeded through the public manual-registration API (no I-Am
+/// exchange) has its advertised Max APDU Length Accepted consumed exactly as
+/// if it had been discovered (#372): a 204-octet request segments at 128
+/// instead of falling back to local config.
+#[tokio::test]
+async fn manual_routed_registration_honors_seeded_peer_limit() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03];
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+    let mut router_rx = router_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .max_apdu_length(1476)
+        .build()
+        .await
+        .unwrap();
+
+    client
+        .add_routed_device(RoutedDeviceConfig {
+            instance: 3003,
+            router_mac: router_mac.clone(),
+            remote_network,
+            remote_mac: remote_mac.clone(),
+            max_apdu_length: 128,
+            segmentation_supported: Segmentation::BOTH,
+            max_segments_accepted: None,
+        })
+        .await
+        .unwrap();
+
+    // The registration must preserve every supplied field.
+    let row = client.device_table.lock().await.get(3003).cloned().unwrap();
+    assert_eq!(row.mac_address.as_slice(), &router_mac);
+    assert_eq!(row.source_network, Some(remote_network));
+    assert_eq!(
+        row.source_address.as_ref().map(|a| a.to_vec()),
+        Some(remote_mac.clone())
+    );
+    assert_eq!(row.max_apdu_length, 128);
+    assert_eq!(row.segmentation_supported, Segmentation::BOTH);
+    assert_eq!(row.max_segments_accepted, None);
+
+    // resolve_device yields the router next-hop plus the remote identity.
+    let (next_hop, routing) = client.resolve_device(3003).await.unwrap();
+    assert_eq!(next_hop, router_mac);
+    assert_eq!(routing, Some((remote_network, remote_mac.clone())));
+
+    let service_data: Vec<u8> = (0..200u16).map(|i| i as u8).collect();
+    let expected_data = service_data.clone();
+    let router_mac_for_request = router_mac.clone();
+    let remote_mac_for_request = remote_mac.clone();
+
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request_routed(
+                &router_mac_for_request,
+                remote_network,
+                &remote_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let mut all_service_data = Vec::new();
+    let invoke_id = loop {
+        let received = timeout(Duration::from_secs(2), router_rx.recv())
+            .await
+            .expect("router timed out waiting for routed segment")
+            .expect("router channel closed");
+
+        let npdu = decode_npdu(received.npdu).unwrap();
+        assert!(
+            npdu.payload.len() <= 128,
+            "APDU of {} octets exceeds the seeded peer's limit of 128",
+            npdu.payload.len()
+        );
+
+        let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+        let Apdu::ConfirmedRequest(req) = decoded else {
+            panic!("Expected ConfirmedRequest, got {:?}", decoded);
+        };
+        assert!(
+            req.segmented,
+            "seeded limit of 128 must force segmentation, not local-config fallback"
+        );
+        let seq = req.sequence_number.unwrap();
+        all_service_data.extend_from_slice(&req.service_request);
+
+        let seg_ack = Apdu::SegmentAck(SegmentAckPdu {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id: req.invoke_id,
+            sequence_number: seq,
+            actual_window_size: 1,
+        });
+        send_routed_response(
+            &router_transport,
+            &client_mac,
+            remote_network,
+            &remote_mac,
+            seg_ack,
+        )
+        .await;
+
+        if !req.more_follows {
+            break req.invoke_id;
+        }
+    };
+
+    assert_eq!(all_service_data, expected_data);
+
+    let ack = Apdu::SimpleAck(SimpleAck {
+        invoke_id,
+        service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+    });
+    send_routed_response(
+        &router_transport,
+        &client_mac,
+        remote_network,
+        &remote_mac,
+        ack,
+    )
+    .await;
+
+    let result = request_task.await.unwrap();
+    assert!(result.unwrap().is_empty());
+    router_transport.stop().await.unwrap();
+}
+
+/// Legacy `add_device` keeps creating unambiguously local rows: the local
+/// lookup finds them and the routed lookup by SNET/SADR does not (#372).
+#[tokio::test]
+async fn legacy_add_device_creates_local_row_only() {
+    let (client_transport, _peer_transport) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    let mac = vec![192, 168, 1, 100, 0xBA, 0xC0];
+    client.add_device(1234, &mac).await.unwrap();
+
+    let dt = client.device_table.lock().await;
+    let local = dt.get_by_mac(&mac).expect("local lookup must find the row");
+    assert_eq!(local.object_identifier.instance_number(), 1234);
+    assert!(
+        dt.get_by_network_address(100, &mac).is_none(),
+        "the same bytes as SNET/SADR must not satisfy a routed lookup"
+    );
 }

--- a/crates/bacnet-client/src/client/routed_max_apdu_tests.rs
+++ b/crates/bacnet-client/src/client/routed_max_apdu_tests.rs
@@ -347,6 +347,38 @@ async fn manual_routed_registration_honors_seeded_peer_limit() {
     router_transport.stop().await.unwrap();
 }
 
+/// Malformed routing metadata is rejected before any table mutation: empty
+/// next-hop or peer addresses can never identify a route or a peer (#372).
+#[tokio::test]
+async fn manual_routed_registration_rejects_empty_addresses() {
+    let (client_transport, _peer_transport) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    for (router_mac, remote_mac) in [(Vec::new(), vec![0x03]), (vec![0x02], Vec::new())] {
+        let result = client
+            .add_routed_device(RoutedDeviceConfig {
+                instance: 3003,
+                router_mac,
+                remote_network: 100,
+                remote_mac,
+                max_apdu_length: 128,
+                segmentation_supported: Segmentation::BOTH,
+                max_segments_accepted: None,
+            })
+            .await;
+        assert!(result.is_err(), "empty address must be rejected");
+    }
+
+    assert!(
+        client.device_table.lock().await.get(3003).is_none(),
+        "a refused registration must not create a row"
+    );
+}
+
 /// Legacy `add_device` keeps creating unambiguously local rows: the local
 /// lookup finds them and the routed lookup by SNET/SADR does not (#372).
 #[tokio::test]

--- a/crates/bacnet-client/src/discovery.rs
+++ b/crates/bacnet-client/src/discovery.rs
@@ -30,10 +30,51 @@ pub struct DiscoveredDevice {
     pub source_address: Option<MacAddr>,
 }
 
+impl DiscoveredDevice {
+    /// True when this row represents a local peer: neither routing field is
+    /// set. See the [`DeviceTable`] address-space invariant.
+    pub fn is_local(&self) -> bool {
+        self.source_network.is_none() && self.source_address.is_none()
+    }
+}
+
+/// Manual registration details for a known routed peer, for use with
+/// [`crate::client::BACnetClient::add_routed_device`].
+///
+/// Everything a caller must supply so requests to the peer route correctly
+/// and are sized by the peer's advertised limits rather than local defaults.
+#[derive(Debug, Clone)]
+pub struct RoutedDeviceConfig {
+    /// Device instance number.
+    pub instance: u32,
+    /// MAC of the immediate-hop router (transport next hop, not peer identity).
+    pub router_mac: Vec<u8>,
+    /// Remote network number (SNET) the peer resides on.
+    pub remote_network: u16,
+    /// Peer's MAC on the remote network (SADR).
+    pub remote_mac: Vec<u8>,
+    /// The peer's advertised Max APDU Length Accepted.
+    pub max_apdu_length: u32,
+    /// The peer's advertised segmentation capability.
+    pub segmentation_supported: Segmentation,
+    /// The peer's Max Segments Accepted, if known (None = unspecified).
+    pub max_segments_accepted: Option<u32>,
+}
+
 /// Thread-safe device discovery table.
 ///
 /// Keyed by device instance number (the instance part of the DEVICE object
 /// identifier). Updated whenever an IAm is received.
+///
+/// # Address-space invariant
+///
+/// A row is *routed* when it carries routed-source identity (`source_network`
+/// and `source_address`, per Clause 6.2.2 the original source SNET/SADR); its
+/// `mac_address` is then only the immediate-hop router, shared by every peer
+/// behind that router. A row is *local* only when it is unambiguously local:
+/// both routing fields are `None`. A row with exactly one routing field set is
+/// malformed; it counts as neither local nor routable and matches no secondary
+/// lookup until a complete I-Am refreshes it.
 #[derive(Debug, Default)]
 pub struct DeviceTable {
     devices: HashMap<u32, DiscoveredDevice>,
@@ -86,11 +127,22 @@ impl DeviceTable {
         self.devices.get(&instance)
     }
 
-    /// Look up a device by its MAC address.
+    /// Look up a local device by its MAC address.
+    ///
+    /// Only unambiguously local rows (no `source_network`/`source_address`)
+    /// are considered: a routed row's `mac_address` is the router it was
+    /// heard through, not the remote device's identity, so a lookup of the
+    /// router's own address must never select a peer behind it (Clause 6.2.2).
+    ///
+    /// The table is keyed by device instance, so two local rows can share one
+    /// MAC until the stale purge; the freshest `last_seen` wins, mirroring
+    /// [`DeviceTable::get_by_network_address`].
     pub fn get_by_mac(&self, mac: &[u8]) -> Option<&DiscoveredDevice> {
         self.devices
             .values()
-            .find(|d| d.mac_address.as_slice() == mac)
+            .filter(|d| d.is_local())
+            .filter(|d| d.mac_address.as_slice() == mac)
+            .max_by_key(|d| d.last_seen)
     }
 
     /// Look up a routed device by its remote network number and MAC address.
@@ -302,6 +354,89 @@ mod tests {
         let dev = table.get_by_network_address(100, &[0x03]).unwrap();
         assert_eq!(dev.object_identifier.instance_number(), 2);
         assert_eq!(dev.max_apdu_length, 128);
+    }
+
+    /// A routed row's `mac_address` is the router it was heard through, not
+    /// the remote device's identity (Clause 6.2.2: SNET/SADR identify the
+    /// original source; the router MAC is only the local next hop). A local
+    /// MAC lookup for the router's own address must therefore never select a
+    /// routed peer behind that router (#372).
+    #[test]
+    fn get_by_mac_ignores_routed_rows() {
+        let mut table = DeviceTable::new();
+        let router_mac = &[192, 168, 1, 1, 0xBA, 0xC0];
+        let routed = make_routed_device(3003, 100, &[0x03]);
+        let mut routed_with_router_mac = routed;
+        routed_with_router_mac.mac_address = MacAddr::from_slice(router_mac);
+        table.upsert(routed_with_router_mac);
+
+        assert!(table.get_by_mac(router_mac).is_none());
+    }
+
+    /// Several routed peers can share one router MAC; none of them may be
+    /// returned by a local lookup of that router's address.
+    #[test]
+    fn get_by_mac_ignores_multiple_routed_rows_behind_one_router() {
+        let mut table = DeviceTable::new();
+        let router_mac = &[192, 168, 1, 1, 0xBA, 0xC0];
+        for instance in [1u32, 2, 3] {
+            let mut peer = make_routed_device(instance, 100, &[instance as u8]);
+            peer.mac_address = MacAddr::from_slice(router_mac);
+            table.upsert(peer);
+        }
+        assert!(table.get_by_mac(router_mac).is_none());
+    }
+
+    fn make_local_device_at_mac(instance: u32, mac: &[u8]) -> DiscoveredDevice {
+        let mut device = make_device(instance);
+        device.mac_address = MacAddr::from_slice(mac);
+        device
+    }
+
+    /// A local device whose MAC byte-equals a routed peer's SADR lives in a
+    /// different address space; the local lookup must return the local row.
+    #[test]
+    fn get_by_mac_returns_local_row_not_routed_sadr_namesake() {
+        let mut table = DeviceTable::new();
+        table.upsert(make_local_device_at_mac(10, &[0x03]));
+        table.upsert(make_routed_device(3003, 100, &[0x03]));
+
+        let dev = table.get_by_mac(&[0x03]).unwrap();
+        assert_eq!(dev.object_identifier.instance_number(), 10);
+    }
+
+    /// Two local rows sharing one MAC (re-commissioned instance surviving
+    /// until the stale purge) must resolve deterministically to the freshest
+    /// advertisement, mirroring the routed lookup rule.
+    #[test]
+    fn get_by_mac_prefers_freshest_local_row() {
+        let mut table = DeviceTable::new();
+        let now = Instant::now();
+        let mut stale = make_device(1);
+        stale.last_seen = now;
+        let mut fresh = make_device(2);
+        fresh.last_seen = now + Duration::from_secs(60);
+        table.upsert(stale);
+        table.upsert(fresh);
+
+        let dev = table.get_by_mac(&[192, 168, 1, 100, 0xBA, 0xC0]).unwrap();
+        assert_eq!(dev.object_identifier.instance_number(), 2);
+    }
+
+    /// Partial routing metadata (one half of SNET/SADR set) is malformed:
+    /// such a row is not unambiguously local, so it is excluded from local
+    /// lookup; the routed lookup already requires both terms.
+    #[test]
+    fn partial_routing_metadata_is_excluded_from_local_lookup() {
+        let mut table = DeviceTable::new();
+        let mut partial = make_device(7);
+        partial.source_network = Some(100);
+        table.upsert(partial);
+
+        assert!(table.get_by_mac(&[192, 168, 1, 100, 0xBA, 0xC0]).is_none());
+        assert!(table
+            .get_by_network_address(100, &[192, 168, 1, 100, 0xBA, 0xC0])
+            .is_none());
     }
 
     #[test]


### PR DESCRIPTION
Closes #372

## Summary

`DeviceTable`'s secondary lookups encoded partial identity assumptions. This PR gives the client one deterministic interpretation of local and routed peer identity, ahead of #371 consuming `segmentation_supported`. No wire-format change.

## Standard anchors (kept light)

- **Clause 6.2.2** — SNET/SADR identify the original source; for a routed peer the router's local MAC is transport next-hop information only.
- **Clause 5.4** — transaction identity binds client/server BACnet addresses and Invoke ID; identity must not depend on which immediate route delivered traffic.

## Behavior changes

| Lookup / operation | Before | After |
|---|---|---|
| `get_by_mac(router_mac)` with a routed peer behind that router | returned the routed peer (wrong limits) | returns None unless a local row matches |
| duplicate local rows sharing a MAC | arbitrary HashMap-order pick | freshest `last_seen` wins |
| duplicate routed rows sharing SNET/SADR | fixed in #369 (freshest wins) — preserved | preserved |
| partial routing metadata (one of SNET/SADR set) | counted as local by `get_by_mac` | deliberately neither local nor routable until refreshed |
| manual routed registration | impossible; silent local-config fallback | new `add_routed_device(RoutedDeviceConfig)` |
| legacy `add_device(instance, mac)` | unchanged behavior | unchanged behavior; docs now state its defaults are manual registration values, not advertised capabilities |

`resolve_device`'s two-lock snapshot/coherence boundary is documented on the method per #372's explicit allowance: address snapshot under one lock, later capability lookup may observe a newer entry; no lock is held across network I/O.

## Files changed

- `crates/bacnet-client/src/discovery.rs` — address-space invariant docs on `DeviceTable`, `DiscoveredDevice::is_local`, local-only + freshest-wins `get_by_mac`, 7 focused table tests
- `crates/bacnet-client/src/client/discovery.rs` — coherence contract rustdoc on `resolve_device`, `add_routed_device`, corrected `add_device` docs
- `crates/bacnet-client/src/client/mod.rs` — import of `RoutedDeviceConfig`
- `crates/bacnet-client/src/client/routed_max_apdu_tests.rs` — end-to-end loopback test proving a manually seeded peer limit (128, Segmentation::BOTH) forces segmentation instead of local-config fallback, plus registration round-trip/resolve assertions and a legacy-add_device-stays-local test
- `CHANGELOG.md` — Fixed + Added entries

Python surface intentionally unchanged (`add_routed_device` is Rust-only for now); no `.pyi`/python-docs changes needed.

## Red evidence (base 34c6dbb00c183e8c46bbd5fd2f7a2a0195355176)

Command: `RUSTFLAGS=-Awarnings cargo test -q -p bacnet-client get_by_mac --locked`

- `get_by_mac_ignores_routed_rows` FAILED — `assertion failed: table.get_by_mac(router_mac).is_none()` (the routed peer was returned)
- `get_by_mac_ignores_multiple_routed_rows_behind_one_router` FAILED — same assertion

This deterministically discriminates facet 1 of #372 (router MAC conflated with routed-peer identity). Facet 2's duplicate-nondeterminism is covered as green coverage via the deterministic freshest-row test, per brief (no hash-order-dependent timing test). The manual-registration API tests are compile-time-absent at base, as allowed.

## Green verification (final head 97c26e4e5c14046dec552e781ac818e7cd314fe8)

- `cargo fmt --all -- --check` — pass
- `RUSTFLAGS=-Awarnings cargo test -q -p bacnet-client --locked` — 131 lib + 3 integration passed
- workspace suite w/ features — 3164 passed, 0 failed, 2 ignored (pre-existing loopback-gated)
- `RUSTFLAGS=-Awarnings cargo clippy -q --workspace --exclude rusty-bacnet --all-targets --locked` — pass
- `RUSTFLAGS=-Awarnings cargo check -q -p rusty-bacnet --tests --locked` — pass
- `check-file-size.sh`, `check-no-secrets.sh`, `generate-conformance-docs.py --check`, `git diff --check` — pass


Note: the counts below were produced at `ef40366`; the only later commit (`97c26e4`) is a CHANGELOG.md section restructure with no code effect. GitHub Actions runs green at the final head.

## Compatibility

- Additive public Rust API: `add_routed_device` method + `RoutedDeviceConfig` struct (public fields, `Clone`); existing `add_device` callers unaffected. `add_routed_device` deliberately rejects empty `router_mac`/`remote_mac` with `Error::Encoding` before any table mutation.
- No public struct fields added to `DiscoveredDevice`; only a new inherent method `is_local()`.
- Python: unchanged by design (documented above).
- Wire behavior: none; only which table rows lookups select and what callers may seed.
- Changelog describes identity/registration fixes; no new BACnet feature-support or conformance claim.

## Non-goals honored

#371 segmentation enforcement, #370 internetwork length discovery, #379/#380 reassembly timeouts, #383 duplicate-window, #384 server reassembly keying, DeviceTable replacement, lock-across-I/O, broad discovery redesign — all untouched. Tracked adjacent backlog (#397–#401) untouched.

No benchmark: lookup scans are small linear passes over an in-memory map on an unmeasured path.


