### PR TITLE
fix(objects): enforce Escalator mode enumeration domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-Enumerated inputs with PROPERTY / INVALID_DATA_TYPE. Failed writes
   leave the prior value unchanged. No wire-format or service-model change.
 
+- The Escalator object's `escalator_mode` (462) now uses the typed
+  `EscalatorMode` with UNKNOWN as its default (#400). Writes accept all six
+  named values, including OUT_OF_SERVICE, and preserve proprietary values in
+  1024..=65535. Reserved values in 6..=1023 and values above 65535 are refused
+  with PROPERTY / VALUE_OUT_OF_RANGE before mutation. Enumerated readback and
+  the existing in-service write behavior are unchanged. No wire-format,
+  public API, or service-model change.
+
 - The bundled server now enforces a File object's declared
   `File_Access_Method` when executing AtomicReadFile and AtomicWriteFile
   (#287). A stream request against a record-access file, or a record

--- a/crates/bacnet-objects/src/elevator.rs
+++ b/crates/bacnet-objects/src/elevator.rs
@@ -4,7 +4,9 @@
 //! - EscalatorObject (type 58): represents an escalator
 //! - LiftObject (type 59): represents a single lift/elevator car
 
-use bacnet_types::enums::{EscalatorOperationDirection, ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{
+    EscalatorMode, EscalatorOperationDirection, ObjectType, PropertyIdentifier,
+};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;
@@ -176,8 +178,9 @@ pub struct EscalatorObject {
     oid: ObjectIdentifier,
     name: String,
     description: String,
-    /// Escalator mode (Enumerated: 0=unknown, 1=stop, 2=up, 3=down, 4=inspection).
-    escalator_mode: u32,
+    /// Escalator mode (BACnetEscalatorMode, Clause 21); proprietary extensions
+    /// (Clause 23.1) are preserved as raw values.
+    escalator_mode: EscalatorMode,
     /// List of fault signal codes (Unsigned).
     fault_signals: Vec<u64>,
     /// Energy meter reading (Real).
@@ -202,7 +205,7 @@ impl EscalatorObject {
             oid,
             name: name.into(),
             description: String::new(),
-            escalator_mode: 0, // unknown
+            escalator_mode: EscalatorMode::UNKNOWN,
             fault_signals: Vec::new(),
             energy_meter: 0.0,
             energy_meter_ref: Vec::new(),
@@ -237,7 +240,7 @@ impl BACnetObject for EscalatorObject {
                 Ok(PropertyValue::Enumerated(ObjectType::ESCALATOR.to_raw()))
             }
             p if p == PropertyIdentifier::ESCALATOR_MODE => {
-                Ok(PropertyValue::Enumerated(self.escalator_mode))
+                Ok(PropertyValue::Enumerated(self.escalator_mode.to_raw()))
             }
             p if p == PropertyIdentifier::FAULT_SIGNALS => {
                 let items: Vec<PropertyValue> = self
@@ -279,10 +282,13 @@ impl BACnetObject for EscalatorObject {
         match property {
             p if p == PropertyIdentifier::ESCALATOR_MODE => {
                 if let PropertyValue::Enumerated(v) = value {
-                    if v > 4 {
+                    let named = EscalatorMode::ALL_NAMED
+                        .iter()
+                        .any(|&(_, value)| value.to_raw() == v);
+                    if !(named || (1024..=65535).contains(&v)) {
                         return Err(common::value_out_of_range_error());
                     }
-                    self.escalator_mode = v;
+                    self.escalator_mode = EscalatorMode::from_raw(v);
                     Ok(())
                 } else {
                     Err(common::invalid_data_type_error())

--- a/crates/bacnet-objects/src/elevator/tests.rs
+++ b/crates/bacnet-objects/src/elevator/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
-use bacnet_types::enums::{ErrorClass, ErrorCode, EscalatorOperationDirection};
+use bacnet_types::enums::{ErrorClass, ErrorCode, EscalatorMode, EscalatorOperationDirection};
 
-/// Operation_Direction is writable for simulation while Out_Of_Service is
-/// true (Clause 12.60); write-domain tests run with OOS enabled.
+/// Escalator write-domain tests run with Out_Of_Service enabled so they do not
+/// set policy for writes while the object is in service.
 fn oos_escalator() -> EscalatorObject {
     let mut esc = EscalatorObject::new(1, "ESC-1").unwrap();
     esc.write_property(
@@ -48,6 +48,16 @@ fn assert_invalid_data_type(result: Result<(), Error>, context: &str) {
             );
         }
         other => panic!("{context}: expected PROPERTY/INVALID_DATA_TYPE, got {other:?}"),
+    }
+}
+
+fn read_mode(esc: &EscalatorObject) -> u32 {
+    match esc
+        .read_property(PropertyIdentifier::ESCALATOR_MODE, None)
+        .unwrap()
+    {
+        PropertyValue::Enumerated(raw) => raw,
+        other => panic!("expected Enumerated readback, got {other:?}"),
     }
 }
 
@@ -197,6 +207,98 @@ fn escalator_property_list() {
     assert!(list.contains(&PropertyIdentifier::POWER_MODE));
     assert!(list.contains(&PropertyIdentifier::OPERATION_DIRECTION));
     assert!(list.contains(&PropertyIdentifier::STATUS_FLAGS));
+}
+
+// --- Escalator_Mode domain (#400) ---
+
+#[test]
+fn escalator_mode_field_is_typed_and_defaults_to_unknown() {
+    let esc = EscalatorObject::new(1, "ESC-1").unwrap();
+    assert_eq!(esc.escalator_mode, EscalatorMode::UNKNOWN);
+}
+
+#[test]
+fn escalator_all_named_modes_round_trip_with_oos() {
+    let mut esc = oos_escalator();
+
+    for &(name, value) in EscalatorMode::ALL_NAMED {
+        esc.write_property(
+            PropertyIdentifier::ESCALATOR_MODE,
+            None,
+            PropertyValue::Enumerated(value.to_raw()),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("named mode {name} must be accepted: {e:?}"));
+        assert_eq!(read_mode(&esc), value.to_raw(), "{name} round-trip");
+    }
+
+    assert_eq!(read_mode(&esc), EscalatorMode::OUT_OF_SERVICE.to_raw());
+}
+
+#[test]
+fn escalator_proprietary_mode_values_round_trip() {
+    let mut esc = oos_escalator();
+
+    for raw in [1024u32, 65535] {
+        esc.write_property(
+            PropertyIdentifier::ESCALATOR_MODE,
+            None,
+            PropertyValue::Enumerated(raw),
+            None,
+        )
+        .unwrap_or_else(|e| panic!("proprietary raw {raw} must be accepted: {e:?}"));
+        assert_eq!(read_mode(&esc), raw, "raw {raw} must not normalize");
+    }
+}
+
+#[test]
+fn escalator_reserved_and_oversized_mode_values_rejected_atomically() {
+    let prior = EscalatorMode::OUT_OF_SERVICE.to_raw();
+    for raw in [6u32, 1023, 65536, u32::MAX] {
+        let mut esc = oos_escalator();
+        esc.write_property(
+            PropertyIdentifier::ESCALATOR_MODE,
+            None,
+            PropertyValue::Enumerated(prior),
+            None,
+        )
+        .unwrap();
+
+        assert_value_out_of_range(
+            esc.write_property(
+                PropertyIdentifier::ESCALATOR_MODE,
+                None,
+                PropertyValue::Enumerated(raw),
+                None,
+            ),
+            &format!("invalid raw {raw}"),
+        );
+        assert_eq!(read_mode(&esc), prior, "raw {raw} changed the mode");
+    }
+}
+
+#[test]
+fn escalator_mode_wrong_datatype_rejected_atomically() {
+    let mut esc = oos_escalator();
+    let prior = EscalatorMode::STOP.to_raw();
+    esc.write_property(
+        PropertyIdentifier::ESCALATOR_MODE,
+        None,
+        PropertyValue::Enumerated(prior),
+        None,
+    )
+    .unwrap();
+
+    assert_invalid_data_type(
+        esc.write_property(
+            PropertyIdentifier::ESCALATOR_MODE,
+            None,
+            PropertyValue::Unsigned(4),
+            None,
+        ),
+        "Unsigned instead of Enumerated",
+    );
+    assert_eq!(read_mode(&esc), prior, "wrong datatype changed the mode");
 }
 
 // --- Operation_Direction typed behavior (#284) ---


### PR DESCRIPTION
## Summary

`EscalatorObject::escalator_mode` was stored as a raw `u32` and rejected every value above 4. That excluded the Clause 21 `OUT_OF_SERVICE` value (5) and proprietary values.

This PR stores the private field as `EscalatorMode`, keeps Enumerated raw readback, and validates writes before mutation.

## Standard scope

- Clause 12.60 — Escalator object and OOS simulation path
- Clause 21 — `BACnetEscalatorMode` values 0 through 5
- Clause 23.1 / Table 23-1 — proprietary enumeration range
- Ledger scope: existing `BACNET-12-OBJECT-MODEL`; no support-status or public-claim change

## Behavior

| Raw value | Result |
|---|---|
| Named 0..=5 | accepted and preserved |
| Proprietary 1024..=65535 | accepted and preserved |
| Reserved 6..=1023 | `PROPERTY / VALUE_OUT_OF_RANGE` |
| Above 65535 | `PROPERTY / VALUE_OUT_OF_RANGE` |
| Non-Enumerated | `PROPERTY / INVALID_DATA_TYPE` |

Failed writes leave the prior mode unchanged. Tests exercise the domain with `Out_Of_Service = TRUE`; the separate in-service policy question in #401 remains unchanged.

## Red evidence

Before the implementation, the new focused tests produced 16 passes and 3 failures: `OUT_OF_SERVICE`, proprietary 1024, and an `OUT_OF_SERVICE` prior value were rejected as `PROPERTY / VALUE_OUT_OF_RANGE`.

## Validation

- `cargo test -p bacnet-objects escalator --locked` — 19 passed
- `cargo test -p bacnet-objects --locked` — 1,033 passed
- macOS workspace suite with `bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls` — 3,265 passed; 2 ignored doc tests
- `cargo fmt --all --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- file-size, no-secret, conformance-generator, and diff checks

Linux serial/Ethernet coverage remains the exact-head CI gate.

## Compatibility

- No public Rust, Python, CLI, wire-format, or service-model change.
- Writes of 5 and proprietary values now succeed where they previously returned Error(-).
- Reserved, oversized, and mistyped values remain refused.
- No benchmark: this is constant-time validation on an unmeasured object-property path.

Head reviewed for packaging: `ff6f81a9cdf8f88040d17f10a44c17d1ab3677f5`.

Closes #400