### PR TITLE
fix(services): correct notification parameter wire models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Correct `NotificationParameters` codecs for complex event values `[6]`,
+  AccessEvent credentials and authentication factors `[13]`, rejection of the
+  omitted choice `[20]`, and independently optional ChangeOfTimer fields `[22]`
+  (#351). The Rust API adds `ComplexEventType`, changes the AccessEvent
+  credential type and ChangeOfTimer suffix fields, and removes `NoneParams`;
+  runtime event-value projection and support claims are unchanged.
+
 - Device `Active_COV_Subscriptions` reads now return one constructed
   `ApplicationData` value containing every field stored in each
   `BACnetCOVSubscription` (#183). This replaces the previous lossy nested

--- a/crates/bacnet-services/src/alarm_event/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/mod.rs
@@ -5,12 +5,14 @@
 //! - GetEventInformation (Clause 13.12)
 
 use bacnet_encoding::{primitives, tags};
-use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetPropertyStates};
+use bacnet_types::constructed::{
+    BACnetDeviceObjectPropertyReference, BACnetDeviceObjectReference, BACnetPropertyStates,
+};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, Date, ObjectIdentifier, Time};
 use bytes::BytesMut;
 
-use crate::common::MAX_DECODED_ITEMS;
+use crate::common::{BACnetPropertyValue, MAX_DECODED_ITEMS};
 
 mod acknowledge_alarm;
 mod event_notification;

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode.rs
@@ -3,6 +3,7 @@ use super::decode_helpers::{
     finish_variant as check_variant_end,
 };
 use super::decode_timer::{decode_change_of_discrete_value, decode_change_of_timer};
+use super::structured::{decode_access_event, decode_complex_event_type};
 use super::*;
 use crate::common::{decode_context, decode_context_u32};
 use bacnet_encoding::constructed::validate_tlv_sequence;
