### PR TITLE
fix(client): implement outgoing segmented request state

### DIFF
--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -40,6 +40,27 @@ async fn take_current_reassembly(
     }
 }
 
+async fn admit_terminal_response(
+    tsm: &Arc<Mutex<Tsm>>,
+    tsm_mac: &MacAddr,
+    invoke_id: u8,
+) -> TerminalResponseAdmission {
+    let mut expected_owner = None;
+    loop {
+        let admission =
+            tsm.lock()
+                .await
+                .admit_terminal_response(tsm_mac, invoke_id, expected_owner.as_ref());
+        match admission {
+            TerminalResponseAdmission::FinalSegmentSendPolling { owner, issue } => {
+                issue.wait_until_polled().await;
+                expected_owner = Some(owner);
+            }
+            admission => return admission,
+        }
+    }
+}
+
 impl<T: TransportPort + 'static> BACnetClient<T> {
     /// Dispatch a received APDU to the appropriate handler.
     #[allow(clippy::too_many_arguments)]
@@ -51,7 +72,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         confirmed_cov_ack_policy: &ConfirmedCOVNotificationAckPolicy,
         device_tx: &broadcast::Sender<DeviceEvent>,
         seg_state: &mut HashMap<SegKey, SegmentedReceiveState>,
-        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
+        seg_ack_senders: &Arc<Mutex<HashMap<SegKey, SegmentAckRoute>>>,
         source_mac: &[u8],
         source_network: &Option<NpduAddress>,
         is_group: bool,
@@ -88,14 +109,30 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     return;
                 }
                 debug!(invoke_id = ack.invoke_id, "Received SimpleAck");
-                let mut tsm = tsm.lock().await;
-                let outcome = tsm.complete_transaction(
-                    &tsm_mac,
-                    ack.invoke_id,
-                    Some(ack.service_choice),
-                    TsmResponse::SimpleAck,
-                );
-                log_mismatch(outcome, ack.invoke_id, "SimpleAck");
+                match admit_terminal_response(tsm, &tsm_mac, ack.invoke_id).await {
+                    TerminalResponseAdmission::Active(owner) => {
+                        let outcome = tsm.lock().await.complete_transaction_for_owner(
+                            &tsm_mac,
+                            ack.invoke_id,
+                            &owner,
+                            Some(ack.service_choice),
+                            TsmResponse::SimpleAck,
+                        );
+                        log_mismatch(outcome, ack.invoke_id, "SimpleAck");
+                    }
+                    TerminalResponseAdmission::PrematureSegmentedRequestAborted => {
+                        Self::send_client_abort(
+                            network,
+                            source_mac,
+                            source_network,
+                            ack.invoke_id,
+                            bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                        )
+                        .await;
+                    }
+                    TerminalResponseAdmission::NoTransaction => {}
+                    TerminalResponseAdmission::FinalSegmentSendPolling { .. } => unreachable!(),
+                }
             }
             Apdu::ComplexAck(ack) => {
                 if ack.segmented {
@@ -134,16 +171,32 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         return;
                     }
                     debug!(invoke_id = ack.invoke_id, "Received ComplexAck");
-                    let mut tsm = tsm.lock().await;
-                    let outcome = tsm.complete_transaction(
-                        &tsm_mac,
-                        ack.invoke_id,
-                        Some(ack.service_choice),
-                        TsmResponse::ComplexAck {
-                            service_data: ack.service_ack,
-                        },
-                    );
-                    log_mismatch(outcome, ack.invoke_id, "ComplexAck");
+                    match admit_terminal_response(tsm, &tsm_mac, ack.invoke_id).await {
+                        TerminalResponseAdmission::Active(owner) => {
+                            let outcome = tsm.lock().await.complete_transaction_for_owner(
+                                &tsm_mac,
+                                ack.invoke_id,
+                                &owner,
+                                Some(ack.service_choice),
+                                TsmResponse::ComplexAck {
+                                    service_data: ack.service_ack,
+                                },
+                            );
+                            log_mismatch(outcome, ack.invoke_id, "ComplexAck");
+                        }
+                        TerminalResponseAdmission::PrematureSegmentedRequestAborted => {
+                            Self::send_client_abort(
+                                network,
+                                source_mac,
+                                source_network,
+                                ack.invoke_id,
+                                bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                            )
+                            .await;
+                        }
+                        TerminalResponseAdmission::NoTransaction => {}
+                        TerminalResponseAdmission::FinalSegmentSendPolling { .. } => unreachable!(),
+                    }
                 }
             }
             Apdu::Error(err) => {
@@ -152,11 +205,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // so the local surface is an ABORT.indication with
                 // INVALID_APDU_IN_THIS_STATE, not the error content (#367).
                 // Checked before the TSM lock below: `abort_reassembly` takes
-                // that lock itself, and tokio's Mutex is not reentrant. Keyed
-                // on `seg_state` only — an Error answering an *outgoing*
-                // segmented request can be legitimate (5.4.4.2 surfaces it
-                // once SentAllSegments is TRUE, a flag this client does not
-                // track), so a `seg_ack_senders` entry must not divert here.
+                // that lock itself, and tokio's Mutex is not reentrant.
                 let key = (tsm_mac.clone(), err.invoke_id);
                 if let Some(state) = take_current_reassembly(tsm, seg_state, &key).await {
                     debug!(
@@ -177,7 +226,6 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     return;
                 }
                 debug!(invoke_id = err.invoke_id, "Received Error PDU");
-                let mut tsm = tsm.lock().await;
                 // Correlated by invoke ID alone. Unlike 20.1.4.2 and 20.1.5.6,
                 // Clause 20.1.7.2 imposes no correspondence to the requested
                 // service: error-choice is "the tag value of the BACnet-Error
@@ -185,15 +233,32 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // `other [127] Error`. Nothing in the Standard forbids a peer
                 // from answering through that tag, so an exact-match gate here
                 // would reject conformant responses.
-                tsm.complete_transaction(
-                    &tsm_mac,
-                    err.invoke_id,
-                    None,
-                    TsmResponse::Error {
-                        class: err.error_class.to_raw() as u32,
-                        code: err.error_code.to_raw() as u32,
-                    },
-                );
+                match admit_terminal_response(tsm, &tsm_mac, err.invoke_id).await {
+                    TerminalResponseAdmission::Active(owner) => {
+                        tsm.lock().await.complete_transaction_for_owner(
+                            &tsm_mac,
+                            err.invoke_id,
+                            &owner,
+                            None,
+                            TsmResponse::Error {
+                                class: err.error_class.to_raw() as u32,
+                                code: err.error_code.to_raw() as u32,
+                            },
+                        );
+                    }
+                    TerminalResponseAdmission::PrematureSegmentedRequestAborted => {
+                        Self::send_client_abort(
+                            network,
+                            source_mac,
+                            source_network,
+                            err.invoke_id,
+                            bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                        )
+                        .await;
+                    }
+                    TerminalResponseAdmission::NoTransaction => {}
+                    TerminalResponseAdmission::FinalSegmentSendPolling { .. } => unreachable!(),
+                }
             }
             Apdu::Reject(rej) => {
                 // Same Clause 5.4.4.4 UnexpectedPDU_Received diversion as the
@@ -442,13 +507,6 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     );
                     return;
                 }
-                // Which of Clause 5.4's four client states this device is in
-                // for `invoke_id` decides the answer, and each gives a
-                // different one. The predicates below are what distinguishes
-                // them: a `seg_state` entry means a segmented response is
-                // being reassembled, a `seg_ack_senders` entry means a
-                // segmented request is still being sent, and a pending TSM
-                // transaction without either means the send is done.
                 let invoke_id = sa.invoke_id;
                 let key = (tsm_mac.clone(), invoke_id);
 
@@ -460,10 +518,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // INVALID_APDU_IN_THIS_STATE to the local application program;
                 // and enter the IDLE state."
                 //
-                // Checked first because it is the narrower state: reassembly
-                // only starts once the request has been sent in full, so a
-                // `seg_state` entry means any `seg_ack_senders` entry that
-                // still lingers belongs to a send that is already finished.
+                // Receive state is checked before the outgoing phase because
+                // SEGMENTED_CONF gives this PDU the opposite disposition.
                 if let Some(state) = take_current_reassembly(tsm, seg_state, &key).await {
                     debug!(invoke_id, "Aborting reassembly on an unexpected SegmentAck");
                     // The stored identity, not this PDU's source. A key match
@@ -486,52 +542,36 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     return;
                 }
 
