### PR TITLE
fix(client): report terminal TSM timeouts as local aborts

### DIFF
--- a/crates/bacnet-client/src/client/cov_renewal_tests.rs
+++ b/crates/bacnet-client/src/client/cov_renewal_tests.rs
@@ -5,7 +5,7 @@ use bacnet_services::common::BACnetPropertyValue;
 use bacnet_services::cov::SubscribeCOVRequest;
 use bacnet_transport::loopback::LoopbackTransport;
 use bacnet_transport::port::{ReceivedNpdu, TransportPort};
-use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{AbortReason, ObjectType, PropertyIdentifier};
 use bacnet_types::primitives::ObjectIdentifier;
 
 fn analog_object(instance: u32) -> ObjectIdentifier {
@@ -547,7 +547,10 @@ async fn managed_cov_subscription_records_failure_without_event_receiver() {
     let Some(ManagedCOVSubscriptionEvent::RenewalFailed { error }) = managed.last_event() else {
         panic!("expected durable RenewalFailed event");
     };
-    assert!(error.contains("request timed out"));
+    assert_eq!(
+        error,
+        format!("BACnet abort: reason={}", AbortReason::TSM_TIMEOUT.to_raw())
+    );
     assert_eq!(client.tsm.lock().await.pending_count(), 0);
 
     managed.stop().await;

--- a/crates/bacnet-client/src/client/request_timer_tests.rs
+++ b/crates/bacnet-client/src/client/request_timer_tests.rs
@@ -6,7 +6,7 @@ use bacnet_encoding::apdu::{self, encode_apdu, Apdu, ComplexAck};
 use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
 use bacnet_transport::loopback::LoopbackTransport;
 use bacnet_transport::port::{ReceivedNpdu, TransportPort};
-use bacnet_types::enums::ConfirmedServiceChoice;
+use bacnet_types::enums::{AbortReason, ConfirmedServiceChoice};
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 use bytes::{Bytes, BytesMut};
@@ -131,13 +131,56 @@ async fn max_retry_budget_sends_exactly_255_retransmissions() {
     )
     .await
     .expect("the maximum retry budget must terminate");
-    assert!(
-        matches!(result, Err(Error::Timeout(duration)) if duration == Duration::from_millis(1))
-    );
+    assert!(matches!(
+        result,
+        Err(Error::Abort { reason }) if reason == AbortReason::TSM_TIMEOUT.to_raw()
+    ));
     assert_eq!(drain.await.unwrap(), 1 + usize::from(u8::MAX));
 
     client.stop().await.unwrap();
     server_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn retry_send_failure_precedes_final_timeout_indication() {
+    let (_inbound_tx, inbound_rx) = mpsc::channel(8);
+    let (outbound_tx, _outbound_rx) = mpsc::unbounded_channel();
+    let retry_started = Arc::new(Notify::new());
+    let release_retry = Arc::new(Notify::new());
+    let send_count = Arc::new(AtomicUsize::new(0));
+    let transport = BlockingRetryTransport {
+        local_mac: MacAddr::from_slice(CLIENT_MAC),
+        inbound_rx: Some(inbound_rx),
+        outbound_tx,
+        send_count: Arc::clone(&send_count),
+        retry_started,
+        release_retry: Arc::clone(&release_retry),
+    };
+    let config = ClientConfig {
+        apdu_timeout_ms: 10,
+        apdu_retries: 1,
+        ..ClientConfig::default()
+    };
+    let mut client = BACnetClient::start(config, transport).await.unwrap();
+    release_retry.notify_one();
+
+    let result = timeout(
+        Duration::from_secs(1),
+        client.confirmed_request(SERVER_MAC, ConfirmedServiceChoice::READ_PROPERTY, &[0x0C]),
+    )
+    .await
+    .expect("retry send failure did not complete the request");
+    match result {
+        Err(Error::Transport(error)) => {
+            assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+            assert_eq!(error.to_string(), "injected retry failure");
+        }
+        other => panic!("expected retry transport failure, got {other:?}"),
+    }
+    assert_eq!(send_count.load(Ordering::SeqCst), 2);
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+
+    client.stop().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -429,7 +429,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                         false,
                                         None,
                                     );
-                                    return Err(Error::Timeout(request_timeout));
+                                    return Err(Error::Abort {
+                                        reason: bacnet_types::enums::AbortReason::TSM_TIMEOUT.to_raw(),
+                                    });
                                 }
                                 RequestTimerExpiration::NoTransaction => {
                                     drop(tsm);

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -657,7 +657,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                             _ = &mut segment_timer => {
                                 ack_retries += 1;
                                 if ack_retries > max_ack_retries {
-                                    return Err(Error::Timeout(timeout_duration));
+                                    return Err(Error::Abort {
+                                        reason: bacnet_types::enums::AbortReason::TSM_TIMEOUT.to_raw(),
+                                    });
                                 }
                                 warn!(
                                     attempt = ack_retries,

--- a/crates/bacnet-client/src/client/segmented_receive_lifecycle_tests.rs
+++ b/crates/bacnet-client/src/client/segmented_receive_lifecycle_tests.rs
@@ -568,7 +568,7 @@ async fn segmented_request_timeout_cleanup_preserves_replacement_sender() {
             .await
             .unwrap()
             .unwrap(),
-        Err(Error::Timeout(_))
+        Err(Error::Abort { reason }) if reason == AbortReason::TSM_TIMEOUT.to_raw()
     ));
     assert_eq!(
         client.tsm.lock().await.pending_count(),

--- a/crates/bacnet-client/src/client/segmented_timeout_tests.rs
+++ b/crates/bacnet-client/src/client/segmented_timeout_tests.rs
@@ -54,6 +54,77 @@ async fn segment_timer_timeout_ends_the_reassembly_session() {
 }
 
 #[tokio::test]
+async fn segmented_request_without_segment_ack_returns_local_tsm_timeout() {
+    let retries = 2;
+    let config = ClientConfig {
+        apdu_timeout_ms: 40,
+        apdu_retries: retries,
+        max_apdu_length: 50,
+        proposed_window_size: 1,
+        ..ClientConfig::default()
+    };
+    let (client_transport, mut server) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), SERVER_MAC.to_vec());
+    let mut rx = server.start().await.unwrap();
+    let client = Arc::new(BACnetClient::start(config, client_transport).await.unwrap());
+
+    let request_client = Arc::clone(&client);
+    let request = tokio::spawn(async move {
+        request_client
+            .confirmed_request(
+                SERVER_MAC,
+                ConfirmedServiceChoice::READ_PROPERTY,
+                &[0x0C; 100],
+            )
+            .await
+    });
+
+    let mut invoke_id = None;
+    for _ in 0..=retries {
+        match recv_apdu(&mut rx, "an unacknowledged outgoing request segment").await {
+            Apdu::ConfirmedRequest(segment) => {
+                assert!(segment.segmented);
+                assert!(segment.more_follows);
+                assert_eq!(segment.sequence_number, Some(0));
+                if let Some(expected_invoke_id) = invoke_id {
+                    assert_eq!(segment.invoke_id, expected_invoke_id);
+                }
+                invoke_id = Some(segment.invoke_id);
+            }
+            other => panic!("expected ConfirmedRequest segment, got {other:?}"),
+        }
+    }
+    let invoke_id = invoke_id.expect("at least one request segment");
+
+    let result = timeout(Duration::from_secs(2), request)
+        .await
+        .expect("SegmentTimer retry exhaustion did not complete the request")
+        .unwrap();
+    assert!(matches!(
+        result,
+        Err(Error::Abort { reason }) if reason == AbortReason::TSM_TIMEOUT.to_raw()
+    ));
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert!(
+        !client
+            .seg_ack_senders
+            .lock()
+            .await
+            .contains_key(&(bacnet_types::MacAddr::from_slice(SERVER_MAC), invoke_id)),
+        "SegmentTimer expiry left the SegmentAck sender registered"
+    );
+    assert!(
+        timeout(Duration::from_millis(50), rx.recv()).await.is_err(),
+        "SegmentTimer expiry sent an unexpected peer PDU"
+    );
+
+    let mut client =
+        Arc::try_unwrap(client).unwrap_or_else(|_| panic!("request task retained client"));
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn delayed_timeout_cleanup_preserves_reused_segmented_response() {
     let config = ClientConfig {
         apdu_timeout_ms: 100,


### PR DESCRIPTION
## Summary
- report terminal RequestTimer and outgoing segmented-request SegmentTimer exhaustion as local `TSM_TIMEOUT` Abort indications
- preserve retry budgets, owner-qualified cleanup, invoke-ID reuse, and transport-failure precedence
- keep timer expiry local without emitting a peer Abort PDU

## Standard basis
- ASHRAE 135-2020, Clause 5.4.4.2 `SEGMENTED_REQUEST` FinalTimeout
- ASHRAE 135-2020, Clause 5.4.4.3 `AWAIT_CONFIRMATION` FinalTimeout

## Validation
- focused request-timer, segmented-timeout, cleanup/reuse, and managed-COV tests
- `cargo test -p bacnet-client --lib --locked`
- `cargo test -p bacnet-client --test integration --locked`
- `cargo test -p bacnet-client --doc --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `cargo fmt --all --check`
- `cargo clippy -p bacnet-client --all-targets --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo deny check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `python3 scripts/generate-conformance-docs.py --check`