### PR TITLE
feat(objects): expose enrollment event timestamps

### DIFF
--- a/crates/bacnet-objects/src/event_enrollment/metadata.rs
+++ b/crates/bacnet-objects/src/event_enrollment/metadata.rs
@@ -1,0 +1,168 @@
+use crate::property_metadata::{PropertyConformance, PropertyMetadata, PropertyWriteCapability};
+use bacnet_types::enums::PropertyIdentifier;
+
+use PropertyConformance::{Optional, RequiredRead};
+use PropertyWriteCapability::{Always, ReadOnly};
+
+pub(super) static EVENT_ENROLLMENT_PROPERTIES: &[PropertyMetadata] = &[
+    PropertyMetadata::new(
+        PropertyIdentifier::OBJECT_IDENTIFIER,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(PropertyIdentifier::OBJECT_NAME, RequiredRead, None, Always),
+    PropertyMetadata::new(PropertyIdentifier::DESCRIPTION, Optional, None, Always),
+    PropertyMetadata::new(
+        PropertyIdentifier::OBJECT_TYPE,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(PropertyIdentifier::EVENT_TYPE, RequiredRead, None, ReadOnly),
+    PropertyMetadata::new(PropertyIdentifier::NOTIFY_TYPE, RequiredRead, None, Always),
+    PropertyMetadata::new(
+        PropertyIdentifier::EVENT_PARAMETERS,
+        RequiredRead,
+        None,
+        Always,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::EVENT_STATE,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(PropertyIdentifier::EVENT_ENABLE, RequiredRead, None, Always),
+    PropertyMetadata::new(
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+        RequiredRead,
+        None,
+        Always,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::NOTIFICATION_CLASS,
+        RequiredRead,
+        None,
+        Always,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::EVENT_TIME_STAMPS,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    // Table 12-14 marks these O2, whose condition is not yet representable in
+    // the shared metadata enum; keep the implemented rows optional.
+    PropertyMetadata::new(PropertyIdentifier::FAULT_TYPE, Optional, None, ReadOnly),
+    PropertyMetadata::new(PropertyIdentifier::FAULT_PARAMETERS, Optional, None, Always),
+    PropertyMetadata::new(
+        PropertyIdentifier::TIME_DELAY_NORMAL,
+        Optional,
+        None,
+        Always,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::STATUS_FLAGS,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    // Out_Of_Service is an existing compatibility projection, not a Table
+    // 12-14 row. Retain it so metadata remains complete for the readable API.
+    PropertyMetadata::new(PropertyIdentifier::OUT_OF_SERVICE, Optional, None, Always),
+    PropertyMetadata::new(
+        PropertyIdentifier::RELIABILITY,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::PROPERTY_LIST,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+];
+
+pub(super) static ALERT_ENROLLMENT_PROPERTIES: &[PropertyMetadata] = &[
+    PropertyMetadata::new(
+        PropertyIdentifier::OBJECT_IDENTIFIER,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::OBJECT_NAME,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(PropertyIdentifier::DESCRIPTION, Optional, None, Always),
+    PropertyMetadata::new(
+        PropertyIdentifier::OBJECT_TYPE,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::PRESENT_VALUE,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::EVENT_STATE,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+        RequiredRead,
+        None,
+        Always,
+    ),
+    PropertyMetadata::new(PropertyIdentifier::EVENT_ENABLE, RequiredRead, None, Always),
+    PropertyMetadata::new(
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::NOTIFICATION_CLASS,
+        RequiredRead,
+        None,
+        Always,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::EVENT_TIME_STAMPS,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    // These three are existing compatibility projections, not Table 12-61
+    // rows. Retain them as optional so metadata covers the readable API.
+    PropertyMetadata::new(PropertyIdentifier::STATUS_FLAGS, Optional, None, ReadOnly),
+    PropertyMetadata::new(PropertyIdentifier::OUT_OF_SERVICE, Optional, None, Always),
+    PropertyMetadata::new(PropertyIdentifier::RELIABILITY, Optional, None, ReadOnly),
+    PropertyMetadata::new(
+        PropertyIdentifier::PROPERTY_LIST,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+];

--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -9,18 +9,15 @@ use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;
 
 use crate::common::{self, read_common_properties};
+use crate::event::history::EventHistory;
+use crate::property_metadata::PropertyMetadata;
 use crate::traits::{BACnetObject, WritePropertyRollback};
 
+mod metadata;
 mod parameters;
 mod state;
-use state::EventEnrollmentWriteRollback;
+use state::{AlertEnrollmentWriteRollback, EventEnrollmentWriteRollback};
 pub use state::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource, EventEnrollmentPending};
-
-struct AlertEnrollmentWriteRollback {
-    enabled: bool,
-    event_state: u32,
-    acked_transitions: u8,
-}
 
 /// BACnet EventEnrollment object.
 ///
@@ -39,6 +36,7 @@ pub struct EventEnrollmentObject {
     event_state: u32,
     event_enable: u8,
     acked_transitions: u8,
+    event_history: EventHistory,
     event_detection_enable: bool,
     notification_class: u32,
     fault_parameters: Option<FaultParameters>,
@@ -88,6 +86,7 @@ impl EventEnrollmentObject {
             // is also the initial condition the detection-disabled reset
             // restores, so `RESET_ACKED_TRANSITIONS` names it once.
             acked_transitions: Self::RESET_ACKED_TRANSITIONS,
+            event_history: EventHistory::default(),
             event_detection_enable: true,
             notification_class: 0,
             fault_parameters: None,
@@ -116,10 +115,6 @@ impl EventEnrollmentObject {
     /// Event_Message_Texts and Acked_Transitions shall be set to their
     /// respective initial conditions."
     ///
-    /// `Event_Time_Stamps` and `Event_Message_Texts` are not modeled on this
-    /// object yet (#264); when they are, their initial conditions belong here
-    /// — X'FF' octets / sequence number 0, and the empty string respectively.
-    ///
     /// The monitored-source identity, pending countdown, and both baselines
     /// are cleared too: they are extensions of the same event-state-detection
     /// state machine the clause freezes ("this state machine is not
@@ -133,6 +128,7 @@ impl EventEnrollmentObject {
     fn apply_detection_disabled_reset(&mut self) {
         self.event_state = EventState::NORMAL.to_raw();
         self.acked_transitions = Self::RESET_ACKED_TRANSITIONS;
+        self.event_history.reset();
         self.pending = None;
         self.monitored_reference = None;
         self.cov_baseline = None;
@@ -250,6 +246,10 @@ impl BACnetObject for EventEnrollmentObject {
             return result;
         }
         match property {
+            p if p == PropertyIdentifier::EVENT_TIME_STAMPS => self
+                .event_history
+                .read(p, array_index)
+                .expect("EventHistory handles Event_Time_Stamps"),
             p if p == PropertyIdentifier::OBJECT_TYPE => Ok(PropertyValue::Enumerated(
                 ObjectType::EVENT_ENROLLMENT.to_raw(),
             )),
@@ -540,6 +540,7 @@ impl BACnetObject for EventEnrollmentObject {
                     enabled: self.event_detection_enable,
                     event_state: self.event_state,
                     acked_transitions: self.acked_transitions,
+                    event_history: self.event_history.clone(),
                     monitored_reference: self.monitored_reference,
                     evaluation: EventEnrollmentEvalState {
                         pending: self.pending.clone(),
@@ -576,12 +577,14 @@ impl BACnetObject for EventEnrollmentObject {
                 enabled,
                 event_state,
                 acked_transitions,
+                event_history,
                 monitored_reference,
                 evaluation,
             } => {
                 self.event_detection_enable = enabled;
                 self.event_state = event_state;
                 self.acked_transitions = acked_transitions;
+                self.event_history = event_history;
                 self.monitored_reference = monitored_reference;
                 self.pending = evaluation.pending;
                 self.cov_baseline = evaluation.cov_baseline;
@@ -639,29 +642,12 @@ impl BACnetObject for EventEnrollmentObject {
             )
     }
 
+    fn property_metadata(&self) -> Cow<'_, [PropertyMetadata]> {
+        Cow::Borrowed(metadata::EVENT_ENROLLMENT_PROPERTIES)
+    }
+
     fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
-        static PROPS: &[PropertyIdentifier] = &[
-            PropertyIdentifier::OBJECT_IDENTIFIER,
-            PropertyIdentifier::OBJECT_NAME,
-            PropertyIdentifier::DESCRIPTION,
-            PropertyIdentifier::OBJECT_TYPE,
-            PropertyIdentifier::EVENT_TYPE,
-            PropertyIdentifier::NOTIFY_TYPE,
-            PropertyIdentifier::EVENT_PARAMETERS,
-            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
-            PropertyIdentifier::EVENT_STATE,
-            PropertyIdentifier::EVENT_ENABLE,
-            PropertyIdentifier::ACKED_TRANSITIONS,
-            PropertyIdentifier::EVENT_DETECTION_ENABLE,
-            PropertyIdentifier::NOTIFICATION_CLASS,
-            PropertyIdentifier::FAULT_TYPE,
-            PropertyIdentifier::FAULT_PARAMETERS,
-            PropertyIdentifier::TIME_DELAY_NORMAL,
-            PropertyIdentifier::STATUS_FLAGS,
-            PropertyIdentifier::OUT_OF_SERVICE,
-            PropertyIdentifier::RELIABILITY,
-        ];
-        Cow::Borrowed(PROPS)
+        crate::property_metadata::property_list_from_metadata(metadata::EVENT_ENROLLMENT_PROPERTIES)
     }
 }
 
@@ -696,6 +682,7 @@ pub struct AlertEnrollmentObject {
     pub event_detection_enable: bool,
     /// Acknowledged transitions in TO_OFFNORMAL, TO_FAULT, TO_NORMAL order.
     acked_transitions: u8,
+    event_history: EventHistory,
     /// Event enable bits: 3-bit (TO_OFFNORMAL, TO_FAULT, TO_NORMAL).
     pub event_enable: u8,
     /// Notification class number.
@@ -717,6 +704,7 @@ impl AlertEnrollmentObject {
             present_value: 0,
             event_detection_enable: true,
             acked_transitions: 0b111,
+            event_history: EventHistory::default(),
             event_enable: 0b111,
             notification_class: 0,
         })
@@ -729,6 +717,7 @@ impl AlertEnrollmentObject {
         if !enabled || !self.event_detection_enable {
             self.event_state = EventState::NORMAL.to_raw();
             self.acked_transitions = 0b111;
+            self.event_history.reset();
         }
         self.event_detection_enable = enabled;
     }
@@ -748,6 +737,17 @@ impl BACnetObject for AlertEnrollmentObject {
         property: PropertyIdentifier,
         array_index: Option<u32>,
     ) -> Result<PropertyValue, Error> {
+        if property == PropertyIdentifier::EVENT_TIME_STAMPS {
+            if !self.event_detection_enable {
+                return EventHistory::default()
+                    .read(property, array_index)
+                    .expect("EventHistory handles Event_Time_Stamps");
+            }
+            return self
+                .event_history
+                .read(property, array_index)
+                .expect("EventHistory handles Event_Time_Stamps");
+        }
         if property == PropertyIdentifier::STATUS_FLAGS {
             return Ok(common::compute_status_flags(
                 self.status_flags,
@@ -853,6 +853,7 @@ impl BACnetObject for AlertEnrollmentObject {
                 enabled: self.event_detection_enable,
                 event_state: self.event_state,
                 acked_transitions: self.acked_transitions,
+                event_history: self.event_history.clone(),
             })
         })
     }
@@ -865,10 +866,12 @@ impl BACnetObject for AlertEnrollmentObject {
             enabled,
             event_state,
             acked_transitions,
+            event_history,
         } = rollback.downcast::<AlertEnrollmentWriteRollback>()?;
         self.event_detection_enable = enabled;
         self.event_state = event_state;
         self.acked_transitions = acked_transitions;
+        self.event_history = event_history;
         Ok(())
     }
 
@@ -888,11 +891,16 @@ impl BACnetObject for AlertEnrollmentObject {
         if !self.event_detection_enable {
             return Err(common::write_access_denied_error());
         }
+        let transition_bit = transition_bit & 0x07;
         if acknowledged {
-            self.acked_transitions |= transition_bit & 0x07;
+            self.acked_transitions |= transition_bit;
         } else {
-            self.acked_transitions &= !(transition_bit & 0x07);
+            // Alert Enrollment never requires acknowledgment for TO_NORMAL
+            // (Clause 12.52.8), so that bit cannot enter the unacknowledged
+            // state even if a generic transition hook asks to clear it.
+            self.acked_transitions &= !(transition_bit & 0x03);
         }
+        self.acked_transitions |= 0x04;
         Ok(())
     }
 
@@ -907,23 +915,12 @@ impl BACnetObject for AlertEnrollmentObject {
         )
     }
 
+    fn property_metadata(&self) -> Cow<'_, [PropertyMetadata]> {
+        Cow::Borrowed(metadata::ALERT_ENROLLMENT_PROPERTIES)
+    }
+
     fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
-        static PROPS: &[PropertyIdentifier] = &[
-            PropertyIdentifier::OBJECT_IDENTIFIER,
-            PropertyIdentifier::OBJECT_NAME,
-            PropertyIdentifier::DESCRIPTION,
-            PropertyIdentifier::OBJECT_TYPE,
-            PropertyIdentifier::PRESENT_VALUE,
-            PropertyIdentifier::EVENT_STATE,
-            PropertyIdentifier::EVENT_DETECTION_ENABLE,
-            PropertyIdentifier::EVENT_ENABLE,
-            PropertyIdentifier::ACKED_TRANSITIONS,
-            PropertyIdentifier::NOTIFICATION_CLASS,
-            PropertyIdentifier::STATUS_FLAGS,
-            PropertyIdentifier::OUT_OF_SERVICE,
-            PropertyIdentifier::RELIABILITY,
-        ];
-        Cow::Borrowed(PROPS)
+        crate::property_metadata::property_list_from_metadata(metadata::ALERT_ENROLLMENT_PROPERTIES)
     }
 }
 

--- a/crates/bacnet-objects/src/event_enrollment/state.rs
+++ b/crates/bacnet-objects/src/event_enrollment/state.rs
@@ -2,6 +2,15 @@ use bacnet_types::constructed::{BACnetEventParameter, FaultParameters};
 use bacnet_types::enums::{EventState, PropertyIdentifier};
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
+use crate::event::history::EventHistory;
+
+pub(super) struct AlertEnrollmentWriteRollback {
+    pub(super) enabled: bool,
+    pub(super) event_state: u32,
+    pub(super) acked_transitions: u8,
+    pub(super) event_history: EventHistory,
+}
+
 /// Effective object, property, and optional array index that own an Event
 /// Enrollment object's private evaluation state.
 pub type EventEnrollmentMonitoredSource = (ObjectIdentifier, PropertyIdentifier, Option<u32>);
@@ -82,6 +91,7 @@ pub(super) enum EventEnrollmentWriteRollback {
         enabled: bool,
         event_state: u32,
         acked_transitions: u8,
+        event_history: EventHistory,
         monitored_reference: Option<EventEnrollmentMonitoredSource>,
         evaluation: EventEnrollmentEvalState,
     },

--- a/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
@@ -5,3 +5,4 @@ mod fault_parameters;
 mod object_name;
 mod status_flags;
 mod time_delay_normal;
+mod timestamps;

--- a/crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs
@@ -1,0 +1,358 @@
+//! Event timestamp and property-metadata contracts for enrollment objects.
+
+use super::super::*;
+use crate::property_metadata::{PropertyConformance, PropertyMetadata, PropertyWriteCapability};
+use bacnet_encoding::primitives::decode_timestamp_choice;
+use bacnet_types::enums::{ErrorClass, ErrorCode};
+use bacnet_types::primitives::{BACnetTimeStamp, Date, Time};
+
+fn assert_default_timestamp_array(object: &dyn BACnetObject, label: &str) {
+    let value = object
+        .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
+        .unwrap_or_else(|error| panic!("{label}: Event_Time_Stamps read failed: {error:?}"));
+    let PropertyValue::List(elements) = value else {
+        panic!("{label}: expected Event_Time_Stamps list");
+    };
+    assert_eq!(elements.len(), 3, "{label}: timestamp count");
+    for (slot, value) in elements.into_iter().enumerate() {
+        let PropertyValue::ApplicationData(bytes) = value else {
+            panic!("{label}: slot {} was not an encoded CHOICE", slot + 1);
+        };
+        let (decoded, end) = decode_timestamp_choice(&bytes, 0).unwrap();
+        assert_eq!(decoded, BACnetTimeStamp::SequenceNumber(0));
+        assert_eq!(end, bytes.len(), "{label}: trailing CHOICE bytes");
+    }
+}
+
+#[test]
+fn enrollment_objects_default_event_time_stamps_are_three_zero_sequences() {
+    let event = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
+    let alert = AlertEnrollmentObject::new(1, "AE-1").unwrap();
+
+    assert_default_timestamp_array(&event, "Event Enrollment");
+    assert_default_timestamp_array(&alert, "Alert Enrollment");
+}
+
+fn seeded_timestamps() -> [BACnetTimeStamp; 3] {
+    [
+        BACnetTimeStamp::Time(Time {
+            hour: 1,
+            minute: 2,
+            second: 3,
+            hundredths: 4,
+        }),
+        BACnetTimeStamp::SequenceNumber(22),
+        BACnetTimeStamp::DateTime {
+            date: Date {
+                year: 126,
+                month: 7,
+                day: 30,
+                day_of_week: 4,
+            },
+            time: Time {
+                hour: 12,
+                minute: 34,
+                second: 56,
+                hundredths: 78,
+            },
+        },
+    ]
+}
+
+fn assert_timestamp_value(actual: PropertyValue, expected: &BACnetTimeStamp, context: &str) {
+    let PropertyValue::ApplicationData(bytes) = actual else {
+        panic!("{context}: expected encoded timestamp CHOICE");
+    };
+    let (decoded, end) = decode_timestamp_choice(&bytes, 0).unwrap();
+    assert_eq!(&decoded, expected, "{context}: timestamp CHOICE");
+    assert_eq!(end, bytes.len(), "{context}: trailing timestamp bytes");
+}
+
+fn assert_seeded_timestamp_reads(
+    object: &dyn BACnetObject,
+    expected: &[BACnetTimeStamp; 3],
+    label: &str,
+) {
+    let whole = object
+        .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
+        .unwrap();
+    let PropertyValue::List(values) = whole else {
+        panic!("{label}: expected timestamp list");
+    };
+    assert_eq!(values.len(), 3, "{label}: array length");
+    for (slot, (actual, expected)) in values.into_iter().zip(expected).enumerate() {
+        assert_timestamp_value(actual, expected, &format!("{label} slot {}", slot + 1));
+    }
+
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(0))
+            .unwrap(),
+        PropertyValue::Unsigned(3),
+        "{label}: array count"
+    );
+    for (slot, expected) in expected.iter().enumerate() {
+        assert_timestamp_value(
+            object
+                .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(slot as u32 + 1))
+                .unwrap(),
+            expected,
+            &format!("{label} indexed slot {}", slot + 1),
+        );
+    }
+    for index in [4, u32::MAX] {
+        assert_property_error(
+            object.read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(index)),
+            ErrorCode::INVALID_ARRAY_INDEX,
+            &format!("{label} index {index}"),
+        );
+    }
+}
+
+fn assert_property_error<T: std::fmt::Debug>(
+    result: Result<T, Error>,
+    expected: ErrorCode,
+    context: &str,
+) {
+    match result.expect_err(context) {
+        Error::Protocol { class, code } => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32, "{context}");
+            assert_eq!(code, expected.to_raw() as u32, "{context}");
+        }
+        other => panic!("{context}: expected property error, got {other:?}"),
+    }
+}
+
+fn assert_history_surface(object: &mut dyn BACnetObject, label: &str) {
+    let properties = object.property_list();
+    assert!(
+        properties.contains(&PropertyIdentifier::EVENT_TIME_STAMPS),
+        "{label}: Event_Time_Stamps missing from Property_List"
+    );
+    assert!(
+        !properties.contains(&PropertyIdentifier::EVENT_MESSAGE_TEXTS),
+        "{label}: optional Event_Message_Texts must remain absent"
+    );
+    assert_property_error(
+        object.read_property(PropertyIdentifier::EVENT_MESSAGE_TEXTS, None),
+        ErrorCode::UNKNOWN_PROPERTY,
+        &format!("{label}: Event_Message_Texts read"),
+    );
+    assert_property_error(
+        object.write_property(
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+            None,
+            PropertyValue::List(Vec::new()),
+            None,
+        ),
+        ErrorCode::WRITE_ACCESS_DENIED,
+        &format!("{label}: Event_Time_Stamps write"),
+    );
+    assert!(!object.is_writable_property(PropertyIdentifier::EVENT_TIME_STAMPS));
+}
+
+#[test]
+fn enrollment_event_time_stamp_arrays_preserve_order_indexes_and_choices() {
+    let expected = seeded_timestamps();
+    let mut event = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
+    event.event_history.time_stamps = expected.clone();
+    let mut alert = AlertEnrollmentObject::new(1, "AE-1").unwrap();
+    alert.event_history.time_stamps = expected.clone();
+
+    assert_seeded_timestamp_reads(&event, &expected, "Event Enrollment");
+    assert_seeded_timestamp_reads(&alert, &expected, "Alert Enrollment");
+    assert_history_surface(&mut event, "Event Enrollment");
+    assert_history_surface(&mut alert, "Alert Enrollment");
+}
+
+#[test]
+fn event_enrollment_detection_disable_resets_history_and_rollback_restores_it() {
+    let expected = seeded_timestamps();
+    let mut object = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
+    object.event_history.time_stamps = expected.clone();
+    let rollback = object
+        .capture_write_property_rollback(
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            &PropertyValue::Boolean(false),
+        )
+        .expect("Event Enrollment detection write needs an opaque rollback");
+
+    object
+        .write_property(
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .unwrap();
+    assert_default_timestamp_array(&object, "disabled Event Enrollment");
+
+    object.restore_write_property_rollback(rollback).unwrap();
+    assert_seeded_timestamp_reads(&object, &expected, "restored Event Enrollment");
+}
+
+#[test]
+fn alert_enrollment_disable_projection_reset_and_rollback_cover_history() {
+    let expected = seeded_timestamps();
+    let mut object = AlertEnrollmentObject::new(1, "AE-1").unwrap();
+    object.event_history.time_stamps = expected.clone();
+    let rollback = object
+        .capture_write_property_rollback(
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            &PropertyValue::Boolean(false),
+        )
+        .expect("Alert Enrollment detection write needs an opaque rollback");
+
+    object.set_event_detection_enable(false);
+    assert_default_timestamp_array(&object, "disabled Alert Enrollment");
+    object.restore_write_property_rollback(rollback).unwrap();
+    assert_seeded_timestamp_reads(&object, &expected, "restored Alert Enrollment");
+
+    object.event_detection_enable = false;
+    assert_default_timestamp_array(&object, "directly-disabled Alert Enrollment");
+    assert_eq!(object.event_history.time_stamps, expected);
+
+    object.set_event_detection_enable(true);
+    assert_default_timestamp_array(&object, "re-enabled Alert Enrollment");
+    assert_eq!(object.event_history.time_stamps, seeded_zero_timestamps());
+}
+
+fn seeded_zero_timestamps() -> [BACnetTimeStamp; 3] {
+    [
+        BACnetTimeStamp::SequenceNumber(0),
+        BACnetTimeStamp::SequenceNumber(0),
+        BACnetTimeStamp::SequenceNumber(0),
+    ]
+}
+
+fn assert_complete_metadata(
+    object: &dyn BACnetObject,
+    expected: &[PropertyIdentifier],
+    label: &str,
+) {
+    let metadata = object.property_metadata();
+    let actual: Vec<_> = metadata.iter().map(|row| row.property_identifier).collect();
+    assert_eq!(actual, expected, "{label}: metadata identifiers");
+
+    let projection: Vec<_> = expected
+        .iter()
+        .copied()
+        .filter(|property| *property != PropertyIdentifier::PROPERTY_LIST)
+        .collect();
+    assert_eq!(object.property_list().as_ref(), projection.as_slice());
+
+    for row in metadata.iter() {
+        object
+            .read_property(row.property_identifier, None)
+            .unwrap_or_else(|error| {
+                panic!(
+                    "{label}: metadata row {:?} is unreadable: {error:?}",
+                    row.property_identifier
+                )
+            });
+        assert_eq!(
+            row.write_capability.is_writable(),
+            object.is_writable_property(row.property_identifier),
+            "{label}: {:?} writability",
+            row.property_identifier
+        );
+    }
+}
+
+fn metadata_row(object: &dyn BACnetObject, property: PropertyIdentifier) -> PropertyMetadata {
+    *object
+        .property_metadata()
+        .iter()
+        .find(|row| row.property_identifier == property)
+        .unwrap_or_else(|| panic!("missing metadata row for {property:?}"))
+}
+
+#[test]
+fn enrollment_property_metadata_is_complete_and_pins_timestamp_requirements() {
+    let event = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
+    let event_ids = [
+        PropertyIdentifier::OBJECT_IDENTIFIER,
+        PropertyIdentifier::OBJECT_NAME,
+        PropertyIdentifier::DESCRIPTION,
+        PropertyIdentifier::OBJECT_TYPE,
+        PropertyIdentifier::EVENT_TYPE,
+        PropertyIdentifier::NOTIFY_TYPE,
+        PropertyIdentifier::EVENT_PARAMETERS,
+        PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+        PropertyIdentifier::EVENT_STATE,
+        PropertyIdentifier::EVENT_ENABLE,
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+        PropertyIdentifier::NOTIFICATION_CLASS,
+        PropertyIdentifier::EVENT_TIME_STAMPS,
+        PropertyIdentifier::FAULT_TYPE,
+        PropertyIdentifier::FAULT_PARAMETERS,
+        PropertyIdentifier::TIME_DELAY_NORMAL,
+        PropertyIdentifier::STATUS_FLAGS,
+        PropertyIdentifier::OUT_OF_SERVICE,
+        PropertyIdentifier::RELIABILITY,
+        PropertyIdentifier::PROPERTY_LIST,
+    ];
+    assert_complete_metadata(&event, &event_ids, "Event Enrollment");
+
+    let alert = AlertEnrollmentObject::new(1, "AE-1").unwrap();
+    let alert_ids = [
+        PropertyIdentifier::OBJECT_IDENTIFIER,
+        PropertyIdentifier::OBJECT_NAME,
+        PropertyIdentifier::DESCRIPTION,
+        PropertyIdentifier::OBJECT_TYPE,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyIdentifier::EVENT_STATE,
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+        PropertyIdentifier::EVENT_ENABLE,
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        PropertyIdentifier::NOTIFICATION_CLASS,
+        PropertyIdentifier::EVENT_TIME_STAMPS,
+        PropertyIdentifier::STATUS_FLAGS,
+        PropertyIdentifier::OUT_OF_SERVICE,
+        PropertyIdentifier::RELIABILITY,
+        PropertyIdentifier::PROPERTY_LIST,
+    ];
+    assert_complete_metadata(&alert, &alert_ids, "Alert Enrollment");
+
+    for object in [&event as &dyn BACnetObject, &alert as &dyn BACnetObject] {
+        let timestamps = metadata_row(object, PropertyIdentifier::EVENT_TIME_STAMPS);
+        assert_eq!(timestamps.conformance, PropertyConformance::RequiredRead);
+        assert_eq!(
+            timestamps.write_capability,
+            PropertyWriteCapability::ReadOnly
+        );
+    }
+
+    assert!(alert
+        .property_metadata()
+        .iter()
+        .all(|row| row.property_identifier != PropertyIdentifier::NOTIFY_TYPE));
+    assert!(!alert
+        .property_list()
+        .contains(&PropertyIdentifier::NOTIFY_TYPE));
+    assert_property_error(
+        alert.read_property(PropertyIdentifier::NOTIFY_TYPE, None),
+        ErrorCode::UNKNOWN_PROPERTY,
+        "Alert Enrollment Notify_Type remains an explicit model limitation",
+    );
+}
+
+#[test]
+fn alert_to_normal_acknowledgment_cannot_be_cleared() {
+    let mut alert = AlertEnrollmentObject::new(1, "AE-1").unwrap();
+
+    alert.set_acked_transitions_internal(0x04, false).unwrap();
+    assert_eq!(alert.acked_transitions, 0b111);
+
+    alert.set_acked_transitions_internal(0x01, false).unwrap();
+    assert_eq!(alert.acked_transitions, 0b110);
+    alert.set_acked_transitions_internal(0x02, false).unwrap();
+    assert_eq!(alert.acked_transitions, 0b100);
+    alert.set_acked_transitions_internal(0x01, true).unwrap();
+    alert.set_acked_transitions_internal(0x02, true).unwrap();
+    assert_eq!(alert.acked_transitions, 0b111);
+
+    alert.set_event_detection_enable(false);
+    assert!(alert.set_acked_transitions_internal(0x04, false).is_err());
+}

--- a/crates/bacnet-server/src/handlers/tests/property_metadata.rs
+++ b/crates/bacnet-server/src/handlers/tests/property_metadata.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use bacnet_objects::binary::BinaryInputObject;
+use bacnet_objects::event_enrollment::{AlertEnrollmentObject, EventEnrollmentObject};
 use bacnet_objects::value_types::TimeValueObject;
 use bacnet_services::common::PropertyReference;
 use bacnet_services::rpm::{ReadAccessSpecification, ReadPropertyMultipleACK};
@@ -10,6 +11,10 @@ fn make_metadata_db() -> ObjectDatabase {
     db.add(Box::new(TimeValueObject::new(1, "TV-1").unwrap()))
         .unwrap();
     db.add(Box::new(BinaryInputObject::new(1, "BI-1").unwrap()))
+        .unwrap();
+    db.add(Box::new(EventEnrollmentObject::new(1, "EE-1", 0).unwrap()))
+        .unwrap();
+    db.add(Box::new(AlertEnrollmentObject::new(1, "AE-1").unwrap()))
         .unwrap();
     db
 }
@@ -34,8 +39,21 @@ fn rpm_property_ids(
     let mut response_bytes = BytesMut::new();
     handle_read_property_multiple(db, &request_bytes, &mut response_bytes).unwrap();
     let ack = ReadPropertyMultipleACK::decode(&response_bytes).unwrap();
-    ack.list_of_read_access_results[0]
-        .list_of_results
+    let results = &ack.list_of_read_access_results[0].list_of_results;
+    for result in results {
+        assert!(
+            result.error.is_none(),
+            "RPM {selector:?} returned an inline error for {:?}: {:?}",
+            result.property_identifier,
+            result.error
+        );
+        assert!(
+            result.property_value.is_some(),
+            "RPM {selector:?} omitted encoded value for {:?}",
+            result.property_identifier
+        );
+    }
+    results
         .iter()
         .map(|result| result.property_identifier)
         .collect()
@@ -147,4 +165,127 @@ fn rpm_metadata_selectors_are_exact_for_binary_input() {
             PropertyIdentifier::ALARM_VALUE,
         ]
     );
+}
+
+#[test]
+fn rpm_metadata_selectors_are_exact_for_event_enrollment() {
+    let db = make_metadata_db();
+    let oid = ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 1).unwrap();
+
+    assert_eq!(
+        rpm_property_ids(&db, oid, PropertyIdentifier::ALL),
+        vec![
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::DESCRIPTION,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::EVENT_TYPE,
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyIdentifier::EVENT_PARAMETERS,
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+            PropertyIdentifier::FAULT_TYPE,
+            PropertyIdentifier::FAULT_PARAMETERS,
+            PropertyIdentifier::TIME_DELAY_NORMAL,
+            PropertyIdentifier::STATUS_FLAGS,
+            PropertyIdentifier::OUT_OF_SERVICE,
+            PropertyIdentifier::RELIABILITY,
+        ]
+    );
+    assert_eq!(
+        rpm_property_ids(&db, oid, PropertyIdentifier::REQUIRED),
+        vec![
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::EVENT_TYPE,
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyIdentifier::EVENT_PARAMETERS,
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+            PropertyIdentifier::STATUS_FLAGS,
+            PropertyIdentifier::RELIABILITY,
+        ]
+    );
+    assert_eq!(
+        rpm_property_ids(&db, oid, PropertyIdentifier::OPTIONAL),
+        vec![
+            PropertyIdentifier::DESCRIPTION,
+            PropertyIdentifier::FAULT_TYPE,
+            PropertyIdentifier::FAULT_PARAMETERS,
+            PropertyIdentifier::TIME_DELAY_NORMAL,
+            PropertyIdentifier::OUT_OF_SERVICE,
+        ]
+    );
+}
+
+#[test]
+fn rpm_metadata_selectors_are_exact_for_alert_enrollment() {
+    let db = make_metadata_db();
+    let oid = ObjectIdentifier::new(ObjectType::ALERT_ENROLLMENT, 1).unwrap();
+
+    assert_eq!(
+        rpm_property_ids(&db, oid, PropertyIdentifier::ALL),
+        vec![
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::DESCRIPTION,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::PRESENT_VALUE,
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+            PropertyIdentifier::STATUS_FLAGS,
+            PropertyIdentifier::OUT_OF_SERVICE,
+            PropertyIdentifier::RELIABILITY,
+        ]
+    );
+    assert_eq!(
+        rpm_property_ids(&db, oid, PropertyIdentifier::REQUIRED),
+        vec![
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::PRESENT_VALUE,
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+        ]
+    );
+    assert_eq!(
+        rpm_property_ids(&db, oid, PropertyIdentifier::OPTIONAL),
+        vec![
+            PropertyIdentifier::DESCRIPTION,
+            PropertyIdentifier::STATUS_FLAGS,
+            PropertyIdentifier::OUT_OF_SERVICE,
+            PropertyIdentifier::RELIABILITY,
+        ]
+    );
+
+    for selector in [
+        PropertyIdentifier::ALL,
+        PropertyIdentifier::REQUIRED,
+        PropertyIdentifier::OPTIONAL,
+    ] {
+        assert!(
+            !rpm_property_ids(&db, oid, selector).contains(&PropertyIdentifier::NOTIFY_TYPE),
+            "Alert Enrollment must not advertise its unimplemented Notify_Type"
+        );
+    }
 }

--- a/crates/bacnet-server/src/pics/property_metadata_tests.rs
+++ b/crates/bacnet-server/src/pics/property_metadata_tests.rs
@@ -1,4 +1,8 @@
-use bacnet_objects::{binary::BinaryInputObject, value_types::TimeValueObject};
+use bacnet_objects::{
+    binary::BinaryInputObject,
+    event_enrollment::{AlertEnrollmentObject, EventEnrollmentObject},
+    value_types::TimeValueObject,
+};
 use bacnet_types::enums::{ObjectType, PropertyIdentifier};
 
 use super::*;
@@ -26,6 +30,10 @@ fn pics_projects_migrated_property_metadata() {
     db.add(Box::new(TimeValueObject::new(1, "tv-1").unwrap()))
         .unwrap();
     db.add(Box::new(BinaryInputObject::new(1, "bi-1").unwrap()))
+        .unwrap();
+    db.add(Box::new(EventEnrollmentObject::new(1, "ee-1", 0).unwrap()))
+        .unwrap();
+    db.add(Box::new(AlertEnrollmentObject::new(1, "ae-1").unwrap()))
         .unwrap();
     let pics = generate_pics(&db, &ServerConfig::default(), &PicsConfig::default());
 
@@ -72,6 +80,18 @@ fn pics_projects_migrated_property_metadata() {
             true,
             false,
         ),
+        (
+            ObjectType::EVENT_ENROLLMENT,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+            false,
+            false,
+        ),
+        (
+            ObjectType::ALERT_ENROLLMENT,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+            false,
+            false,
+        ),
     ] {
         let support = property_support(&pics, object_type, property_id);
         assert_eq!(
@@ -84,9 +104,24 @@ fn pics_projects_migrated_property_metadata() {
         );
     }
 
-    for object_type in [ObjectType::TIME_VALUE, ObjectType::BINARY_INPUT] {
+    for object_type in [
+        ObjectType::TIME_VALUE,
+        ObjectType::BINARY_INPUT,
+        ObjectType::EVENT_ENROLLMENT,
+        ObjectType::ALERT_ENROLLMENT,
+    ] {
         let property_list = property_support(&pics, object_type, PropertyIdentifier::PROPERTY_LIST);
         assert!(!property_list.access.optional);
         assert!(!property_list.access.writable);
     }
+
+    let alert = pics
+        .supported_object_types
+        .iter()
+        .find(|support| support.object_type == ObjectType::ALERT_ENROLLMENT)
+        .expect("Alert Enrollment support");
+    assert!(alert
+        .supported_properties
+        .iter()
+        .all(|property| property.property_id != PropertyIdentifier::NOTIFY_TYPE));
 }

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -707,6 +707,37 @@
    "notes": "Split child of BACNET-12-OBJECT-MODEL (#182). The four arms share one objects-layer helper (reference.rs) so the local List form (in-process compatibility) and the framed ApplicationData form (network) converge on the same strict Clause 21 decode; error pairings follow Clause 15.9.1.3: wrong value datatype is PROPERTY / INVALID_DATA_TYPE, malformed framing / device qualification / unknown trailing context tag is PROPERTY / INVALID_DATA_ENCODING, and a mixed flat+framed element list is refused rather than reinterpreted. Null clears, and read arms carry the reference's optional array index as a third list element. Setpoint_Reference additionally accepts the BACnetSetpointReference opening/closing tag [0] frame (unambiguous against the bare form's leading primitive [0]) while refusing unbalanced frames. WritePropertyMultiple in-order commit and rollback are proven for a reference+setpoint request failing its second property. Review round: the adversary lane's blocker on the Averaging arm (silent member drop / member retype / as-u32 truncation, newly network-reachable) is fixed by routing it through the same shared decode; the runtime+dataflow empty-frame finding is fixed by the Option-returning decode_setpoint_reference; the dataflow PICS incoherence is fixed by exact is_writable_property overrides on Pulse Converter (PRESENT_VALUE / SCALE_FACTOR / ADJUST_VALUE / INPUT_REFERENCE + DESCRIPTION / OUT_OF_SERVICE / COV_INCREMENT) and Averaging (OBJECT_PROPERTY_REFERENCE + DESCRIPTION / OUT_OF_SERVICE), which also stop advertising OBJECT_NAME on both types (no arm routes it - a truth-toward-arms PICS correction). Limitation: reads still emit the flat application-tagged list form rather than re-framing context tags - the encode side is unchanged by this tranche; interop evidence against a second implementation remains open."
   },
   {
+   "id": "BACNET-12-ENROLLMENT-EVENT-TIME-STAMPS",
+   "standard_anchor": "Clause 12.12 Table 12-14; Clause 12.52 Table 12-61; Clause 12.1.5.1; Clause 13.2.2.1; Clause 21 BACnetTimeStamp",
+   "priority": "P1",
+   "requirement_summary": "Event Enrollment and Alert Enrollment expose required Event_Time_Stamps as a read-only BACnetARRAY[3] ordered TO_OFFNORMAL, TO_FAULT, TO_NORMAL. The initial condition is SequenceNumber(0) in every slot; omitted-index, count, element, invalid-index, detection-disabled reset, and lossless BACnetTimeStamp CHOICE reads are implemented. Complete property metadata drives Property_List, RPM ALL/REQUIRED/OPTIONAL, and generated PICS required/read-only truth for both object types.",
+   "status": "implementation-present-needs-state-machine-audit",
+   "code_anchors": [
+    "crates/bacnet-objects/src/event_enrollment/mod.rs",
+    "crates/bacnet-objects/src/event_enrollment/metadata.rs",
+    "crates/bacnet-objects/src/event_enrollment/state.rs",
+    "crates/bacnet-objects/src/event/history.rs"
+   ],
+   "positive_tests": [
+    "crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs::enrollment_objects_default_event_time_stamps_are_three_zero_sequences",
+    "crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs::enrollment_event_time_stamp_arrays_preserve_order_indexes_and_choices",
+    "crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs::event_enrollment_detection_disable_resets_history_and_rollback_restores_it",
+    "crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs::alert_enrollment_disable_projection_reset_and_rollback_cover_history",
+    "crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs::enrollment_property_metadata_is_complete_and_pins_timestamp_requirements",
+    "crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs::alert_to_normal_acknowledgment_cannot_be_cleared",
+    "crates/bacnet-server/src/handlers/tests/property_metadata.rs::rpm_metadata_selectors_are_exact_for_event_enrollment",
+    "crates/bacnet-server/src/handlers/tests/property_metadata.rs::rpm_metadata_selectors_are_exact_for_alert_enrollment",
+    "crates/bacnet-server/src/pics/property_metadata_tests.rs::pics_projects_migrated_property_metadata"
+   ],
+   "negative_tests": [
+    "crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs::enrollment_event_time_stamp_arrays_preserve_order_indexes_and_choices (invalid indexes, write denial, and Event_Message_Texts absence)",
+    "crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs::enrollment_property_metadata_is_complete_and_pins_timestamp_requirements (Alert Enrollment Notify_Type limitation)"
+   ],
+   "benchmarks": [],
+   "public_claims": [],
+   "notes": "#264 property-surface slice. EventHistory is embedded privately, but only an exact Event_Time_Stamps match delegates to it; optional Event_Message_Texts remains unlisted and unreadable. Detection-disabled resets restore timestamp initial conditions, including projection after direct assignment to Alert Enrollment's compatibility-public Event_Detection_Enable field, and object-owned WPM rollback tokens restore seeded history atomically. Alert Enrollment's TO_NORMAL Acked_Transitions bit is held TRUE because Clause 12.52.8 makes that transition acknowledgment-not-required. This row does not claim complete transition maintenance: evaluator/lifecycle writes of each transition timestamp remain deferred to PR-0205/PR-0305, and notification transition-history sourcing remains deferred to PR-0207. Alert Enrollment remains a partial Table 12-61 model: required Notify_Type is still unimplemented and deliberately absent from metadata/PICS (#291); Event_Message_Texts is optional and remains absent."
+  },
+  {
    "id": "BACNET-12-TIME-DELAY-NORMAL",
    "standard_anchor": "Clause 13.3.2 CHANGE_OF_STATE, Clause 13.3.4 COMMAND_FAILURE, Clause 13.3.6 OUT_OF_RANGE (pTimeDelayNormal definitions and condition letters); Clause 12.2 Table 12-2 (Analog Input, O5), 12.3 Table 12-3 (Analog Output, O4), 12.4 Table 12-4 (Analog Value, O6), 12.6 Table 12-6 (Binary Input, O7), 12.7 Table 12-8 (Binary Output, O6), 12.8 Table 12-10 (Binary Value, O8), 12.18 Table 12-21 (Multi-state Input, O5), 12.19 Table 12-22 (Multi-state Output, O3), 12.20 Table 12-23 (Multi-state Value, O6)",
    "priority": "P1",

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -13,7 +13,7 @@
 | Dimension | Value | Count |
 |---|---|---|
 | Priority | P0 | 16 |
-| Priority | P1 | 33 |
+| Priority | P1 | 34 |
 | Priority | P2 | 5 |
 | Priority | P3 | 4 |
 | Status | deferred-pending-owner-decision | 2 |
@@ -22,7 +22,7 @@
 | Status | implementation-present-needs-platform-tests | 1 |
 | Status | implementation-present-needs-security-tests | 1 |
 | Status | implementation-present-needs-source-review | 3 |
-| Status | implementation-present-needs-state-machine-audit | 3 |
+| Status | implementation-present-needs-state-machine-audit | 4 |
 | Status | implementation-present-needs-timeout-tests | 1 |
 | Status | implementation-present-needs-window-tests | 1 |
 | Status | in-progress | 5 |
@@ -58,6 +58,7 @@
 | `BACNET-12-OOS-RELIABILITY-WRITABILITY` | Clause 12.17 Table 12-20 footnote 7 (Loop); Clause 12 Out_Of_Service property texts (12.2/12.3/12.4/12.6/12.7/12.8/12.19/12.21/12.22 families); Clause 12.24 Schedule Reliability_Evaluation_Inhibit text; Clause 12.25 Table 12-29 and Clause 12.30 Table 12-35 (Trend Log / Trend Log Multiple); Clause 21 BACnetReliability | P1 | supported-with-clause-evidence | 0 |
 | `BACNET-12-RELINQUISH-DEFAULT-WRITABILITY` | Clause 12.3 Table 12-3 (Analog Output), Clause 12.7 Table 12-8 (Binary Output), Clause 12.8 Table 12-10 (Binary Value), Clause 12.19 Table 12-22 (Multi-state Output), Clause 12.20 Table 12-23 (Multi-state Value), Clause 12.26 Table 12-30 (Access Door), Clause 12.54 Table 12-64 (Lighting Output), Clause 12.55 Table 12-69 (Binary Lighting Output), Clause 12 value object tables; Clause 19 command prioritization | P1 | supported-with-clause-evidence | 0 |
 | `BACNET-12-REFERENCE-PROPERTY-WRITABILITY` | Clause 12.17 with Table 12-20 (Loop), Clause 12.23 with Table 12-27 (Pulse Converter Input_Reference), Clause 12.5 Table 12-5 (Averaging Object_Property_Reference - BACnetDeviceObjectPropertyReference), Clause 21 BACnetObjectPropertyReference / BACnetSetpointReference productions | P1 | supported-with-clause-evidence | 0 |
+| `BACNET-12-ENROLLMENT-EVENT-TIME-STAMPS` | Clause 12.12 Table 12-14; Clause 12.52 Table 12-61; Clause 12.1.5.1; Clause 13.2.2.1; Clause 21 BACnetTimeStamp | P1 | implementation-present-needs-state-machine-audit | 0 |
 | `BACNET-12-TIME-DELAY-NORMAL` | Clause 13.3.2 CHANGE_OF_STATE, Clause 13.3.4 COMMAND_FAILURE, Clause 13.3.6 OUT_OF_RANGE (pTimeDelayNormal definitions and condition letters); Clause 12.2 Table 12-2 (Analog Input, O5), 12.3 Table 12-3 (Analog Output, O4), 12.4 Table 12-4 (Analog Value, O6), 12.6 Table 12-6 (Binary Input, O7), 12.7 Table 12-8 (Binary Output, O6), 12.8 Table 12-10 (Binary Value, O8), 12.18 Table 12-21 (Multi-state Input, O5), 12.19 Table 12-22 (Multi-state Output, O3), 12.20 Table 12-23 (Multi-state Value, O6) | P1 | supported-with-clause-evidence | 0 |
 | `BACNET-13-COV-SUBSCRIPTIONS` | Clauses 13.14-13.18 | P1 | implementation-present-needs-conformance-tests | 0 |
 | `BACNET-13-AUDIT-WIRE-MODELS` | Clauses 13.19-13.21; Clause 21.2.1, Clause 21.2.3, Clause 21.3.1, BACnetAuditNotification, BACnetAuditLogQueryParameters, and BACnetAuditOperationFlags productions | P1 | implementation-present-needs-source-review | 0 |


### PR DESCRIPTION
## Summary

- add required `Event_Time_Stamps` BACnetARRAY[3] storage and indexed reads to Event Enrollment and Alert Enrollment
- reset and restore timestamp history atomically with `Event_Detection_Enable`, while preserving Alert Enrollment's TO_NORMAL acknowledgment exception
- migrate both implemented property surfaces to complete metadata so Property_List, RPM ALL/REQUIRED/OPTIONAL, and generated PICS agree
- add qualified executable conformance evidence without broadening public support claims

## Standard anchors

- Clause 12.12, Table 12-14
- Clause 12.52, Table 12-61 and §12.52.8
- Clause 12.1.5.1
- Clause 13.2.2.1
- Clause 21 `BACnetTimeStamp`

## Validation

- focused Event/Alert Enrollment timestamp and metadata tests
- focused RPM selector and PICS metadata tests
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and diff checks

## Boundaries

This completes the required property exposure, initialization/reset, metadata, RPM, and PICS slice. Clause 13.2 transition-time timestamp writes remain deferred to PR-0205/PR-0305, and notification history sourcing remains deferred to PR-0207. Optional `Event_Message_Texts` remains absent. Alert Enrollment's broader required `Notify_Type` gap remains tracked by #291.

Closes #264