@@ -26,7 +27,6 @@ impl NotificationParameters {
         let framed = data.get(offset..).ok_or_else(|| {
             Error::decoding(offset, "NotificationParameters offset exceeds input")
         })?;
-        validate_tlv_sequence(framed, "NotificationParameters")?;
         // Peek the inner opening tag to determine the variant
         if offset >= data.len() {
             return Err(Error::decoding(
@@ -42,6 +42,17 @@ impl NotificationParameters {
             ));
         }
         let variant_tag = inner_tag.number;
+        if variant_tag == 6 {
+            let (_, next) = tags::extract_context_value(data, inner_start, 6)?;
+            if next != data.len() {
+                return Err(Error::decoding(
+                    next,
+                    "ComplexEventType has trailing encoded fields",
+                ));
+            }
+        } else {
+            validate_tlv_sequence(framed, "NotificationParameters")?;
+        }
         let variant_body_end = closing_tag_start(
             data,
             data.len(),
@@ -182,6 +193,8 @@ impl NotificationParameters {
                     pos,
                 )
             }
+            // [6] Complex event type
+            6 => decode_complex_event_type(data, inner_start, variant_body_end),
             // [10] Buffer ready
             10 => {
                 let mut pos = inner_start;
@@ -391,69 +404,7 @@ impl NotificationParameters {
                 )
             }
             // [13] Access event
-            13 => {
-                // [0] access-event
-                let (access_event, pos) =
-                    decode_context_u32(data, inner_start, 0, "AccessEvent access-event")?;
-                // [1] status-flags
-                let (status_flags, pos) =
-                    decode_context_status_flags(data, pos, 1, "AccessEvent status-flags")?;
-                // [2] access-event-tag
-                let (access_event_tag, mut pos) =
-                    decode_context_u32(data, pos, 2, "AccessEvent access-event-tag")?;
-                // [3] access-event-time: BACnetTimeStamp (DateTime)
-                let (ts, new_pos) = primitives::decode_timestamp(data, pos, 3)?;
-                pos = new_pos;
-                let access_event_time = match ts {
-                    BACnetTimeStamp::DateTime { date, time } => (date, time),
-                    _ => {
-                        return Err(Error::decoding(
-                            pos,
-                            "AccessEvent: expected DateTime timestamp",
-                        ))
-                    }
-                };
-                // [4] access-credential: BACnetDeviceObjectPropertyReference
-                let (t, p) = tags::decode_tag(data, pos)?;
-                if !t.is_opening || t.number != 4 {
-                    return Err(Error::decoding(
-                        pos,
-                        "AccessEvent: expected opening [4] for access-credential",
-                    ));
-                }
-                pos = p;
-                let access_credential = decode_device_obj_prop_ref(data, &mut pos)?;
-                let (ct, cp) = tags::decode_tag(data, pos)?;
-                if !ct.is_closing || ct.number != 4 {
-                    return Err(Error::decoding(pos, "AccessEvent: expected closing [4]"));
-                }
-                pos = cp;
-                // [5] authentication-factor — opening/closing, raw, optional
-                let (authentication_factor, after) = if pos < variant_body_end {
-                    let (t, p) = tags::decode_tag(data, pos)?;
-                    if !t.is_opening_tag(5) {
-                        return Err(Error::decoding(
-                            pos,
-                            "AccessEvent: expected opening [5] for authentication-factor",
-                        ));
-                    }
-                    let (value, after) = extract_raw_context(data, p, 5)?;
-                    (Some(value), after)
-                } else {
-                    (None, pos)
-                };
-                finish_variant(
-                    Self::AccessEvent {
-                        access_event,
-                        status_flags,
-                        access_event_tag,
-                        access_event_time,
-                        access_credential,
-                        authentication_factor,
-                    },
-                    after,
-                )
-            }
+            13 => decode_access_event(data, inner_start, variant_body_end),
             // [14] Double out of range
             14 => {
                 // [0] exceeding-value
@@ -666,8 +617,6 @@ impl NotificationParameters {
                     after,
                 )
             }
-            // [20] None
-            20 => finish_variant(Self::NoneParams, inner_start),
             // [21] Change of discrete value
             21 => decode_change_of_discrete_value(data, inner_start, variant_body_end),
             // [22] Change of timer

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/decode_timer.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/decode_timer.rs
@@ -20,6 +20,12 @@ fn decode_date_time(
     if date_tag.class != tags::TagClass::Application || date_tag.number != tags::app_tag::DATE {
         return Err(Error::decoding(pos, format!("{field} expected Date")));
     }
+    if date_tag.length != 4 {
+        return Err(Error::decoding(
+            pos,
+            format!("{field} Date must be four octets"),
+        ));
+    }
     let content_end = content_start
         .checked_add(date_tag.length as usize)
         .ok_or_else(|| Error::decoding(content_start, format!("{field} Date length overflow")))?;
@@ -32,6 +38,12 @@ fn decode_date_time(
     let (time_tag, content_start) = tags::decode_tag(data, pos)?;
     if time_tag.class != tags::TagClass::Application || time_tag.number != tags::app_tag::TIME {
         return Err(Error::decoding(pos, format!("{field} expected Time")));
+    }
+    if time_tag.length != 4 {
+        return Err(Error::decoding(
+            pos,
+            format!("{field} Time must be four octets"),
+        ));
     }
     let content_end = content_start
         .checked_add(time_tag.length as usize)
@@ -64,13 +76,32 @@ pub(super) fn decode_change_of_timer(
         decode_context_status_flags(data, pos, 1, "ChangeOfTimer status-flags")?;
     // [2] update-time: BACnetDateTime — opening/closing [2]
     let (update_time, pos) = decode_date_time(data, pos, 2, "ChangeOfTimer update-time")?;
-    // [3] last-state-change
-    let (last_state_change, pos) =
-        decode_context_u32(data, pos, 3, "ChangeOfTimer last-state-change")?;
-    // [4] initial-timeout
-    let (initial_timeout, pos) = decode_context_u32(data, pos, 4, "ChangeOfTimer initial-timeout")?;
-    // [5] expiration-time: BACnetDateTime — opening/closing [5]
-    let (expiration_time, pos) = decode_date_time(data, pos, 5, "ChangeOfTimer expiration-time")?;
+    let mut pos = pos;
+    let last_state_change = if pos < variant_body_end
+        && tags::decode_tag(data, pos)?.0.is_context(3)
+    {
+        let (value, next) = decode_context_u32(data, pos, 3, "ChangeOfTimer last-state-change")?;
+        pos = next;
+        Some(value)
+    } else {
+        None
+    };
+    let initial_timeout = if pos < variant_body_end && tags::decode_tag(data, pos)?.0.is_context(4)
+    {
+        let (value, next) = decode_context_u32(data, pos, 4, "ChangeOfTimer initial-timeout")?;
+        pos = next;
+        Some(value)
+    } else {
+        None
+    };
+    let expiration_time =
+        if pos < variant_body_end && tags::decode_tag(data, pos)?.0.is_opening_tag(5) {
+            let (value, next) = decode_date_time(data, pos, 5, "ChangeOfTimer expiration-time")?;
+            pos = next;
+            Some(value)
+        } else {
+            None
+        };
     if pos != variant_body_end {
         return Err(Error::decoding(
             pos,

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/encode.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/encode.rs
@@ -9,8 +9,25 @@ impl NotificationParameters {
     pub fn encode(&self, buf: &mut BytesMut) -> Result<(), Error> {
         let mut encoded = BytesMut::new();
         self.encode_into(&mut encoded)?;
-        validate_tlv_sequence(&encoded, "NotificationParameters")
-            .map_err(|error| Error::Encoding(error.to_string()))?;
+        if matches!(self, Self::ComplexEventType { .. }) {
+            let (opening, content_start) = tags::decode_tag(&encoded, 0)
+                .map_err(|error| Error::Encoding(error.to_string()))?;
+            if !opening.is_opening_tag(6) {
+                return Err(Error::Encoding(
+                    "ComplexEventType missing opening tag [6]".into(),
+                ));
+            }
+            let (_, next) = tags::extract_context_value(&encoded, content_start, 6)
+                .map_err(|error| Error::Encoding(error.to_string()))?;
+            if next != encoded.len() {
+                return Err(Error::Encoding(
+                    "ComplexEventType has trailing encoded fields".into(),
+                ));
+            }
+        } else {
+            validate_tlv_sequence(&encoded, "NotificationParameters")
+                .map_err(|error| Error::Encoding(error.to_string()))?;
+        }
         buf.extend_from_slice(&encoded);
         Ok(())
     }
@@ -108,6 +125,28 @@ impl NotificationParameters {
                 primitives::encode_ctx_real(buf, 3, *exceeded_limit);
                 tags::encode_closing_tag(buf, 5);
             }
+            Self::ComplexEventType { property_values } => {
+                if property_values.len() > MAX_DECODED_ITEMS {
+                    return Err(Error::Encoding(format!(
+                        "ComplexEventType exceeds {MAX_DECODED_ITEMS} property values"
+                    )));
+                }
+                tags::encode_opening_tag(buf, 6);
+                for property_value in property_values {
+                    if property_value
+                        .priority
+                        .is_some_and(|priority| !(1..=16).contains(&priority))
+                    {
+                        return Err(Error::Encoding(
+                            "ComplexEventType property priority must be in 1..=16".into(),
+                        ));
+                    }
+                    validate_tlv_sequence(&property_value.value, "ComplexEventType property value")
+                        .map_err(|error| Error::Encoding(error.to_string()))?;
+                    property_value.encode(buf);
+                }
+                tags::encode_closing_tag(buf, 6);
+            }
             Self::ChangeOfLifeSafety {
                 new_state,
                 new_mode,
@@ -177,6 +216,10 @@ impl NotificationParameters {
                 access_credential,
                 authentication_factor,
             } => {
+                if let Some(authentication_factor) = authentication_factor {
+                    structured::validate_authentication_factor(authentication_factor)
+                        .map_err(|error| Error::Encoding(error.to_string()))?;
+                }
                 tags::encode_opening_tag(buf, 13);
                 primitives::encode_ctx_enumerated(buf, 0, *access_event);
                 primitives::encode_ctx_bit_string(buf, 1, 4, &[*status_flags << 4]);
@@ -190,20 +233,12 @@ impl NotificationParameters {
                         time: access_event_time.1,
                     },
                 )?;
-                // [4] access-credential: BACnetDeviceObjectPropertyReference
+                // [4] access-credential: BACnetDeviceObjectReference
                 tags::encode_opening_tag(buf, 4);
-                primitives::encode_ctx_object_id(buf, 0, &access_credential.object_identifier);
-                primitives::encode_ctx_unsigned(
-                    buf,
-                    1,
-                    access_credential.property_identifier as u64,
-                );
-                if let Some(idx) = access_credential.property_array_index {
-                    primitives::encode_ctx_unsigned(buf, 2, idx as u64);
-                }
                 if let Some(ref dev) = access_credential.device_identifier {
-                    primitives::encode_ctx_object_id(buf, 3, dev);
+                    primitives::encode_ctx_object_id(buf, 0, dev);
                 }
+                primitives::encode_ctx_object_id(buf, 1, &access_credential.object_identifier);
                 tags::encode_closing_tag(buf, 4);
                 if let Some(authentication_factor) = authentication_factor {
                     // [5] authentication-factor — raw, optional
@@ -292,10 +327,6 @@ impl NotificationParameters {
                 tags::encode_closing_tag(buf, 2);
                 tags::encode_closing_tag(buf, 19);
             }
-            Self::NoneParams => {
-                tags::encode_opening_tag(buf, 20);
-                tags::encode_closing_tag(buf, 20);
-            }
             Self::ChangeOfDiscreteValue {
                 new_value,
                 status_flags,
@@ -325,15 +356,18 @@ impl NotificationParameters {
                 primitives::encode_app_date(buf, &update_time.0);
                 primitives::encode_app_time(buf, &update_time.1);
                 tags::encode_closing_tag(buf, 2);
-                // [3] last-state-change (optional enumerated — always encode)
-                primitives::encode_ctx_enumerated(buf, 3, *last_state_change);
-                // [4] initial-timeout (optional unsigned — always encode)
-                primitives::encode_ctx_unsigned(buf, 4, *initial_timeout as u64);
-                // [5] expiration-time: BACnetDateTime
-                tags::encode_opening_tag(buf, 5);
-                primitives::encode_app_date(buf, &expiration_time.0);
-                primitives::encode_app_time(buf, &expiration_time.1);
-                tags::encode_closing_tag(buf, 5);
+                if let Some(last_state_change) = last_state_change {
+                    primitives::encode_ctx_enumerated(buf, 3, *last_state_change);
+                }
+                if let Some(initial_timeout) = initial_timeout {
+                    primitives::encode_ctx_unsigned(buf, 4, *initial_timeout as u64);
+                }
+                if let Some(expiration_time) = expiration_time {
+                    tags::encode_opening_tag(buf, 5);
+                    primitives::encode_app_date(buf, &expiration_time.0);
+                    primitives::encode_app_time(buf, &expiration_time.1);
+                    tags::encode_closing_tag(buf, 5);
+                }
                 tags::encode_closing_tag(buf, 22);
             }
         }

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/mod.rs
@@ -7,6 +7,7 @@ mod decode;
 mod decode_helpers;
 mod decode_timer;
 mod encode;
+mod structured;
 
 // ---------------------------------------------------------------------------
 // NotificationParameters
@@ -50,6 +51,10 @@ pub enum NotificationParameters {
         deadband: f32,
         exceeded_limit: f32,
     },
+    /// [6] Complex event type.
+    ComplexEventType {
+        property_values: Vec<BACnetPropertyValue>,
+    },
     /// [8] Change of life safety.
     ChangeOfLifeSafety {
         new_state: u32,
@@ -75,13 +80,13 @@ pub enum NotificationParameters {
         status_flags: u8,
         exceeded_limit: u64,
     },
-    /// [13] Access event. `authentication_factor` is `None` when context [5] is absent.
+    /// [13] Access event. Authentication-factor bytes contain its three inner context fields.
     AccessEvent {
         access_event: u32,
         status_flags: u8,
         access_event_tag: u32,
         access_event_time: (Date, Time),
-        access_credential: BACnetDeviceObjectPropertyReference,
+        access_credential: BACnetDeviceObjectReference,
         authentication_factor: Option<Vec<u8>>,
     },
     /// [14] Double out of range.
@@ -122,8 +127,6 @@ pub enum NotificationParameters {
         status_flags: u8,
         property_values: Vec<u8>,
     },
-    /// [20] None.
-    NoneParams,
     /// [21] Change of discrete value. `new_value` contains encoded BACnet TLVs.
     ChangeOfDiscreteValue {
         new_value: Vec<u8>,
@@ -134,9 +137,9 @@ pub enum NotificationParameters {
         new_state: u32,
         status_flags: u8,
         update_time: (Date, Time),
-        last_state_change: u32,
-        initial_timeout: u32,
-        expiration_time: (Date, Time),
+        last_state_change: Option<u32>,
+        initial_timeout: Option<u32>,
+        expiration_time: Option<(Date, Time)>,
     },
 }
 

--- a/crates/bacnet-services/src/alarm_event/notification_parameters/structured.rs
+++ b/crates/bacnet-services/src/alarm_event/notification_parameters/structured.rs
@@ -1,0 +1,152 @@
+use super::decode_helpers::{decode_context_status_flags, finish_variant};
+use super::*;
+use crate::common::{decode_context, decode_context_u32};
+use bacnet_encoding::constructed::validate_tlv_sequence;
+
+pub(super) fn validate_authentication_factor(data: &[u8]) -> Result<(), Error> {
+    let (_, pos) = decode_context_u32(data, 0, 0, "AuthenticationFactor format-type")?;
+    let (format_class, pos) = decode_context(data, pos, 1, "AuthenticationFactor format-class")?;
+    primitives::decode_unsigned(format_class)?;
+    let (_, pos) = decode_context(data, pos, 2, "AuthenticationFactor value")?;
+    if pos != data.len() {
+        return Err(Error::decoding(
+            pos,
+            "AuthenticationFactor has unexpected fields",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn decode_complex_event_type(
+    data: &[u8],
+    inner_start: usize,
+    variant_body_end: usize,
+) -> Result<NotificationParameters, Error> {
+    let mut property_values = Vec::new();
+    let mut pos = inner_start;
+    while pos < variant_body_end {
+        if property_values.len() >= MAX_DECODED_ITEMS {
+            return Err(Error::decoding(
+                pos,
+                format!("ComplexEventType exceeds {MAX_DECODED_ITEMS} property values"),
+            ));
+        }
+        let (property_value, next) = BACnetPropertyValue::decode_in_list(data, pos, 6)?;
+        if next <= pos || next > variant_body_end {
+            return Err(Error::decoding(
+                pos,
+                "ComplexEventType property value made invalid progress",
+            ));
+        }
+        validate_tlv_sequence(&property_value.value, "ComplexEventType property value")?;
+        property_values.push(property_value);
+        pos = next;
+    }
+    finish_variant(
+        NotificationParameters::ComplexEventType { property_values },
+        pos,
+        variant_body_end,
+        6,
+    )
+}
+
+fn decode_object_identifier(
+    data: &[u8],
+    offset: usize,
+    context_tag: u8,
+    field: &str,
+) -> Result<(ObjectIdentifier, usize), Error> {
+    let (content, next) = decode_context(data, offset, context_tag, field)?;
+    Ok((ObjectIdentifier::decode(content)?, next))
+}
+
+fn decode_access_credential(
+    data: &[u8],
+    offset: usize,
+) -> Result<(BACnetDeviceObjectReference, usize), Error> {
+    let (opening, mut pos) = tags::decode_tag(data, offset)?;
+    if !opening.is_opening_tag(4) {
+        return Err(Error::decoding(
+            offset,
+            "AccessEvent expected opening [4] for access-credential",
+        ));
+    }
+
+    let device_identifier = if tags::decode_tag(data, pos)?.0.is_context(0) {
+        let (value, next) =
+            decode_object_identifier(data, pos, 0, "AccessEvent credential device-identifier")?;
+        pos = next;
+        Some(value)
+    } else {
+        None
+    };
+    let (object_identifier, next) =
+        decode_object_identifier(data, pos, 1, "AccessEvent credential object-identifier")?;
+    pos = next;
+
+    let (closing, next) = tags::decode_tag(data, pos)?;
+    if !closing.is_closing_tag(4) {
+        return Err(Error::decoding(
+            pos,
+            "AccessEvent credential has duplicate, out-of-order, or trailing fields",
+        ));
+    }
+    Ok((
+        BACnetDeviceObjectReference {
+            device_identifier,
+            object_identifier,
+        },
+        next,
+    ))
+}
+
+pub(super) fn decode_access_event(
+    data: &[u8],
+    inner_start: usize,
+    variant_body_end: usize,
+) -> Result<NotificationParameters, Error> {
+    let (access_event, pos) = decode_context_u32(data, inner_start, 0, "AccessEvent access-event")?;
+    let (status_flags, pos) =
+        decode_context_status_flags(data, pos, 1, "AccessEvent status-flags")?;
+    let (access_event_tag, pos) = decode_context_u32(data, pos, 2, "AccessEvent access-event-tag")?;
+    let (timestamp, pos) = primitives::decode_timestamp(data, pos, 3)?;
+    let access_event_time = match timestamp {
+        BACnetTimeStamp::DateTime { date, time } => (date, time),
+        _ => {
+            return Err(Error::decoding(
+                pos,
+                "AccessEvent expected a DateTime timestamp",
+            ));
+        }
+    };
+    let (access_credential, pos) = decode_access_credential(data, pos)?;
+
+    let (authentication_factor, pos) = if pos < variant_body_end {
+        let (opening, content_start) = tags::decode_tag(data, pos)?;
+        if !opening.is_opening_tag(5) {
+            return Err(Error::decoding(
+                pos,
+                "AccessEvent expected opening [5] for authentication-factor",
+            ));
+        }
+        let (value, next) = extract_raw_context(data, content_start, 5)?;
+        validate_authentication_factor(&value)?;
+        (Some(value), next)
+    } else {
+        (None, pos)
+    };
+
+    finish_variant(
+        NotificationParameters::AccessEvent {
+            access_event,
+            status_flags,
+            access_event_tag,
+            access_event_time,
+            access_credential,
+            authentication_factor,
+        },
+        pos,
+        variant_body_end,
+        13,
+    )
+}

--- a/crates/bacnet-services/src/alarm_event/tests/mod.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/mod.rs
@@ -7,5 +7,6 @@ mod get_event_information_timestamps;
 mod notification_parameters;
 mod notification_parameters_boundaries;
 mod notification_parameters_life_safety;
+mod notification_parameters_structured;
 mod property_states;
 mod service_round_trip;

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters.rs
@@ -147,19 +147,6 @@ fn notification_params_buffer_ready_round_trip() {
 }
 
 #[test]
-fn notification_params_none_round_trip() {
-    let params = NotificationParameters::NoneParams;
-    let req = make_event_req(Some(params));
-    let mut buf = BytesMut::new();
-    req.encode(&mut buf).unwrap();
-    let decoded = EventNotificationRequest::decode(&buf).unwrap();
-    assert_eq!(
-        decoded.event_values,
-        Some(NotificationParameters::NoneParams)
-    );
-}
-
-#[test]
 fn notification_params_unsigned_range_round_trip() {
     let params = NotificationParameters::UnsignedRange {
         exceeding_value: 500,
@@ -378,10 +365,10 @@ fn notification_params_extended_round_trip() {
 fn notification_params_access_event_round_trip() {
     use bacnet_types::primitives::{Date, Time};
 
-    let cred = BACnetDeviceObjectPropertyReference::new_local(
-        ObjectIdentifier::new(ObjectType::ACCESS_CREDENTIAL, 1).unwrap(),
-        85, // PRESENT_VALUE
-    );
+    let cred = BACnetDeviceObjectReference {
+        device_identifier: None,
+        object_identifier: ObjectIdentifier::new(ObjectType::ACCESS_CREDENTIAL, 1).unwrap(),
+    };
     let params = NotificationParameters::AccessEvent {
         access_event: 5,
         status_flags: 0b1000,
@@ -401,7 +388,7 @@ fn notification_params_access_event_round_trip() {
             },
         ),
         access_credential: cred.clone(),
-        authentication_factor: Some(vec![0x62, 0xAB, 0xCD]),
+        authentication_factor: Some(vec![0x09, 0x01, 0x19, 0x02, 0x2a, 0xab, 0xcd]),
     };
     let req = make_event_req(Some(params));
     let mut buf = BytesMut::new();
@@ -423,7 +410,10 @@ fn notification_params_access_event_round_trip() {
             assert_eq!(access_event_time.0.year, 124);
             assert_eq!(access_event_time.1.hour, 10);
             assert_eq!(access_credential, cred);
-            assert_eq!(authentication_factor, Some(vec![0x62, 0xAB, 0xCD]));
+            assert_eq!(
+                authentication_factor,
+                Some(vec![0x09, 0x01, 0x19, 0x02, 0x2a, 0xab, 0xcd])
+            );
         }
         other => panic!("expected AccessEvent, got {:?}", other),
     }
@@ -635,9 +625,9 @@ fn notification_params_change_of_timer_round_trip() {
                 hundredths: 0,
             },
         ),
-        last_state_change: 0,
-        initial_timeout: 300,
-        expiration_time: (
+        last_state_change: Some(0),
+        initial_timeout: Some(300),
+        expiration_time: Some((
             Date {
                 year: 124,
                 month: 3,
@@ -650,7 +640,7 @@ fn notification_params_change_of_timer_round_trip() {
                 second: 0,
                 hundredths: 0,
             },
-        ),
+        )),
     };
     let req = make_event_req(Some(params));
     let mut buf = BytesMut::new();
@@ -670,8 +660,9 @@ fn notification_params_change_of_timer_round_trip() {
             assert_eq!(status_flags, 0b1000);
             assert_eq!(update_time.0.year, 124);
             assert_eq!(update_time.1.hour, 8);
-            assert_eq!(last_state_change, 0);
-            assert_eq!(initial_timeout, 300);
+            assert_eq!(last_state_change, Some(0));
+            assert_eq!(initial_timeout, Some(300));
+            let expiration_time = expiration_time.unwrap();
             assert_eq!(expiration_time.0.year, 124);
             assert_eq!(expiration_time.1.minute, 5);
         }

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters_boundaries.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters_boundaries.rs
@@ -54,12 +54,18 @@ fn test_date_time() -> (Date, Time) {
     )
 }
 
-fn encode_device_property_reference(buf: &mut BytesMut) {
+fn encode_device_object_reference(buf: &mut BytesMut) {
     tags::encode_opening_tag(buf, 4);
     let object = ObjectIdentifier::new(ObjectType::ACCESS_CREDENTIAL, 1).unwrap();
-    primitives::encode_ctx_object_id(buf, 0, &object);
-    primitives::encode_ctx_unsigned(buf, 1, 85);
+    primitives::encode_ctx_object_id(buf, 1, &object);
     tags::encode_closing_tag(buf, 4);
+}
+
+fn authentication_factor(value: &[u8]) -> Vec<u8> {
+    let mut factor = BytesMut::from(&[0x09, 0x01, 0x19, 0x02][..]);
+    tags::encode_tag(&mut factor, 2, tags::TagClass::Context, value.len() as u32);
+    factor.extend_from_slice(value);
+    factor.to_vec()
 }
 
 fn raw_access_event(values: [&[u8]; 2], field_tags: [u8; 2], flags: &[u8]) -> BytesMut {
@@ -77,8 +83,9 @@ fn raw_access_event(values: [&[u8]; 2], field_tags: [u8; 2], flags: &[u8]) -> By
         },
     )
     .unwrap();
-    encode_device_property_reference(&mut buf);
+    encode_device_object_reference(&mut buf);
     tags::encode_opening_tag(&mut buf, 5);
+    buf.extend_from_slice(&[0x09, 0x01, 0x19, 0x02, 0x28]);
     tags::encode_closing_tag(&mut buf, 5);
     tags::encode_closing_tag(&mut buf, 13);
     buf
@@ -148,10 +155,10 @@ fn access_event(authentication_factor: Option<Vec<u8>>) -> NotificationParameter
         status_flags: 0b1000,
         access_event_tag: 10,
         access_event_time: test_date_time(),
-        access_credential: BACnetDeviceObjectPropertyReference::new_local(
-            ObjectIdentifier::new(ObjectType::ACCESS_CREDENTIAL, 1).unwrap(),
-            85,
-        ),
+        access_credential: BACnetDeviceObjectReference {
+            device_identifier: None,
+            object_identifier: ObjectIdentifier::new(ObjectType::ACCESS_CREDENTIAL, 1).unwrap(),
+        },
         authentication_factor,
     }
 }
@@ -249,8 +256,8 @@ fn notification_parameter_values_accept_fitting_leading_zero() {
         )),
         Ok(NotificationParameters::ChangeOfTimer {
             new_state: u32::MAX,
-            last_state_change: u32::MAX,
-            initial_timeout: u32::MAX,
+            last_state_change: Some(u32::MAX),
+            initial_timeout: Some(u32::MAX),
             ..
         })
     ));
@@ -319,7 +326,7 @@ fn event_notification_preserves_trailing_opaque_payload_bytes() {
             extended_event_type: 7,
             parameters: encoded_octet_string(&[0x2e, 0x2f, 0xcf, 0x9f]),
         },
-        access_event(Some(encoded_octet_string(&[0x5e, 0x5f, 0xcf, 0xdf]))),
+        access_event(Some(authentication_factor(&[0x5e, 0x5f, 0xcf, 0xdf]))),
         NotificationParameters::ChangeOfReliability {
             reliability: 7,
             status_flags: 0b1000,
@@ -350,14 +357,14 @@ fn event_notification_requires_exact_event_values_suffix() {
             extended_event_type: 7,
             parameters: encoded_octet_string(&[0x01, 0x02]),
         },
-        access_event(Some(encoded_octet_string(&[0xab, 0xcd]))),
+        access_event(Some(authentication_factor(&[0xab, 0xcd]))),
         NotificationParameters::ChangeOfTimer {
             new_state: 1,
             status_flags: 0b1000,
             update_time: test_date_time(),
-            last_state_change: 2,
-            initial_timeout: 3,
-            expiration_time: test_date_time(),
+            last_state_change: Some(2),
+            initial_timeout: Some(3),
+            expiration_time: Some(test_date_time()),
         },
     ];
 
@@ -460,7 +467,7 @@ fn raw_fields_reject_same_tag_siblings_and_truncated_close_aliases() {
             extended_event_type: 7,
             parameters: raw.clone(),
         },
-        access_event(Some(raw.clone())),
+        access_event(Some(authentication_factor(&raw))),
         NotificationParameters::ChangeOfReliability {
             reliability: 7,
             status_flags: 0b1000,

--- a/crates/bacnet-services/src/alarm_event/tests/notification_parameters_structured.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/notification_parameters_structured.rs
@@ -1,0 +1,492 @@
+use super::*;
+use bacnet_types::enums::PropertyIdentifier;
+
+const DATE_TIME: &[u8] = &[0xa4, 0x7c, 0x06, 0x0f, 0x03, 0xb4, 0x0a, 0x1e, 0x00, 0x00];
+const TIMER_REQUIRED_BODY: &[u8] = &[
+    0xfe, 0x16, 0x09, 0x01, 0x1a, 0x04, 0x80, 0x2e, 0xa4, 0x7c, 0x06, 0x0f, 0x03, 0xb4, 0x0a, 0x1e,
+    0x00, 0x00, 0x2f,
+];
+const LOCAL_ACCESS: &[u8] = &[
+    0xde, 0x09, 0x05, 0x1a, 0x04, 0x80, 0x29, 0x0a, 0x3e, 0x2e, 0xa4, 0x7c, 0x06, 0x0f, 0x03, 0xb4,
+    0x0a, 0x1e, 0x00, 0x00, 0x2f, 0x3f, 0x4e, 0x1c, 0x08, 0x00, 0x00, 0x01, 0x4f, 0xdf,
+];
+const REMOTE_ACCESS_WITH_FACTOR: &[u8] = &[
+    0xde, 0x09, 0x05, 0x1a, 0x04, 0x80, 0x29, 0x0a, 0x3e, 0x2e, 0xa4, 0x7c, 0x06, 0x0f, 0x03, 0xb4,
+    0x0a, 0x1e, 0x00, 0x00, 0x2f, 0x3f, 0x4e, 0x0c, 0x02, 0x00, 0x00, 0x02, 0x1c, 0x08, 0x00, 0x00,
+    0x01, 0x4f, 0x5e, 0x09, 0x01, 0x19, 0x02, 0x2a, 0xab, 0xcd, 0x5f, 0xdf,
+];
+
+fn date_time() -> (Date, Time) {
+    (
+        Date {
+            year: 124,
+            month: 6,
+            day: 15,
+            day_of_week: 3,
+        },
+        Time {
+            hour: 10,
+            minute: 30,
+            second: 0,
+            hundredths: 0,
+        },
+    )
+}
+
+fn property_value(
+    property_identifier: PropertyIdentifier,
+    property_array_index: Option<u32>,
+    value: &[u8],
+    priority: Option<u8>,
+) -> BACnetPropertyValue {
+    BACnetPropertyValue {
+        property_identifier,
+        property_array_index,
+        value: value.to_vec(),
+        priority,
+    }
+}
+
+fn exact_round_trip(expected: NotificationParameters, literal: &[u8]) {
+    let mut encoded = BytesMut::new();
+    expected.encode(&mut encoded).unwrap();
+    assert_eq!(encoded.as_ref(), literal);
+    assert_eq!(
+        NotificationParameters::decode(literal, 0).unwrap(),
+        expected
+    );
+}
+
+fn access_credential(remote: bool) -> BACnetDeviceObjectReference {
+    BACnetDeviceObjectReference {
+        device_identifier: remote.then(|| ObjectIdentifier::new(ObjectType::DEVICE, 2).unwrap()),
+        object_identifier: ObjectIdentifier::new(ObjectType::ACCESS_CREDENTIAL, 1).unwrap(),
+    }
+}
+
+fn access_event(remote: bool, authentication_factor: Option<Vec<u8>>) -> NotificationParameters {
+    NotificationParameters::AccessEvent {
+        access_event: 5,
+        status_flags: 0b1000,
+        access_event_tag: 10,
+        access_event_time: date_time(),
+        access_credential: access_credential(remote),
+        authentication_factor,
+    }
+}
+
+fn raw_access_event(credential_fields: &[u8], authentication_factor: Option<&[u8]>) -> Vec<u8> {
+    let mut wire = vec![
+        0xde, 0x09, 0x05, 0x1a, 0x04, 0x80, 0x29, 0x0a, 0x3e, 0x2e, 0xa4, 0x7c, 0x06, 0x0f, 0x03,
+        0xb4, 0x0a, 0x1e, 0x00, 0x00, 0x2f, 0x3f, 0x4e,
+    ];
+    wire.extend_from_slice(credential_fields);
+    wire.push(0x4f);
+    if let Some(authentication_factor) = authentication_factor {
+        wire.push(0x5e);
+        wire.extend_from_slice(authentication_factor);
+        wire.push(0x5f);
+    }
+    wire.push(0xdf);
+    wire
+}
+
+fn timer(mask: u8) -> NotificationParameters {
+    NotificationParameters::ChangeOfTimer {
+        new_state: 1,
+        status_flags: 0b1000,
+        update_time: date_time(),
+        last_state_change: (mask & 1 != 0).then_some(2),
+        initial_timeout: (mask & 2 != 0).then_some(3),
+        expiration_time: (mask & 4 != 0).then_some(date_time()),
+    }
+}
+
+fn literal_timer(mask: u8) -> Vec<u8> {
+    let mut wire = TIMER_REQUIRED_BODY.to_vec();
+    if mask & 1 != 0 {
+        wire.extend_from_slice(&[0x39, 0x02]);
+    }
+    if mask & 2 != 0 {
+        wire.extend_from_slice(&[0x49, 0x03]);
+    }
+    if mask & 4 != 0 {
+        wire.push(0x5e);
+        wire.extend_from_slice(DATE_TIME);
+        wire.push(0x5f);
+    }
+    wire.extend_from_slice(&[0xff, 0x16]);
+    wire
+}
+
+#[test]
+fn choice_20_is_rejected() {
+    let encoded = [0xfe, 0x14, 0xff, 0x14];
+    assert!(NotificationParameters::decode(&encoded, 0).is_err());
+}
+
+#[test]
+fn complex_event_type_literal_vectors_round_trip() {
+    exact_round_trip(
+        NotificationParameters::ComplexEventType {
+            property_values: Vec::new(),
+        },
+        &[0x6e, 0x6f],
+    );
+
+    exact_round_trip(
+        NotificationParameters::ComplexEventType {
+            property_values: vec![property_value(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                &[0x00],
+                None,
+            )],
+        },
+        &[0x6e, 0x09, 0x55, 0x2e, 0x00, 0x2f, 0x6f],
+    );
+
+    exact_round_trip(
+        NotificationParameters::ComplexEventType {
+            property_values: vec![
+                property_value(PropertyIdentifier::PRESENT_VALUE, None, &[0x00], None),
+                property_value(
+                    PropertyIdentifier::STATUS_FLAGS,
+                    Some(2),
+                    &[0x21, 0x07],
+                    Some(16),
+                ),
+            ],
+        },
+        &[
+            0x6e, 0x09, 0x55, 0x2e, 0x00, 0x2f, 0x09, 0x6f, 0x19, 0x02, 0x2e, 0x21, 0x07, 0x2f,
+            0x39, 0x10, 0x6f,
+        ],
+    );
+}
+
+#[test]
+fn complex_event_type_preserves_raw_property_values() {
+    let expected = NotificationParameters::ComplexEventType {
+        property_values: vec![property_value(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            &[0x6e, 0x00, 0x6f],
+            None,
+        )],
+    };
+    exact_round_trip(
+        expected,
+        &[0x6e, 0x09, 0x55, 0x2e, 0x6e, 0x00, 0x6f, 0x2f, 0x6f],
+    );
+}
+
+#[test]
+fn complex_event_type_rejects_malformed_property_fields() {
+    let malformed = [
+        &[0x6e, 0x09, 0x55, 0x09, 0x6f, 0x2e, 0x00, 0x2f, 0x6f][..],
+        &[
+            0x6e, 0x09, 0x55, 0x19, 0x01, 0x19, 0x02, 0x2e, 0x00, 0x2f, 0x6f,
+        ],
+        &[0x6e, 0x09, 0x55, 0x2e, 0x00, 0x2f, 0x2e, 0x00, 0x2f, 0x6f],
+        &[
+            0x6e, 0x09, 0x55, 0x2e, 0x00, 0x2f, 0x39, 0x01, 0x39, 0x02, 0x6f,
+        ],
+        &[0x6e, 0x09, 0x55, 0x2e, 0x00, 0x2f, 0x39, 0x00, 0x6f],
+        &[0x6e, 0x09, 0x55, 0x2e, 0x00, 0x2f, 0x39, 0x11, 0x6f],
+        &[0x6e, 0x09, 0x55, 0x49, 0x01, 0x6f],
+        &[0x6e, 0x09, 0x55, 0x2e, 0x00, 0x2f, 0x49, 0x01, 0x6f],
+        &[0x6e, 0x09, 0x55, 0x2e, 0x00, 0x6f],
+        &[0x6e, 0x09, 0x55, 0x2e, 0x00, 0x2f, 0x5f],
+    ];
+    for wire in malformed {
+        assert!(
+            NotificationParameters::decode(wire, 0).is_err(),
+            "{wire:02x?}"
+        );
+    }
+}
+
+#[test]
+fn complex_event_type_enforces_count_cap_on_encode_and_decode() {
+    let value = property_value(PropertyIdentifier::PRESENT_VALUE, None, &[0x00], None);
+    let accepted = NotificationParameters::ComplexEventType {
+        property_values: vec![value.clone(); MAX_DECODED_ITEMS],
+    };
+    let mut encoded = BytesMut::new();
+    accepted.encode(&mut encoded).unwrap();
+    let NotificationParameters::ComplexEventType { property_values } =
+        NotificationParameters::decode(&encoded, 0).unwrap()
+    else {
+        panic!("expected ComplexEventType");
+    };
+    assert_eq!(property_values.len(), MAX_DECODED_ITEMS);
+
+    let over_cap = NotificationParameters::ComplexEventType {
+        property_values: vec![value; MAX_DECODED_ITEMS + 1],
+    };
+    let mut untouched = BytesMut::from(&[0xaa, 0xbb][..]);
+    assert!(over_cap.encode(&mut untouched).is_err());
+    assert_eq!(untouched.as_ref(), &[0xaa, 0xbb]);
+
+    let mut literal = BytesMut::with_capacity((MAX_DECODED_ITEMS + 1) * 6 + 2);
+    literal.extend_from_slice(&[0x6e]);
+    for _ in 0..=MAX_DECODED_ITEMS {
+        literal.extend_from_slice(&[0x09, 0x55, 0x2e, 0x00, 0x2f]);
+    }
+    literal.extend_from_slice(&[0x6f]);
+    assert!(NotificationParameters::decode(&literal, 0).is_err());
+}
+
+#[test]
+fn complex_event_type_failed_encodes_are_atomic() {
+    for property_value in [
+        property_value(PropertyIdentifier::PRESENT_VALUE, None, &[0x9f], None),
+        property_value(PropertyIdentifier::PRESENT_VALUE, None, &[0x00], Some(17)),
+    ] {
+        let invalid = NotificationParameters::ComplexEventType {
+            property_values: vec![property_value],
+        };
+        let mut untouched = BytesMut::from(&[0xaa, 0xbb][..]);
+        assert!(invalid.encode(&mut untouched).is_err());
+        assert_eq!(untouched.as_ref(), &[0xaa, 0xbb]);
+    }
+}
+
+#[test]
+fn complex_event_type_enforces_total_nesting() {
+    let nested_value = |depth| {
+        let mut value = vec![0x0e; depth];
+        value.extend(vec![0x0f; depth]);
+        NotificationParameters::ComplexEventType {
+            property_values: vec![property_value(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                &value,
+                None,
+            )],
+        }
+    };
+
+    let accepted = nested_value(tags::MAX_CONTEXT_NESTING_DEPTH - 2);
+    let mut encoded = BytesMut::new();
+    accepted.encode(&mut encoded).unwrap();
+    assert_eq!(
+        NotificationParameters::decode(&encoded, 0).unwrap(),
+        accepted
+    );
+
+    let too_deep = nested_value(tags::MAX_CONTEXT_NESTING_DEPTH - 1);
+    let mut untouched = BytesMut::from(&[0xaa, 0xbb][..]);
+    assert!(too_deep.encode(&mut untouched).is_err());
+    assert_eq!(untouched.as_ref(), &[0xaa, 0xbb]);
+
+    let mut raw = BytesMut::new();
+    tags::encode_opening_tag(&mut raw, 6);
+    primitives::encode_ctx_unsigned(&mut raw, 0, 85);
+    tags::encode_opening_tag(&mut raw, 2);
+    for _ in 0..tags::MAX_CONTEXT_NESTING_DEPTH - 1 {
+        tags::encode_opening_tag(&mut raw, 0);
+    }
+    for _ in 0..tags::MAX_CONTEXT_NESTING_DEPTH - 1 {
+        tags::encode_closing_tag(&mut raw, 0);
+    }
+    tags::encode_closing_tag(&mut raw, 2);
+    tags::encode_closing_tag(&mut raw, 6);
+    assert!(NotificationParameters::decode(&raw, 0).is_err());
+}
+
+#[test]
+fn access_event_literal_vectors_round_trip() {
+    exact_round_trip(access_event(false, None), LOCAL_ACCESS);
+    exact_round_trip(
+        access_event(true, Some(vec![0x09, 0x01, 0x19, 0x02, 0x2a, 0xab, 0xcd])),
+        REMOTE_ACCESS_WITH_FACTOR,
+    );
+
+    let empty_value = access_event(false, Some(vec![0x09, 0x01, 0x19, 0x02, 0x28]));
+    let mut empty_literal = LOCAL_ACCESS[..LOCAL_ACCESS.len() - 1].to_vec();
+    empty_literal.extend_from_slice(&[0x5e, 0x09, 0x01, 0x19, 0x02, 0x28, 0x5f, 0xdf]);
+    exact_round_trip(empty_value, &empty_literal);
+}
+
+#[test]
+fn access_event_rejects_invalid_device_object_references() {
+    let object = [0x1c, 0x08, 0x00, 0x00, 0x01];
+    let device = [0x0c, 0x02, 0x00, 0x00, 0x02];
+    let malformed = [
+        &[][..],
+        &[0x0c, 0x08, 0x00, 0x00, 0x01, 0x19, 0x55],
+        &[object.as_slice(), object.as_slice()].concat(),
+        &[device.as_slice(), device.as_slice(), object.as_slice()].concat(),
+        &[object.as_slice(), device.as_slice()].concat(),
+        &[object.as_slice(), &[0x29, 0x01]].concat(),
+    ];
+    for credential_fields in malformed {
+        let wire = raw_access_event(credential_fields, None);
+        assert!(NotificationParameters::decode(&wire, 0).is_err());
+    }
+}
+
+#[test]
+fn access_event_rejects_malformed_authentication_factors_atomically() {
+    let malformed: &[&[u8]] = &[
+        &[],
+        &[0x19, 0x02, 0x28],
+        &[0x09, 0x01, 0x28],
+        &[0x09, 0x01, 0x19, 0x02],
+        &[0x09, 0x01, 0x09, 0x02, 0x19, 0x02, 0x28],
+        &[0x09, 0x01, 0x19, 0x02, 0x19, 0x03, 0x28],
+        &[0x09, 0x01, 0x19, 0x02, 0x28, 0x28],
+        &[0x19, 0x02, 0x09, 0x01, 0x28],
+        &[0x09, 0x01, 0x28, 0x19, 0x02],
+        &[0x91, 0x01, 0x19, 0x02, 0x28],
+        &[0x09, 0x01, 0x21, 0x02, 0x28],
+        &[0x09, 0x01, 0x19, 0x02, 0x60],
+        &[0x09, 0x01, 0x29, 0x02, 0x28],
+        &[0x0a, 0x01],
+        &[0x09, 0x01, 0x19, 0x02, 0x2a, 0xab],
+        &[0x0d, 0x05, 0x01, 0x00, 0x00, 0x00, 0x00, 0x19, 0x02, 0x28],
+        &[0x09, 0x01, 0x18, 0x28],
+        &[0x09, 0x01, 0x19, 0x02, 0x28, 0x39, 0x01],
+    ];
+    let credential = [0x1c, 0x08, 0x00, 0x00, 0x01];
+    for factor in malformed {
+        let wire = raw_access_event(&credential, Some(factor));
+        assert!(
+            NotificationParameters::decode(&wire, 0).is_err(),
+            "{factor:02x?}"
+        );
+
+        let invalid = access_event(false, Some(factor.to_vec()));
+        let mut untouched = BytesMut::from(&[0xaa, 0xbb][..]);
+        assert!(invalid.encode(&mut untouched).is_err(), "{factor:02x?}");
+        assert_eq!(untouched.as_ref(), &[0xaa, 0xbb]);
+    }
+}
+
+#[test]
+fn change_of_timer_all_optional_combinations_have_exact_wire_bytes() {
+    for mask in 0..8 {
+        exact_round_trip(timer(mask), &literal_timer(mask));
+    }
+}
+
+#[test]
+fn change_of_timer_rejects_noncanonical_optional_fields() {
+    let mut malformed = Vec::new();
+    for suffix in [
+        &[0x39, 0x02, 0x39, 0x03][..],
+        &[0x49, 0x03, 0x39, 0x02],
+        &[0x91, 0x02],
+        &[0x3e, 0x3f],
+        &[0x49, 0x03, 0x49, 0x04],
+        &[0x69, 0x01],
+    ] {
+        let mut wire = TIMER_REQUIRED_BODY.to_vec();
+        wire.extend_from_slice(suffix);
+        wire.extend_from_slice(&[0xff, 0x16]);
+        malformed.push(wire);
+    }
+
+    let mut reversed_date_time = TIMER_REQUIRED_BODY.to_vec();
+    reversed_date_time.extend_from_slice(&[
+        0x5e, 0xb4, 0x0a, 0x1e, 0x00, 0x00, 0xa4, 0x7c, 0x06, 0x0f, 0x03, 0x5f, 0xff, 0x16,
+    ]);
+    malformed.push(reversed_date_time);
+
+    let mut wrong_date_length = TIMER_REQUIRED_BODY.to_vec();
+    wrong_date_length.extend_from_slice(&[
+        0x5e, 0xa3, 0x7c, 0x06, 0x0f, 0xb4, 0x0a, 0x1e, 0x00, 0x00, 0x5f, 0xff, 0x16,
+    ]);
+    malformed.push(wrong_date_length);
+
+    let mut duplicate_expiration = TIMER_REQUIRED_BODY.to_vec();
+    for _ in 0..2 {
+        duplicate_expiration.push(0x5e);
+        duplicate_expiration.extend_from_slice(DATE_TIME);
+        duplicate_expiration.push(0x5f);
+    }
+    duplicate_expiration.extend_from_slice(&[0xff, 0x16]);
+    malformed.push(duplicate_expiration);
+
+    let mut wrong_close = literal_timer(0);
+    *wrong_close.last_mut().unwrap() = 0x15;
+    malformed.push(wrong_close);
+
+    for wire in malformed {
+        assert!(
+            NotificationParameters::decode(&wire, 0).is_err(),
+            "{wire:02x?}"
+        );
+    }
+}
+
+fn event_request(event_values: Option<NotificationParameters>) -> EventNotificationRequest {
+    EventNotificationRequest {
+        process_identifier: 1,
+        initiating_device_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap(),
+        event_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 3).unwrap(),
+        timestamp: BACnetTimeStamp::SequenceNumber(7),
+        notification_class: 5,
+        priority: 100,
+        event_type: 6,
+        message_text: None,
+        notify_type: 0,
+        ack_required: true,
+        from_state: 0,
+        to_state: 3,
+        event_values,
+    }
+}
+
+#[test]
+fn corrected_variants_preserve_event_values_framing() {
+    let corrected = [
+        NotificationParameters::ComplexEventType {
+            property_values: vec![property_value(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                &[0x00],
+                None,
+            )],
+        },
+        access_event(true, Some(vec![0x09, 0x01, 0x19, 0x02, 0x2a, 0xab, 0xcd])),
+        timer(5),
+    ];
+
+    for expected in corrected {
+        let mut direct = BytesMut::new();
+        expected.encode(&mut direct).unwrap();
+        assert_eq!(
+            NotificationParameters::decode(&direct, 0).unwrap(),
+            expected
+        );
+
+        let mut wrapped = BytesMut::from(&[0xce][..]);
+        wrapped.extend_from_slice(&direct);
+        wrapped.extend_from_slice(&[0xcf]);
+        assert_eq!(
+            NotificationParameters::decode(&wrapped, 1).unwrap(),
+            expected
+        );
+
+        let mut service = BytesMut::new();
+        event_request(Some(expected.clone()))
+            .encode(&mut service)
+            .unwrap();
+        assert_eq!(
+            EventNotificationRequest::decode(&service)
+                .unwrap()
+                .event_values,
+            Some(expected)
+        );
+    }
+
+    let mut without_values = BytesMut::new();
+    event_request(None).encode(&mut without_values).unwrap();
+    assert!(EventNotificationRequest::decode(&without_values)
+        .unwrap()
+        .event_values
+        .is_none());
+}


### PR DESCRIPTION
## Summary

Correct the remaining public `NotificationParameters` wire models tracked by #351:

- add complex-event-type `[6]` as a bounded sequence of typed `BACnetPropertyValue` entries;
- encode and decode AccessEvent credential `[4]` as `BACnetDeviceObjectReference`;
- validate and preserve the optional raw `BACnetAuthenticationFactor [5]` body;
- reject the intentionally omitted choice `[20]`;
- model ChangeOfTimer `[3]`, `[4]`, and `[5]` as independently optional fields.

Encoding remains atomic: validation failures do not append partial bytes to the caller buffer.

## Standard grounding

This change is grounded in the local ANSI/ASHRAE Standard 135-2020 PDF:

- Clause 21, printed p. 860: EventNotification owns optional `event-values [12] BACnetNotificationParameters`.
- Clause 21, printed p. 887: `BACnetAuthenticationFactor` contains context fields `[0]`, `[1]`, and `[2]`.
- Clause 21, printed p. 891: `BACnetDeviceObjectReference` contains optional device `[0]` and required object `[1]`.
- Clause 21, printed pp. 916–918: `BACnetNotificationParameters` defines complex-event-type `[6]`, AccessEvent `[13]`, ChangeOfTimer `[22]`, and intentionally omits choice `[20]`.

| Requirement | Code | Evidence |
| --- | --- | --- |
| `[6]` is `SEQUENCE OF BACnetPropertyValue` | `notification_parameters::{mod,encode,structured}` | literal empty, single, multi-entry, priority, malformed, cap, nesting, and atomicity tests |
| AccessEvent `[4]` is a device-object reference | `structured::decode_access_credential` and the corrected encoder | local/remote literal vectors plus missing, duplicate, and out-of-order field rejection |
| Optional factor `[5]` has exact `[0]/[1]/[2]` structure | `structured::validate_authentication_factor` | valid raw preservation and malformed encode/decode matrix |
| `[20]` is absent | removed `NoneParams` and decoder arm | `choice_20_is_rejected` |
| Timer `[3]/[4]/[5]` are independent optionals | model, encoder, and `decode_change_of_timer` | all eight presence combinations plus ordering, duplication, type, DateTime, and trailing-data negatives |
| EventNotification owns `[12]` | existing `event_notification.rs` remains unchanged | direct, wrapped, service, and absent-event-values tests |

## Red and green evidence

- Baseline: `cargo test -p bacnet-services alarm_event::tests::notification_parameters --locked` — 56 passed.
- Red: `cargo test -p bacnet-services alarm_event::tests::notification_parameters_structured::choice_20_is_rejected --locked -- --exact` — failed because the old decoder returned `NoneParams`.
- Focused final: `cargo test -p bacnet-services alarm_event::tests::notification_parameters --locked` — 57 passed.
- `cargo test -p bacnet-server event_notification --locked` — 11 passed.
- `cargo test -p bacnet-services --locked` — 497 passed.
- `cargo test -p bacnet-server --locked` — 529 passed.
- `cargo test -p bacnet-integration-tests --test conformance_ledger --locked` — 10 passed.

## Repository gates

Passed:

- `cargo fmt --all --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `RUSTUP_TOOLCHAIN=1.93 bash .github/scripts/check-msrv.sh`
- `cargo deny check`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

An extra `cargo audit --color always` run reports RUSTSEC-2026-0258 against unchanged `h2 0.4.15` through the benchmark dependency graph. The feature-to-`dev` CI workflow does not run the heavy audit job; the advisory requires a separate dependency update before the next `dev`-to-`main` gate.

## Compatibility and limits

This intentionally changes the public Rust source API:

- `ComplexEventType` is a new enum variant and affects exhaustive matches;
- `AccessEvent.access_credential` changes to `BACnetDeviceObjectReference`;
- malformed authentication-factor bodies are now rejected;
- `NoneParams` is removed; absence remains `EventNotificationRequest::event_values = None`;
- ChangeOfTimer suffix fields become `Option` values.

No server producer, client, Python binding, detector, routing, lifecycle, README, PICS, BIBB, or conformance-support claim changes in this slice. Runtime event-value projection remains deferred. PR-0106 will re-audit current producers and consumers before issue closure.

## Exact-head review

Cycle one reviewed immutable head `3d51b5dcd251bc9ae6285e4c713ac34fed8117dd`:

- `review-luna`: PASS; no blocker/major or deferred minor findings.
- `review-dataflow-inkling`: PASS; no blocker/major or deferred minor findings.
- Exact-head CI: required feature-to-`dev` checks succeeded.

Result: **PASS**. No repair cycle was required.

Refs #351