### PR TITLE
feat(objects): add atomic event transition commit kernel

### DIFF
--- a/crates/bacnet-objects/src/event.rs
+++ b/crates/bacnet-objects/src/event.rs
@@ -7,6 +7,7 @@
 use core::ops::ControlFlow;
 
 use bacnet_types::enums::{EventState, EventType, Reliability};
+use bacnet_types::primitives::BACnetTimeStamp;
 
 pub(crate) mod history;
 
@@ -119,6 +120,46 @@ impl EventTransition {
             EventTransition::ToNormal => 2,
         }
     }
+}
+
+/// All object-owned values needed to commit one event-state transition.
+///
+/// Callers stage the timestamp and optional message before invoking an
+/// object's internal commit hook. The object then validates the transition
+/// coordinate and source state before changing any of its event properties.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventTransitionCommit {
+    /// The expected source state and exact destination state.
+    pub change: EventStateChange,
+    /// The destination state's transition coordinate.
+    pub coordinate: EventTransition,
+    /// Whether the referenced Notification Class requires acknowledgment.
+    pub ack_required: bool,
+    /// The timestamp CHOICE to store for `coordinate`.
+    pub timestamp: BACnetTimeStamp,
+    /// Replacement message for `coordinate`, or `None` when the property is absent.
+    pub message_text: Option<String>,
+}
+
+/// Failure to atomically commit an event-state transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventTransitionCommitError {
+    /// The object does not implement the internal transition-commit channel.
+    Unsupported,
+    /// The supplied coordinate does not classify the exact destination state.
+    CoordinateTargetMismatch {
+        /// The coordinate supplied by the caller.
+        coordinate: EventTransition,
+        /// The exact destination state supplied by the caller.
+        target: EventState,
+    },
+    /// The object's current state no longer matches the staged source state.
+    CurrentStateMismatch {
+        /// The source state expected by the staged transition.
+        expected: EventState,
+        /// The object's current state when the commit was attempted.
+        actual: EventState,
+    },
 }
 
 /// Which limits are enabled.

--- a/crates/bacnet-objects/src/event/history.rs
+++ b/crates/bacnet-objects/src/event/history.rs
@@ -1,10 +1,12 @@
 //! Shared storage for intrinsic-reporting event history properties.
 
 use bacnet_encoding::primitives::encode_timestamp_choice;
-use bacnet_types::enums::PropertyIdentifier;
+use bacnet_types::enums::{EventState, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, PropertyValue};
 use bytes::BytesMut;
