### PR TITLE
feat(endpoint-core): prepare crate for publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,12 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - run: sleep 30
 
+      - name: Publish bacnet-endpoint-core
+        run: cargo publish -p bacnet-endpoint-core --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - run: sleep 30
+
       - name: Publish bacnet-server
         run: cargo publish -p bacnet-server --no-verify
         env:

--- a/crates/bacnet-endpoint-core/Cargo.toml
+++ b/crates/bacnet-endpoint-core/Cargo.toml
@@ -5,8 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-publish = false
-description = "Private shared BACnet endpoint ownership and transaction coordination"
+description = "Shared BACnet endpoint ownership and transaction coordination"
 
 [dependencies]
 bacnet-types.workspace = true

--- a/crates/bacnet-endpoint-core/src/coordinator.rs
+++ b/crates/bacnet-endpoint-core/src/coordinator.rs
@@ -61,6 +61,18 @@ pub enum TerminalPolicy {
     SimpleAck,
     /// The service completes with an unsegmented or reassembled ComplexACK.
     ComplexAck,
+    /// The service may complete with either a SimpleACK or ComplexACK.
+    EitherAck,
+}
+
+impl TerminalPolicy {
+    fn accepts_simple_ack(self) -> bool {
+        matches!(self, Self::SimpleAck | Self::EitherAck)
+    }
+
+    fn accepts_complex_ack(self) -> bool {
+        matches!(self, Self::ComplexAck | Self::EitherAck)
+    }
 }
 
 /// Correlation and response policy retained for one active invoke ID.
@@ -133,7 +145,7 @@ impl LeaseMetadata {
         self.service_choice
     }
 
-    /// Returns the accepted successful acknowledgment shape.
+    /// Returns the accepted successful acknowledgment policy.
     pub fn terminal_policy(&self) -> TerminalPolicy {
         self.terminal_policy
     }