-                let delivered = {
-                    let senders = seg_ack_senders.lock().await;
-                    match senders.get(&key) {
-                        Some(tx) => {
-                            let _ = tx.try_send(sa);
-                            true
+                // Hold the TSM lock through the route lookup and try_send.
+                // Terminal completion uses this same lock, so a raw sender
+                // entry cannot outlive the authoritative phase for delivery.
+                let tsm_guard = tsm.lock().await;
+                match tsm_guard.segment_ack_phase(&tsm_mac, invoke_id) {
+                    SegmentAckPhase::SegmentedRequest(owner) => {
+                        // Lock order is TSM then SegmentACK routes. Setup and
+                        // cleanup never hold both locks.
+                        let senders = seg_ack_senders.lock().await;
+                        if let Some(route) = senders
+                            .get(&key)
+                            .filter(|route| route.owner.same_as(&owner))
+                        {
+                            let _ = route.sender.try_send(sa);
                         }
-                        None => false,
+                        return;
                     }
-                };
-                if delivered {
-                    // SEGMENTED_REQUEST (5.4.4.2): still sending, so this is
-                    // the flow control the send loop is waiting on.
-                    return;
+                    SegmentAckPhase::Outstanding => {
+                        debug!(
+                            invoke_id,
+                            "Discarding duplicate SegmentAck for an outstanding transaction"
+                        );
+                        return;
+                    }
+                    SegmentAckPhase::Idle => {}
                 }
-
-                // AWAIT_CONFIRMATION (5.4.4.3) `SegmentACK_Received`: a
-                // transaction is outstanding but its send phase is over, so
-                // the Standard is explicit — "discard the PDU as a duplicate,
-                // and re-enter the current state."
-                //
-                // This case is not hypothetical. `release_invoke_id` drops a
-                // peer's allocator once every ID is free, so the next request
-                // to an idle peer reuses invoke ID 0. A duplicated SegmentACK
-                // from a finished segmented transfer therefore lands on a live
-                // unsegmented request — which has no `seg_ack_senders` entry —
-                // and aborting here would kill this client's own healthy
-                // request at the peer.
-                if tsm
-                    .lock()
-                    .await
-                    .expected_service_choice(&tsm_mac, invoke_id)
-                    .is_some()
-                {
-                    debug!(
-                        invoke_id,
-                        "Discarding duplicate SegmentAck for an outstanding transaction"
-                    );
-                    return;
-                }
+                drop(tsm_guard);
 
                 // IDLE (5.4.4.1) `UnexpectedSegmentInfoReceived`: nothing is
-                // outstanding, so a "BACnet-SegmentACK-PDU with 'server' =
-                // TRUE" is unexpected evidence of an active server TSM and
-                // earns the Abort ('server' = FALSE,
-                // INVALID_APDU_IN_THIS_STATE).
+                // outstanding, so a server SegmentACK earns a client Abort.
                 debug!(invoke_id, "Aborting SegmentAck received while idle");
                 Self::send_client_abort(
                     network,

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -67,7 +67,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let confirmed_cov_ack_policy = options.confirmed_cov_notification_ack_policy.clone();
         let (device_tx, _) = broadcast::channel::<DeviceEvent>(DEVICE_EVENT_CHANNEL_CAPACITY);
         let device_tx_dispatch = device_tx.clone();
-        let seg_ack_senders: Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>> =
+        let seg_ack_senders: Arc<Mutex<HashMap<SegKey, SegmentAckRoute>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let seg_ack_senders_dispatch = Arc::clone(&seg_ack_senders);
         let (cleanup_tx, mut cleanup_rx) = mpsc::unbounded_channel::<TransactionCleanup>();
@@ -108,7 +108,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                             let mut senders = seg_ack_senders_dispatch.lock().await;
                             if senders
                                 .get(&key)
-                                .is_some_and(|sender| sender.same_channel(&expected_sender))
+                                .is_some_and(|route| {
+                                    route.owner.same_as(&cleanup.owner)
+                                        && route.sender.same_channel(&expected_sender)
+                                })
                             {
                                 senders.remove(&key);
                             }

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -14,7 +14,9 @@ use std::time::Instant;
 use bytes::{Bytes, BytesMut};
 use tokio::sync::{broadcast, mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
-use tokio::time::{timeout, Duration};
+#[cfg(test)]
+use tokio::time::timeout;
+use tokio::time::Duration;
 use tracing::{debug, warn};
 
 use bacnet_encoding::apdu::{
@@ -39,8 +41,8 @@ use crate::segmentation::{
     duplicate_in_window, max_segment_payload, split_payload, SegmentReceiver, SegmentedPduType,
 };
 use crate::tsm::{
-    RequestTimerExpiration, SegmentTimerExpiration, TransactionOwner, TransactionProgress, Tsm,
-    TsmConfig, TsmResponse,
+    RequestTimerExpiration, SegmentAckPhase, SegmentTimerExpiration, SegmentedResponseAdmission,
+    TerminalResponseAdmission, TransactionOwner, TransactionProgress, Tsm, TsmConfig, TsmResponse,
 };
 #[cfg(test)]
 use transaction_cleanup::{SegmentedCleanupHook, SegmentedPostWaitCleanupHook};
@@ -375,6 +377,11 @@ struct SegmentedReceiveState {
 /// Key for tracking in-progress segmented receives: (correlation_mac, invoke_id).
 type SegKey = (MacAddr, u8);
 
+struct SegmentAckRoute {
+    owner: TransactionOwner,
+    sender: mpsc::Sender<SegmentAckPdu>,
+}
+
 /// BACnet client with low-level and high-level request APIs.
 pub struct BACnetClient<T: TransportPort> {
     config: ClientConfig,
@@ -384,14 +391,12 @@ pub struct BACnetClient<T: TransportPort> {
     cov_tx: broadcast::Sender<ReceivedCOVNotification>,
     device_tx: broadcast::Sender<DeviceEvent>,
     dispatch_task: Option<JoinHandle<()>>,
-    /// Channels feeding SegmentACKs to in-flight segmented sends.
+    /// Owner-qualified channels feeding SegmentACKs to in-flight segmented sends.
     ///
-    /// Lock invariant: never hold this and [`Self::tsm`] at the same time.
-    /// They are acquired in both orders by design — setup registers the
-    /// transaction and then inserts the sender, while teardown and inbound
-    /// dispatch go the other way — so the pair is deadlock-free only because
-    /// neither is ever held across the other's acquisition.
-    seg_ack_senders: Arc<Mutex<HashMap<SegKey, mpsc::Sender<SegmentAckPdu>>>>,
+    /// Dispatch may hold [`Self::tsm`] while acquiring this lock so phase
+    /// validation and delivery cannot race terminal completion. No path may
+    /// acquire the locks in the opposite order.
+    seg_ack_senders: Arc<Mutex<HashMap<SegKey, SegmentAckRoute>>>,
     cleanup_tx: mpsc::UnboundedSender<TransactionCleanup>,
     #[cfg(test)]
     segmented_post_wait_cleanup: Arc<SegmentedPostWaitCleanupHook>,
@@ -789,6 +794,7 @@ mod object_mgmt;
 mod property;
 mod requests;
 mod segmentation;
+mod segmented_request;
 mod transaction_cleanup;
 
 pub use cov_notifications::{
@@ -833,6 +839,10 @@ mod segmentation_retransmit_tests;
 mod segmented_receive_duplicate_tests;
 #[cfg(test)]
 mod segmented_receive_lifecycle_tests;
+#[cfg(test)]
+mod segmented_request_ordering_tests;
+#[cfg(test)]
+mod segmented_request_state_tests;
 #[cfg(test)]
 mod segmented_timeout_tests;
 #[cfg(test)]

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -1,3 +1,4 @@
+use super::segmented_request::{OutgoingSegmentContext, OutgoingSegmentSend};
 use super::*;
 use crate::tsm::CompletionOutcome;
 use bacnet_encoding::apdu::advertised_max_segments;
@@ -118,6 +119,37 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let tsm_mac = response_tsm_mac(source_mac, source_network);
         let key = (tsm_mac.clone(), ack.invoke_id);
 
+        let mut deferred_owner = None;
+        let admitted_owner = loop {
+            let admission = {
+                let mut tsm = tsm.lock().await;
+                if let Some(owner) = deferred_owner.as_ref() {
+                    tsm.admit_segmented_complex_ack_for_owner(&tsm_mac, ack.invoke_id, seq, owner)
+                } else {
+                    tsm.admit_segmented_complex_ack(&tsm_mac, ack.invoke_id, seq)
+                }
+            };
+            match admission {
+                SegmentedResponseAdmission::Active(owner) => break Some(owner),
+                SegmentedResponseAdmission::FinalSegmentSendPolling { owner, issue } => {
+                    issue.wait_until_polled().await;
+                    deferred_owner = Some(owner);
+                }
+                SegmentedResponseAdmission::PrematureSegmentedRequestAborted => {
+                    Self::send_client_abort(
+                        network,
+                        source_mac,
+                        source_network,
+                        ack.invoke_id,
+                        bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
+                    )
+                    .await;
+                    return;
+                }
+                SegmentedResponseAdmission::NoTransaction => break None,
+            }
+        };
+
         debug!(
             invoke_id = ack.invoke_id,
             seq = seq,
@@ -168,7 +200,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         //
         // Bind the guard so its scope is obvious: it must not be held across
         // the send below, and an `if let` here would extend it silently.
-        let owner = {
+        let owner = if let Some(owner) = admitted_owner {
+            Some(owner)
+        } else {
             tsm.lock()
                 .await
                 .owner_and_expected_service(&tsm_mac, ack.invoke_id)
@@ -455,6 +489,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             }
         }
     }
+
     /// Send a confirmed request using segmented transfer with windowed flow control.
     pub(super) async fn segmented_confirmed_request(
         &self,
@@ -486,18 +521,21 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             "Starting segmented confirmed request"
         );
 
+        let (seg_ack_tx, mut seg_ack_rx) = mpsc::channel(16);
         let (invoke_id, registration) = {
             let mut tsm = self.tsm.lock().await;
             let invoke_id = tsm.allocate_invoke_id(&tsm_mac).ok_or_else(|| {
                 Error::Encoding("all invoke IDs exhausted for destination".into())
             })?;
-            let registration =
-                tsm.register_transaction_with_progress(tsm_mac.clone(), invoke_id, service_choice);
+            let registration = tsm.register_segmented_transaction_with_progress(
+                tsm_mac.clone(),
+                invoke_id,
+                service_choice,
+            );
             (invoke_id, registration)
         };
 
         let owner = registration.owner.clone();
-        let (seg_ack_tx, mut seg_ack_rx) = mpsc::channel(16);
         let mut guard = TransactionGuard::new(
             Arc::clone(&self.tsm),
             self.cleanup_tx.clone(),
@@ -508,10 +546,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         );
         {
             let key = (tsm_mac.clone(), invoke_id);
-            self.seg_ack_senders
-                .lock()
-                .await
-                .insert(key, seg_ack_tx.clone());
+            self.seg_ack_senders.lock().await.insert(
+                key,
+                SegmentAckRoute {
+                    owner: owner.clone(),
+                    sender: seg_ack_tx.clone(),
+                },
+            );
         }
 
         // Tseg: use APDU timeout for now (configurable via apdu_timeout_ms)
@@ -527,9 +568,22 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         // transfer off is a local matter, like every bounded resource here.
         const MAX_NEG_ACK_RETRIES: u32 = 10;
         let mut owns_tsm_cleanup = true;
+        let mut response_rx = registration.response;
+        let mut progress_rx = registration.progress;
+        let send_context = OutgoingSegmentContext {
+            target,
+            service_choice,
+            advertised_max_apdu,
+            remote_max_apdu,
+            invoke_id,
+            total_segments,
+            tsm_mac: &tsm_mac,
+            owner: &owner,
+        };
 
         let result = async {
-            while next_seq < total_segments {
+            let mut segmented_response_started = false;
+            'send: while next_seq < total_segments {
                 let window_start = next_seq;
                 let window_end = (window_start + window_size).min(total_segments);
 
@@ -539,32 +593,61 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     .map(|(i, s)| (window_start + i, s))
                 {
                     let is_last = seq == total_segments - 1;
-                    let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
-                        segmented: true,
-                        more_follows: !is_last,
-                        segmented_response_accepted: self.config.segmented_response_accepted,
-                        max_segments: self.config.max_segments,
-                        max_apdu_length: advertised_max_apdu,
-                        invoke_id,
-                        sequence_number: Some(seq as u8),
-                        proposed_window_size: Some(self.config.proposed_window_size.max(1)),
-                        service_choice,
-                        service_request: segment_data.clone(),
-                    });
-
-                    let mut buf = BytesMut::with_capacity(remote_max_apdu as usize);
-                    encode_apdu(&mut buf, &pdu)?;
-
-                    self.send_confirmed_target_apdu(target, &buf).await?;
-
-                    debug!(seq, is_last, "Sent segment");
+                    match self
+                        .send_outgoing_segment(
+                            send_context,
+                            seq,
+                            segment_data,
+                            is_last,
+                            &mut response_rx,
+                            &mut progress_rx,
+                        )
+                        .await?
+                    {
+                        OutgoingSegmentSend::Sent => {
+                            debug!(seq, is_last, "Sent segment");
+                        }
+                        OutgoingSegmentSend::Terminal(response) => {
+                            owns_tsm_cleanup = false;
+                            return Ok(response);
+                        }
+                        OutgoingSegmentSend::SegmentedResponse => {
+                            segmented_response_started = true;
+                            break 'send;
+                        }
+                    }
                 }
 
                 let ack = {
                     let mut ack_retries: u8 = 0;
                     loop {
-                        match timeout(timeout_duration, seg_ack_rx.recv()).await {
-                            Ok(Some(ack)) => {
+                        let segment_timer = tokio::time::sleep(timeout_duration);
+                        tokio::pin!(segment_timer);
+                        tokio::select! {
+                            biased;
+                            response = &mut response_rx => {
+                                owns_tsm_cleanup = false;
+                                return response.map_err(|_| {
+                                    Error::Encoding("TSM response channel closed".into())
+                                });
+                            }
+                            changed = progress_rx.changed() => {
+                                if changed.is_err() {
+                                    owns_tsm_cleanup = false;
+                                    return (&mut response_rx).await.map_err(|_| {
+                                        Error::Encoding("TSM response channel closed".into())
+                                    });
+                                }
+                                if matches!(
+                                    *progress_rx.borrow_and_update(),
+                                    TransactionProgress::SegmentedResponse { .. }
+                                ) {
+                                    segmented_response_started = true;
+                                    break 'send;
+                                }
+                            }
+                            received = seg_ack_rx.recv() => match received {
+                                Some(ack) => {
                                 let ack_seq = ack.sequence_number as usize;
 
                                 // The sole gate on an inbound SegmentACK,
@@ -608,11 +691,12 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                 }
 
                                 break ack;
-                            }
-                            Ok(None) => {
+                                }
+                                None => {
                                 return Err(Error::Encoding("SegmentAck channel closed".into()));
-                            }
-                            Err(_timeout) => {
+                                }
+                            },
+                            _ = &mut segment_timer => {
                                 ack_retries += 1;
                                 if ack_retries > max_ack_retries {
                                     return Err(Error::Timeout(timeout_duration));
@@ -627,27 +711,29 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     .map(|(i, s)| (window_start + i, s))
                                 {
                                     let is_last = seq == total_segments - 1;
-                                    let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
-                                        segmented: true,
-                                        more_follows: !is_last,
-                                        segmented_response_accepted: self
-                                            .config
-                                            .segmented_response_accepted,
-                                        max_segments: self.config.max_segments,
-                                        max_apdu_length: advertised_max_apdu,
-                                        invoke_id,
-                                        sequence_number: Some(seq as u8),
-                                        proposed_window_size: Some(
-                                            self.config.proposed_window_size.max(1),
-                                        ),
-                                        service_choice,
-                                        service_request: segment_data.clone(),
-                                    });
-
-                                    let mut buf = BytesMut::with_capacity(remote_max_apdu as usize);
-                                    encode_apdu(&mut buf, &pdu)?;
-
-                                    self.send_confirmed_target_apdu(target, &buf).await?;
+                                    match self
+                                        .send_outgoing_segment(
+                                            send_context,
+                                            seq,
+                                            segment_data,
+                                            false,
+                                            &mut response_rx,
+                                            &mut progress_rx,
+                                        )
+                                        .await?
+                                    {
+                                        OutgoingSegmentSend::Sent => {
+                                            debug!(seq, is_last, "Retransmitted segment");
+                                        }
+                                        OutgoingSegmentSend::Terminal(response) => {
+                                            owns_tsm_cleanup = false;
+                                            return Ok(response);
+                                        }
+                                        OutgoingSegmentSend::SegmentedResponse => {
+                                                segmented_response_started = true;
+                                                break 'send;
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -683,6 +769,12 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 next_seq = ack_seq + 1;
             }
 
+            if !segmented_response_started {
+                self.tsm
+                    .lock()
+                    .await
+                    .finish_segmented_request(&tsm_mac, invoke_id, &owner);
+            }
             // Once entered, the phase-aware waiter owns terminal TSM removal.
             // A later key-only cancellation could target a reused invoke ID.
             owns_tsm_cleanup = false;
@@ -691,8 +783,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 &tsm_mac,
                 invoke_id,
                 &owner,
-                registration.response,
-                registration.progress,
+                response_rx,
+                progress_rx,
                 None,
             )
             .await
@@ -705,10 +797,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         {
             let key = (tsm_mac.clone(), invoke_id);
             let mut senders = self.seg_ack_senders.lock().await;
-            if senders
-                .get(&key)
-                .is_some_and(|sender| sender.same_channel(&seg_ack_tx))
-            {
+            if senders.get(&key).is_some_and(|route| {
+                route.owner.same_as(&owner) && route.sender.same_channel(&seg_ack_tx)
+            }) {
                 senders.remove(&key);
             }
         }

--- a/crates/bacnet-client/src/client/segmented_request.rs
+++ b/crates/bacnet-client/src/client/segmented_request.rs
@@ -1,0 +1,119 @@
+use super::*;
+use std::future::{poll_fn, Future};
+use std::task::Poll;
+
+#[derive(Clone, Copy)]
+pub(super) struct OutgoingSegmentContext<'a> {
+    pub(super) target: ConfirmedTarget<'a>,
+    pub(super) service_choice: ConfirmedServiceChoice,
+    pub(super) advertised_max_apdu: u16,
+    pub(super) remote_max_apdu: u16,
+    pub(super) invoke_id: u8,
+    pub(super) total_segments: usize,
+    pub(super) tsm_mac: &'a MacAddr,
+    pub(super) owner: &'a TransactionOwner,
+}
+
+pub(super) enum OutgoingSegmentSend {
+    Sent,
+    Terminal(TsmResponse),
+    SegmentedResponse,
+}
+
+impl<T: TransportPort + 'static> BACnetClient<T> {
+    pub(super) async fn send_outgoing_segment(
+        &self,
+        context: OutgoingSegmentContext<'_>,
+        seq: usize,
+        segment_data: &Bytes,
+        first_final_issue: bool,
+        response_rx: &mut oneshot::Receiver<TsmResponse>,
+        progress_rx: &mut tokio::sync::watch::Receiver<TransactionProgress>,
+    ) -> Result<OutgoingSegmentSend, Error> {
+        let is_last = seq == context.total_segments - 1;
+        let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+            segmented: true,
+            more_follows: !is_last,
+            segmented_response_accepted: self.config.segmented_response_accepted,
+            max_segments: self.config.max_segments,
+            max_apdu_length: context.advertised_max_apdu,
+            invoke_id: context.invoke_id,
+            sequence_number: Some(seq as u8),
+            proposed_window_size: Some(self.config.proposed_window_size.max(1)),
+            service_choice: context.service_choice,
+            service_request: segment_data.clone(),
+        });
+        let mut buf = BytesMut::with_capacity(context.remote_max_apdu as usize);
+        encode_apdu(&mut buf, &pdu)?;
+        let send = self.send_confirmed_target_apdu(context.target, &buf);
+        tokio::pin!(send);
+
+        if first_final_issue {
+            let Some(mut token) = self.tsm.lock().await.begin_final_segment_send(
+                context.tsm_mac,
+                context.invoke_id,
+                context.owner,
+            ) else {
+                return response_rx
+                    .await
+                    .map(OutgoingSegmentSend::Terminal)
+                    .map_err(|_| Error::Encoding("TSM response channel closed".into()));
+            };
+
+            // Poll without a TSM lock. Dispatch defers terminal admission while
+            // the token is unresolved, so a response produced by this poll is
+            // accepted only after SentAllSegments is published below.
+            let first_poll = poll_fn(|cx| Poll::Ready(send.as_mut().poll(cx))).await;
+            let send_completed = match first_poll {
+                Poll::Ready(result) => {
+                    result?;
+                    true
+                }
+                Poll::Pending => false,
+            };
+            if !self.tsm.lock().await.mark_final_segment_issued(
+                context.tsm_mac,
+                context.invoke_id,
+                context.owner,
+                &mut token,
+            ) {
+                return response_rx
+                    .await
+                    .map(OutgoingSegmentSend::Terminal)
+                    .map_err(|_| Error::Encoding("TSM response channel closed".into()));
+            }
+            if send_completed {
+                return Ok(OutgoingSegmentSend::Sent);
+            }
+        }
+
+        loop {
+            tokio::select! {
+                biased;
+                response = &mut *response_rx => {
+                    return response
+                        .map(OutgoingSegmentSend::Terminal)
+                        .map_err(|_| Error::Encoding("TSM response channel closed".into()));
+                }
+                changed = progress_rx.changed() => {
+                    if changed.is_err() {
+                        return response_rx
+                            .await
+                            .map(OutgoingSegmentSend::Terminal)
+                            .map_err(|_| Error::Encoding("TSM response channel closed".into()));
+                    }
+                    if matches!(
+                        *progress_rx.borrow_and_update(),
+                        TransactionProgress::SegmentedResponse { .. }
+                    ) {
+                        return Ok(OutgoingSegmentSend::SegmentedResponse);
+                    }
+                }
+                sent = &mut send => {
+                    sent?;
+                    return Ok(OutgoingSegmentSend::Sent);
+                }
+            }
+        }
+    }
+}

--- a/crates/bacnet-client/src/client/segmented_request_ordering_tests.rs
+++ b/crates/bacnet-client/src/client/segmented_request_ordering_tests.rs
@@ -1,0 +1,166 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use bacnet_encoding::apdu::{self, encode_apdu, AbortPdu, Apdu, SegmentAck, SimpleAck};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_types::enums::{AbortReason, ConfirmedServiceChoice};
+use bacnet_types::error::Error;
+use bacnet_types::MacAddr;
+use bytes::{Bytes, BytesMut};
+use tokio::sync::{mpsc, Notify};
+use tokio::time::{timeout, Duration};
+
+use super::{BACnetClient, ClientConfig};
+
+const CLIENT_MAC: &[u8] = &[0x01];
+const SERVER_MAC: &[u8] = &[0x02];
+
+struct EarlyReadyResponseTransport {
+    inbound_rx: Option<mpsc::Receiver<ReceivedNpdu>>,
+    inbound_tx: mpsc::Sender<ReceivedNpdu>,
+    wire_abort_tx: mpsc::Sender<AbortPdu>,
+    wire_abort_seen: Arc<Notify>,
+    response_injected: AtomicBool,
+    final_segment_polled: Arc<AtomicBool>,
+}
+
+impl EarlyReadyResponseTransport {
+    fn inbound(apdu: Apdu) -> ReceivedNpdu {
+        let mut apdu_buf = BytesMut::new();
+        encode_apdu(&mut apdu_buf, &apdu).unwrap();
+        let mut npdu_buf = BytesMut::new();
+        encode_npdu(
+            &mut npdu_buf,
+            &Npdu {
+                payload: apdu_buf.freeze(),
+                ..Npdu::default()
+            },
+        )
+        .unwrap();
+        ReceivedNpdu {
+            npdu: npdu_buf.freeze(),
+            source_mac: MacAddr::from_slice(SERVER_MAC),
+            link_layer_group: false,
+            data_attributes: Vec::new(),
+            reply_tx: None,
+        }
+    }
+}
+
+impl TransportPort for EarlyReadyResponseTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        Ok(self.inbound_rx.take().expect("transport starts once"))
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        let npdu = decode_npdu(Bytes::copy_from_slice(npdu)).unwrap();
+        match apdu::decode_apdu(npdu.payload).unwrap() {
+            Apdu::Abort(abort) => {
+                self.wire_abort_tx.send(abort).await.unwrap();
+                self.wire_abort_seen.notify_one();
+            }
+            Apdu::ConfirmedRequest(request) if request.segmented => {
+                if !request.more_follows {
+                    self.final_segment_polled.store(true, Ordering::Release);
+                    return Ok(());
+                }
+                if self.response_injected.swap(true, Ordering::AcqRel) {
+                    return Ok(());
+                }
+
+                self.inbound_tx
+                    .send(Self::inbound(Apdu::SegmentAck(SegmentAck {
+                        negative_ack: false,
+                        sent_by_server: true,
+                        invoke_id: request.invoke_id,
+                        sequence_number: request.sequence_number.unwrap(),
+                        actual_window_size: 1,
+                    })))
+                    .await
+                    .unwrap();
+                self.inbound_tx
+                    .send(Self::inbound(Apdu::SimpleAck(SimpleAck {
+                        invoke_id: request.invoke_id,
+                        service_choice: request.service_choice,
+                    })))
+                    .await
+                    .unwrap();
+                // Do not complete the first send until dispatch has admitted
+                // the already-queued terminal PDU and emitted its wire Abort.
+                self.wire_abort_seen.notified().await;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        CLIENT_MAC
+    }
+}
+
+#[tokio::test]
+async fn ready_terminal_before_final_send_aborts_without_polling_final_send() {
+    let (inbound_tx, inbound_rx) = mpsc::channel(16);
+    let (wire_abort_tx, mut wire_abort_rx) = mpsc::channel(1);
+    let wire_abort_seen = Arc::new(Notify::new());
+    let final_segment_polled = Arc::new(AtomicBool::new(false));
+    let transport = EarlyReadyResponseTransport {
+        inbound_rx: Some(inbound_rx),
+        inbound_tx,
+        wire_abort_tx,
+        wire_abort_seen,
+        response_injected: AtomicBool::new(false),
+        final_segment_polled: Arc::clone(&final_segment_polled),
+    };
+    let mut client = BACnetClient::start(
+        ClientConfig {
+            apdu_timeout_ms: 2_000,
+            apdu_retries: 0,
+            max_apdu_length: 50,
+            proposed_window_size: 1,
+            ..ClientConfig::default()
+        },
+        transport,
+    )
+    .await
+    .unwrap();
+
+    let result = timeout(
+        Duration::from_secs(2),
+        client.confirmed_request(
+            SERVER_MAC,
+            ConfirmedServiceChoice::WRITE_PROPERTY,
+            &[0x0C; 100],
+        ),
+    )
+    .await
+    .expect("premature response did not wake the sender");
+    let abort = timeout(Duration::from_secs(2), wire_abort_rx.recv())
+        .await
+        .expect("client did not send a wire Abort")
+        .expect("wire Abort channel closed");
+
+    assert!(!abort.sent_by_server);
+    assert_eq!(abort.abort_reason, AbortReason::INVALID_APDU_IN_THIS_STATE);
+    assert!(matches!(
+        result,
+        Err(Error::Abort { reason })
+            if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+    ));
+    assert!(
+        !final_segment_polled.load(Ordering::Acquire),
+        "the final send future was polled after the premature response completed the transaction"
+    );
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    client.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/segmented_request_state_tests.rs
+++ b/crates/bacnet-client/src/client/segmented_request_state_tests.rs
@@ -1,0 +1,647 @@
+use std::sync::Arc;
+
+use bacnet_encoding::apdu::{self, encode_apdu, Apdu, ComplexAck, ErrorPdu, SegmentAck, SimpleAck};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_types::enums::{
+    AbortReason, ConfirmedServiceChoice, ErrorClass, ErrorCode, RejectReason,
+};
+use bacnet_types::error::Error;
+use bacnet_types::MacAddr;
+use bytes::{Bytes, BytesMut};
+use tokio::sync::{mpsc, Notify};
+use tokio::time::{timeout, Duration};
+
+use super::{BACnetClient, ClientConfig};
+
+const CLIENT_MAC: &[u8] = &[0x01];
+const SERVER_MAC: &[u8] = &[0x02];
+
+fn config() -> ClientConfig {
+    ClientConfig {
+        apdu_timeout_ms: 2_000,
+        apdu_retries: 0,
+        max_apdu_length: 50,
+        proposed_window_size: 1,
+        ..ClientConfig::default()
+    }
+}
+
+async fn send_to_client<T: TransportPort>(transport: &T, apdu: Apdu) {
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &apdu).unwrap();
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(
+        &mut npdu_buf,
+        &Npdu {
+            payload: apdu_buf.freeze(),
+            ..Npdu::default()
+        },
+    )
+    .unwrap();
+    transport.send_unicast(&npdu_buf, CLIENT_MAC).await.unwrap();
+}
+
+async fn recv_apdu(rx: &mut mpsc::Receiver<ReceivedNpdu>, context: &str) -> Apdu {
+    let received = timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .unwrap_or_else(|_| panic!("{context}: timed out waiting for APDU"))
+        .unwrap_or_else(|| panic!("{context}: channel closed"));
+    let npdu = decode_npdu(received.npdu).unwrap();
+    apdu::decode_apdu(npdu.payload).unwrap()
+}
+
+async fn expect_silence(rx: &mut mpsc::Receiver<ReceivedNpdu>, context: &str) {
+    if let Ok(Some(received)) = timeout(Duration::from_millis(100), rx.recv()).await {
+        let npdu = decode_npdu(received.npdu).unwrap();
+        let apdu = apdu::decode_apdu(npdu.payload).unwrap();
+        panic!("{context}: expected no traffic, got {apdu:?}");
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum PrematureResponse {
+    SimpleAck,
+    UnsegmentedComplexAck,
+    SegmentedComplexAck,
+    Error,
+}
+
+impl PrematureResponse {
+    fn apdu(self, invoke_id: u8) -> Apdu {
+        match self {
+            Self::SimpleAck => Apdu::SimpleAck(SimpleAck {
+                invoke_id,
+                service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+            }),
+            Self::UnsegmentedComplexAck => Apdu::ComplexAck(ComplexAck {
+                segmented: false,
+                more_follows: false,
+                invoke_id,
+                sequence_number: None,
+                proposed_window_size: None,
+                service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+                service_ack: Bytes::from_static(b"premature"),
+            }),
+            Self::SegmentedComplexAck => Apdu::ComplexAck(ComplexAck {
+                segmented: true,
+                more_follows: true,
+                invoke_id,
+                sequence_number: Some(0),
+                proposed_window_size: Some(1),
+                service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+                service_ack: Bytes::from_static(b"premature"),
+            }),
+            Self::Error => Apdu::Error(ErrorPdu {
+                invoke_id,
+                service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+                error_class: ErrorClass::DEVICE,
+                error_code: ErrorCode::OPERATIONAL_PROBLEM,
+                error_data: Bytes::new(),
+            }),
+        }
+    }
+}
+
+async fn assert_premature_response_aborts(kind: PrematureResponse) {
+    let (client_transport, mut server) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), SERVER_MAC.to_vec());
+    let mut rx = server.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::start(config(), client_transport)
+            .await
+            .unwrap(),
+    );
+
+    let request_client = Arc::clone(&client);
+    let request = tokio::spawn(async move {
+        request_client
+            .confirmed_request(
+                SERVER_MAC,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &[0x0C; 100],
+            )
+            .await
+    });
+    let first = match recv_apdu(&mut rx, "initial request segment").await {
+        Apdu::ConfirmedRequest(request) => request,
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    };
+    assert_eq!(first.sequence_number, Some(0));
+    assert!(first.more_follows);
+
+    send_to_client(&server, kind.apdu(first.invoke_id)).await;
+    match recv_apdu(&mut rx, "client Abort").await {
+        Apdu::Abort(abort) => {
+            assert_eq!(abort.invoke_id, first.invoke_id);
+            assert!(!abort.sent_by_server);
+            assert_eq!(abort.abort_reason, AbortReason::INVALID_APDU_IN_THIS_STATE);
+        }
+        other => panic!("expected client Abort, got {other:?}"),
+    }
+
+    assert!(matches!(
+        timeout(Duration::from_secs(2), request)
+            .await
+            .unwrap()
+            .unwrap(),
+        Err(Error::Abort { reason })
+            if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+    ));
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert!(
+        !client
+            .seg_ack_senders
+            .lock()
+            .await
+            .contains_key(&(MacAddr::from_slice(SERVER_MAC), first.invoke_id)),
+        "completed request retained its SegmentACK route"
+    );
+    expect_silence(&mut rx, "after the premature response Abort").await;
+
+    let mut client = Arc::try_unwrap(client).unwrap_or_else(|_| panic!("request retained client"));
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn premature_simple_ack_aborts_segmented_request() {
+    assert_premature_response_aborts(PrematureResponse::SimpleAck).await;
+}
+
+#[tokio::test]
+async fn premature_unsegmented_complex_ack_aborts_segmented_request() {
+    assert_premature_response_aborts(PrematureResponse::UnsegmentedComplexAck).await;
+}
+
+#[tokio::test]
+async fn premature_segmented_complex_ack_aborts_segmented_request() {
+    assert_premature_response_aborts(PrematureResponse::SegmentedComplexAck).await;
+}
+
+#[tokio::test]
+async fn premature_error_aborts_segmented_request() {
+    assert_premature_response_aborts(PrematureResponse::Error).await;
+}
+
+#[tokio::test]
+async fn reject_during_segmented_send_stops_the_sender() {
+    let (client_transport, mut server) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), SERVER_MAC.to_vec());
+    let mut rx = server.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::start(config(), client_transport)
+            .await
+            .unwrap(),
+    );
+    let request_client = Arc::clone(&client);
+    let request = tokio::spawn(async move {
+        request_client
+            .confirmed_request(
+                SERVER_MAC,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &[0x0C; 100],
+            )
+            .await
+    });
+    let invoke_id = match recv_apdu(&mut rx, "initial request segment").await {
+        Apdu::ConfirmedRequest(request) => request.invoke_id,
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    };
+
+    send_to_client(
+        &server,
+        Apdu::Reject(bacnet_encoding::apdu::RejectPdu {
+            invoke_id,
+            reject_reason: RejectReason::OTHER,
+        }),
+    )
+    .await;
+    assert!(matches!(
+        timeout(Duration::from_secs(2), request)
+            .await
+            .unwrap()
+            .unwrap(),
+        Err(Error::Reject { reason }) if reason == RejectReason::OTHER.to_raw()
+    ));
+    expect_silence(&mut rx, "after Reject completed the send").await;
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+
+    let mut client = Arc::try_unwrap(client).unwrap_or_else(|_| panic!("request retained client"));
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn server_abort_during_segmented_send_stops_the_sender() {
+    let (client_transport, mut server) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), SERVER_MAC.to_vec());
+    let mut rx = server.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::start(config(), client_transport)
+            .await
+            .unwrap(),
+    );
+    let request_client = Arc::clone(&client);
+    let request = tokio::spawn(async move {
+        request_client
+            .confirmed_request(
+                SERVER_MAC,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &[0x0C; 100],
+            )
+            .await
+    });
+    let invoke_id = match recv_apdu(&mut rx, "initial request segment").await {
+        Apdu::ConfirmedRequest(request) => request.invoke_id,
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    };
+
+    send_to_client(
+        &server,
+        Apdu::Abort(bacnet_encoding::apdu::AbortPdu {
+            sent_by_server: false,
+            invoke_id,
+            abort_reason: AbortReason::OTHER,
+        }),
+    )
+    .await;
+    expect_silence(&mut rx, "after server=FALSE Abort").await;
+    assert_eq!(client.tsm.lock().await.pending_count(), 1);
+
+    send_to_client(
+        &server,
+        Apdu::Abort(bacnet_encoding::apdu::AbortPdu {
+            sent_by_server: true,
+            invoke_id,
+            abort_reason: AbortReason::BUFFER_OVERFLOW,
+        }),
+    )
+    .await;
+    assert!(matches!(
+        timeout(Duration::from_secs(2), request)
+            .await
+            .unwrap()
+            .unwrap(),
+        Err(Error::Abort { reason }) if reason == AbortReason::BUFFER_OVERFLOW.to_raw()
+    ));
+    expect_silence(&mut rx, "after server Abort completed the send").await;
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+
+    let mut client = Arc::try_unwrap(client).unwrap_or_else(|_| panic!("request retained client"));
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}
+
+struct ImmediateFinalResponseTransport {
+    inbound_rx: Option<mpsc::Receiver<ReceivedNpdu>>,
+    inbound_tx: mpsc::Sender<ReceivedNpdu>,
+    final_response_sent: Arc<Notify>,
+}
+
+impl ImmediateFinalResponseTransport {
+    fn inbound(apdu: Apdu) -> ReceivedNpdu {
+        let mut apdu_buf = BytesMut::new();
+        encode_apdu(&mut apdu_buf, &apdu).unwrap();
+        let mut npdu_buf = BytesMut::new();
+        encode_npdu(
+            &mut npdu_buf,
+            &Npdu {
+                payload: apdu_buf.freeze(),
+                ..Npdu::default()
+            },
+        )
+        .unwrap();
+        ReceivedNpdu {
+            npdu: npdu_buf.freeze(),
+            source_mac: MacAddr::from_slice(SERVER_MAC),
+            link_layer_group: false,
+            data_attributes: Vec::new(),
+            reply_tx: None,
+        }
+    }
+}
+
+impl TransportPort for ImmediateFinalResponseTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        Ok(self.inbound_rx.take().expect("transport starts once"))
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        let npdu = decode_npdu(Bytes::copy_from_slice(npdu)).unwrap();
+        let Apdu::ConfirmedRequest(request) = apdu::decode_apdu(npdu.payload).unwrap() else {
+            return Ok(());
+        };
+        if !request.segmented {
+            return Ok(());
+        }
+
+        let response = if request.more_follows {
+            Apdu::SegmentAck(SegmentAck {
+                negative_ack: false,
+                sent_by_server: true,
+                invoke_id: request.invoke_id,
+                sequence_number: request.sequence_number.unwrap(),
+                actual_window_size: 1,
+            })
+        } else {
+            Apdu::SimpleAck(SimpleAck {
+                invoke_id: request.invoke_id,
+                service_choice: request.service_choice,
+            })
+        };
+        self.inbound_tx.send(Self::inbound(response)).await.unwrap();
+
+        if !request.more_follows {
+            // Keep the transport future pending after the peer has received
+            // the final segment and replied. The request must complete from
+            // the TSM response without waiting for this send future to return.
+            self.final_response_sent.notify_one();
+            std::future::pending::<()>().await;
+        }
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        CLIENT_MAC
+    }
+}
+
+#[tokio::test]
+async fn response_after_final_segment_before_final_segment_ack_succeeds() {
+    let (inbound_tx, inbound_rx) = mpsc::channel(16);
+    let final_response_sent = Arc::new(Notify::new());
+    let transport = ImmediateFinalResponseTransport {
+        inbound_rx: Some(inbound_rx),
+        inbound_tx,
+        final_response_sent: Arc::clone(&final_response_sent),
+    };
+    let mut client = BACnetClient::start(config(), transport).await.unwrap();
+
+    let result = timeout(
+        Duration::from_secs(2),
+        client.confirmed_request(
+            SERVER_MAC,
+            ConfirmedServiceChoice::WRITE_PROPERTY,
+            &[0x0C; 100],
+        ),
+    )
+    .await
+    .expect("request waited for a final SegmentACK");
+    final_response_sent.notified().await;
+    assert!(result.unwrap().is_empty());
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn segmented_response_before_final_segment_ack_hands_off_to_receive_timer() {
+    let (client_transport, mut server) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), SERVER_MAC.to_vec());
+    let mut rx = server.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::start(config(), client_transport)
+            .await
+            .unwrap(),
+    );
+    let request_client = Arc::clone(&client);
+    let request = tokio::spawn(async move {
+        request_client
+            .confirmed_request(
+                SERVER_MAC,
+                ConfirmedServiceChoice::READ_PROPERTY,
+                &[0x0C; 100],
+            )
+            .await
+    });
+
+    let invoke_id = loop {
+        let segment = match recv_apdu(&mut rx, "request segment").await {
+            Apdu::ConfirmedRequest(request) => request,
+            other => panic!("expected ConfirmedRequest, got {other:?}"),
+        };
+        if segment.more_follows {
+            send_to_client(
+                &server,
+                Apdu::SegmentAck(SegmentAck {
+                    negative_ack: false,
+                    sent_by_server: true,
+                    invoke_id: segment.invoke_id,
+                    sequence_number: segment.sequence_number.unwrap(),
+                    actual_window_size: 1,
+                }),
+            )
+            .await;
+        } else {
+            send_to_client(
+                &server,
+                Apdu::ComplexAck(ComplexAck {
+                    segmented: true,
+                    more_follows: true,
+                    invoke_id: segment.invoke_id,
+                    sequence_number: Some(0),
+                    proposed_window_size: Some(1),
+                    service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+                    service_ack: Bytes::from_static(b"first-"),
+                }),
+            )
+            .await;
+            break segment.invoke_id;
+        }
+    };
+
+    match recv_apdu(&mut rx, "response SegmentACK zero").await {
+        Apdu::SegmentAck(ack) => {
+            assert!(!ack.sent_by_server);
+            assert_eq!(ack.invoke_id, invoke_id);
+            assert_eq!(ack.sequence_number, 0);
+        }
+        other => panic!("expected response SegmentACK, got {other:?}"),
+    }
+    send_to_client(
+        &server,
+        Apdu::ComplexAck(ComplexAck {
+            segmented: true,
+            more_follows: false,
+            invoke_id,
+            sequence_number: Some(1),
+            proposed_window_size: Some(1),
+            service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+            service_ack: Bytes::from_static(b"response"),
+        }),
+    )
+    .await;
+    match recv_apdu(&mut rx, "final response SegmentACK").await {
+        Apdu::SegmentAck(ack) => assert_eq!(ack.sequence_number, 1),
+        other => panic!("expected response SegmentACK, got {other:?}"),
+    }
+    assert_eq!(
+        timeout(Duration::from_secs(2), request)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap()
+            .as_ref(),
+        b"first-response"
+    );
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+
+    let mut client = Arc::try_unwrap(client).unwrap_or_else(|_| panic!("request retained client"));
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn stale_segment_ack_after_terminal_completion_is_not_routed() {
+    let (client_transport, mut server) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), SERVER_MAC.to_vec());
+    let mut rx = server.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::start(config(), client_transport)
+            .await
+            .unwrap(),
+    );
+    client.segmented_post_wait_cleanup.enable();
+
+    let first_client = Arc::clone(&client);
+    let first = tokio::spawn(async move {
+        first_client
+            .confirmed_request(
+                SERVER_MAC,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &[0x0C; 100],
+            )
+            .await
+    });
+
+    let invoke_id = loop {
+        let request = match recv_apdu(&mut rx, "segmented request").await {
+            Apdu::ConfirmedRequest(request) => request,
+            other => panic!("expected ConfirmedRequest, got {other:?}"),
+        };
+        if request.more_follows {
+            send_to_client(
+                &server,
+                Apdu::SegmentAck(SegmentAck {
+                    negative_ack: false,
+                    sent_by_server: true,
+                    invoke_id: request.invoke_id,
+                    sequence_number: request.sequence_number.unwrap(),
+                    actual_window_size: 1,
+                }),
+            )
+            .await;
+        } else {
+            send_to_client(
+                &server,
+                Apdu::SimpleAck(SimpleAck {
+                    invoke_id: request.invoke_id,
+                    service_choice: request.service_choice,
+                }),
+            )
+            .await;
+            break request.invoke_id;
+        }
+    };
+
+    timeout(
+        Duration::from_secs(2),
+        client.segmented_post_wait_cleanup.wait_until_reached(),
+    )
+    .await
+    .expect("terminal response did not reach delayed route cleanup");
+    assert!(client
+        .seg_ack_senders
+        .lock()
+        .await
+        .contains_key(&(MacAddr::from_slice(SERVER_MAC), invoke_id)));
+
+    send_to_client(
+        &server,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 2,
+            actual_window_size: 1,
+        }),
+    )
+    .await;
+    match recv_apdu(&mut rx, "stale SegmentACK after completion").await {
+        Apdu::Abort(abort) => {
+            assert_eq!(abort.invoke_id, invoke_id);
+            assert!(!abort.sent_by_server);
+            assert_eq!(abort.abort_reason, AbortReason::INVALID_APDU_IN_THIS_STATE);
+        }
+        other => panic!("expected idle-state Abort, got {other:?}"),
+    }
+
+    let second_client = Arc::clone(&client);
+    let second = tokio::spawn(async move {
+        second_client
+            .confirmed_request(SERVER_MAC, ConfirmedServiceChoice::READ_PROPERTY, &[0x01])
+            .await
+    });
+    let replacement = match recv_apdu(&mut rx, "replacement request").await {
+        Apdu::ConfirmedRequest(request) => request,
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    };
+    assert_eq!(replacement.invoke_id, invoke_id);
+    assert!(!replacement.segmented);
+
+    send_to_client(
+        &server,
+        Apdu::SegmentAck(SegmentAck {
+            negative_ack: false,
+            sent_by_server: true,
+            invoke_id,
+            sequence_number: 2,
+            actual_window_size: 1,
+        }),
+    )
+    .await;
+    expect_silence(&mut rx, "stale SegmentACK after invoke-ID reuse").await;
+    send_to_client(
+        &server,
+        Apdu::ComplexAck(ComplexAck {
+            segmented: false,
+            more_follows: false,
+            invoke_id,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: replacement.service_choice,
+            service_ack: Bytes::from_static(b"replacement"),
+        }),
+    )
+    .await;
+    assert_eq!(
+        timeout(Duration::from_secs(2), second)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap()
+            .as_ref(),
+        b"replacement"
+    );
+
+    client.segmented_post_wait_cleanup.release();
+    assert!(timeout(Duration::from_secs(2), first)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap()
+        .is_empty());
+
+    let mut client = Arc::try_unwrap(client).unwrap_or_else(|_| panic!("requests retained client"));
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/tsm.rs
+++ b/crates/bacnet-client/src/tsm.rs
@@ -3,13 +3,18 @@
 //! Tracks in-flight confirmed requests. Each request gets a unique invoke_id
 //! (0-255) scoped per destination MAC. Responses are delivered via oneshot channels.
 
