### PR TITLE
feat(device): add truthful clock synchronization

### DIFF
--- a/crates/bacnet-objects/src/clock.rs
+++ b/crates/bacnet-objects/src/clock.rs
@@ -1,0 +1,35 @@
+//! Dependency-neutral clock data exposed to BACnet objects.
+
+use bacnet_types::primitives::{Date, Time};
+
+/// One coherent sample of the Device clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClockFrame {
+    /// Device local date.
+    pub local_date: Date,
+    /// Device local time.
+    pub local_time: Time,
+    /// Signed minutes west of UTC.
+    pub utc_offset: i16,
+    /// Whether daylight-saving time is currently applied.
+    pub daylight_savings_status: bool,
+}
+
+impl ClockFrame {
+    /// Return the BACnetDaysOfWeek bit for this frame, or `None` for an
+    /// unavailable/invalid day-of-week value.
+    pub fn day_of_week_bit(self) -> Option<u8> {
+        (1..=7)
+            .contains(&self.local_date.day_of_week)
+            .then(|| 1 << (self.local_date.day_of_week - 1))
+    }
+}
+
+/// Synchronous read port for a coherent Device clock sample.
+///
+/// `None` means that no wall-clock frame is available. Implementations must
+/// return all four fields from the same sample.
+pub trait ClockReader: Send + Sync {
+    /// Read one coherent frame, or report that no wall clock is available.
+    fn read_clock(&self) -> Option<ClockFrame>;
+}

--- a/crates/bacnet-objects/src/database.rs
+++ b/crates/bacnet-objects/src/database.rs
@@ -1,11 +1,13 @@
 //! ObjectDatabase — stores and retrieves BACnet objects by identifier.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 
+use crate::clock::{ClockFrame, ClockReader};
 use crate::event_enrollment::EventEnrollmentMonitoredSource;
 use crate::traits::BACnetObject;
 
