### PR TITLE
feat(endpoint): add shared loopback runtime seam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
 name = "bacnet-server"
 version = "0.10.1"
 dependencies = [
+ "bacnet-client",
  "bacnet-encoding",
  "bacnet-endpoint-core",
  "bacnet-network",

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -51,13 +51,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 
         let network = Arc::new(network);
 
-        let tsm_config = TsmConfig {
-            apdu_timeout_ms: config.apdu_timeout_ms,
-            apdu_segment_timeout_ms: config.apdu_timeout_ms,
-            apdu_retries: config.apdu_retries,
-        };
         let coordinator = Arc::new(OutboundTransactionCoordinator::new());
-        let tsm = Arc::new(Mutex::new(Tsm::new_coordinated(tsm_config, coordinator)));
+        let tsm = Arc::new(Mutex::new(new_coordinated_tsm(&config, coordinator)));
         let tsm_dispatch = Arc::clone(&tsm);
         let device_table = Arc::new(Mutex::new(DeviceTable::new()));
         let device_table_dispatch = Arc::clone(&device_table);

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -144,6 +144,30 @@ impl Default for ClientOptions {
     }
 }
 
+pub(crate) fn new_coordinated_tsm(
+    config: &ClientConfig,
+    coordinator: Arc<OutboundTransactionCoordinator>,
+) -> Tsm {
+    Tsm::new_coordinated(
+        TsmConfig {
+            apdu_timeout_ms: config.apdu_timeout_ms,
+            apdu_segment_timeout_ms: config.apdu_timeout_ms,
+            apdu_retries: config.apdu_retries,
+        },
+        coordinator,
+    )
+}
+
+pub(crate) fn confirmed_response_result(response: TsmResponse) -> Result<Bytes, Error> {
+    match response {
+        TsmResponse::SimpleAck => Ok(Bytes::new()),
+        TsmResponse::ComplexAck { service_data } => Ok(service_data),
+        TsmResponse::Error { class, code } => Err(Error::Protocol { class, code }),
+        TsmResponse::Reject { reason } => Err(Error::Reject { reason }),
+        TsmResponse::Abort { reason } => Err(Error::Abort { reason }),
+    }
+}
+
 impl ClientOptions {
     /// Set the COV notification broadcast channel capacity.
     pub fn with_cov_channel_capacity(mut self, capacity: usize) -> Self {

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -499,13 +499,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     }
 
     pub(super) fn confirmed_response_result(response: TsmResponse) -> Result<Bytes, Error> {
-        match response {
-            TsmResponse::SimpleAck => Ok(Bytes::new()),
-            TsmResponse::ComplexAck { service_data } => Ok(service_data),
-            TsmResponse::Error { class, code } => Err(Error::Protocol { class, code }),
-            TsmResponse::Reject { reason } => Err(Error::Reject { reason }),
-            TsmResponse::Abort { reason } => Err(Error::Abort { reason }),
-        }
+        super::confirmed_response_result(response)
     }
 
     pub(super) async fn send_confirmed_target_apdu(

--- a/crates/bacnet-client/src/endpoint_requester.rs
+++ b/crates/bacnet-client/src/endpoint_requester.rs
@@ -3,15 +3,17 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use bacnet_encoding::apdu::{
-    encode_apdu, validate_max_apdu_length, Apdu, ConfirmedRequest as ConfirmedRequestPdu,
+    encode_apdu, validate_max_apdu_length, AbortPdu, Apdu, ConfirmedRequest as ConfirmedRequestPdu,
 };
 use bacnet_endpoint_core::coordinator::{
-    Admission, CanonicalPeer, OutboundTransactionCoordinator, TerminalPolicy,
+    Admission, AdmissionKind, CanonicalPeer, OutboundTransactionCoordinator, TerminalPolicy,
 };
 use bacnet_endpoint_core::endpoint_ingress::EndpointEgress;
 use bacnet_network::layer::ReceivedApdu;
 use bacnet_services::read_property::{ReadPropertyACK, ReadPropertyRequest};
-use bacnet_types::enums::{ConfirmedServiceChoice, NetworkPriority, PropertyIdentifier};
+use bacnet_types::enums::{
+    AbortReason, ConfirmedServiceChoice, NetworkPriority, PropertyIdentifier,
+};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bacnet_types::MacAddr;
@@ -179,9 +181,9 @@ impl EndpointRequester {
         unreachable!("the inclusive retry loop always returns")
     }
 
-    /// Delivers a terminal already admitted by the shared coordinator.
+    /// Handles a response already admitted by the shared coordinator.
     #[doc(hidden)]
-    pub fn complete_pre_admitted(
+    pub async fn complete_pre_admitted(
         &self,
         admission: Admission,
         apdu: Apdu,
@@ -190,41 +192,76 @@ impl EndpointRequester {
         if !self.inner.open.load(Ordering::Acquire) || received.source_network.is_some() {
             return false;
         }
-        let response = match &apdu {
-            Apdu::SimpleAck(_) => TsmResponse::SimpleAck,
-            Apdu::ComplexAck(ack) if !ack.segmented => TsmResponse::ComplexAck {
-                service_data: ack.service_ack.clone(),
-            },
-            Apdu::Error(error) => TsmResponse::Error {
-                class: error.error_class.to_raw() as u32,
-                code: error.error_code.to_raw() as u32,
-            },
-            Apdu::Reject(reject) => TsmResponse::Reject {
-                reason: reject.reject_reason.to_raw(),
-            },
-            Apdu::Abort(abort) => TsmResponse::Abort {
-                reason: abort.abort_reason.to_raw(),
-            },
-            Apdu::SegmentAck(_)
-            | Apdu::ConfirmedRequest(_)
-            | Apdu::UnconfirmedRequest(_)
-            | Apdu::ComplexAck(_) => return false,
-        };
+        match admission.kind() {
+            AdmissionKind::Terminal => {
+                let response = match &apdu {
+                    Apdu::SimpleAck(_) => TsmResponse::SimpleAck,
+                    Apdu::ComplexAck(ack) if !ack.segmented => TsmResponse::ComplexAck {
+                        service_data: ack.service_ack.clone(),
+                    },
+                    Apdu::Error(error) => TsmResponse::Error {
+                        class: error.error_class.to_raw() as u32,
+                        code: error.error_code.to_raw() as u32,
+                    },
+                    Apdu::Reject(reject) => TsmResponse::Reject {
+                        reason: reject.reject_reason.to_raw(),
+                    },
+                    Apdu::Abort(abort) => TsmResponse::Abort {
+                        reason: abort.abort_reason.to_raw(),
+                    },
+                    Apdu::SegmentAck(_)
+                    | Apdu::ConfirmedRequest(_)
+                    | Apdu::UnconfirmedRequest(_)
+                    | Apdu::ComplexAck(_) => return false,
+                };
+                let completion = self.inner.tsm.lock().ok().map(|mut tsm| {
+                    tsm.complete_pre_admitted_terminal_response(
+                        &received.source_mac,
+                        &admission,
+                        &apdu,
+                        response,
+                    )
+                });
+                matches!(
+                    completion,
+                    Some(CoordinatedCompletion::Completed(
+                        CompletionOutcome::Delivered
+                    ))
+                )
+            }
+            AdmissionKind::NonTerminal => {
+                let rejected = self.inner.tsm.lock().is_ok_and(|mut tsm| {
+                    tsm.reject_pre_admitted_segmented_response(
+                        &received.source_mac,
+                        &admission,
+                        &apdu,
+                    )
+                });
+                if !rejected {
+                    return false;
+                }
 
-        let completion = self.inner.tsm.lock().ok().map(|mut tsm| {
-            tsm.complete_pre_admitted_terminal_response(
-                &received.source_mac,
-                &admission,
-                &apdu,
-                response,
-            )
-        });
-        matches!(
-            completion,
-            Some(CoordinatedCompletion::Completed(
-                CompletionOutcome::Delivered
-            ))
-        )
+                let abort = Apdu::Abort(AbortPdu {
+                    sent_by_server: false,
+                    invoke_id: admission.token().invoke_id(),
+                    abort_reason: AbortReason::SEGMENTATION_NOT_SUPPORTED,
+                });
+                let mut encoded = BytesMut::new();
+                if encode_apdu(&mut encoded, &abort).is_err() {
+                    return false;
+                }
+                self.inner
+                    .egress
+                    .send_direct(
+                        encoded.to_vec(),
+                        received.source_mac,
+                        false,
+                        NetworkPriority::NORMAL,
+                    )
+                    .await
+                    .is_ok()
+            }
+        }
     }
 
     /// Cancels exact pending leases and rejects later requester work.

--- a/crates/bacnet-client/src/endpoint_requester.rs
+++ b/crates/bacnet-client/src/endpoint_requester.rs
@@ -1,0 +1,263 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use bacnet_encoding::apdu::{
+    encode_apdu, validate_max_apdu_length, Apdu, ConfirmedRequest as ConfirmedRequestPdu,
+};
+use bacnet_endpoint_core::coordinator::{
+    Admission, CanonicalPeer, OutboundTransactionCoordinator, TerminalPolicy,
+};
+use bacnet_endpoint_core::endpoint_ingress::EndpointEgress;
+use bacnet_network::layer::ReceivedApdu;
+use bacnet_services::read_property::{ReadPropertyACK, ReadPropertyRequest};
+use bacnet_types::enums::{ConfirmedServiceChoice, NetworkPriority, PropertyIdentifier};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+use bytes::BytesMut;
+
+use crate::client::{confirmed_response_result, new_coordinated_tsm, ClientConfig};
+use crate::tsm::{CompletionOutcome, CoordinatedCompletion, TransactionOwner, Tsm, TsmResponse};
+
+fn shutdown_error() -> Error {
+    Error::Encoding("endpoint shutdown".into())
+}
+
+struct EndpointRequesterInner {
+    egress: EndpointEgress,
+    tsm: Mutex<Tsm>,
+    open: AtomicBool,
+    timeout: Duration,
+    retries: u8,
+    max_apdu_length: u16,
+}
+
+impl Drop for EndpointRequesterInner {
+    fn drop(&mut self) {
+        self.open.store(false, Ordering::Release);
+        if let Ok(tsm) = self.tsm.get_mut() {
+            tsm.cancel_all_transactions();
+        }
+    }
+}
+
+/// Direct, unsegmented ReadProperty requester attached to a shared endpoint.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct EndpointRequester {
+    inner: Arc<EndpointRequesterInner>,
+}
+
+impl EndpointRequester {
+    /// Attaches requester state to endpoint egress and a device-wide coordinator.
+    #[doc(hidden)]
+    pub fn new(
+        egress: EndpointEgress,
+        coordinator: Arc<OutboundTransactionCoordinator>,
+        config: ClientConfig,
+    ) -> Result<Self, Error> {
+        validate_max_apdu_length(config.max_apdu_length)?;
+        let timeout = Duration::from_millis(config.apdu_timeout_ms);
+        let retries = config.apdu_retries;
+        let max_apdu_length = config.max_apdu_length;
+        let tsm = new_coordinated_tsm(&config, coordinator);
+        Ok(Self {
+            inner: Arc::new(EndpointRequesterInner {
+                egress,
+                tsm: Mutex::new(tsm),
+                open: AtomicBool::new(true),
+                timeout,
+                retries,
+                max_apdu_length,
+            }),
+        })
+    }
+
+    /// Performs one direct ReadProperty transaction.
+    #[doc(hidden)]
+    pub async fn read_property(
+        &self,
+        destination_mac: &[u8],
+        object_identifier: ObjectIdentifier,
+        property_identifier: PropertyIdentifier,
+        property_array_index: Option<u32>,
+    ) -> Result<ReadPropertyACK, Error> {
+        if !self.inner.open.load(Ordering::Acquire) {
+            return Err(shutdown_error());
+        }
+
+        let request = ReadPropertyRequest {
+            object_identifier,
+            property_identifier,
+            property_array_index,
+        };
+        let mut service_data = BytesMut::new();
+        request.encode(&mut service_data);
+        if 4 + service_data.len() > usize::from(self.inner.max_apdu_length) {
+            return Err(Error::Segmentation(
+                "endpoint requester supports only unsegmented ReadProperty".into(),
+            ));
+        }
+
+        let destination = MacAddr::from_slice(destination_mac);
+        let (invoke_id, registration) = {
+            let mut tsm = self
+                .inner
+                .tsm
+                .lock()
+                .map_err(|_| Error::Encoding("endpoint requester state is poisoned".into()))?;
+            if !self.inner.open.load(Ordering::Acquire) {
+                return Err(shutdown_error());
+            }
+            tsm.register_coordinated_transaction_with_policy(
+                destination.clone(),
+                CanonicalPeer::direct(destination_mac),
+                ConfirmedServiceChoice::READ_PROPERTY,
+                false,
+                TerminalPolicy::ComplexAck,
+            )
+            .map_err(|error| Error::Encoding(error.to_string()))?
+        };
+
+        let owner = registration.owner.clone();
+        let mut guard = EndpointRequestGuard {
+            inner: Arc::clone(&self.inner),
+            destination: destination.clone(),
+            invoke_id,
+            owner,
+            active: true,
+        };
+        let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+            segmented: false,
+            more_follows: false,
+            segmented_response_accepted: false,
+            max_segments: None,
+            max_apdu_length: self.inner.max_apdu_length,
+            invoke_id,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+            service_request: service_data.freeze(),
+        });
+        let mut encoded = BytesMut::new();
+        encode_apdu(&mut encoded, &pdu)?;
+        let encoded = encoded.to_vec();
+        let mut response = registration.response;
+
+        for attempt in 0..=self.inner.retries {
+            if !self.inner.open.load(Ordering::Acquire) {
+                return Err(shutdown_error());
+            }
+            self.inner
+                .egress
+                .send_direct(
+                    encoded.clone(),
+                    destination.clone(),
+                    true,
+                    NetworkPriority::NORMAL,
+                )
+                .await?;
+
+            match tokio::time::timeout(self.inner.timeout, &mut response).await {
+                Ok(Ok(response)) => {
+                    guard.active = false;
+                    let service_data = confirmed_response_result(response)?;
+                    return ReadPropertyACK::decode(&service_data);
+                }
+                Ok(Err(_)) if !self.inner.open.load(Ordering::Acquire) => {
+                    return Err(shutdown_error());
+                }
+                Ok(Err(_)) => {
+                    return Err(Error::Encoding("TSM response channel closed".into()));
+                }
+                Err(_) if attempt < self.inner.retries => {}
+                Err(_) => return Err(Error::Timeout(self.inner.timeout)),
+            }
+        }
+
+        unreachable!("the inclusive retry loop always returns")
+    }
+
+    /// Delivers a terminal already admitted by the shared coordinator.
+    #[doc(hidden)]
+    pub fn complete_pre_admitted(
+        &self,
+        admission: Admission,
+        apdu: Apdu,
+        received: ReceivedApdu,
+    ) -> bool {
+        if !self.inner.open.load(Ordering::Acquire) || received.source_network.is_some() {
+            return false;
+        }
+        let response = match &apdu {
+            Apdu::SimpleAck(_) => TsmResponse::SimpleAck,
+            Apdu::ComplexAck(ack) if !ack.segmented => TsmResponse::ComplexAck {
+                service_data: ack.service_ack.clone(),
+            },
+            Apdu::Error(error) => TsmResponse::Error {
+                class: error.error_class.to_raw() as u32,
+                code: error.error_code.to_raw() as u32,
+            },
+            Apdu::Reject(reject) => TsmResponse::Reject {
+                reason: reject.reject_reason.to_raw(),
+            },
+            Apdu::Abort(abort) => TsmResponse::Abort {
+                reason: abort.abort_reason.to_raw(),
+            },
+            Apdu::SegmentAck(_)
+            | Apdu::ConfirmedRequest(_)
+            | Apdu::UnconfirmedRequest(_)
+            | Apdu::ComplexAck(_) => return false,
+        };
+
+        let completion = self.inner.tsm.lock().ok().map(|mut tsm| {
+            tsm.complete_pre_admitted_terminal_response(
+                &received.source_mac,
+                &admission,
+                &apdu,
+                response,
+            )
+        });
+        matches!(
+            completion,
+            Some(CoordinatedCompletion::Completed(
+                CompletionOutcome::Delivered
+            ))
+        )
+    }
+
+    /// Cancels exact pending leases and rejects later requester work.
+    #[doc(hidden)]
+    pub fn close(&self) {
+        if !self.inner.open.swap(false, Ordering::AcqRel) {
+            return;
+        }
+        if let Ok(mut tsm) = self.inner.tsm.lock() {
+            tsm.cancel_all_transactions();
+        }
+    }
+}
+
+struct EndpointRequestGuard {
+    inner: Arc<EndpointRequesterInner>,
+    destination: MacAddr,
+    invoke_id: u8,
+    owner: TransactionOwner,
+    active: bool,
+}
+
+impl Drop for EndpointRequestGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        if let Ok(mut tsm) = self.inner.tsm.lock() {
+            tsm.cancel_transaction_for_owner(&self.destination, self.invoke_id, &self.owner);
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "endpoint_requester_tests.rs"]
+mod tests;

--- a/crates/bacnet-client/src/endpoint_requester_tests.rs
+++ b/crates/bacnet-client/src/endpoint_requester_tests.rs
@@ -1,0 +1,188 @@
+use std::sync::Arc;
+
+use bacnet_encoding::apdu::{
+    decode_apdu, encode_apdu, Apdu, ComplexAck, SegmentAck as SegmentAckPdu,
+};
+use bacnet_encoding::primitives::encode_property_value;
+use bacnet_endpoint_core::coordinator::{
+    AdmissionOutcome, CanonicalPeer, LeaseOwner, OutboundTransactionCoordinator,
+};
+use bacnet_endpoint_core::endpoint_ingress::EndpointIngress;
+use bacnet_network::layer::{NetworkLayer, ReceivedApdu};
+use bacnet_services::read_property::ReadPropertyACK;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_types::enums::{ConfirmedServiceChoice, ObjectType, PropertyIdentifier};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+use bacnet_types::MacAddr;
+use bytes::{Bytes, BytesMut};
+use tokio::time::{timeout, Duration};
+
+use super::*;
+
+const WAIT: Duration = Duration::from_secs(1);
+
+fn config() -> ClientConfig {
+    ClientConfig {
+        apdu_timeout_ms: 1_000,
+        apdu_retries: 0,
+        max_apdu_length: 480,
+        ..ClientConfig::default()
+    }
+}
+
+fn object_identifier() -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap()
+}
+
+fn encoded_ack(invoke_id: u8, property_value: PropertyValue) -> (Apdu, Bytes) {
+    let mut value = BytesMut::new();
+    encode_property_value(&mut value, &property_value).unwrap();
+    let ack = ReadPropertyACK {
+        object_identifier: object_identifier(),
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+        property_value: value.to_vec(),
+    };
+    let mut service_ack = BytesMut::new();
+    ack.encode(&mut service_ack);
+    let apdu = Apdu::ComplexAck(ComplexAck {
+        segmented: false,
+        more_follows: false,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: service_ack.freeze(),
+    });
+    let mut encoded = BytesMut::new();
+    encode_apdu(&mut encoded, &apdu).unwrap();
+    (apdu, encoded.freeze())
+}
+
+fn received(apdu: Bytes, source: &[u8]) -> ReceivedApdu {
+    ReceivedApdu {
+        apdu,
+        source_mac: MacAddr::from_slice(source),
+        source_network: None,
+        is_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
+#[tokio::test]
+async fn pre_admitted_completion_checks_role_token_owner_peer_and_service_without_readmitting() {
+    let (endpoint_transport, peer_transport) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let mut endpoint = EndpointIngress::new(endpoint_transport, 4);
+    let ingress = endpoint.start().await.unwrap();
+    let mut peer = NetworkLayer::new(peer_transport);
+    let mut peer_rx = peer.start().await.unwrap();
+    let coordinator = Arc::new(OutboundTransactionCoordinator::new());
+    let requester =
+        EndpointRequester::new(ingress.egress.clone(), Arc::clone(&coordinator), config()).unwrap();
+
+    let request_handle = {
+        let requester = requester.clone();
+        tokio::spawn(async move {
+            requester
+                .read_property(
+                    &[0x02],
+                    object_identifier(),
+                    PropertyIdentifier::PRESENT_VALUE,
+                    None,
+                )
+                .await
+        })
+    };
+    let request = timeout(WAIT, peer_rx.recv()).await.unwrap().unwrap();
+    let invoke_id = match decode_apdu(request.apdu).unwrap() {
+        Apdu::ConfirmedRequest(request) => request.invoke_id,
+        other => panic!("expected confirmed request, got {other:?}"),
+    };
+    assert_eq!(invoke_id, 0);
+
+    let (ack, ack_bytes) = encoded_ack(invoke_id, PropertyValue::Real(12.5));
+    let admission = match coordinator
+        .admit(&CanonicalPeer::direct(&[0x02]), &ack)
+        .unwrap()
+    {
+        AdmissionOutcome::Admitted(admission) => admission,
+        other => panic!("expected requester admission, got {other:?}"),
+    };
+    assert_eq!(admission.metadata().owner(), LeaseOwner::Requester);
+
+    let segment_ack = Apdu::SegmentAck(SegmentAckPdu {
+        negative_ack: false,
+        sent_by_server: true,
+        invoke_id,
+        sequence_number: 0,
+        actual_window_size: 1,
+    });
+    assert!(!requester.complete_pre_admitted(
+        admission.clone(),
+        segment_ack,
+        received(Bytes::from_static(&[0x40, 0x00, 0x00, 0x01]), &[0x02]),
+    ));
+    assert_eq!(coordinator.active_count().unwrap(), 1);
+
+    assert!(requester.complete_pre_admitted(admission, ack, received(ack_bytes, &[0x02]),));
+    let result = request_handle.await.unwrap().unwrap();
+    let mut expected_value = BytesMut::new();
+    encode_property_value(&mut expected_value, &PropertyValue::Real(12.5)).unwrap();
+    assert_eq!(result.property_value, expected_value.to_vec());
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+
+    requester.close();
+    endpoint.stop().await.unwrap();
+    peer.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn close_cancels_exact_pending_lease_and_rejects_future_requests() {
+    let (endpoint_transport, peer_transport) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let mut endpoint = EndpointIngress::new(endpoint_transport, 2);
+    let ingress = endpoint.start().await.unwrap();
+    let mut peer = NetworkLayer::new(peer_transport);
+    let mut peer_rx = peer.start().await.unwrap();
+    let coordinator = Arc::new(OutboundTransactionCoordinator::new());
+    let requester =
+        EndpointRequester::new(ingress.egress.clone(), Arc::clone(&coordinator), config()).unwrap();
+
+    let request_handle = {
+        let requester = requester.clone();
+        tokio::spawn(async move {
+            requester
+                .read_property(
+                    &[0x02],
+                    object_identifier(),
+                    PropertyIdentifier::PRESENT_VALUE,
+                    None,
+                )
+                .await
+        })
+    };
+    timeout(WAIT, peer_rx.recv()).await.unwrap().unwrap();
+    assert_eq!(coordinator.active_count().unwrap(), 1);
+
+    requester.close();
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+    assert!(matches!(
+        request_handle.await.unwrap(),
+        Err(Error::Encoding(message)) if message == "endpoint shutdown"
+    ));
+    assert!(matches!(
+        requester
+            .read_property(
+                &[0x02],
+                object_identifier(),
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+            )
+            .await,
+        Err(Error::Encoding(message)) if message == "endpoint shutdown"
+    ));
+
+    endpoint.stop().await.unwrap();
+    peer.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/endpoint_requester_tests.rs
+++ b/crates/bacnet-client/src/endpoint_requester_tests.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use bacnet_encoding::apdu::{
@@ -5,13 +6,15 @@ use bacnet_encoding::apdu::{
 };
 use bacnet_encoding::primitives::encode_property_value;
 use bacnet_endpoint_core::coordinator::{
-    AdmissionOutcome, CanonicalPeer, LeaseOwner, OutboundTransactionCoordinator,
+    AdmissionKind, AdmissionOutcome, CanonicalPeer, LeaseOwner, OutboundTransactionCoordinator,
 };
 use bacnet_endpoint_core::endpoint_ingress::EndpointIngress;
 use bacnet_network::layer::{NetworkLayer, ReceivedApdu};
 use bacnet_services::read_property::ReadPropertyACK;
 use bacnet_transport::loopback::LoopbackTransport;
-use bacnet_types::enums::{ConfirmedServiceChoice, ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{
+    AbortReason, ConfirmedServiceChoice, NetworkPriority, ObjectType, PropertyIdentifier,
+};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 use bacnet_types::MacAddr;
@@ -71,6 +74,12 @@ fn received(apdu: Bytes, source: &[u8]) -> ReceivedApdu {
     }
 }
 
+fn encoded_apdu(apdu: &Apdu) -> Bytes {
+    let mut encoded = BytesMut::new();
+    encode_apdu(&mut encoded, apdu).unwrap();
+    encoded.freeze()
+}
+
 #[tokio::test]
 async fn pre_admitted_completion_checks_role_token_owner_peer_and_service_without_readmitting() {
     let (endpoint_transport, peer_transport) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
@@ -119,14 +128,22 @@ async fn pre_admitted_completion_checks_role_token_owner_peer_and_service_withou
         sequence_number: 0,
         actual_window_size: 1,
     });
-    assert!(!requester.complete_pre_admitted(
-        admission.clone(),
-        segment_ack,
-        received(Bytes::from_static(&[0x40, 0x00, 0x00, 0x01]), &[0x02]),
-    ));
+    assert!(
+        !requester
+            .complete_pre_admitted(
+                admission.clone(),
+                segment_ack,
+                received(Bytes::from_static(&[0x40, 0x00, 0x00, 0x01]), &[0x02]),
+            )
+            .await
+    );
     assert_eq!(coordinator.active_count().unwrap(), 1);
 
-    assert!(requester.complete_pre_admitted(admission, ack, received(ack_bytes, &[0x02]),));
+    assert!(
+        requester
+            .complete_pre_admitted(admission, ack, received(ack_bytes, &[0x02]),)
+            .await
+    );
     let result = request_handle.await.unwrap().unwrap();
     let mut expected_value = BytesMut::new();
     encode_property_value(&mut expected_value, &PropertyValue::Real(12.5)).unwrap();
@@ -183,6 +200,162 @@ async fn close_cancels_exact_pending_lease_and_rejects_future_requests() {
         Err(Error::Encoding(message)) if message == "endpoint shutdown"
     ));
 
+    endpoint.stop().await.unwrap();
+    peer.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn pre_admitted_segmented_response_sends_one_abort_and_releases_exact_lease() {
+    let (endpoint_transport, peer_transport) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let mut endpoint = EndpointIngress::new(endpoint_transport, 4);
+    let mut ingress = endpoint.start().await.unwrap();
+    let mut peer = NetworkLayer::new(peer_transport);
+    let mut peer_rx = peer.start().await.unwrap();
+    let coordinator = Arc::new(OutboundTransactionCoordinator::new());
+    let requester =
+        EndpointRequester::new(ingress.egress.clone(), Arc::clone(&coordinator), config()).unwrap();
+
+    let request_handle = {
+        let requester = requester.clone();
+        tokio::spawn(async move {
+            requester
+                .read_property(
+                    &[0x02],
+                    object_identifier(),
+                    PropertyIdentifier::PRESENT_VALUE,
+                    None,
+                )
+                .await
+        })
+    };
+    let request = timeout(WAIT, peer_rx.recv()).await.unwrap().unwrap();
+    let invoke_id = match decode_apdu(request.apdu).unwrap() {
+        Apdu::ConfirmedRequest(request) => request.invoke_id,
+        other => panic!("expected confirmed request, got {other:?}"),
+    };
+
+    let segmented = Apdu::ComplexAck(ComplexAck {
+        segmented: true,
+        more_follows: true,
+        invoke_id,
+        sequence_number: Some(0),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_ack: Bytes::from_static(&[0xaa]),
+    });
+    peer.send_apdu(
+        &encoded_apdu(&segmented),
+        &[0x01],
+        false,
+        NetworkPriority::NORMAL,
+    )
+    .await
+    .unwrap();
+    let segmented_received = timeout(WAIT, ingress.terminal_or_segment.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let decoded = decode_apdu(segmented_received.apdu.clone()).unwrap();
+    let admit_calls = AtomicUsize::new(0);
+    admit_calls.fetch_add(1, Ordering::SeqCst);
+    let admission = match coordinator
+        .admit(&CanonicalPeer::direct(&[0x02]), &decoded)
+        .unwrap()
+    {
+        AdmissionOutcome::Admitted(admission) => admission,
+        other => panic!("expected segmented requester admission, got {other:?}"),
+    };
+    assert_eq!(admission.kind(), AdmissionKind::NonTerminal);
+
+    let wrong_sequence = match decoded.clone() {
+        Apdu::ComplexAck(mut ack) => {
+            ack.sequence_number = Some(1);
+            Apdu::ComplexAck(ack)
+        }
+        _ => unreachable!(),
+    };
+    assert!(
+        !requester
+            .complete_pre_admitted(
+                admission.clone(),
+                wrong_sequence.clone(),
+                received(encoded_apdu(&wrong_sequence), &[0x02]),
+            )
+            .await
+    );
+    let wrong_service = match decoded.clone() {
+        Apdu::ComplexAck(mut ack) => {
+            ack.service_choice = ConfirmedServiceChoice::WRITE_PROPERTY;
+            Apdu::ComplexAck(ack)
+        }
+        _ => unreachable!(),
+    };
+    assert!(
+        !requester
+            .complete_pre_admitted(
+                admission.clone(),
+                wrong_service.clone(),
+                received(encoded_apdu(&wrong_service), &[0x02]),
+            )
+            .await
+    );
+    let non_segment = Apdu::SegmentAck(SegmentAckPdu {
+        negative_ack: false,
+        sent_by_server: true,
+        invoke_id,
+        sequence_number: 0,
+        actual_window_size: 1,
+    });
+    assert!(
+        !requester
+            .complete_pre_admitted(
+                admission.clone(),
+                non_segment.clone(),
+                received(encoded_apdu(&non_segment), &[0x02]),
+            )
+            .await
+    );
+    assert_eq!(coordinator.active_count().unwrap(), 1);
+    assert!(timeout(Duration::from_millis(25), peer_rx.recv())
+        .await
+        .is_err());
+
+    assert!(
+        requester
+            .complete_pre_admitted(admission.clone(), decoded.clone(), segmented_received,)
+            .await
+    );
+    let abort = timeout(WAIT, peer_rx.recv()).await.unwrap().unwrap();
+    match decode_apdu(abort.apdu).unwrap() {
+        Apdu::Abort(abort) => {
+            assert!(!abort.sent_by_server);
+            assert_eq!(abort.invoke_id, invoke_id);
+            assert_eq!(abort.abort_reason, AbortReason::SEGMENTATION_NOT_SUPPORTED);
+        }
+        other => panic!("expected client Abort, got {other:?}"),
+    }
+    assert!(matches!(
+        request_handle.await.unwrap(),
+        Err(Error::Abort { reason })
+            if reason == AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw()
+    ));
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+    assert_eq!(admit_calls.load(Ordering::SeqCst), 1);
+
+    assert!(
+        !requester
+            .complete_pre_admitted(
+                admission,
+                decoded.clone(),
+                received(encoded_apdu(&decoded), &[0x02]),
+            )
+            .await
+    );
+    assert!(timeout(Duration::from_millis(25), peer_rx.recv())
+        .await
+        .is_err());
+
+    requester.close();
     endpoint.stop().await.unwrap();
     peer.stop().await.unwrap();
 }

--- a/crates/bacnet-client/src/lib.rs
+++ b/crates/bacnet-client/src/lib.rs
@@ -2,5 +2,9 @@
 
 pub mod client;
 pub mod discovery;
+mod endpoint_requester;
 pub mod segmentation;
 pub mod tsm;
+
+#[doc(hidden)]
+pub use endpoint_requester::EndpointRequester;

--- a/crates/bacnet-client/src/tsm/coordinated.rs
+++ b/crates/bacnet-client/src/tsm/coordinated.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use bacnet_encoding::apdu::Apdu;
 use bacnet_endpoint_core::coordinator::{
-    AdmissionKind, AdmissionOutcome, CanonicalPeer, LeaseMetadata, LeaseToken,
-    OutboundTransactionCoordinator, ReserveError, TerminalPolicy,
+    Admission, AdmissionKind, AdmissionOutcome, CanonicalPeer, LeaseMetadata, LeaseOwner,
+    LeaseToken, OutboundTransactionCoordinator, ReserveError, TerminalPolicy,
 };
 use bacnet_types::enums::ConfirmedServiceChoice;
 use bacnet_types::MacAddr;
@@ -103,14 +103,31 @@ impl Tsm {
         service_choice: ConfirmedServiceChoice,
         segmented: bool,
     ) -> Result<(u8, TransactionRegistration), CoordinatedRegistrationError> {
+        self.register_coordinated_transaction_with_policy(
+            destination_mac,
+            peer,
+            service_choice,
+            segmented,
+            TerminalPolicy::EitherAck,
+        )
+    }
+
+    pub(crate) fn register_coordinated_transaction_with_policy(
+        &mut self,
+        destination_mac: MacAddr,
+        peer: CanonicalPeer,
+        service_choice: ConfirmedServiceChoice,
+        segmented: bool,
+        terminal_policy: TerminalPolicy,
+    ) -> Result<(u8, TransactionRegistration), CoordinatedRegistrationError> {
         let coordinator = self
             .coordinator
             .as_ref()
             .ok_or(CoordinatedRegistrationError::CoordinatorUnavailable)?;
         let metadata = if segmented {
-            LeaseMetadata::segmented_requester(peer, service_choice, TerminalPolicy::EitherAck)
+            LeaseMetadata::segmented_requester(peer, service_choice, terminal_policy)
         } else {
-            LeaseMetadata::requester(peer, service_choice, TerminalPolicy::EitherAck)
+            LeaseMetadata::requester(peer, service_choice, terminal_policy)
         };
         let token = coordinator
             .reserve(metadata)
@@ -136,6 +153,66 @@ impl Tsm {
                 Err(CoordinatedRegistrationError::DuplicateInvokeId)
             }
         }
+    }
+
+    pub(crate) fn complete_pre_admitted_terminal_response(
+        &mut self,
+        source_mac: &[u8],
+        admission: &Admission,
+        apdu: &Apdu,
+        response: TsmResponse,
+    ) -> CoordinatedCompletion {
+        if admission.kind() != AdmissionKind::Terminal
+            || admission.metadata().owner() != LeaseOwner::Requester
+            || admission.metadata().peer() != &CanonicalPeer::direct(source_mac)
+        {
+            return CoordinatedCompletion::Rejected;
+        }
+
+        let invoke_id = admission.token().invoke_id();
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Some(pending) = self.pending.get(&key) else {
+            return CoordinatedCompletion::Rejected;
+        };
+        if pending.lease != PendingLease::Coordinated(admission.token())
+            || pending.expected_service_choice != admission.metadata().service_choice()
+            || !matches!(pending.phase, TransactionPhase::AwaitingResponse)
+        {
+            return CoordinatedCompletion::Rejected;
+        }
+        let owner = pending.owner.clone();
+
+        let observed_service_choice = match (apdu, &response) {
+            (Apdu::SimpleAck(pdu), TsmResponse::SimpleAck) if pdu.invoke_id == invoke_id => {
+                Some(pdu.service_choice)
+            }
+            (Apdu::ComplexAck(pdu), TsmResponse::ComplexAck { .. })
+                if !pdu.segmented && pdu.invoke_id == invoke_id =>
+            {
+                Some(pdu.service_choice)
+            }
+            (Apdu::Error(pdu), TsmResponse::Error { .. }) if pdu.invoke_id == invoke_id => None,
+            (Apdu::Reject(pdu), TsmResponse::Reject { .. }) if pdu.invoke_id == invoke_id => None,
+            (Apdu::Abort(pdu), TsmResponse::Abort { .. }) if pdu.invoke_id == invoke_id => None,
+            _ => return CoordinatedCompletion::Rejected,
+        };
+        if observed_service_choice
+            .is_some_and(|observed| observed != admission.metadata().service_choice())
+        {
+            return CoordinatedCompletion::ServiceChoiceMismatch {
+                expected: admission.metadata().service_choice(),
+                observed: observed_service_choice.expect("observed service exists"),
+            };
+        }
+
+        CoordinatedCompletion::Completed(self.complete_transaction_inner(
+            source_mac,
+            invoke_id,
+            Some(&owner),
+            observed_service_choice,
+            response,
+            PendingRelease::Complete,
+        ))
     }
 
     pub(crate) fn complete_coordinated_terminal_response(

--- a/crates/bacnet-client/src/tsm/coordinated.rs
+++ b/crates/bacnet-client/src/tsm/coordinated.rs
@@ -215,6 +215,46 @@ impl Tsm {
         ))
     }
 
+    pub(crate) fn reject_pre_admitted_segmented_response(
+        &mut self,
+        source_mac: &[u8],
+        admission: &Admission,
+        apdu: &Apdu,
+    ) -> bool {
+        if admission.kind() != AdmissionKind::NonTerminal
+            || admission.metadata().owner() != LeaseOwner::Requester
+            || admission.metadata().peer() != &CanonicalPeer::direct(source_mac)
+        {
+            return false;
+        }
+
+        let Apdu::ComplexAck(ack) = apdu else {
+            return false;
+        };
+        let invoke_id = admission.token().invoke_id();
+        if !ack.segmented
+            || ack.invoke_id != invoke_id
+            || ack.sequence_number != Some(0)
+            || ack.service_choice != admission.metadata().service_choice()
+        {
+            return false;
+        }
+
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Some(pending) = self.pending.get(&key) else {
+            return false;
+        };
+        if pending.lease != PendingLease::Coordinated(admission.token())
+            || pending.expected_service_choice != admission.metadata().service_choice()
+            || !matches!(pending.phase, TransactionPhase::AwaitingResponse)
+        {
+            return false;
+        }
+        let owner = pending.owner.clone();
+        self.abort_invalid_apdu_in_current_state(source_mac, invoke_id, &owner);
+        true
+    }
+
     pub(crate) fn complete_coordinated_terminal_response(
         &mut self,
         source_mac: &[u8],

--- a/crates/bacnet-endpoint-core/src/endpoint_ingress.rs
+++ b/crates/bacnet-endpoint-core/src/endpoint_ingress.rs
@@ -260,52 +260,145 @@ async fn session_task<T: TransportPort + 'static>(
     egress_open: Arc<AtomicBool>,
 ) -> Result<ClassifierExit, Error> {
     let mut receive_egress = true;
+    let mut prefer_ingress = true;
     let exit = loop {
-        tokio::select! {
-            biased;
-            _ = &mut cancel_rx => break ClassifierExit::Cancelled,
-            command = egress_rx.recv(), if receive_egress => {
-                let Some(command) = command else {
-                    receive_egress = false;
-                    continue;
-                };
-                let send = network.send_apdu(
-                    &command.apdu,
-                    &command.destination_mac,
-                    command.expecting_reply,
-                    command.priority,
-                );
-                tokio::pin!(send);
-                tokio::select! {
-                    biased;
-                    _ = &mut cancel_rx => {
-                        let _ = command.completion.send(Err(shutdown_error()));
-                        break ClassifierExit::Cancelled;
-                    }
-                    result = &mut send => {
-                        let _ = command.completion.send(result);
-                    }
+        let event = if prefer_ingress {
+            tokio::select! {
+                biased;
+                _ = &mut cancel_rx => SessionEvent::Cancelled,
+                received = apdu_rx.recv() => SessionEvent::Received(received),
+                command = egress_rx.recv(), if receive_egress => SessionEvent::Egress(command),
+            }
+        } else {
+            tokio::select! {
+                biased;
+                _ = &mut cancel_rx => SessionEvent::Cancelled,
+                command = egress_rx.recv(), if receive_egress => SessionEvent::Egress(command),
+                received = apdu_rx.recv() => SessionEvent::Received(received),
+            }
+        };
+
+        match event {
+            SessionEvent::Cancelled => break ClassifierExit::Cancelled,
+            SessionEvent::Received(Some(received)) => {
+                prefer_ingress = !prefer_ingress;
+                if let Some(exit) = route_received(received, &inbound_tx, &terminal_tx, &policy_tx)
+                {
+                    break exit;
                 }
             }
-            received = apdu_rx.recv() => {
-                let Some(received) = received else {
-                    break ClassifierExit::InputClosed;
-                };
-                if let Some(exit) = route_received(
-                    received,
+            SessionEvent::Received(None) => break ClassifierExit::InputClosed,
+            SessionEvent::Egress(Some(command)) => {
+                prefer_ingress = !prefer_ingress;
+                match drive_direct_egress(
+                    &network,
+                    command,
+                    &mut apdu_rx,
                     &inbound_tx,
                     &terminal_tx,
                     &policy_tx,
-                ) {
-                    break exit;
+                    &mut cancel_rx,
+                    &mut prefer_ingress,
+                )
+                .await
+                {
+                    EgressDrive::Complete => {}
+                    EgressDrive::Cancelled => break ClassifierExit::Cancelled,
+                    EgressDrive::Exit(exit) => break exit,
+                }
+            }
+            SessionEvent::Egress(None) => receive_egress = false,
+        }
+    };
+
+    egress_open.store(false, Ordering::Release);
+    egress_rx.close();
+    while let Ok(command) = egress_rx.try_recv() {
+        let _ = command.completion.send(Err(shutdown_error()));
+    }
+    network.stop().await?;
+    Ok(exit)
+}
+
+enum SessionEvent {
+    Cancelled,
+    Received(Option<ReceivedApdu>),
+    Egress(Option<DirectEgress>),
+}
+
+enum EgressDrive {
+    Complete,
+    Cancelled,
+    Exit(ClassifierExit),
+}
+
+enum PendingEvent {
+    Cancelled,
+    Received(Option<ReceivedApdu>),
+    Sent(Result<(), Error>),
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn drive_direct_egress<T: TransportPort + 'static>(
+    network: &NetworkLayer<T>,
+    command: DirectEgress,
+    apdu_rx: &mut mpsc::Receiver<ReceivedApdu>,
+    inbound_tx: &mpsc::Sender<ReceivedApdu>,
+    terminal_tx: &mpsc::Sender<ReceivedApdu>,
+    policy_tx: &mpsc::Sender<PolicyOutcome>,
+    cancel_rx: &mut oneshot::Receiver<()>,
+    prefer_ingress: &mut bool,
+) -> EgressDrive {
+    let DirectEgress {
+        apdu,
+        destination_mac,
+        expecting_reply,
+        priority,
+        completion,
+    } = command;
+    let outcome = {
+        let send = network.send_apdu(&apdu, &destination_mac, expecting_reply, priority);
+        tokio::pin!(send);
+        loop {
+            let event = if *prefer_ingress {
+                tokio::select! {
+                    biased;
+                    _ = &mut *cancel_rx => PendingEvent::Cancelled,
+                    received = apdu_rx.recv() => PendingEvent::Received(received),
+                    result = &mut send => PendingEvent::Sent(result),
+                }
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = &mut *cancel_rx => PendingEvent::Cancelled,
+                    result = &mut send => PendingEvent::Sent(result),
+                    received = apdu_rx.recv() => PendingEvent::Received(received),
+                }
+            };
+
+            match event {
+                PendingEvent::Cancelled => break EgressDrive::Cancelled,
+                PendingEvent::Received(Some(received)) => {
+                    *prefer_ingress = !*prefer_ingress;
+                    if let Some(exit) = route_received(received, inbound_tx, terminal_tx, policy_tx)
+                    {
+                        break EgressDrive::Exit(exit);
+                    }
+                }
+                PendingEvent::Received(None) => {
+                    break EgressDrive::Exit(ClassifierExit::InputClosed);
+                }
+                PendingEvent::Sent(result) => {
+                    *prefer_ingress = !*prefer_ingress;
+                    let _ = completion.send(result);
+                    return EgressDrive::Complete;
                 }
             }
         }
     };
 
-    egress_open.store(false, Ordering::Release);
-    network.stop().await?;
-    Ok(exit)
+    let _ = completion.send(Err(shutdown_error()));
+    outcome
 }
 
 fn route_received(

--- a/crates/bacnet-endpoint-core/src/endpoint_ingress.rs
+++ b/crates/bacnet-endpoint-core/src/endpoint_ingress.rs
@@ -1,9 +1,71 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use bacnet_encoding::apdu::{decode_apdu, Apdu};
 use bacnet_network::layer::{NetworkLayer, ReceivedApdu};
 use bacnet_transport::port::TransportPort;
+use bacnet_types::enums::NetworkPriority;
 use bacnet_types::error::Error;
+use bacnet_types::MacAddr;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
+
+fn shutdown_error() -> Error {
+    Error::Encoding("endpoint shutdown".into())
+}
+
+struct DirectEgress {
+    apdu: Vec<u8>,
+    destination_mac: MacAddr,
+    expecting_reply: bool,
+    priority: NetworkPriority,
+    completion: oneshot::Sender<Result<(), Error>>,
+}
+
+/// Bounded direct-APDU sender for roles attached to an endpoint session.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct EndpointEgress {
+    commands: mpsc::Sender<DirectEgress>,
+    open: Arc<AtomicBool>,
+}
+
+impl EndpointEgress {
+    /// Sends one direct unicast APDU without granting network lifecycle access.
+    #[doc(hidden)]
+    pub async fn send_direct(
+        &self,
+        apdu: Vec<u8>,
+        destination_mac: MacAddr,
+        expecting_reply: bool,
+        priority: NetworkPriority,
+    ) -> Result<(), Error> {
+        if !self.open.load(Ordering::Acquire) {
+            return Err(shutdown_error());
+        }
+
+        let (completion, result) = oneshot::channel();
+        let command = DirectEgress {
+            apdu,
+            destination_mac,
+            expecting_reply,
+            priority,
+            completion,
+        };
+        match self.commands.try_send(command) {
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Closed(_)) => return Err(shutdown_error()),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                if !self.open.load(Ordering::Acquire) {
+                    return Err(shutdown_error());
+                }
+                return Err(Error::Encoding("endpoint egress queue is full".into()));
+            }
+        }
+
+        result.await.unwrap_or_else(|_| Err(shutdown_error()))
+    }
+}
 
 /// Destination selected for one decoded APDU.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,6 +106,9 @@ pub struct IngressReceivers {
     pub terminal_or_segment: mpsc::Receiver<ReceivedApdu>,
     /// Traffic that endpoint policy must handle or reclaim.
     pub policy_outcomes: mpsc::Receiver<PolicyOutcome>,
+    /// Direct egress for endpoint role adapters.
+    #[doc(hidden)]
+    pub egress: EndpointEgress,
 }
 
 /// Terminal state reported by the classifier task.
@@ -68,22 +133,24 @@ enum Lifecycle {
 
 /// Owns one network layer and classifies each received APDU exactly once.
 pub struct EndpointIngress<T: TransportPort> {
-    network: NetworkLayer<T>,
+    network: Option<NetworkLayer<T>>,
     queue_capacity: usize,
     lifecycle: Lifecycle,
     cancel_tx: Option<oneshot::Sender<()>>,
-    classifier_task: Option<JoinHandle<ClassifierExit>>,
+    session_task: Option<JoinHandle<Result<ClassifierExit, Error>>>,
+    egress_open: Option<Arc<AtomicBool>>,
 }
 
 impl<T: TransportPort + 'static> EndpointIngress<T> {
     /// Creates ingress with the same capacity for each bounded output queue.
     pub fn new(transport: T, queue_capacity: usize) -> Self {
         Self {
-            network: NetworkLayer::new(transport),
+            network: Some(NetworkLayer::new(transport)),
             queue_capacity,
             lifecycle: Lifecycle::Ready,
             cancel_tx: None,
-            classifier_task: None,
+            session_task: None,
+            egress_open: None,
         }
     }
 
@@ -100,26 +167,45 @@ impl<T: TransportPort + 'static> EndpointIngress<T> {
             ));
         }
 
-        let apdu_rx = self.network.start().await?;
+        let network = self
+            .network
+            .as_mut()
+            .ok_or_else(|| Error::Encoding("endpoint ingress network owner is missing".into()))?;
+        let apdu_rx = network.start().await?;
         let (inbound_tx, inbound_requests) = mpsc::channel(self.queue_capacity);
         let (terminal_tx, terminal_or_segment) = mpsc::channel(self.queue_capacity);
         let (policy_tx, policy_outcomes) = mpsc::channel(self.queue_capacity);
+        let (egress_tx, egress_rx) = mpsc::channel(self.queue_capacity);
         let (cancel_tx, cancel_rx) = oneshot::channel();
+        let egress_open = Arc::new(AtomicBool::new(true));
+        let egress = EndpointEgress {
+            commands: egress_tx,
+            open: Arc::clone(&egress_open),
+        };
+        let network = self
+            .network
+            .take()
+            .ok_or_else(|| Error::Encoding("endpoint ingress network owner is missing".into()))?;
 
-        self.classifier_task = Some(tokio::spawn(classifier_task(
+        self.session_task = Some(tokio::spawn(session_task(
+            network,
             apdu_rx,
             inbound_tx,
             terminal_tx,
             policy_tx,
+            egress_rx,
             cancel_rx,
+            Arc::clone(&egress_open),
         )));
         self.cancel_tx = Some(cancel_tx);
+        self.egress_open = Some(egress_open);
         self.lifecycle = Lifecycle::Running;
 
         Ok(IngressReceivers {
             inbound_requests,
             terminal_or_segment,
             policy_outcomes,
+            egress,
         })
     }
 
@@ -130,82 +216,123 @@ impl<T: TransportPort + 'static> EndpointIngress<T> {
         }
 
         self.lifecycle = Lifecycle::Stopped;
+        if let Some(open) = self.egress_open.take() {
+            open.store(false, Ordering::Release);
+        }
         if let Some(cancel_tx) = self.cancel_tx.take() {
             let _ = cancel_tx.send(());
         }
 
-        let classifier_result = match self.classifier_task.take() {
+        match self.session_task.take() {
             Some(task) => task.await.map_err(|error| {
-                Error::Encoding(format!("endpoint ingress classifier failed: {error}"))
-            }),
+                Error::Encoding(format!("endpoint ingress session failed: {error}"))
+            })?,
             None => Err(Error::Encoding(
-                "endpoint ingress classifier task is missing".into(),
+                "endpoint ingress session task is missing".into(),
             )),
-        };
-        let stop_result = self.network.stop().await;
-
-        stop_result?;
-        classifier_result
+        }
     }
 }
 
 impl<T: TransportPort> Drop for EndpointIngress<T> {
     fn drop(&mut self) {
+        if let Some(open) = self.egress_open.take() {
+            open.store(false, Ordering::Release);
+        }
         if let Some(cancel_tx) = self.cancel_tx.take() {
             let _ = cancel_tx.send(());
         }
-        if let Some(task) = self.classifier_task.take() {
+        if let Some(task) = self.session_task.take() {
             task.abort();
         }
     }
 }
 
-async fn classifier_task(
+#[allow(clippy::too_many_arguments)]
+async fn session_task<T: TransportPort + 'static>(
+    mut network: NetworkLayer<T>,
     mut apdu_rx: mpsc::Receiver<ReceivedApdu>,
     inbound_tx: mpsc::Sender<ReceivedApdu>,
     terminal_tx: mpsc::Sender<ReceivedApdu>,
     policy_tx: mpsc::Sender<PolicyOutcome>,
+    mut egress_rx: mpsc::Receiver<DirectEgress>,
     mut cancel_rx: oneshot::Receiver<()>,
-) -> ClassifierExit {
-    loop {
-        let received = tokio::select! {
+    egress_open: Arc<AtomicBool>,
+) -> Result<ClassifierExit, Error> {
+    let mut receive_egress = true;
+    let exit = loop {
+        tokio::select! {
             biased;
-            _ = &mut cancel_rx => return ClassifierExit::Cancelled,
-            received = apdu_rx.recv() => match received {
-                Some(received) => received,
-                None => return ClassifierExit::InputClosed,
-            },
-        };
-
-        let route = match classify(&received) {
-            Ok(route) => route,
-            Err(reason) => {
-                let outcome = PolicyOutcome { reason, received };
-                if let Some(exit) = send_policy(&policy_tx, outcome) {
-                    return exit;
+            _ = &mut cancel_rx => break ClassifierExit::Cancelled,
+            command = egress_rx.recv(), if receive_egress => {
+                let Some(command) = command else {
+                    receive_egress = false;
+                    continue;
+                };
+                let send = network.send_apdu(
+                    &command.apdu,
+                    &command.destination_mac,
+                    command.expecting_reply,
+                    command.priority,
+                );
+                tokio::pin!(send);
+                tokio::select! {
+                    biased;
+                    _ = &mut cancel_rx => {
+                        let _ = command.completion.send(Err(shutdown_error()));
+                        break ClassifierExit::Cancelled;
+                    }
+                    result = &mut send => {
+                        let _ = command.completion.send(result);
+                    }
                 }
-                continue;
             }
-        };
-
-        let send_result = match route {
-            IngressRoute::InboundRequest => inbound_tx.try_send(received),
-            IngressRoute::TerminalOrSegment => terminal_tx.try_send(received),
-        };
-        if let Err(error) = send_result {
-            let (reason, received) = match error {
-                mpsc::error::TrySendError::Full(received) => {
-                    (PolicyReason::RouteFull(route), received)
+            received = apdu_rx.recv() => {
+                let Some(received) = received else {
+                    break ClassifierExit::InputClosed;
+                };
+                if let Some(exit) = route_received(
+                    received,
+                    &inbound_tx,
+                    &terminal_tx,
+                    &policy_tx,
+                ) {
+                    break exit;
                 }
-                mpsc::error::TrySendError::Closed(received) => {
-                    (PolicyReason::RouteClosed(route), received)
-                }
-            };
-            if let Some(exit) = send_policy(&policy_tx, PolicyOutcome { reason, received }) {
-                return exit;
             }
         }
+    };
+
+    egress_open.store(false, Ordering::Release);
+    network.stop().await?;
+    Ok(exit)
+}
+
+fn route_received(
+    received: ReceivedApdu,
+    inbound_tx: &mpsc::Sender<ReceivedApdu>,
+    terminal_tx: &mpsc::Sender<ReceivedApdu>,
+    policy_tx: &mpsc::Sender<PolicyOutcome>,
+) -> Option<ClassifierExit> {
+    let route = match classify(&received) {
+        Ok(route) => route,
+        Err(reason) => return send_policy(policy_tx, PolicyOutcome { reason, received }),
+    };
+
+    let send_result = match route {
+        IngressRoute::InboundRequest => inbound_tx.try_send(received),
+        IngressRoute::TerminalOrSegment => terminal_tx.try_send(received),
+    };
+    if let Err(error) = send_result {
+        let (reason, received) = match error {
+            mpsc::error::TrySendError::Full(received) => (PolicyReason::RouteFull(route), received),
+            mpsc::error::TrySendError::Closed(received) => {
+                (PolicyReason::RouteClosed(route), received)
+            }
+        };
+        return send_policy(policy_tx, PolicyOutcome { reason, received });
     }
+    None
 }
 
 fn classify(received: &ReceivedApdu) -> Result<IngressRoute, PolicyReason> {

--- a/crates/bacnet-endpoint-core/src/endpoint_ingress_tests.rs
+++ b/crates/bacnet-endpoint-core/src/endpoint_ingress_tests.rs
@@ -89,7 +89,7 @@ struct BlockingTransport {
 }
 
 struct BlockingTransportHandle {
-    _sender: mpsc::Sender<ReceivedNpdu>,
+    sender: mpsc::Sender<ReceivedNpdu>,
     entered_send: Arc<Notify>,
     stops: Arc<AtomicUsize>,
 }
@@ -106,7 +106,7 @@ fn blocking_transport() -> (BlockingTransport, BlockingTransportHandle) {
             local_mac: MacAddr::from_slice(&[0xaa]),
         },
         BlockingTransportHandle {
-            _sender: sender,
+            sender,
             entered_send,
             stops,
         },
@@ -256,7 +256,7 @@ async fn direct_egress_preserves_npdu_flags_priority_and_destination() {
 async fn saturated_egress_is_bounded_and_stop_cancels_accepted_commands() {
     let (transport, handle) = blocking_transport();
     let mut endpoint = EndpointIngress::new(transport, 1);
-    let ingress = endpoint.start().await.unwrap();
+    let mut ingress = endpoint.start().await.unwrap();
     let egress = ingress.egress.clone();
 
     let first_egress = egress.clone();
@@ -296,6 +296,17 @@ async fn saturated_egress_is_bounded_and_stop_cancels_accepted_commands() {
             .await,
         Err(Error::Encoding(message)) if message == "endpoint egress queue is full"
     ));
+
+    handle
+        .sender
+        .send(received_npdu(&[0x20, 0x44, 0x0c]))
+        .await
+        .unwrap();
+    let terminal = timeout(WAIT, ingress.terminal_or_segment.recv())
+        .await
+        .expect("blocked egress starved terminal classification")
+        .expect("terminal route closed while egress was blocked");
+    assert_eq!(terminal.apdu.as_ref(), &[0x20, 0x44, 0x0c]);
 
     assert!(matches!(
         timeout(WAIT, endpoint.stop()).await.unwrap().unwrap(),

--- a/crates/bacnet-endpoint-core/src/endpoint_ingress_tests.rs
+++ b/crates/bacnet-endpoint-core/src/endpoint_ingress_tests.rs
@@ -1,14 +1,14 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use bacnet_encoding::npdu::{encode_npdu, Npdu, NpduAddress};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu, NpduAddress};
 use bacnet_transport::loopback::LoopbackTransport;
 use bacnet_transport::port::{DataAttribute, ReceivedNpdu, TransportPort};
 use bacnet_types::enums::NetworkPriority;
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 use bytes::{Bytes, BytesMut};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, Notify};
 use tokio::time::{timeout, Duration};
 
 use super::*;
@@ -17,6 +17,7 @@ const WAIT: Duration = Duration::from_secs(1);
 
 struct TestTransport {
     receiver: Option<mpsc::Receiver<ReceivedNpdu>>,
+    sent: mpsc::Sender<(Vec<u8>, Vec<u8>)>,
     starts: Arc<AtomicUsize>,
     stops: Arc<AtomicUsize>,
     local_mac: MacAddr,
@@ -24,23 +25,27 @@ struct TestTransport {
 
 struct TestTransportHandle {
     sender: mpsc::Sender<ReceivedNpdu>,
+    sent: mpsc::Receiver<(Vec<u8>, Vec<u8>)>,
     starts: Arc<AtomicUsize>,
     stops: Arc<AtomicUsize>,
 }
 
 fn test_transport() -> (TestTransport, TestTransportHandle) {
     let (sender, receiver) = mpsc::channel(32);
+    let (sent_tx, sent_rx) = mpsc::channel(32);
     let starts = Arc::new(AtomicUsize::new(0));
     let stops = Arc::new(AtomicUsize::new(0));
     (
         TestTransport {
             receiver: Some(receiver),
+            sent: sent_tx,
             starts: Arc::clone(&starts),
             stops: Arc::clone(&stops),
             local_mac: MacAddr::from_slice(&[0xaa]),
         },
         TestTransportHandle {
             sender,
+            sent: sent_rx,
             starts,
             stops,
         },
@@ -60,8 +65,70 @@ impl TransportPort for TestTransport {
         Ok(())
     }
 
-    async fn send_unicast(&self, _npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+    async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
+        self.sent
+            .send((npdu.to_vec(), mac.to_vec()))
+            .await
+            .map_err(|_| Error::Encoding("test sent-frame receiver closed".into()))
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
         Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &self.local_mac
+    }
+}
+
+struct BlockingTransport {
+    receiver: Option<mpsc::Receiver<ReceivedNpdu>>,
+    entered_send: Arc<Notify>,
+    stops: Arc<AtomicUsize>,
+    local_mac: MacAddr,
+}
+
+struct BlockingTransportHandle {
+    _sender: mpsc::Sender<ReceivedNpdu>,
+    entered_send: Arc<Notify>,
+    stops: Arc<AtomicUsize>,
+}
+
+fn blocking_transport() -> (BlockingTransport, BlockingTransportHandle) {
+    let (sender, receiver) = mpsc::channel(1);
+    let entered_send = Arc::new(Notify::new());
+    let stops = Arc::new(AtomicUsize::new(0));
+    (
+        BlockingTransport {
+            receiver: Some(receiver),
+            entered_send: Arc::clone(&entered_send),
+            stops: Arc::clone(&stops),
+            local_mac: MacAddr::from_slice(&[0xaa]),
+        },
+        BlockingTransportHandle {
+            _sender: sender,
+            entered_send,
+            stops,
+        },
+    )
+}
+
+impl TransportPort for BlockingTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        self.receiver
+            .take()
+            .ok_or_else(|| Error::Encoding("blocking transport already started".into()))
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        self.stops.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn send_unicast(&self, _npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        self.entered_send.notify_one();
+        std::future::pending::<()>().await;
+        unreachable!("blocking test send is cancelled by endpoint stop")
     }
 
     async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
@@ -145,6 +212,102 @@ async fn loopback_routes_all_apdu_classes_once_and_in_order() {
         endpoint.stop().await.unwrap(),
         ClassifierExit::Cancelled
     ));
+}
+
+#[tokio::test]
+async fn direct_egress_preserves_npdu_flags_priority_and_destination() {
+    let (transport, mut handle) = test_transport();
+    let mut endpoint = EndpointIngress::new(transport, 2);
+    let ingress = endpoint.start().await.unwrap();
+    let egress = ingress.egress.clone();
+
+    egress
+        .send_direct(
+            vec![0x20, 0x2a, 0x0c],
+            MacAddr::from_slice(&[0x44, 0x55]),
+            true,
+            NetworkPriority::URGENT,
+        )
+        .await
+        .unwrap();
+
+    let (npdu, destination) = timeout(WAIT, handle.sent.recv()).await.unwrap().unwrap();
+    let decoded = decode_npdu(Bytes::from(npdu)).unwrap();
+    assert_eq!(destination, [0x44, 0x55]);
+    assert!(decoded.expecting_reply);
+    assert_eq!(decoded.priority, NetworkPriority::URGENT);
+    assert_eq!(decoded.payload.as_ref(), &[0x20, 0x2a, 0x0c]);
+
+    endpoint.stop().await.unwrap();
+    assert!(matches!(
+        egress
+            .send_direct(
+                vec![0x20, 0x2b, 0x0c],
+                MacAddr::from_slice(&[0x44]),
+                false,
+                NetworkPriority::NORMAL,
+            )
+            .await,
+        Err(Error::Encoding(message)) if message == "endpoint shutdown"
+    ));
+}
+
+#[tokio::test]
+async fn saturated_egress_is_bounded_and_stop_cancels_accepted_commands() {
+    let (transport, handle) = blocking_transport();
+    let mut endpoint = EndpointIngress::new(transport, 1);
+    let ingress = endpoint.start().await.unwrap();
+    let egress = ingress.egress.clone();
+
+    let first_egress = egress.clone();
+    let first = tokio::spawn(async move {
+        first_egress
+            .send_direct(
+                vec![0x20, 0x01, 0x0c],
+                MacAddr::from_slice(&[0x01]),
+                false,
+                NetworkPriority::NORMAL,
+            )
+            .await
+    });
+    timeout(WAIT, handle.entered_send.notified()).await.unwrap();
+
+    let second_egress = egress.clone();
+    let second = tokio::spawn(async move {
+        second_egress
+            .send_direct(
+                vec![0x20, 0x02, 0x0c],
+                MacAddr::from_slice(&[0x01]),
+                false,
+                NetworkPriority::NORMAL,
+            )
+            .await
+    });
+    tokio::task::yield_now().await;
+
+    assert!(matches!(
+        egress
+            .send_direct(
+                vec![0x20, 0x03, 0x0c],
+                MacAddr::from_slice(&[0x01]),
+                false,
+                NetworkPriority::NORMAL,
+            )
+            .await,
+        Err(Error::Encoding(message)) if message == "endpoint egress queue is full"
+    ));
+
+    assert!(matches!(
+        timeout(WAIT, endpoint.stop()).await.unwrap().unwrap(),
+        ClassifierExit::Cancelled
+    ));
+    assert_eq!(handle.stops.load(Ordering::SeqCst), 1);
+    for result in [first.await.unwrap(), second.await.unwrap()] {
+        assert!(matches!(
+            result,
+            Err(Error::Encoding(message)) if message == "endpoint shutdown"
+        ));
+    }
 }
 
 #[tokio::test]

--- a/crates/bacnet-server/Cargo.toml
+++ b/crates/bacnet-server/Cargo.toml
@@ -26,6 +26,7 @@ tokio-rustls = { workspace = true, optional = true }
 sc-tls = ["bacnet-transport/sc-tls", "tokio-rustls"]
 
 [dev-dependencies]
+bacnet-client.workspace = true
 bacnet-transport.workspace = true
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "sync", "macros", "time", "test-util"] }
 

--- a/crates/bacnet-server/src/server/notification_transactions.rs
+++ b/crates/bacnet-server/src/server/notification_transactions.rs
@@ -6,8 +6,8 @@ use std::sync::{Arc, Mutex};
 use bacnet_encoding::apdu::Apdu;
 use bacnet_encoding::npdu::NpduAddress;
 use bacnet_endpoint_core::coordinator::{
-    AdmissionKind, AdmissionOutcome, CanonicalPeer, LeaseMetadata, LeaseToken,
-    OutboundTransactionCoordinator, ReserveError,
+    Admission, AdmissionKind, AdmissionOutcome, CanonicalPeer, LeaseMetadata, LeaseOwner,
+    LeaseToken, OutboundTransactionCoordinator, ReserveError,
 };
 use bacnet_types::enums::ConfirmedServiceChoice;
 use tokio::sync::oneshot;
@@ -54,8 +54,12 @@ pub(super) struct NotificationTransactions {
 
 impl NotificationTransactions {
     pub(super) fn new() -> Arc<Self> {
+        Self::with_coordinator(Arc::new(OutboundTransactionCoordinator::new()))
+    }
+
+    pub(super) fn with_coordinator(coordinator: Arc<OutboundTransactionCoordinator>) -> Arc<Self> {
         Arc::new(Self {
-            coordinator: Arc::new(OutboundTransactionCoordinator::new()),
+            coordinator,
             state: Mutex::new(NotificationState {
                 closed: false,
                 pending: HashMap::new(),
@@ -116,12 +120,28 @@ impl NotificationTransactions {
             Ok(_) | Err(_) => return false,
         };
 
+        self.complete_pre_admitted(admission, apdu)
+    }
+
+    pub(super) fn complete_pre_admitted(&self, admission: Admission, apdu: &Apdu) -> bool {
+        if admission.kind() != AdmissionKind::Terminal
+            || admission.metadata().owner() != LeaseOwner::ServerNotification
+        {
+            return false;
+        }
+        let token = admission.token();
         let result = match apdu {
-            Apdu::SimpleAck(_) => CovAckResult::Ack,
-            Apdu::Error(_) | Apdu::Reject(_) | Apdu::Abort(_) => CovAckResult::Error,
+            Apdu::SimpleAck(pdu)
+                if pdu.invoke_id == token.invoke_id()
+                    && pdu.service_choice == admission.metadata().service_choice() =>
+            {
+                CovAckResult::Ack
+            }
+            Apdu::Error(pdu) if pdu.invoke_id == token.invoke_id() => CovAckResult::Error,
+            Apdu::Reject(pdu) if pdu.invoke_id == token.invoke_id() => CovAckResult::Error,
+            Apdu::Abort(pdu) if pdu.invoke_id == token.invoke_id() => CovAckResult::Error,
             _ => return false,
         };
-        let token = admission.token();
         let sender = match self.state.lock() {
             Ok(mut state) => state.pending.remove(&token),
             Err(_) => None,

--- a/crates/bacnet-server/src/server/notification_transactions_tests.rs
+++ b/crates/bacnet-server/src/server/notification_transactions_tests.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
 
 use bacnet_encoding::apdu::{AbortPdu, ComplexAck, ErrorPdu, RejectPdu, SegmentAck};
-use bacnet_endpoint_core::coordinator::ReserveError;
+use bacnet_endpoint_core::coordinator::{
+    AdmissionOutcome, OutboundTransactionCoordinator, ReserveError,
+};
 use bacnet_types::enums::{AbortReason, ErrorClass, ErrorCode, RejectReason};
 use bytes::Bytes;
 use tokio::sync::{mpsc, Notify};
@@ -161,6 +163,25 @@ async fn notification_terminals_complete_exactly_once() {
         assert!(!transactions.admit_terminal(&direct_mac, None, &pdu));
         drop(operation);
     }
+}
+
+#[tokio::test]
+async fn injected_coordinator_terminal_is_completed_from_exact_pre_admission() {
+    let coordinator = StdArc::new(OutboundTransactionCoordinator::new());
+    let transactions = NotificationTransactions::with_coordinator(StdArc::clone(&coordinator));
+    let peer = direct_peer(1);
+    let (operation, receiver) = transactions.reserve(peer.clone(), COV_SERVICE).unwrap();
+    let apdu = simple_ack(operation.invoke_id(), COV_SERVICE);
+    let admission = match coordinator.admit(&peer, &apdu).unwrap() {
+        AdmissionOutcome::Admitted(admission) => admission,
+        other => panic!("expected notification admission, got {other:?}"),
+    };
+
+    assert!(transactions.complete_pre_admitted(admission.clone(), &apdu));
+    assert_eq!(receiver.await.unwrap(), CovAckResult::Ack);
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+    assert!(!transactions.complete_pre_admitted(admission, &apdu));
+    drop(operation);
 }
 
 #[tokio::test]

--- a/crates/bacnet-server/src/server/requests/confirmed_response.rs
+++ b/crates/bacnet-server/src/server/requests/confirmed_response.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+pub(super) async fn read_property_response(
+    db: &RwLock<ObjectDatabase>,
+    request: &ConfirmedRequestPdu,
+) -> Apdu {
+    let mut service_ack = BytesMut::with_capacity(512);
+    let db = db.read().await;
+    match handlers::handle_read_property(&db, &request.service_request, &mut service_ack) {
+        Ok(()) => Apdu::ComplexAck(ComplexAck {
+            segmented: false,
+            more_follows: false,
+            invoke_id: request.invoke_id,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: request.service_choice,
+            service_ack: service_ack.freeze(),
+        }),
+        Err(error) => error_apdu_from_error(request.invoke_id, request.service_choice, &error),
+    }
+}
+
+pub(super) fn error_apdu_from_error(
+    invoke_id: u8,
+    service_choice: ConfirmedServiceChoice,
+    error: &Error,
+) -> Apdu {
+    if let Error::Reject { reason } = error {
+        return Apdu::Reject(RejectPdu {
+            invoke_id,
+            reject_reason: RejectReason::from_raw(*reason),
+        });
+    }
+    let (class, code) = match error {
+        Error::Protocol { class, code } => (*class, *code),
+        _ => (
+            ErrorClass::SERVICES.to_raw() as u32,
+            ErrorCode::OTHER.to_raw() as u32,
+        ),
+    };
+    Apdu::Error(ErrorPdu {
+        invoke_id,
+        service_choice,
+        error_class: ErrorClass::from_raw(class as u16),
+        error_code: ErrorCode::from_raw(code as u16),
+        error_data: Bytes::new(),
+    })
+}

--- a/crates/bacnet-server/src/server/requests/endpoint_responder.rs
+++ b/crates/bacnet-server/src/server/requests/endpoint_responder.rs
@@ -1,0 +1,115 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use bacnet_encoding::apdu::{decode_apdu, encode_apdu};
+use bacnet_encoding::npdu::{encode_npdu, Npdu};
+use bacnet_endpoint_core::endpoint_ingress::EndpointEgress;
+use bacnet_network::layer::ReceivedApdu;
+
+use super::confirmed_response;
+use super::*;
+
+#[allow(dead_code)]
+fn shutdown_error() -> Error {
+    Error::Encoding("endpoint shutdown".into())
+}
+
+#[allow(dead_code)]
+pub(super) struct EndpointResponder {
+    db: Arc<RwLock<ObjectDatabase>>,
+    egress: EndpointEgress,
+    open: AtomicBool,
+}
+
+#[allow(dead_code)]
+impl EndpointResponder {
+    pub(super) fn new(db: Arc<RwLock<ObjectDatabase>>, egress: EndpointEgress) -> Self {
+        Self {
+            db,
+            egress,
+            open: AtomicBool::new(true),
+        }
+    }
+
+    pub(super) async fn handle(&self, mut received: ReceivedApdu) -> Result<bool, Error> {
+        if !self.open.load(Ordering::Acquire) {
+            return Err(shutdown_error());
+        }
+        if received.is_group {
+            return Ok(false);
+        }
+        let Apdu::ConfirmedRequest(request) = decode_apdu(received.apdu.clone())? else {
+            return Ok(false);
+        };
+
+        let invoke_id = request.invoke_id;
+        let mut response = if request.segmented {
+            Apdu::Abort(AbortPdu {
+                sent_by_server: true,
+                invoke_id,
+                abort_reason: AbortReason::SEGMENTATION_NOT_SUPPORTED,
+            })
+        } else if request.service_choice == ConfirmedServiceChoice::READ_PROPERTY {
+            confirmed_response::read_property_response(&self.db, &request).await
+        } else {
+            Apdu::Reject(RejectPdu {
+                invoke_id,
+                reject_reason: RejectReason::UNRECOGNIZED_SERVICE,
+            })
+        };
+
+        let mut encoded = BytesMut::new();
+        encode_apdu(&mut encoded, &response)?;
+        if matches!(response, Apdu::ComplexAck(_))
+            && encoded.len() > usize::from(request.max_apdu_length)
+        {
+            response = Apdu::Abort(AbortPdu {
+                sent_by_server: true,
+                invoke_id,
+                abort_reason: AbortReason::SEGMENTATION_NOT_SUPPORTED,
+            });
+            encoded.clear();
+            encode_apdu(&mut encoded, &response)?;
+        }
+
+        if let Some(reply_tx) = received.reply_tx.take() {
+            let apdu = encoded.freeze();
+            let npdu = Npdu {
+                is_network_message: false,
+                expecting_reply: false,
+                priority: NetworkPriority::NORMAL,
+                destination: received.source_network,
+                source: None,
+                payload: apdu,
+                ..Npdu::default()
+            };
+            let mut wrapped = BytesMut::new();
+            encode_npdu(&mut wrapped, &npdu)?;
+            let _ = reply_tx.send(wrapped.freeze());
+            return Ok(true);
+        }
+
+        if received.source_network.is_some() {
+            return Err(Error::Encoding(
+                "endpoint responder does not support routed replies".into(),
+            ));
+        }
+        self.egress
+            .send_direct(
+                encoded.to_vec(),
+                received.source_mac,
+                false,
+                NetworkPriority::NORMAL,
+            )
+            .await?;
+        Ok(true)
+    }
+
+    pub(super) fn close(&self) {
+        self.open.store(false, Ordering::Release);
+    }
+}
+
+#[cfg(test)]
+#[path = "endpoint_responder_tests.rs"]
+mod tests;

--- a/crates/bacnet-server/src/server/requests/endpoint_responder_tests.rs
+++ b/crates/bacnet-server/src/server/requests/endpoint_responder_tests.rs
@@ -1,0 +1,90 @@
+use bacnet_encoding::apdu::{decode_apdu, encode_apdu};
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_endpoint_core::endpoint_ingress::EndpointIngress;
+use bacnet_objects::analog::AnalogInputObject;
+use bacnet_services::read_property::{ReadPropertyACK, ReadPropertyRequest};
+use bacnet_transport::loopback::LoopbackTransport;
+
+use super::*;
+
+fn read_property_request(invoke_id: u8) -> Bytes {
+    let mut service_request = BytesMut::new();
+    ReadPropertyRequest {
+        object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 7).unwrap(),
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+    }
+    .encode(&mut service_request);
+    let request = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 480,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_request: service_request.freeze(),
+    });
+    let mut encoded = BytesMut::new();
+    encode_apdu(&mut encoded, &request).unwrap();
+    encoded.freeze()
+}
+
+#[tokio::test]
+async fn responder_moves_reply_sender_once_and_preserves_routed_destination() {
+    let (endpoint_transport, _peer_transport) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let mut endpoint = EndpointIngress::new(endpoint_transport, 2);
+    let ingress = endpoint.start().await.unwrap();
+    let mut db = ObjectDatabase::new();
+    let mut analog = AnalogInputObject::new(7, "shared-runtime-input", 0).unwrap();
+    analog.set_present_value(42.0);
+    db.add(Box::new(analog)).unwrap();
+    let responder = EndpointResponder::new(Arc::new(RwLock::new(db)), ingress.egress.clone());
+    let routed_source = NpduAddress {
+        network: 77,
+        mac_address: MacAddr::from_slice(&[0x44, 0x55]),
+    };
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let received = ReceivedApdu {
+        apdu: read_property_request(0x31),
+        source_mac: MacAddr::from_slice(&[0x02]),
+        source_network: Some(routed_source.clone()),
+        is_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: Some(reply_tx),
+    };
+
+    assert!(responder.handle(received).await.unwrap());
+    let npdu = decode_npdu(reply_rx.await.unwrap()).unwrap();
+    assert_eq!(npdu.destination, Some(routed_source));
+    let service_ack = match decode_apdu(npdu.payload).unwrap() {
+        Apdu::ComplexAck(ack) => {
+            assert_eq!(ack.invoke_id, 0x31);
+            ack.service_ack
+        }
+        other => panic!("expected ComplexAck, got {other:?}"),
+    };
+    let ack = ReadPropertyACK::decode(&service_ack).unwrap();
+    let mut expected = BytesMut::new();
+    bacnet_encoding::primitives::encode_property_value(&mut expected, &PropertyValue::Real(42.0))
+        .unwrap();
+    assert_eq!(ack.property_value, expected.to_vec());
+
+    responder.close();
+    assert!(matches!(
+        responder
+            .handle(ReceivedApdu {
+                apdu: read_property_request(0x32),
+                source_mac: MacAddr::from_slice(&[0x02]),
+                source_network: None,
+                is_group: false,
+                data_attributes: Vec::new(),
+                reply_tx: None,
+            })
+            .await,
+        Err(Error::Encoding(message)) if message == "endpoint shutdown"
+    ));
+    endpoint.stop().await.unwrap();
+}

--- a/crates/bacnet-server/src/server/requests/endpoint_shared_runtime_tests.rs
+++ b/crates/bacnet-server/src/server/requests/endpoint_shared_runtime_tests.rs
@@ -149,7 +149,9 @@ async fn loopback_shared_runtime_routes_same_invoke_id_by_admitted_role() {
             match coordinator.admit(&peer, &decoded).unwrap() {
                 AdmissionOutcome::Admitted(admission) => match admission.metadata().owner() {
                     LeaseOwner::Requester => {
-                        requester.complete_pre_admitted(admission, decoded, received)
+                        requester
+                            .complete_pre_admitted(admission, decoded, received)
+                            .await
                     }
                     LeaseOwner::ServerNotification => {
                         notification_transactions.complete_pre_admitted(admission, &decoded)

--- a/crates/bacnet-server/src/server/requests/endpoint_shared_runtime_tests.rs
+++ b/crates/bacnet-server/src/server/requests/endpoint_shared_runtime_tests.rs
@@ -1,0 +1,261 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use bacnet_client::client::ClientConfig;
+use bacnet_client::EndpointRequester;
+use bacnet_encoding::apdu::{decode_apdu, encode_apdu};
+use bacnet_encoding::primitives::encode_property_value;
+use bacnet_endpoint_core::coordinator::{
+    AdmissionOutcome, CanonicalPeer, LeaseOwner, OutboundTransactionCoordinator,
+};
+use bacnet_endpoint_core::endpoint_ingress::{ClassifierExit, EndpointIngress, IngressReceivers};
+use bacnet_network::layer::NetworkLayer;
+use bacnet_objects::analog::AnalogInputObject;
+use bacnet_services::read_property::{ReadPropertyACK, ReadPropertyRequest};
+use bacnet_transport::loopback::LoopbackTransport;
+use tokio::time::timeout;
+
+use super::endpoint_responder::EndpointResponder;
+use super::*;
+
+const WAIT: Duration = Duration::from_secs(1);
+
+fn object_identifier() -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 7).unwrap()
+}
+
+fn read_request(invoke_id: u8) -> Vec<u8> {
+    let mut service_request = BytesMut::new();
+    ReadPropertyRequest {
+        object_identifier: object_identifier(),
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+    }
+    .encode(&mut service_request);
+    let apdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 480,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_request: service_request.freeze(),
+    });
+    let mut encoded = BytesMut::new();
+    encode_apdu(&mut encoded, &apdu).unwrap();
+    encoded.to_vec()
+}
+
+fn read_ack(request: &ConfirmedRequestPdu, value: f32) -> Vec<u8> {
+    let mut property_value = BytesMut::new();
+    encode_property_value(&mut property_value, &PropertyValue::Real(value)).unwrap();
+    let ack = ReadPropertyACK {
+        object_identifier: object_identifier(),
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+        property_value: property_value.to_vec(),
+    };
+    let mut service_ack = BytesMut::new();
+    ack.encode(&mut service_ack);
+    let apdu = Apdu::ComplexAck(ComplexAck {
+        segmented: false,
+        more_follows: false,
+        invoke_id: request.invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: request.service_choice,
+        service_ack: service_ack.freeze(),
+    });
+    let mut encoded = BytesMut::new();
+    encode_apdu(&mut encoded, &apdu).unwrap();
+    encoded.to_vec()
+}
+
+fn assert_real_value(ack: &ReadPropertyACK, expected: f32) {
+    let mut encoded = BytesMut::new();
+    encode_property_value(&mut encoded, &PropertyValue::Real(expected)).unwrap();
+    assert_eq!(ack.property_value, encoded.to_vec());
+}
+
+#[tokio::test]
+async fn loopback_shared_runtime_routes_same_invoke_id_by_admitted_role() {
+    let (endpoint_transport, peer_transport) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let mut endpoint = EndpointIngress::new(endpoint_transport, 8);
+    let IngressReceivers {
+        inbound_requests: mut inbound_rx,
+        terminal_or_segment: mut terminal_rx,
+        policy_outcomes: mut policy_rx,
+        egress,
+    } = endpoint.start().await.unwrap();
+    assert!(endpoint.start().await.is_err());
+
+    let coordinator = Arc::new(OutboundTransactionCoordinator::new());
+    let requester = EndpointRequester::new(
+        egress.clone(),
+        Arc::clone(&coordinator),
+        ClientConfig {
+            apdu_timeout_ms: 1_000,
+            apdu_retries: 0,
+            max_apdu_length: 480,
+            ..ClientConfig::default()
+        },
+    )
+    .unwrap();
+    let notification_transactions =
+        NotificationTransactions::with_coordinator(Arc::clone(&coordinator));
+
+    let mut db = ObjectDatabase::new();
+    let mut analog = AnalogInputObject::new(7, "endpoint-value", 0).unwrap();
+    analog.set_present_value(42.0);
+    db.add(Box::new(analog)).unwrap();
+    let responder = Arc::new(EndpointResponder::new(
+        Arc::new(RwLock::new(db)),
+        egress.clone(),
+    ));
+
+    let (inbound_seen_tx, inbound_seen_rx) = oneshot::channel();
+    let (release_responder_tx, release_responder_rx) = oneshot::channel();
+    let responder_task = {
+        let responder = Arc::clone(&responder);
+        tokio::spawn(async move {
+            let received = timeout(WAIT, inbound_rx.recv())
+                .await
+                .unwrap()
+                .expect("inbound request route closed");
+            inbound_seen_tx.send(()).unwrap();
+            release_responder_rx.await.unwrap();
+            responder.handle(received).await.unwrap()
+        })
+    };
+
+    let admit_calls = Arc::new(AtomicUsize::new(0));
+    let terminal_task = {
+        let coordinator = Arc::clone(&coordinator);
+        let requester = requester.clone();
+        let notification_transactions = Arc::clone(&notification_transactions);
+        let admit_calls = Arc::clone(&admit_calls);
+        tokio::spawn(async move {
+            let received = timeout(WAIT, terminal_rx.recv())
+                .await
+                .unwrap()
+                .expect("terminal route closed");
+            let peer =
+                CanonicalPeer::from_source(&received.source_mac, received.source_network.as_ref());
+            let decoded = decode_apdu(received.apdu.clone()).unwrap();
+            admit_calls.fetch_add(1, Ordering::SeqCst);
+            match coordinator.admit(&peer, &decoded).unwrap() {
+                AdmissionOutcome::Admitted(admission) => match admission.metadata().owner() {
+                    LeaseOwner::Requester => {
+                        requester.complete_pre_admitted(admission, decoded, received)
+                    }
+                    LeaseOwner::ServerNotification => {
+                        notification_transactions.complete_pre_admitted(admission, &decoded)
+                    }
+                },
+                AdmissionOutcome::NotOutbound
+                | AdmissionOutcome::UnknownInvokeId
+                | AdmissionOutcome::PeerMismatch
+                | AdmissionOutcome::OwnerMismatch
+                | AdmissionOutcome::ServiceMismatch { .. }
+                | AdmissionOutcome::PolicyMismatch
+                | AdmissionOutcome::DirectionMismatch
+                | AdmissionOutcome::DuplicateTerminal => false,
+            }
+        })
+    };
+
+    let mut peer = NetworkLayer::new(peer_transport);
+    let mut peer_rx = peer.start().await.unwrap();
+    let (responder_wire_tx, responder_wire_rx) = oneshot::channel();
+    let peer_task = tokio::spawn(async move {
+        peer.send_apdu(&read_request(0), &[0x01], true, NetworkPriority::NORMAL)
+            .await
+            .unwrap();
+
+        let requester_wire = timeout(WAIT, peer_rx.recv()).await.unwrap().unwrap();
+        let requester_request = match decode_apdu(requester_wire.apdu).unwrap() {
+            Apdu::ConfirmedRequest(request) => request,
+            other => panic!("expected requester ConfirmedRequest, got {other:?}"),
+        };
+        assert_eq!(requester_request.invoke_id, 0);
+        peer.send_apdu(
+            &read_ack(&requester_request, 12.5),
+            &[0x01],
+            false,
+            NetworkPriority::NORMAL,
+        )
+        .await
+        .unwrap();
+
+        let responder_wire = timeout(WAIT, peer_rx.recv()).await.unwrap().unwrap();
+        let responder_ack = match decode_apdu(responder_wire.apdu).unwrap() {
+            Apdu::ComplexAck(ack) => ack,
+            other => panic!("expected responder ComplexAck, got {other:?}"),
+        };
+        assert_eq!(responder_ack.invoke_id, 0);
+        let response = ReadPropertyACK::decode(&responder_ack.service_ack).unwrap();
+        assert_real_value(&response, 42.0);
+        responder_wire_tx.send(()).unwrap();
+        assert!(timeout(Duration::from_millis(50), peer_rx.recv())
+            .await
+            .is_err());
+        (requester_request.invoke_id, responder_ack.invoke_id, peer)
+    });
+
+    timeout(WAIT, inbound_seen_rx).await.unwrap().unwrap();
+    let requester_result = requester
+        .read_property(
+            &[0x02],
+            object_identifier(),
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_real_value(&requester_result, 12.5);
+    assert!(terminal_task.await.unwrap());
+    assert_eq!(admit_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(coordinator.active_count().unwrap(), 0);
+
+    release_responder_tx.send(()).unwrap();
+    timeout(WAIT, responder_wire_rx).await.unwrap().unwrap();
+    requester.close();
+    notification_transactions.close();
+    responder.close();
+    assert!(responder_task.await.unwrap());
+    let (requester_invoke_id, responder_invoke_id, mut peer) = peer_task.await.unwrap();
+    assert_eq!((requester_invoke_id, responder_invoke_id), (0, 0));
+
+    assert!(matches!(
+        endpoint.stop().await.unwrap(),
+        ClassifierExit::Cancelled
+    ));
+    peer.stop().await.unwrap();
+    assert!(endpoint.stop().await.is_err());
+    assert!(policy_rx.recv().await.is_none());
+    assert!(matches!(
+        egress
+            .send_direct(
+                vec![0x20, 0x00, 0x0c],
+                MacAddr::from_slice(&[0x02]),
+                false,
+                NetworkPriority::NORMAL,
+            )
+            .await,
+        Err(Error::Encoding(message)) if message == "endpoint shutdown"
+    ));
+    assert!(matches!(
+        requester
+            .read_property(
+                &[0x02],
+                object_identifier(),
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+            )
+            .await,
+        Err(Error::Encoding(message)) if message == "endpoint shutdown"
+    ));
+}

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+mod confirmed_response;
+mod endpoint_responder;
+#[cfg(test)]
+#[path = "endpoint_shared_runtime_tests.rs"]
+mod endpoint_shared_runtime_tests;
 mod unconfirmed;
 #[cfg(test)]
 pub(crate) use unconfirmed::EXECUTED_UNCONFIRMED;
@@ -104,11 +109,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let mut ack_buf = BytesMut::with_capacity(512);
         let response = match service_choice {
             s if s == ConfirmedServiceChoice::READ_PROPERTY => {
-                let db = db.read().await;
-                match handlers::handle_read_property(&db, &req.service_request, &mut ack_buf) {
-                    Ok(()) => complex_ack(ack_buf),
-                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
-                }
+                confirmed_response::read_property_response(db, &req).await
             }
             s if s == ConfirmedServiceChoice::WRITE_PROPERTY => {
                 let result = {
@@ -662,25 +663,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         service_choice: ConfirmedServiceChoice,
         error: &Error,
     ) -> Apdu {
-        if let Error::Reject { reason } = error {
-            return Apdu::Reject(RejectPdu {
-                invoke_id,
-                reject_reason: RejectReason::from_raw(*reason),
-            });
-        }
-        let (class, code) = match error {
-            Error::Protocol { class, code } => (*class, *code),
-            _ => (
-                ErrorClass::SERVICES.to_raw() as u32,
-                ErrorCode::OTHER.to_raw() as u32,
-            ),
-        };
-        Apdu::Error(ErrorPdu {
-            invoke_id,
-            service_choice,
-            error_class: ErrorClass::from_raw(class as u16),
-            error_code: ErrorCode::from_raw(code as u16),
-            error_data: Bytes::new(),
-        })
+        confirmed_response::error_apdu_from_error(invoke_id, service_choice, error)
     }
 }


### PR DESCRIPTION
## Summary

- add a bounded direct egress handle to the single-owner endpoint session
- add a hidden direct ReadProperty requester using an injected coordinator
- add a private ReadProperty responder that reuses standalone server response construction
- support exact completion from centrally pre-admitted requester and notification terminals
- prove concurrent requester/responder traffic over one Loopback ingress with both wire transactions using invoke ID 0
- preserve exact `reply_tx` movement and endpoint-only shutdown authority

## Scope

This is the internal runtime prerequisite for PR-0115. It does not add a public B/IP device API, real UDP, routed/broadcast egress, segmentation, discovery, service expansion, Python bindings, or production server-to-client dependency. Existing standalone client and server lifecycles remain unchanged.

`bacnet-server` uses `bacnet-client` only as a dev-dependency for the private composition proof.

## Verification

- `cargo test -p bacnet-endpoint-core --locked`
- `cargo test -p bacnet-client --locked`
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-transport loopback --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

Before implementation, `cargo clean` reclaimed 25.2 GiB. No package, publication, or B/IP gate was run for this internal Loopback-only slice.

Refs #431