@@ -258,7 +270,7 @@ pub enum AdmissionOutcome {
     PeerMismatch,
     /// The APDU is not valid for the role or request segmentation mode.
     OwnerMismatch,
-    /// A service-labelled response named a different confirmed service.
+    /// An unsegmented successful acknowledgment named a different service.
     ServiceMismatch {
         /// Service retained by the active lease.
         expected: ConfirmedServiceChoice,
@@ -461,17 +473,19 @@ fn validate_apdu(metadata: &LeaseMetadata, apdu: &Apdu) -> Result<AdmissionKind,
     match apdu {
         Apdu::SimpleAck(pdu) => {
             validate_service(metadata, pdu.service_choice)?;
-            if metadata.terminal_policy != TerminalPolicy::SimpleAck {
+            if !metadata.terminal_policy.accepts_simple_ack() {
                 return Err(AdmissionOutcome::PolicyMismatch);
             }
             Ok(AdmissionKind::Terminal)
         }
         Apdu::ComplexAck(pdu) => {
-            validate_service(metadata, pdu.service_choice)?;
+            if !pdu.segmented {
+                validate_service(metadata, pdu.service_choice)?;
+            }
             if metadata.owner != LeaseOwner::Requester {
                 return Err(AdmissionOutcome::OwnerMismatch);
             }
-            if metadata.terminal_policy != TerminalPolicy::ComplexAck {
+            if !metadata.terminal_policy.accepts_complex_ack() {
                 return Err(AdmissionOutcome::PolicyMismatch);
             }
             if pdu.segmented {
@@ -480,10 +494,7 @@ fn validate_apdu(metadata: &LeaseMetadata, apdu: &Apdu) -> Result<AdmissionKind,
                 Ok(AdmissionKind::Terminal)
             }
         }
-        Apdu::Error(pdu) => {
-            validate_service(metadata, pdu.service_choice)?;
-            Ok(AdmissionKind::Terminal)
-        }
+        Apdu::Error(_) => Ok(AdmissionKind::Terminal),
         Apdu::Reject(_) => Ok(AdmissionKind::Terminal),
         Apdu::Abort(pdu) => {
             let expected_server_bit = match metadata.owner {

--- a/crates/bacnet-endpoint-core/src/coordinator_tests.rs
+++ b/crates/bacnet-endpoint-core/src/coordinator_tests.rs
@@ -207,6 +207,115 @@ fn simple_ack_claims_once_and_completion_is_idempotent() {
 }
 
 #[test]
+fn either_ack_requester_accepts_matching_simple_and_unsegmented_complex_ack() {
+    let coordinator = OutboundTransactionCoordinator::new();
+    let expected_peer = peer(2);
+    let simple_token = coordinator
+        .reserve(requester(expected_peer.clone(), TerminalPolicy::EitherAck))
+        .unwrap();
+    let complex_token = coordinator
+        .reserve(requester(expected_peer.clone(), TerminalPolicy::EitherAck))
+        .unwrap();
+
+    assert_admitted_kind(
+        coordinator
+            .admit(
+                &expected_peer,
+                &simple_ack(simple_token.invoke_id(), SERVICE),
+            )
+            .unwrap(),
+        AdmissionKind::Terminal,
+    );
+    assert_admitted_kind(
+        coordinator
+            .admit(
+                &expected_peer,
+                &complex_ack(complex_token.invoke_id(), SERVICE, false),
+            )
+            .unwrap(),
+        AdmissionKind::Terminal,
+    );
+}
+
+#[test]
+fn strict_ack_policies_reject_opposite_ack_without_mutation() {
+    let coordinator = OutboundTransactionCoordinator::new();
+    let expected_peer = peer(3);
+    let simple_token = coordinator
+        .reserve(requester(expected_peer.clone(), TerminalPolicy::SimpleAck))
+        .unwrap();
+    let complex_token = coordinator
+        .reserve(requester(expected_peer.clone(), TerminalPolicy::ComplexAck))
+        .unwrap();
+
+    assert_eq!(
+        coordinator.admit(
+            &expected_peer,
+            &complex_ack(simple_token.invoke_id(), SERVICE, false)
+        ),
+        Ok(AdmissionOutcome::PolicyMismatch)
+    );
+    assert_eq!(
+        coordinator.admit(
+            &expected_peer,
+            &simple_ack(complex_token.invoke_id(), SERVICE)
+        ),
+        Ok(AdmissionOutcome::PolicyMismatch)
+    );
+    assert_eq!(coordinator.active_count(), Ok(2));
+    assert_admitted_kind(
+        coordinator
+            .admit(
+                &expected_peer,
+                &simple_ack(simple_token.invoke_id(), SERVICE),
+            )
+            .unwrap(),
+        AdmissionKind::Terminal,
+    );
+    assert_admitted_kind(
+        coordinator
+            .admit(
+                &expected_peer,
+                &complex_ack(complex_token.invoke_id(), SERVICE, false),
+            )
+            .unwrap(),
+        AdmissionKind::Terminal,
+    );
+}
+
+#[test]
+fn unsegmented_ack_requires_matching_service_under_either_policy() {
+    let coordinator = OutboundTransactionCoordinator::new();
+    let expected_peer = peer(4);
+    let simple_token = coordinator
+        .reserve(requester(expected_peer.clone(), TerminalPolicy::EitherAck))
+        .unwrap();
+    let complex_token = coordinator
+        .reserve(requester(expected_peer.clone(), TerminalPolicy::EitherAck))
+        .unwrap();
+    let mismatch = AdmissionOutcome::ServiceMismatch {
+        expected: SERVICE,
+        observed: OTHER_SERVICE,
+    };
+
+    assert_eq!(
+        coordinator.admit(
+            &expected_peer,
+            &simple_ack(simple_token.invoke_id(), OTHER_SERVICE)
+        ),
+        Ok(mismatch.clone())
+    );
+    assert_eq!(
+        coordinator.admit(
+            &expected_peer,
+            &complex_ack(complex_token.invoke_id(), OTHER_SERVICE, false)
+        ),
+        Ok(mismatch)
+    );
+    assert_eq!(coordinator.active_count(), Ok(2));
+}
+
+#[test]
 fn segmented_complex_ack_and_segment_ack_remain_non_terminal() {
     let coordinator = OutboundTransactionCoordinator::new();
     let expected_peer = peer(2);
@@ -241,6 +350,69 @@ fn segmented_complex_ack_and_segment_ack_remain_non_terminal() {
 }
 
 #[test]
+fn segmented_complex_ack_defers_service_validation_and_completion_is_generation_safe() {
+    let coordinator = OutboundTransactionCoordinator::new();
+    let expected_peer = peer(3);
+    let strict = coordinator
+        .reserve(requester(expected_peer.clone(), TerminalPolicy::SimpleAck))
+        .unwrap();
+    assert_eq!(
+        coordinator.admit(
+            &expected_peer,
+            &complex_ack(strict.invoke_id(), OTHER_SERVICE, true)
+        ),
+        Ok(AdmissionOutcome::PolicyMismatch)
+    );
+    assert_eq!(coordinator.release(strict), Ok(ReleaseOutcome::Released));
+
+    let original = coordinator
+        .reserve(requester(expected_peer.clone(), TerminalPolicy::EitherAck))
+        .unwrap();
+
+    let admission = assert_admitted_kind(
+        coordinator
+            .admit(
+                &expected_peer,
+                &complex_ack(original.invoke_id(), OTHER_SERVICE, true),
+            )
+            .unwrap(),
+        AdmissionKind::NonTerminal,
+    );
+    assert_eq!(admission.token(), original);
+    assert_eq!(
+        coordinator.complete(admission.token()),
+        Ok(ReleaseOutcome::Released)
+    );
+    assert_eq!(
+        coordinator.complete(original),
+        Ok(ReleaseOutcome::AlreadyReleased)
+    );
+
+    let mut active = Vec::new();
+    for index in 0..INVOKE_ID_COUNT {
+        active.push(
+            coordinator
+                .reserve(requester(peer(index as u8), TerminalPolicy::SimpleAck))
+                .unwrap(),
+        );
+    }
+    let replacement = *active
+        .iter()
+        .find(|token| token.invoke_id() == original.invoke_id())
+        .unwrap();
+    assert_ne!(replacement.generation, original.generation);
+    assert_eq!(
+        coordinator.complete(original),
+        Ok(ReleaseOutcome::StaleToken)
+    );
+    assert_eq!(coordinator.active_count(), Ok(INVOKE_ID_COUNT));
+    assert_eq!(
+        coordinator.complete(replacement),
+        Ok(ReleaseOutcome::Released)
+    );
+}
+
+#[test]
 fn server_notification_accepts_simple_ack_but_never_complex_ack() {
     let coordinator = OutboundTransactionCoordinator::new();
     let expected_peer = peer(3);
@@ -266,58 +438,36 @@ fn server_notification_accepts_simple_ack_but_never_complex_ack() {
         AdmissionKind::Terminal,
     );
     assert_eq!(coordinator.complete(token), Ok(ReleaseOutcome::Released));
+}
 
-    let complex_token = coordinator
+#[test]
+fn error_is_terminal_without_service_validation_and_claims_once() {
+    let coordinator = OutboundTransactionCoordinator::new();
+    let expected_peer = peer(4);
+    let error_token = coordinator
         .reserve(requester(expected_peer.clone(), TerminalPolicy::ComplexAck))
         .unwrap();
-    assert_eq!(
-        coordinator.admit(
-            &expected_peer,
-            &simple_ack(complex_token.invoke_id(), SERVICE)
-        ),
-        Ok(AdmissionOutcome::PolicyMismatch)
-    );
-    assert_eq!(coordinator.active_count(), Ok(1));
+
     assert_admitted_kind(
         coordinator
             .admit(
                 &expected_peer,
-                &complex_ack(complex_token.invoke_id(), SERVICE, false),
+                &error_pdu(error_token.invoke_id(), OTHER_SERVICE),
             )
             .unwrap(),
         AdmissionKind::Terminal,
     );
     assert_eq!(
-        coordinator.complete(complex_token),
-        Ok(ReleaseOutcome::Released)
+        coordinator.admit(&expected_peer, &error_pdu(error_token.invoke_id(), SERVICE)),
+        Ok(AdmissionOutcome::DuplicateTerminal)
     );
+    coordinator.complete(error_token).unwrap();
 }
 
 #[test]
-fn error_reject_and_requester_abort_are_terminal_with_required_checks() {
+fn reject_and_requester_abort_are_terminal_with_required_checks() {
     let coordinator = OutboundTransactionCoordinator::new();
     let expected_peer = peer(4);
-
-    let error_token = coordinator
-        .reserve(requester(expected_peer.clone(), TerminalPolicy::ComplexAck))
-        .unwrap();
-    assert_eq!(
-        coordinator.admit(
-            &expected_peer,
-            &error_pdu(error_token.invoke_id(), OTHER_SERVICE)
-        ),
-        Ok(AdmissionOutcome::ServiceMismatch {
-            expected: SERVICE,
-            observed: OTHER_SERVICE,
-        })
-    );
-    assert_admitted_kind(
-        coordinator
-            .admit(&expected_peer, &error_pdu(error_token.invoke_id(), SERVICE))
-            .unwrap(),
-        AdmissionKind::Terminal,
-    );
-    coordinator.complete(error_token).unwrap();
 
     let reject_token = coordinator
         .reserve(requester(expected_peer.clone(), TerminalPolicy::SimpleAck))

--- a/crates/bacnet-endpoint-core/src/lib.rs
+++ b/crates/bacnet-endpoint-core/src/lib.rs
@@ -1,4 +1,4 @@
-//! Private shared endpoint primitives for workspace role crates.
+//! BACnet endpoint ownership and transaction coordination primitives.
 
 /// Device-wide outbound invoke-ID leasing and response admission.
 pub mod coordinator;


### PR DESCRIPTION
## Summary

- make `bacnet-endpoint-core` a publishable workspace package
- add it to the existing crates.io release sequence before server and client
- add an explicit requester policy that accepts either SimpleACK or ComplexACK
- preserve lenient Error correlation and defer segmented ComplexACK service validation to reassembly
- keep strict ACK policies and server-notification restrictions available

## Why

Published role crates cannot depend on endpoint-core while it is marked `publish = false` and absent from crates.io. This is the owner-approved packaging and compatibility prerequisite for the client/server transaction-adapter slices.

No client or server dependency, TSM integration, lifecycle change, combined-device API, or transport composition is included here.

## Verification

- `cargo package -p bacnet-endpoint-core --locked --allow-dirty`
- `cargo publish -p bacnet-endpoint-core --dry-run --locked --allow-dirty`
- `cargo test -p bacnet-endpoint-core --locked`
- `cargo check -p bacnet-endpoint-core --all-targets --locked`
- `cargo test -p bacnet-client --locked`
- `cargo test -p bacnet-server server_tsm --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

The package and publish dry-run both completed verification; no crate was uploaded.

Refs #431