### PR TITLE
fix(objects): reject overwide color temperature values

### DIFF
--- a/crates/bacnet-objects/src/color.rs
+++ b/crates/bacnet-objects/src/color.rs
@@ -366,7 +366,7 @@ impl BACnetObject for ColorTemperatureObject {
         match property {
             p if p == PropertyIdentifier::PRESENT_VALUE => {
                 if let PropertyValue::Unsigned(v) = value {
-                    let v32 = v as u32;
+                    let v32 = common::u64_to_u32(v)?;
                     // Clamp to min/max if supported
                     if let Some(min) = self.min_pres_value {
                         if v32 < min {
@@ -424,5 +424,92 @@ impl BACnetObject for ColorTemperatureObject {
 
     fn supports_cov(&self) -> bool {
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bacnet_types::enums::{ErrorClass, ErrorCode};
+
+    fn assert_property_error(error: Error, expected_code: ErrorCode) {
+        match error {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+                assert_eq!(code, expected_code.to_raw() as u32);
+            }
+            other => panic!("expected PROPERTY/{expected_code:?}, got {other:?}"),
+        }
+    }
+
+    fn assert_present_and_tracking(object: &ColorTemperatureObject, expected: u64) {
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::PRESENT_VALUE, None)
+                .unwrap(),
+            PropertyValue::Unsigned(expected)
+        );
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::TRACKING_VALUE, None)
+                .unwrap(),
+            PropertyValue::Unsigned(expected)
+        );
+    }
+
+    #[test]
+    fn color_temperature_rejects_overwide_present_value_without_mutation() {
+        let mut object = ColorTemperatureObject::new(1, "CT-1").unwrap();
+
+        let error = object
+            .write_property(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                PropertyValue::Unsigned(0x1_0000_03E8),
+                None,
+            )
+            .expect_err("over-wide Present_Value must be rejected");
+
+        assert_property_error(error, ErrorCode::VALUE_OUT_OF_RANGE);
+        assert_present_and_tracking(&object, 4000);
+    }
+
+    #[test]
+    fn color_temperature_preserves_present_value_boundaries() {
+        let mut object = ColorTemperatureObject::new(1, "CT-1").unwrap();
+
+        for value in [1000, 30000] {
+            object
+                .write_property(
+                    PropertyIdentifier::PRESENT_VALUE,
+                    None,
+                    PropertyValue::Unsigned(value),
+                    None,
+                )
+                .unwrap();
+            assert_present_and_tracking(&object, value);
+        }
+
+        let error = object
+            .write_property(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                PropertyValue::Unsigned(u32::MAX as u64),
+                None,
+            )
+            .expect_err("u32::MAX remains outside the configured range");
+        assert_property_error(error, ErrorCode::VALUE_OUT_OF_RANGE);
+        assert_present_and_tracking(&object, 30000);
+
+        let error = object
+            .write_property(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                PropertyValue::Real(1000.0),
+                None,
+            )
+            .expect_err("wrong datatype must be rejected");
+        assert_property_error(error, ErrorCode::INVALID_DATA_TYPE);
+        assert_present_and_tracking(&object, 30000);
     }
 }

--- a/crates/bacnet-server/src/handlers/tests/write_validation.rs
+++ b/crates/bacnet-server/src/handlers/tests/write_validation.rs
@@ -11,6 +11,7 @@
 use super::*;
 use bacnet_objects::analog::{AnalogInputObject, AnalogOutputObject};
 use bacnet_objects::binary::BinaryValueObject;
+use bacnet_objects::color::ColorTemperatureObject;
 use bacnet_objects::event_enrollment::EventEnrollmentObject;
 use bacnet_objects::loop_obj::LoopObject;
 use bacnet_objects::multistate::MultiStateOutputObject;
@@ -551,4 +552,56 @@ fn time_delay_normal_round_trips_over_write_property_and_read_property() {
         PropertyValue::Unsigned(9),
         "AI oversized Time_Delay_Normal",
     );
+}
+
+#[test]
+fn write_property_rejects_overwide_color_temperature_without_mutation() {
+    const HOSTILE: u64 = 0x1_0000_03E8;
+
+    let mut db = ObjectDatabase::new();
+    let object = ColorTemperatureObject::new(1, "CT-1").unwrap();
+    let oid = object.object_identifier();
+    db.add(Box::new(object)).unwrap();
+
+    let property_value = encode_value(PropertyValue::Unsigned(HOSTILE));
+    assert_eq!(property_value[0], 0x25);
+    let (tag, content_start) = bacnet_encoding::tags::decode_tag(&property_value, 0).unwrap();
+    assert_eq!(tag.class, bacnet_encoding::tags::TagClass::Application);
+    assert_eq!(tag.number, bacnet_encoding::tags::app_tag::UNSIGNED);
+    assert_eq!(tag.length, 5);
+    assert_eq!(
+        &property_value[content_start..],
+        &[0x01, 0x00, 0x00, 0x03, 0xE8]
+    );
+
+    let request = WritePropertyRequest {
+        object_identifier: oid,
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+        property_value,
+        priority: None,
+    };
+    let mut request_bytes = BytesMut::new();
+    request.encode(&mut request_bytes);
+
+    match handle_write_property(&mut db, &request_bytes)
+        .expect_err("over-wide Color Temperature Present_Value must be rejected")
+    {
+        Error::Protocol { class, code } => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(code, ErrorCode::VALUE_OUT_OF_RANGE.to_raw() as u32);
+        }
+        other => panic!("expected PROPERTY/VALUE_OUT_OF_RANGE, got {other:?}"),
+    }
+
+    for property in [
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyIdentifier::TRACKING_VALUE,
+    ] {
+        assert_eq!(
+            read_wire(&db, oid, property),
+            PropertyValue::Unsigned(4000),
+            "refused write must leave {property:?} unchanged"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Reject `ColorTemperatureObject` `Present_Value` writes when the peer-supplied BACnet Unsigned value cannot fit the object's `u32` storage.

The write arm now uses the existing checked conversion before configured range checks or mutation. Direct-object and server WriteProperty regressions cover the canonical five-octet value `0x1_0000_03E8` and verify that both `Present_Value` and `Tracking_Value` remain unchanged.

## Scope

- preserves the current configured min/max and wrong-datatype behavior
- does not change the shared Unsigned decoder or `PropertyValue`
- does not import Addendum 135-2020ca range/clamping semantics or alter public support claims
- leaves the broader narrowing audit and example sites for separate work

## Validation

- `cargo test -p bacnet-objects color --locked`
- `cargo test -p bacnet-server write_property --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test -p bacnet-integration-tests --test conformance_ledger --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

Refs #309; object slice only