### PR TITLE
feat(network): introduce single-owner endpoint ingress

### DIFF
--- a/crates/bacnet-network/src/endpoint_ingress.rs
+++ b/crates/bacnet-network/src/endpoint_ingress.rs
@@ -1,0 +1,230 @@
+use bacnet_encoding::apdu::{decode_apdu, Apdu};
+use bacnet_transport::port::TransportPort;
+use bacnet_types::error::Error;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+
+use crate::layer::{NetworkLayer, ReceivedApdu};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IngressRoute {
+    InboundRequest,
+    TerminalOrSegment,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PolicyReason {
+    MalformedApdu,
+    UnsupportedPduType(u8),
+    RouteFull(IngressRoute),
+    RouteClosed(IngressRoute),
+}
+
+#[derive(Debug)]
+pub(crate) struct PolicyOutcome {
+    pub(crate) reason: PolicyReason,
+    pub(crate) received: ReceivedApdu,
+}
+
+pub(crate) struct IngressReceivers {
+    pub(crate) inbound_requests: mpsc::Receiver<ReceivedApdu>,
+    pub(crate) terminal_or_segment: mpsc::Receiver<ReceivedApdu>,
+    pub(crate) policy_outcomes: mpsc::Receiver<PolicyOutcome>,
+}
+
+#[derive(Debug)]
+pub(crate) enum ClassifierExit {
+    Cancelled,
+    InputClosed,
+    PolicyRouteFull(PolicyOutcome),
+    PolicyRouteClosed(PolicyOutcome),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Lifecycle {
+    Ready,
+    Running,
+    Stopped,
+}
+
+pub(crate) struct EndpointIngress<T: TransportPort> {
+    network: NetworkLayer<T>,
+    queue_capacity: usize,
+    lifecycle: Lifecycle,
+    cancel_tx: Option<oneshot::Sender<()>>,
+    classifier_task: Option<JoinHandle<ClassifierExit>>,
+}
+
+impl<T: TransportPort + 'static> EndpointIngress<T> {
+    pub(crate) fn new(transport: T, queue_capacity: usize) -> Self {
+        Self {
+            network: NetworkLayer::new(transport),
+            queue_capacity,
+            lifecycle: Lifecycle::Ready,
+            cancel_tx: None,
+            classifier_task: None,
+        }
+    }
+
+    pub(crate) async fn start(&mut self) -> Result<IngressReceivers, Error> {
+        if self.lifecycle != Lifecycle::Ready {
+            return Err(Error::Encoding(
+                "endpoint ingress cannot be started more than once".into(),
+            ));
+        }
+        if self.queue_capacity == 0 {
+            return Err(Error::Encoding(
+                "endpoint ingress queue capacity must be greater than zero".into(),
+            ));
+        }
+
+        let apdu_rx = self.network.start().await?;
+        let (inbound_tx, inbound_requests) = mpsc::channel(self.queue_capacity);
+        let (terminal_tx, terminal_or_segment) = mpsc::channel(self.queue_capacity);
+        let (policy_tx, policy_outcomes) = mpsc::channel(self.queue_capacity);
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+
+        self.classifier_task = Some(tokio::spawn(classifier_task(
+            apdu_rx,
+            inbound_tx,
+            terminal_tx,
+            policy_tx,
+            cancel_rx,
+        )));
+        self.cancel_tx = Some(cancel_tx);
+        self.lifecycle = Lifecycle::Running;
+
+        Ok(IngressReceivers {
+            inbound_requests,
+            terminal_or_segment,
+            policy_outcomes,
+        })
+    }
+
+    pub(crate) async fn stop(&mut self) -> Result<ClassifierExit, Error> {
+        if self.lifecycle != Lifecycle::Running {
+            return Err(Error::Encoding("endpoint ingress is not running".into()));
+        }
+
+        self.lifecycle = Lifecycle::Stopped;
+        if let Some(cancel_tx) = self.cancel_tx.take() {
+            let _ = cancel_tx.send(());
+        }
+
+        let classifier_result = match self.classifier_task.take() {
+            Some(task) => task.await.map_err(|error| {
+                Error::Encoding(format!("endpoint ingress classifier failed: {error}"))
+            }),
+            None => Err(Error::Encoding(
+                "endpoint ingress classifier task is missing".into(),
+            )),
+        };
+        let stop_result = self.network.stop().await;
+
+        stop_result?;
+        classifier_result
+    }
+}
+
+impl<T: TransportPort> Drop for EndpointIngress<T> {
+    fn drop(&mut self) {
+        if let Some(cancel_tx) = self.cancel_tx.take() {
+            let _ = cancel_tx.send(());
+        }
+        if let Some(task) = self.classifier_task.take() {
+            task.abort();
+        }
+    }
+}
+
+async fn classifier_task(
+    mut apdu_rx: mpsc::Receiver<ReceivedApdu>,
+    inbound_tx: mpsc::Sender<ReceivedApdu>,
+    terminal_tx: mpsc::Sender<ReceivedApdu>,
+    policy_tx: mpsc::Sender<PolicyOutcome>,
+    mut cancel_rx: oneshot::Receiver<()>,
+) -> ClassifierExit {
+    loop {
+        let received = tokio::select! {
+            biased;
+            _ = &mut cancel_rx => return ClassifierExit::Cancelled,
+            received = apdu_rx.recv() => match received {
+                Some(received) => received,
+                None => return ClassifierExit::InputClosed,
+            },
+        };
+
+        let route = match classify(&received) {
+            Ok(route) => route,
+            Err(reason) => {
+                let outcome = PolicyOutcome { reason, received };
+                if let Some(exit) = send_policy(&policy_tx, outcome) {
+                    return exit;
+                }
+                continue;
+            }
+        };
+
+        let send_result = match route {
+            IngressRoute::InboundRequest => inbound_tx.try_send(received),
+            IngressRoute::TerminalOrSegment => terminal_tx.try_send(received),
+        };
+        if let Err(error) = send_result {
+            let (reason, received) = match error {
+                mpsc::error::TrySendError::Full(received) => {
+                    (PolicyReason::RouteFull(route), received)
+                }
+                mpsc::error::TrySendError::Closed(received) => {
+                    (PolicyReason::RouteClosed(route), received)
+                }
+            };
+            if let Some(exit) = send_policy(&policy_tx, PolicyOutcome { reason, received }) {
+                return exit;
+            }
+        }
+    }
+}
+
+fn classify(received: &ReceivedApdu) -> Result<IngressRoute, PolicyReason> {
+    let Some(first) = received.apdu.first() else {
+        return Err(PolicyReason::MalformedApdu);
+    };
+    let pdu_type = (first >> 4) & 0x0f;
+    if pdu_type > 7 {
+        return Err(PolicyReason::UnsupportedPduType(pdu_type));
+    }
+
+    match decode_apdu(received.apdu.clone()) {
+        Ok(Apdu::ConfirmedRequest(_) | Apdu::UnconfirmedRequest(_)) => {
+            Ok(IngressRoute::InboundRequest)
+        }
+        Ok(
+            Apdu::SimpleAck(_)
+            | Apdu::ComplexAck(_)
+            | Apdu::Error(_)
+            | Apdu::Reject(_)
+            | Apdu::Abort(_)
+            | Apdu::SegmentAck(_),
+        ) => Ok(IngressRoute::TerminalOrSegment),
+        Err(_) => Err(PolicyReason::MalformedApdu),
+    }
+}
+
+fn send_policy(
+    policy_tx: &mpsc::Sender<PolicyOutcome>,
+    outcome: PolicyOutcome,
+) -> Option<ClassifierExit> {
+    match policy_tx.try_send(outcome) {
+        Ok(()) => None,
+        Err(mpsc::error::TrySendError::Full(outcome)) => {
+            Some(ClassifierExit::PolicyRouteFull(outcome))
+        }
+        Err(mpsc::error::TrySendError::Closed(outcome)) => {
+            Some(ClassifierExit::PolicyRouteClosed(outcome))
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "endpoint_ingress_tests.rs"]
+mod tests;

--- a/crates/bacnet-network/src/endpoint_ingress_tests.rs
+++ b/crates/bacnet-network/src/endpoint_ingress_tests.rs
@@ -1,0 +1,330 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use bacnet_encoding::npdu::{encode_npdu, Npdu, NpduAddress};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::{DataAttribute, ReceivedNpdu, TransportPort};
+use bacnet_types::enums::NetworkPriority;
+use bacnet_types::error::Error;
+use bacnet_types::MacAddr;
+use bytes::{Bytes, BytesMut};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::{timeout, Duration};
+
+use super::*;
+
+const WAIT: Duration = Duration::from_secs(1);
+
+struct TestTransport {
+    receiver: Option<mpsc::Receiver<ReceivedNpdu>>,
+    starts: Arc<AtomicUsize>,
+    stops: Arc<AtomicUsize>,
+    local_mac: MacAddr,
+}
+
+struct TestTransportHandle {
+    sender: mpsc::Sender<ReceivedNpdu>,
+    starts: Arc<AtomicUsize>,
+    stops: Arc<AtomicUsize>,
+}
+
+fn test_transport() -> (TestTransport, TestTransportHandle) {
+    let (sender, receiver) = mpsc::channel(32);
+    let starts = Arc::new(AtomicUsize::new(0));
+    let stops = Arc::new(AtomicUsize::new(0));
+    (
+        TestTransport {
+            receiver: Some(receiver),
+            starts: Arc::clone(&starts),
+            stops: Arc::clone(&stops),
+            local_mac: MacAddr::from_slice(&[0xaa]),
+        },
+        TestTransportHandle {
+            sender,
+            starts,
+            stops,
+        },
+    )
+}
+
+impl TransportPort for TestTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        self.starts.fetch_add(1, Ordering::SeqCst);
+        self.receiver
+            .take()
+            .ok_or_else(|| Error::Encoding("test transport already started".into()))
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        self.stops.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn send_unicast(&self, _npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &self.local_mac
+    }
+}
+
+fn npdu_bytes(apdu: &[u8]) -> Bytes {
+    let npdu = Npdu {
+        is_network_message: false,
+        expecting_reply: false,
+        priority: NetworkPriority::NORMAL,
+        payload: Bytes::copy_from_slice(apdu),
+        ..Npdu::default()
+    };
+    let mut buffer = BytesMut::new();
+    encode_npdu(&mut buffer, &npdu).unwrap();
+    buffer.freeze()
+}
+
+fn received_npdu(apdu: &[u8]) -> ReceivedNpdu {
+    ReceivedNpdu {
+        npdu: npdu_bytes(apdu),
+        source_mac: MacAddr::from_slice(&[0x11]),
+        link_layer_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
+async fn inject(handle: &TestTransportHandle, apdu: &[u8]) {
+    handle.sender.send(received_npdu(apdu)).await.unwrap();
+}
+
+async fn receive<T>(receiver: &mut mpsc::Receiver<T>) -> T {
+    timeout(WAIT, receiver.recv())
+        .await
+        .expect("ingress receive timed out")
+        .expect("ingress route closed")
+}
+
+#[tokio::test]
+async fn loopback_routes_all_apdu_classes_once_and_in_order() {
+    let (transport, peer) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let mut endpoint = EndpointIngress::new(transport, 8);
+    let mut ingress = endpoint.start().await.unwrap();
+    let apdus: [&[u8]; 8] = [
+        &[0x00, 0x05, 0x11, 0x0c],
+        &[0x20, 0x12, 0x0c],
+        &[0x10, 0x08],
+        &[0x30, 0x13, 0x0c],
+        &[0x50, 0x14, 0x0c, 0x91, 0x00, 0x91, 0x00],
+        &[0x60, 0x15, 0x00],
+        &[0x70, 0x16, 0x00],
+        &[0x40, 0x17, 0x00, 0x01],
+    ];
+
+    for apdu in apdus {
+        peer.send_unicast(&npdu_bytes(apdu), &[0x01]).await.unwrap();
+    }
+
+    let mut inbound_types = Vec::new();
+    for _ in 0..2 {
+        inbound_types.push(receive(&mut ingress.inbound_requests).await.apdu[0] >> 4);
+    }
+    let mut terminal_types = Vec::new();
+    for _ in 0..6 {
+        terminal_types.push(receive(&mut ingress.terminal_or_segment).await.apdu[0] >> 4);
+    }
+
+    assert_eq!(inbound_types, [0, 1]);
+    assert_eq!(terminal_types, [2, 3, 5, 6, 7, 4]);
+    assert!(ingress.inbound_requests.try_recv().is_err());
+    assert!(ingress.terminal_or_segment.try_recv().is_err());
+    assert!(ingress.policy_outcomes.try_recv().is_err());
+    assert!(matches!(
+        endpoint.stop().await.unwrap(),
+        ClassifierExit::Cancelled
+    ));
+}
+
+#[tokio::test]
+async fn malformed_and_unsupported_apdus_have_policy_outcomes() {
+    let (transport, handle) = test_transport();
+    let mut endpoint = EndpointIngress::new(transport, 4);
+    let mut ingress = endpoint.start().await.unwrap();
+
+    inject(&handle, &[]).await;
+    inject(&handle, &[0x80]).await;
+
+    let malformed = receive(&mut ingress.policy_outcomes).await;
+    assert_eq!(malformed.reason, PolicyReason::MalformedApdu);
+    assert!(malformed.received.apdu.is_empty());
+    let unsupported = receive(&mut ingress.policy_outcomes).await;
+    assert_eq!(unsupported.reason, PolicyReason::UnsupportedPduType(8));
+    assert_eq!(unsupported.received.apdu.as_ref(), &[0x80]);
+    assert!(ingress.inbound_requests.try_recv().is_err());
+    assert!(ingress.terminal_or_segment.try_recv().is_err());
+
+    endpoint.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn request_route_preserves_the_complete_envelope_and_reply_sender() {
+    let (transport, handle) = test_transport();
+    let mut endpoint = EndpointIngress::new(transport, 2);
+    let mut ingress = endpoint.start().await.unwrap();
+    let apdu = [0x00, 0x05, 0x33, 0x0c];
+    let source_network = NpduAddress {
+        network: 77,
+        mac_address: MacAddr::from_slice(&[0x44, 0x55]),
+    };
+    let destination = NpduAddress {
+        network: 0xffff,
+        mac_address: MacAddr::new(),
+    };
+    let npdu = Npdu {
+        is_network_message: false,
+        expecting_reply: true,
+        priority: NetworkPriority::URGENT,
+        destination: Some(destination),
+        source: Some(source_network.clone()),
+        hop_count: 255,
+        payload: Bytes::copy_from_slice(&apdu),
+        ..Npdu::default()
+    };
+    let mut buffer = BytesMut::new();
+    encode_npdu(&mut buffer, &npdu).unwrap();
+    let attributes = vec![DataAttribute {
+        option_type: 9,
+        must_understand: true,
+        data: vec![1, 2, 3],
+    }];
+    let (reply_tx, reply_rx) = oneshot::channel();
+    handle
+        .sender
+        .send(ReceivedNpdu {
+            npdu: buffer.freeze(),
+            source_mac: MacAddr::from_slice(&[0xde, 0xad]),
+            link_layer_group: true,
+            data_attributes: attributes.clone(),
+            reply_tx: Some(reply_tx),
+        })
+        .await
+        .unwrap();
+
+    let mut received = receive(&mut ingress.inbound_requests).await;
+    assert_eq!(received.apdu.as_ref(), apdu);
+    assert_eq!(received.source_mac.as_slice(), &[0xde, 0xad]);
+    assert_eq!(received.source_network, Some(source_network));
+    assert!(received.is_group);
+    assert_eq!(received.data_attributes, attributes);
+    received
+        .reply_tx
+        .take()
+        .expect("reply sender was lost")
+        .send(Bytes::from_static(b"reply"))
+        .unwrap();
+    assert_eq!(reply_rx.await.unwrap().as_ref(), b"reply");
+    assert!(ingress.terminal_or_segment.try_recv().is_err());
+    assert!(ingress.policy_outcomes.try_recv().is_err());
+
+    endpoint.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn duplicate_start_is_rejected_before_transport_and_stop_is_single_owner() {
+    let (transport, handle) = test_transport();
+    let mut endpoint = EndpointIngress::new(transport, 1);
+    let mut ingress = endpoint.start().await.unwrap();
+    assert_eq!(handle.starts.load(Ordering::SeqCst), 1);
+
+    assert!(endpoint.start().await.is_err());
+    assert_eq!(handle.starts.load(Ordering::SeqCst), 1);
+    assert!(matches!(
+        endpoint.stop().await.unwrap(),
+        ClassifierExit::Cancelled
+    ));
+    assert_eq!(handle.stops.load(Ordering::SeqCst), 1);
+    assert!(endpoint.stop().await.is_err());
+    assert_eq!(handle.stops.load(Ordering::SeqCst), 1);
+    assert!(ingress.inbound_requests.recv().await.is_none());
+    assert!(ingress.terminal_or_segment.recv().await.is_none());
+    assert!(ingress.policy_outcomes.recv().await.is_none());
+}
+
+#[tokio::test]
+async fn zero_capacity_is_rejected_before_transport_start() {
+    let (transport, handle) = test_transport();
+    let mut endpoint = EndpointIngress::new(transport, 0);
+
+    assert!(endpoint.start().await.is_err());
+    assert_eq!(handle.starts.load(Ordering::SeqCst), 0);
+    assert_eq!(handle.stops.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn full_and_closed_role_routes_are_explicit_and_stop_does_not_block() {
+    let (transport, handle) = test_transport();
+    let mut endpoint = EndpointIngress::new(transport, 1);
+    let ingress = endpoint.start().await.unwrap();
+    let mut inbound = ingress.inbound_requests;
+    let terminal = ingress.terminal_or_segment;
+    let mut policies = ingress.policy_outcomes;
+
+    inject(&handle, &[0x00, 0x05, 0x01, 0x0c]).await;
+    inject(&handle, &[0x00, 0x05, 0x02, 0x0c]).await;
+    let full = receive(&mut policies).await;
+    assert_eq!(
+        full.reason,
+        PolicyReason::RouteFull(IngressRoute::InboundRequest)
+    );
+    assert_eq!(full.received.apdu[2], 2);
+
+    drop(terminal);
+    inject(&handle, &[0x20, 0x03, 0x0c]).await;
+    let closed = receive(&mut policies).await;
+    assert_eq!(
+        closed.reason,
+        PolicyReason::RouteClosed(IngressRoute::TerminalOrSegment)
+    );
+    assert_eq!(closed.received.apdu[1], 3);
+
+    timeout(WAIT, endpoint.stop())
+        .await
+        .expect("stop blocked on a saturated role route")
+        .unwrap();
+    assert_eq!(handle.stops.load(Ordering::SeqCst), 1);
+    assert_eq!(inbound.recv().await.unwrap().apdu[2], 1);
+    assert!(inbound.recv().await.is_none());
+    assert!(policies.recv().await.is_none());
+}
+
+#[tokio::test]
+async fn full_policy_route_returns_the_unrouted_envelope_on_reclaim() {
+    let (transport, handle) = test_transport();
+    let mut endpoint = EndpointIngress::new(transport, 1);
+    let mut ingress = endpoint.start().await.unwrap();
+
+    inject(&handle, &[0x00, 0x05, 0x01, 0x0c]).await;
+    inject(&handle, &[0x00, 0x05, 0x02, 0x0c]).await;
+    inject(&handle, &[0x00, 0x05, 0x03, 0x0c]).await;
+
+    assert!(timeout(WAIT, ingress.terminal_or_segment.recv())
+        .await
+        .expect("classifier did not stop when its policy route filled")
+        .is_none());
+
+    let exit = timeout(WAIT, endpoint.stop()).await.unwrap().unwrap();
+    match exit {
+        ClassifierExit::PolicyRouteFull(outcome) => {
+            assert_eq!(
+                outcome.reason,
+                PolicyReason::RouteFull(IngressRoute::InboundRequest)
+            );
+            assert_eq!(outcome.received.apdu[2], 3);
+        }
+        other => panic!("unexpected classifier exit: {other:?}"),
+    }
+    assert_eq!(handle.stops.load(Ordering::SeqCst), 1);
+    drop(ingress);
+}

--- a/crates/bacnet-network/src/lib.rs
+++ b/crates/bacnet-network/src/lib.rs
@@ -1,5 +1,7 @@
 //! BACnet network layer: packet assembly, dispatch, and routing.
 
+#[allow(dead_code)]
+mod endpoint_ingress;
 pub mod layer;
 pub mod priority_channel;
 pub mod router;


### PR DESCRIPTION
## Summary

- add a crate-private endpoint ingress owner around one `NetworkLayer`
- route inbound requests separately from terminal and segment traffic without cloning `ReceivedApdu`
- preserve transport metadata and the single-use reply channel through routing
- make malformed, unsupported, full, and closed-route outcomes explicit
- cover lifecycle ownership, bounded queues, cancellation, and exact-once classification

## Scope

This is the private ingress and lifecycle foundation for the shared-device endpoint work in #431. Transaction correlation, invoke-ID coordination, public combined-device APIs, and B/IP or MS/TP composition remain in later slices. Existing standalone client and server lifecycle code is unchanged.

## Verification

- `cargo test -p bacnet-network --locked`
- `cargo test -p bacnet-transport loopback --locked`
- `cargo test -p bacnet-client lifecycle --locked`
- `cargo test -p bacnet-server lifecycle --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

Refs #431