+
+use super::{EventTransition, EventTransitionCommit, EventTransitionCommitError};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct EventHistory {
@@ -12,6 +14,71 @@ pub(crate) struct EventHistory {
     pub(crate) time_stamps: [BACnetTimeStamp; 3],
     /// Transition slots ordered `[TO_OFFNORMAL, TO_FAULT, TO_NORMAL]`.
     pub(crate) message_texts: [String; 3],
+}
+
+/// Borrowed object-owned state for one atomic event-transition commit.
+///
+/// This aggregate is staged for object-family adoption: it keeps the generic
+/// commit policy centralized while each object remains responsible for
+/// lending its own three property stores through its trait hook.
+#[allow(dead_code)]
+pub(crate) struct EventTransitionState<'a> {
+    event_state: &'a mut EventState,
+    acked_transitions: &'a mut u8,
+    history: &'a mut EventHistory,
+}
+
+#[allow(dead_code)]
+impl<'a> EventTransitionState<'a> {
+    pub(crate) fn new(
+        event_state: &'a mut EventState,
+        acked_transitions: &'a mut u8,
+        history: &'a mut EventHistory,
+    ) -> Self {
+        Self {
+            event_state,
+            acked_transitions,
+            history,
+        }
+    }
+
+    /// Validate and commit all event properties for exactly one coordinate.
+    pub(crate) fn commit(
+        self,
+        commit: EventTransitionCommit,
+    ) -> Result<(), EventTransitionCommitError> {
+        let expected_coordinate = EventTransition::for_target_state(commit.change.to);
+        if commit.coordinate != expected_coordinate {
+            return Err(EventTransitionCommitError::CoordinateTargetMismatch {
+                coordinate: commit.coordinate,
+                target: commit.change.to,
+            });
+        }
+
+        if *self.event_state != commit.change.from {
+            return Err(EventTransitionCommitError::CurrentStateMismatch {
+                expected: commit.change.from,
+                actual: *self.event_state,
+            });
+        }
+
+        let index = commit.coordinate.index();
+        let bit = commit.coordinate.bit_mask();
+        let acknowledged = !commit.ack_required;
+
+        *self.event_state = commit.change.to;
+        if acknowledged {
+            *self.acked_transitions |= bit;
+        } else {
+            *self.acked_transitions &= !bit;
+        }
+        self.history.time_stamps[index] = commit.timestamp;
+        if let Some(message_text) = commit.message_text {
+            self.history.message_texts[index] = message_text;
+        }
+
+        Ok(())
+    }
 }
 
 impl Default for EventHistory {
@@ -76,6 +143,60 @@ fn timestamp_value(stamp: &BACnetTimeStamp) -> PropertyValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::borrow::Cow;
+
+    use bacnet_types::enums::{EventState, ObjectType};
+    use bacnet_types::primitives::{Date, ObjectIdentifier, Time};
+
+    use crate::event::{
+        EventStateChange, EventTransition, EventTransitionCommit, EventTransitionCommitError,
+    };
+    use crate::traits::BACnetObject;
+
+    fn time(hour: u8) -> BACnetTimeStamp {
+        BACnetTimeStamp::Time(Time {
+            hour,
+            minute: 2,
+            second: 3,
+            hundredths: 4,
+        })
+    }
+
+    fn date_time(day: u8) -> BACnetTimeStamp {
+        BACnetTimeStamp::DateTime {
+            date: Date {
+                year: 126,
+                month: 8,
+                day,
+                day_of_week: 3,
+            },
+            time: Time {
+                hour: 5,
+                minute: 6,
+                second: 7,
+                hundredths: 8,
+            },
+        }
+    }
+
+    fn commit(
+        state: &mut EventState,
+        acked: &mut u8,
+        history: &mut EventHistory,
+        change: EventStateChange,
+        coordinate: EventTransition,
+        ack_required: bool,
+        timestamp: BACnetTimeStamp,
+        message_text: Option<&str>,
+    ) -> Result<(), EventTransitionCommitError> {
+        EventTransitionState::new(state, acked, history).commit(EventTransitionCommit {
+            change,
+            coordinate,
+            ack_required,
+            timestamp,
+            message_text: message_text.map(str::to_owned),
+        })
+    }
 
     #[test]
     fn reset_restores_mutated_history_to_default() {
@@ -86,5 +207,270 @@ mod tests {
         history.reset();
 
         assert_eq!(history, EventHistory::default());
+    }
+
+    #[test]
+    fn commit_updates_each_coordinate_and_preserves_exact_timestamp_choices() {
+        let mut state = EventState::NORMAL;
+        let mut acked = 0b101;
+        let mut history = EventHistory {
+            time_stamps: [
+                BACnetTimeStamp::SequenceNumber(10),
+                BACnetTimeStamp::SequenceNumber(20),
+                BACnetTimeStamp::SequenceNumber(30),
+            ],
+            message_texts: [
+                "old-offnormal".into(),
+                "old-fault".into(),
+                "old-normal".into(),
+            ],
+        };
+
+        commit(
+            &mut state,
+            &mut acked,
+            &mut history,
+            EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            EventTransition::ToOffnormal,
+            true,
+            time(1),
+            Some("high-limit"),
+        )
+        .unwrap();
+        assert_eq!(state, EventState::HIGH_LIMIT);
+        assert_eq!(acked, 0b100, "only TO_OFFNORMAL is cleared");
+        assert_eq!(history.time_stamps[0], time(1));
+        assert_eq!(history.time_stamps[1], BACnetTimeStamp::SequenceNumber(20));
+        assert_eq!(history.time_stamps[2], BACnetTimeStamp::SequenceNumber(30));
+        assert_eq!(
+            history.message_texts,
+            ["high-limit", "old-fault", "old-normal"]
+        );
+
+        commit(
+            &mut state,
+            &mut acked,
+            &mut history,
+            EventStateChange {
+                from: EventState::HIGH_LIMIT,
+                to: EventState::FAULT,
+            },
+            EventTransition::ToFault,
+            false,
+            BACnetTimeStamp::SequenceNumber(0),
+            Some("fault"),
+        )
+        .unwrap();
+        assert_eq!(state, EventState::FAULT);
+        assert_eq!(acked, 0b110, "TO_FAULT is set and other bits are untouched");
+        assert_eq!(history.time_stamps[0], time(1));
+        assert_eq!(history.time_stamps[1], BACnetTimeStamp::SequenceNumber(0));
+        assert_eq!(history.time_stamps[2], BACnetTimeStamp::SequenceNumber(30));
+        assert_eq!(history.message_texts, ["high-limit", "fault", "old-normal"]);
+
+        commit(
+            &mut state,
+            &mut acked,
+            &mut history,
+            EventStateChange {
+                from: EventState::FAULT,
+                to: EventState::NORMAL,
+            },
+            EventTransition::ToNormal,
+            true,
+            date_time(27),
+            Some("normal"),
+        )
+        .unwrap();
+        assert_eq!(state, EventState::NORMAL);
+        assert_eq!(acked, 0b010, "only TO_NORMAL is cleared");
+        assert_eq!(
+            history.time_stamps,
+            [time(1), BACnetTimeStamp::SequenceNumber(0), date_time(27)]
+        );
+        assert_eq!(history.message_texts, ["high-limit", "fault", "normal"]);
+    }
+
+    #[test]
+    fn same_state_reindication_commits_and_none_preserves_every_message() {
+        let mut state = EventState::NORMAL;
+        let mut acked = 0b001;
+        let mut history = EventHistory {
+            time_stamps: [
+                BACnetTimeStamp::SequenceNumber(1),
+                BACnetTimeStamp::SequenceNumber(2),
+                BACnetTimeStamp::SequenceNumber(3),
+            ],
+            message_texts: ["offnormal".into(), "fault".into(), "normal".into()],
+        };
+        let messages_before = history.message_texts.clone();
+
+        commit(
+            &mut state,
+            &mut acked,
+            &mut history,
+            EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::NORMAL,
+            },
+            EventTransition::ToNormal,
+            false,
+            BACnetTimeStamp::SequenceNumber(u16::MAX),
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(state, EventState::NORMAL);
+        assert_eq!(
+            acked, 0b101,
+            "TO_NORMAL is set and other bits are untouched"
+        );
+        assert_eq!(
+            history.time_stamps,
+            [
+                BACnetTimeStamp::SequenceNumber(1),
+                BACnetTimeStamp::SequenceNumber(2),
+                BACnetTimeStamp::SequenceNumber(u16::MAX),
+            ]
+        );
+        assert_eq!(history.message_texts, messages_before);
+    }
+
+    #[test]
+    fn coordinate_mismatch_rejects_without_mutating_any_state() {
+        let mut state = EventState::HIGH_LIMIT;
+        let mut acked = 0b101;
+        let mut history = EventHistory {
+            time_stamps: [time(9), BACnetTimeStamp::SequenceNumber(44), date_time(26)],
+            message_texts: ["offnormal".into(), "fault".into(), "normal".into()],
+        };
+        let expected_state = state;
+        let expected_acked = acked;
+        let expected_history = history.clone();
+
+        let error = commit(
+            &mut state,
+            &mut acked,
+            &mut history,
+            EventStateChange {
+                from: EventState::HIGH_LIMIT,
+                to: EventState::NORMAL,
+            },
+            EventTransition::ToOffnormal,
+            false,
+            BACnetTimeStamp::SequenceNumber(99),
+            Some("must-not-commit"),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            EventTransitionCommitError::CoordinateTargetMismatch {
+                coordinate: EventTransition::ToOffnormal,
+                target: EventState::NORMAL,
+            }
+        );
+        assert_eq!(state, expected_state);
+        assert_eq!(acked, expected_acked);
+        assert_eq!(history, expected_history);
+    }
+
+    #[test]
+    fn stale_state_changing_replay_rejects_without_mutating_first_commit() {
+        let mut state = EventState::NORMAL;
+        let mut acked = 0b111;
+        let mut history = EventHistory::default();
+        let first = EventTransitionCommit {
+            change: EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::LOW_LIMIT,
+            },
+            coordinate: EventTransition::ToOffnormal,
+            ack_required: true,
+            timestamp: BACnetTimeStamp::SequenceNumber(77),
+            message_text: Some("low-limit".into()),
+        };
+
+        EventTransitionState::new(&mut state, &mut acked, &mut history)
+            .commit(first.clone())
+            .unwrap();
+        let expected_acked = acked;
+        let expected_history = history.clone();
+
+        let error = EventTransitionState::new(&mut state, &mut acked, &mut history)
+            .commit(first)
+            .unwrap_err();
+
+        assert_eq!(
+            error,
+            EventTransitionCommitError::CurrentStateMismatch {
+                expected: EventState::NORMAL,
+                actual: EventState::LOW_LIMIT,
+            }
+        );
+        assert_eq!(state, EventState::LOW_LIMIT);
+        assert_eq!(acked, expected_acked);
+        assert_eq!(history, expected_history);
+    }
+
+    #[test]
+    fn object_trait_default_rejects_event_transition_commit() {
+        struct DefaultOnly {
+            oid: ObjectIdentifier,
+        }
+
+        impl BACnetObject for DefaultOnly {
+            fn object_identifier(&self) -> ObjectIdentifier {
+                self.oid
+            }
+
+            fn object_name(&self) -> &str {
+                "default-only"
+            }
+
+            fn read_property(
+                &self,
+                _property: PropertyIdentifier,
+                _array_index: Option<u32>,
+            ) -> Result<PropertyValue, Error> {
+                Err(Error::Encoding("not used by this test".into()))
+            }
+
+            fn write_property(
+                &mut self,
+                _property: PropertyIdentifier,
+                _array_index: Option<u32>,
+                _value: PropertyValue,
+                _priority: Option<u8>,
+            ) -> Result<(), Error> {
+                Err(Error::Encoding("not used by this test".into()))
+            }
+
+            fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+                Cow::Borrowed(&[])
+            }
+        }
+
+        let mut object = DefaultOnly {
+            oid: ObjectIdentifier::new(ObjectType::ACCUMULATOR, 1).unwrap(),
+        };
+        let commit = EventTransitionCommit {
+            change: EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::FAULT,
+            },
+            coordinate: EventTransition::ToFault,
+            ack_required: false,
+            timestamp: BACnetTimeStamp::SequenceNumber(1),
+            message_text: None,
+        };
+
+        assert_eq!(
+            object.commit_event_transition_internal(commit),
+            Err(EventTransitionCommitError::Unsupported)
+        );
     }
 }

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -12,7 +12,7 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
 use crate::clock::ClockReader;
