### PR TITLE
feat(client): coordinate confirmed requester transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ name = "bacnet-client"
 version = "0.10.1"
 dependencies = [
  "bacnet-encoding",
+ "bacnet-endpoint-core",
  "bacnet-network",
  "bacnet-objects",
  "bacnet-services",

--- a/crates/bacnet-client/Cargo.toml
+++ b/crates/bacnet-client/Cargo.toml
@@ -15,6 +15,7 @@ bacnet-encoding.workspace = true
 bacnet-services.workspace = true
 bacnet-transport.workspace = true
 bacnet-network.workspace = true
+bacnet-endpoint-core.workspace = true
 bytes.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["net", "rt", "sync", "macros", "time"] }

--- a/crates/bacnet-client/src/client/coordinator_tests.rs
+++ b/crates/bacnet-client/src/client/coordinator_tests.rs
@@ -1,0 +1,200 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use bacnet_encoding::apdu::{self, Apdu};
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_endpoint_core::coordinator::CanonicalPeer;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::enums::ConfirmedServiceChoice;
+use bacnet_types::error::Error;
+use bacnet_types::MacAddr;
+use bytes::Bytes;
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Duration};
+
+use super::{BACnetClient, ClientConfig};
+
+const CLIENT_MAC: &[u8] = &[1];
+const ROUTER_MAC: &[u8] = &[2];
+
+async fn receive_invoke_id(
+    receiver: &mut tokio::sync::mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>,
+) -> u8 {
+    let received = timeout(Duration::from_secs(2), receiver.recv())
+        .await
+        .expect("request send timed out")
+        .expect("request channel closed");
+    let npdu = decode_npdu(received.npdu).expect("valid request NPDU");
+    match apdu::decode_apdu(npdu.payload).expect("valid request APDU") {
+        Apdu::ConfirmedRequest(request) => request.invoke_id,
+        other => panic!("expected ConfirmedRequest, got {other:?}"),
+    }
+}
+
+async fn wait_for_active_count(client: &BACnetClient<LoopbackTransport>, expected: usize) {
+    timeout(Duration::from_secs(2), async {
+        loop {
+            if client.tsm.lock().await.coordinated_active_count() == expected {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("coordinator active count did not reach {expected}"));
+}
+
+async fn seed_pending_transaction(client: &BACnetClient<LoopbackTransport>) {
+    client
+        .tsm
+        .lock()
+        .await
+        .register_coordinated_transaction_with_progress(
+            MacAddr::from_slice(ROUTER_MAC),
+            CanonicalPeer::direct(ROUTER_MAC),
+            ConfirmedServiceChoice::READ_PROPERTY,
+            false,
+        )
+        .unwrap();
+}
+
+#[tokio::test]
+async fn client_stop_releases_coordinated_pending_transactions() {
+    let (client_transport, _peer_transport) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), ROUTER_MAC.to_vec());
+    let mut client = BACnetClient::start(ClientConfig::default(), client_transport)
+        .await
+        .unwrap();
+    seed_pending_transaction(&client).await;
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 1);
+
+    client.stop().await.unwrap();
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
+}
+
+#[tokio::test]
+async fn client_drop_releases_coordinated_pending_transactions() {
+    let (client_transport, _peer_transport) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), ROUTER_MAC.to_vec());
+    let client = BACnetClient::start(ClientConfig::default(), client_transport)
+        .await
+        .unwrap();
+    seed_pending_transaction(&client).await;
+    let tsm = Arc::clone(&client.tsm);
+    assert_eq!(tsm.lock().await.coordinated_active_count(), 1);
+
+    drop(client);
+    assert_eq!(tsm.lock().await.coordinated_active_count(), 0);
+}
+
+#[tokio::test]
+async fn initial_send_failure_cancels_the_exact_coordinated_lease() {
+    let (client_transport, peer_transport) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), ROUTER_MAC.to_vec());
+    drop(peer_transport);
+    let mut client = BACnetClient::start(ClientConfig::default(), client_transport)
+        .await
+        .unwrap();
+
+    assert!(client
+        .confirmed_request(ROUTER_MAC, ConfirmedServiceChoice::READ_PROPERTY, &[0x0C],)
+        .await
+        .is_err());
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
+
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn client_uses_one_global_generation_safe_pool_across_direct_and_routed_peers() {
+    let (client_transport, mut peer_transport) =
+        LoopbackTransport::pair(CLIENT_MAC.to_vec(), ROUTER_MAC.to_vec());
+    let mut peer_rx = peer_transport.start().await.unwrap();
+    let client = Arc::new(
+        BACnetClient::start(
+            ClientConfig {
+                apdu_timeout_ms: 60_000,
+                apdu_retries: 0,
+                ..ClientConfig::default()
+            },
+            client_transport,
+        )
+        .await
+        .unwrap(),
+    );
+    let mut requests: Vec<JoinHandle<Result<Bytes, Error>>> = Vec::new();
+    let mut invoke_ids = HashSet::new();
+
+    for index in 0..256u16 {
+        let request_client = Arc::clone(&client);
+        let request = if index % 2 == 0 {
+            let destination = index.to_be_bytes().to_vec();
+            tokio::spawn(async move {
+                request_client
+                    .confirmed_request(&destination, ConfirmedServiceChoice::READ_PROPERTY, &[0x0C])
+                    .await
+            })
+        } else {
+            let destination = index.to_be_bytes().to_vec();
+            tokio::spawn(async move {
+                request_client
+                    .confirmed_request_routed(
+                        ROUTER_MAC,
+                        index,
+                        &destination,
+                        ConfirmedServiceChoice::READ_PROPERTY,
+                        &[0x0C],
+                    )
+                    .await
+            })
+        };
+        let invoke_id = receive_invoke_id(&mut peer_rx).await;
+        assert!(invoke_ids.insert(invoke_id));
+        requests.push(request);
+    }
+    assert_eq!(invoke_ids.len(), 256);
+    wait_for_active_count(&client, 256).await;
+
+    let exhausted = timeout(
+        Duration::from_secs(1),
+        client.confirmed_request(&[0xFF], ConfirmedServiceChoice::READ_PROPERTY, &[0x0C]),
+    )
+    .await
+    .expect("exhaustion did not return synchronously");
+    assert!(matches!(
+        exhausted,
+        Err(Error::Encoding(message)) if message == "all invoke IDs exhausted for destination"
+    ));
+    assert!(timeout(Duration::from_millis(50), peer_rx.recv())
+        .await
+        .is_err());
+
+    let released_invoke_id = 0;
+    let first = requests.remove(0);
+    first.abort();
+    let _ = first.await;
+    wait_for_active_count(&client, 255).await;
+
+    let replacement_client = Arc::clone(&client);
+    let replacement = tokio::spawn(async move {
+        replacement_client
+            .confirmed_request(&[0, 0], ConfirmedServiceChoice::READ_PROPERTY, &[0x0D])
+            .await
+    });
+    assert_eq!(receive_invoke_id(&mut peer_rx).await, released_invoke_id);
+    wait_for_active_count(&client, 256).await;
+
+    replacement.abort();
+    let _ = replacement.await;
+    for request in requests {
+        request.abort();
+        let _ = request.await;
+    }
+    wait_for_active_count(&client, 0).await;
+
+    let mut client = Arc::try_unwrap(client).unwrap_or_else(|_| panic!("client still shared"));
+    client.stop().await.unwrap();
+    peer_transport.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -1,65 +1,9 @@
+use super::response_admission::{
+    admit_terminal_during_reassembly, complete_terminal_response, current_reassembly_owner,
+    log_coordinated_mismatch, take_current_reassembly, TerminalDispatchOutcome,
+};
 use super::*;
-use crate::tsm::CompletionOutcome;
-
-/// Report an acknowledgment that named a different confirmed service.
-///
-/// Clauses 20.1.4.2 and 20.1.5.6 both require an acknowledgment's
-/// service-ack-choice to carry "the value of the BACnetConfirmedServiceChoice
-/// corresponding to the service contained in the previous
-/// BACnet-Confirmed-Service-Request that has resulted in this
-/// acknowledgment", so a mismatch means the peer is not answering this
-/// request. The transaction stays pending; nothing else is needed here beyond
-/// making the peer's misbehavior visible.
-fn log_mismatch(outcome: CompletionOutcome, invoke_id: u8, pdu: &str) {
-    if let CompletionOutcome::ServiceChoiceMismatch { expected, observed } = outcome {
-        warn!(
-            invoke_id,
-            pdu,
-            expected = expected.to_raw(),
-            observed = observed.to_raw(),
-            "Ignoring acknowledgment labelled for a different confirmed service"
-        );
-    }
-}
-
-async fn take_current_reassembly(
-    tsm: &Arc<Mutex<Tsm>>,
-    seg_state: &mut HashMap<SegKey, SegmentedReceiveState>,
-    key: &SegKey,
-) -> Option<SegmentedReceiveState> {
-    let state = seg_state.remove(key)?;
-    if tsm
-        .lock()
-        .await
-        .owner_is_current(&key.0, key.1, &state.owner)
-    {
-        Some(state)
-    } else {
-        debug!(invoke_id = key.1, "Reclaimed stale segmented receive state");
-        None
-    }
-}
-
-async fn admit_terminal_response(
-    tsm: &Arc<Mutex<Tsm>>,
-    tsm_mac: &MacAddr,
-    invoke_id: u8,
-) -> TerminalResponseAdmission {
-    let mut expected_owner = None;
-    loop {
-        let admission =
-            tsm.lock()
-                .await
-                .admit_terminal_response(tsm_mac, invoke_id, expected_owner.as_ref());
-        match admission {
-            TerminalResponseAdmission::FinalSegmentSendPolling { owner, issue } => {
-                issue.wait_until_polled().await;
-                expected_owner = Some(owner);
-            }
-            admission => return admission,
-        }
-    }
-}
+use crate::tsm::{CompletionOutcome, CoordinatedCompletion};
 
 impl<T: TransportPort + 'static> BACnetClient<T> {
     /// Dispatch a received APDU to the appropriate handler.
@@ -80,7 +24,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         apdu: Apdu,
         limits: ResponseLimits,
     ) {
-        let tsm_mac = response_tsm_mac(source_mac, source_network);
+        let transaction_peer = response_transaction_peer(source_mac, source_network);
+        let tsm_mac = transaction_peer.tsm_mac;
+        let canonical_peer = transaction_peer.canonical;
         match apdu {
             Apdu::SimpleAck(ack) => {
                 // Mid-reassembly, a SimpleACK is in Clause 5.4.4.4
@@ -90,6 +36,15 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // second one is not answering it. Checked before the TSM
                 // lock: `abort_reassembly` takes that lock itself (#367).
                 let key = (tsm_mac.clone(), ack.invoke_id);
+                let coordinator_apdu = Apdu::SimpleAck(ack.clone());
+                admit_terminal_during_reassembly(
+                    tsm,
+                    seg_state,
+                    &key,
+                    &canonical_peer,
+                    &coordinator_apdu,
+                )
+                .await;
                 if let Some(state) = take_current_reassembly(tsm, seg_state, &key).await {
                     debug!(
                         invoke_id = ack.invoke_id,
@@ -109,18 +64,22 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     return;
                 }
                 debug!(invoke_id = ack.invoke_id, "Received SimpleAck");
-                match admit_terminal_response(tsm, &tsm_mac, ack.invoke_id).await {
-                    TerminalResponseAdmission::Active(owner) => {
-                        let outcome = tsm.lock().await.complete_transaction_for_owner(
-                            &tsm_mac,
-                            ack.invoke_id,
-                            &owner,
-                            Some(ack.service_choice),
-                            TsmResponse::SimpleAck,
-                        );
-                        log_mismatch(outcome, ack.invoke_id, "SimpleAck");
+                match complete_terminal_response(
+                    tsm,
+                    &tsm_mac,
+                    ack.invoke_id,
+                    &canonical_peer,
+                    &coordinator_apdu,
+                    TsmResponse::SimpleAck,
+                    true,
+                    None,
+                )
+                .await
+                {
+                    TerminalDispatchOutcome::Completion(outcome) => {
+                        log_coordinated_mismatch(&outcome, ack.invoke_id, "SimpleAck");
                     }
-                    TerminalResponseAdmission::PrematureSegmentedRequestAborted => {
+                    TerminalDispatchOutcome::PrematureSegmentedRequestAborted => {
                         Self::send_client_abort(
                             network,
                             source_mac,
@@ -130,8 +89,6 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         )
                         .await;
                     }
-                    TerminalResponseAdmission::NoTransaction => {}
-                    TerminalResponseAdmission::FinalSegmentSendPolling { .. } => unreachable!(),
                 }
             }
             Apdu::ComplexAck(ack) => {
@@ -152,6 +109,15 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     // UnexpectedPDU_Received list: the transaction's answer
                     // is the segmented ComplexACK already under reassembly.
                     let key = (tsm_mac.clone(), ack.invoke_id);
+                    let coordinator_apdu = Apdu::ComplexAck(ack.clone());
+                    admit_terminal_during_reassembly(
+                        tsm,
+                        seg_state,
+                        &key,
+                        &canonical_peer,
+                        &coordinator_apdu,
+                    )
+                    .await;
                     if let Some(state) = take_current_reassembly(tsm, seg_state, &key).await {
                         debug!(
                             invoke_id = ack.invoke_id,
@@ -171,20 +137,24 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         return;
                     }
                     debug!(invoke_id = ack.invoke_id, "Received ComplexAck");
-                    match admit_terminal_response(tsm, &tsm_mac, ack.invoke_id).await {
-                        TerminalResponseAdmission::Active(owner) => {
-                            let outcome = tsm.lock().await.complete_transaction_for_owner(
-                                &tsm_mac,
-                                ack.invoke_id,
-                                &owner,
-                                Some(ack.service_choice),
-                                TsmResponse::ComplexAck {
-                                    service_data: ack.service_ack,
-                                },
-                            );
-                            log_mismatch(outcome, ack.invoke_id, "ComplexAck");
+                    match complete_terminal_response(
+                        tsm,
+                        &tsm_mac,
+                        ack.invoke_id,
+                        &canonical_peer,
+                        &coordinator_apdu,
+                        TsmResponse::ComplexAck {
+                            service_data: ack.service_ack,
+                        },
+                        true,
+                        None,
+                    )
+                    .await
+                    {
+                        TerminalDispatchOutcome::Completion(outcome) => {
+                            log_coordinated_mismatch(&outcome, ack.invoke_id, "ComplexAck");
                         }
-                        TerminalResponseAdmission::PrematureSegmentedRequestAborted => {
+                        TerminalDispatchOutcome::PrematureSegmentedRequestAborted => {
                             Self::send_client_abort(
                                 network,
                                 source_mac,
@@ -194,8 +164,6 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                             )
                             .await;
                         }
-                        TerminalResponseAdmission::NoTransaction => {}
-                        TerminalResponseAdmission::FinalSegmentSendPolling { .. } => unreachable!(),
                     }
                 }
             }
@@ -207,6 +175,15 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // Checked before the TSM lock below: `abort_reassembly` takes
                 // that lock itself, and tokio's Mutex is not reentrant.
                 let key = (tsm_mac.clone(), err.invoke_id);
+                let coordinator_apdu = Apdu::Error(err.clone());
+                admit_terminal_during_reassembly(
+                    tsm,
+                    seg_state,
+                    &key,
+                    &canonical_peer,
+                    &coordinator_apdu,
+                )
+                .await;
                 if let Some(state) = take_current_reassembly(tsm, seg_state, &key).await {
                     debug!(
                         invoke_id = err.invoke_id,
@@ -233,20 +210,23 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // `other [127] Error`. Nothing in the Standard forbids a peer
                 // from answering through that tag, so an exact-match gate here
                 // would reject conformant responses.
-                match admit_terminal_response(tsm, &tsm_mac, err.invoke_id).await {
-                    TerminalResponseAdmission::Active(owner) => {
-                        tsm.lock().await.complete_transaction_for_owner(
-                            &tsm_mac,
-                            err.invoke_id,
-                            &owner,
-                            None,
-                            TsmResponse::Error {
-                                class: err.error_class.to_raw() as u32,
-                                code: err.error_code.to_raw() as u32,
-                            },
-                        );
-                    }
-                    TerminalResponseAdmission::PrematureSegmentedRequestAborted => {
+                match complete_terminal_response(
+                    tsm,
+                    &tsm_mac,
+                    err.invoke_id,
+                    &canonical_peer,
+                    &coordinator_apdu,
+                    TsmResponse::Error {
+                        class: err.error_class.to_raw() as u32,
+                        code: err.error_code.to_raw() as u32,
+                    },
+                    true,
+                    None,
+                )
+                .await
+                {
+                    TerminalDispatchOutcome::Completion(_) => {}
+                    TerminalDispatchOutcome::PrematureSegmentedRequestAborted => {
                         Self::send_client_abort(
                             network,
                             source_mac,
@@ -256,8 +236,6 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         )
                         .await;
                     }
-                    TerminalResponseAdmission::NoTransaction => {}
-                    TerminalResponseAdmission::FinalSegmentSendPolling { .. } => unreachable!(),
                 }
             }
             Apdu::Reject(rej) => {
@@ -265,6 +243,15 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // Error arm above ("BACnet-Reject-PDU" is in the same list),
                 // with the same lock-ordering constraint (#367).
                 let key = (tsm_mac.clone(), rej.invoke_id);
+                let coordinator_apdu = Apdu::Reject(rej.clone());
+                admit_terminal_during_reassembly(
+                    tsm,
+                    seg_state,
+                    &key,
+                    &canonical_peer,
+                    &coordinator_apdu,
+                )
+                .await;
                 if let Some(state) = take_current_reassembly(tsm, seg_state, &key).await {
                     debug!(
                         invoke_id = rej.invoke_id,
@@ -284,17 +271,21 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     return;
                 }
                 debug!(invoke_id = rej.invoke_id, "Received Reject PDU");
-                let mut tsm = tsm.lock().await;
                 // Carries no service choice (Clause 20.1.8); invoke ID is the
                 // only correlation the Standard provides.
-                tsm.complete_transaction(
+                let _ = complete_terminal_response(
+                    tsm,
                     &tsm_mac,
                     rej.invoke_id,
-                    None,
+                    &canonical_peer,
+                    &coordinator_apdu,
                     TsmResponse::Reject {
                         reason: rej.reject_reason.to_raw(),
                     },
-                );
+                    false,
+                    None,
+                )
+                .await;
             }
             Apdu::Abort(abt) => {
                 // Clause 5.4.4.3 AbortPDU_Received fires only for an Abort
@@ -321,23 +312,38 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // anyway — so no test can pin this line alone; it is kept so
                 // the slot frees at the Abort, not at the peer's next move.
                 let key = (tsm_mac.clone(), abt.invoke_id);
-                let state = take_current_reassembly(tsm, seg_state, &key).await;
+                let reassembly_owner = current_reassembly_owner(tsm, seg_state, &key).await;
                 debug!(invoke_id = abt.invoke_id, "Received Abort PDU");
-                let mut tsm = tsm.lock().await;
                 // Carries no service choice (Clause 20.1.9).
                 let response = TsmResponse::Abort {
                     reason: abt.abort_reason.to_raw(),
                 };
-                if let Some(state) = state {
-                    tsm.complete_transaction_for_owner(
-                        &tsm_mac,
-                        abt.invoke_id,
-                        &state.owner,
-                        None,
-                        response,
-                    );
-                } else {
-                    tsm.complete_transaction(&tsm_mac, abt.invoke_id, None, response);
+                let coordinator_apdu = Apdu::Abort(abt.clone());
+                let outcome = complete_terminal_response(
+                    tsm,
+                    &tsm_mac,
+                    abt.invoke_id,
+                    &canonical_peer,
+                    &coordinator_apdu,
+                    response,
+                    false,
+                    reassembly_owner.clone(),
+                )
+                .await;
+                if matches!(
+                    outcome,
+                    TerminalDispatchOutcome::Completion(CoordinatedCompletion::Completed(
+                        CompletionOutcome::Delivered
+                    ))
+                ) {
+                    if let Some(owner) = reassembly_owner {
+                        if seg_state
+                            .get(&key)
+                            .is_some_and(|state| state.owner.same_as(&owner))
+                        {
+                            seg_state.remove(&key);
+                        }
+                    }
                 }
             }
             Apdu::ConfirmedRequest(req) => {
@@ -546,7 +552,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 // Terminal completion uses this same lock, so a raw sender
                 // entry cannot outlive the authoritative phase for delivery.
                 let tsm_guard = tsm.lock().await;
-                match tsm_guard.segment_ack_phase(&tsm_mac, invoke_id) {
+                let coordinator_apdu = Apdu::SegmentAck(sa.clone());
+                match tsm_guard.coordinated_segment_ack_phase(
+                    &tsm_mac,
+                    invoke_id,
+                    &canonical_peer,
+                    &coordinator_apdu,
+                ) {
                     SegmentAckPhase::SegmentedRequest(owner) => {
                         // Lock order is TSM then SegmentACK routes. Setup and
                         // cleanup never hold both locks.
@@ -566,6 +578,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         );
                         return;
                     }
+                    SegmentAckPhase::CoordinatorRejected => return,
                     SegmentAckPhase::Idle => {}
                 }
                 drop(tsm_guard);

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -56,7 +56,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             apdu_segment_timeout_ms: config.apdu_timeout_ms,
             apdu_retries: config.apdu_retries,
         };
-        let tsm = Arc::new(Mutex::new(Tsm::new(tsm_config)));
+        let coordinator = Arc::new(OutboundTransactionCoordinator::new());
+        let tsm = Arc::new(Mutex::new(Tsm::new_coordinated(tsm_config, coordinator)));
         let tsm_dispatch = Arc::clone(&tsm);
         let device_table = Arc::new(Mutex::new(DeviceTable::new()));
         let device_table_dispatch = Arc::clone(&device_table);
@@ -214,6 +215,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         if let Some(task) = self.abort_dispatch_task() {
             let _ = task.await;
         }
+        self.tsm.lock().await.cancel_all_transactions();
         let network = Arc::get_mut(&mut self.network).ok_or_else(|| {
             Error::Encoding("cannot stop BACnetClient while network references remain".into())
         })?;
@@ -225,5 +227,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 impl<T: TransportPort> Drop for BACnetClient<T> {
     fn drop(&mut self) {
         let _ = self.abort_dispatch_task();
+        if let Ok(mut tsm) = self.tsm.try_lock() {
+            tsm.cancel_all_transactions();
+        }
     }
 }

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -24,6 +24,7 @@ use bacnet_encoding::apdu::{
     ConfirmedRequest as ConfirmedRequestPdu, RejectPdu, SegmentAck as SegmentAckPdu, SimpleAck,
 };
 use bacnet_encoding::npdu::{encode_npdu, Npdu, NpduAddress};
+use bacnet_endpoint_core::coordinator::{CanonicalPeer, OutboundTransactionCoordinator};
 use bacnet_network::layer::NetworkLayer;
 use bacnet_services::cov::COVNotificationRequest;
 use bacnet_transport::bip::BipTransport;
@@ -42,7 +43,7 @@ use crate::segmentation::{
 };
 use crate::tsm::{
     RequestTimerExpiration, SegmentAckPhase, SegmentTimerExpiration, SegmentedResponseAdmission,
-    TerminalResponseAdmission, TransactionOwner, TransactionProgress, Tsm, TsmConfig, TsmResponse,
+    TransactionOwner, TransactionProgress, Tsm, TsmConfig, TsmResponse,
 };
 #[cfg(test)]
 use transaction_cleanup::{SegmentedCleanupHook, SegmentedPostWaitCleanupHook};
@@ -723,18 +724,6 @@ enum ConfirmedTarget<'a> {
 }
 
 impl<'a> ConfirmedTarget<'a> {
-    /// The key used for TSM transaction matching.
-    fn tsm_mac(&self) -> MacAddr {
-        match self {
-            Self::Local { mac } => MacAddr::from_slice(mac),
-            Self::Routed {
-                dest_network,
-                dest_mac,
-                ..
-            } => routed_tsm_mac(*dest_network, dest_mac),
-        }
-    }
-
     fn additional_npdu_header_len(&self) -> u16 {
         match self {
             Self::Local { .. } => 0,
@@ -762,24 +751,6 @@ fn cap_max_apdu_to_transport(configured: u16, transport_limit: u16) -> Result<u1
     })
 }
 
-fn routed_tsm_mac(network: u16, mac: &[u8]) -> MacAddr {
-    let mut key = MacAddr::new();
-    key.extend_from_slice(&[0xFF, b'R']);
-    key.extend_from_slice(&network.to_be_bytes());
-    key.push(mac.len() as u8);
-    key.extend_from_slice(mac);
-    key
-}
-
-fn response_tsm_mac(source_mac: &[u8], source_network: &Option<NpduAddress>) -> MacAddr {
-    match source_network {
-        Some(address) if !address.mac_address.is_empty() => {
-            routed_tsm_mac(address.network, &address.mac_address)
-        }
-        _ => MacAddr::from_slice(source_mac),
-    }
-}
-
 mod builder_options;
 mod cov;
 mod cov_notifications;
@@ -793,9 +764,12 @@ mod lifecycle;
 mod object_mgmt;
 mod property;
 mod requests;
+mod response_admission;
 mod segmentation;
 mod segmented_request;
 mod transaction_cleanup;
+mod transaction_peer;
+use transaction_peer::response_transaction_peer;
 
 pub use cov_notifications::{
     COVNotificationDelivery, ConfirmedCOVNotificationAckPolicy, ConfirmedCOVNotificationResponse,
@@ -809,6 +783,8 @@ pub use cov_renewal::{
 mod builder_options_tests;
 #[cfg(test)]
 mod confirmed_request_dispatch_tests;
+#[cfg(test)]
+mod coordinator_tests;
 #[cfg(test)]
 mod cov_notification_tests;
 #[cfg(test)]

--- a/crates/bacnet-client/src/client/request_timer_tests.rs
+++ b/crates/bacnet-client/src/client/request_timer_tests.rs
@@ -179,6 +179,7 @@ async fn retry_send_failure_precedes_final_timeout_indication() {
     }
     assert_eq!(send_count.load(Ordering::SeqCst), 2);
     assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
 
     client.stop().await.unwrap();
 }

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -175,7 +175,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         service_choice: ConfirmedServiceChoice,
         service_data: &[u8],
     ) -> Result<Bytes, Error> {
-        let tsm_mac = target.tsm_mac();
+        let transaction_peer = target.transaction_peer();
+        let tsm_mac = transaction_peer.tsm_mac;
         let unsegmented_apdu_size = 4 + service_data.len();
         let target_transport_max_apdu = self.target_transport_max_apdu_length(target);
 
@@ -250,12 +251,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let advertised_max_apdu = self.advertised_max_apdu_length_for_target(target)?;
         let (invoke_id, registration) = {
             let mut tsm = self.tsm.lock().await;
-            let invoke_id = tsm.allocate_invoke_id(&tsm_mac).ok_or_else(|| {
-                Error::Encoding("all invoke IDs exhausted for destination".into())
-            })?;
-            let registration =
-                tsm.register_transaction_with_progress(tsm_mac.clone(), invoke_id, service_choice);
-            (invoke_id, registration)
+            tsm.register_coordinated_transaction_with_progress(
+                tsm_mac.clone(),
+                transaction_peer.canonical,
+                service_choice,
+                false,
+            )
+            .map_err(|error| Error::Encoding(error.to_string()))?
         };
 
         let owner = registration.owner.clone();

--- a/crates/bacnet-client/src/client/response_admission.rs
+++ b/crates/bacnet-client/src/client/response_admission.rs
@@ -1,0 +1,155 @@
+use super::*;
+use crate::tsm::{CompletionOutcome, CoordinatedCompletion, CoordinatedTerminalPhase};
+
+fn log_mismatch(outcome: &CompletionOutcome, invoke_id: u8, pdu: &str) {
+    if let CompletionOutcome::ServiceChoiceMismatch { expected, observed } = outcome {
+        warn!(
+            invoke_id,
+            pdu,
+            expected = expected.to_raw(),
+            observed = observed.to_raw(),
+            "Ignoring acknowledgment labelled for a different confirmed service"
+        );
+    }
+}
+
+pub(super) fn log_coordinated_mismatch(outcome: &CoordinatedCompletion, invoke_id: u8, pdu: &str) {
+    match outcome {
+        CoordinatedCompletion::Completed(outcome) => {
+            log_mismatch(outcome, invoke_id, pdu);
+        }
+        CoordinatedCompletion::ServiceChoiceMismatch { expected, observed } => {
+            warn!(
+                invoke_id,
+                pdu,
+                expected = expected.to_raw(),
+                observed = observed.to_raw(),
+                "Ignoring acknowledgment labelled for a different confirmed service"
+            );
+        }
+        CoordinatedCompletion::Rejected => {}
+    }
+}
+
+pub(super) async fn take_current_reassembly(
+    tsm: &Arc<Mutex<Tsm>>,
+    seg_state: &mut HashMap<SegKey, SegmentedReceiveState>,
+    key: &SegKey,
+) -> Option<SegmentedReceiveState> {
+    let state = seg_state.remove(key)?;
+    if tsm
+        .lock()
+        .await
+        .owner_is_current(&key.0, key.1, &state.owner)
+    {
+        Some(state)
+    } else {
+        debug!(invoke_id = key.1, "Reclaimed stale segmented receive state");
+        None
+    }
+}
+
+pub(super) async fn current_reassembly_owner(
+    tsm: &Arc<Mutex<Tsm>>,
+    seg_state: &mut HashMap<SegKey, SegmentedReceiveState>,
+    key: &SegKey,
+) -> Option<TransactionOwner> {
+    let owner = seg_state.get(key)?.owner.clone();
+    if tsm.lock().await.owner_is_current(&key.0, key.1, &owner) {
+        Some(owner)
+    } else {
+        seg_state.remove(key);
+        debug!(invoke_id = key.1, "Reclaimed stale segmented receive state");
+        None
+    }
+}
+
+pub(super) async fn admit_terminal_during_reassembly(
+    tsm: &Arc<Mutex<Tsm>>,
+    seg_state: &mut HashMap<SegKey, SegmentedReceiveState>,
+    key: &SegKey,
+    peer: &CanonicalPeer,
+    apdu: &Apdu,
+) {
+    let Some(owner) = current_reassembly_owner(tsm, seg_state, key).await else {
+        return;
+    };
+    let _ = tsm
+        .lock()
+        .await
+        .try_claim_coordinated_terminal(&key.0, key.1, &owner, peer, apdu);
+}
+
+pub(super) enum TerminalDispatchOutcome {
+    Completion(CoordinatedCompletion),
+    PrematureSegmentedRequestAborted,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn complete_terminal_response(
+    tsm: &Arc<Mutex<Tsm>>,
+    tsm_mac: &MacAddr,
+    invoke_id: u8,
+    peer: &CanonicalPeer,
+    apdu: &Apdu,
+    response: TsmResponse,
+    phase_gate: bool,
+    owner: Option<TransactionOwner>,
+) -> TerminalDispatchOutcome {
+    let mut expected_owner = owner;
+    let mut response = Some(response);
+    loop {
+        let mut tsm = tsm.lock().await;
+        let admission = if phase_gate {
+            tsm.coordinated_terminal_phase(tsm_mac, invoke_id, expected_owner.as_ref())
+        } else {
+            let owner = match expected_owner.clone() {
+                Some(owner) if tsm.owner_is_current(tsm_mac, invoke_id, &owner) => Some(owner),
+                Some(_) => None,
+                None => tsm.current_owner(tsm_mac, invoke_id),
+            };
+            match owner {
+                Some(owner) => CoordinatedTerminalPhase::Active(owner),
+                None => CoordinatedTerminalPhase::NoTransaction,
+            }
+        };
+        match admission {
+            CoordinatedTerminalPhase::FinalSegmentSendPolling { owner, issue } => {
+                drop(tsm);
+                issue.wait_until_polled().await;
+                expected_owner = Some(owner);
+            }
+            CoordinatedTerminalPhase::Active(owner) => {
+                let Some(response) = response.take() else {
+                    return TerminalDispatchOutcome::Completion(CoordinatedCompletion::Rejected);
+                };
+                let completion = tsm.complete_coordinated_terminal_response(
+                    tsm_mac,
+                    invoke_id,
+                    Some(&owner),
+                    peer,
+                    apdu,
+                    response,
+                );
+                return TerminalDispatchOutcome::Completion(completion);
+            }
+            CoordinatedTerminalPhase::PrematureSegmentedRequest(owner) => {
+                let _ = tsm.try_claim_coordinated_terminal(tsm_mac, invoke_id, &owner, peer, apdu);
+                tsm.complete_transaction_for_owner(
+                    tsm_mac,
+                    invoke_id,
+                    &owner,
+                    None,
+                    TsmResponse::Abort {
+                        reason: bacnet_types::enums::AbortReason::INVALID_APDU_IN_THIS_STATE
+                            .to_raw(),
+                    },
+                );
+                return TerminalDispatchOutcome::PrematureSegmentedRequestAborted;
+            }
+            CoordinatedTerminalPhase::NoTransaction => {
+                return TerminalDispatchOutcome::Completion(CoordinatedCompletion::Rejected);
+            }
+        }
+    }
+}

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -116,7 +116,10 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         limits: ResponseLimits,
     ) {
         let seq = ack.sequence_number.unwrap_or(0);
-        let tsm_mac = response_tsm_mac(source_mac, source_network);
+        let transaction_peer = response_transaction_peer(source_mac, source_network);
+        let tsm_mac = transaction_peer.tsm_mac;
+        let canonical_peer = transaction_peer.canonical;
+        let coordinator_apdu = Apdu::ComplexAck(ack.clone());
         let key = (tsm_mac.clone(), ack.invoke_id);
 
         let mut deferred_owner = None;
@@ -124,19 +127,23 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             let admission = {
                 let mut tsm = tsm.lock().await;
                 if let Some(owner) = deferred_owner.as_ref() {
-                    tsm.admit_segmented_complex_ack_for_owner(
+                    tsm.coordinated_admit_segmented_complex_ack_for_owner(
                         &tsm_mac,
                         ack.invoke_id,
                         seq,
                         limits.segmented_response_accepted,
                         owner,
+                        &canonical_peer,
+                        &coordinator_apdu,
                     )
                 } else {
-                    tsm.admit_segmented_complex_ack(
+                    tsm.coordinated_admit_segmented_complex_ack(
                         &tsm_mac,
                         ack.invoke_id,
                         seq,
                         limits.segmented_response_accepted,
+                        &canonical_peer,
+                        &coordinator_apdu,
                     )
                 }
             };
@@ -158,6 +165,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     .await;
                     return;
                 }
+                SegmentedResponseAdmission::CoordinatorRejected => return,
                 SegmentedResponseAdmission::NoTransaction => {
                     seg_state.remove(&key);
                     Self::send_client_abort(
@@ -427,7 +435,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                         "Reassembled segmented ComplexAck"
                     );
                     let mut tsm = tsm.lock().await;
-                    let outcome = tsm.complete_transaction_for_owner(
+                    let outcome = tsm.complete_admitted_transaction_for_owner(
                         &tsm_mac,
                         ack.invoke_id,
                         &state.owner,
@@ -468,7 +476,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         remote_max_apdu: u16,
         remote_max_segments: Option<u32>,
     ) -> Result<Bytes, Error> {
-        let tsm_mac = target.tsm_mac();
+        let transaction_peer = target.transaction_peer();
+        let tsm_mac = transaction_peer.tsm_mac;
         let advertised_max_apdu = self.advertised_max_apdu_length_for_target(target)?;
         let max_seg_size = max_segment_payload(remote_max_apdu, SegmentedPduType::ConfirmedRequest);
         let segments = split_payload(service_data, max_seg_size)?;
@@ -493,15 +502,13 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let (seg_ack_tx, mut seg_ack_rx) = mpsc::channel(16);
         let (invoke_id, registration) = {
             let mut tsm = self.tsm.lock().await;
-            let invoke_id = tsm.allocate_invoke_id(&tsm_mac).ok_or_else(|| {
-                Error::Encoding("all invoke IDs exhausted for destination".into())
-            })?;
-            let registration = tsm.register_segmented_transaction_with_progress(
+            tsm.register_coordinated_transaction_with_progress(
                 tsm_mac.clone(),
-                invoke_id,
+                transaction_peer.canonical,
                 service_choice,
-            );
-            (invoke_id, registration)
+                true,
+            )
+            .map_err(|error| Error::Encoding(error.to_string()))?
         };
 
         let owner = registration.owner.clone();

--- a/crates/bacnet-client/src/client/segmented_receive_lifecycle_tests.rs
+++ b/crates/bacnet-client/src/client/segmented_receive_lifecycle_tests.rs
@@ -499,7 +499,7 @@ async fn segmented_request_response_stops_its_request_timer() {
 }
 
 /// Cleanup after a completed response wait must preserve a newer segmented
-/// request that reused the released invoke ID.
+/// request, regardless of invoke-ID reuse.
 #[tokio::test]
 async fn segmented_request_timeout_cleanup_preserves_replacement_sender() {
     let config = ClientConfig {
@@ -560,7 +560,7 @@ async fn segmented_request_timeout_cleanup_preserves_replacement_sender() {
         other => panic!("expected replacement ConfirmedRequest, got {other:?}"),
     };
     assert!(replacement_first_segment.segmented);
-    assert_eq!(replacement_first_segment.invoke_id, first_invoke_id);
+    assert_ne!(replacement_first_segment.invoke_id, first_invoke_id);
 
     client.segmented_post_wait_cleanup.release();
     assert!(matches!(

--- a/crates/bacnet-client/src/client/segmented_request_state_tests.rs
+++ b/crates/bacnet-client/src/client/segmented_request_state_tests.rs
@@ -595,7 +595,7 @@ async fn stale_segment_ack_after_terminal_completion_is_not_routed() {
         Apdu::ConfirmedRequest(request) => request,
         other => panic!("expected ConfirmedRequest, got {other:?}"),
     };
-    assert_eq!(replacement.invoke_id, invoke_id);
+    assert_ne!(replacement.invoke_id, invoke_id);
     assert!(!replacement.segmented);
 
     send_to_client(
@@ -603,19 +603,19 @@ async fn stale_segment_ack_after_terminal_completion_is_not_routed() {
         Apdu::SegmentAck(SegmentAck {
             negative_ack: false,
             sent_by_server: true,
-            invoke_id,
+            invoke_id: replacement.invoke_id,
             sequence_number: 2,
             actual_window_size: 1,
         }),
     )
     .await;
-    expect_silence(&mut rx, "stale SegmentACK after invoke-ID reuse").await;
+    expect_silence(&mut rx, "SegmentACK during replacement request").await;
     send_to_client(
         &server,
         Apdu::ComplexAck(ComplexAck {
             segmented: false,
             more_follows: false,
-            invoke_id,
+            invoke_id: replacement.invoke_id,
             sequence_number: None,
             proposed_window_size: None,
             service_choice: replacement.service_choice,

--- a/crates/bacnet-client/src/client/segmented_timeout_tests.rs
+++ b/crates/bacnet-client/src/client/segmented_timeout_tests.rs
@@ -34,6 +34,7 @@ async fn segment_timer_timeout_ends_the_reassembly_session() {
         Err(Error::Abort { reason }) if reason == AbortReason::TSM_TIMEOUT.to_raw()
     ));
     assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
     assert!(
         timeout(
             Duration::from_secs(2),
@@ -105,6 +106,7 @@ async fn segmented_request_without_segment_ack_returns_local_tsm_timeout() {
         Err(Error::Abort { reason }) if reason == AbortReason::TSM_TIMEOUT.to_raw()
     ));
     assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
     assert!(
         !client
             .seg_ack_senders
@@ -125,7 +127,7 @@ async fn segmented_request_without_segment_ack_returns_local_tsm_timeout() {
 }
 
 #[tokio::test]
-async fn delayed_timeout_cleanup_preserves_reused_segmented_response() {
+async fn delayed_timeout_cleanup_preserves_newer_segmented_response() {
     let config = ClientConfig {
         apdu_timeout_ms: 100,
         apdu_retries: 0,
@@ -166,7 +168,7 @@ async fn delayed_timeout_cleanup_preserves_reused_segmented_response() {
         Apdu::ConfirmedRequest(request) => request.invoke_id,
         other => panic!("expected ConfirmedRequest, got {other:?}"),
     };
-    assert_eq!(second_invoke_id, first_invoke_id);
+    assert_ne!(second_invoke_id, first_invoke_id);
     send_to_client(
         &server,
         &response_segment(second_invoke_id, 0, true, b"new-"),
@@ -183,15 +185,16 @@ async fn delayed_timeout_cleanup_preserves_reused_segmented_response() {
         Err(Error::Abort { reason }) if reason == AbortReason::TSM_TIMEOUT.to_raw()
     ));
     assert!(
-        !timeout(
+        timeout(
             Duration::from_secs(2),
             client.segmented_cleanup.wait_processed()
         )
         .await
         .expect("dispatch did not process delayed cleanup"),
-        "owner A cleanup removed owner B reassembly state"
+        "owner A cleanup did not reclaim its stale reassembly state"
     );
     assert_eq!(client.tsm.lock().await.pending_count(), 1);
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 1);
 
     send_to_client(
         &server,
@@ -257,6 +260,7 @@ async fn caller_cancellation_reclaims_reassembly_after_tsm_lock_contention() {
         "cancellation cleanup did not remove the matching reassembly"
     );
     assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
     assert!(
         timeout(Duration::from_millis(50), rx.recv()).await.is_err(),
         "cancellation cleanup sent an unexpected peer PDU"
@@ -311,6 +315,7 @@ async fn caller_cancellation_reclaims_segmented_request_sender() {
         "outgoing request unexpectedly owned receive reassembly state"
     );
     assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
     assert!(
         !client
             .seg_ack_senders

--- a/crates/bacnet-client/src/client/tests.rs
+++ b/crates/bacnet-client/src/client/tests.rs
@@ -414,6 +414,7 @@ async fn confirmed_request_timeout() {
         .confirmed_request(&fake_mac, ConfirmedServiceChoice::READ_PROPERTY, &[0x01])
         .await;
     assert!(result.is_err());
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
     client.stop().await.unwrap();
 }
 

--- a/crates/bacnet-client/src/client/transaction_peer.rs
+++ b/crates/bacnet-client/src/client/transaction_peer.rs
@@ -1,0 +1,92 @@
+use super::*;
+
+pub(super) struct TransactionPeer {
+    pub(super) tsm_mac: MacAddr,
+    pub(super) canonical: CanonicalPeer,
+}
+
+impl ConfirmedTarget<'_> {
+    pub(super) fn transaction_peer(self) -> TransactionPeer {
+        match self {
+            Self::Local { mac } => TransactionPeer {
+                tsm_mac: MacAddr::from_slice(mac),
+                canonical: CanonicalPeer::direct(mac),
+            },
+            Self::Routed {
+                dest_network,
+                dest_mac,
+                ..
+            } => TransactionPeer {
+                tsm_mac: routed_tsm_mac(dest_network, dest_mac),
+                canonical: CanonicalPeer::routed(dest_network, dest_mac),
+            },
+        }
+    }
+}
+
+pub(super) fn response_transaction_peer(
+    source_mac: &[u8],
+    source_network: &Option<NpduAddress>,
+) -> TransactionPeer {
+    match source_network {
+        Some(address) if !address.mac_address.is_empty() => TransactionPeer {
+            tsm_mac: routed_tsm_mac(address.network, &address.mac_address),
+            canonical: CanonicalPeer::routed(address.network, &address.mac_address),
+        },
+        _ => TransactionPeer {
+            tsm_mac: MacAddr::from_slice(source_mac),
+            canonical: CanonicalPeer::direct(source_mac),
+        },
+    }
+}
+
+fn routed_tsm_mac(network: u16, mac: &[u8]) -> MacAddr {
+    let mut key = MacAddr::new();
+    key.extend_from_slice(&[0xFF, b'R']);
+    key.extend_from_slice(&network.to_be_bytes());
+    key.push(mac.len() as u8);
+    key.extend_from_slice(mac);
+    key
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outbound_and_inbound_transaction_identities_agree() {
+        let direct = ConfirmedTarget::Local { mac: &[1, 2, 3] }.transaction_peer();
+        let direct_response = response_transaction_peer(&[1, 2, 3], &None);
+        assert_eq!(direct.tsm_mac, direct_response.tsm_mac);
+        assert_eq!(direct.canonical, direct_response.canonical);
+
+        let routed = ConfirmedTarget::Routed {
+            router_mac: &[9],
+            dest_network: 42,
+            dest_mac: &[4, 5],
+        }
+        .transaction_peer();
+        let routed_response = response_transaction_peer(
+            &[8],
+            &Some(NpduAddress {
+                network: 42,
+                mac_address: MacAddr::from_slice(&[4, 5]),
+            }),
+        );
+        assert_eq!(routed.tsm_mac, routed_response.tsm_mac);
+        assert_eq!(routed.canonical, routed_response.canonical);
+    }
+
+    #[test]
+    fn empty_routed_source_falls_back_to_immediate_mac() {
+        let identity = response_transaction_peer(
+            &[7, 8],
+            &Some(NpduAddress {
+                network: 99,
+                mac_address: MacAddr::new(),
+            }),
+        );
+        assert_eq!(identity.tsm_mac, MacAddr::from_slice(&[7, 8]));
+        assert_eq!(identity.canonical, CanonicalPeer::direct(&[7, 8]));
+    }
+}

--- a/crates/bacnet-client/src/tsm.rs
+++ b/crates/bacnet-client/src/tsm.rs
@@ -17,6 +17,9 @@ pub(crate) use final_segment::{
 };
 mod segmented_response;
 pub(crate) use segmented_response::SegmentedResponseAdmission;
+mod coordinated;
+pub(crate) use coordinated::{CoordinatedCompletion, CoordinatedTerminalPhase};
+use coordinated::{PendingLease, PendingRelease};
 
 /// TSM configuration.
 #[derive(Debug, Clone)]
@@ -123,6 +126,7 @@ pub enum CompletionOutcome {
 pub(crate) enum SegmentAckPhase {
     SegmentedRequest(TransactionOwner),
     Outstanding,
+    CoordinatorRejected,
     Idle,
 }
 
@@ -197,6 +201,7 @@ struct PendingTransaction {
     /// this acknowledgment", so anything else is not this transaction's
     /// response.
     expected_service_choice: ConfirmedServiceChoice,
+    lease: PendingLease,
 }
 
 /// Transaction State Machine.
@@ -208,6 +213,7 @@ pub struct Tsm {
     config: TsmConfig,
     allocators: HashMap<MacAddr, InvokeIdAllocator>,
     pending: HashMap<(MacAddr, u8), PendingTransaction>,
+    coordinator: Option<Arc<bacnet_endpoint_core::coordinator::OutboundTransactionCoordinator>>,
 }
 
 impl Tsm {
@@ -216,6 +222,7 @@ impl Tsm {
             config,
             allocators: HashMap::new(),
             pending: HashMap::new(),
+            coordinator: None,
         }
     }
 
@@ -276,6 +283,7 @@ impl Tsm {
             invoke_id,
             service_choice,
             TransactionPhase::AwaitingResponse,
+            PendingLease::Legacy,
         )
     }
 
@@ -292,6 +300,7 @@ impl Tsm {
             TransactionPhase::SegmentedRequest {
                 sent_all_segments: false,
             },
+            PendingLease::Legacy,
         )
     }
 
@@ -301,12 +310,9 @@ impl Tsm {
         invoke_id: u8,
         service_choice: ConfirmedServiceChoice,
         phase: TransactionPhase,
+        lease: PendingLease,
     ) -> TransactionRegistration {
-        let (tx, rx) = oneshot::channel();
-        let (progress_tx, progress_rx) = watch::channel(TransactionProgress::AwaitingResponse);
-        let owner = TransactionOwner::new();
-        let final_segment_issue =
-            matches!(phase, TransactionPhase::SegmentedRequest { .. }).then(FinalSegmentIssue::new);
+        let (pending, registration) = Self::new_pending_transaction(service_choice, phase, lease);
         debug_assert!(
             !self
                 .pending
@@ -314,8 +320,21 @@ impl Tsm {
             "duplicate TSM registration for invoke_id {}",
             invoke_id
         );
-        self.pending.insert(
-            (destination_mac, invoke_id),
+        self.pending.insert((destination_mac, invoke_id), pending);
+        registration
+    }
+
+    fn new_pending_transaction(
+        service_choice: ConfirmedServiceChoice,
+        phase: TransactionPhase,
+        lease: PendingLease,
+    ) -> (PendingTransaction, TransactionRegistration) {
+        let (tx, rx) = oneshot::channel();
+        let (progress_tx, progress_rx) = watch::channel(TransactionProgress::AwaitingResponse);
+        let owner = TransactionOwner::new();
+        let final_segment_issue =
+            matches!(phase, TransactionPhase::SegmentedRequest { .. }).then(FinalSegmentIssue::new);
+        (
             PendingTransaction {
                 responder: tx,
                 progress: progress_tx,
@@ -324,13 +343,14 @@ impl Tsm {
                 final_segment_issue,
                 segment_generation: 0,
                 expected_service_choice: service_choice,
+                lease,
             },
-        );
-        TransactionRegistration {
-            response: rx,
-            progress: progress_rx,
-            owner,
-        }
+            TransactionRegistration {
+                response: rx,
+                progress: progress_rx,
+                owner,
+            },
+        )
     }
 
     /// Reserve the first poll of the final N-UNITDATA.request. A terminal PDU
@@ -570,8 +590,11 @@ impl Tsm {
         if !final_timeout {
             return RequestTimerExpiration::Retry;
         }
-        self.pending.remove(&key);
-        self.release_invoke_id(destination_mac, invoke_id);
+        let pending = self
+            .pending
+            .remove(&key)
+            .expect("pending transaction exists");
+        self.release_pending(destination_mac, invoke_id, pending, PendingRelease::Release);
         RequestTimerExpiration::TimedOut
     }
 
@@ -598,8 +621,11 @@ impl Tsm {
                 generation: pending.segment_generation,
             };
         }
-        self.pending.remove(&key);
-        self.release_invoke_id(destination_mac, invoke_id);
+        let pending = self
+            .pending
+            .remove(&key)
+            .expect("pending transaction exists");
+        self.release_pending(destination_mac, invoke_id, pending, PendingRelease::Release);
         SegmentTimerExpiration::TimedOut
     }
 
@@ -653,6 +679,7 @@ impl Tsm {
             None,
             observed_service_choice,
             response,
+            PendingRelease::Complete,
         )
     }
 
@@ -670,6 +697,25 @@ impl Tsm {
             Some(owner),
             observed_service_choice,
             response,
+            PendingRelease::Release,
+        )
+    }
+
+    pub(crate) fn complete_admitted_transaction_for_owner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+        observed_service_choice: Option<ConfirmedServiceChoice>,
+        response: TsmResponse,
+    ) -> CompletionOutcome {
+        self.complete_transaction_inner(
+            source_mac,
+            invoke_id,
+            Some(owner),
+            observed_service_choice,
+            response,
+            PendingRelease::Complete,
         )
     }
 
@@ -680,6 +726,7 @@ impl Tsm {
         owner: Option<&TransactionOwner>,
         observed_service_choice: Option<ConfirmedServiceChoice>,
         response: TsmResponse,
+        release: PendingRelease,
     ) -> CompletionOutcome {
         let key = (MacAddr::from_slice(source_mac), invoke_id);
         let Entry::Occupied(entry) = self.pending.entry(key) else {
@@ -701,10 +748,7 @@ impl Tsm {
             )
         {
             let pending = entry.remove();
-            self.release_invoke_id(source_mac, invoke_id);
-            let _ = pending.responder.send(TsmResponse::Abort {
-                reason: AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw(),
-            });
+            self.abort_pending_invalid_state(source_mac, invoke_id, pending);
             return CompletionOutcome::Delivered;
         }
         let expected = entry.get().expected_service_choice;
@@ -713,12 +757,29 @@ impl Tsm {
                 return CompletionOutcome::ServiceChoiceMismatch { expected, observed };
             }
         }
-        // Taking the entry ends the borrow of `pending`, so the invoke ID can
-        // be released without a second lookup that would have to be `expect`ed.
         let pending = entry.remove();
-        self.release_invoke_id(source_mac, invoke_id);
-        let _ = pending.responder.send(response);
+        let responder = pending.responder;
+        self.release_pending_lease(source_mac, invoke_id, pending.lease, release);
+        let _ = responder.send(response);
         CompletionOutcome::Delivered
+    }
+
+    fn abort_pending_invalid_state(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        pending: PendingTransaction,
+    ) {
+        let responder = pending.responder;
+        self.release_pending_lease(
+            source_mac,
+            invoke_id,
+            pending.lease,
+            PendingRelease::Release,
+        );
+        let _ = responder.send(TsmResponse::Abort {
+            reason: AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw(),
+        });
     }
 
     fn abort_invalid_apdu_in_current_state(
@@ -766,8 +827,8 @@ impl Tsm {
         }) {
             return false;
         }
-        if self.pending.remove(&key).is_some() {
-            self.release_invoke_id(destination_mac, invoke_id);
+        if let Some(pending) = self.pending.remove(&key) {
+            self.release_pending(destination_mac, invoke_id, pending, PendingRelease::Cancel);
             true
         } else {
             false
@@ -779,5 +840,8 @@ impl Tsm {
     }
 }
 
+#[cfg(test)]
+#[path = "tsm/coordinated_tests.rs"]
+mod coordinated_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-client/src/tsm/coordinated.rs
+++ b/crates/bacnet-client/src/tsm/coordinated.rs
@@ -1,0 +1,442 @@
+use std::collections::hash_map::Entry;
+use std::fmt;
+use std::sync::Arc;
+
+use bacnet_encoding::apdu::Apdu;
+use bacnet_endpoint_core::coordinator::{
+    AdmissionKind, AdmissionOutcome, CanonicalPeer, LeaseMetadata, LeaseToken,
+    OutboundTransactionCoordinator, ReserveError, TerminalPolicy,
+};
+use bacnet_types::enums::ConfirmedServiceChoice;
+use bacnet_types::MacAddr;
+
+use super::{
+    CompletionOutcome, FinalSegmentIssue, PendingTransaction, SegmentAckPhase,
+    SegmentedResponseAdmission, TransactionOwner, TransactionPhase, TransactionRegistration, Tsm,
+    TsmConfig, TsmResponse,
+};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PendingLease {
+    Legacy,
+    Coordinated(LeaseToken),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PendingRelease {
+    Complete,
+    Cancel,
+    Release,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CoordinatedRegistrationError {
+    CoordinatorUnavailable,
+    Reserve(ReserveError),
+    DuplicateInvokeId,
+}
+
+impl fmt::Display for CoordinatedRegistrationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CoordinatorUnavailable => {
+                formatter.write_str("coordinator is unavailable for client transaction")
+            }
+            Self::Reserve(ReserveError::Exhausted) => {
+                formatter.write_str("all invoke IDs exhausted for destination")
+            }
+            Self::Reserve(error) => write!(formatter, "invoke ID coordinator failed: {error}"),
+            Self::DuplicateInvokeId => {
+                formatter.write_str("coordinator reserved an invoke ID already pending in the TSM")
+            }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum CoordinatedCompletion {
+    Completed(CompletionOutcome),
+    ServiceChoiceMismatch {
+        expected: ConfirmedServiceChoice,
+        observed: ConfirmedServiceChoice,
+    },
+    Rejected,
+}
+
+#[derive(Debug)]
+pub(crate) enum CoordinatedTerminalPhase {
+    Active(TransactionOwner),
+    FinalSegmentSendPolling {
+        owner: TransactionOwner,
+        issue: FinalSegmentIssue,
+    },
+    PrematureSegmentedRequest(TransactionOwner),
+    NoTransaction,
+}
+
+impl Tsm {
+    pub(crate) fn current_owner(
+        &self,
+        source_mac: &[u8],
+        invoke_id: u8,
+    ) -> Option<TransactionOwner> {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        self.pending.get(&key).map(|pending| pending.owner.clone())
+    }
+
+    pub(crate) fn new_coordinated(
+        config: TsmConfig,
+        coordinator: Arc<OutboundTransactionCoordinator>,
+    ) -> Self {
+        Self {
+            config,
+            allocators: Default::default(),
+            pending: Default::default(),
+            coordinator: Some(coordinator),
+        }
+    }
+
+    pub(crate) fn register_coordinated_transaction_with_progress(
+        &mut self,
+        destination_mac: MacAddr,
+        peer: CanonicalPeer,
+        service_choice: ConfirmedServiceChoice,
+        segmented: bool,
+    ) -> Result<(u8, TransactionRegistration), CoordinatedRegistrationError> {
+        let coordinator = self
+            .coordinator
+            .as_ref()
+            .ok_or(CoordinatedRegistrationError::CoordinatorUnavailable)?;
+        let metadata = if segmented {
+            LeaseMetadata::segmented_requester(peer, service_choice, TerminalPolicy::EitherAck)
+        } else {
+            LeaseMetadata::requester(peer, service_choice, TerminalPolicy::EitherAck)
+        };
+        let token = coordinator
+            .reserve(metadata)
+            .map_err(CoordinatedRegistrationError::Reserve)?;
+        let invoke_id = token.invoke_id();
+        let phase = if segmented {
+            TransactionPhase::SegmentedRequest {
+                sent_all_segments: false,
+            }
+        } else {
+            TransactionPhase::AwaitingResponse
+        };
+        let (pending, registration) =
+            Self::new_pending_transaction(service_choice, phase, PendingLease::Coordinated(token));
+
+        match self.pending.entry((destination_mac, invoke_id)) {
+            Entry::Vacant(entry) => {
+                entry.insert(pending);
+                Ok((invoke_id, registration))
+            }
+            Entry::Occupied(_) => {
+                let _ = coordinator.cancel(token);
+                Err(CoordinatedRegistrationError::DuplicateInvokeId)
+            }
+        }
+    }
+
+    pub(crate) fn complete_coordinated_terminal_response(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: Option<&TransactionOwner>,
+        peer: &CanonicalPeer,
+        apdu: &Apdu,
+        response: TsmResponse,
+    ) -> CoordinatedCompletion {
+        let Some(current_owner) = self.current_owner(source_mac, invoke_id) else {
+            return CoordinatedCompletion::Rejected;
+        };
+        if owner.is_some_and(|owner| !current_owner.same_as(owner)) {
+            return CoordinatedCompletion::Rejected;
+        }
+        match self.claim_coordinated_terminal(source_mac, invoke_id, &current_owner, peer, apdu) {
+            Ok(()) => {}
+            Err(AdmissionOutcome::ServiceMismatch { expected, observed }) => {
+                return CoordinatedCompletion::ServiceChoiceMismatch { expected, observed };
+            }
+            Err(_) => return CoordinatedCompletion::Rejected,
+        }
+
+        let observed_service_choice = match apdu {
+            Apdu::SimpleAck(pdu) => Some(pdu.service_choice),
+            Apdu::ComplexAck(pdu) if !pdu.segmented => Some(pdu.service_choice),
+            Apdu::Error(_) | Apdu::Reject(_) | Apdu::Abort(_) => None,
+            _ => return CoordinatedCompletion::Rejected,
+        };
+        CoordinatedCompletion::Completed(self.complete_transaction_inner(
+            source_mac,
+            invoke_id,
+            Some(&current_owner),
+            observed_service_choice,
+            response,
+            PendingRelease::Complete,
+        ))
+    }
+
+    pub(crate) fn coordinated_terminal_phase(
+        &self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: Option<&TransactionOwner>,
+    ) -> CoordinatedTerminalPhase {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Some(pending) = self.pending.get(&key) else {
+            return CoordinatedTerminalPhase::NoTransaction;
+        };
+        if owner.is_some_and(|owner| !pending.owner.same_as(owner)) {
+            return CoordinatedTerminalPhase::NoTransaction;
+        }
+        let current_owner = pending.owner.clone();
+        if matches!(
+            pending.phase,
+            TransactionPhase::SegmentedRequest {
+                sent_all_segments: false
+            }
+        ) {
+            if let Some(issue) = pending
+                .final_segment_issue
+                .as_ref()
+                .filter(|issue| issue.is_polling())
+            {
+                return CoordinatedTerminalPhase::FinalSegmentSendPolling {
+                    owner: current_owner,
+                    issue: issue.clone(),
+                };
+            }
+            return CoordinatedTerminalPhase::PrematureSegmentedRequest(current_owner);
+        }
+        CoordinatedTerminalPhase::Active(current_owner)
+    }
+
+    pub(crate) fn try_claim_coordinated_terminal(
+        &self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+        peer: &CanonicalPeer,
+        apdu: &Apdu,
+    ) -> bool {
+        self.claim_coordinated_terminal(source_mac, invoke_id, owner, peer, apdu)
+            .is_ok()
+    }
+
+    fn claim_coordinated_terminal(
+        &self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+        peer: &CanonicalPeer,
+        apdu: &Apdu,
+    ) -> Result<(), AdmissionOutcome> {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Some(pending) = self
+            .pending
+            .get(&key)
+            .filter(|pending| pending.owner.same_as(owner))
+        else {
+            return Err(AdmissionOutcome::UnknownInvokeId);
+        };
+        let PendingLease::Coordinated(token) = pending.lease else {
+            return Ok(());
+        };
+        let Some(coordinator) = self.coordinator.as_ref() else {
+            return Err(AdmissionOutcome::UnknownInvokeId);
+        };
+        match coordinator.admit(peer, apdu) {
+            Ok(AdmissionOutcome::Admitted(admission))
+                if admission.kind() == AdmissionKind::Terminal && admission.token() == token =>
+            {
+                Ok(())
+            }
+            Ok(outcome) => Err(outcome),
+            Err(_) => Err(AdmissionOutcome::UnknownInvokeId),
+        }
+    }
+
+    pub(crate) fn coordinated_segment_ack_phase(
+        &self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        peer: &CanonicalPeer,
+        apdu: &Apdu,
+    ) -> SegmentAckPhase {
+        let phase = self.segment_ack_phase(source_mac, invoke_id);
+        let SegmentAckPhase::SegmentedRequest(owner) = phase else {
+            return phase;
+        };
+        if self.coordinated_nonterminal_admitted(source_mac, invoke_id, &owner, peer, apdu) {
+            SegmentAckPhase::SegmentedRequest(owner)
+        } else {
+            SegmentAckPhase::CoordinatorRejected
+        }
+    }
+
+    pub(crate) fn coordinated_admit_segmented_complex_ack(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        sequence_number: u8,
+        segmented_response_accepted: bool,
+        peer: &CanonicalPeer,
+        apdu: &Apdu,
+    ) -> SegmentedResponseAdmission {
+        let admission = self.admit_segmented_complex_ack(
+            source_mac,
+            invoke_id,
+            sequence_number,
+            segmented_response_accepted,
+        );
+        self.coordinate_segmented_response_admission(source_mac, invoke_id, peer, apdu, admission)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn coordinated_admit_segmented_complex_ack_for_owner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        sequence_number: u8,
+        segmented_response_accepted: bool,
+        owner: &TransactionOwner,
+        peer: &CanonicalPeer,
+        apdu: &Apdu,
+    ) -> SegmentedResponseAdmission {
+        let admission = self.admit_segmented_complex_ack_for_owner(
+            source_mac,
+            invoke_id,
+            sequence_number,
+            segmented_response_accepted,
+            owner,
+        );
+        self.coordinate_segmented_response_admission(source_mac, invoke_id, peer, apdu, admission)
+    }
+
+    fn coordinate_segmented_response_admission(
+        &self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        peer: &CanonicalPeer,
+        apdu: &Apdu,
+        admission: SegmentedResponseAdmission,
+    ) -> SegmentedResponseAdmission {
+        let SegmentedResponseAdmission::Active(owner) = admission else {
+            return admission;
+        };
+        if self.coordinated_nonterminal_admitted(source_mac, invoke_id, &owner, peer, apdu) {
+            SegmentedResponseAdmission::Active(owner)
+        } else {
+            SegmentedResponseAdmission::CoordinatorRejected
+        }
+    }
+
+    fn coordinated_nonterminal_admitted(
+        &self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+        peer: &CanonicalPeer,
+        apdu: &Apdu,
+    ) -> bool {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Some(pending) = self
+            .pending
+            .get(&key)
+            .filter(|pending| pending.owner.same_as(owner))
+        else {
+            return false;
+        };
+        let PendingLease::Coordinated(token) = pending.lease else {
+            return true;
+        };
+        let Some(coordinator) = self.coordinator.as_ref() else {
+            return false;
+        };
+        matches!(
+            coordinator.admit(peer, apdu),
+            Ok(AdmissionOutcome::Admitted(admission))
+                if admission.kind() == AdmissionKind::NonTerminal && admission.token() == token
+        )
+    }
+
+    pub(super) fn release_pending(
+        &mut self,
+        mac: &[u8],
+        invoke_id: u8,
+        pending: PendingTransaction,
+        release: PendingRelease,
+    ) {
+        self.release_pending_lease(mac, invoke_id, pending.lease, release);
+    }
+
+    pub(super) fn release_pending_lease(
+        &mut self,
+        mac: &[u8],
+        invoke_id: u8,
+        lease: PendingLease,
+        release: PendingRelease,
+    ) {
+        match lease {
+            PendingLease::Legacy => self.release_invoke_id(mac, invoke_id),
+            PendingLease::Coordinated(token) => {
+                let Some(coordinator) = self.coordinator.as_ref() else {
+                    return;
+                };
+                let _ = match release {
+                    PendingRelease::Complete => coordinator.complete(token),
+                    PendingRelease::Cancel => coordinator.cancel(token),
+                    PendingRelease::Release => coordinator.release(token),
+                };
+            }
+        }
+    }
+
+    pub(crate) fn cancel_all_transactions(&mut self) {
+        let coordinated: Vec<_> = self
+            .pending
+            .drain()
+            .filter_map(|(_, pending)| match pending.lease {
+                PendingLease::Legacy => None,
+                PendingLease::Coordinated(token) => Some(token),
+            })
+            .collect();
+        self.allocators.clear();
+        if let Some(coordinator) = self.coordinator.as_ref() {
+            for token in coordinated {
+                let _ = coordinator.cancel(token);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn coordinated_active_count(&self) -> usize {
+        self.coordinator
+            .as_ref()
+            .and_then(|coordinator| coordinator.active_count().ok())
+            .unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn coordinated_token(&self, mac: &[u8], invoke_id: u8) -> Option<LeaseToken> {
+        let pending = self.pending.get(&(MacAddr::from_slice(mac), invoke_id))?;
+        match pending.lease {
+            PendingLease::Legacy => None,
+            PendingLease::Coordinated(token) => Some(token),
+        }
+    }
+}
+
+impl Drop for Tsm {
+    fn drop(&mut self) {
+        let Some(coordinator) = self.coordinator.as_ref() else {
+            return;
+        };
+        for (_, pending) in self.pending.drain() {
+            if let PendingLease::Coordinated(token) = pending.lease {
+                let _ = coordinator.release(token);
+            }
+        }
+    }
+}

--- a/crates/bacnet-client/src/tsm/coordinated_tests.rs
+++ b/crates/bacnet-client/src/tsm/coordinated_tests.rs
@@ -1,0 +1,437 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use bacnet_encoding::apdu::{AbortPdu, Apdu, ComplexAck, SegmentAck, SimpleAck};
+use bacnet_endpoint_core::coordinator::{
+    CanonicalPeer, OutboundTransactionCoordinator, ReserveError,
+};
+use bacnet_types::enums::{AbortReason, ConfirmedServiceChoice};
+use bytes::Bytes;
+
+use super::coordinated::CoordinatedRegistrationError;
+use super::*;
+
+fn coordinated_tsm() -> (Tsm, Arc<OutboundTransactionCoordinator>) {
+    let coordinator = Arc::new(OutboundTransactionCoordinator::new());
+    (
+        Tsm::new_coordinated(TsmConfig::default(), Arc::clone(&coordinator)),
+        coordinator,
+    )
+}
+
+fn register(
+    tsm: &mut Tsm,
+    mac: &[u8],
+    peer: CanonicalPeer,
+    service: ConfirmedServiceChoice,
+    segmented: bool,
+) -> (u8, TransactionRegistration) {
+    tsm.register_coordinated_transaction_with_progress(
+        MacAddr::from_slice(mac),
+        peer,
+        service,
+        segmented,
+    )
+    .unwrap()
+}
+
+fn complete_phase_gated(
+    tsm: &mut Tsm,
+    mac: &[u8],
+    peer: &CanonicalPeer,
+    apdu: &Apdu,
+    response: TsmResponse,
+) -> CoordinatedCompletion {
+    let invoke_id = match apdu {
+        Apdu::SimpleAck(pdu) => pdu.invoke_id,
+        Apdu::ComplexAck(pdu) => pdu.invoke_id,
+        _ => panic!("test helper requires an acknowledgment"),
+    };
+    let owner = match tsm.admit_terminal_response(mac, invoke_id, None) {
+        TerminalResponseAdmission::Active(owner) => owner,
+        other => panic!("unexpected local admission: {other:?}"),
+    };
+    tsm.complete_coordinated_terminal_response(mac, invoke_id, Some(&owner), peer, apdu, response)
+}
+
+#[test]
+fn global_capacity_spans_direct_and_routed_peers_and_reuses_exactly() {
+    let (mut tsm, coordinator) = coordinated_tsm();
+    let mut registrations = Vec::new();
+    let mut invoke_ids = HashSet::new();
+
+    for index in 0..256u16 {
+        let mac = index.to_be_bytes().to_vec();
+        let peer = if index % 2 == 0 {
+            CanonicalPeer::direct(&mac)
+        } else {
+            CanonicalPeer::routed(index, &mac)
+        };
+        let (invoke_id, registration) = register(
+            &mut tsm,
+            &mac,
+            peer,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            false,
+        );
+        assert!(invoke_ids.insert(invoke_id));
+        registrations.push((mac, registration));
+    }
+    assert_eq!(invoke_ids.len(), 256);
+    assert_eq!(coordinator.active_count().unwrap(), 256);
+
+    let exhausted = match tsm.register_coordinated_transaction_with_progress(
+        MacAddr::from_slice(&[0xFE]),
+        CanonicalPeer::direct(&[0xFE]),
+        ConfirmedServiceChoice::READ_PROPERTY,
+        false,
+    ) {
+        Ok(_) => panic!("the 257th coordinated registration must fail"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        exhausted,
+        CoordinatedRegistrationError::Reserve(ReserveError::Exhausted)
+    );
+
+    let (first_mac, first) = &registrations[0];
+    let first_token = tsm.coordinated_token(first_mac, 0).unwrap();
+    let stale_owner = first.owner.clone();
+    assert!(tsm.cancel_transaction_for_owner(first_mac, 0, &stale_owner));
+    assert_eq!(coordinator.active_count().unwrap(), 255);
+
+    let (replacement_id, replacement) = register(
+        &mut tsm,
+        first_mac,
+        CanonicalPeer::direct(first_mac),
+        ConfirmedServiceChoice::READ_PROPERTY,
+        false,
+    );
+    assert_eq!(replacement_id, 0);
+    let replacement_token = tsm.coordinated_token(first_mac, replacement_id).unwrap();
+    assert_ne!(replacement_token, first_token);
+    assert!(!tsm.cancel_transaction_for_owner(first_mac, replacement_id, &stale_owner));
+    assert_eq!(coordinator.active_count().unwrap(), 256);
+    assert!(tsm.owner_is_current(first_mac, replacement_id, &replacement.owner));
+
+    tsm.cancel_all_transactions();
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+}
+
+#[test]
+fn retries_retain_the_same_token_and_active_count() {
+    let (mut tsm, coordinator) = coordinated_tsm();
+    let mac = [1, 2, 3];
+    let (invoke_id, registration) = register(
+        &mut tsm,
+        &mac,
+        CanonicalPeer::direct(&mac),
+        ConfirmedServiceChoice::READ_PROPERTY,
+        false,
+    );
+    let token = tsm.coordinated_token(&mac, invoke_id).unwrap();
+
+    for _ in 0..8 {
+        assert_eq!(
+            tsm.expire_request_timer(&mac, invoke_id, &registration.owner, false),
+            RequestTimerExpiration::Retry
+        );
+        assert_eq!(tsm.coordinated_token(&mac, invoke_id), Some(token));
+        assert_eq!(coordinator.active_count().unwrap(), 1);
+    }
+
+    assert_eq!(
+        tsm.expire_request_timer(&mac, invoke_id, &registration.owner, true),
+        RequestTimerExpiration::TimedOut
+    );
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn either_ack_completes_simple_and_complex_once() {
+    for complex in [false, true] {
+        let (mut tsm, coordinator) = coordinated_tsm();
+        let mac = [4, u8::from(complex)];
+        let peer = CanonicalPeer::direct(&mac);
+        let (invoke_id, registration) = register(
+            &mut tsm,
+            &mac,
+            peer.clone(),
+            ConfirmedServiceChoice::READ_PROPERTY,
+            false,
+        );
+        let (apdu, response) = if complex {
+            (
+                Apdu::ComplexAck(ComplexAck {
+                    segmented: false,
+                    more_follows: false,
+                    invoke_id,
+                    sequence_number: None,
+                    proposed_window_size: None,
+                    service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+                    service_ack: Bytes::from_static(b"ok"),
+                }),
+                TsmResponse::ComplexAck {
+                    service_data: Bytes::from_static(b"ok"),
+                },
+            )
+        } else {
+            (
+                Apdu::SimpleAck(SimpleAck {
+                    invoke_id,
+                    service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+                }),
+                TsmResponse::SimpleAck,
+            )
+        };
+
+        assert_eq!(
+            complete_phase_gated(&mut tsm, &mac, &peer, &apdu, response),
+            CoordinatedCompletion::Completed(CompletionOutcome::Delivered)
+        );
+        assert_eq!(coordinator.active_count().unwrap(), 0);
+        assert!(registration.response.await.is_ok());
+        assert_eq!(
+            tsm.complete_coordinated_terminal_response(
+                &mac,
+                invoke_id,
+                None,
+                &peer,
+                &apdu,
+                TsmResponse::SimpleAck,
+            ),
+            CoordinatedCompletion::Rejected
+        );
+    }
+}
+
+#[test]
+fn hostile_terminal_mismatches_leave_the_transaction_active() {
+    let (mut tsm, coordinator) = coordinated_tsm();
+    let mac = [7];
+    let peer = CanonicalPeer::direct(&mac);
+    let (invoke_id, registration) = register(
+        &mut tsm,
+        &mac,
+        peer.clone(),
+        ConfirmedServiceChoice::READ_PROPERTY,
+        false,
+    );
+    let owner = registration.owner.clone();
+
+    let wrong_service = Apdu::SimpleAck(SimpleAck {
+        invoke_id,
+        service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+    });
+    assert!(matches!(
+        tsm.complete_coordinated_terminal_response(
+            &mac,
+            invoke_id,
+            Some(&owner),
+            &peer,
+            &wrong_service,
+            TsmResponse::SimpleAck,
+        ),
+        CoordinatedCompletion::ServiceChoiceMismatch { .. }
+    ));
+
+    let matching = Apdu::SimpleAck(SimpleAck {
+        invoke_id,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+    });
+    assert_eq!(
+        tsm.complete_coordinated_terminal_response(
+            &mac,
+            invoke_id,
+            Some(&owner),
+            &CanonicalPeer::direct(&[8]),
+            &matching,
+            TsmResponse::SimpleAck,
+        ),
+        CoordinatedCompletion::Rejected
+    );
+    let wrong_direction = Apdu::Abort(AbortPdu {
+        sent_by_server: false,
+        invoke_id,
+        abort_reason: AbortReason::OTHER,
+    });
+    assert_eq!(
+        tsm.complete_coordinated_terminal_response(
+            &mac,
+            invoke_id,
+            Some(&owner),
+            &peer,
+            &wrong_direction,
+            TsmResponse::Abort {
+                reason: AbortReason::OTHER.to_raw(),
+            },
+        ),
+        CoordinatedCompletion::Rejected
+    );
+    assert_eq!(
+        tsm.complete_coordinated_terminal_response(
+            &[9],
+            invoke_id.wrapping_add(1),
+            None,
+            &peer,
+            &matching,
+            TsmResponse::SimpleAck,
+        ),
+        CoordinatedCompletion::Rejected
+    );
+    assert_eq!(tsm.pending_count(), 1);
+    assert_eq!(coordinator.active_count().unwrap(), 1);
+    assert!(tsm.cancel_transaction_for_owner(&mac, invoke_id, &owner));
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+}
+
+#[test]
+fn segmented_progress_is_nonterminal_until_valid_reassembly() {
+    let (mut tsm, coordinator) = coordinated_tsm();
+    let mac = [10];
+    let peer = CanonicalPeer::direct(&mac);
+    let (invoke_id, registration) = register(
+        &mut tsm,
+        &mac,
+        peer.clone(),
+        ConfirmedServiceChoice::READ_PROPERTY,
+        true,
+    );
+    let segment_ack = Apdu::SegmentAck(SegmentAck {
+        negative_ack: false,
+        sent_by_server: true,
+        invoke_id,
+        sequence_number: 0,
+        actual_window_size: 1,
+    });
+    assert!(matches!(
+        tsm.coordinated_segment_ack_phase(
+            &mac,
+            invoke_id,
+            &CanonicalPeer::direct(&[11]),
+            &segment_ack,
+        ),
+        SegmentAckPhase::CoordinatorRejected
+    ));
+    assert!(matches!(
+        tsm.segment_ack_phase(&mac, invoke_id),
+        SegmentAckPhase::SegmentedRequest(ref owner) if owner.same_as(&registration.owner)
+    ));
+    assert!(matches!(
+        tsm.coordinated_segment_ack_phase(&mac, invoke_id, &peer, &segment_ack),
+        SegmentAckPhase::SegmentedRequest(ref owner) if owner.same_as(&registration.owner)
+    ));
+    assert_eq!(coordinator.active_count().unwrap(), 1);
+
+    let mut final_issue = tsm
+        .begin_final_segment_send(&mac, invoke_id, &registration.owner)
+        .unwrap();
+    assert!(tsm.mark_final_segment_issued(&mac, invoke_id, &registration.owner, &mut final_issue,));
+    assert!(tsm.finish_segmented_request(&mac, invoke_id, &registration.owner));
+
+    let first = Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows: true,
+        invoke_id,
+        sequence_number: Some(0),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(b"a"),
+    });
+    assert!(matches!(
+        tsm.coordinated_admit_segmented_complex_ack(
+            &mac,
+            invoke_id,
+            0,
+            true,
+            &CanonicalPeer::direct(&[11]),
+            &first,
+        ),
+        SegmentedResponseAdmission::CoordinatorRejected
+    ));
+    assert!(matches!(
+        tsm.segment_ack_phase(&mac, invoke_id),
+        SegmentAckPhase::Outstanding
+    ));
+    assert_eq!(coordinator.active_count().unwrap(), 1);
+    assert!(matches!(
+        tsm.coordinated_admit_segmented_complex_ack(
+            &mac, invoke_id, 0, true, &peer, &first,
+        ),
+        SegmentedResponseAdmission::Active(ref owner) if owner.same_as(&registration.owner)
+    ));
+    assert_eq!(coordinator.active_count().unwrap(), 1);
+    tsm.begin_segmented_response(&mac, invoke_id, &registration.owner)
+        .unwrap();
+
+    let final_segment = Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows: false,
+        invoke_id,
+        sequence_number: Some(1),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(b"b"),
+    });
+    assert!(matches!(
+        tsm.coordinated_admit_segmented_complex_ack_for_owner(
+            &mac,
+            invoke_id,
+            1,
+            true,
+            &registration.owner,
+            &peer,
+            &final_segment,
+        ),
+        SegmentedResponseAdmission::Active(_)
+    ));
+    assert_eq!(coordinator.active_count().unwrap(), 1);
+    assert_eq!(
+        tsm.complete_admitted_transaction_for_owner(
+            &mac,
+            invoke_id,
+            &registration.owner,
+            Some(ConfirmedServiceChoice::WRITE_PROPERTY),
+            TsmResponse::ComplexAck {
+                service_data: Bytes::from_static(b"wrong"),
+            },
+        ),
+        CompletionOutcome::ServiceChoiceMismatch {
+            expected: ConfirmedServiceChoice::READ_PROPERTY,
+            observed: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }
+    );
+    assert_eq!(coordinator.active_count().unwrap(), 1);
+    assert_eq!(
+        tsm.complete_admitted_transaction_for_owner(
+            &mac,
+            invoke_id,
+            &registration.owner,
+            Some(ConfirmedServiceChoice::READ_PROPERTY),
+            TsmResponse::ComplexAck {
+                service_data: Bytes::from_static(b"ab"),
+            },
+        ),
+        CompletionOutcome::Delivered
+    );
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+}
+
+#[test]
+fn drop_releases_every_coordinated_lease() {
+    let coordinator = Arc::new(OutboundTransactionCoordinator::new());
+    {
+        let mut tsm = Tsm::new_coordinated(TsmConfig::default(), Arc::clone(&coordinator));
+        for mac in [[1], [2], [3]] {
+            register(
+                &mut tsm,
+                &mac,
+                CanonicalPeer::direct(&mac),
+                ConfirmedServiceChoice::READ_PROPERTY,
+                false,
+            );
+        }
+        assert_eq!(coordinator.active_count().unwrap(), 3);
+    }
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+}

--- a/crates/bacnet-client/src/tsm/segmented_response.rs
+++ b/crates/bacnet-client/src/tsm/segmented_response.rs
@@ -13,6 +13,7 @@ pub(crate) enum SegmentedResponseAdmission {
     InitialResponseAborted {
         wire_reason: AbortReason,
     },
+    CoordinatorRejected,
     NoTransaction,
 }
 


### PR DESCRIPTION
## Summary

- make standalone client confirmed requests use the endpoint-core coordinator for device-wide invoke-ID leasing
- store exact coordinator tokens with pending TSM transactions while preserving legacy public TSM behavior
- gate terminal and segmented response admission through canonical direct/routed peer identity
- retain the same lease across retries, segmentation, and reassembly
- release exact leases on completion, timeout, cancellation, send failure, stop, or drop

## Scope

This is the client requester-adapter continuation of the shared endpoint work in #431. Existing `BACnetClient<T>` APIs and standalone network ownership remain unchanged. Server-notification adaptation, shared ingress composition, public combined-device APIs, B/IP composition, and MS/TP proof remain deferred.

Endpoint-core is not yet present on crates.io, so client package/publish dry-runs are intentionally deferred to the tag release that now publishes endpoint-core before client. Workspace, feature, and repository gates are green.

## Verification

- `cargo test -p bacnet-endpoint-core --locked`
- `cargo test -p bacnet-client --locked`
- `cargo test -p bacnet-client tsm --locked`
- `cargo test -p bacnet-client lifecycle --locked`
- `cargo test -p bacnet-client response_correlation --locked`
- `cargo test -p bacnet-client segmented --locked`
- `cargo test -p bacnet-client --features sc-tls --locked`
- `cargo test -p bacnet-client --features ipv6 --locked`
- `cargo test -p bacnet-server server_tsm --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

Refs #431