-use bacnet_types::enums::ConfirmedServiceChoice;
+use bacnet_types::enums::{AbortReason, ConfirmedServiceChoice};
 use bacnet_types::MacAddr;
 use bytes::Bytes;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{oneshot, watch};
+
+mod final_segment;
+pub(crate) use final_segment::{
+    FinalSegmentIssue, FinalSegmentSendToken, SegmentedResponseAdmission, TerminalResponseAdmission,
+};
 
 /// TSM configuration.
 #[derive(Debug, Clone)]
@@ -112,6 +117,13 @@ pub enum CompletionOutcome {
     },
 }
 
+#[derive(Debug)]
+pub(crate) enum SegmentAckPhase {
+    SegmentedRequest(TransactionOwner),
+    Outstanding,
+    Idle,
+}
+
 /// Request-side timer state delivered to the task waiting for a response.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum TransactionProgress {
@@ -130,7 +142,7 @@ pub(crate) struct TransactionRegistration {
 /// Pointer identity is stable while delayed work retains a clone. The
 /// allocation therefore cannot be reused for a replacement transaction until
 /// every stale owner reference has gone away.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct TransactionOwner(Arc<()>);
 
 impl TransactionOwner {
@@ -162,6 +174,7 @@ pub(crate) enum SegmentTimerExpiration {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TransactionPhase {
     AwaitingResponse,
+    SegmentedRequest { sent_all_segments: bool },
     SegmentedResponse,
 }
 
@@ -171,6 +184,7 @@ struct PendingTransaction {
     progress: watch::Sender<TransactionProgress>,
     owner: TransactionOwner,
     phase: TransactionPhase,
+    final_segment_issue: Option<FinalSegmentIssue>,
     /// Monotonic token used to reject a SegmentTimer expiry observed before
     /// newer segment activity acquired the TSM lock.
     segment_generation: u64,
@@ -255,9 +269,42 @@ impl Tsm {
         invoke_id: u8,
         service_choice: ConfirmedServiceChoice,
     ) -> TransactionRegistration {
+        self.register_transaction_in_phase(
+            destination_mac,
+            invoke_id,
+            service_choice,
+            TransactionPhase::AwaitingResponse,
+        )
+    }
+
+    pub(crate) fn register_segmented_transaction_with_progress(
+        &mut self,
+        destination_mac: MacAddr,
+        invoke_id: u8,
+        service_choice: ConfirmedServiceChoice,
+    ) -> TransactionRegistration {
+        self.register_transaction_in_phase(
+            destination_mac,
+            invoke_id,
+            service_choice,
+            TransactionPhase::SegmentedRequest {
+                sent_all_segments: false,
+            },
+        )
+    }
+
+    fn register_transaction_in_phase(
+        &mut self,
+        destination_mac: MacAddr,
+        invoke_id: u8,
+        service_choice: ConfirmedServiceChoice,
+        phase: TransactionPhase,
+    ) -> TransactionRegistration {
         let (tx, rx) = oneshot::channel();
         let (progress_tx, progress_rx) = watch::channel(TransactionProgress::AwaitingResponse);
         let owner = TransactionOwner::new();
+        let final_segment_issue =
+            matches!(phase, TransactionPhase::SegmentedRequest { .. }).then(FinalSegmentIssue::new);
         debug_assert!(
             !self
                 .pending
@@ -271,7 +318,8 @@ impl Tsm {
                 responder: tx,
                 progress: progress_tx,
                 owner: owner.clone(),
-                phase: TransactionPhase::AwaitingResponse,
+                phase,
+                final_segment_issue,
                 segment_generation: 0,
                 expected_service_choice: service_choice,
             },
@@ -281,6 +329,199 @@ impl Tsm {
             progress: progress_rx,
             owner,
         }
+    }
+
+    /// Reserve the first poll of the final N-UNITDATA.request. A terminal PDU
+    /// that reaches dispatch while this token is live waits for that poll to
+    /// resolve instead of being admitted or rejected early.
+    pub(crate) fn begin_final_segment_send(
+        &mut self,
+        destination_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+    ) -> Option<FinalSegmentSendToken> {
+        let key = (MacAddr::from_slice(destination_mac), invoke_id);
+        let pending = self.pending.get(&key)?;
+        if !pending.owner.same_as(owner)
+            || !matches!(
+                pending.phase,
+                TransactionPhase::SegmentedRequest {
+                    sent_all_segments: false
+                }
+            )
+        {
+            return None;
+        }
+        let issue = pending.final_segment_issue.as_ref()?.clone();
+        issue.begin().then_some(FinalSegmentSendToken {
+            issue,
+            resolved: false,
+        })
+    }
+
+    /// Publish `SentAllSegments` after the final send future has been polled.
+    /// The caller must not hold the TSM lock while performing that poll.
+    pub(crate) fn mark_final_segment_issued(
+        &mut self,
+        destination_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+        token: &mut FinalSegmentSendToken,
+    ) -> bool {
+        let key = (MacAddr::from_slice(destination_mac), invoke_id);
+        let Some(pending) = self.pending.get_mut(&key) else {
+            return false;
+        };
+        if !pending.owner.same_as(owner) {
+            return false;
+        }
+        let TransactionPhase::SegmentedRequest { sent_all_segments } = &mut pending.phase else {
+            return false;
+        };
+        if !pending
+            .final_segment_issue
+            .as_ref()
+            .is_some_and(|issue| issue.same_as(&token.issue))
+            || !token.issue.is_polling()
+        {
+            return false;
+        }
+        *sent_all_segments = true;
+        token.issued();
+        true
+    }
+
+    /// FinalACK_Received moves the same owner into AWAIT_CONFIRMATION.
+    pub(crate) fn finish_segmented_request(
+        &mut self,
+        destination_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+    ) -> bool {
+        let key = (MacAddr::from_slice(destination_mac), invoke_id);
+        let Some(pending) = self.pending.get_mut(&key) else {
+            return false;
+        };
+        if !pending.owner.same_as(owner)
+            || !matches!(
+                pending.phase,
+                TransactionPhase::SegmentedRequest {
+                    sent_all_segments: true
+                }
+            )
+        {
+            return false;
+        }
+        pending.phase = TransactionPhase::AwaitingResponse;
+        pending
+            .progress
+            .send_replace(TransactionProgress::AwaitingResponse);
+        true
+    }
+
+    pub(crate) fn segment_ack_phase(&self, source_mac: &[u8], invoke_id: u8) -> SegmentAckPhase {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        match self.pending.get(&key) {
+            Some(pending) if matches!(pending.phase, TransactionPhase::SegmentedRequest { .. }) => {
+                SegmentAckPhase::SegmentedRequest(pending.owner.clone())
+            }
+            Some(_) => SegmentAckPhase::Outstanding,
+            None => SegmentAckPhase::Idle,
+        }
+    }
+
+    /// Gate segment zero before receive state is allocated. In
+    /// SEGMENTED_REQUEST, any ComplexACK before `SentAllSegments`, and any
+    /// segmented ComplexACK not starting at sequence zero, is UnexpectedPDU.
+    pub(crate) fn admit_segmented_complex_ack(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        sequence_number: u8,
+    ) -> SegmentedResponseAdmission {
+        self.admit_segmented_complex_ack_inner(source_mac, invoke_id, sequence_number, None)
+    }
+
+    pub(crate) fn admit_segmented_complex_ack_for_owner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        sequence_number: u8,
+        owner: &TransactionOwner,
+    ) -> SegmentedResponseAdmission {
+        self.admit_segmented_complex_ack_inner(source_mac, invoke_id, sequence_number, Some(owner))
+    }
+
+    fn admit_segmented_complex_ack_inner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        sequence_number: u8,
+        owner: Option<&TransactionOwner>,
+    ) -> SegmentedResponseAdmission {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Some(pending) = self.pending.get(&key) else {
+            return SegmentedResponseAdmission::NoTransaction;
+        };
+        if owner.is_some_and(|owner| !pending.owner.same_as(owner)) {
+            return SegmentedResponseAdmission::NoTransaction;
+        }
+        if let TransactionPhase::SegmentedRequest { sent_all_segments } = pending.phase {
+            if sequence_number != 0 {
+                self.abort_invalid_apdu_in_current_state(source_mac, invoke_id);
+                return SegmentedResponseAdmission::PrematureSegmentedRequestAborted;
+            }
+            if !sent_all_segments {
+                if let Some(issue) = pending
+                    .final_segment_issue
+                    .as_ref()
+                    .filter(|issue| issue.is_polling())
+                {
+                    return SegmentedResponseAdmission::FinalSegmentSendPolling {
+                        owner: pending.owner.clone(),
+                        issue: issue.clone(),
+                    };
+                }
+                self.abort_invalid_apdu_in_current_state(source_mac, invoke_id);
+                return SegmentedResponseAdmission::PrematureSegmentedRequestAborted;
+            }
+        }
+        SegmentedResponseAdmission::Active(pending.owner.clone())
+    }
+
+    pub(crate) fn admit_terminal_response(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: Option<&TransactionOwner>,
+    ) -> TerminalResponseAdmission {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Some(pending) = self.pending.get(&key) else {
+            return TerminalResponseAdmission::NoTransaction;
+        };
+        if owner.is_some_and(|owner| !pending.owner.same_as(owner)) {
+            return TerminalResponseAdmission::NoTransaction;
+        }
+        if matches!(
+            pending.phase,
+            TransactionPhase::SegmentedRequest {
+                sent_all_segments: false
+            }
+        ) {
+            if let Some(issue) = pending
+                .final_segment_issue
+                .as_ref()
+                .filter(|issue| issue.is_polling())
+            {
+                return TerminalResponseAdmission::FinalSegmentSendPolling {
+                    owner: pending.owner.clone(),
+                    issue: issue.clone(),
+                };
+            }
+            self.abort_invalid_apdu_in_current_state(source_mac, invoke_id);
+            return TerminalResponseAdmission::PrematureSegmentedRequestAborted;
+        }
+        TerminalResponseAdmission::Active(pending.owner.clone())
     }
 
     /// Enter SEGMENTED_CONF after the first segment has been saved.
@@ -297,6 +538,14 @@ impl Tsm {
         let key = (MacAddr::from_slice(source_mac), invoke_id);
         let pending = self.pending.get_mut(&key)?;
         if !pending.owner.same_as(owner) {
+            return None;
+        }
+        if matches!(
+            pending.phase,
+            TransactionPhase::SegmentedRequest {
+                sent_all_segments: false
+            }
+        ) {
             return None;
         }
         pending.segment_generation = pending.segment_generation.wrapping_add(1);
@@ -506,6 +755,25 @@ impl Tsm {
         if owner.is_some_and(|owner| !entry.get().owner.same_as(owner)) {
             return CompletionOutcome::NoTransaction;
         }
+        let requires_sent_all_segments = matches!(
+            &response,
+            TsmResponse::SimpleAck | TsmResponse::ComplexAck { .. } | TsmResponse::Error { .. }
+        );
+        if requires_sent_all_segments
+            && matches!(
+                entry.get().phase,
+                TransactionPhase::SegmentedRequest {
+                    sent_all_segments: false
+                }
+            )
+        {
+            let pending = entry.remove();
+            self.release_invoke_id(source_mac, invoke_id);
+            let _ = pending.responder.send(TsmResponse::Abort {
+                reason: AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw(),
+            });
+            return CompletionOutcome::Delivered;
+        }
         let expected = entry.get().expected_service_choice;
         if let Some(observed) = observed_service_choice {
             if observed != expected {
@@ -518,6 +786,17 @@ impl Tsm {
         self.release_invoke_id(source_mac, invoke_id);
         let _ = pending.responder.send(response);
         CompletionOutcome::Delivered
+    }
+
+    fn abort_invalid_apdu_in_current_state(&mut self, source_mac: &[u8], invoke_id: u8) {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Some(pending) = self.pending.remove(&key) else {
+            return;
+        };
+        self.release_invoke_id(source_mac, invoke_id);
+        let _ = pending.responder.send(TsmResponse::Abort {
+            reason: AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw(),
+        });
     }
 
     /// Cancel a pending transaction. Returns `true` if found.

--- a/crates/bacnet-client/src/tsm/final_segment.rs
+++ b/crates/bacnet-client/src/tsm/final_segment.rs
@@ -1,0 +1,102 @@
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::Notify;
+
+use super::TransactionOwner;
+
+const NOT_STARTED: u8 = 0;
+const POLLING: u8 = 1;
+const ISSUED: u8 = 2;
+const FAILED: u8 = 3;
+
+#[derive(Debug)]
+pub(crate) enum SegmentedResponseAdmission {
+    Active(TransactionOwner),
+    FinalSegmentSendPolling {
+        owner: TransactionOwner,
+        issue: FinalSegmentIssue,
+    },
+    PrematureSegmentedRequestAborted,
+    NoTransaction,
+}
+
+#[derive(Debug)]
+pub(crate) enum TerminalResponseAdmission {
+    Active(TransactionOwner),
+    FinalSegmentSendPolling {
+        owner: TransactionOwner,
+        issue: FinalSegmentIssue,
+    },
+    PrematureSegmentedRequestAborted,
+    NoTransaction,
+}
+
+#[derive(Debug)]
+struct FinalSegmentIssueInner {
+    state: AtomicU8,
+    resolved: Notify,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FinalSegmentIssue(Arc<FinalSegmentIssueInner>);
+
+impl FinalSegmentIssue {
+    pub(super) fn new() -> Self {
+        Self(Arc::new(FinalSegmentIssueInner {
+            state: AtomicU8::new(NOT_STARTED),
+            resolved: Notify::new(),
+        }))
+    }
+
+    pub(super) fn begin(&self) -> bool {
+        self.0
+            .state
+            .compare_exchange(NOT_STARTED, POLLING, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    pub(super) fn is_polling(&self) -> bool {
+        self.0.state.load(Ordering::Acquire) == POLLING
+    }
+
+    pub(super) fn same_as(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+
+    fn resolve(&self, state: u8) {
+        self.0.state.store(state, Ordering::Release);
+        self.0.resolved.notify_waiters();
+    }
+
+    pub(crate) async fn wait_until_polled(&self) {
+        loop {
+            let resolved = self.0.resolved.notified();
+            if !self.is_polling() {
+                return;
+            }
+            resolved.await;
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct FinalSegmentSendToken {
+    pub(super) issue: FinalSegmentIssue,
+    pub(super) resolved: bool,
+}
+
+impl FinalSegmentSendToken {
+    pub(super) fn issued(&mut self) {
+        self.issue.resolve(ISSUED);
+        self.resolved = true;
+    }
+}
+
+impl Drop for FinalSegmentSendToken {
+    fn drop(&mut self) {
+        if !self.resolved {
+            self.issue.resolve(FAILED);
+        }
+    }
+}

--- a/crates/bacnet-client/src/tsm/tests.rs
+++ b/crates/bacnet-client/src/tsm/tests.rs
@@ -142,6 +142,154 @@ async fn a_response_without_a_service_choice_completes_any_transaction() {
 }
 
 #[tokio::test]
+async fn segmented_request_rejects_premature_terminal_response_kinds() {
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+
+    for response_kind in 0..3 {
+        let mut tsm = Tsm::new(TsmConfig::default());
+        let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+        let registration = tsm.register_segmented_transaction_with_progress(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+        assert!(
+            matches!(
+                tsm.admit_terminal_response(&mac, invoke_id, None),
+                TerminalResponseAdmission::PrematureSegmentedRequestAborted
+            ),
+            "response kind {response_kind} must be phase-gated before service correlation"
+        );
+        assert!(matches!(
+            registration.response.await.unwrap(),
+            TsmResponse::Abort { reason }
+                if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+        ));
+        assert_eq!(tsm.pending_count(), 0);
+        assert_eq!(tsm.allocate_invoke_id(&mac), Some(invoke_id));
+    }
+}
+
+#[tokio::test]
+async fn segmented_complex_ack_zero_is_rejected_until_all_segments_are_sent() {
+    let mut tsm = Tsm::new(TsmConfig::default());
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+    let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+    let registration = tsm.register_segmented_transaction_with_progress(
+        mac.clone(),
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY,
+    );
+
+    assert!(matches!(
+        tsm.admit_segmented_complex_ack(&mac, invoke_id, 0),
+        SegmentedResponseAdmission::PrematureSegmentedRequestAborted
+    ));
+    assert!(matches!(
+        registration.response.await.unwrap(),
+        TsmResponse::Abort { reason }
+            if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+    ));
+    assert_eq!(tsm.pending_count(), 0);
+}
+
+#[tokio::test]
+async fn reject_and_abort_are_valid_throughout_segmented_request() {
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+
+    for response in [
+        TsmResponse::Reject { reason: 3 },
+        TsmResponse::Abort { reason: 4 },
+    ] {
+        let mut tsm = Tsm::new(TsmConfig::default());
+        let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+        let registration = tsm.register_segmented_transaction_with_progress(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+        assert_eq!(
+            tsm.complete_transaction(&mac, invoke_id, None, response),
+            CompletionOutcome::Delivered
+        );
+        assert!(matches!(
+            registration.response.await.unwrap(),
+            TsmResponse::Reject { reason: 3 } | TsmResponse::Abort { reason: 4 }
+        ));
+        assert_eq!(tsm.pending_count(), 0);
+    }
+}
+
+#[tokio::test]
+async fn sent_all_segments_enables_response_correlation_before_final_ack() {
+    let mut tsm = Tsm::new(TsmConfig::default());
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+    let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+    let registration = tsm.register_segmented_transaction_with_progress(
+        mac.clone(),
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY,
+    );
+    let mut token = tsm
+        .begin_final_segment_send(&mac, invoke_id, &registration.owner)
+        .unwrap();
+    assert!(tsm.mark_final_segment_issued(&mac, invoke_id, &registration.owner, &mut token));
+
+    assert_eq!(
+        tsm.complete_transaction(
+            &mac,
+            invoke_id,
+            Some(ConfirmedServiceChoice::WRITE_PROPERTY),
+            TsmResponse::SimpleAck,
+        ),
+        CompletionOutcome::ServiceChoiceMismatch {
+            expected: ConfirmedServiceChoice::READ_PROPERTY,
+            observed: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }
+    );
+    assert_eq!(tsm.pending_count(), 1);
+    assert_eq!(
+        tsm.complete_transaction(
+            &mac,
+            invoke_id,
+            Some(ConfirmedServiceChoice::READ_PROPERTY),
+            TsmResponse::SimpleAck,
+        ),
+        CompletionOutcome::Delivered
+    );
+    assert!(matches!(
+        registration.response.await.unwrap(),
+        TsmResponse::SimpleAck
+    ));
+}
+
+#[test]
+fn final_segment_ack_preserves_owner_in_await_confirmation() {
+    let mut tsm = Tsm::new(TsmConfig::default());
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+    let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+    let registration = tsm.register_segmented_transaction_with_progress(
+        mac.clone(),
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY,
+    );
+    assert!(matches!(
+        tsm.segment_ack_phase(&mac, invoke_id),
+        SegmentAckPhase::SegmentedRequest(ref owner) if owner.same_as(&registration.owner)
+    ));
+    let mut token = tsm
+        .begin_final_segment_send(&mac, invoke_id, &registration.owner)
+        .unwrap();
+    assert!(tsm.mark_final_segment_issued(&mac, invoke_id, &registration.owner, &mut token));
+    assert!(tsm.finish_segmented_request(&mac, invoke_id, &registration.owner));
+    assert!(matches!(
+        tsm.segment_ack_phase(&mac, invoke_id),
+        SegmentAckPhase::Outstanding
+    ));
+    assert!(tsm.owner_is_current(&mac, invoke_id, &registration.owner));
+}
+
+#[tokio::test]
 async fn complete_unknown_transaction_reports_no_transaction() {
     let mut tsm = Tsm::new(TsmConfig::default());
     let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
@@ -309,6 +457,10 @@ async fn stale_owner_cannot_mutate_reused_transaction_key() {
         tsm.record_segmented_response_activity(&mac, invoke_id, &first.owner),
         None
     );
+    assert!(tsm
+        .begin_final_segment_send(&mac, invoke_id, &first.owner)
+        .is_none());
+    assert!(!tsm.finish_segmented_request(&mac, invoke_id, &first.owner));
     assert!(!tsm.reset_segmented_response(&mac, invoke_id, &first.owner));
     assert_eq!(
         tsm.complete_transaction_for_owner(


### PR DESCRIPTION
## Summary

- model Clause 5.4.4.2 `SEGMENTED_REQUEST` and `SentAllSegments` in the client TSM
- reject premature SimpleACK, ComplexACK, and Error PDUs with the required client/local Abort while preserving Reject and server-Abort transitions
- accept terminal replies after the final segment is issued, including before the final SegmentACK
- qualify SegmentACK routes by immutable transaction owner and authoritative TSM phase

## Ordering and safety

The final send is polled without the TSM lock. Terminal admission observed during that first poll waits for the owner-qualified issuance token to resolve, so a response caused by the final send is accepted without allowing an already-ready response to skip the final segment. Cleanup and delayed transitions remain owner-qualified for immediate invoke-ID reuse.

## Validation

- `cargo test -p bacnet-client --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --locked`
- `cargo fmt --all --check`
- `cargo deny check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `python3 scripts/generate-conformance-docs.py --check`