-use crate::event::TransitionOutcome;
+use crate::event::{EventTransitionCommit, EventTransitionCommitError, TransitionOutcome};
 use crate::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource};
 use crate::file::FileStorage;
 
@@ -272,6 +272,27 @@ pub trait BACnetObject: Send + Sync {
     /// Objects without a delayed transition return `None`.
     fn tick_intrinsic_reporting(&mut self) -> Option<TransitionOutcome> {
         None
+    }
+
+    /// Atomically commit all object-owned state for one event transition.
+    ///
+    /// The caller supplies an exact state change, its transition coordinate,
+    /// the resolved Notification Class `Ack_Required` value, a typed
+    /// timestamp, and an optional message. Implementations must validate the
+    /// coordinate and source state before changing `Event_State`,
+    /// `Acked_Transitions`, `Event_Time_Stamps`, or stored message state, and
+    /// must leave every value unchanged on error.
+    ///
+    /// This internal channel is deliberately separate from network property
+    /// writes and notification distribution. The default fails closed so an
+    /// object family participates only after it can lend all required state to
+    /// the shared commit kernel.
+    #[doc(hidden)]
+    fn commit_event_transition_internal(
+        &mut self,
+        _commit: EventTransitionCommit,
+    ) -> Result<(), EventTransitionCommitError> {
+        Err(EventTransitionCommitError::Unsupported)
     }
 
     /// Evaluate this object's schedule for the given time.


### PR DESCRIPTION
Summary
- add one typed commit input and fail-closed internal object hook
- validate transition coordinate and source state before atomically updating Event_State, Acked_Transitions, one timestamp slot, and optional stored message text
- preserve same-state re-indications and exact BACnetTimeStamp choices

Standard anchors
- ASHRAE 135-2020 §§13.2.2.1.4 and 13.2.3
- Table 13-3 and §21.6

Validation
- focused transition-kernel tests
- workspace formatting, clippy, tests, root check, conformance generation, file-size, secret, and diff gates

Scope
- no producer, object-family, Event Enrollment evaluator, or notification migration
- no conformance, PICS, README, or runtime support-claim change

Refs #123