### PR TITLE
fix(client): validate initial segmented responses

### DIFF
--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -844,6 +844,8 @@ mod segmented_request_ordering_tests;
 #[cfg(test)]
 mod segmented_request_state_tests;
 #[cfg(test)]
+mod segmented_response_admission_tests;
+#[cfg(test)]
 mod segmented_timeout_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -120,22 +120,46 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let key = (tsm_mac.clone(), ack.invoke_id);
 
         let mut deferred_owner = None;
-        let admitted_owner = loop {
+        let owner = loop {
             let admission = {
                 let mut tsm = tsm.lock().await;
                 if let Some(owner) = deferred_owner.as_ref() {
-                    tsm.admit_segmented_complex_ack_for_owner(&tsm_mac, ack.invoke_id, seq, owner)
+                    tsm.admit_segmented_complex_ack_for_owner(
+                        &tsm_mac,
+                        ack.invoke_id,
+                        seq,
+                        limits.segmented_response_accepted,
+                        owner,
+                    )
                 } else {
-                    tsm.admit_segmented_complex_ack(&tsm_mac, ack.invoke_id, seq)
+                    tsm.admit_segmented_complex_ack(
+                        &tsm_mac,
+                        ack.invoke_id,
+                        seq,
+                        limits.segmented_response_accepted,
+                    )
                 }
             };
             match admission {
-                SegmentedResponseAdmission::Active(owner) => break Some(owner),
+                SegmentedResponseAdmission::Active(owner) => break owner,
                 SegmentedResponseAdmission::FinalSegmentSendPolling { owner, issue } => {
                     issue.wait_until_polled().await;
                     deferred_owner = Some(owner);
                 }
-                SegmentedResponseAdmission::PrematureSegmentedRequestAborted => {
+                SegmentedResponseAdmission::InitialResponseAborted { wire_reason } => {
+                    seg_state.remove(&key);
+                    Self::send_client_abort(
+                        network,
+                        source_mac,
+                        source_network,
+                        ack.invoke_id,
+                        wire_reason,
+                    )
+                    .await;
+                    return;
+                }
+                SegmentedResponseAdmission::NoTransaction => {
+                    seg_state.remove(&key);
                     Self::send_client_abort(
                         network,
                         source_mac,
@@ -146,7 +170,6 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     .await;
                     return;
                 }
-                SegmentedResponseAdmission::NoTransaction => break None,
             }
         };
 
@@ -157,73 +180,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             "Received segmented ComplexAck"
         );
 
-        // A segmented ComplexACK when this device does not support
-        // segmentation is Clause 5.4.4.3's UnexpectedPDU_Received, which
-        // requires an Abort with 'server' = FALSE. The transmitted reason
-        // follows Clause 18.10, which names SEGMENTATION_NOT_SUPPORTED for
-        // exactly this case.
-        if !limits.segmented_response_accepted {
-            let abort = Apdu::Abort(AbortPdu {
-                sent_by_server: false,
-                invoke_id: ack.invoke_id,
-                abort_reason: bacnet_types::enums::AbortReason::SEGMENTATION_NOT_SUPPORTED,
-            });
-            let mut buf = BytesMut::with_capacity(4);
-            if let Err(e) = encode_apdu(&mut buf, &abort) {
-                warn!(error = %e, "Failed to encode segmentation-not-supported Abort");
-                return;
-            }
-            let _ = Self::send_reply_apdu(network, &buf, source_mac, source_network).await;
-            return;
-        }
-
-        // A reassembly session lives exactly as long as its transaction, so
-        // the TSM is consulted for EVERY segment, not only at session open.
-        // Clause 5.4's SEGMENTED_CONF is a state of the transaction itself:
-        // once the transaction ends — peer Abort/Error/Reject, or the caller
-        // cancelling on timeout — this device is in IDLE for that invoke ID,
-        // and 5.4.4.1 UnexpectedSegmentInfoReceived names this exact PDU as
-        // "an unexpected PDU indicating the existence of an active server
-        // TSM", prescribing an answer, not silence: "transmit a
-        // BACnet-Abort-PDU with 'server' = FALSE and 'abort-reason' =
-        // INVALID_APDU_IN_THIS_STATE and enter the IDLE state." A session
-        // whose transaction is gone is removed here rather than lingering to
-        // ack segments nobody is waiting on (#367). The per-open version of
-        // this gate also kept an unsolicited peer from occupying all 64
-        // session slots; requiring it per-segment keeps that property.
-        //
-        // Residual, deliberate: `release_invoke_id` drops a peer's allocator
-        // once every ID is free, so the caller's next request to this peer
-        // reuses the same invoke ID and a stale segment stream can alias
-        // onto the new pending transaction. This gate removes the orphaned
-        // session; it cannot tell that aliased stream from a genuine one.
-        //
-        // Bind the guard so its scope is obvious: it must not be held across
-        // the send below, and an `if let` here would extend it silently.
-        let owner = if let Some(owner) = admitted_owner {
-            Some(owner)
-        } else {
-            tsm.lock()
-                .await
-                .owner_and_expected_service(&tsm_mac, ack.invoke_id)
-                .map(|(owner, _)| owner)
-        };
-        let Some(owner) = owner else {
-            seg_state.remove(&key);
-            debug!(
-                invoke_id = ack.invoke_id,
-                "Aborting segmented ComplexAck for a transaction that is not pending"
-            );
-            Self::send_client_abort(
-                network,
-                source_mac,
-                source_network,
-                ack.invoke_id,
-                bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE,
-            )
-            .await;
-            return;
-        };
+        // Admission is owner-qualified on every segment. A receive session
+        // left by an earlier owner cannot attach to a reused invoke ID.
         if seg_state
             .get(&key)
             .is_some_and(|state| !state.owner.same_as(&owner))
@@ -231,8 +189,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             seg_state.remove(&key);
         }
 
-        // Below the pending gate: a non-pending segment must draw the 5.4.4.1
-        // Abort above even when every session slot is occupied.
+        // Admission precedes this capacity check so an unsolicited segment
+        // draws the Clause 5.4.4.1 Abort even when every slot is occupied.
         const MAX_CONCURRENT_SEG_SESSIONS: usize = 64;
         if !seg_state.contains_key(&key) && seg_state.len() >= MAX_CONCURRENT_SEG_SESSIONS {
             warn!(

--- a/crates/bacnet-client/src/client/segmented_response_admission_tests.rs
+++ b/crates/bacnet-client/src/client/segmented_response_admission_tests.rs
@@ -1,0 +1,141 @@
+use bacnet_encoding::apdu::{self, Apdu};
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_types::enums::AbortReason;
+use bacnet_types::error::Error;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+use super::segmented_receive_lifecycle_tests::{
+    expect_segment_ack, response_segment, send_to_client, start_reassembly, CLIENT_MAC, SERVER_MAC,
+};
+use super::{BACnetClient, ClientConfig};
+
+fn config(segmented_response_accepted: bool) -> ClientConfig {
+    ClientConfig {
+        apdu_timeout_ms: 50,
+        apdu_retries: 2,
+        segmented_response_accepted,
+        ..ClientConfig::default()
+    }
+}
+
+async fn expect_abort(
+    rx: &mut mpsc::Receiver<ReceivedNpdu>,
+    invoke_id: u8,
+    expected_reason: AbortReason,
+) {
+    let received = timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("timed out waiting for the client Abort")
+        .expect("peer channel closed");
+    let npdu = decode_npdu(received.npdu).unwrap();
+    match apdu::decode_apdu(npdu.payload).unwrap() {
+        Apdu::Abort(abort) => {
+            assert!(!abort.sent_by_server);
+            assert_eq!(abort.invoke_id, invoke_id);
+            assert_eq!(abort.abort_reason, expected_reason);
+        }
+        other => panic!("expected client Abort, got {other:?}"),
+    }
+}
+
+async fn expect_silence(rx: &mut mpsc::Receiver<ReceivedNpdu>) {
+    match timeout(Duration::from_millis(200), rx.recv()).await {
+        Err(_) => {}
+        Ok(None) => panic!("peer channel closed while checking for retry traffic"),
+        Ok(Some(received)) => {
+            let npdu = decode_npdu(received.npdu).unwrap();
+            let apdu = apdu::decode_apdu(npdu.payload).unwrap();
+            panic!("expected no SegmentACK or retry, got {apdu:?}");
+        }
+    }
+}
+
+async fn assert_active_initial_abort(
+    sequence_number: u8,
+    segmented_response_accepted: bool,
+    expected_wire_reason: AbortReason,
+) {
+    let (request, mut server, mut rx, invoke_id) =
+        start_reassembly(config(segmented_response_accepted)).await;
+
+    send_to_client(
+        &server,
+        &response_segment(invoke_id, sequence_number, true, &[0xAA]),
+    )
+    .await;
+    expect_abort(&mut rx, invoke_id, expected_wire_reason).await;
+
+    let (mut client, result) = timeout(Duration::from_secs(2), request)
+        .await
+        .expect("request remained pending after initial-response rejection")
+        .unwrap();
+    assert!(matches!(
+        result,
+        Err(Error::Abort { reason })
+            if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+    ));
+    {
+        let mut tsm = client.tsm.lock().await;
+        assert_eq!(tsm.pending_count(), 0);
+        assert_eq!(tsm.allocate_invoke_id(SERVER_MAC), Some(invoke_id));
+        tsm.release_invoke_id(SERVER_MAC, invoke_id);
+    }
+    expect_silence(&mut rx).await;
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn nonzero_initial_sequence_aborts_an_active_request() {
+    assert_active_initial_abort(1, true, AbortReason::INVALID_APDU_IN_THIS_STATE).await;
+}
+
+#[tokio::test]
+async fn unsupported_initial_segment_completes_with_local_invalid_state_abort() {
+    assert_active_initial_abort(0, false, AbortReason::SEGMENTATION_NOT_SUPPORTED).await;
+}
+
+#[tokio::test]
+async fn nonzero_sequence_precedes_unsupported_capability() {
+    assert_active_initial_abort(1, false, AbortReason::INVALID_APDU_IN_THIS_STATE).await;
+}
+
+#[tokio::test]
+async fn idle_precedes_unsupported_capability() {
+    let (client_transport, mut server) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), SERVER_MAC.to_vec());
+    let mut rx = server.start().await.unwrap();
+    let mut client = BACnetClient::start(config(false), client_transport)
+        .await
+        .unwrap();
+
+    send_to_client(&server, &response_segment(42, 0, true, &[0xAA])).await;
+    expect_abort(&mut rx, 42, AbortReason::INVALID_APDU_IN_THIS_STATE).await;
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    expect_silence(&mut rx).await;
+
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn supported_sequence_zero_enters_segmented_response_and_completes() {
+    let (request, mut server, mut rx, invoke_id) = start_reassembly(config(true)).await;
+
+    send_to_client(&server, &response_segment(invoke_id, 0, true, b"first-")).await;
+    expect_segment_ack(&mut rx, invoke_id, 0).await;
+    send_to_client(&server, &response_segment(invoke_id, 1, false, b"response")).await;
+    expect_segment_ack(&mut rx, invoke_id, 1).await;
+
+    let (mut client, result) = timeout(Duration::from_secs(2), request)
+        .await
+        .expect("valid segmented response did not complete")
+        .unwrap();
+    assert_eq!(result.unwrap().as_ref(), b"first-response");
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/tsm.rs
+++ b/crates/bacnet-client/src/tsm.rs
@@ -13,8 +13,10 @@ use tokio::sync::{oneshot, watch};
 
 mod final_segment;
 pub(crate) use final_segment::{
-    FinalSegmentIssue, FinalSegmentSendToken, SegmentedResponseAdmission, TerminalResponseAdmission,
+    FinalSegmentIssue, FinalSegmentSendToken, TerminalResponseAdmission,
 };
+mod segmented_response;
+pub(crate) use segmented_response::SegmentedResponseAdmission;
 
 /// TSM configuration.
 #[derive(Debug, Clone)]
@@ -430,65 +432,6 @@ impl Tsm {
         }
     }
 
-    /// Gate segment zero before receive state is allocated. In
-    /// SEGMENTED_REQUEST, any ComplexACK before `SentAllSegments`, and any
-    /// segmented ComplexACK not starting at sequence zero, is UnexpectedPDU.
-    pub(crate) fn admit_segmented_complex_ack(
-        &mut self,
-        source_mac: &[u8],
-        invoke_id: u8,
-        sequence_number: u8,
-    ) -> SegmentedResponseAdmission {
-        self.admit_segmented_complex_ack_inner(source_mac, invoke_id, sequence_number, None)
-    }
-
-    pub(crate) fn admit_segmented_complex_ack_for_owner(
-        &mut self,
-        source_mac: &[u8],
-        invoke_id: u8,
-        sequence_number: u8,
-        owner: &TransactionOwner,
-    ) -> SegmentedResponseAdmission {
-        self.admit_segmented_complex_ack_inner(source_mac, invoke_id, sequence_number, Some(owner))
-    }
-
-    fn admit_segmented_complex_ack_inner(
-        &mut self,
-        source_mac: &[u8],
-        invoke_id: u8,
-        sequence_number: u8,
-        owner: Option<&TransactionOwner>,
-    ) -> SegmentedResponseAdmission {
-        let key = (MacAddr::from_slice(source_mac), invoke_id);
-        let Some(pending) = self.pending.get(&key) else {
-            return SegmentedResponseAdmission::NoTransaction;
-        };
-        if owner.is_some_and(|owner| !pending.owner.same_as(owner)) {
-            return SegmentedResponseAdmission::NoTransaction;
-        }
-        if let TransactionPhase::SegmentedRequest { sent_all_segments } = pending.phase {
-            if sequence_number != 0 {
-                self.abort_invalid_apdu_in_current_state(source_mac, invoke_id);
-                return SegmentedResponseAdmission::PrematureSegmentedRequestAborted;
-            }
-            if !sent_all_segments {
-                if let Some(issue) = pending
-                    .final_segment_issue
-                    .as_ref()
-                    .filter(|issue| issue.is_polling())
-                {
-                    return SegmentedResponseAdmission::FinalSegmentSendPolling {
-                        owner: pending.owner.clone(),
-                        issue: issue.clone(),
-                    };
-                }
-                self.abort_invalid_apdu_in_current_state(source_mac, invoke_id);
-                return SegmentedResponseAdmission::PrematureSegmentedRequestAborted;
-            }
-        }
-        SegmentedResponseAdmission::Active(pending.owner.clone())
-    }
-
     pub(crate) fn admit_terminal_response(
         &mut self,
         source_mac: &[u8],
@@ -502,6 +445,7 @@ impl Tsm {
         if owner.is_some_and(|owner| !pending.owner.same_as(owner)) {
             return TerminalResponseAdmission::NoTransaction;
         }
+        let current_owner = pending.owner.clone();
         if matches!(
             pending.phase,
             TransactionPhase::SegmentedRequest {
@@ -514,14 +458,14 @@ impl Tsm {
                 .filter(|issue| issue.is_polling())
             {
                 return TerminalResponseAdmission::FinalSegmentSendPolling {
-                    owner: pending.owner.clone(),
+                    owner: current_owner,
                     issue: issue.clone(),
                 };
             }
-            self.abort_invalid_apdu_in_current_state(source_mac, invoke_id);
+            self.abort_invalid_apdu_in_current_state(source_mac, invoke_id, &current_owner);
             return TerminalResponseAdmission::PrematureSegmentedRequestAborted;
         }
-        TerminalResponseAdmission::Active(pending.owner.clone())
+        TerminalResponseAdmission::Active(current_owner)
     }
 
     /// Enter SEGMENTED_CONF after the first segment has been saved.
@@ -673,17 +617,6 @@ impl Tsm {
         self.pending.get(&key).map(|p| p.expected_service_choice)
     }
 
-    pub(crate) fn owner_and_expected_service(
-        &self,
-        source_mac: &[u8],
-        invoke_id: u8,
-    ) -> Option<(TransactionOwner, ConfirmedServiceChoice)> {
-        let key = (MacAddr::from_slice(source_mac), invoke_id);
-        self.pending
-            .get(&key)
-            .map(|pending| (pending.owner.clone(), pending.expected_service_choice))
-    }
-
     pub(crate) fn owner_is_current(
         &self,
         source_mac: &[u8],
@@ -788,15 +721,21 @@ impl Tsm {
         CompletionOutcome::Delivered
     }
 
-    fn abort_invalid_apdu_in_current_state(&mut self, source_mac: &[u8], invoke_id: u8) {
-        let key = (MacAddr::from_slice(source_mac), invoke_id);
-        let Some(pending) = self.pending.remove(&key) else {
-            return;
-        };
-        self.release_invoke_id(source_mac, invoke_id);
-        let _ = pending.responder.send(TsmResponse::Abort {
-            reason: AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw(),
-        });
+    fn abort_invalid_apdu_in_current_state(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+    ) {
+        let _ = self.complete_transaction_for_owner(
+            source_mac,
+            invoke_id,
+            owner,
+            None,
+            TsmResponse::Abort {
+                reason: AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw(),
+            },
+        );
     }
 
     /// Cancel a pending transaction. Returns `true` if found.

--- a/crates/bacnet-client/src/tsm/final_segment.rs
+++ b/crates/bacnet-client/src/tsm/final_segment.rs
@@ -11,17 +11,6 @@ const ISSUED: u8 = 2;
 const FAILED: u8 = 3;
 
 #[derive(Debug)]
-pub(crate) enum SegmentedResponseAdmission {
-    Active(TransactionOwner),
-    FinalSegmentSendPolling {
-        owner: TransactionOwner,
-        issue: FinalSegmentIssue,
-    },
-    PrematureSegmentedRequestAborted,
-    NoTransaction,
-}
-
-#[derive(Debug)]
 pub(crate) enum TerminalResponseAdmission {
     Active(TransactionOwner),
     FinalSegmentSendPolling {

--- a/crates/bacnet-client/src/tsm/segmented_response.rs
+++ b/crates/bacnet-client/src/tsm/segmented_response.rs
@@ -1,0 +1,108 @@
+use bacnet_types::enums::AbortReason;
+use bacnet_types::MacAddr;
+
+use super::{FinalSegmentIssue, TransactionOwner, TransactionPhase, Tsm};
+
+#[derive(Debug)]
+pub(crate) enum SegmentedResponseAdmission {
+    Active(TransactionOwner),
+    FinalSegmentSendPolling {
+        owner: TransactionOwner,
+        issue: FinalSegmentIssue,
+    },
+    InitialResponseAborted {
+        wire_reason: AbortReason,
+    },
+    NoTransaction,
+}
+
+impl Tsm {
+    /// Gate an initial segmented ComplexACK before receive state is allocated.
+    pub(crate) fn admit_segmented_complex_ack(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        sequence_number: u8,
+        segmented_response_accepted: bool,
+    ) -> SegmentedResponseAdmission {
+        self.admit_segmented_complex_ack_inner(
+            source_mac,
+            invoke_id,
+            sequence_number,
+            segmented_response_accepted,
+            None,
+        )
+    }
+
+    pub(crate) fn admit_segmented_complex_ack_for_owner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        sequence_number: u8,
+        segmented_response_accepted: bool,
+        owner: &TransactionOwner,
+    ) -> SegmentedResponseAdmission {
+        self.admit_segmented_complex_ack_inner(
+            source_mac,
+            invoke_id,
+            sequence_number,
+            segmented_response_accepted,
+            Some(owner),
+        )
+    }
+
+    fn admit_segmented_complex_ack_inner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        sequence_number: u8,
+        segmented_response_accepted: bool,
+        expected_owner: Option<&TransactionOwner>,
+    ) -> SegmentedResponseAdmission {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Some(pending) = self.pending.get(&key) else {
+            return SegmentedResponseAdmission::NoTransaction;
+        };
+        if expected_owner.is_some_and(|owner| !pending.owner.same_as(owner)) {
+            return SegmentedResponseAdmission::NoTransaction;
+        }
+
+        let owner = pending.owner.clone();
+        let phase = pending.phase;
+        let polling_issue = pending
+            .final_segment_issue
+            .as_ref()
+            .filter(|issue| issue.is_polling())
+            .cloned();
+
+        if phase != TransactionPhase::SegmentedResponse {
+            // Sequence validity wins when both initial-response conditions fail.
+            let wire_reason = if sequence_number != 0 {
+                Some(AbortReason::INVALID_APDU_IN_THIS_STATE)
+            } else if !segmented_response_accepted {
+                Some(AbortReason::SEGMENTATION_NOT_SUPPORTED)
+            } else {
+                None
+            };
+            if let Some(wire_reason) = wire_reason {
+                self.abort_invalid_apdu_in_current_state(source_mac, invoke_id, &owner);
+                return SegmentedResponseAdmission::InitialResponseAborted { wire_reason };
+            }
+        }
+
+        if let TransactionPhase::SegmentedRequest {
+            sent_all_segments: false,
+        } = phase
+        {
+            if let Some(issue) = polling_issue {
+                return SegmentedResponseAdmission::FinalSegmentSendPolling { owner, issue };
+            }
+            self.abort_invalid_apdu_in_current_state(source_mac, invoke_id, &owner);
+            return SegmentedResponseAdmission::InitialResponseAborted {
+                wire_reason: AbortReason::INVALID_APDU_IN_THIS_STATE,
+            };
+        }
+
+        SegmentedResponseAdmission::Active(owner)
+    }
+}

--- a/crates/bacnet-client/src/tsm/tests.rs
+++ b/crates/bacnet-client/src/tsm/tests.rs
@@ -1,4 +1,17 @@
 use super::*;
+use tokio::time::{timeout, Duration};
+
+fn assert_initial_response_aborted(
+    admission: SegmentedResponseAdmission,
+    expected_wire_reason: AbortReason,
+) {
+    match admission {
+        SegmentedResponseAdmission::InitialResponseAborted { wire_reason } => {
+            assert_eq!(wire_reason, expected_wire_reason);
+        }
+        other => panic!("expected aborted initial response, got {other:?}"),
+    }
+}
 
 #[test]
 fn allocate_invoke_id_sequential() {
@@ -182,8 +195,10 @@ async fn segmented_complex_ack_zero_is_rejected_until_all_segments_are_sent() {
     );
 
     assert!(matches!(
-        tsm.admit_segmented_complex_ack(&mac, invoke_id, 0),
-        SegmentedResponseAdmission::PrematureSegmentedRequestAborted
+        tsm.admit_segmented_complex_ack(&mac, invoke_id, 0, true),
+        SegmentedResponseAdmission::InitialResponseAborted {
+            wire_reason: AbortReason::INVALID_APDU_IN_THIS_STATE
+        }
     ));
     assert!(matches!(
         registration.response.await.unwrap(),
@@ -191,6 +206,205 @@ async fn segmented_complex_ack_zero_is_rejected_until_all_segments_are_sent() {
             if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
     ));
     assert_eq!(tsm.pending_count(), 0);
+}
+
+#[tokio::test]
+async fn awaiting_response_initial_segment_admission_matrix() {
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+    for (sequence_number, accepted, expected_wire_reason) in [
+        (1, true, AbortReason::INVALID_APDU_IN_THIS_STATE),
+        (0, false, AbortReason::SEGMENTATION_NOT_SUPPORTED),
+        (1, false, AbortReason::INVALID_APDU_IN_THIS_STATE),
+    ] {
+        let mut tsm = Tsm::new(TsmConfig::default());
+        let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+        let registration = tsm.register_transaction_with_progress(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+
+        assert_initial_response_aborted(
+            tsm.admit_segmented_complex_ack(&mac, invoke_id, sequence_number, accepted),
+            expected_wire_reason,
+        );
+        assert!(matches!(
+            registration.response.await.unwrap(),
+            TsmResponse::Abort { reason }
+                if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+        ));
+        assert_eq!(tsm.pending_count(), 0);
+        assert_eq!(tsm.allocate_invoke_id(&mac), Some(invoke_id));
+    }
+}
+
+#[test]
+fn segmented_response_continuations_do_not_repeat_initial_admission() {
+    let mut tsm = Tsm::new(TsmConfig::default());
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+    let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+    let registration = tsm.register_transaction_with_progress(
+        mac.clone(),
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY,
+    );
+
+    assert!(matches!(
+        tsm.admit_segmented_complex_ack(&mac, invoke_id, 0, true),
+        SegmentedResponseAdmission::Active(ref owner) if owner.same_as(&registration.owner)
+    ));
+    tsm.begin_segmented_response(&mac, invoke_id, &registration.owner)
+        .unwrap();
+    for (sequence_number, accepted) in [(1, true), (2, false)] {
+        assert!(matches!(
+            tsm.admit_segmented_complex_ack_for_owner(
+                &mac,
+                invoke_id,
+                sequence_number,
+                accepted,
+                &registration.owner,
+            ),
+            SegmentedResponseAdmission::Active(ref owner)
+                if owner.same_as(&registration.owner)
+        ));
+    }
+    assert_eq!(tsm.pending_count(), 1);
+}
+
+#[tokio::test]
+async fn segmented_request_initial_segment_admission_matrix() {
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+    for (sequence_number, accepted, expected_wire_reason) in [
+        (0, true, AbortReason::INVALID_APDU_IN_THIS_STATE),
+        (0, false, AbortReason::SEGMENTATION_NOT_SUPPORTED),
+        (1, false, AbortReason::INVALID_APDU_IN_THIS_STATE),
+    ] {
+        let mut tsm = Tsm::new(TsmConfig::default());
+        let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+        let registration = tsm.register_segmented_transaction_with_progress(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+
+        assert_initial_response_aborted(
+            tsm.admit_segmented_complex_ack(&mac, invoke_id, sequence_number, accepted),
+            expected_wire_reason,
+        );
+        assert!(matches!(
+            registration.response.await.unwrap(),
+            TsmResponse::Abort { reason }
+                if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+        ));
+        assert_eq!(tsm.pending_count(), 0);
+    }
+}
+
+#[tokio::test]
+async fn sent_all_segments_still_applies_initial_segment_admission() {
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+    for (sequence_number, accepted, expected_wire_reason) in [
+        (0, false, AbortReason::SEGMENTATION_NOT_SUPPORTED),
+        (1, false, AbortReason::INVALID_APDU_IN_THIS_STATE),
+    ] {
+        let mut tsm = Tsm::new(TsmConfig::default());
+        let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+        let registration = tsm.register_segmented_transaction_with_progress(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+        let mut token = tsm
+            .begin_final_segment_send(&mac, invoke_id, &registration.owner)
+            .unwrap();
+        assert!(tsm.mark_final_segment_issued(&mac, invoke_id, &registration.owner, &mut token));
+
+        assert_initial_response_aborted(
+            tsm.admit_segmented_complex_ack_for_owner(
+                &mac,
+                invoke_id,
+                sequence_number,
+                accepted,
+                &registration.owner,
+            ),
+            expected_wire_reason,
+        );
+        assert!(matches!(
+            registration.response.await.unwrap(),
+            TsmResponse::Abort { reason }
+                if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+        ));
+        assert_eq!(tsm.pending_count(), 0);
+    }
+
+    let mut tsm = Tsm::new(TsmConfig::default());
+    let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+    let registration = tsm.register_segmented_transaction_with_progress(
+        mac.clone(),
+        invoke_id,
+        ConfirmedServiceChoice::READ_PROPERTY,
+    );
+    let mut token = tsm
+        .begin_final_segment_send(&mac, invoke_id, &registration.owner)
+        .unwrap();
+    assert!(tsm.mark_final_segment_issued(&mac, invoke_id, &registration.owner, &mut token));
+    assert!(matches!(
+        tsm.admit_segmented_complex_ack_for_owner(
+            &mac,
+            invoke_id,
+            0,
+            true,
+            &registration.owner,
+        ),
+        SegmentedResponseAdmission::Active(ref owner) if owner.same_as(&registration.owner)
+    ));
+}
+
+#[tokio::test]
+async fn invalid_initial_segment_resolves_final_send_polling() {
+    let mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC0]);
+    for (sequence_number, accepted, expected_wire_reason) in [
+        (0, false, AbortReason::SEGMENTATION_NOT_SUPPORTED),
+        (1, true, AbortReason::INVALID_APDU_IN_THIS_STATE),
+    ] {
+        let mut tsm = Tsm::new(TsmConfig::default());
+        let invoke_id = tsm.allocate_invoke_id(&mac).unwrap();
+        let registration = tsm.register_segmented_transaction_with_progress(
+            mac.clone(),
+            invoke_id,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+        let mut token = tsm
+            .begin_final_segment_send(&mac, invoke_id, &registration.owner)
+            .unwrap();
+        let (deferred_owner, issue) = match tsm
+            .admit_segmented_complex_ack(&mac, invoke_id, 0, true)
+        {
+            SegmentedResponseAdmission::FinalSegmentSendPolling { owner, issue } => (owner, issue),
+            other => panic!("expected final-send deferral, got {other:?}"),
+        };
+
+        assert_initial_response_aborted(
+            tsm.admit_segmented_complex_ack_for_owner(
+                &mac,
+                invoke_id,
+                sequence_number,
+                accepted,
+                &deferred_owner,
+            ),
+            expected_wire_reason,
+        );
+        assert!(!tsm.mark_final_segment_issued(&mac, invoke_id, &registration.owner, &mut token));
+        drop(token);
+        timeout(Duration::from_millis(100), issue.wait_until_polled())
+            .await
+            .expect("final-send admission waiter remained blocked");
+        assert!(matches!(
+            registration.response.await.unwrap(),
+            TsmResponse::Abort { reason }
+                if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+        ));
+    }
 }
 
 #[tokio::test]
@@ -437,6 +651,11 @@ async fn stale_owner_cannot_mutate_reused_transaction_key() {
         invoke_id,
         ConfirmedServiceChoice::READ_PROPERTY,
     );
+    assert!(matches!(
+        tsm.admit_segmented_complex_ack_for_owner(&mac, invoke_id, 1, false, &first.owner,),
+        SegmentedResponseAdmission::NoTransaction
+    ));
+    assert_eq!(tsm.pending_count(), 1);
     let generation = tsm
         .begin_segmented_response(&mac, invoke_id, &replacement.owner)
         .unwrap();


### PR DESCRIPTION
## Summary
- validate initial segmented ComplexACK sequence and local segmentation capability before starting reassembly
- complete the active client transaction with `INVALID_APDU_IN_THIS_STATE` while preserving the protocol-specific wire abort reason
- keep established segmented-response continuation and final request-poll behavior unchanged

## Standard basis
- ASHRAE 135-2020, Clauses 5.4.4.1–5.4.4.3 and 18.10

## Validation
- `cargo test -p bacnet-client --locked segmented_response_admission_tests`
- `cargo test -p bacnet-client --locked awaiting_response_initial_segment_admission_matrix`
- `cargo test -p bacnet-client --locked segmented_request_state_tests`
- `cargo test -p bacnet-client --lib --locked`
- `cargo test --workspace --locked`
- `cargo test --workspace --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --locked`
- `cargo deny check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `python3 scripts/generate-conformance-docs.py --check`