### PR TITLE
fix(client): honor peer receive-segmentation capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The client no longer segments confirmed requests to peers whose
+  authoritative `Segmentation_Supported` says they cannot receive segments
+  (#371). When request sizing requires segmentation and the selected
+  device-table row's capability is authoritative — learned from the peer's
+  I-Am or explicitly supplied via `add_routed_device` or an explicit
+  `DeviceTable::upsert` — a `NO_SEGMENTATION` or `SEGMENTED_TRANSMIT` peer
+  now produces a local `Error::Segmentation` naming the advertised
+  capability before any frame is sent or transaction allocated, instead of
+  the guaranteed Clause 18 SEGMENTATION_NOT_SUPPORTED abort. Legacy manual
+  `add_device` rows keep their previous behavior: their capability fields
+  are documented placeholders, so unknown capability never causes a local
+  refusal, and a later I-Am refresh makes the row authoritative. Receive-
+  capable (`SEGMENTED_RECEIVE`/`SEGMENTED_BOTH`) peers segment exactly as
+  before.
+
 - DeviceTable address identity no longer conflates routers with routed
   peers, and duplicate matches resolve deterministically (#372). A local
   `get_by_mac` lookup now considers only unambiguously local rows: a routed

--- a/crates/bacnet-client/src/client/discovery.rs
+++ b/crates/bacnet-client/src/client/discovery.rs
@@ -158,7 +158,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             source_network: None,
             source_address: None,
         };
-        self.device_table.lock().await.upsert(device);
+        // Placeholder capability defaults (NONE, 1476) are not I-Am evidence;
+        // they must never drive a segmentation-capability decision (#371).
+        self.device_table.lock().await.upsert_placeholder(device);
         Ok(())
     }
 

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -797,6 +797,8 @@ mod device_events_tests;
 #[cfg(test)]
 mod peer_max_apdu_tests;
 #[cfg(test)]
+mod peer_segmentation_tests;
+#[cfg(test)]
 mod response_correlation_tests;
 #[cfg(test)]
 mod routed_max_apdu_tests;