@@ -15,6 +17,8 @@ use crate::traits::BACnetObject;
 /// Maintains secondary indexes for O(1) name lookup and O(1) type lookup.
 pub struct ObjectDatabase {
     objects: HashMap<ObjectIdentifier, Box<dyn BACnetObject>>,
+    /// Shared Device clock reader. `None` is an explicit clockless database.
+    clock: Option<Arc<dyn ClockReader>>,
     /// Reverse index: object name → ObjectIdentifier for uniqueness enforcement.
     name_index: HashMap<String, ObjectIdentifier>,
     /// Type index: object type → set of ObjectIdentifiers for fast enumeration.
@@ -38,6 +42,7 @@ impl ObjectDatabase {
     pub fn new() -> Self {
         Self {
             objects: HashMap::new(),
+            clock: None,
             name_index: HashMap::new(),
             type_index: HashMap::new(),
             invalid_enrollment_eval_state: HashSet::new(),
@@ -49,7 +54,8 @@ impl ObjectDatabase {
     ///
     /// Returns `Err` if another object already has the same `object_name()`.
     /// Replacing an object with the same OID is allowed (the old object is removed).
-    pub fn add(&mut self, object: Box<dyn BACnetObject>) -> Result<(), Error> {
+    pub fn add(&mut self, mut object: Box<dyn BACnetObject>) -> Result<(), Error> {
+        object.bind_clock_internal(self.clock.clone());
         let oid = object.object_identifier();
         let name = object.object_name().to_string();
 
@@ -242,6 +248,21 @@ impl ObjectDatabase {
     /// Avoids the double-lookup pattern of `list_objects()` followed by `get()`.
     pub fn iter_objects(&self) -> impl Iterator<Item = (ObjectIdentifier, &dyn BACnetObject)> {
         self.objects.iter().map(|(&oid, obj)| (oid, obj.as_ref()))
+    }
+
+    /// Bind one clock reader to the database and every object it contains.
+    ///
+    /// Devices added after this call receive the same reader in [`add`](Self::add).
+    pub fn set_clock_reader(&mut self, clock: Option<Arc<dyn ClockReader>>) {
+        self.clock = clock;
+        for object in self.objects.values_mut() {
+            object.bind_clock_internal(self.clock.clone());
+        }
+    }
+
+    /// Read one coherent sample from the database's shared clock.
+    pub fn clock_frame(&self) -> Option<ClockFrame> {
+        self.clock.as_ref()?.read_clock()
     }
 
     /// Visit every `(ObjectIdentifier, &mut dyn BACnetObject)` pair.

--- a/crates/bacnet-objects/src/device/mod.rs
+++ b/crates/bacnet-objects/src/device/mod.rs
@@ -6,14 +6,16 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use bacnet_types::constructed::BACnetCOVSubscription;
 use bacnet_types::enums::{
     ErrorClass, ErrorCode, ObjectType, PropertyIdentifier, Segmentation, ServiceSupported,
 };
 use bacnet_types::error::Error;
-use bacnet_types::primitives::{Date, ObjectIdentifier, PropertyValue, Time};
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
+use crate::clock::{ClockFrame, ClockReader};
 use crate::common::read_property_list_property;
 use crate::traits::BACnetObject;
 
@@ -145,9 +147,10 @@ pub struct DeviceObject {
     /// Protocol_Object_Types_Supported — bitstring indicating which object
     /// types this device supports (one bit per type, MSB-first within each byte).
     protocol_object_types_supported: Vec<u8>,
-    /// Protocol_Services_Supported — bitstring indicating which services
-    /// this device supports (one bit per service, MSB-first within each byte).
-    protocol_services_supported: Vec<u8>,
+    /// Configured executed services before clock-availability filtering.
+    configured_services_supported: Vec<ServiceSupported>,
+    /// Shared dynamic clock sample source. `None` is explicitly clockless.
+    clock: Option<Arc<dyn ClockReader>>,
     /// Active COV subscriptions maintained by the server.
     active_cov_subscriptions: Vec<BACnetCOVSubscription>,
 }
@@ -231,33 +234,6 @@ impl DeviceObject {
         properties.insert(
             PropertyIdentifier::DEVICE_ADDRESS_BINDING,
             PropertyValue::List(Vec::new()),
-        );
-
-        // Placeholder values updated by the server's time sync or system clock.
-        properties.insert(
-            PropertyIdentifier::LOCAL_DATE,
-            PropertyValue::Date(Date {
-                year: 126, // 2026 - 1900
-                month: 3,
-                day: 18,
-                day_of_week: 3, // Wednesday
-            }),
-        );
-        properties.insert(
-            PropertyIdentifier::LOCAL_TIME,
-            PropertyValue::Time(Time {
-                hour: 12,
-                minute: 0,
-                second: 0,
-                hundredths: 0,
-            }),
-        );
-
-        // UTC_Offset: minutes west of UTC (e.g., +300 for EST); subtract it
-        // from UTC to obtain local standard time.
-        properties.insert(
-            PropertyIdentifier::UTC_OFFSET,
-            PropertyValue::Signed(0), // UTC
         );
 
         // Last_Restart_Reason: 0=unknown, 1=coldstart, 2=warmstart, etc.
@@ -353,14 +329,13 @@ impl DeviceObject {
             ObjectType::COLOR_TEMPERATURE.to_raw(),
         ]);
 
-        let protocol_services_supported = compute_services_supported(EXECUTED_SERVICES);
-
         Ok(Self {
             oid,
             properties,
             object_list: vec![oid], // Device itself is always in the list
             protocol_object_types_supported,
-            protocol_services_supported,
+            configured_services_supported: EXECUTED_SERVICES.to_vec(),
+            clock: None,
             active_cov_subscriptions: Vec::new(),
         })
     }
@@ -377,7 +352,7 @@ impl DeviceObject {
     /// The production is closed at you-Are (bit 48); values past it are not
     /// representable and are dropped.
     pub fn set_services_supported(&mut self, services: &[ServiceSupported]) {
-        self.protocol_services_supported = compute_services_supported(services);
+        self.configured_services_supported = services.to_vec();
     }
 
     /// Get the device instance number.
@@ -401,6 +376,25 @@ impl DeviceObject {
     /// Add a single COV subscription.
     pub fn add_cov_subscription(&mut self, sub: BACnetCOVSubscription) {
         self.active_cov_subscriptions.push(sub);
+    }
+
+    fn clock_frame(&self) -> Option<ClockFrame> {
+        self.clock.as_ref()?.read_clock()
+    }
+
+    fn services_supported(&self) -> Vec<u8> {
+        let clock_available = self.clock_frame().is_some();
+        let services = self
+            .configured_services_supported
+            .iter()
+            .copied()
+            .filter(|service| {
+                clock_available
+                    || (*service != ServiceSupported::TIME_SYNCHRONIZATION
+                        && *service != ServiceSupported::UTC_TIME_SYNCHRONIZATION)
+            })
+            .collect::<Vec<_>>();
+        compute_services_supported(&services)
     }
 }
 
@@ -453,6 +447,30 @@ impl BACnetObject for DeviceObject {
             return read_property_list_property(&self.property_list(), array_index);
         }
 
+        if matches!(
+            property,
+            PropertyIdentifier::LOCAL_DATE
+                | PropertyIdentifier::LOCAL_TIME
+                | PropertyIdentifier::UTC_OFFSET
+                | PropertyIdentifier::DAYLIGHT_SAVINGS_STATUS
+        ) {
+            let frame = self.clock_frame().ok_or(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            })?;
+            return Ok(match property {
+                PropertyIdentifier::LOCAL_DATE => PropertyValue::Date(frame.local_date),
+                PropertyIdentifier::LOCAL_TIME => PropertyValue::Time(frame.local_time),
+                PropertyIdentifier::UTC_OFFSET => {
+                    PropertyValue::Signed(i32::from(frame.utc_offset))
+                }
+                PropertyIdentifier::DAYLIGHT_SAVINGS_STATUS => {
+                    PropertyValue::Boolean(frame.daylight_savings_status)
+                }
+                _ => unreachable!(),
+            });
+        }
+
         if property == PropertyIdentifier::PROTOCOL_OBJECT_TYPES_SUPPORTED {
             let num_bytes = self.protocol_object_types_supported.len();
             let total_bits = num_bytes * 8;
@@ -474,11 +492,11 @@ impl BACnetObject for DeviceObject {
         }
 
         if property == PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED {
-            let unused =
-                (self.protocol_services_supported.len() * 8 - SERVICES_SUPPORTED_BITS) as u8;
+            let services_supported = self.services_supported();
+            let unused = (services_supported.len() * 8 - SERVICES_SUPPORTED_BITS) as u8;
             return Ok(PropertyValue::BitString {
                 unused_bits: unused,
-                data: self.protocol_services_supported.clone(),
+                data: services_supported,
             });
         }
 
@@ -530,6 +548,14 @@ impl BACnetObject for DeviceObject {
         props.push(PropertyIdentifier::PROTOCOL_OBJECT_TYPES_SUPPORTED);
         props.push(PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED);
         props.push(PropertyIdentifier::ACTIVE_COV_SUBSCRIPTIONS);
+        if self.clock_frame().is_some() {
+            props.extend([
+                PropertyIdentifier::LOCAL_DATE,
+                PropertyIdentifier::LOCAL_TIME,
+                PropertyIdentifier::UTC_OFFSET,
+                PropertyIdentifier::DAYLIGHT_SAVINGS_STATUS,
+            ]);
+        }
         props.sort_by_key(|p| p.to_raw());
         Cow::Owned(props)
     }
@@ -540,6 +566,10 @@ impl BACnetObject for DeviceObject {
     }
     fn is_deleteable(&self) -> bool {
         false
+    }
+
+    fn bind_clock_internal(&mut self, clock: Option<Arc<dyn ClockReader>>) {
+        self.clock = clock;
     }
 }
 

--- a/crates/bacnet-objects/src/device/tests.rs
+++ b/crates/bacnet-objects/src/device/tests.rs
@@ -1,4 +1,49 @@
 use super::*;
+use crate::clock::{ClockFrame, ClockReader};
+use bacnet_types::primitives::{Date, Time};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct FakeClock(Arc<Mutex<Option<ClockFrame>>>);
+
+impl FakeClock {
+    fn new(frame: ClockFrame) -> Self {
+        Self(Arc::new(Mutex::new(Some(frame))))
+    }
+
+    fn set(&self, frame: ClockFrame) {
+        *self.0.lock().unwrap() = Some(frame);
+    }
+}
+
+impl ClockReader for FakeClock {
+    fn read_clock(&self) -> Option<ClockFrame> {
+        *self.0.lock().ok()?
+    }
+}
+
+fn clock_frame(hour: u8, minute: u8) -> ClockFrame {
+    ClockFrame {
+        local_date: Date {
+            year: 126,
+            month: 8,
+            day: 26,
+            day_of_week: 3,
+        },
+        local_time: Time {
+            hour,
+            minute,
+            second: 30,
+            hundredths: 25,
+        },
+        utc_offset: 300,
+        daylight_savings_status: true,
+    }
+}
+
+fn bind_clock(device: &mut DeviceObject, clock: FakeClock) {
+    device.bind_clock_internal(Some(Arc::new(clock)));
+}
 
 fn make_device() -> DeviceObject {
     DeviceObject::new(DeviceConfig {
@@ -276,7 +321,8 @@ fn read_protocol_services_supported() {
     use bacnet_types::bitstring::ServicesSupported;
     use bacnet_types::enums::ServiceSupported;
 
-    let dev = make_device();
+    let mut dev = make_device();
+    bind_clock(&mut dev, FakeClock::new(clock_frame(12, 0)));
     let val = dev
         .read_property(PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED, None)
         .unwrap();
@@ -309,6 +355,76 @@ fn read_protocol_services_supported() {
             assert!(!ss.contains(ServiceSupported::UNCONFIRMED_COV_NOTIFICATION));
         }
         _ => panic!("Expected BitString"),
+    }
+}
+
+#[test]
+fn clockless_device_omits_clock_properties_and_sync_services() {
+    use bacnet_types::bitstring::ServicesSupported;
+
+    let dev = make_device();
+    let props = dev.property_list();
+    for property in [
+        PropertyIdentifier::LOCAL_DATE,
+        PropertyIdentifier::LOCAL_TIME,
+        PropertyIdentifier::UTC_OFFSET,
+        PropertyIdentifier::DAYLIGHT_SAVINGS_STATUS,
+    ] {
+        assert!(!props.contains(&property));
+        assert!(matches!(
+            dev.read_property(property, None),
+            Err(Error::Protocol { class, code })
+                if class == ErrorClass::PROPERTY.to_raw() as u32
+                    && code == ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32
+        ));
+    }
+
+    let PropertyValue::BitString { data, .. } = dev
+        .read_property(PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED, None)
+        .unwrap()
+    else {
+        panic!("Expected BitString");
+    };
+    let services = ServicesSupported::from_bacnet(&data);
+    assert!(!services.contains(ServiceSupported::TIME_SYNCHRONIZATION));
+    assert!(!services.contains(ServiceSupported::UTC_TIME_SYNCHRONIZATION));
+}
+
+#[test]
+fn bound_device_reads_one_advancing_clock_source() {
+    let mut dev = make_device();
+    let clock = FakeClock::new(clock_frame(9, 15));
+    bind_clock(&mut dev, clock.clone());
+
+    assert_eq!(
+        dev.read_property(PropertyIdentifier::LOCAL_TIME, None)
+            .unwrap(),
+        PropertyValue::Time(clock_frame(9, 15).local_time)
+    );
+    assert_eq!(
+        dev.read_property(PropertyIdentifier::UTC_OFFSET, None)
+            .unwrap(),
+        PropertyValue::Signed(300)
+    );
+    assert_eq!(
+        dev.read_property(PropertyIdentifier::DAYLIGHT_SAVINGS_STATUS, None)
+            .unwrap(),
+        PropertyValue::Boolean(true)
+    );
+
+    clock.set(clock_frame(9, 16));
+    assert_eq!(
+        dev.read_property(PropertyIdentifier::LOCAL_TIME, None)
+            .unwrap(),
+        PropertyValue::Time(clock_frame(9, 16).local_time)
+    );
+    for property in [
+        PropertyIdentifier::LOCAL_DATE,
+        PropertyIdentifier::LOCAL_TIME,
+        PropertyIdentifier::UTC_OFFSET,
+        PropertyIdentifier::DAYLIGHT_SAVINGS_STATUS,
+    ] {
+        assert!(dev.property_list().contains(&property));
     }
 }
 

--- a/crates/bacnet-objects/src/lib.rs
+++ b/crates/bacnet-objects/src/lib.rs
@@ -6,6 +6,7 @@ pub mod analog;
 pub mod audit;
 pub mod averaging;
 pub mod binary;
+pub mod clock;
 pub mod color;
 pub mod command;
 pub(crate) mod common;

--- a/crates/bacnet-objects/src/notification_class/mod.rs
+++ b/crates/bacnet-objects/src/notification_class/mod.rs
@@ -293,17 +293,15 @@ fn time_in_window(current: &Time, from: &Time, to: &Time) -> bool {
 ///
 /// `utc_secs` is seconds since the Unix epoch (1970-01-01, a Thursday).
 /// `utc_offset_minutes` is the Device object's `UTC_Offset` (signed minutes
-/// east of UTC, Clause 12.32); 0 keeps UTC. The day-of-week follows
+/// west of UTC); 0 keeps UTC. The day-of-week follows
 /// `BACnetDaysOfWeek` (monday(0)..sunday(6), Clause 21): the `+3` makes
 /// Monday=0 because the epoch was a Thursday, and `today_bit = 1 << dow`
 /// uses the same convention as `valid_days`. The returned `Time` is the
 /// local time of day (hundredths are supplied by the caller via `subsec`).
 pub fn local_day_and_time(utc_secs: u64, utc_offset_minutes: i32) -> (u8, Time) {
-    // Shift to local seconds. `saturating_add_signed` clamps to 0 if a negative
-    // offset would cross below the Unix epoch; this only matters for timestamps
-    // in the first ~24h of 1970 and is otherwise a no-op. The offset is bounded
-    // by ±24*60 minutes in practice.
-    let local_secs = utc_secs.saturating_add_signed((utc_offset_minutes as i64) * 60);
+    // BACnet UTC_Offset is signed minutes west of UTC, so local standard time
+    // subtracts it. Saturation only affects values close to the Unix epoch.
+    let local_secs = utc_secs.saturating_add_signed(-i64::from(utc_offset_minutes) * 60);
     let dow = ((local_secs / 86400 + 3) % 7) as u8;
     let today_bit = 1u8 << dow;
     let day_secs = (local_secs % 86400) as u32;

--- a/crates/bacnet-objects/src/notification_class/tests/recipients.rs
+++ b/crates/bacnet-objects/src/notification_class/tests/recipients.rs
@@ -320,12 +320,12 @@ fn local_day_and_time_day_bits_match_bacnet_days_of_week() {
 
 #[test]
 fn local_day_and_time_offset_shifts_day_and_time() {
-    // +60 min: UTC 23:00 Thu -> Fri 00:00 local (bit 4 = 0x10).
-    let (bit, t) = local_day_and_time(23 * 3600, 60);
+    // -60 min (east): UTC 23:00 Thu -> Fri 00:00 local (bit 4 = 0x10).
+    let (bit, t) = local_day_and_time(23 * 3600, -60);
     assert_eq!(bit, 0x10, "UTC 23:00 Thu +60min rolls to Friday bit 4");
     assert_eq!((t.hour, t.minute, t.second), (0, 0, 0));
-    // -60 min: UTC 00:30 Fri (86400+30*60) -> Thu 23:30 local (bit 3 = 0x08).
-    let (bit, t) = local_day_and_time(86400 + 30 * 60, -60);
+    // +60 min (west): UTC 00:30 Fri -> Thu 23:30 local (bit 3 = 0x08).
+    let (bit, t) = local_day_and_time(86400 + 30 * 60, 60);
     assert_eq!(
         bit, 0x08,
         "UTC 00:30 next day -60min rolls back to Thursday"

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -2,6 +2,7 @@
 
 use std::any::Any;
 use std::borrow::Cow;
+use std::sync::Arc;
 
 use bacnet_types::constructed::BACnetLogRecord;
 use bacnet_types::enums::{
@@ -10,6 +11,7 @@ use bacnet_types::enums::{
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
+use crate::clock::ClockReader;
 use crate::event::TransitionOutcome;
 use crate::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource};
 use crate::file::FileStorage;
@@ -96,6 +98,13 @@ pub trait BACnetObject: Send + Sync {
     /// Object_Type but omits Property_List. Reading the BACnet Property_List
     /// property applies the additional wire-level universal-property filter.
     fn property_list(&self) -> Cow<'static, [PropertyIdentifier]>;
+
+    /// Bind or remove the database's shared wall-clock reader.
+    ///
+    /// Objects that do not expose clock-derived state ignore this internal
+    /// lifecycle hook.
+    #[doc(hidden)]
+    fn bind_clock_internal(&mut self, _clock: Option<Arc<dyn ClockReader>>) {}
 
     /// Whether `write_property` accepts `property` for this object.
     ///

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -20,7 +20,7 @@ fn make_db_with_msi() -> ObjectDatabase {
 }
 
 fn make_db_with_device_and_ai() -> ObjectDatabase {
-    let mut db = ObjectDatabase::new();
+    let mut db = crate::server::clocked_test_database();
     let device = bacnet_objects::device::DeviceObject::new(bacnet_objects::device::DeviceConfig {
         instance: 1,
         name: "TestDevice".into(),

--- a/crates/bacnet-server/src/pics/mod.rs
+++ b/crates/bacnet-server/src/pics/mod.rs
@@ -9,7 +9,9 @@ use std::fmt;
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_objects::device::EXECUTED_SERVICES;
 use bacnet_objects::property_metadata::PropertyConformance;
+use bacnet_types::bitstring::ServicesSupported;
 use bacnet_types::enums::{ObjectType, PropertyIdentifier, ServiceSupported};
+use bacnet_types::primitives::PropertyValue;
 
 use crate::server::ServerConfig;
 
@@ -337,14 +339,38 @@ impl<'a> PicsGenerator<'a> {
     ];
 
     fn build_services(&self) -> Vec<ServiceSupport> {
-        // Executor column comes from the same constant the Device object's
-        // Protocol_Services_Supported is built from, so the PICS cannot drift
-        // from the property (both are cross-checked against the dispatch
-        // table by `executed_services_match_dispatch_table`).
+        // Prefer the effective Device bit string so runtime modes such as an
+        // explicitly clockless server cannot drift from generated PICS. The
+        // static dispatch contract remains the fallback for databases without
+        // a readable Device service property, filtered by database clock mode.
+        let effective_executed = self
+            .db
+            .iter_objects()
+            .filter(|(oid, _)| oid.object_type() == ObjectType::DEVICE)
+            .find_map(|(_, device)| {
+                match device
+                    .read_property(PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED, None)
+                    .ok()?
+                {
+                    PropertyValue::BitString { data, .. } => {
+                        Some(ServicesSupported::from_bacnet(&data))
+                    }
+                    _ => None,
+                }
+            });
         let mut service_map: BTreeMap<&'static str, (bool, bool)> = BTreeMap::new();
-        for service in EXECUTED_SERVICES {
+        let clock_available = self.db.clock_frame().is_some();
+        let executed: Box<dyn Iterator<Item = ServiceSupported> + '_> = match &effective_executed {
+            Some(services) => Box::new(services.iter()),
+            None => Box::new(EXECUTED_SERVICES.iter().copied().filter(move |service| {
+                clock_available
+                    || (*service != ServiceSupported::TIME_SYNCHRONIZATION
+                        && *service != ServiceSupported::UTC_TIME_SYNCHRONIZATION)
+            })),
+        };
+        for service in executed {
             service_map
-                .entry(service_display_name(*service))
+                .entry(service_display_name(service))
                 .or_default()
                 .1 = true;
         }

--- a/crates/bacnet-server/src/schedule.rs
+++ b/crates/bacnet-server/src/schedule.rs
@@ -4,37 +4,29 @@
 //! to all controlled object-property references.
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
+use bacnet_objects::clock::ClockFrame;
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_types::enums::{ObjectType, PropertyIdentifier};
 use tokio::sync::RwLock;
 use tracing::{debug, warn};
 
-/// Compute (day_of_week, hour, minute) from the current time with UTC offset.
-///
-/// day_of_week: 0=Monday .. 6=Sunday (matching BACnet weekly_schedule index).
-/// `utc_offset_minutes`: offset from UTC in minutes (e.g. -300 for US Eastern).
-fn current_time_components(utc_offset_minutes: i16) -> (u8, u8, u8) {
-    let secs = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    let local_secs = (secs as i64 + (utc_offset_minutes as i64) * 60) as u64;
-    let day_of_week = ((local_secs / 86400 + 3) % 7) as u8;
-    let time_of_day = local_secs % 86400;
-    let hour = (time_of_day / 3600) as u8;
-    let minute = ((time_of_day % 3600) / 60) as u8;
-    (day_of_week, hour, minute)
+/// Compute the weekly-schedule index and time from one shared clock frame.
+pub(crate) fn current_time_components(frame: ClockFrame) -> Option<(u8, u8, u8)> {
+    let day_of_week = frame.local_date.day_of_week.checked_sub(1)?;
+    (day_of_week <= 6).then_some((day_of_week, frame.local_time.hour, frame.local_time.minute))
 }
 
 /// Evaluate all Schedule objects and write to their controlled properties.
 ///
-/// Called periodically by the server (every 60 seconds). Uses the current
-/// system time (with UTC offset) to determine the active schedule value.
-/// `utc_offset_minutes`: device's UTC offset (from Device object UTC_Offset property).
-pub async fn tick_schedules(db: &Arc<RwLock<ObjectDatabase>>, utc_offset_minutes: i16) {
-    let (day_of_week, hour, minute) = current_time_components(utc_offset_minutes);
+/// Called periodically by the server (every 60 seconds). The offset argument
+/// remains for source compatibility; evaluation uses the database clock frame.
+pub async fn tick_schedules(db: &Arc<RwLock<ObjectDatabase>>, _utc_offset_minutes: i16) {
+    let frame = db.read().await.clock_frame();
+    let Some((day_of_week, hour, minute)) = frame.and_then(current_time_components) else {
+        debug!("Skipping Schedule evaluation without a valid Device clock");
+        return;
+    };
 
     let mut writes = Vec::new();
     {

--- a/crates/bacnet-server/src/server/clock.rs
+++ b/crates/bacnet-server/src/server/clock.rs
@@ -1,0 +1,430 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use bacnet_objects::clock::{ClockFrame, ClockReader};
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{Date, Time};
+
+use super::{BACnetServer, ServerConfig};
+
+const HUNDREDTHS_PER_SECOND: i128 = 100;
+const HUNDREDTHS_PER_MINUTE: i128 = 60 * HUNDREDTHS_PER_SECOND;
+const HUNDREDTHS_PER_DAY: i128 = 24 * 60 * HUNDREDTHS_PER_MINUTE;
+
+/// Validated civil-time settings for the bundled server clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClockConfig {
+    utc_offset_minutes: i16,
+    daylight_savings_status: bool,
+}
+
+impl ClockConfig {
+    /// Configure signed minutes west of UTC and daylight-saving status.
+    pub fn new(utc_offset_minutes: i16, daylight_savings_status: bool) -> Result<Self, Error> {
+        if !(-1440..=1440).contains(&utc_offset_minutes) || utc_offset_minutes % 15 != 0 {
+            return Err(Error::Encoding(format!(
+                "UTC offset {utc_offset_minutes} must be within -1440..=1440 minutes in 15-minute increments"
+            )));
+        }
+        Ok(Self {
+            utc_offset_minutes,
+            daylight_savings_status,
+        })
+    }
+
+    /// Return the configured signed minutes west of UTC.
+    pub fn utc_offset_minutes(self) -> i16 {
+        self.utc_offset_minutes
+    }
+
+    /// Return whether the one-hour daylight-saving adjustment is active.
+    pub fn daylight_savings_status(self) -> bool {
+        self.daylight_savings_status
+    }
+}
+
+impl Default for ClockConfig {
+    fn default() -> Self {
+        Self {
+            utc_offset_minutes: 0,
+            daylight_savings_status: false,
+        }
+    }
+}
+
+impl<T: TransportPort + 'static> BACnetServer<T> {
+    /// Start with the default system-UTC Device clock.
+    pub async fn start(
+        config: ServerConfig,
+        db: ObjectDatabase,
+        transport: T,
+    ) -> Result<Self, Error> {
+        Self::start_with_clock(config, db, transport, ClockConfig::default()).await
+    }
+
+    /// Start with a validated Device clock configuration.
+    pub async fn start_with_clock(
+        config: ServerConfig,
+        db: ObjectDatabase,
+        transport: T,
+        clock_config: ClockConfig,
+    ) -> Result<Self, Error> {
+        Self::start_with_clock_mode(config, db, transport, Some(clock_config)).await
+    }
+
+    /// Start without a Device wall clock or time-synchronization execution.
+    pub async fn start_clockless(
+        config: ServerConfig,
+        db: ObjectDatabase,
+        transport: T,
+    ) -> Result<Self, Error> {
+        Self::start_with_clock_mode(config, db, transport, None).await
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ClockState {
+    synchronized_utc: Option<(i128, Instant)>,
+    config: ClockConfig,
+}
+
+/// Mutable server-owned controller behind the object layer's read-only port.
+pub(super) struct ServerClock {
+    state: Mutex<ClockState>,
+}
+
+impl ServerClock {
+    pub(super) fn new(config: ClockConfig) -> Self {
+        Self {
+            state: Mutex::new(ClockState {
+                synchronized_utc: None,
+                config,
+            }),
+        }
+    }
+
+    /// Apply a fully specified local or UTC synchronization value.
+    ///
+    /// Validation and conversion finish before the controller is mutated.
+    pub(super) fn synchronize(&self, date: Date, time: Time, is_utc: bool) -> Result<(), Error> {
+        let supplied_hundredths = date_time_to_hundredths(date, time)?;
+        let config = self
+            .state
+            .lock()
+            .map_err(|_| Error::Encoding("Device clock lock poisoned".into()))?
+            .config;
+
+        let utc_hundredths = if is_utc {
+            supplied_hundredths
+        } else {
+            supplied_hundredths + i128::from(config.utc_offset_minutes) * HUNDREDTHS_PER_MINUTE
+                - if config.daylight_savings_status {
+                    60 * HUNDREDTHS_PER_MINUTE
+                } else {
+                    0
+                }
+        };
+
+        frame_from_utc_hundredths(utc_hundredths, config).ok_or_else(|| {
+            Error::Encoding("synchronized time is outside the BACnet Date range".into())
+        })?;
+
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| Error::Encoding("Device clock lock poisoned".into()))?;
+        state.synchronized_utc = Some((utc_hundredths, Instant::now()));
+        Ok(())
+    }
+}
+
+impl ClockReader for ServerClock {
+    fn read_clock(&self) -> Option<ClockFrame> {
+        let state = *self.state.lock().ok()?;
+        let utc_hundredths = match state.synchronized_utc {
+            Some((anchor, monotonic_anchor)) => {
+                let elapsed_hundredths =
+                    i128::try_from(monotonic_anchor.elapsed().as_millis() / 10).ok()?;
+                anchor + elapsed_hundredths
+            }
+            None => system_utc_hundredths(),
+        };
+        frame_from_utc_hundredths(utc_hundredths, state.config)
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn clocked_test_database() -> ObjectDatabase {
+    let mut db = ObjectDatabase::new();
+    db.set_clock_reader(Some(std::sync::Arc::new(ServerClock::new(
+        ClockConfig::default(),
+    ))));
+    db
+}
+
+fn system_utc_hundredths() -> i128 {
+    let elapsed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO);
+    i128::from(elapsed.as_secs()) * HUNDREDTHS_PER_SECOND + i128::from(elapsed.subsec_millis() / 10)
+}
+
+fn date_time_to_hundredths(date: Date, time: Time) -> Result<i128, Error> {
+    let year = date
+        .actual_year()
+        .ok_or_else(|| invalid_datetime("date contains an unspecified year"))?;
+    if !(1..=12).contains(&date.month) {
+        return Err(invalid_datetime("date month must be 1..=12"));
+    }
+    let max_day = days_in_month(year, date.month);
+    if date.day == 0 || date.day > max_day {
+        return Err(invalid_datetime("date day is invalid for its month"));
+    }
+    if !(1..=7).contains(&date.day_of_week) {
+        return Err(invalid_datetime("date day-of-week must be 1..=7"));
+    }
+
+    let days = days_from_civil(i64::from(year), i64::from(date.month), i64::from(date.day));
+    let expected_day_of_week = (days + 3).rem_euclid(7) as u8 + 1;
+    if date.day_of_week != expected_day_of_week {
+        return Err(invalid_datetime("date day-of-week is inconsistent"));
+    }
+    if time.hour > 23 || time.minute > 59 || time.second > 59 || time.hundredths > 99 {
+        return Err(invalid_datetime(
+            "time must be fully specified and within its field ranges",
+        ));
+    }
+
+    let day_hundredths = i128::from(time.hour) * 60 * HUNDREDTHS_PER_MINUTE
+        + i128::from(time.minute) * HUNDREDTHS_PER_MINUTE
+        + i128::from(time.second) * HUNDREDTHS_PER_SECOND
+        + i128::from(time.hundredths);
+    Ok(i128::from(days) * HUNDREDTHS_PER_DAY + day_hundredths)
+}
+
+fn invalid_datetime(message: &str) -> Error {
+    Error::Encoding(format!("invalid time synchronization value: {message}"))
+}
+
+fn frame_from_utc_hundredths(utc_hundredths: i128, config: ClockConfig) -> Option<ClockFrame> {
+    let dst_minutes = if config.daylight_savings_status {
+        60
+    } else {
+        0
+    };
+    let local_hundredths = utc_hundredths
+        - i128::from(config.utc_offset_minutes) * HUNDREDTHS_PER_MINUTE
+        + i128::from(dst_minutes) * HUNDREDTHS_PER_MINUTE;
+    let days = local_hundredths.div_euclid(HUNDREDTHS_PER_DAY);
+    let within_day = local_hundredths.rem_euclid(HUNDREDTHS_PER_DAY);
+    let days = i64::try_from(days).ok()?;
+    let (year, month, day) = civil_from_days(days);
+    let encoded_year = year.checked_sub(1900)?;
+    if !(0..=254).contains(&encoded_year) {
+        return None;
+    }
+
+    let total_seconds = within_day / HUNDREDTHS_PER_SECOND;
+    Some(ClockFrame {
+        local_date: Date {
+            year: encoded_year as u8,
+            month: month as u8,
+            day: day as u8,
+            day_of_week: (days + 3).rem_euclid(7) as u8 + 1,
+        },
+        local_time: Time {
+            hour: (total_seconds / 3600) as u8,
+            minute: ((total_seconds % 3600) / 60) as u8,
+            second: (total_seconds % 60) as u8,
+            hundredths: (within_day % HUNDREDTHS_PER_SECOND) as u8,
+        },
+        utc_offset: config.utc_offset_minutes,
+        daylight_savings_status: config.daylight_savings_status,
+    })
+}
+
+fn days_in_month(year: u16, month: u8) -> u8 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: u16) -> bool {
+    year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400))
+}
+
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year = year - i64::from(month <= 2);
+    let era = year.div_euclid(400);
+    let year_of_era = year - era * 400;
+    let month_prime = month + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * month_prime + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+fn civil_from_days(days: i64) -> (i64, i64, i64) {
+    let shifted = days + 719_468;
+    let era = shifted.div_euclid(146_097);
+    let day_of_era = shifted - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_prime = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
+    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
+    year += i64::from(month <= 2);
+    (year, month, day)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn date(year: u16, month: u8, day: u8, day_of_week: u8) -> Date {
+        Date {
+            year: (year - 1900) as u8,
+            month,
+            day,
+            day_of_week,
+        }
+    }
+
+    fn time(hour: u8, minute: u8, second: u8, hundredths: u8) -> Time {
+        Time {
+            hour,
+            minute,
+            second,
+            hundredths,
+        }
+    }
+
+    #[test]
+    fn clock_config_rejects_invalid_offsets() {
+        assert!(ClockConfig::new(-1440, false).is_ok());
+        assert!(ClockConfig::new(1440, true).is_ok());
+        assert!(ClockConfig::new(14, false).is_err());
+        assert!(ClockConfig::new(1441, false).is_err());
+    }
+
+    #[test]
+    fn civil_conversion_covers_offsets_dst_and_rollover() {
+        let utc = date_time_to_hundredths(date(2024, 3, 1, 5), time(0, 30, 0, 25)).unwrap();
+
+        let west = frame_from_utc_hundredths(utc, ClockConfig::new(60, false).unwrap()).unwrap();
+        assert_eq!(west.local_date, date(2024, 2, 29, 4));
+        assert_eq!(west.local_time, time(23, 30, 0, 25));
+
+        let east = frame_from_utc_hundredths(utc, ClockConfig::new(-60, false).unwrap()).unwrap();
+        assert_eq!(east.local_date, date(2024, 3, 1, 5));
+        assert_eq!(east.local_time, time(1, 30, 0, 25));
+
+        let dst = frame_from_utc_hundredths(utc, ClockConfig::new(60, true).unwrap()).unwrap();
+        assert_eq!(dst.local_date, date(2024, 3, 1, 5));
+        assert_eq!(dst.local_time, time(0, 30, 0, 25));
+    }
+
+    #[test]
+    fn synchronization_validation_rejects_wildcards_calendar_errors_and_inconsistent_days() {
+        let clock = ServerClock::new(ClockConfig::default());
+        let anchor = clock.state.lock().unwrap().synchronized_utc;
+        for invalid_date in [
+            date(2023, 2, 29, 3),
+            date(2024, 2, 29, 5),
+            Date {
+                year: Date::UNSPECIFIED,
+                month: 1,
+                day: 1,
+                day_of_week: 1,
+            },
+        ] {
+            assert!(clock
+                .synchronize(invalid_date, time(12, 0, 0, 0), true)
+                .is_err());
+        }
+        assert!(clock
+            .synchronize(
+                date(2024, 2, 29, 4),
+                Time {
+                    hour: Time::UNSPECIFIED,
+                    minute: 0,
+                    second: 0,
+                    hundredths: 0,
+                },
+                true,
+            )
+            .is_err());
+        assert!(clock
+            .synchronize(date(2024, 2, 29, 4), time(24, 0, 0, 0), true)
+            .is_err());
+        assert_eq!(clock.state.lock().unwrap().synchronized_utc, anchor);
+    }
+
+    #[test]
+    fn local_and_utc_synchronization_share_the_configured_frame() {
+        let clock = ServerClock::new(ClockConfig::new(300, true).unwrap());
+        clock
+            .synchronize(date(2024, 7, 4, 4), time(9, 15, 0, 0), false)
+            .unwrap();
+        let local = clock.read_clock().unwrap();
+        assert_eq!(local.local_date, date(2024, 7, 4, 4));
+        assert_eq!((local.local_time.hour, local.local_time.minute), (9, 15));
+
+        clock
+            .synchronize(date(2024, 7, 4, 4), time(13, 15, 0, 0), true)
+            .unwrap();
+        let utc = clock.read_clock().unwrap();
+        assert_eq!(utc.local_date, date(2024, 7, 4, 4));
+        assert_eq!((utc.local_time.hour, utc.local_time.minute), (9, 15));
+        assert_eq!(utc.utc_offset, 300);
+        assert!(utc.daylight_savings_status);
+    }
+
+    #[test]
+    fn device_schedule_recipient_and_cov_use_the_same_frame() {
+        use bacnet_objects::database::ObjectDatabase;
+        use bacnet_objects::device::{DeviceConfig, DeviceObject};
+        use bacnet_objects::traits::BACnetObject;
+        use bacnet_types::enums::PropertyIdentifier;
+        use bacnet_types::primitives::PropertyValue;
+        use std::sync::Arc;
+
+        let clock = Arc::new(ServerClock::new(ClockConfig::new(300, true).unwrap()));
+        clock
+            .synchronize(date(2024, 7, 4, 4), time(9, 15, 0, 0), false)
+            .unwrap();
+
+        let device = DeviceObject::new(DeviceConfig::default()).unwrap();
+        let device_oid = device.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(device)).unwrap();
+        db.set_clock_reader(Some(
+            Arc::clone(&clock) as Arc<dyn bacnet_objects::clock::ClockReader>
+        ));
+
+        let frame = db.clock_frame().unwrap();
+        assert_eq!(
+            db.get(&device_oid)
+                .unwrap()
+                .read_property(PropertyIdentifier::LOCAL_TIME, None)
+                .unwrap(),
+            PropertyValue::Time(frame.local_time)
+        );
+        assert_eq!(
+            crate::schedule::current_time_components(frame),
+            Some((3, 9, 15))
+        );
+        assert_eq!(frame.day_of_week_bit(), Some(0x08));
+        assert_eq!(
+            crate::server::cov_clock::cov_multiple_datetime(frame),
+            (frame.local_date, frame.local_time)
+        );
+    }
+}

--- a/crates/bacnet-server/src/server/cov_clock.rs
+++ b/crates/bacnet-server/src/server/cov_clock.rs
@@ -1,21 +1,6 @@
-use bacnet_objects::database::ObjectDatabase;
-use bacnet_types::enums::PropertyIdentifier;
-use bacnet_types::primitives::{Date, ObjectIdentifier, PropertyValue, Time};
-use std::time::{Duration, Instant};
-
-pub(crate) fn device_utc_offset(db: &ObjectDatabase, device_oid: &ObjectIdentifier) -> i32 {
-    db.get(device_oid)
-        .and_then(|device| {
-            device
-                .read_property(PropertyIdentifier::UTC_OFFSET, None)
-                .ok()
-        })
-        .and_then(|value| match value {
-            PropertyValue::Signed(minutes) => Some(minutes),
-            _ => None,
-        })
-        .unwrap_or(0)
-}
+use bacnet_objects::clock::ClockFrame;
+use bacnet_types::primitives::{Date, Time};
+use std::time::Instant;
 
 pub(crate) fn cov_multiple_time_remaining(expires_at: Option<Instant>) -> u32 {
     expires_at.map_or(0, |expires_at| {
@@ -28,46 +13,7 @@ pub(crate) fn cov_multiple_time_remaining(expires_at: Option<Instant>) -> u32 {
     })
 }
 
-/// Convert a UTC duration since the Unix epoch to local BACnet Date and Time.
-///
-/// COVNotificationMultiple carries an optional BACnetDateTime at the request
-/// level and an optional primitive Time for each timestamped value. Keeping
-/// both values on the same conversion path prevents them from disagreeing at
-/// a day boundary. BACnet `UTC_Offset` is positive west of UTC and is
-/// subtracted from UTC to obtain local standard time.
-pub(crate) fn cov_multiple_datetime(elapsed: Duration, utc_offset_minutes: i32) -> (Date, Time) {
-    let total_secs = elapsed
-        .as_secs()
-        .saturating_add_signed(-i64::from(utc_offset_minutes) * 60);
-    let days_since_epoch = (total_secs / 86_400) as i64;
-    let seconds_today = total_secs % 86_400;
-
-    // Howard Hinnant's civil-from-days algorithm. The input epoch is
-    // 1970-01-01; 719_468 shifts it to the algorithm's civil epoch.
-    let z = days_since_epoch + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let day_of_era = z - era * 146_097;
-    let year_of_era =
-        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
-    let mut year = year_of_era + era * 400;
-    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
-    let month_prime = (5 * day_of_year + 2) / 153;
-    let day = day_of_year - (153 * month_prime + 2) / 5 + 1;
-    let month = month_prime + if month_prime < 10 { 3 } else { -9 };
-    year += i64::from(month <= 2);
-
-    let date = Date {
-        year: u8::try_from(year - 1900).unwrap_or(Date::UNSPECIFIED),
-        month: month as u8,
-        day: day as u8,
-        day_of_week: ((days_since_epoch + 3).rem_euclid(7) + 1) as u8,
-    };
-    let time = Time {
-        hour: (seconds_today / 3_600) as u8,
-        minute: ((seconds_today % 3_600) / 60) as u8,
-        second: (seconds_today % 60) as u8,
-        hundredths: (elapsed.subsec_millis() / 10) as u8,
-    };
-
-    (date, time)
+/// Project the request-level and per-value COV timestamps from one sample.
+pub(crate) fn cov_multiple_datetime(frame: ClockFrame) -> (Date, Time) {
+    (frame.local_date, frame.local_time)
 }

--- a/crates/bacnet-server/src/server/cov_notifications.rs
+++ b/crates/bacnet-server/src/server/cov_notifications.rs
@@ -301,11 +301,16 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 .find(|o| o.object_type() == ObjectType::DEVICE)
                 .unwrap_or_else(|| ObjectIdentifier::new(ObjectType::DEVICE, 0).unwrap());
             let timestamp = if subscriptions.iter().any(|sub| sub.timestamped) {
-                let Some(clock_frame) = db.clock_frame() else {
-                    debug!("Skipping timestamped COVNotificationMultiple without a Device clock");
-                    return;
-                };
-                Some(cov_multiple_datetime(clock_frame))
+                match db.clock_frame() {
+                    Some(clock_frame) => Some(cov_multiple_datetime(clock_frame)),
+                    None => {
+                        // A timestamp request cannot manufacture a Device
+                        // DateTime in clockless mode. Preserve delivery while
+                        // omitting both request and value timestamps.
+                        debug!("Delivering clockless COVNotificationMultiple without timestamps");
+                        None
+                    }
+                }
             } else {
                 None
             };

--- a/crates/bacnet-server/src/server/cov_notifications.rs
+++ b/crates/bacnet-server/src/server/cov_notifications.rs
@@ -1,4 +1,4 @@
-use super::cov_clock::{cov_multiple_datetime, cov_multiple_time_remaining, device_utc_offset};
+use super::cov_clock::{cov_multiple_datetime, cov_multiple_time_remaining};
 use super::*;
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
@@ -293,18 +293,22 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         }
 
         let representative = &subscriptions[0];
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default();
-        let (device_oid, items, last_notified, timestamp_date, timestamp_time) = {
+        let (device_oid, items, last_notified, timestamp) = {
             let db = db.read().await;
             let device_oid = db
                 .list_objects()
                 .into_iter()
                 .find(|o| o.object_type() == ObjectType::DEVICE)
                 .unwrap_or_else(|| ObjectIdentifier::new(ObjectType::DEVICE, 0).unwrap());
-            let utc_offset_minutes = device_utc_offset(&db, &device_oid);
-            let (timestamp_date, timestamp_time) = cov_multiple_datetime(now, utc_offset_minutes);
+            let timestamp = if subscriptions.iter().any(|sub| sub.timestamped) {
+                let Some(clock_frame) = db.clock_frame() else {
+                    debug!("Skipping timestamped COVNotificationMultiple without a Device clock");
+                    return;
+                };
+                Some(cov_multiple_datetime(clock_frame))
+            } else {
+                None
+            };
 
             let mut items: Vec<COVNotificationItem> = Vec::new();
             let mut last_notified = Vec::new();
@@ -344,7 +348,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     property_identifier,
                     property_array_index: sub.monitored_property_array_index,
                     value: value_buf.to_vec(),
-                    time_of_change: sub.timestamped.then_some(timestamp_time),
+                    time_of_change: if sub.timestamped {
+                        timestamp.map(|(_, time)| time)
+                    } else {
+                        None
+                    },
                 };
 
                 if let Some(item) = items.iter_mut().find(|item| {
@@ -359,24 +367,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 }
             }
 
-            (
-                device_oid,
-                items,
-                last_notified,
-                timestamp_date,
-                timestamp_time,
-            )
+            (device_oid, items, last_notified, timestamp)
         };
 
         if items.is_empty() {
             return;
         }
 
-        let timestamp = items
-            .iter()
-            .flat_map(|item| &item.list_of_values)
-            .any(|value| value.time_of_change.is_some())
-            .then_some((timestamp_date, timestamp_time));
         let time_remaining = cov_multiple_time_remaining(representative.expires_at);
 
         let notification = COVNotificationMultipleRequest {

--- a/crates/bacnet-server/src/server/cov_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/cov_notifications_tests.rs
@@ -3,6 +3,7 @@ use super::*;
 use bacnet_encoding::apdu::decode_apdu;
 use bacnet_encoding::npdu::decode_npdu;
 use bacnet_objects::analog::AnalogOutputObject;
+use bacnet_objects::clock::ClockFrame;
 use bacnet_objects::device::{DeviceConfig, DeviceObject};
 use bacnet_types::enums::ObjectType;
 use bacnet_types::primitives::{Date, Time};
@@ -133,73 +134,26 @@ fn confirmed_cov_multiple_apdu_uses_multiple_service_choice() {
 
 #[test]
 fn cov_multiple_timestamp_uses_device_local_bacnet_date_and_time() {
-    let (date, time) = cov_multiple_datetime(Duration::ZERO, 0);
-    assert_eq!(
-        date,
-        Date {
-            year: 70,
-            month: 1,
-            day: 1,
-            day_of_week: 4,
-        }
-    );
-    assert_eq!(
-        time,
-        Time {
-            hour: 0,
-            minute: 0,
-            second: 0,
-            hundredths: 0,
-        }
-    );
-
-    // 2024-02-29T12:34:56.780Z exercises leap-day and hundredths handling.
-    let (date, time) = cov_multiple_datetime(Duration::new(1_709_210_096, 780_000_000), 0);
-    assert_eq!(
-        date,
-        Date {
+    let frame = ClockFrame {
+        local_date: Date {
             year: 124,
             month: 2,
             day: 29,
             day_of_week: 4,
-        }
-    );
-    assert_eq!(
-        time,
-        Time {
+        },
+        local_time: Time {
             hour: 12,
             minute: 34,
             second: 56,
             hundredths: 78,
-        }
-    );
-
-    // BACnet UTC_Offset is positive west of UTC and is subtracted. At +60,
-    // 1970-01-02T00:00Z is still 1970-01-01 locally.
-    let (date, time) = cov_multiple_datetime(Duration::new(86_400, 0), 60);
+        },
+        utc_offset: 300,
+        daylight_savings_status: true,
+    };
     assert_eq!(
-        date,
-        Date {
-            year: 70,
-            month: 1,
-            day: 1,
-            day_of_week: 4,
-        }
+        cov_multiple_datetime(frame),
+        (frame.local_date, frame.local_time)
     );
-    assert_eq!(time.hour, 23);
-
-    // A negative (east-of-UTC) offset advances the local civil day.
-    let (date, time) = cov_multiple_datetime(Duration::new(86_399, 0), -60);
-    assert_eq!(
-        date,
-        Date {
-            year: 70,
-            month: 1,
-            day: 2,
-            day_of_week: 5,
-        }
-    );
-    assert_eq!(time.hour, 0);
 }
 
 #[tokio::test]
@@ -396,7 +350,7 @@ async fn timestamped_cov_multiple_reports_datetime_and_remaining_lifetime() {
 
     let ao_oid = ObjectIdentifier::new(ObjectType::ANALOG_OUTPUT, 1).unwrap();
     let device_oid = ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap();
-    let mut db = ObjectDatabase::new();
+    let mut db = clocked_test_database();
     let mut device = DeviceObject::new(DeviceConfig {
         instance: 1234,
         name: "Timestamped-COV-Multiple-Test".into(),
@@ -469,7 +423,7 @@ async fn confirmed_cov_single_and_multiple_retries_retain_their_leases() {
     let single_mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC1]);
     let multiple_mac = MacAddr::from_slice(&[127, 0, 0, 1, 0xBA, 0xC2]);
 
-    let mut db = ObjectDatabase::new();
+    let mut db = clocked_test_database();
     let mut device = DeviceObject::new(DeviceConfig {
         instance: 1234,
         name: "Confirmed-COV-Retry-Test".into(),

--- a/crates/bacnet-server/src/server/cov_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/cov_notifications_tests.rs
@@ -341,8 +341,7 @@ async fn cov_property_multiple_subscription_uses_multiple_notification_on_change
     }
 }
 
-#[tokio::test]
-async fn timestamped_cov_multiple_reports_datetime_and_remaining_lifetime() {
+async fn capture_timestamped_cov_multiple(clocked: bool) -> COVNotificationMultipleRequest {
     let sent = StdArc::new(StdMutex::new(Vec::new()));
     let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
         &sent,
@@ -350,7 +349,11 @@ async fn timestamped_cov_multiple_reports_datetime_and_remaining_lifetime() {
 
     let ao_oid = ObjectIdentifier::new(ObjectType::ANALOG_OUTPUT, 1).unwrap();
     let device_oid = ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap();
-    let mut db = clocked_test_database();
+    let mut db = if clocked {
+        clocked_test_database()
+    } else {
+        ObjectDatabase::new()
+    };
     let mut device = DeviceObject::new(DeviceConfig {
         instance: 1234,
         name: "Timestamped-COV-Multiple-Test".into(),
@@ -400,7 +403,12 @@ async fn timestamped_cov_multiple_reports_datetime_and_remaining_lifetime() {
     let Apdu::UnconfirmedRequest(request) = decode_apdu(npdu.payload).unwrap() else {
         panic!("expected unconfirmed COVNotificationMultiple");
     };
-    let notification = COVNotificationMultipleRequest::decode(&request.service_request).unwrap();
+    COVNotificationMultipleRequest::decode(&request.service_request).unwrap()
+}
+
+#[tokio::test]
+async fn timestamped_cov_multiple_reports_datetime_and_remaining_lifetime() {
+    let notification = capture_timestamped_cov_multiple(true).await;
     assert!((298..=300).contains(&notification.time_remaining));
     let (_, request_time) = notification
         .timestamp
@@ -408,6 +416,16 @@ async fn timestamped_cov_multiple_reports_datetime_and_remaining_lifetime() {
     assert_eq!(
         notification.list_of_cov_notifications[0].list_of_values[0].time_of_change,
         Some(request_time)
+    );
+}
+
+#[tokio::test]
+async fn clockless_timestamped_cov_multiple_delivers_without_timestamps() {
+    let notification = capture_timestamped_cov_multiple(false).await;
+    assert!(notification.timestamp.is_none());
+    assert_eq!(
+        notification.list_of_cov_notifications[0].list_of_values[0].time_of_change,
+        None
     );
 }
 

--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -91,6 +91,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         comm_state: &Arc<AtomicU8>,
         dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
         config: &Arc<ServerConfig>,
+        clock: &Option<Arc<ServerClock>>,
         source_mac: &[u8],
         apdu: Apdu,
         mut received: bacnet_network::layer::ReceivedApdu,
@@ -136,12 +137,14 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let db = Arc::clone(db);
                 let network = Arc::clone(network);
                 let config = Arc::clone(config);
+                let clock = clock.clone();
                 let comm_state = Arc::clone(comm_state);
                 tokio::spawn(async move {
                     Self::handle_unconfirmed_request(
                         &db,
                         &network,
                         &config,
+                        clock.as_ref(),
                         &comm_state,
                         req,
                         &received,

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -85,7 +85,7 @@ impl Harness {
         let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
         let notification_transactions = NotificationTransactions::new();
 
-        let mut db = ObjectDatabase::new();
+        let mut db = clocked_test_database();
         let mut nc = NotificationClass::new(0, "NC-0").unwrap();
         nc.priority = [255, 255, 255];
         for destination in destinations {
@@ -200,6 +200,7 @@ impl Harness {
             &self.comm_state,
             &Arc::new(Mutex::new(None::<JoinHandle<()>>)),
             &Arc::new(ServerConfig::default()),
+            &None,
             source_mac,
             apdu,
             bacnet_network::layer::ReceivedApdu {

--- a/crates/bacnet-server/src/server/event_enable_distribution_tests.rs
+++ b/crates/bacnet-server/src/server/event_enable_distribution_tests.rs
@@ -116,7 +116,7 @@ impl Fixture {
     async fn from_object(object: Box<dyn BACnetObject>) -> Self {
         let oid = object.object_identifier();
 
-        let mut db = ObjectDatabase::new();
+        let mut db = clocked_test_database();
         db.add(object).unwrap();
         db.add(Box::new(
             DeviceObject::new(DeviceConfig {

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -227,11 +227,10 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         }
 
         let NotificationTransition { change, event_type } = transition.into();
-        let now = std::time::SystemTime::now()
+        let utc_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default();
-        let utc_secs = now.as_secs();
-
+            .unwrap_or_default()
+            .as_secs();
         let (notification, recipients) = {
             let mut db = db.write().await;
 
@@ -241,21 +240,15 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 .find(|o| o.object_type() == ObjectType::DEVICE)
                 .unwrap_or_else(|| ObjectIdentifier::new(ObjectType::DEVICE, 0).unwrap());
 
-            // Project the wall clock into the device's local time using its
-            // UTC_Offset property (signed minutes from UTC, Clause 12.32),
-            // so the Recipient_List day/time filters are evaluated in the same
-            // frame the device's schedule uses. With the default UTC_Offset of 0
-            // this is a no-op (UTC).
-            let utc_offset_minutes = db
-                .get(&device_oid)
-                .and_then(|dev| dev.read_property(PropertyIdentifier::UTC_OFFSET, None).ok())
-                .and_then(|v| match v {
-                    PropertyValue::Signed(m) => Some(m),
-                    _ => None,
-                })
-                .unwrap_or(0);
-            let (today_bit, mut current_time) = local_day_and_time(utc_secs, utc_offset_minutes);
-            current_time.hundredths = (now.subsec_millis() / 10) as u8;
+            let Some(clock_frame) = db.clock_frame() else {
+                debug!("Skipping recipient-window evaluation without a Device clock");
+                return;
+            };
+            let Some(today_bit) = clock_frame.day_of_week_bit() else {
+                debug!("Skipping recipient-window evaluation for an invalid Device clock frame");
+                return;
+            };
+            let current_time = clock_frame.local_time;
 
             let object = match db.get_mut(oid) {
                 Some(o) => o,

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -1,6 +1,8 @@
 use super::*;
+use bacnet_objects::notification_class::local_day_and_time;
 use bacnet_types::constructed::BACnetRecipient;
 use bacnet_types::enums::EventType;
+use bacnet_types::primitives::Time;
 
 pub(super) struct NotificationTransition {
     change: EventStateChange,
@@ -29,6 +31,17 @@ pub(super) fn network_priority_for_event(priority: u8) -> NetworkPriority {
         128..=191 => NetworkPriority::URGENT,
         192..=255 => NetworkPriority::NORMAL,
     }
+}
+
+/// Operational fallback for recipient-window filtering in clockless mode.
+///
+/// This uses system UTC only to avoid dropping an alarm while no Device clock
+/// is advertised; it does not create a Device DateTime or change wire
+/// timestamp selection.
+fn system_utc_recipient_filter_time(now: Duration) -> (u8, Time) {
+    let (today_bit, mut current_time) = local_day_and_time(now.as_secs(), 0);
+    current_time.hundredths = (now.subsec_millis() / 10) as u8;
+    (today_bit, current_time)
 }
 
 /// The network destination a Notification Class recipient resolves to.
@@ -227,10 +240,10 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         }
 
         let NotificationTransition { change, event_type } = transition.into();
-        let utc_secs = std::time::SystemTime::now()
+        let system_utc = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+            .unwrap_or_default();
+        let utc_secs = system_utc.as_secs();
         let (notification, recipients) = {
             let mut db = db.write().await;
 
@@ -240,15 +253,21 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 .find(|o| o.object_type() == ObjectType::DEVICE)
                 .unwrap_or_else(|| ObjectIdentifier::new(ObjectType::DEVICE, 0).unwrap());
 
-            let Some(clock_frame) = db.clock_frame() else {
-                debug!("Skipping recipient-window evaluation without a Device clock");
-                return;
+            let (today_bit, current_time) = match db.clock_frame() {
+                Some(clock_frame) => {
+                    let Some(today_bit) = clock_frame.day_of_week_bit() else {
+                        debug!(
+                            "Skipping recipient-window evaluation for an invalid Device clock frame"
+                        );
+                        return;
+                    };
+                    (today_bit, clock_frame.local_time)
+                }
+                None => {
+                    debug!("Using system UTC to filter recipients without a Device clock");
+                    system_utc_recipient_filter_time(system_utc)
+                }
             };
-            let Some(today_bit) = clock_frame.day_of_week_bit() else {
-                debug!("Skipping recipient-window evaluation for an invalid Device clock frame");
-                return;
-            };
-            let current_time = clock_frame.local_time;
 
             let object = match db.get_mut(oid) {
                 Some(o) => o,

--- a/crates/bacnet-server/src/server/event_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_tests.rs
@@ -57,7 +57,7 @@ async fn dcc_suppresses_periodic_event_send() {
     let comm_state = Arc::new(AtomicU8::new(1)); // DCC disabled
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
 
-    let mut db = ObjectDatabase::new();
+    let mut db = clocked_test_database();
     db.add(Box::new(AnalogInputObject::new(1, "AI-1", 0).unwrap()))
         .unwrap();
     db.add(Box::new(
@@ -199,7 +199,7 @@ async fn fixture_with_commanded_nc(
     let comm_state = Arc::new(AtomicU8::new(0)); // DCC enabled
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
 
-    let mut db = ObjectDatabase::new();
+    let mut db = clocked_test_database();
     // NotificationClass with the configured per-transition arrays and a single
     // local-broadcast recipient, so the notification lands on the broadcast wire.
     let mut notification_class =
@@ -406,7 +406,7 @@ async fn event_notification_missing_class_distributes_nothing() {
     let comm_state = Arc::new(AtomicU8::new(0));
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
 
-    let mut db = ObjectDatabase::new();
+    let mut db = clocked_test_database();
     db.add(Box::new(
         DeviceObject::new(DeviceConfig {
             instance: 1,
@@ -546,7 +546,7 @@ pub(super) fn db_with_high_limit_transition(
     .unwrap();
     ai.set_present_value(81.0); // above high_limit -> NORMAL -> HIGH_LIMIT
 
-    let mut db = ObjectDatabase::new();
+    let mut db = clocked_test_database();
     db.add(Box::new(ai)).unwrap();
     db.add(Box::new(
         DeviceObject::new(DeviceConfig {
@@ -707,7 +707,7 @@ async fn event_enable_cleared_suppresses_periodic_time_delay_send() {
     ai.set_present_value(81.0); // already above high_limit
     let oid = ai.object_identifier();
 
-    let mut db = ObjectDatabase::new();
+    let mut db = clocked_test_database();
     db.add(Box::new(ai)).unwrap();
     db.add(Box::new(
         DeviceObject::new(DeviceConfig {
@@ -812,7 +812,7 @@ async fn periodic_time_delay_carries_detector_event_type_to_wire() {
     ai.set_present_value(81.0);
     let oid = ai.object_identifier();
 
-    let mut db = ObjectDatabase::new();
+    let mut db = clocked_test_database();
     db.add(Box::new(ai)).unwrap();
     db.add(Box::new(
         DeviceObject::new(DeviceConfig {

--- a/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
@@ -99,6 +99,14 @@ pub(super) async fn distribute_with_priority(
     priority: [u8; 3],
     destinations: Vec<BACnetDestination>,
 ) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
+    distribute_with_clock_mode(priority, destinations, true).await
+}
+
+async fn distribute_with_clock_mode(
+    priority: [u8; 3],
+    destinations: Vec<BACnetDestination>,
+    clocked: bool,
+) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
     let transport = RoutingTransport::default();
     let broadcasts = StdArc::clone(&transport.broadcasts);
     let unicasts = StdArc::clone(&transport.unicasts);
@@ -106,7 +114,11 @@ pub(super) async fn distribute_with_priority(
     let comm_state = Arc::new(AtomicU8::new(0));
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
 
-    let mut db = clocked_test_database();
+    let mut db = if clocked {
+        clocked_test_database()
+    } else {
+        ObjectDatabase::new()
+    };
     let mut nc = NotificationClass::new(0, "NC-0").unwrap();
     nc.priority = priority;
     for destination in destinations {
@@ -162,6 +174,19 @@ pub(super) async fn distribute_with_priority(
     let broadcasts = broadcasts.lock().unwrap().clone();
     let unicasts = unicasts.lock().unwrap().clone();
     (broadcasts, unicasts)
+}
+
+#[tokio::test]
+async fn clockless_all_day_recipient_uses_system_utc_filter_fallback() {
+    let (broadcasts, unicasts) = distribute_with_clock_mode(
+        [255; 3],
+        vec![destination_for(address_recipient(0, &[]), false)],
+        false,
+    )
+    .await;
+
+    assert_eq!(broadcasts.len(), 1, "clockless mode preserves delivery");
+    assert!(unicasts.is_empty());
 }
 
 /// The NPDU destination (DNET/DADR) of a captured frame, or `None` when the

--- a/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
@@ -106,7 +106,7 @@ pub(super) async fn distribute_with_priority(
     let comm_state = Arc::new(AtomicU8::new(0));
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
 
-    let mut db = ObjectDatabase::new();
+    let mut db = clocked_test_database();
     let mut nc = NotificationClass::new(0, "NC-0").unwrap();
     nc.priority = priority;
     for destination in destinations {

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -20,10 +20,11 @@ pub(super) fn event_enrollment_period(secs: u64) -> Duration {
 }
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
-    pub async fn start(
+    pub(super) async fn start_with_clock_mode(
         mut config: ServerConfig,
-        db: ObjectDatabase,
+        mut db: ObjectDatabase,
         transport: T,
+        clock_config: Option<ClockConfig>,
     ) -> Result<Self, Error> {
         let transport_max = transport.max_apdu_length() as u32;
         config.max_apdu_length = config.max_apdu_length.min(transport_max);
@@ -38,6 +39,12 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         if config.vendor_id == 0 {
             warn!("vendor_id is 0 (ASHRAE reserved); set a valid vendor ID for production use");
         }
+
+        let clock = clock_config.map(|config| Arc::new(ServerClock::new(config)));
+        let reader = clock
+            .as_ref()
+            .map(|clock| Arc::clone(clock) as Arc<dyn bacnet_objects::clock::ClockReader>);
+        db.set_clock_reader(reader);
 
         let mut network = NetworkLayer::new(transport);
         let apdu_rx = network.start().await?;
@@ -67,6 +74,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let comm_state_dispatch = Arc::clone(&comm_state);
         let dcc_timer_dispatch = Arc::clone(&dcc_timer);
         let config_dispatch = Arc::new(config.clone());
+        let clock_dispatch = clock.clone();
 
         let dispatch_task = tokio::spawn(async move {
             let mut apdu_rx = apdu_rx;
@@ -399,6 +407,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 	                                                    &comm_state_dispatch,
 	                                                    &dcc_timer_dispatch,
 	                                                    &config_dispatch,
+	                                                    &clock_dispatch,
 	                                                    &source_mac,
 	                                                    Apdu::ConfirmedRequest(reassembled),
 	                                                    received.take().unwrap_or_else(|| {
@@ -447,6 +456,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 &comm_state_dispatch,
                                 &dcc_timer_dispatch,
                                 &config_dispatch,
+                                &clock_dispatch,
                                 &source_mac,
                                 decoded,
                                 received.take().unwrap_or_else(|| {
@@ -565,7 +575,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let mut interval = tokio::time::interval(Duration::from_secs(60));
             loop {
                 interval.tick().await;
-                // TODO: Read UTC_Offset from Device object for local time
                 crate::schedule::tick_schedules(&db_schedule, 0).await;
             }
         }));
@@ -651,6 +660,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
         Ok(Self {
             config,
+            _clock: clock,
             network,
             db,
             cov_table,

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -30,7 +30,7 @@ use bacnet_network::layer::NetworkLayer;
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_objects::event::EventStateChange;
 use bacnet_objects::notification_class::{
-    get_notification_recipients_strict, local_day_and_time, resolve_transition_priority_ack,
+    get_notification_recipients_strict, resolve_transition_priority_ack,
 };
 use bacnet_services::alarm_event::EventNotificationRequest;
 use bacnet_services::common::BACnetPropertyValue;
@@ -284,7 +284,7 @@ pub struct ServerConfig {
     pub vendor_id: u16,
     /// Timeout in ms before retrying a failed confirmed COV notification send (default 3000ms).
     pub cov_retry_timeout_ms: u64,
-    /// Optional callback invoked when a TimeSynchronization request is received.
+    /// Optional observer invoked after a time-synchronization request is accepted.
     pub on_time_sync: Option<Arc<dyn Fn(TimeSyncData) + Send + Sync>>,
     /// Optional LifeSafetyOperation authorization policy.
     ///
@@ -746,6 +746,8 @@ struct SegmentedRequestState {
 /// BACnet server with APDU dispatch and service handling.
 pub struct BACnetServer<T: TransportPort> {
     config: ServerConfig,
+    /// Server-owned clock controller; absent in explicit clockless mode.
+    _clock: Option<Arc<ServerClock>>,
     /// Shared network layer (also held by dispatch task; read by
     /// [`write_local`](Self::write_local) for post-write COV/event sends).
     network: Arc<NetworkLayer<T>>,
@@ -989,6 +991,11 @@ impl ScServerBuilder {
     }
 }
 
+mod clock;
+#[cfg(test)]
+pub(crate) use clock::clocked_test_database;
+pub use clock::ClockConfig;
+use clock::ServerClock;
 mod cov_clock;
 mod cov_notifications;
 mod dispatch;

--- a/crates/bacnet-server/src/server/notification_transactions_tests.rs
+++ b/crates/bacnet-server/src/server/notification_transactions_tests.rs
@@ -399,6 +399,7 @@ async fn dispatch_keeps_segment_and_complex_acks_out_of_notification_completion(
             &comm_state,
             &dcc_timer,
             &config,
+            &None,
             source_mac.as_slice(),
             apdu,
             bacnet_network::layer::ReceivedApdu {

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -7,6 +7,8 @@ mod endpoint_responder;
 mod endpoint_shared_runtime_tests;
 mod unconfirmed;
 #[cfg(test)]
+mod unconfirmed_tests;
+#[cfg(test)]
 pub(crate) use unconfirmed::EXECUTED_UNCONFIRMED;
 
 #[cfg(test)]

--- a/crates/bacnet-server/src/server/requests/unconfirmed.rs
+++ b/crates/bacnet-server/src/server/requests/unconfirmed.rs
@@ -4,6 +4,7 @@
 //! Split out of `requests.rs` to keep every file under the 700-LOC cap.
 
 use super::super::*;
+use bacnet_services::device_mgmt::TimeSynchronizationRequest;
 
 #[cfg(test)]
 /// Every unconfirmed service choice with an inbound execution arm in
@@ -24,6 +25,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         db: &Arc<RwLock<ObjectDatabase>>,
         network: &Arc<NetworkLayer<T>>,
         config: &ServerConfig,
+        clock: Option<&Arc<ServerClock>>,
         comm_state: &Arc<AtomicU8>,
         req: UnconfirmedRequestPdu,
         received: &bacnet_network::layer::ReceivedApdu,
@@ -138,13 +140,14 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             || req.service_choice == UnconfirmedServiceChoice::UTC_TIME_SYNCHRONIZATION
         {
             debug!("Received time synchronization request");
-            if let Some(ref callback) = config.on_time_sync {
-                let data = TimeSyncData {
-                    raw_service_data: req.service_request.clone(),
-                    is_utc: req.service_choice
-                        == UnconfirmedServiceChoice::UTC_TIME_SYNCHRONIZATION,
-                };
-                callback(data);
+            let is_utc = req.service_choice == UnconfirmedServiceChoice::UTC_TIME_SYNCHRONIZATION;
+            if let Err(error) = apply_time_sync_request(
+                clock.map(Arc::as_ref),
+                config,
+                req.service_request.clone(),
+                is_utc,
+            ) {
+                debug!(%error, is_utc, "Ignoring time synchronization request");
             }
         } else if req.service_choice == UnconfirmedServiceChoice::UNCONFIRMED_TEXT_MESSAGE {
             match handlers::handle_text_message(&req.service_request) {
@@ -167,4 +170,23 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             );
         }
     }
+}
+
+pub(super) fn apply_time_sync_request(
+    clock: Option<&ServerClock>,
+    config: &ServerConfig,
+    raw_service_data: Bytes,
+    is_utc: bool,
+) -> Result<(), Error> {
+    let clock = clock.ok_or_else(|| Error::Encoding("Device clock is disabled".into()))?;
+    let request = TimeSynchronizationRequest::decode(&raw_service_data)?;
+    clock.synchronize(request.date, request.time, is_utc)?;
+
+    if let Some(callback) = &config.on_time_sync {
+        callback(TimeSyncData {
+            raw_service_data,
+            is_utc,
+        });
+    }
+    Ok(())
 }

--- a/crates/bacnet-server/src/server/requests/unconfirmed_tests.rs
+++ b/crates/bacnet-server/src/server/requests/unconfirmed_tests.rs
@@ -1,0 +1,106 @@
+use super::super::{ClockConfig, ServerClock, ServerConfig};
+use super::unconfirmed::apply_time_sync_request;
+use crate::server::TimeSyncData;
+use bacnet_objects::clock::ClockReader;
+use bacnet_services::device_mgmt::TimeSynchronizationRequest;
+use bacnet_types::primitives::{Date, Time};
+use bytes::{Bytes, BytesMut};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+fn date(year: u16, month: u8, day: u8, day_of_week: u8) -> Date {
+    Date {
+        year: (year - 1900) as u8,
+        month,
+        day,
+        day_of_week,
+    }
+}
+
+fn time(hour: u8, minute: u8) -> Time {
+    Time {
+        hour,
+        minute,
+        second: 0,
+        hundredths: 0,
+    }
+}
+
+fn encoded(date: Date, time: Time) -> Bytes {
+    let mut bytes = BytesMut::new();
+    TimeSynchronizationRequest { date, time }.encode(&mut bytes);
+    bytes.freeze()
+}
+
+fn config_with_counter(counter: Arc<AtomicUsize>) -> ServerConfig {
+    ServerConfig {
+        on_time_sync: Some(Arc::new(move |_: TimeSyncData| {
+            counter.fetch_add(1, Ordering::SeqCst);
+        })),
+        ..ServerConfig::default()
+    }
+}
+
+#[test]
+fn accepted_local_and_utc_requests_update_then_notify() {
+    let clock = ServerClock::new(ClockConfig::new(300, true).unwrap());
+    let callbacks = Arc::new(AtomicUsize::new(0));
+    let config = config_with_counter(Arc::clone(&callbacks));
+
+    apply_time_sync_request(
+        Some(&clock),
+        &config,
+        encoded(date(2024, 7, 4, 4), time(9, 15)),
+        false,
+    )
+    .unwrap();
+    let frame = clock.read_clock().unwrap();
+    assert_eq!((frame.local_time.hour, frame.local_time.minute), (9, 15));
+    assert_eq!(callbacks.load(Ordering::SeqCst), 1);
+
+    apply_time_sync_request(
+        Some(&clock),
+        &config,
+        encoded(date(2024, 7, 4, 4), time(13, 15)),
+        true,
+    )
+    .unwrap();
+    let frame = clock.read_clock().unwrap();
+    assert_eq!((frame.local_time.hour, frame.local_time.minute), (9, 15));
+    assert_eq!(callbacks.load(Ordering::SeqCst), 2);
+}
+
+#[test]
+fn invalid_and_clockless_requests_do_not_notify() {
+    let clock = ServerClock::new(ClockConfig::default());
+    let callbacks = Arc::new(AtomicUsize::new(0));
+    let config = config_with_counter(Arc::clone(&callbacks));
+
+    assert!(
+        apply_time_sync_request(Some(&clock), &config, Bytes::from_static(&[0xff]), false,)
+            .is_err()
+    );
+    assert!(apply_time_sync_request(
+        Some(&clock),
+        &config,
+        encoded(
+            Date {
+                year: Date::UNSPECIFIED,
+                month: 1,
+                day: 1,
+                day_of_week: 1,
+            },
+            time(0, 0),
+        ),
+        false,
+    )
+    .is_err());
+    assert!(apply_time_sync_request(
+        None,
+        &config,
+        encoded(date(2024, 7, 4, 4), time(9, 15)),
+        false,
+    )
+    .is_err());
+    assert_eq!(callbacks.load(Ordering::SeqCst), 0);
+}

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -288,6 +288,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
         &comm_state,
         &dcc_timer,
         &config,
+        &None,
         source_mac.as_slice(),
         apdu,
         bacnet_network::layer::ReceivedApdu {

--- a/crates/bacnet-server/src/server/tests.rs
+++ b/crates/bacnet-server/src/server/tests.rs
@@ -13,6 +13,62 @@ fn server_config_time_sync_callback_default_is_none() {
     assert!(config.life_safety_operation_authorizer.is_none());
 }
 
+#[tokio::test]
+async fn default_and_clockless_start_bind_truthful_device_clock() {
+    use bacnet_objects::device::{DeviceConfig, DeviceObject};
+    use bacnet_objects::traits::BACnetObject;
+    use bacnet_types::bitstring::ServicesSupported;
+    use bacnet_types::enums::ServiceSupported;
+
+    async fn assert_mode(clockless: bool) {
+        let device = DeviceObject::new(DeviceConfig::default()).unwrap();
+        let oid = device.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(device)).unwrap();
+        let transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+        let mut server = if clockless {
+            BACnetServer::start_clockless(ServerConfig::default(), db, transport)
+                .await
+                .unwrap()
+        } else {
+            BACnetServer::start(ServerConfig::default(), db, transport)
+                .await
+                .unwrap()
+        };
+
+        let db = server.db.read().await;
+        let device = db.get(&oid).unwrap();
+        for property in [
+            PropertyIdentifier::LOCAL_DATE,
+            PropertyIdentifier::LOCAL_TIME,
+            PropertyIdentifier::UTC_OFFSET,
+            PropertyIdentifier::DAYLIGHT_SAVINGS_STATUS,
+        ] {
+            assert_eq!(device.read_property(property, None).is_ok(), !clockless);
+        }
+        let PropertyValue::BitString { data, .. } = device
+            .read_property(PropertyIdentifier::PROTOCOL_SERVICES_SUPPORTED, None)
+            .unwrap()
+        else {
+            panic!("expected services bit string");
+        };
+        let services = ServicesSupported::from_bacnet(&data);
+        assert_eq!(
+            services.contains(ServiceSupported::TIME_SYNCHRONIZATION),
+            !clockless
+        );
+        assert_eq!(
+            services.contains(ServiceSupported::UTC_TIME_SYNCHRONIZATION),
+            !clockless
+        );
+        drop(db);
+        server.stop().await.unwrap();
+    }
+
+    assert_mode(false).await;
+    assert_mode(true).await;
+}
+
 #[test]
 fn all_builders_assign_life_safety_operation_authorizer() {
     let generic =

--- a/crates/bacnet-server/src/server/tests.rs
+++ b/crates/bacnet-server/src/server/tests.rs
@@ -62,6 +62,18 @@ async fn default_and_clockless_start_bind_truthful_device_clock() {
             !clockless
         );
         drop(db);
+
+        let pics = server
+            .generate_pics(&crate::pics::PicsConfig::default())
+            .await;
+        for service_name in ["TimeSynchronization", "UTCTimeSynchronization"] {
+            let executed = pics
+                .supported_services
+                .iter()
+                .find(|service| service.service_name == service_name)
+                .is_some_and(|service| service.executor);
+            assert_eq!(executed, !clockless, "PICS service {service_name}");
+        }
         server.stop().await.unwrap();
     }
 

--- a/crates/bacnet-services/src/device_mgmt.rs
+++ b/crates/bacnet-services/src/device_mgmt.rs
@@ -2,8 +2,8 @@
 //!
 //! - DeviceCommunicationControl (Clause 15.4)
 //! - ReinitializeDevice (Clause 15.4)
-//! - TimeSynchronization (Clause 16.10)
-//! - UTCTimeSynchronization (Clause 16.10)
+//! - TimeSynchronization (§16.7)
+//! - UTCTimeSynchronization (§16.8)
 
 use bacnet_encoding::primitives;
 use bacnet_encoding::tags;
@@ -189,6 +189,15 @@ impl TimeSynchronizationRequest {
         let mut offset = 0;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if tag.class != tags::TagClass::Application
+            || tag.number != tags::app_tag::DATE
+            || tag.length != 4
+        {
+            return Err(Error::decoding(
+                offset,
+                "TimeSync expected application Date",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(pos, "TimeSync truncated at date"));
@@ -197,11 +206,23 @@ impl TimeSynchronizationRequest {
         offset = end;
 
         let (tag, pos) = tags::decode_tag(data, offset)?;
+        if tag.class != tags::TagClass::Application
+            || tag.number != tags::app_tag::TIME
+            || tag.length != 4
+        {
+            return Err(Error::decoding(
+                offset,
+                "TimeSync expected application Time",
+            ));
+        }
         let end = pos + tag.length as usize;
         if end > data.len() {
             return Err(Error::decoding(pos, "TimeSync truncated at time"));
         }
         let time = Time::decode(&data[pos..end])?;
+        if end != data.len() {
+            return Err(Error::decoding(end, "TimeSync contains trailing data"));
+        }
 
         Ok(Self { date, time })
     }
@@ -352,6 +373,49 @@ mod tests {
         req.encode(&mut buf);
         let decoded = TimeSynchronizationRequest::decode(&buf).unwrap();
         assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn time_sync_requires_exact_application_tags_and_no_trailing_data() {
+        let mut wrong_date = BytesMut::new();
+        primitives::encode_app_time(
+            &mut wrong_date,
+            &Time {
+                hour: 1,
+                minute: 2,
+                second: 3,
+                hundredths: 4,
+            },
+        );
+        primitives::encode_app_time(
+            &mut wrong_date,
+            &Time {
+                hour: 1,
+                minute: 2,
+                second: 3,
+                hundredths: 4,
+            },
+        );
+        assert!(TimeSynchronizationRequest::decode(&wrong_date).is_err());
+
+        let request = TimeSynchronizationRequest {
+            date: Date {
+                year: 124,
+                month: 7,
+                day: 4,
+                day_of_week: 4,
+            },
+            time: Time {
+                hour: 9,
+                minute: 15,
+                second: 0,
+                hundredths: 0,
+            },
+        };
+        let mut trailing = BytesMut::new();
+        request.encode(&mut trailing);
+        trailing.extend_from_slice(&[0]);
+        assert!(TimeSynchronizationRequest::decode(&trailing).is_err());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- replace frozen Device `Local_Date`/`Local_Time` values with one coherent clock frame
- default servers expose a live UTC-backed clock; explicit clockless servers omit clock properties and synchronization service bits
- execute validated TimeSynchronization and UTCTimeSynchronization requests against the same server-owned controller
- use the west-positive offset convention consistently for Device reads, schedules, notification recipient windows, and COV Multiple timestamps

## Standard alignment

- Device clock properties and `UTC_Offset`: §12.11
- TimeSynchronization: §16.7
- UTCTimeSynchronization: §16.8

## Safety and compatibility

- malformed, wildcard, invalid-calendar, invalid-time, and trailing-data requests fail before clock mutation or callback
- the existing time-sync callback remains a post-acceptance observer
- clockless servers preserve event and COV delivery without inventing unavailable timestamps
- generated PICS follow the effective Device service set for clocked and clockless servers
- existing Rust and Python constructors remain compatible; no dependency or public support-claim changes
- Event_Time_Stamps, File timestamps, trend logs, and COV timestamp-choice policy remain follow-up work

## Validation

- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls,bacnet-transport/serial,bacnet-transport/ethernet` — 3,365 passed, 2 ignored doc tests
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- conformance-doc, file-size, no-secret, formatting, and diff checks

Closes #265