--- a/crates/bacnet-client/src/client/peer_segmentation_tests.rs
+++ b/crates/bacnet-client/src/client/peer_segmentation_tests.rs
@@ -1,0 +1,602 @@
+//! The client must not knowingly segment a confirmed request to a peer whose
+//! authoritative Segmentation_Supported says it cannot receive segments.
+//!
+//! Clause 12.11: NO_SEGMENTATION and SEGMENTED_TRANSMIT peers accept exactly
+//! one segment — only unsegmented requests. Clause 18: sending anyway yields
+//! the peer's SEGMENTATION_NOT_SUPPORTED abort, so the client refuses locally
+//! before allocating a transaction or transmitting (issue #371).
+//!
+//! Capability provenance matters: only I-Am-learned or explicitly supplied
+//! capability is authoritative. Legacy `add_device` rows store placeholder
+//! defaults and must not cause a local refusal (#372 follow-up constraint).
+//!
+//! New file: `tests.rs` is over the 700-LOC cap.
+
+use std::time::Instant;
+
+use bacnet_encoding::apdu::{self, Apdu, SegmentAck as SegmentAckPdu, SimpleAck};
+use bacnet_encoding::npdu::{decode_npdu, Npdu};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::enums::{ConfirmedServiceChoice, ObjectType, Segmentation};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+use bytes::{Bytes, BytesMut};
+use tokio::time::{timeout, Duration};
+
+use crate::discovery::{DiscoveredDevice, RoutedDeviceConfig};
+
+use super::BACnetClient;
+
+const OVERSIZED: usize = 200;
+const PEER_MAX_APDU: u32 = 128;
+
+fn local_peer(
+    instance: u32,
+    mac: &[u8],
+    max_apdu_length: u32,
+    segmentation_supported: Segmentation,
+) -> DiscoveredDevice {
+    DiscoveredDevice {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, instance).unwrap(),
+        mac_address: MacAddr::from_slice(mac),
+        max_apdu_length,
+        segmentation_supported,
+        max_segments_accepted: None,
+        vendor_id: 42,
+        last_seen: Instant::now(),
+        source_network: None,
+        source_address: None,
+    }
+}
+
+fn oversized_data(len: usize) -> Vec<u8> {
+    (0..len as u16).map(|i| i as u8).collect()
+}
+
+/// Assert the error is the typed local segmentation refusal naming the
+/// peer's advertised capability.
+fn assert_segmentation_unsupported(err: Error, capability: &str) {
+    let text = err.to_string();
+    assert!(
+        matches!(err, Error::Segmentation(_)),
+        "expected Error::Segmentation, got: {text}"
+    );
+    assert!(
+        text.contains(capability),
+        "refusal must name the advertised capability {capability}, got: {text}"
+    );
+}
+
+/// A refusal must leave the wire silent: no frame reaches the peer.
+async fn assert_no_frame_reaches(
+    peer_rx: &mut tokio::sync::mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>,
+) {
+    // A closed channel (the request task dropped its transport end) is not a
+    // transmission; only a delivered NPDU fails this assertion.
+    match timeout(Duration::from_millis(50), peer_rx.recv()).await {
+        Err(_) | Ok(None) => {}
+        Ok(Some(received)) => panic!(
+            "no frame may be transmitted for a locally refused request; got npdu {:x?}",
+            received.npdu
+        ),
+    }
+}
+
+async fn send_local_reply(peer_transport: &LoopbackTransport, client_mac: &[u8], apdu: Apdu) {
+    let mut apdu_buf = BytesMut::new();
+    bacnet_encoding::apdu::encode_apdu(&mut apdu_buf, &apdu).expect("valid APDU encoding");
+    let npdu = Npdu {
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    bacnet_encoding::npdu::encode_npdu(&mut npdu_buf, &npdu).unwrap();
+    peer_transport
+        .send_unicast(&npdu_buf, client_mac)
+        .await
+        .unwrap();
+}
+
+struct ScriptedExchange {
+    all_service_data: Vec<u8>,
+    every_apdu_segmented: bool,
+}
+
+/// Drive one segmented send to completion against a scripted peer that
+/// acknowledges each segment (window 1) and finally SimpleAcks.
+async fn script_segmented_exchange(
+    peer_rx: &mut tokio::sync::mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>,
+    peer_transport: &LoopbackTransport,
+    client_mac: &[u8],
+    service_choice: ConfirmedServiceChoice,
+) -> ScriptedExchange {
+    let mut all_service_data = Vec::new();
+    let mut every_apdu_segmented = true;
+    let invoke_id = loop {
+        let received = timeout(Duration::from_secs(2), peer_rx.recv())
+            .await
+            .expect("timed out waiting for a segment")
+            .expect("peer channel closed");
+        let npdu = decode_npdu(received.npdu).unwrap();
+        let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+        let Apdu::ConfirmedRequest(req) = decoded else {
+            panic!("Expected ConfirmedRequest, got {decoded:?}");
+        };
+        if !req.segmented {
+            every_apdu_segmented = false;
+        }
+        let seq = req.sequence_number.unwrap();
+        all_service_data.extend_from_slice(&req.service_request);
+
+        let seg_ack = Apdu::SegmentAck(SegmentAckPdu {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id: req.invoke_id,
+            sequence_number: seq,
+            actual_window_size: 1,
+        });
+        send_local_reply(peer_transport, client_mac, seg_ack).await;
+
+        if !req.more_follows {
+            break req.invoke_id;
+        }
+    };
+
+    send_local_reply(
+        peer_transport,
+        client_mac,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice,
+        }),
+    )
+    .await;
+
+    ScriptedExchange {
+        all_service_data,
+        every_apdu_segmented,
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Authoritative refusals (red discriminators against #371's base)
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn authoritative_local_no_segmentation_refuses_segmented_request() {
+    let client_mac = vec![0x01];
+    let peer_mac = vec![0x02];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(1000)
+        .build()
+        .await
+        .unwrap();
+
+    // Explicit upsert is authoritative configuration (Clause 12.11 values).
+    client.device_table.lock().await.upsert(local_peer(
+        1234,
+        &peer_mac,
+        PEER_MAX_APDU,
+        Segmentation::NONE,
+    ));
+
+    let service_data = oversized_data(OVERSIZED);
+    let peer_mac_for_request = peer_mac.clone();
+    let request_task = tokio::spawn(async move {
+        client
+            .confirmed_request(
+                &peer_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await
+    });
+
+    let err = timeout(Duration::from_secs(2), request_task)
+        .await
+        .expect("refusal must be immediate, not a timeout")
+        .unwrap()
+        .unwrap_err();
+    assert_segmentation_unsupported(err, "NONE");
+    assert_no_frame_reaches(&mut peer_rx).await;
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn authoritative_local_transmit_only_refuses_segmented_request() {
+    let client_mac = vec![0x01];
+    let peer_mac = vec![0x02];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(1000)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(local_peer(
+        1234,
+        &peer_mac,
+        PEER_MAX_APDU,
+        Segmentation::TRANSMIT,
+    ));
+
+    let service_data = oversized_data(OVERSIZED);
+    let peer_mac_for_request = peer_mac.clone();
+    let request_task = tokio::spawn(async move {
+        client
+            .confirmed_request(
+                &peer_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await
+    });
+
+    let err = timeout(Duration::from_secs(2), request_task)
+        .await
+        .expect("refusal must be immediate, not a timeout")
+        .unwrap()
+        .unwrap_err();
+    assert_segmentation_unsupported(err, "TRANSMIT");
+    assert_no_frame_reaches(&mut peer_rx).await;
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn authoritative_routed_no_segmentation_refuses_segmented_request() {
+    let client_mac = vec![0x01];
+    let router_mac = vec![0x02];
+    let remote_network = 100;
+    let remote_mac = vec![0x03];
+    let (client_transport, mut router_transport) =
+        LoopbackTransport::pair(client_mac.clone(), router_mac.clone());
+    let mut router_rx = router_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(1000)
+        .build()
+        .await
+        .unwrap();
+
+    // add_routed_device capability is explicitly supplied -> authoritative.
+    client
+        .add_routed_device(RoutedDeviceConfig {
+            instance: 3003,
+            router_mac: router_mac.clone(),
+            remote_network,
+            remote_mac: remote_mac.clone(),
+            max_apdu_length: PEER_MAX_APDU,
+            segmentation_supported: Segmentation::NONE,
+            max_segments_accepted: None,
+        })
+        .await
+        .unwrap();
+
+    let service_data = oversized_data(OVERSIZED);
+    let router_mac_for_request = router_mac.clone();
+    let remote_mac_for_request = remote_mac.clone();
+    let request_task = tokio::spawn(async move {
+        client
+            .confirmed_request_routed(
+                &router_mac_for_request,
+                remote_network,
+                &remote_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await
+    });
+
+    let err = timeout(Duration::from_secs(2), request_task)
+        .await
+        .expect("refusal must be immediate, not a timeout")
+        .unwrap()
+        .unwrap_err();
+    assert_segmentation_unsupported(err, "NONE");
+    assert_no_frame_reaches(&mut router_rx).await;
+    router_transport.stop().await.unwrap();
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Receive-capable peers still segment; fitting requests stay unsegmented
+// ──────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn authoritative_receive_peer_still_segments_successfully() {
+    let client_mac = vec![0x01];
+    let peer_mac = vec![0x02];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(local_peer(
+        1234,
+        &peer_mac,
+        PEER_MAX_APDU,
+        Segmentation::RECEIVE,
+    ));
+
+    let expected = oversized_data(OVERSIZED);
+    let service_data = expected.clone();
+    let peer_mac_for_request = peer_mac.clone();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request(
+                &peer_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let exchange = script_segmented_exchange(
+        &mut peer_rx,
+        &peer_transport,
+        &client_mac,
+        ConfirmedServiceChoice::WRITE_PROPERTY,
+    )
+    .await;
+    assert_eq!(exchange.all_service_data, expected);
+    assert!(
+        exchange.every_apdu_segmented,
+        "an oversized request to a RECEIVE peer segments"
+    );
+
+    let result = request_task.await.unwrap();
+    assert!(result.unwrap().is_empty());
+    peer_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn fitting_request_to_no_segmentation_peer_still_sends() {
+    let client_mac = vec![0x01];
+    let peer_mac = vec![0x02];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(local_peer(
+        1234,
+        &peer_mac,
+        PEER_MAX_APDU,
+        Segmentation::NONE,
+    ));
+
+    let service_data = oversized_data(10);
+    let peer_mac_for_request = peer_mac.clone();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request(
+                &peer_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    // The request fits inside the peer's Max APDU, so it goes out whole even
+    // though the peer cannot receive segments.
+    let received = timeout(Duration::from_secs(2), peer_rx.recv())
+        .await
+        .expect("timed out waiting for the request")
+        .expect("peer channel closed");
+    let npdu = decode_npdu(received.npdu).unwrap();
+    let decoded = apdu::decode_apdu(npdu.payload).unwrap();
+    let Apdu::ConfirmedRequest(req) = decoded else {
+        panic!("Expected ConfirmedRequest, got {decoded:?}");
+    };
+    assert!(!req.segmented, "a fitting request must not be segmented");
+
+    send_local_reply(
+        &peer_transport,
+        &client_mac,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id: req.invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+
+    let result = request_task.await.unwrap();
+    assert!(result.unwrap().is_empty());
+    peer_transport.stop().await.unwrap();
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Provenance: legacy placeholder stays unknown; refresh becomes authoritative
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Legacy `add_device` stores placeholder NONE/1476 that are NOT I-Am
+/// evidence: an oversized request must still enter the segmented path rather
+/// than being locally refused on placeholder values (#371 constraint from
+/// the Round 3 review).
+#[tokio::test]
+async fn legacy_add_device_placeholder_does_not_refuse_segmented_request() {
+    let client_mac = vec![0x01];
+    let peer_mac = vec![0x02];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    client.add_device(1234, &peer_mac).await.unwrap();
+
+    // 1600 octets exceed the placeholder Max APDU of 1476, so sizing already
+    // requires segmentation; the placeholder NONE must not refuse it.
+    let expected = oversized_data(1600);
+    let service_data = expected.clone();
+    let peer_mac_for_request = peer_mac.clone();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request(
+                &peer_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let exchange = script_segmented_exchange(
+        &mut peer_rx,
+        &peer_transport,
+        &client_mac,
+        ConfirmedServiceChoice::WRITE_PROPERTY,
+    )
+    .await;
+    assert_eq!(exchange.all_service_data, expected);
+    assert!(
+        exchange.every_apdu_segmented,
+        "the request must actually enter the segmented path, proving no placeholder refusal"
+    );
+
+    let result = request_task.await.unwrap();
+    assert!(result.unwrap().is_empty());
+    peer_transport.stop().await.unwrap();
+}
+
+/// A legacy placeholder row refreshed through an explicit authoritative
+/// upsert becomes authoritative: the same oversized request that previously
+/// segmented is now refused locally (provenance transition + explicit-upsert
+/// semantics in one request-path test).
+#[tokio::test]
+async fn explicit_upsert_refresh_makes_placeholder_authoritative() {
+    let client_mac = vec![0x01];
+    let peer_mac = vec![0x02];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(1000)
+        .build()
+        .await
+        .unwrap();
+
+    // Placeholder row via legacy add_device: oversized requests segment.
+    client.add_device(1234, &peer_mac).await.unwrap();
+
+    // Authoritative replacement of the same instance: now NONE at a small
+    // Max APDU is real configuration, not a placeholder.
+    client.device_table.lock().await.upsert(local_peer(
+        1234,
+        &peer_mac,
+        PEER_MAX_APDU,
+        Segmentation::NONE,
+    ));
+
+    let service_data = oversized_data(OVERSIZED);
+    let peer_mac_for_request = peer_mac.clone();
+    let request_task = tokio::spawn(async move {
+        client
+            .confirmed_request(
+                &peer_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await
+    });
+
+    let err = timeout(Duration::from_secs(2), request_task)
+        .await
+        .expect("refusal must be immediate, not a timeout")
+        .unwrap()
+        .unwrap_err();
+    assert_segmentation_unsupported(err, "NONE");
+    assert_no_frame_reaches(&mut peer_rx).await;
+    peer_transport.stop().await.unwrap();
+}
+
+/// An authoritative row carrying an unknown raw Segmentation value must not
+/// be classified as a known receive prohibition: the oversized request still
+/// enters the segmented path (Clause 12.11 enumerates only the four named
+/// capabilities; nothing here invents receive capability either way).
+#[tokio::test]
+async fn unknown_raw_capability_is_not_treated_as_no_segmentation() {
+    let client_mac = vec![0x01];
+    let peer_mac = vec![0x02];
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(client_mac.clone(), peer_mac.clone());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2000)
+        .build()
+        .await
+        .unwrap();
+
+    client.device_table.lock().await.upsert(local_peer(
+        1234,
+        &peer_mac,
+        PEER_MAX_APDU,
+        Segmentation::from_raw(200),
+    ));
+
+    let expected = oversized_data(OVERSIZED);
+    let service_data = expected.clone();
+    let peer_mac_for_request = peer_mac.clone();
+    let request_task = tokio::spawn(async move {
+        let result = client
+            .confirmed_request(
+                &peer_mac_for_request,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await;
+        client.stop().await.unwrap();
+        result
+    });
+
+    let exchange = script_segmented_exchange(
+        &mut peer_rx,
+        &peer_transport,
+        &client_mac,
+        ConfirmedServiceChoice::WRITE_PROPERTY,
+    )
+    .await;
+    assert_eq!(exchange.all_service_data, expected);
+    assert!(exchange.every_apdu_segmented);
+
+    let result = request_task.await.unwrap();
+    assert!(result.unwrap().is_empty());
+    peer_transport.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/peer_segmentation_tests.rs
+++ b/crates/bacnet-client/src/client/peer_segmentation_tests.rs
@@ -22,7 +22,7 @@ use bacnet_types::enums::{ConfirmedServiceChoice, ObjectType, Segmentation};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bacnet_types::MacAddr;
-use bytes::{Bytes, BytesMut};
+use bytes::BytesMut;
 use tokio::time::{timeout, Duration};
 
 use crate::discovery::{DiscoveredDevice, RoutedDeviceConfig};

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -179,19 +179,24 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let unsegmented_apdu_size = 4 + service_data.len();
         let target_transport_max_apdu = self.target_transport_max_apdu_length(target);
 
-        let (remote_max_apdu, remote_max_segments, advertised) = {
+        let (remote_max_apdu, remote_max_segments, advertised, peer_segmentation) = {
             let dt = self.device_table.lock().await;
             // A routed peer is recorded under the router's MAC, so only the
             // SNET/SADR of the NPDU that carried its I-Am identifies it
             // (Clause 5.2.1.2 term (c) binds the peer's Max APDU Length
             // Accepted regardless of how the peer is reached).
-            let device = match target {
-                ConfirmedTarget::Local { mac } => dt.get_by_mac(mac),
+            let (device, peer_segmentation) = match target {
+                ConfirmedTarget::Local { mac } => {
+                    (dt.get_by_mac(mac), dt.local_peer_segmentation(mac))
+                }
                 ConfirmedTarget::Routed {
                     dest_network,
                     dest_mac,
                     ..
-                } => dt.get_by_network_address(dest_network, dest_mac),
+                } => (
+                    dt.get_by_network_address(dest_network, dest_mac),
+                    dt.routed_peer_segmentation(dest_network, dest_mac),
+                ),
             };
             let max_apdu = device
                 .map(|d| u16::try_from(d.max_apdu_length).unwrap_or(u16::MAX))
@@ -202,10 +207,35 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             } else {
                 LengthBoundedBy::LocalConfig(max_apdu)
             };
-            (max_apdu.min(target_transport_max_apdu), max_seg, advertised)
+            (
+                max_apdu.min(target_transport_max_apdu),
+                max_seg,
+                advertised,
+                peer_segmentation,
+            )
         };
         check_transmittable_length(advertised, target_transport_max_apdu)?;
         if unsegmented_apdu_size > remote_max_apdu as usize {
+            // Clause 12.11: a NO_SEGMENTATION or SEGMENTED_TRANSMIT peer
+            // accepts exactly one segment — only unsegmented requests — and
+            // Clause 18's SEGMENTATION_NOT_SUPPORTED abort is the certain
+            // outcome of sending anyway. Refuse locally when the capability
+            // is authoritative (I-Am or explicit configuration); a legacy
+            // placeholder row stays unknown and keeps today's behavior.
+            if let Some(crate::discovery::PeerSegmentation::Authoritative(capability)) =
+                peer_segmentation
+            {
+                if matches!(
+                    capability,
+                    bacnet_types::enums::Segmentation::NONE
+                        | bacnet_types::enums::Segmentation::TRANSMIT
+                ) {
+                    return Err(Error::Segmentation(format!(
+                        "request requires segmentation but the peer advertised \
+                         {capability:?} and cannot receive segmented requests"
+                    )));
+                }
+            }
             return self
                 .segmented_confirmed_request(
                     target,

--- a/crates/bacnet-client/src/discovery.rs
+++ b/crates/bacnet-client/src/discovery.rs
@@ -99,7 +99,7 @@ struct TableEntry {
 /// # Capability provenance
 ///
 /// Each row records whether its `segmentation_supported` is authoritative
-/// ([I-Am ingestion][DeviceTable::upsert_with_result], explicit
+/// (I-Am ingestion via `upsert_with_result`, explicit
 /// [`upsert`][DeviceTable::upsert], or `add_routed_device`) or a legacy
 /// placeholder (`add_device`). Provenance lives in the same table entry as
 /// the device data, so it stays coherent across insert, update, purge, and

--- a/crates/bacnet-client/src/discovery.rs
+++ b/crates/bacnet-client/src/discovery.rs
@@ -61,6 +61,26 @@ pub struct RoutedDeviceConfig {
     pub max_segments_accepted: Option<u32>,
 }
 
+/// Provenance of a row's `Segmentation_Supported` value (Clause 12.11).
+///
+/// Only authoritative capability may drive a preflight refusal: a legacy
+/// manual registration stores placeholder defaults that must not be mistaken
+/// for a peer advertising NO_SEGMENTATION (#371).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PeerSegmentation {
+    /// The value is authoritative: learned from the peer's I-Am or explicitly
+    /// supplied by a caller (`add_routed_device`, `DeviceTable::upsert`).
+    Authoritative(Segmentation),
+    /// The row stores manual placeholder defaults; capability is unknown.
+    Placeholder,
+}
+
+#[derive(Debug)]
+struct TableEntry {
+    device: DiscoveredDevice,
+    segmentation: PeerSegmentation,
+}
+
 /// Thread-safe device discovery table.
 ///
 /// Keyed by device instance number (the instance part of the DEVICE object
@@ -75,9 +95,18 @@ pub struct RoutedDeviceConfig {
 /// both routing fields are `None`. A row with exactly one routing field set is
 /// malformed; it counts as neither local nor routable and matches no secondary
 /// lookup until a complete I-Am refreshes it.
+///
+/// # Capability provenance
+///
+/// Each row records whether its `segmentation_supported` is authoritative
+/// ([I-Am ingestion][DeviceTable::upsert_with_result], explicit
+/// [`upsert`][DeviceTable::upsert], or `add_routed_device`) or a legacy
+/// placeholder (`add_device`). Provenance lives in the same table entry as
+/// the device data, so it stays coherent across insert, update, purge, and
+/// clear: any replacement of an instance replaces its provenance with it.
 #[derive(Debug, Default)]
 pub struct DeviceTable {
-    devices: HashMap<u32, DiscoveredDevice>,
+    devices: HashMap<u32, TableEntry>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,6 +125,9 @@ impl DeviceTable {
 
     /// Insert or update a discovered device.
     ///
+    /// The row's `segmentation_supported` is treated as authoritative
+    /// capability (explicit configuration); see [`PeerSegmentation`].
+    ///
     /// The table is capped at 4096 entries. If the table is full and the
     /// device is not already present, the new entry is silently dropped.
     pub fn upsert(&mut self, device: DiscoveredDevice) {
@@ -103,13 +135,36 @@ impl DeviceTable {
     }
 
     pub(crate) fn upsert_with_result(&mut self, device: DiscoveredDevice) -> DeviceUpsertResult {
+        let segmentation = PeerSegmentation::Authoritative(device.segmentation_supported);
+        self.insert_entry(device, segmentation)
+    }
+
+    /// Insert or update a device whose capability fields are manual
+    /// placeholders rather than learned or explicitly supplied values
+    /// (legacy `add_device`). Its `segmentation_supported` must never drive
+    /// a capability decision (#371).
+    pub(crate) fn upsert_placeholder(&mut self, device: DiscoveredDevice) {
+        let _ = self.insert_entry(device, PeerSegmentation::Placeholder);
+    }
+
+    fn insert_entry(
+        &mut self,
+        device: DiscoveredDevice,
+        segmentation: PeerSegmentation,
+    ) -> DeviceUpsertResult {
         const MAX_DEVICE_TABLE_ENTRIES: usize = 4096;
         let key = device.object_identifier.instance_number();
         let is_existing = self.devices.contains_key(&key);
         if !is_existing && self.devices.len() >= MAX_DEVICE_TABLE_ENTRIES {
             return DeviceUpsertResult::Dropped;
         }
-        self.devices.insert(key, device);
+        self.devices.insert(
+            key,
+            TableEntry {
+                device,
+                segmentation,
+            },
+        );
         if is_existing {
             DeviceUpsertResult::Updated
         } else {
@@ -119,12 +174,12 @@ impl DeviceTable {
 
     /// Get all discovered devices as a snapshot.
     pub fn all(&self) -> Vec<DiscoveredDevice> {
-        self.devices.values().cloned().collect()
+        self.devices.values().map(|e| e.device.clone()).collect()
     }
 
     /// Look up a device by instance number.
     pub fn get(&self, instance: u32) -> Option<&DiscoveredDevice> {
-        self.devices.get(&instance)
+        self.devices.get(&instance).map(|e| &e.device)
     }
 
     /// Look up a local device by its MAC address.
@@ -140,9 +195,10 @@ impl DeviceTable {
     pub fn get_by_mac(&self, mac: &[u8]) -> Option<&DiscoveredDevice> {
         self.devices
             .values()
-            .filter(|d| d.is_local())
-            .filter(|d| d.mac_address.as_slice() == mac)
-            .max_by_key(|d| d.last_seen)
+            .filter(|e| e.device.is_local())
+            .filter(|e| e.device.mac_address.as_slice() == mac)
+            .max_by_key(|e| e.device.last_seen)
+            .map(|e| &e.device)
     }
 
     /// Look up a routed device by its remote network number and MAC address.
@@ -163,13 +219,38 @@ impl DeviceTable {
     ) -> Option<&DiscoveredDevice> {
         self.devices
             .values()
-            .filter(|d| {
-                d.source_network == Some(network)
-                    && d.source_address
+            .filter(|e| {
+                e.device.source_network == Some(network)
+                    && e.device
+                        .source_address
                         .as_ref()
                         .is_some_and(|a| a.as_slice() == address)
             })
-            .max_by_key(|d| d.last_seen)
+            .max_by_key(|e| e.device.last_seen)
+            .map(|e| &e.device)
+    }
+
+    /// Segmentation capability knowledge for the local row [`get_by_mac`]
+    /// selects, or `None` when no local row matches. Coherent with request
+    /// sizing: both consult the same row under one shared borrow.
+    pub(crate) fn local_peer_segmentation(&self, mac: &[u8]) -> Option<PeerSegmentation> {
+        let device = self.get_by_mac(mac)?;
+        self.devices
+            .get(&device.object_identifier.instance_number())
+            .map(|e| e.segmentation)
+    }
+
+    /// Segmentation capability knowledge for the routed row
+    /// [`get_by_network_address`] selects, or `None` when no row matches.
+    pub(crate) fn routed_peer_segmentation(
+        &self,
+        network: u16,
+        address: &[u8],
+    ) -> Option<PeerSegmentation> {
+        let device = self.get_by_network_address(network, address)?;
+        self.devices
+            .get(&device.object_identifier.instance_number())
+            .map(|e| e.segmentation)
     }
 
     /// Clear all entries.
@@ -200,9 +281,9 @@ impl DeviceTable {
         let stale_keys: Vec<u32> = self
             .devices
             .iter()
-            .filter_map(|(key, device)| {
+            .filter_map(|(key, entry)| {
                 let is_stale = now
-                    .checked_duration_since(device.last_seen)
+                    .checked_duration_since(entry.device.last_seen)
                     .is_some_and(|age| age > max_age);
                 is_stale.then_some(*key)
             })
@@ -210,7 +291,7 @@ impl DeviceTable {
 
         stale_keys
             .into_iter()
-            .filter_map(|key| self.devices.remove(&key))
+            .filter_map(|key| self.devices.remove(&key).map(|e| e.device))
             .collect()
     }
 }
@@ -361,6 +442,44 @@ mod tests {
     /// original source; the router MAC is only the local next hop). A local
     /// MAC lookup for the router's own address must therefore never select a
     /// routed peer behind that router (#372).
+    /// Provenance transitions (#371): a legacy placeholder row becomes
+    /// authoritative when refreshed through the I-Am insertion path, and
+    /// provenance never outlives its row across purge/clear.
+    #[test]
+    fn segmentation_provenance_tracks_row_lifecycle() {
+        let mut table = DeviceTable::new();
+        table.upsert_placeholder(make_device(1));
+        assert_eq!(
+            table.local_peer_segmentation(&[192, 168, 1, 100, 0xBA, 0xC0]),
+            Some(PeerSegmentation::Placeholder)
+        );
+
+        // I-Am refresh of the same instance (the dispatch path).
+        table.upsert_with_result(make_device(1));
+        assert_eq!(
+            table.local_peer_segmentation(&[192, 168, 1, 100, 0xBA, 0xC0]),
+            Some(PeerSegmentation::Authoritative(Segmentation::NONE))
+        );
+
+        // Purge removes the row and its provenance with it.
+        let mut stale = make_device(1);
+        stale.last_seen = Instant::now() - Duration::from_secs(120);
+        table.upsert_placeholder(stale);
+        table.purge_stale(Duration::from_secs(60));
+        assert_eq!(
+            table.local_peer_segmentation(&[192, 168, 1, 100, 0xBA, 0xC0]),
+            None
+        );
+
+        // Clear leaves no orphan provenance either.
+        table.upsert(make_device(2));
+        table.clear();
+        assert_eq!(
+            table.local_peer_segmentation(&[192, 168, 1, 100, 0xBA, 0xC0]),
+            None
+        );
+    }
+
     #[test]
     fn get_by_mac_ignores_routed_rows() {
         let mut table = DeviceTable::new();


### PR DESCRIPTION
Closes #371

## Summary

`confirmed_request_inner` consulted the peer's Max APDU Length Accepted but discarded `Segmentation_Supported`, so a request larger than the peer's limit was segmented and sent regardless of capability. For a peer that advertised `NO_SEGMENTATION` or `SEGMENTED_TRANSMIT`, the Clause 18 SEGMENTATION_NOT_SUPPORTED abort was predetermined one round-trip later. The client now refuses locally — before transaction allocation or transmission — when the capability is authoritative.

## Standard anchors (kept light)

- **Clause 12.11** — Segmentation_Supported distinguishes BOTH/TRANSMIT/RECEIVE/NONE; TRANSMIT and NONE peers accept exactly one segment (only unsegmented requests).
- **Clause 18** — SEGMENTATION_NOT_SUPPORTED is the certain outcome of sending a segmented APDU to such a peer; refusing locally surfaces the known outcome immediately.
- **Clause 5.2.1.2** — the existing maximum-transmittable-APDU calculation is unchanged; this PR only gates entry into the segmented-send path.

## Capability provenance (Round 3 review constraint)

| Source | Authoritative? | Behavior |
|---|---|---|
| I-Am ingestion (`upsert_with_result`) | yes | honored |
| `add_routed_device(RoutedDeviceConfig)` | yes | honored |
| explicit `DeviceTable::upsert` | yes | honored |
| legacy `add_device(instance, mac)` | no — placeholder | never preflight-rejects |
| no matching row | no | current behavior preserved |

Provenance is a private `PeerSegmentation` marker stored in the same internal table entry as the device data — no public struct fields added, no inference from field values (NONE/1476/vendor 0 are all legitimately producible by a real I-Am). Any replacement of an instance replaces its provenance; purge and clear cannot orphan it. Address-space identity rules from #402 are untouched.

## Refusal rule

Only when segmentation is already required by the existing sizing calculation AND the selected row's capability is authoritative NONE or TRANSMIT: `Error::Segmentation` naming the advertised capability, before TSM invoke-ID allocation, before any NPDU/APDU, before the segmented loop. RECEIVE/BOTH proceed; unknown raw capability values proceed (nothing invents receive capability or a prohibition); `max_segments_accepted` is untouched.

## Files changed

- `crates/bacnet-client/src/discovery.rs` — private `TableEntry` + `PeerSegmentation` provenance, `upsert_placeholder`, `local_peer_segmentation`/`routed_peer_segmentation`, provenance-lifecycle test
- `crates/bacnet-client/src/client/requests.rs` — preflight in the unified sizing block
- `crates/bacnet-client/src/client/discovery.rs` — `add_device` uses placeholder provenance
- `crates/bacnet-client/src/client/peer_segmentation_tests.rs` (new) — 8 request-path tests (matrix below)
- `crates/bacnet-client/src/client/mod.rs` — test module registration
- `CHANGELOG.md` — Fixed entry

## Red evidence (base 758ee906924b7211cc94002e96535e9d6ab31b2b)

Command: `RUSTFLAGS=-Awarnings cargo test -q -p bacnet-client peer_segmentation --locked` → 4 passed, 4 failed.

Failed (the discriminators — base segmented and transmitted instead of refusing locally):

- `authoritative_local_no_segmentation_refuses_segmented_request`
- `authoritative_local_transmit_only_refuses_segmented_request`
- `authoritative_routed_no_segmentation_refuses_segmented_request`
- `explicit_upsert_refresh_makes_placeholder_authoritative`

The failures prove #371 specifically: each asserts the typed `Error::Segmentation` naming the capability plus wire silence; base instead entered the segmented-send path. The four passing tests (RECEIVE segments, fitting request sends, legacy placeholder does not refuse, unknown raw value does not masquerade) already passed at base — they are regression guards, not discriminators. The provenance primitive tests are compile-time-absent at base (allowed).

## Test matrix coverage

A. authoritative local NONE → typed refusal, no frame ✓ (red)
B. authoritative local TRANSMIT → typed refusal, no frame ✓ (red)
C. authoritative routed NONE via `add_routed_device` → typed refusal, no frame to router ✓ (red)
D. authoritative RECEIVE → full segmented exchange completes ✓ (BOTH already covered by the preserved Round 3 test)
E. fitting request to NONE peer → unsegmented, completes ✓
F. legacy `add_device` placeholder → 1600-octet request enters and completes the segmented path, no local refusal ✓
G/H. placeholder refreshed by explicit authoritative upsert → oversized now refused locally ✓ (red)
I. authoritative unknown raw capability (from_raw(200)) → not treated as a prohibition; segmented path proceeds ✓

## Verification (final head 5e1953cd07011441017833544c29c865b8f05df0)

- `cargo fmt --all -- --check` — pass
- `RUSTFLAGS=-Awarnings cargo test -q -p bacnet-client --locked` — 140 lib + 3 integration passed
- workspace suite w/ features — 3173 passed, 0 failed, 2 ignored (pre-existing loopback-gated)
- `RUSTFLAGS=-Awarnings cargo clippy -q --workspace --exclude rusty-bacnet --all-targets --locked` — pass
- `RUSTFLAGS=-Awarnings cargo check -q -p rusty-bacnet --tests --locked` — pass
- file-size / no-secret / conformance `--check` / `git diff --check` — pass


Note: test/clippy/fmt counts were produced at `3c2728a`; the only later commit (`5e1953c`) removes an unused test import and fixes a private intra-doc link — no behavioral change. GitHub Actions runs green at the final head.

## Compatibility

- Rust API: no public API change. Private `DeviceTable` storage refactor keeps `upsert`, `upsert_with_result`, `all`, `get`, secondary lookups, `purge_stale*`, `clear` contracts intact (existing tests unchanged and passing). `DiscoveredDevice`/`RoutedDeviceConfig` fields untouched.
- Python: unchanged; no stub or docs changes.
- Wire behavior: only that a known no-receive peer now gets a local refusal instead of guaranteed remote abort. Unknown peers, placeholder peers, receive-capable peers: unchanged.
- Changelog: describes refusal only when receive inability is known; explicitly states placeholder/unknown peers are not refused; no conformance/PICS/BIBB claim.

## Non-goals honored

#370 path limits, #379/#380 timers, #383 duplicate-window, #384 server reassembly, equal-last_seen tie-break, #397–#401 backlog, server segmentation, discovery-table redesign, Python exposure, new CI — all untouched.

No benchmark: constant-time capability check on the existing sizing path.
