### PR TITLE
feat(events): commit intrinsic transitions atomically

### DIFF
--- a/crates/bacnet-objects/src/analog/input.rs
+++ b/crates/bacnet-objects/src/analog/input.rs
@@ -258,8 +258,9 @@ impl BACnetObject for AnalogInputObject {
         Some(self.cov_increment)
     }
 
-    crate::impl_intrinsic_reporting!(
+    crate::event::impl_builtin_intrinsic_reporting!(
         event_detector,
+        event_history,
         present_value,
         reliability,
         event_detection_enable
@@ -300,6 +301,126 @@ impl BACnetObject for AnalogInputObject {
 #[cfg(test)]
 mod detection_enable_reset_tests {
     use super::*;
+
+    #[test]
+    fn built_in_intrinsic_transition_is_a_proposal_until_committed() {
+        use crate::event::EventTransitionCommit;
+
+        let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+        ai.event_detector.high_limit = 80.0;
+        ai.event_detector.limit_enable = crate::event::LimitEnable::BOTH;
+        ai.event_detector.event_enable = 0x07;
+        ai.set_present_value(81.0);
+
+        let outcome = ai
+            .evaluate_intrinsic_reporting()
+            .expect("out-of-range value should propose TO_OFFNORMAL");
+        assert_eq!(
+            outcome.change.to,
+            bacnet_types::enums::EventState::HIGH_LIMIT
+        );
+        assert_eq!(
+            ai.event_detector.event_state,
+            bacnet_types::enums::EventState::NORMAL,
+            "built-in evaluation must not confirm its own proposal"
+        );
+        assert_eq!(ai.event_detector.acked_transitions, 0b111);
+        assert!(ai.event_detector.pending.is_none());
+
+        ai.commit_event_transition_internal(EventTransitionCommit {
+            coordinate: outcome.change.transition(),
+            change: outcome.change,
+            ack_required: true,
+            timestamp: BACnetTimeStamp::SequenceNumber(41),
+            message_text: None,
+        })
+        .expect("built-in object should lend all transition state to the kernel");
+
+        assert_eq!(
+            ai.event_detector.event_state,
+            bacnet_types::enums::EventState::HIGH_LIMIT
+        );
+        assert_eq!(ai.event_detector.acked_transitions, 0b110);
+        assert_eq!(
+            ai.event_history.time_stamps[0],
+            BACnetTimeStamp::SequenceNumber(41)
+        );
+    }
+
+    #[test]
+    fn rejected_delayed_and_fault_reindication_proposals_remain_retryable() {
+        use crate::event::{
+            EventStateChange, EventTransition, EventTransitionCommit, EventTransitionCommitError,
+        };
+        use bacnet_types::enums::{EventState, Reliability};
+
+        let mut delayed = AnalogInputObject::new(1, "AI-delayed", 62).unwrap();
+        delayed.event_detector.high_limit = 80.0;
+        delayed.event_detector.limit_enable = crate::event::LimitEnable::BOTH;
+        delayed.event_detector.time_delay = 1;
+        delayed.set_present_value(81.0);
+        assert_eq!(delayed.evaluate_intrinsic_reporting(), None);
+        let proposal = delayed.tick_intrinsic_reporting().unwrap();
+        assert_eq!(
+            delayed.event_detector.pending.as_ref().unwrap().remaining,
+            1
+        );
+
+        let stale = EventTransitionCommit {
+            change: EventStateChange {
+                from: EventState::FAULT,
+                to: proposal.change.to,
+            },
+            coordinate: proposal.change.transition(),
+            ack_required: false,
+            timestamp: BACnetTimeStamp::SequenceNumber(9),
+            message_text: None,
+        };
+        assert_eq!(
+            delayed.commit_event_transition_internal(stale),
+            Err(EventTransitionCommitError::CurrentStateMismatch {
+                expected: EventState::FAULT,
+                actual: EventState::NORMAL,
+            })
+        );
+        assert_eq!(
+            delayed.event_detector.pending.as_ref().unwrap().remaining,
+            1
+        );
+        assert_eq!(delayed.tick_intrinsic_reporting(), Some(proposal));
+
+        let mut faulted = AnalogInputObject::new(2, "AI-fault", 62).unwrap();
+        faulted.reliability = Reliability::OVER_RANGE.to_raw();
+        let entry = faulted.evaluate_intrinsic_reporting().unwrap();
+        crate::event::commit_test_proposal(&mut faulted, entry);
+        faulted.reliability = Reliability::NO_SENSOR.to_raw();
+        let reindication = faulted.evaluate_intrinsic_reporting().unwrap();
+        assert_eq!(
+            reindication.change,
+            EventStateChange {
+                from: EventState::FAULT,
+                to: EventState::FAULT,
+            }
+        );
+        assert_eq!(
+            faulted.commit_event_transition_internal(EventTransitionCommit {
+                change: reindication.change.clone(),
+                coordinate: EventTransition::ToNormal,
+                ack_required: false,
+                timestamp: BACnetTimeStamp::SequenceNumber(10),
+                message_text: None,
+            }),
+            Err(EventTransitionCommitError::CoordinateTargetMismatch {
+                coordinate: EventTransition::ToNormal,
+                target: EventState::FAULT,
+            })
+        );
+        assert_eq!(
+            faulted.event_detector.fault_reliability,
+            Some(Reliability::OVER_RANGE.to_raw())
+        );
+        assert_eq!(faulted.evaluate_intrinsic_reporting(), Some(reindication));
+    }
 
     /// Regression guard for issue #123: once transitions populate timestamps and messages,
     /// disabling event detection must still restore their Clause 13.2.2.1 initial conditions.

--- a/crates/bacnet-objects/src/analog/output.rs
+++ b/crates/bacnet-objects/src/analog/output.rs
@@ -310,8 +310,9 @@ impl BACnetObject for AnalogOutputObject {
         Some(self.cov_increment)
     }
 
-    crate::impl_intrinsic_reporting!(
+    crate::event::impl_builtin_intrinsic_reporting!(
         event_detector,
+        event_history,
         present_value,
         reliability,
         event_detection_enable

--- a/crates/bacnet-objects/src/analog/tests/input.rs
+++ b/crates/bacnet-objects/src/analog/tests/input.rs
@@ -213,7 +213,9 @@ fn ai_intrinsic_reporting_triggers_on_present_value_change() {
 
     // Go above high limit
     ai.set_present_value(81.0);
-    let change = ai.evaluate_intrinsic_reporting().unwrap().change;
+    let proposal = ai.evaluate_intrinsic_reporting().unwrap();
+    let outcome = crate::event::commit_test_proposal(&mut ai, proposal);
+    let change = outcome.change;
     assert_eq!(change.from, EventState::NORMAL);
     assert_eq!(change.to, EventState::HIGH_LIMIT);
 
@@ -694,7 +696,8 @@ fn ai_time_delay_normal_gates_the_return_to_normal() {
     ai.set_present_value(81.0);
     assert_eq!(ai.evaluate_intrinsic_reporting(), None);
     assert_eq!(ai.tick_intrinsic_reporting(), None);
-    let outcome = ai.tick_intrinsic_reporting().unwrap();
+    let proposal = ai.tick_intrinsic_reporting().unwrap();
+    let outcome = crate::event::commit_test_proposal(&mut ai, proposal);
     assert_eq!(
         outcome.change.to,
         EventState::HIGH_LIMIT,

--- a/crates/bacnet-objects/src/analog/tests/value.rs
+++ b/crates/bacnet-objects/src/analog/tests/value.rs
@@ -356,7 +356,9 @@ fn av_intrinsic_reporting_normal_to_high_limit_to_normal() {
 
     // Go above high limit
     av.set_present_value(81.0);
-    let change = av.evaluate_intrinsic_reporting().unwrap().change;
+    let proposal = av.evaluate_intrinsic_reporting().unwrap();
+    let outcome = crate::event::commit_test_proposal(&mut av, proposal);
+    let change = outcome.change;
     assert_eq!(change.from, EventState::NORMAL);
     assert_eq!(change.to, EventState::HIGH_LIMIT);
 

--- a/crates/bacnet-objects/src/analog/value.rs
+++ b/crates/bacnet-objects/src/analog/value.rs
@@ -322,8 +322,9 @@ impl BACnetObject for AnalogValueObject {
         Some(self.cov_increment)
     }
 
-    crate::impl_intrinsic_reporting!(
+    crate::event::impl_builtin_intrinsic_reporting!(
         event_detector,
+        event_history,
         present_value,
         reliability,
         event_detection_enable

--- a/crates/bacnet-objects/src/binary/input.rs
+++ b/crates/bacnet-objects/src/binary/input.rs
@@ -226,8 +226,9 @@ impl BACnetObject for BinaryInputObject {
         true
     }
 
-    crate::impl_intrinsic_reporting!(
+    crate::event::impl_builtin_intrinsic_reporting!(
         event_detector,
+        event_history,
         present_value,
         reliability,
         event_detection_enable

--- a/crates/bacnet-objects/src/binary/output.rs
+++ b/crates/bacnet-objects/src/binary/output.rs
@@ -96,8 +96,9 @@ impl BACnetObject for BinaryOutputObject {
         true
     }
 
-    crate::impl_intrinsic_reporting!(
+    crate::event::impl_builtin_intrinsic_reporting!(
         event_detector,
+        event_history,
         present_value,
         feedback_value,
         reliability,

--- a/crates/bacnet-objects/src/binary/tests/command_failure.rs
+++ b/crates/bacnet-objects/src/binary/tests/command_failure.rs
@@ -185,7 +185,8 @@ fn bo_time_delay_gates_command_failure() {
 
     assert_eq!(bo.evaluate_intrinsic_reporting(), None);
     assert_eq!(bo.tick_intrinsic_reporting(), None);
-    let outcome = bo.tick_intrinsic_reporting().unwrap();
+    let proposal = bo.tick_intrinsic_reporting().unwrap();
+    let outcome = crate::event::commit_test_proposal(&mut bo, proposal);
     assert_eq!(outcome.change.to, EventState::OFFNORMAL);
     assert_eq!(outcome.event_type, EventType::COMMAND_FAILURE);
 }
@@ -217,7 +218,8 @@ fn bo_time_delay_normal_selects_the_return_to_normal_delay() {
 
     assert_eq!(bo.evaluate_intrinsic_reporting(), None);
     assert_eq!(bo.tick_intrinsic_reporting(), None);
-    let outcome = bo.tick_intrinsic_reporting().unwrap();
+    let proposal = bo.tick_intrinsic_reporting().unwrap();
+    let outcome = crate::event::commit_test_proposal(&mut bo, proposal);
     assert_eq!(
         outcome.change.to,
         EventState::OFFNORMAL,

--- a/crates/bacnet-objects/src/binary/value.rs
+++ b/crates/bacnet-objects/src/binary/value.rs
@@ -97,8 +97,9 @@ impl BACnetObject for BinaryValueObject {
         true
     }
 
-    crate::impl_intrinsic_reporting!(
+    crate::event::impl_builtin_intrinsic_reporting!(
         event_detector,
+        event_history,
         present_value,
         reliability,
         event_detection_enable

--- a/crates/bacnet-objects/src/database.rs
+++ b/crates/bacnet-objects/src/database.rs
@@ -33,6 +33,21 @@ pub struct ObjectDatabase {
     enrollment_eval_sources: HashMap<ObjectIdentifier, EventEnrollmentMonitoredSource>,
 }
 
+/// A non-consuming reservation of the database-local event sequence source.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventSequenceReservation {
+    number: u16,
+}
+
+impl EventSequenceReservation {
+    /// The sequence number selected by this reservation.
+    #[doc(hidden)]
+    pub fn number(self) -> u16 {
+        self.number
+    }
+}
+
 impl Default for ObjectDatabase {
     fn default() -> Self {
         Self::new()
@@ -273,9 +288,32 @@ impl ObjectDatabase {
     /// The counter wraps modulo 65536 as required by the timestamp production.
     #[doc(hidden)]
     pub fn next_event_sequence_number(&mut self) -> u16 {
-        let current = self.event_sequence_number;
+        let reservation = self.reserve_event_sequence_number();
+        let number = reservation.number();
+        let confirmed = self.confirm_event_sequence_number(reservation);
+        debug_assert!(
+            confirmed,
+            "a reservation cannot become stale without mutation"
+        );
+        number
+    }
+
+    /// Reserve the current sequence number without consuming it.
+    #[doc(hidden)]
+    pub fn reserve_event_sequence_number(&self) -> EventSequenceReservation {
+        EventSequenceReservation {
+            number: self.event_sequence_number,
+        }
+    }
+
+    /// Consume an exact reservation if it is still current.
+    #[doc(hidden)]
+    pub fn confirm_event_sequence_number(&mut self, reservation: EventSequenceReservation) -> bool {
+        if reservation.number != self.event_sequence_number {
+            return false;
+        }
         self.event_sequence_number = self.event_sequence_number.wrapping_add(1);
-        current
+        true
     }
 
     /// Visit every `(ObjectIdentifier, &mut dyn BACnetObject)` pair.
@@ -309,9 +347,68 @@ mod tests {
     use std::borrow::Cow;
 
     use super::*;
-    use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
+    use crate::analog::{AnalogInputObject, AnalogOutputObject, AnalogValueObject};
+    use crate::binary::{BinaryInputObject, BinaryOutputObject, BinaryValueObject};
+    use crate::event::{EventStateChange, EventTransition, EventTransitionCommit};
+    use crate::multistate::{MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject};
+    use bacnet_types::enums::{ErrorClass, ErrorCode, EventState, ObjectType, PropertyIdentifier};
     use bacnet_types::error::Error;
-    use bacnet_types::primitives::PropertyValue;
+    use bacnet_types::primitives::{BACnetTimeStamp, PropertyValue};
+
+    #[test]
+    fn all_nine_builtin_intrinsic_families_implement_atomic_commit() {
+        let mut objects: Vec<Box<dyn BACnetObject>> = vec![
+            Box::new(AnalogInputObject::new(1, "AI", 0).unwrap()),
+            Box::new(AnalogOutputObject::new(1, "AO", 0).unwrap()),
+            Box::new(AnalogValueObject::new(1, "AV", 0).unwrap()),
+            Box::new(BinaryInputObject::new(1, "BI").unwrap()),
+            Box::new(BinaryOutputObject::new(1, "BO").unwrap()),
+            Box::new(BinaryValueObject::new(1, "BV").unwrap()),
+            Box::new(MultiStateInputObject::new(1, "MSI", 3).unwrap()),
+            Box::new(MultiStateOutputObject::new(1, "MSO", 3).unwrap()),
+            Box::new(MultiStateValueObject::new(1, "MSV", 3).unwrap()),
+        ];
+
+        for object in &mut objects {
+            object
+                .commit_event_transition_internal(EventTransitionCommit {
+                    change: EventStateChange {
+                        from: EventState::NORMAL,
+                        to: EventState::OFFNORMAL,
+                    },
+                    coordinate: EventTransition::ToOffnormal,
+                    ack_required: true,
+                    timestamp: BACnetTimeStamp::SequenceNumber(73),
+                    message_text: None,
+                })
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "{} must implement the shared commit hook: {error:?}",
+                        object.object_name()
+                    )
+                });
+
+            assert_eq!(
+                object
+                    .read_property(PropertyIdentifier::EVENT_STATE, None)
+                    .unwrap(),
+                PropertyValue::Enumerated(EventState::OFFNORMAL.to_raw()),
+                "{} Event_State",
+                object.object_name()
+            );
+            assert_eq!(
+                object
+                    .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+                    .unwrap(),
+                PropertyValue::BitString {
+                    unused_bits: 5,
+                    data: vec![0x60],
+                },
+                "{} Acked_Transitions",
+                object.object_name()
+            );
+        }
+    }
 
     #[test]
     fn event_sequence_wraps_and_is_database_local() {
@@ -326,6 +423,17 @@ mod tests {
         assert_eq!(first.next_event_sequence_number(), u16::MAX);
         assert_eq!(first.next_event_sequence_number(), 0);
         assert_eq!(second.next_event_sequence_number(), 1);
+    }
+
+    #[test]
+    fn event_sequence_reservation_is_non_consuming_until_confirmed() {
+        let mut db = ObjectDatabase::new();
+
+        let reservation = db.reserve_event_sequence_number();
+        assert_eq!(reservation.number(), 0);
+        assert_eq!(db.reserve_event_sequence_number().number(), 0);
+        assert!(db.confirm_event_sequence_number(reservation));
+        assert_eq!(db.reserve_event_sequence_number().number(), 1);
     }
 
     /// Minimal test object.

--- a/crates/bacnet-objects/src/database.rs
+++ b/crates/bacnet-objects/src/database.rs
@@ -370,6 +370,11 @@ mod tests {
         ];
 
         for object in &mut objects {
+            assert!(
+                object.intrinsic_reporting_requires_atomic_commit(),
+                "{} must opt into the atomic server path",
+                object.object_name()
+            );
             object
                 .commit_event_transition_internal(EventTransitionCommit {
                     change: EventStateChange {

--- a/crates/bacnet-objects/src/event.rs
+++ b/crates/bacnet-objects/src/event.rs
@@ -279,10 +279,10 @@ fn delay_toward(time_delay: u32, time_delay_normal: Option<u32>, target: EventSt
 /// the current value alone. That is what `fault_reliability` stores: the value in
 /// force at the last entry to FAULT, and nothing else.
 ///
-/// The distinction matters because `fault_step` runs at the head of both `probe`
-/// and `tick`, and the server drives `tick` once per second. Deciding re-entry
-/// from the standing condition rather than the edge would emit a notification
-/// every second for as long as any object stayed faulted.
+/// The distinction matters because the fault proposal runs at the head of both
+/// detector paths, and the server drives the periodic path once per second.
+/// Deciding re-entry from the standing condition rather than the edge would
+/// emit a notification every second for as long as any object stayed faulted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FaultPrecedence {
     /// Reliability is bad and FAULT does not hold yet: transition immediately.
@@ -445,56 +445,18 @@ impl OutOfRangeDetector {
     /// hands the decision to the algorithm.
     ///
     /// Each detector carries its own copy because each reaches its own
-    /// `event_state`, `pending` and `fire`; the clause interpretation they share
-    /// lives once, in [`fault_precedence`].
-    fn fault_step(&mut self, reliability: u32) -> ControlFlow<Option<TransitionOutcome>> {
+    /// `event_state`, `pending`, and confirmation; the clause interpretation
+    /// they share lives once, in [`fault_precedence`].
+    fn fault_proposal(&self, reliability: u32) -> ControlFlow<Option<TransitionOutcome>> {
         match fault_precedence(reliability, self.fault_reliability, self.event_state) {
-            FaultPrecedence::EnterFault => {
-                // Drop any in-flight countdown. The standard does not say what
-                // becomes of one (Clauses 13.2.2, 13.2.2.1 and 13.3 are all
-                // silent), and this is the project's ruled choice rather than a
-                // quotation: on recovery the machine re-enters NORMAL, so a
-                // countdown seeded before the fault targets a transition out of
-                // a state the machine no longer occupies. The nearest analogous
-                // rule agrees — Clause 13.2.2.1.5 restarts the *full* delay when
-                // Event_Algorithm_Inhibit clears rather than resuming a partial
-                // one — but it is scoped to inhibition, not faults.
-                self.pending = None;
-                self.fault_reliability = Some(reliability);
-                ControlFlow::Break(self.fire(EventState::FAULT))
-            }
-            FaultPrecedence::ReenterFault => {
-                // `pending = None` is unreachable today for the same reason it is
-                // in `RecoverToNormal` below — nothing can be in flight while
-                // FAULT holds — and mutation testing confirms no test fails when
-                // it is removed. It stays as the invariant this arm relies on,
-                // matching the treatment of the identical statement there.
-                self.pending = None;
-                self.fault_reliability = Some(reliability);
-                ControlFlow::Break(self.fire(EventState::FAULT))
+            FaultPrecedence::EnterFault | FaultPrecedence::ReenterFault => {
+                ControlFlow::Break(self.proposal(EventState::FAULT))
             }
             FaultPrecedence::HoldFault => ControlFlow::Break(None),
             FaultPrecedence::RecoverToNormal => {
-                // Unreachable today, and kept deliberately: `EnterFault` above
-                // already cleared `pending`, and `HoldFault` returns before the
-                // algorithm can seed a new one, so nothing can be in flight
-                // while FAULT holds. Mutation testing confirms no test fails
-                // when this line is removed. It stays because it is the
-                // invariant this arm relies on rather than dead weight — were
-                // `HoldFault` ever to let the algorithm run, its absence would
-                // silently resurrect a stale countdown across the fault.
-                self.pending = None;
-                self.fault_reliability = None;
-                ControlFlow::Break(self.fire(EventState::NORMAL))
+                ControlFlow::Break(self.proposal(EventState::NORMAL))
             }
-            FaultPrecedence::RunAlgorithm => {
-                // Also unreachable today and also kept: this arm requires
-                // `!faulted`, and the invariant means the field is already `None`
-                // whenever FAULT does not hold. Removing it leaves the suite
-                // green. It stays as the statement of that invariant.
-                self.fault_reliability = None;
-                ControlFlow::Continue(())
-            }
+            FaultPrecedence::RunAlgorithm => ControlFlow::Continue(()),
         }
     }
 
@@ -507,7 +469,20 @@ impl OutOfRangeDetector {
     /// reverted) and `None` is returned; the periodic [`Self::tick`]
     /// advances and eventually confirms it.
     pub fn probe(&mut self, present_value: f32, reliability: u32) -> Option<TransitionOutcome> {
-        if let ControlFlow::Break(result) = self.fault_step(reliability) {
+        let outcome = self.propose(present_value, reliability);
+        if let Some(ref outcome) = outcome {
+            self.confirm_transition(&outcome.change, reliability);
+        }
+        outcome
+    }
+
+    /// Stage a per-write transition without confirming any transition-owned state.
+    pub(crate) fn propose(
+        &mut self,
+        present_value: f32,
+        reliability: u32,
+    ) -> Option<TransitionOutcome> {
+        if let ControlFlow::Break(result) = self.fault_proposal(reliability) {
             return result;
         }
         let desired = self.compute_new_state(present_value);
@@ -519,7 +494,7 @@ impl OutOfRangeDetector {
         }
         let delay = delay_toward(self.time_delay, self.time_delay_normal, desired);
         if delay == 0 {
-            return self.fire(desired);
+            return self.proposal(desired);
         }
         // Nonzero delay: seed a pending transition only when there is none to
         // the same target. A redundant write of the same qualifying value must
@@ -538,7 +513,20 @@ impl OutOfRangeDetector {
     /// elapses this tick, or `None` if still counting down / no pending
     /// transition / the condition reverted (which cancels the pending).
     pub fn tick(&mut self, present_value: f32, reliability: u32) -> Option<TransitionOutcome> {
-        if let ControlFlow::Break(result) = self.fault_step(reliability) {
+        let outcome = self.tick_proposal(present_value, reliability);
+        if let Some(ref outcome) = outcome {
+            self.confirm_transition(&outcome.change, reliability);
+        }
+        outcome
+    }
+
+    /// Advance a pending countdown, leaving a fire-ready transition retryable.
+    pub(crate) fn tick_proposal(
+        &mut self,
+        present_value: f32,
+        reliability: u32,
+    ) -> Option<TransitionOutcome> {
+        if let ControlFlow::Break(result) = self.fault_proposal(reliability) {
             return result;
         }
         let desired = self.compute_new_state(present_value);
@@ -548,14 +536,11 @@ impl OutOfRangeDetector {
         }
         match &mut self.pending {
             Some(p) if p.state == desired => {
-                if p.remaining > 0 {
+                if p.remaining > 1 {
                     p.remaining -= 1;
+                    return None;
                 }
-                if p.remaining == 0 {
-                    self.pending = None;
-                    return self.fire(desired);
-                }
-                None
+                self.proposal(desired)
             }
             _ => {
                 // Condition changed target mid-delay, or no pending yet: re-seed
@@ -576,12 +561,11 @@ impl OutOfRangeDetector {
     /// — the property disables external distribution downstream, inside the
     /// event-notification-distribution process (Clause 13.2.5, and Clause 12.12
     /// which defines the property in those terms).
-    fn fire(&mut self, new_state: EventState) -> Option<TransitionOutcome> {
+    fn proposal(&self, new_state: EventState) -> Option<TransitionOutcome> {
         let change = EventStateChange {
             from: self.event_state,
             to: new_state,
         };
-        self.event_state = new_state;
         let transition_bit = EventTransition::for_target_state(new_state).bit_mask();
         let distribute = self.event_enable & transition_bit != 0;
         let event_type = change.event_type(Self::ALGORITHM);
@@ -590,6 +574,17 @@ impl OutOfRangeDetector {
             event_type,
             distribute,
         })
+    }
+
+    /// Finalize detector-local state only after the object commit kernel succeeds.
+    pub(crate) fn confirm_transition(&mut self, change: &EventStateChange, reliability: u32) {
+        self.event_state = change.to;
+        self.pending = None;
+        self.fault_reliability = if change.to == EventState::FAULT {
+            Some(reliability)
+        } else {
+            None
+        };
     }
 
     fn compute_new_state(&self, pv: f32) -> EventState {
@@ -694,44 +689,36 @@ impl ChangeOfStateDetector {
         self.probe(present_value, reliability)
     }
 
-    /// Clause 13.2.2 fault precedence; see [`OutOfRangeDetector::fault_step`].
-    fn fault_step(&mut self, reliability: u32) -> ControlFlow<Option<TransitionOutcome>> {
+    /// Clause 13.2.2 fault precedence; see [`OutOfRangeDetector::fault_proposal`].
+    fn fault_proposal(&self, reliability: u32) -> ControlFlow<Option<TransitionOutcome>> {
         match fault_precedence(reliability, self.fault_reliability, self.event_state) {
-            FaultPrecedence::EnterFault => {
-                self.pending = None;
-                self.fault_reliability = Some(reliability);
-                ControlFlow::Break(self.fire(EventState::FAULT))
-            }
-            FaultPrecedence::ReenterFault => {
-                // `pending = None` is unreachable today for the same reason it is
-                // in `RecoverToNormal` below — nothing can be in flight while
-                // FAULT holds — and mutation testing confirms no test fails when
-                // it is removed. It stays as the invariant this arm relies on,
-                // matching the treatment of the identical statement there.
-                self.pending = None;
-                self.fault_reliability = Some(reliability);
-                ControlFlow::Break(self.fire(EventState::FAULT))
+            FaultPrecedence::EnterFault | FaultPrecedence::ReenterFault => {
+                ControlFlow::Break(self.proposal(EventState::FAULT))
             }
             FaultPrecedence::HoldFault => ControlFlow::Break(None),
             FaultPrecedence::RecoverToNormal => {
-                self.pending = None;
-                self.fault_reliability = None;
-                ControlFlow::Break(self.fire(EventState::NORMAL))
+                ControlFlow::Break(self.proposal(EventState::NORMAL))
             }
-            FaultPrecedence::RunAlgorithm => {
-                // Also unreachable today and also kept: this arm requires
-                // `!faulted`, and the invariant means the field is already `None`
-                // whenever FAULT does not hold. Removing it leaves the suite
-                // green. It stays as the statement of that invariant.
-                self.fault_reliability = None;
-                ControlFlow::Continue(())
-            }
+            FaultPrecedence::RunAlgorithm => ControlFlow::Continue(()),
         }
     }
 
     /// Per-write probe: seed or cancel a pending transition, fire on zero delay.
     pub fn probe(&mut self, present_value: u32, reliability: u32) -> Option<TransitionOutcome> {
-        if let ControlFlow::Break(result) = self.fault_step(reliability) {
+        let outcome = self.propose(present_value, reliability);
+        if let Some(ref outcome) = outcome {
+            self.confirm_transition(&outcome.change, reliability);
+        }
+        outcome
+    }
+
+    /// Stage a per-write transition without confirming any transition-owned state.
+    pub(crate) fn propose(
+        &mut self,
+        present_value: u32,
+        reliability: u32,
+    ) -> Option<TransitionOutcome> {
+        if let ControlFlow::Break(result) = self.fault_proposal(reliability) {
             return result;
         }
         let desired = self.compute_new_state(present_value);
@@ -741,7 +728,7 @@ impl ChangeOfStateDetector {
         }
         let delay = delay_toward(self.time_delay, self.time_delay_normal, desired);
         if delay == 0 {
-            return self.fire(desired);
+            return self.proposal(desired);
         }
         // See [`OutOfRangeDetector::probe`]: do not restart an in-flight
         // countdown to the same target on a redundant qualifying write.
@@ -753,7 +740,20 @@ impl ChangeOfStateDetector {
 
     /// Periodic tick: advance the countdown and fire on expiry.
     pub fn tick(&mut self, present_value: u32, reliability: u32) -> Option<TransitionOutcome> {
-        if let ControlFlow::Break(result) = self.fault_step(reliability) {
+        let outcome = self.tick_proposal(present_value, reliability);
+        if let Some(ref outcome) = outcome {
+            self.confirm_transition(&outcome.change, reliability);
+        }
+        outcome
+    }
+
+    /// Advance a pending countdown, leaving a fire-ready transition retryable.
+    pub(crate) fn tick_proposal(
+        &mut self,
+        present_value: u32,
+        reliability: u32,
+    ) -> Option<TransitionOutcome> {
+        if let ControlFlow::Break(result) = self.fault_proposal(reliability) {
             return result;
         }
         let desired = self.compute_new_state(present_value);
@@ -763,14 +763,11 @@ impl ChangeOfStateDetector {
         }
         match &mut self.pending {
             Some(p) if p.state == desired => {
-                if p.remaining > 0 {
+                if p.remaining > 1 {
                     p.remaining -= 1;
+                    return None;
                 }
-                if p.remaining == 0 {
-                    self.pending = None;
-                    return self.fire(desired);
-                }
-                None
+                self.proposal(desired)
             }
             _ => {
                 // Re-seed with the delay for the CURRENT target's direction.
@@ -784,12 +781,11 @@ impl ChangeOfStateDetector {
     /// Confirm a transition to `new_state`, reporting whether `Event_Enable`
     /// permits distributing it. The transition itself is always reported; see
     /// [`TransitionOutcome`].
-    fn fire(&mut self, new_state: EventState) -> Option<TransitionOutcome> {
+    fn proposal(&self, new_state: EventState) -> Option<TransitionOutcome> {
         let change = EventStateChange {
             from: self.event_state,
             to: new_state,
         };
-        self.event_state = new_state;
         let transition_bit = EventTransition::for_target_state(new_state).bit_mask();
         let distribute = self.event_enable & transition_bit != 0;
         let event_type = change.event_type(Self::ALGORITHM);
@@ -798,6 +794,17 @@ impl ChangeOfStateDetector {
             event_type,
             distribute,
         })
+    }
+
+    /// Finalize detector-local state only after the object commit kernel succeeds.
+    pub(crate) fn confirm_transition(&mut self, change: &EventStateChange, reliability: u32) {
+        self.event_state = change.to;
+        self.pending = None;
+        self.fault_reliability = if change.to == EventState::FAULT {
+            Some(reliability)
+        } else {
+            None
+        };
     }
 
     fn compute_new_state(&self, present_value: u32) -> EventState {
@@ -866,38 +873,17 @@ impl CommandFailureDetector {
         self.probe(present_value, feedback_value, reliability)
     }
 
-    /// Clause 13.2.2 fault precedence; see [`OutOfRangeDetector::fault_step`].
-    fn fault_step(&mut self, reliability: u32) -> ControlFlow<Option<TransitionOutcome>> {
+    /// Clause 13.2.2 fault precedence; see [`OutOfRangeDetector::fault_proposal`].
+    fn fault_proposal(&self, reliability: u32) -> ControlFlow<Option<TransitionOutcome>> {
         match fault_precedence(reliability, self.fault_reliability, self.event_state) {
-            FaultPrecedence::EnterFault => {
-                self.pending = None;
-                self.fault_reliability = Some(reliability);
-                ControlFlow::Break(self.fire(EventState::FAULT))
-            }
-            FaultPrecedence::ReenterFault => {
-                // `pending = None` is unreachable today for the same reason it is
-                // in `RecoverToNormal` below — nothing can be in flight while
-                // FAULT holds — and mutation testing confirms no test fails when
-                // it is removed. It stays as the invariant this arm relies on,
-                // matching the treatment of the identical statement there.
-                self.pending = None;
-                self.fault_reliability = Some(reliability);
-                ControlFlow::Break(self.fire(EventState::FAULT))
+            FaultPrecedence::EnterFault | FaultPrecedence::ReenterFault => {
+                ControlFlow::Break(self.proposal(EventState::FAULT))
             }
             FaultPrecedence::HoldFault => ControlFlow::Break(None),
             FaultPrecedence::RecoverToNormal => {
-                self.pending = None;
-                self.fault_reliability = None;
-                ControlFlow::Break(self.fire(EventState::NORMAL))
+                ControlFlow::Break(self.proposal(EventState::NORMAL))
             }
-            FaultPrecedence::RunAlgorithm => {
-                // Also unreachable today and also kept: this arm requires
-                // `!faulted`, and the invariant means the field is already `None`
-                // whenever FAULT does not hold. Removing it leaves the suite
-                // green. It stays as the statement of that invariant.
-                self.fault_reliability = None;
-                ControlFlow::Continue(())
-            }
+            FaultPrecedence::RunAlgorithm => ControlFlow::Continue(()),
         }
     }
 
@@ -908,7 +894,21 @@ impl CommandFailureDetector {
         feedback_value: u32,
         reliability: u32,
     ) -> Option<TransitionOutcome> {
-        if let ControlFlow::Break(result) = self.fault_step(reliability) {
+        let outcome = self.propose(present_value, feedback_value, reliability);
+        if let Some(ref outcome) = outcome {
+            self.confirm_transition(&outcome.change, reliability);
+        }
+        outcome
+    }
+
+    /// Stage a per-write transition without confirming any transition-owned state.
+    pub(crate) fn propose(
+        &mut self,
+        present_value: u32,
+        feedback_value: u32,
+        reliability: u32,
+    ) -> Option<TransitionOutcome> {
+        if let ControlFlow::Break(result) = self.fault_proposal(reliability) {
             return result;
         }
         let desired = self.compute_new_state(present_value, feedback_value);
@@ -918,7 +918,7 @@ impl CommandFailureDetector {
         }
         let delay = delay_toward(self.time_delay, self.time_delay_normal, desired);
         if delay == 0 {
-            return self.fire(desired);
+            return self.proposal(desired);
         }
         // See [`OutOfRangeDetector::probe`]: do not restart an in-flight
         // countdown to the same target on a redundant qualifying write.
@@ -935,7 +935,21 @@ impl CommandFailureDetector {
         feedback_value: u32,
         reliability: u32,
     ) -> Option<TransitionOutcome> {
-        if let ControlFlow::Break(result) = self.fault_step(reliability) {
+        let outcome = self.tick_proposal(present_value, feedback_value, reliability);
+        if let Some(ref outcome) = outcome {
+            self.confirm_transition(&outcome.change, reliability);
+        }
+        outcome
+    }
+
+    /// Advance a pending countdown, leaving a fire-ready transition retryable.
+    pub(crate) fn tick_proposal(
+        &mut self,
+        present_value: u32,
+        feedback_value: u32,
+        reliability: u32,
+    ) -> Option<TransitionOutcome> {
+        if let ControlFlow::Break(result) = self.fault_proposal(reliability) {
             return result;
         }
         let desired = self.compute_new_state(present_value, feedback_value);
@@ -945,14 +959,11 @@ impl CommandFailureDetector {
         }
         match &mut self.pending {
             Some(p) if p.state == desired => {
-                if p.remaining > 0 {
+                if p.remaining > 1 {
                     p.remaining -= 1;
+                    return None;
                 }
-                if p.remaining == 0 {
-                    self.pending = None;
-                    return self.fire(desired);
-                }
-                None
+                self.proposal(desired)
             }
             _ => {
                 // Re-seed with the delay for the CURRENT target's direction.
@@ -966,12 +977,11 @@ impl CommandFailureDetector {
     /// Confirm a transition to `new_state`, reporting whether `Event_Enable`
     /// permits distributing it. The transition itself is always reported; see
     /// [`TransitionOutcome`].
-    fn fire(&mut self, new_state: EventState) -> Option<TransitionOutcome> {
+    fn proposal(&self, new_state: EventState) -> Option<TransitionOutcome> {
         let change = EventStateChange {
             from: self.event_state,
             to: new_state,
         };
-        self.event_state = new_state;
         // The FAULT arm reads `Event_Enable` like the other two. It previously
         // hardcoded `false`, which was unobservable only because no reliability
         // ever reached a detector (#200); Clause 13.2.5 scopes `Event_Enable` to
@@ -987,6 +997,17 @@ impl CommandFailureDetector {
         })
     }
 
+    /// Finalize detector-local state only after the object commit kernel succeeds.
+    pub(crate) fn confirm_transition(&mut self, change: &EventStateChange, reliability: u32) {
+        self.event_state = change.to;
+        self.pending = None;
+        self.fault_reliability = if change.to == EventState::FAULT {
+            Some(reliability)
+        } else {
+            None
+        };
+    }
+
     fn compute_new_state(&self, present_value: u32, feedback_value: u32) -> EventState {
         if present_value != feedback_value {
             EventState::OFFNORMAL
@@ -996,24 +1017,14 @@ impl CommandFailureDetector {
     }
 }
 
-/// Implement the `BACnetObject` intrinsic-reporting trait methods for an
-/// object whose detector is exposed as a field, with object fields supplying
-/// the detector inputs.
+#[cfg(test)]
+pub(crate) use history::commit_test_proposal;
+pub(crate) use history::impl_builtin_intrinsic_reporting;
+
+/// Implement legacy immediate intrinsic-reporting detector delegation.
 ///
-/// This wires both the per-write [`evaluate_intrinsic_reporting`](crate::traits::BACnetObject::evaluate_intrinsic_reporting)
-/// probe and the periodic [`tick_intrinsic_reporting`](crate::traits::BACnetObject::tick_intrinsic_reporting)
-/// tick to the detector's split `probe` / `tick` entry points, honoring
-/// `Time_Delay` without the object types repeating the delegation.
-///
-/// Reliability is passed on every call rather than only when it changes: per
-/// ASHRAE 135-2020 Clause 13.2.2 the FAULT determination is a standing
-/// condition, so the detector re-derives it each evaluation. That also means a
-/// Reliability written by any route — the server's fault detector, a local
-/// write, or a network write — reaches event-state-detection without each route
-/// needing to notify it.
-///
-/// The gated arms enforce ASHRAE 135-2020 Clause 13.2.2.1: "If the
-/// Event_Detection_Enable property is FALSE, then this state machine is not evaluated."
+/// This exported macro preserves the downstream behavior in which detector
+/// `probe` and `tick` calls immediately update detector-local state.
 #[macro_export]
 macro_rules! impl_intrinsic_reporting {
     (

--- a/crates/bacnet-objects/src/event/fault_tests.rs
+++ b/crates/bacnet-objects/src/event/fault_tests.rs
@@ -774,9 +774,10 @@ fn ticking_an_object_uses_reliability_for_fault_and_recovery() {
         None,
     )
     .expect("reliability is writable");
-    let fault = ai
+    let proposal = ai
         .tick_intrinsic_reporting()
         .expect("periodic tick must observe bad reliability");
+    let fault = commit_test_proposal(&mut ai, proposal);
     assert_eq!(fault.change.to, EventState::FAULT);
 
     ai.write_property(
@@ -810,7 +811,10 @@ fn faulted_object_reports_both_fault_and_in_alarm_status_flags() {
     let mut ai = AnalogInputObject::new(2, "ai-2", 62).expect("construct");
     ai.set_reliability_internal(OVER_RANGE)
         .expect("in-service reliability evaluation is supported");
-    ai.evaluate_intrinsic_reporting();
+    let proposal = ai
+        .evaluate_intrinsic_reporting()
+        .expect("bad reliability must propose FAULT");
+    commit_test_proposal(&mut ai, proposal);
 
     let flags = ai
         .read_property(PropertyIdentifier::STATUS_FLAGS, None)

--- a/crates/bacnet-objects/src/event/history.rs
+++ b/crates/bacnet-objects/src/event/history.rs
@@ -94,6 +94,10 @@ macro_rules! impl_builtin_intrinsic_reporting {
         $reliability_field:ident,
         $event_detection_enable_field:ident
     ) => {
+        fn intrinsic_reporting_requires_atomic_commit(&self) -> bool {
+            true
+        }
+
         fn evaluate_intrinsic_reporting(&mut self) -> Option<$crate::event::TransitionOutcome> {
             if !self.$event_detection_enable_field {
                 return None;
@@ -139,6 +143,10 @@ macro_rules! impl_builtin_intrinsic_reporting {
         $reliability_field:ident,
         $event_detection_enable_field:ident
     ) => {
+        fn intrinsic_reporting_requires_atomic_commit(&self) -> bool {
+            true
+        }
+
         fn evaluate_intrinsic_reporting(&mut self) -> Option<$crate::event::TransitionOutcome> {
             if !self.$event_detection_enable_field {
                 return None;

--- a/crates/bacnet-objects/src/event/history.rs
+++ b/crates/bacnet-objects/src/event/history.rs
@@ -21,14 +21,12 @@ pub(crate) struct EventHistory {
 /// This aggregate is staged for object-family adoption: it keeps the generic
 /// commit policy centralized while each object remains responsible for
 /// lending its own three property stores through its trait hook.
-#[allow(dead_code)]
 pub(crate) struct EventTransitionState<'a> {
     event_state: &'a mut EventState,
     acked_transitions: &'a mut u8,
     history: &'a mut EventHistory,
 }
 
-#[allow(dead_code)]
 impl<'a> EventTransitionState<'a> {
     pub(crate) fn new(
         event_state: &'a mut EventState,
@@ -79,6 +77,127 @@ impl<'a> EventTransitionState<'a> {
 
         Ok(())
     }
+}
+
+/// Implement proposal-and-commit intrinsic reporting for built-in object families.
+///
+/// The evaluation hooks only propose transitions. The commit hook lends the
+/// detector and object history to the shared kernel and finalizes private
+/// detector state only after that kernel succeeds. The gated arms enforce
+/// Clause 13.2.2.1's Event_Detection_Enable state-machine gate.
+macro_rules! impl_builtin_intrinsic_reporting {
+    (
+        $detector_field:ident,
+        $history_field:ident,
+        $present_value_field:ident,
+        $feedback_value_field:ident,
+        $reliability_field:ident,
+        $event_detection_enable_field:ident
+    ) => {
+        fn evaluate_intrinsic_reporting(&mut self) -> Option<$crate::event::TransitionOutcome> {
+            if !self.$event_detection_enable_field {
+                return None;
+            }
+            self.$detector_field.propose(
+                self.$present_value_field,
+                self.$feedback_value_field,
+                self.$reliability_field,
+            )
+        }
+
+        fn tick_intrinsic_reporting(&mut self) -> Option<$crate::event::TransitionOutcome> {
+            if !self.$event_detection_enable_field {
+                return None;
+            }
+            self.$detector_field.tick_proposal(
+                self.$present_value_field,
+                self.$feedback_value_field,
+                self.$reliability_field,
+            )
+        }
+
+        fn commit_event_transition_internal(
+            &mut self,
+            commit: $crate::event::EventTransitionCommit,
+        ) -> Result<(), $crate::event::EventTransitionCommitError> {
+            let change = commit.change.clone();
+            $crate::event::history::EventTransitionState::new(
+                &mut self.$detector_field.event_state,
+                &mut self.$detector_field.acked_transitions,
+                &mut self.$history_field,
+            )
+            .commit(commit)?;
+            self.$detector_field
+                .confirm_transition(&change, self.$reliability_field);
+            Ok(())
+        }
+    };
+    (
+        $detector_field:ident,
+        $history_field:ident,
+        $present_value_field:ident,
+        $reliability_field:ident,
+        $event_detection_enable_field:ident
+    ) => {
+        fn evaluate_intrinsic_reporting(&mut self) -> Option<$crate::event::TransitionOutcome> {
+            if !self.$event_detection_enable_field {
+                return None;
+            }
+            self.$detector_field
+                .propose(self.$present_value_field, self.$reliability_field)
+        }
+
+        fn tick_intrinsic_reporting(&mut self) -> Option<$crate::event::TransitionOutcome> {
+            if !self.$event_detection_enable_field {
+                return None;
+            }
+            self.$detector_field
+                .tick_proposal(self.$present_value_field, self.$reliability_field)
+        }
+
+        fn commit_event_transition_internal(
+            &mut self,
+            commit: $crate::event::EventTransitionCommit,
+        ) -> Result<(), $crate::event::EventTransitionCommitError> {
+            let change = commit.change.clone();
+            $crate::event::history::EventTransitionState::new(
+                &mut self.$detector_field.event_state,
+                &mut self.$detector_field.acked_transitions,
+                &mut self.$history_field,
+            )
+            .commit(commit)?;
+            self.$detector_field
+                .confirm_transition(&change, self.$reliability_field);
+            Ok(())
+        }
+    };
+}
+
+pub(crate) use impl_builtin_intrinsic_reporting;
+
+/// Commit a built-in proposal with fixed, explicit test policy.
+///
+/// Object-level tests that need a later state transition use no-acknowledgment
+/// policy and sequence timestamp zero. Production resolves both values from
+/// the Notification Class and database-local timestamp source instead.
+#[cfg(test)]
+pub(crate) fn commit_test_proposal<O>(
+    object: &mut O,
+    outcome: super::TransitionOutcome,
+) -> super::TransitionOutcome
+where
+    O: crate::traits::BACnetObject + ?Sized,
+{
+    object
+        .commit_event_transition_internal(EventTransitionCommit {
+            coordinate: outcome.change.transition(),
+            change: outcome.change.clone(),
+            ack_required: false,
+            timestamp: BACnetTimeStamp::SequenceNumber(0),
+            message_text: None,
+        })
+        .expect("built-in test proposal must commit");
+    outcome
 }
 
 impl Default for EventHistory {

--- a/crates/bacnet-objects/src/multistate/input.rs
+++ b/crates/bacnet-objects/src/multistate/input.rs
@@ -84,8 +84,9 @@ impl BACnetObject for MultiStateInputObject {
         true
     }
 
-    crate::impl_intrinsic_reporting!(
+    crate::event::impl_builtin_intrinsic_reporting!(
         event_detector,
+        event_history,
         present_value,
         reliability,
         event_detection_enable

--- a/crates/bacnet-objects/src/multistate/output.rs
+++ b/crates/bacnet-objects/src/multistate/output.rs
@@ -110,8 +110,9 @@ impl BACnetObject for MultiStateOutputObject {
         true
     }
 
-    crate::impl_intrinsic_reporting!(
+    crate::event::impl_builtin_intrinsic_reporting!(
         event_detector,
+        event_history,
         present_value,
         feedback_value,
         reliability,
@@ -510,7 +511,8 @@ mod command_failure_tests {
         set_detection_enabled(&mut mso, true);
         write_unsigned(&mut mso, PropertyIdentifier::PRESENT_VALUE, 2);
 
-        let outcome = mso.evaluate_intrinsic_reporting().unwrap();
+        let proposal = mso.evaluate_intrinsic_reporting().unwrap();
+        let outcome = crate::event::commit_test_proposal(&mut mso, proposal);
         assert_eq!(outcome.change.to, EventState::OFFNORMAL);
         assert_eq!(outcome.event_type, EventType::COMMAND_FAILURE);
 

--- a/crates/bacnet-objects/src/multistate/tests/generic_event_properties.rs
+++ b/crates/bacnet-objects/src/multistate/tests/generic_event_properties.rs
@@ -86,9 +86,10 @@ fn msi_event_enable_bit_selects_whether_the_return_to_normal_distributes() {
         write_event_enable(&mut msi, bits);
 
         msi.set_present_value(2);
-        let entry = msi
+        let proposal = msi
             .evaluate_intrinsic_reporting()
             .expect("an alarm value must report the entry into OFFNORMAL");
+        let entry = crate::event::commit_test_proposal(&mut msi, proposal);
         assert_eq!(entry.change.to, EventState::OFFNORMAL);
 
         msi.set_present_value(1);
@@ -610,10 +611,9 @@ fn recommissioning_alarm_values_while_offnormal_returns_to_normal() {
     let mut msi = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
     msi.set_alarm_values(vec![2]);
     msi.set_present_value(2);
-    assert_eq!(
-        msi.evaluate_intrinsic_reporting().unwrap().change.to,
-        EventState::OFFNORMAL
-    );
+    let proposal = msi.evaluate_intrinsic_reporting().unwrap();
+    let entry = crate::event::commit_test_proposal(&mut msi, proposal);
+    assert_eq!(entry.change.to, EventState::OFFNORMAL);
     msi.write_property(
         PropertyIdentifier::ALARM_VALUES,
         None,

--- a/crates/bacnet-objects/src/multistate/value.rs
+++ b/crates/bacnet-objects/src/multistate/value.rs
@@ -109,8 +109,9 @@ impl BACnetObject for MultiStateValueObject {
         true
     }
 
-    crate::impl_intrinsic_reporting!(
+    crate::event::impl_builtin_intrinsic_reporting!(
         event_detector,
+        event_history,
         present_value,
         reliability,
         event_detection_enable

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -250,11 +250,15 @@ pub trait BACnetObject: Send + Sync {
     /// countdown advances once per elapsed second via
     /// [`tick_intrinsic_reporting`](Self::tick_intrinsic_reporting)).
     ///
-    /// Returns `Some(TransitionOutcome)` whenever a transition fired, or
+    /// Returns `Some(TransitionOutcome)` whenever a transition is ready to be
+    /// committed, or
     /// `None` when none did (no change, delay seeded, or the object does not
     /// support intrinsic reporting). A cleared `Event_Enable` bit sets the
     /// outcome's `distribute` flag to false rather than withholding the
-    /// transition — Clause 13.2.2.1.4's transition actions run either way, and
+    /// transition. Built-in object families leave `Event_State`,
+    /// `Acked_Transitions`, event history, and fire-ready detector state
+    /// unchanged until [`commit_event_transition_internal`](Self::commit_event_transition_internal)
+    /// succeeds. Clause 13.2.2.1.4's transition actions run either way, and
     /// `Event_Enable` disables only external distribution, downstream in the
     /// notification-distribution process (Clause 13.2.5).
     fn evaluate_intrinsic_reporting(&mut self) -> Option<TransitionOutcome> {
@@ -266,7 +270,8 @@ pub trait BACnetObject: Send + Sync {
     /// Called by the server's one-second intrinsic-reporting task. Fires the
     /// pending transition when its delay elapses this tick, cancels it if the
     /// triggering condition reverted, and returns `Some(TransitionOutcome)`
-    /// when a transition fires. As with
+    /// when a transition is ready. A fire-ready built-in proposal remains
+    /// retryable until the commit hook succeeds. As with
     /// [`evaluate_intrinsic_reporting`](Self::evaluate_intrinsic_reporting),
     /// `Event_Enable` is reported via `distribute`, not by returning `None`.
     /// Objects without a delayed transition return `None`.
@@ -281,7 +286,9 @@ pub trait BACnetObject: Send + Sync {
     /// timestamp, and an optional message. Implementations must validate the
     /// coordinate and source state before changing `Event_State`,
     /// `Acked_Transitions`, `Event_Time_Stamps`, or stored message state, and
-    /// must leave every value unchanged on error.
+    /// must leave every value unchanged on error. A successful built-in
+    /// implementation also finalizes the detector's pending and fault-edge
+    /// state; a failed commit leaves that state retryable.
     ///
     /// This internal channel is deliberately separate from network property
     /// writes and notification distribution. The default fails closed so an

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -279,6 +279,20 @@ pub trait BACnetObject: Send + Sync {
         None
     }
 
+    /// Whether intrinsic-reporting outcomes require the atomic commit hook.
+    ///
+    /// The default preserves the legacy contract used by downstream objects
+    /// and [`crate::impl_intrinsic_reporting!`]: evaluation mutates detector
+    /// state immediately, so the server must distribute its outcome without
+    /// attempting another commit. Built-in proposal-based objects override
+    /// this to return `true`; their outcomes are uncommitted and must be
+    /// rejected unless [`commit_event_transition_internal`](Self::commit_event_transition_internal)
+    /// succeeds.
+    #[doc(hidden)]
+    fn intrinsic_reporting_requires_atomic_commit(&self) -> bool {
+        false
+    }
+
     /// Atomically commit all object-owned state for one event transition.
     ///
     /// The caller supplies an exact state change, its transition coordinate,

--- a/crates/bacnet-server/src/fault_detection.rs
+++ b/crates/bacnet-server/src/fault_detection.rs
@@ -224,6 +224,22 @@ mod tests {
     use bacnet_types::enums::{ErrorClass, ErrorCode, EventState};
     use bacnet_types::error::Error;
 
+    fn commit_test_proposal(
+        object: &mut dyn bacnet_objects::traits::BACnetObject,
+        outcome: bacnet_objects::event::TransitionOutcome,
+    ) -> bacnet_objects::event::TransitionOutcome {
+        object
+            .commit_event_transition_internal(bacnet_objects::event::EventTransitionCommit {
+                coordinate: outcome.change.transition(),
+                change: outcome.change.clone(),
+                ack_required: false,
+                timestamp: bacnet_types::primitives::BACnetTimeStamp::SequenceNumber(0),
+                message_text: None,
+            })
+            .expect("built-in test proposal must commit");
+        outcome
+    }
+
     /// Helper: build an ObjectDatabase with a single AI that has min/max limits.
     fn db_with_analog_input(
         present_value: f32,
@@ -299,9 +315,10 @@ mod tests {
         assert_eq!(changes[0].new_reliability, Reliability::OVER_RANGE.to_raw());
 
         let obj = db.get_mut(&oid).unwrap();
-        let real_fault = obj
+        let proposal = obj
             .evaluate_intrinsic_reporting()
             .expect("derived Reliability must enter FAULT");
+        let real_fault = commit_test_proposal(obj.as_mut(), proposal);
         assert_eq!(real_fault.change.to, EventState::FAULT);
 
         obj.write_property(
@@ -318,9 +335,10 @@ mod tests {
             None,
         )
         .unwrap();
-        let simulated_fault = obj
+        let proposal = obj
             .evaluate_intrinsic_reporting()
             .expect("different simulated fault must re-enter FAULT");
+        let simulated_fault = commit_test_proposal(obj.as_mut(), proposal);
         assert_eq!(simulated_fault.change.to, EventState::FAULT);
 
         obj.write_property(
@@ -341,9 +359,10 @@ mod tests {
             PropertyValue::Enumerated(EventState::FAULT.to_raw())
         );
 
-        let restored_fault = obj
+        let proposal = obj
             .evaluate_intrinsic_reporting()
             .expect("restored real fault must re-enter FAULT");
+        let restored_fault = commit_test_proposal(obj.as_mut(), proposal);
         assert_eq!(restored_fault.change.to, EventState::FAULT);
         assert_eq!(
             obj.read_property(PropertyIdentifier::EVENT_STATE, None)

--- a/crates/bacnet-server/src/handlers/tests/device_event.rs
+++ b/crates/bacnet-server/src/handlers/tests/device_event.rs
@@ -97,6 +97,21 @@ fn timestamp_value(timestamp: &BACnetTimeStamp) -> PropertyValue {
     PropertyValue::ApplicationData(encoded.to_vec())
 }
 
+fn commit_test_proposal(
+    object: &mut dyn BACnetObject,
+    outcome: bacnet_objects::event::TransitionOutcome,
+) {
+    object
+        .commit_event_transition_internal(bacnet_objects::event::EventTransitionCommit {
+            coordinate: outcome.change.transition(),
+            change: outcome.change,
+            ack_required: false,
+            timestamp: BACnetTimeStamp::SequenceNumber(0),
+            message_text: None,
+        })
+        .expect("built-in test proposal must commit");
+}
+
 fn get_event_information_ack(
     db: &ObjectDatabase,
     cursor: Option<ObjectIdentifier>,
@@ -239,7 +254,10 @@ fn get_event_information_reports_non_normal_objects() {
     .unwrap();
     // Push value above high limit and evaluate
     ai.set_present_value(85.0);
-    ai.evaluate_intrinsic_reporting(); // → HIGH_LIMIT
+    let proposal = ai
+        .evaluate_intrinsic_reporting()
+        .expect("out-of-range value must propose HIGH_LIMIT");
+    commit_test_proposal(&mut ai, proposal);
     db.add(Box::new(ai)).unwrap();
 
     let request = bacnet_services::alarm_event::GetEventInformationRequest {
@@ -321,7 +339,10 @@ fn get_event_information_reads_event_enable_notify_type_and_priorities() {
     .unwrap();
     // Push above high limit and evaluate to trigger alarm
     ai.set_present_value(85.0);
-    ai.evaluate_intrinsic_reporting();
+    let proposal = ai
+        .evaluate_intrinsic_reporting()
+        .expect("out-of-range value must propose HIGH_LIMIT");
+    commit_test_proposal(&mut ai, proposal);
     db.add(Box::new(ai)).unwrap();
 
     // Add NotificationClass object with custom priorities

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -1,5 +1,9 @@
-use super::event_timestamp::{sample_event_timestamp, SampledEventClock};
+use super::event_timestamp::{
+    confirm_event_timestamp, sample_event_timestamp, stage_event_timestamp, EventTimestampSample,
+    SampledEventClock,
+};
 use super::*;
+use bacnet_objects::event::{EventTransitionCommit, TransitionOutcome};
 use bacnet_objects::notification_class::local_day_and_time;
 use bacnet_types::constructed::BACnetRecipient;
 use bacnet_types::enums::EventType;
@@ -8,11 +12,34 @@ use bacnet_types::primitives::Time;
 pub(super) struct NotificationTransition {
     change: EventStateChange,
     event_type: EventType,
+    timestamp_sample: Option<EventTimestampSample>,
 }
 
 impl From<(EventStateChange, EventType)> for NotificationTransition {
     fn from((change, event_type): (EventStateChange, EventType)) -> Self {
-        Self { change, event_type }
+        Self {
+            change,
+            event_type,
+            timestamp_sample: None,
+        }
+    }
+}
+
+/// One built-in intrinsic transition committed under the database write guard.
+pub(super) struct CommittedIntrinsicTransition {
+    pub(super) change: EventStateChange,
+    pub(super) event_type: EventType,
+    pub(super) distribute: bool,
+    timestamp_sample: EventTimestampSample,
+}
+
+impl From<CommittedIntrinsicTransition> for NotificationTransition {
+    fn from(committed: CommittedIntrinsicTransition) -> Self {
+        Self {
+            change: committed.change,
+            event_type: committed.event_type,
+            timestamp_sample: Some(committed.timestamp_sample),
+        }
     }
 }
 
@@ -159,6 +186,46 @@ impl RecipientRoute {
 }
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
+    /// Resolve policy and atomically commit one intrinsic proposal.
+    pub(super) fn commit_intrinsic_transition(
+        db: &mut ObjectDatabase,
+        oid: &ObjectIdentifier,
+        outcome: TransitionOutcome,
+    ) -> Option<CommittedIntrinsicTransition> {
+        let coordinate = outcome.change.transition();
+        let notification_class = db
+            .get(oid)?
+            .read_property(PropertyIdentifier::NOTIFICATION_CLASS, None)
+            .ok()
+            .and_then(|value| match value {
+                PropertyValue::Unsigned(number) => Some(number as u32),
+                _ => None,
+            })
+            .unwrap_or(0);
+        let (_, ack_required) = resolve_transition_priority_ack(db, notification_class, coordinate);
+        let staged_timestamp = stage_event_timestamp(db);
+        let commit = EventTransitionCommit {
+            change: outcome.change.clone(),
+            coordinate,
+            ack_required,
+            timestamp: staged_timestamp.sample.timestamp.clone(),
+            message_text: None,
+        };
+
+        if let Err(error) = db.get_mut(oid)?.commit_event_transition_internal(commit) {
+            debug!(%oid, ?error, "Intrinsic transition commit rejected");
+            return None;
+        }
+
+        let timestamp_sample = confirm_event_timestamp(db, staged_timestamp);
+        Some(CommittedIntrinsicTransition {
+            change: outcome.change,
+            event_type: outcome.event_type,
+            distribute: outcome.distribute,
+            timestamp_sample,
+        })
+    }
+
     /// Evaluate intrinsic reporting on an object and send event notifications
     /// to the recipients the object's NotificationClass names.
     /// DCC gates network-message initiation (Clause 16.1), not the local
@@ -179,30 +246,27 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         oid: &ObjectIdentifier,
         retry_timeout_ms: u64,
     ) {
-        let outcome = {
+        let committed = {
             let mut db = db.write().await;
-            match db.get_mut(oid) {
+            let outcome = match db.get_mut(oid) {
                 Some(object) => object.evaluate_intrinsic_reporting(),
                 None => return,
-            }
+            };
+            outcome.and_then(|outcome| Self::commit_intrinsic_transition(&mut db, oid, outcome))
         };
 
-        // The transition is already stored in Event_State by the detector,
+        // A successful commit has already applied the local transition actions,
         // whatever Event_Enable says. Only external distribution is gated here:
         // Clause 12.12 defines Event_Enable as enabling and disabling the
         // distribution of notifications, and Clause 13.2.5 places that gate
         // inside the notification-distribution process — downstream of the
         // transition actions, none of which it governs.
         //
-        // Three of Clause 13.2.2.1.4's transition actions are still missing and
-        // hook this same point, ahead of the `distribute` check: the
-        // Event_Time_Stamps write, the Event_Message_Texts write (only "if
-        // present"), and the indication to the alarm-acknowledgment process.
-        // The first two are independent actions, not consequences of the third;
-        // the third is what maintains Acked_Transitions, and Clause 13.2.3 gates
-        // that on Ack_Required, never on Event_Enable. All tracked as #123.
-        if let Some(outcome) = outcome {
-            if outcome.distribute {
+        // The shared commit kernel has also stored the selected timestamp and
+        // updated Acked_Transitions from the Notification Class policy. Message
+        // text is intentionally absent for this built-in path.
+        if let Some(committed) = committed {
+            if committed.distribute {
                 Self::build_and_send_event_notification(
                     db,
                     network,
@@ -210,7 +274,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     server_tsm,
                     notification_transactions,
                     oid,
-                    (outcome.change, outcome.event_type),
+                    committed,
                     retry_timeout_ms,
                 )
                 .await;
@@ -240,14 +304,19 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             return;
         }
 
-        let NotificationTransition { change, event_type } = transition.into();
+        let NotificationTransition {
+            change,
+            event_type,
+            timestamp_sample,
+        } = transition.into();
         let system_utc = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default();
         let (notification, recipients) = {
             let mut db = db.write().await;
 
-            let timestamp_sample = sample_event_timestamp(&mut db);
+            let timestamp_sample =
+                timestamp_sample.unwrap_or_else(|| sample_event_timestamp(&mut db));
 
             let device_oid = db
                 .list_objects()

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -13,6 +13,7 @@ pub(super) struct NotificationTransition {
     change: EventStateChange,
     event_type: EventType,
     timestamp_sample: Option<EventTimestampSample>,
+    ack_required: Option<bool>,
 }
 
 impl From<(EventStateChange, EventType)> for NotificationTransition {
@@ -21,6 +22,7 @@ impl From<(EventStateChange, EventType)> for NotificationTransition {
             change,
             event_type,
             timestamp_sample: None,
+            ack_required: None,
         }
     }
 }
@@ -31,6 +33,7 @@ pub(super) struct CommittedIntrinsicTransition {
     pub(super) event_type: EventType,
     pub(super) distribute: bool,
     timestamp_sample: EventTimestampSample,
+    ack_required: bool,
 }
 
 impl From<CommittedIntrinsicTransition> for NotificationTransition {
@@ -39,6 +42,37 @@ impl From<CommittedIntrinsicTransition> for NotificationTransition {
             change: committed.change,
             event_type: committed.event_type,
             timestamp_sample: Some(committed.timestamp_sample),
+            ack_required: Some(committed.ack_required),
+        }
+    }
+}
+
+/// A server-ready intrinsic outcome under its declared object contract.
+///
+/// Built-ins carry their atomic commit snapshot. Legacy implementations have
+/// already mutated state during evaluation and retain send-time policy and
+/// timestamp sampling.
+pub(super) enum ResolvedIntrinsicTransition {
+    Committed(CommittedIntrinsicTransition),
+    Legacy(TransitionOutcome),
+}
+
+impl ResolvedIntrinsicTransition {
+    pub(super) fn distribute(&self) -> bool {
+        match self {
+            Self::Committed(committed) => committed.distribute,
+            Self::Legacy(outcome) => outcome.distribute,
+        }
+    }
+}
+
+impl From<ResolvedIntrinsicTransition> for NotificationTransition {
+    fn from(transition: ResolvedIntrinsicTransition) -> Self {
+        match transition {
+            ResolvedIntrinsicTransition::Committed(committed) => committed.into(),
+            ResolvedIntrinsicTransition::Legacy(outcome) => {
+                (outcome.change, outcome.event_type).into()
+            }
         }
     }
 }
@@ -223,6 +257,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             event_type: outcome.event_type,
             distribute: outcome.distribute,
             timestamp_sample,
+            ack_required,
         })
     }
 
@@ -246,17 +281,28 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         oid: &ObjectIdentifier,
         retry_timeout_ms: u64,
     ) {
-        let committed = {
+        let resolved = {
             let mut db = db.write().await;
-            let outcome = match db.get_mut(oid) {
-                Some(object) => object.evaluate_intrinsic_reporting(),
+            let (requires_atomic_commit, outcome) = match db.get_mut(oid) {
+                Some(object) => (
+                    object.intrinsic_reporting_requires_atomic_commit(),
+                    object.evaluate_intrinsic_reporting(),
+                ),
                 None => return,
             };
-            outcome.and_then(|outcome| Self::commit_intrinsic_transition(&mut db, oid, outcome))
+            outcome.and_then(|outcome| {
+                if requires_atomic_commit {
+                    Self::commit_intrinsic_transition(&mut db, oid, outcome)
+                        .map(ResolvedIntrinsicTransition::Committed)
+                } else {
+                    Some(ResolvedIntrinsicTransition::Legacy(outcome))
+                }
+            })
         };
 
-        // A successful commit has already applied the local transition actions,
-        // whatever Event_Enable says. Only external distribution is gated here:
+        // A successful built-in commit has already applied the local transition
+        // actions; a legacy object applied them during evaluation. Whatever
+        // Event_Enable says, only external distribution is gated here:
         // Clause 12.12 defines Event_Enable as enabling and disabling the
         // distribution of notifications, and Clause 13.2.5 places that gate
         // inside the notification-distribution process — downstream of the
@@ -265,8 +311,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         // The shared commit kernel has also stored the selected timestamp and
         // updated Acked_Transitions from the Notification Class policy. Message
         // text is intentionally absent for this built-in path.
-        if let Some(committed) = committed {
-            if committed.distribute {
+        if let Some(resolved) = resolved {
+            if resolved.distribute() {
                 Self::build_and_send_event_notification(
                     db,
                     network,
@@ -274,7 +320,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     server_tsm,
                     notification_transactions,
                     oid,
-                    committed,
+                    resolved,
                     retry_timeout_ms,
                 )
                 .await;
@@ -308,6 +354,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             change,
             event_type,
             timestamp_sample,
+            ack_required: ack_required_snapshot,
         } = transition.into();
         let system_utc = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -372,8 +419,9 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             // referenced NotificationClass (ASHRAE 135-2020 §13.2.1), falling
             // back to the BACnet defaults (Priority 255, no ack) when the
             // class is missing.
-            let (priority, ack_required) =
+            let (priority, resolved_ack_required) =
                 resolve_transition_priority_ack(&db, notification_class, transition);
+            let ack_required = ack_required_snapshot.unwrap_or(resolved_ack_required);
 
             let base_notification = EventNotificationRequest {
                 process_identifier: 0,

--- a/crates/bacnet-server/src/server/event_notifications_commit_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_commit_tests.rs
@@ -1,11 +1,179 @@
 use super::*;
-use bacnet_objects::event::EventStateChange;
+use bacnet_objects::event::{EventStateChange, LimitEnable, OutOfRangeDetector};
 use bacnet_objects::traits::BACnetObject;
 use bacnet_types::enums::{EventState, EventType};
 use bacnet_types::primitives::BACnetTimeStamp;
 
+struct LegacyMacroObject {
+    oid: ObjectIdentifier,
+    event_detector: OutOfRangeDetector,
+    present_value: f32,
+    reliability: u32,
+    event_detection_enable: bool,
+}
+
+impl BACnetObject for LegacyMacroObject {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "legacy-macro"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        match property {
+            p if p == PropertyIdentifier::OBJECT_IDENTIFIER => {
+                Ok(PropertyValue::ObjectIdentifier(self.oid))
+            }
+            p if p == PropertyIdentifier::OBJECT_NAME => {
+                Ok(PropertyValue::CharacterString(self.object_name().into()))
+            }
+            p if p == PropertyIdentifier::OBJECT_TYPE => {
+                Ok(PropertyValue::Enumerated(ObjectType::ANALOG_INPUT.to_raw()))
+            }
+            p if p == PropertyIdentifier::EVENT_STATE => Ok(PropertyValue::Enumerated(
+                self.event_detector.event_state.to_raw(),
+            )),
+            p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(
+                self.event_detector.notification_class as u64,
+            )),
+            p if p == PropertyIdentifier::NOTIFY_TYPE => {
+                Ok(PropertyValue::Enumerated(self.event_detector.notify_type))
+            }
+            _ => Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            }),
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> std::borrow::Cow<'static, [PropertyIdentifier]> {
+        std::borrow::Cow::Borrowed(&[
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::NOTIFY_TYPE,
+        ])
+    }
+
+    bacnet_objects::impl_intrinsic_reporting!(
+        event_detector,
+        present_value,
+        reliability,
+        event_detection_enable
+    );
+}
+
+fn legacy_macro_object(time_delay: u32) -> LegacyMacroObject {
+    let event_detector = OutOfRangeDetector {
+        high_limit: 80.0,
+        low_limit: 20.0,
+        limit_enable: LimitEnable::BOTH,
+        event_enable: 0x07,
+        time_delay,
+        ..OutOfRangeDetector::default()
+    };
+    LegacyMacroObject {
+        oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+        event_detector,
+        present_value: 81.0,
+        reliability: bacnet_types::enums::Reliability::NO_FAULT_DETECTED.to_raw(),
+        event_detection_enable: true,
+    }
+}
+
+fn legacy_macro_database(time_delay: u32) -> ObjectDatabase {
+    let mut db = clocked_test_database();
+    db.add(Box::new(legacy_macro_object(time_delay))).unwrap();
+    db.add(Box::new(
+        DeviceObject::new(DeviceConfig {
+            instance: 1,
+            name: "Legacy Device".into(),
+            ..DeviceConfig::default()
+        })
+        .unwrap(),
+    ))
+    .unwrap();
+    db.add(Box::new(notification_class_0_broadcasting()))
+        .unwrap();
+    db
+}
+
 struct UnsupportedFaultReindication {
     oid: ObjectIdentifier,
+}
+
+#[tokio::test]
+async fn legacy_exported_macro_per_write_outcome_still_sends() {
+    let db = Arc::new(RwLock::new(legacy_macro_database(0)));
+
+    let sent = broadcasts_from_per_write_path(&db, 0).await;
+
+    assert_eq!(
+        sent.len(),
+        1,
+        "legacy immediate outcomes must bypass commit"
+    );
+    let notification = decode_broadcast_notification(&StdMutex::new(sent));
+    assert_eq!(notification.to_state, EventState::HIGH_LIMIT.to_raw());
+}
+
+#[tokio::test(start_paused = true)]
+async fn legacy_exported_macro_delayed_periodic_outcome_still_sends() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let transport = RecordingTransport {
+        sent_broadcast: StdArc::clone(&sent),
+        local_mac: vec![127, 0, 0, 1, 0xBA, 0xC0],
+    };
+    let mut db = legacy_macro_database(1);
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    assert_eq!(
+        db.get_mut(&oid).unwrap().evaluate_intrinsic_reporting(),
+        None,
+        "legacy probe should seed rather than advance the delay"
+    );
+
+    let server = BACnetServer::start(ServerConfig::default(), db, transport)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    assert_eq!(
+        sent.lock().unwrap().len(),
+        1,
+        "legacy delayed outcomes must bypass commit"
+    );
+    assert_eq!(
+        server
+            .database()
+            .read()
+            .await
+            .get(&oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw())
+    );
 }
 
 impl BACnetObject for UnsupportedFaultReindication {
@@ -193,5 +361,65 @@ async fn clockless_intrinsic_commit_stores_and_sends_one_reserved_sequence() {
             data: vec![0x60],
         },
         "later Notification Class edits must not rewrite committed acknowledgment state"
+    );
+}
+
+#[tokio::test]
+async fn committed_ack_required_snapshot_survives_notification_class_replacement() {
+    let db = db_with_high_limit_transition(0x80);
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let committed = {
+        let mut guard = db.write().await;
+        let mut notification_class = notification_class_0_broadcasting();
+        notification_class.ack_required = [true, false, false];
+        guard.add(Box::new(notification_class)).unwrap();
+        let outcome = guard
+            .get_mut(&oid)
+            .unwrap()
+            .evaluate_intrinsic_reporting()
+            .unwrap();
+        BACnetServer::<RecordingTransport>::commit_intrinsic_transition(&mut guard, &oid, outcome)
+            .unwrap()
+    };
+
+    {
+        let mut guard = db.write().await;
+        let mut replacement = notification_class_0_broadcasting();
+        replacement.ack_required = [false; 3];
+        guard.add(Box::new(replacement)).unwrap();
+        assert_eq!(
+            guard
+                .get(&oid)
+                .unwrap()
+                .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+                .unwrap(),
+            PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0x60],
+            },
+            "the committed TO_OFFNORMAL acknowledgment bit stays cleared"
+        );
+    }
+
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let network = Arc::new(NetworkLayer::new(RecordingTransport {
+        sent_broadcast: StdArc::clone(&sent),
+        local_mac: vec![127, 0, 0, 1, 0xBA, 0xC0],
+    }));
+    BACnetServer::<RecordingTransport>::build_and_send_event_notification(
+        &db,
+        &network,
+        &Arc::new(AtomicU8::new(0)),
+        &Arc::new(Mutex::new(ServerTsm::new())),
+        &NotificationTransactions::new(),
+        &oid,
+        committed,
+        1000,
+    )
+    .await;
+
+    assert!(
+        decode_broadcast_notification(&sent).ack_required,
+        "wire Ack_Required must use the commit-time snapshot"
     );
 }

--- a/crates/bacnet-server/src/server/event_notifications_commit_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_commit_tests.rs
@@ -1,0 +1,197 @@
+use super::*;
+use bacnet_objects::event::EventStateChange;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::enums::{EventState, EventType};
+use bacnet_types::primitives::BACnetTimeStamp;
+
+struct UnsupportedFaultReindication {
+    oid: ObjectIdentifier,
+}
+
+impl BACnetObject for UnsupportedFaultReindication {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "unsupported-fault"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        if property == PropertyIdentifier::NOTIFICATION_CLASS {
+            Ok(PropertyValue::Unsigned(0))
+        } else {
+            Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            })
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> std::borrow::Cow<'static, [PropertyIdentifier]> {
+        std::borrow::Cow::Borrowed(&[PropertyIdentifier::NOTIFICATION_CLASS])
+    }
+
+    fn evaluate_intrinsic_reporting(&mut self) -> Option<bacnet_objects::event::TransitionOutcome> {
+        Some(bacnet_objects::event::TransitionOutcome {
+            change: EventStateChange {
+                from: EventState::FAULT,
+                to: EventState::FAULT,
+            },
+            event_type: EventType::CHANGE_OF_RELIABILITY,
+            distribute: true,
+        })
+    }
+}
+
+#[tokio::test]
+async fn no_recipient_transition_commits_locally_without_sending() {
+    let db = db_with_high_limit_transition(0x80);
+    {
+        let mut guard = db.write().await;
+        guard
+            .add(Box::new(
+                bacnet_objects::notification_class::NotificationClass::new(0, "NC-0").unwrap(),
+            ))
+            .unwrap();
+    }
+
+    let sent = broadcasts_from_per_write_path(&db, 0).await;
+    assert!(sent.is_empty());
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    assert_eq!(
+        db.read()
+            .await
+            .get(&oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw())
+    );
+}
+
+#[test]
+fn unsupported_fault_reindication_is_retryable_without_sequence_consumption() {
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 99).unwrap();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(UnsupportedFaultReindication { oid }))
+        .unwrap();
+
+    let proposal = db
+        .get_mut(&oid)
+        .unwrap()
+        .evaluate_intrinsic_reporting()
+        .unwrap();
+    assert!(
+        BACnetServer::<RecordingTransport>::commit_intrinsic_transition(
+            &mut db,
+            &oid,
+            proposal.clone(),
+        )
+        .is_none()
+    );
+    assert_eq!(db.reserve_event_sequence_number().number(), 0);
+    assert_eq!(
+        db.get_mut(&oid).unwrap().evaluate_intrinsic_reporting(),
+        Some(proposal)
+    );
+}
+
+#[tokio::test]
+async fn dcc_suppressed_intrinsic_transition_commits_locally_without_sending() {
+    let db = db_with_high_limit_transition(0x80);
+    let sent = broadcasts_from_per_write_path(&db, 1).await;
+
+    assert!(sent.is_empty(), "DCC must suppress external distribution");
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    assert_eq!(
+        db.read()
+            .await
+            .get(&oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw()),
+        "DCC must not suppress the local transition commit"
+    );
+}
+
+#[tokio::test]
+async fn clockless_intrinsic_commit_stores_and_sends_one_reserved_sequence() {
+    let db = db_with_high_limit_transition(0x80);
+    {
+        let mut guard = db.write().await;
+        guard.set_clock_reader(None);
+        let mut notification_class = notification_class_0_broadcasting();
+        notification_class.ack_required = [true, false, false];
+        guard.add(Box::new(notification_class)).unwrap();
+    }
+
+    let sent = broadcasts_from_per_write_path(&db, 0).await;
+    let notification = decode_broadcast_notification(&StdMutex::new(sent));
+    assert_eq!(
+        notification.timestamp,
+        BACnetTimeStamp::SequenceNumber(0),
+        "the outbound request must reuse the timestamp committed under the lock"
+    );
+
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let mut encoded = BytesMut::new();
+    bacnet_encoding::primitives::encode_timestamp_choice(
+        &mut encoded,
+        &BACnetTimeStamp::SequenceNumber(0),
+    )
+    .unwrap();
+    let mut guard = db.write().await;
+    let object = guard.get(&oid).unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(1))
+            .unwrap(),
+        PropertyValue::ApplicationData(encoded.to_vec())
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0x60],
+        },
+        "Ack_Required clears only TO_OFFNORMAL"
+    );
+    assert_eq!(guard.reserve_event_sequence_number().number(), 1);
+
+    let mut replacement = notification_class_0_broadcasting();
+    replacement.ack_required = [false; 3];
+    guard.add(Box::new(replacement)).unwrap();
+    assert_eq!(
+        guard
+            .get(&oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0x60],
+        },
+        "later Notification Class edits must not rewrite committed acknowledgment state"
+    );
+}

--- a/crates/bacnet-server/src/server/event_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_tests.rs
@@ -9,6 +9,9 @@ use bytes::Bytes;
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
 use tokio::sync::mpsc;
 
+#[path = "event_notifications_commit_tests.rs"]
+mod commit_tests;
+
 /// A transport that records every broadcast NPDU it is asked to send and
 /// discards unicasts. Used to capture the EventNotification a server
 /// actually puts on the wire.
@@ -17,6 +20,7 @@ pub(super) struct RecordingTransport {
     pub(super) sent_broadcast: StdArc<StdMutex<Vec<Bytes>>>,
     pub(super) local_mac: Vec<u8>,
 }
+
 impl TransportPort for RecordingTransport {
     async fn start(
         &mut self,

--- a/crates/bacnet-server/src/server/event_timestamp.rs
+++ b/crates/bacnet-server/src/server/event_timestamp.rs
@@ -1,5 +1,5 @@
 use bacnet_objects::clock::ClockFrame;
-use bacnet_objects::database::ObjectDatabase;
+use bacnet_objects::database::{EventSequenceReservation, ObjectDatabase};
 use bacnet_types::primitives::BACnetTimeStamp;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,27 +15,62 @@ pub(super) struct EventTimestampSample {
     pub(super) clock: SampledEventClock,
 }
 
+/// A timestamp selected without consuming the clockless sequence source.
+pub(super) struct StagedEventTimestamp {
+    pub(super) sample: EventTimestampSample,
+    sequence: Option<EventSequenceReservation>,
+}
+
+/// Select a timestamp while leaving a clockless sequence retryable.
+pub(super) fn stage_event_timestamp(db: &ObjectDatabase) -> StagedEventTimestamp {
+    match db.clock_frame() {
+        Some(frame) if frame.is_valid_actual_datetime() => StagedEventTimestamp {
+            sample: EventTimestampSample {
+                timestamp: BACnetTimeStamp::DateTime {
+                    date: frame.local_date,
+                    time: frame.local_time,
+                },
+                clock: SampledEventClock::Valid(frame),
+            },
+            sequence: None,
+        },
+        frame => {
+            let reservation = db.reserve_event_sequence_number();
+            StagedEventTimestamp {
+                sample: EventTimestampSample {
+                    timestamp: BACnetTimeStamp::SequenceNumber(reservation.number()),
+                    clock: if frame.is_some() {
+                        SampledEventClock::Invalid
+                    } else {
+                        SampledEventClock::Unavailable
+                    },
+                },
+                sequence: Some(reservation),
+            }
+        }
+    }
+}
+
+/// Confirm staged sequence consumption after the transition commit succeeds.
+pub(super) fn confirm_event_timestamp(
+    db: &mut ObjectDatabase,
+    staged: StagedEventTimestamp,
+) -> EventTimestampSample {
+    if let Some(reservation) = staged.sequence {
+        assert!(
+            db.confirm_event_sequence_number(reservation),
+            "event sequence reservation changed while one database guard was held"
+        );
+    }
+    staged.sample
+}
+
 /// Sample the Device clock once and select one valid EventNotification
 /// timestamp. A missing or malformed wall clock consumes the database-local
 /// sequence source instead of inventing a DateTime.
 pub(super) fn sample_event_timestamp(db: &mut ObjectDatabase) -> EventTimestampSample {
-    match db.clock_frame() {
-        Some(frame) if frame.is_valid_actual_datetime() => EventTimestampSample {
-            timestamp: BACnetTimeStamp::DateTime {
-                date: frame.local_date,
-                time: frame.local_time,
-            },
-            clock: SampledEventClock::Valid(frame),
-        },
-        Some(_) => EventTimestampSample {
-            timestamp: BACnetTimeStamp::SequenceNumber(db.next_event_sequence_number()),
-            clock: SampledEventClock::Invalid,
-        },
-        None => EventTimestampSample {
-            timestamp: BACnetTimeStamp::SequenceNumber(db.next_event_sequence_number()),
-            clock: SampledEventClock::Unavailable,
-        },
-    }
+    let staged = stage_event_timestamp(db);
+    confirm_event_timestamp(db, staged)
 }
 
 #[cfg(test)]
@@ -124,6 +159,19 @@ mod tests {
             sample_event_timestamp(&mut second).timestamp,
             BACnetTimeStamp::SequenceNumber(0)
         );
+    }
+
+    #[test]
+    fn clockless_staging_does_not_consume_until_confirmed() {
+        let mut db = ObjectDatabase::new();
+
+        let staged = stage_event_timestamp(&db);
+        assert_eq!(staged.sample.timestamp, BACnetTimeStamp::SequenceNumber(0));
+        assert_eq!(db.reserve_event_sequence_number().number(), 0);
+
+        let sample = confirm_event_timestamp(&mut db, staged);
+        assert_eq!(sample.timestamp, BACnetTimeStamp::SequenceNumber(0));
+        assert_eq!(db.reserve_event_sequence_number().number(), 1);
     }
 
     #[test]

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -622,27 +622,27 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 // drop it before sending (never hold the db lock across a
                 // network send — matches the per-write notification path).
                 //
-                // Event_Enable gates distribution only (Clause 12.12), so a
-                // suppressed transition is dropped here rather than at
-                // detection — its Event_State write already happened inside
-                // the detector.
-                let fired: Vec<(
-                    ObjectIdentifier,
-                    bacnet_objects::event::EventStateChange,
-                    bacnet_types::enums::EventType,
-                )> = {
+                // Event_Enable gates distribution only (Clause 12.12), so every
+                // proposal is committed locally before a suppressed transition
+                // is omitted from the outbound work list.
+                let fired = {
                     let mut db = db_intrinsic.write().await;
                     let mut out = Vec::new();
-                    db.for_each_object_mut(|oid, object| {
-                        if let Some(outcome) = object.tick_intrinsic_reporting() {
-                            if outcome.distribute {
-                                out.push((oid, outcome.change, outcome.event_type));
+                    for oid in db.list_objects() {
+                        let outcome = db
+                            .get_mut(&oid)
+                            .and_then(|object| object.tick_intrinsic_reporting());
+                        if let Some(committed) = outcome.and_then(|outcome| {
+                            Self::commit_intrinsic_transition(&mut db, &oid, outcome)
+                        }) {
+                            if committed.distribute {
+                                out.push((oid, committed));
                             }
                         }
-                    });
+                    }
                     out
                 };
-                for (oid, change, event_type) in fired {
+                for (oid, committed) in fired {
                     Self::build_and_send_event_notification(
                         &db_intrinsic,
                         &network_intrinsic,
@@ -650,7 +650,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         &server_tsm_intrinsic,
                         &notification_transactions_intrinsic,
                         &oid,
-                        (change, event_type),
+                        committed,
                         intrinsic_retry_ms,
                     )
                     .await;

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -1,3 +1,4 @@
+use super::event_notifications::ResolvedIntrinsicTransition;
 use super::*;
 
 /// Resolve the configured Event Enrollment interval into a tick period.
@@ -618,31 +619,43 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 interval.tick().await;
                 // DCC gates the outbound sender, not event-state detection or
                 // the local transition actions in Clause 13.2.2.1.4.
-                // Collect confirmed transitions under a brief write lock, then
+                // Collect resolved transitions under a brief write lock, then
                 // drop it before sending (never hold the db lock across a
                 // network send — matches the per-write notification path).
                 //
                 // Event_Enable gates distribution only (Clause 12.12), so every
-                // proposal is committed locally before a suppressed transition
-                // is omitted from the outbound work list.
+                // built-in proposal is committed locally before a suppressed
+                // transition is omitted from the outbound work list. Legacy
+                // implementations already commit during their tick and bypass
+                // the atomic hook explicitly.
                 let fired = {
                     let mut db = db_intrinsic.write().await;
                     let mut out = Vec::new();
                     for oid in db.list_objects() {
-                        let outcome = db
-                            .get_mut(&oid)
-                            .and_then(|object| object.tick_intrinsic_reporting());
-                        if let Some(committed) = outcome.and_then(|outcome| {
-                            Self::commit_intrinsic_transition(&mut db, &oid, outcome)
-                        }) {
-                            if committed.distribute {
-                                out.push((oid, committed));
+                        let evaluated = db.get_mut(&oid).and_then(|object| {
+                            let requires_atomic_commit =
+                                object.intrinsic_reporting_requires_atomic_commit();
+                            object
+                                .tick_intrinsic_reporting()
+                                .map(|outcome| (requires_atomic_commit, outcome))
+                        });
+                        let resolved = evaluated.and_then(|(requires_atomic_commit, outcome)| {
+                            if requires_atomic_commit {
+                                Self::commit_intrinsic_transition(&mut db, &oid, outcome)
+                                    .map(ResolvedIntrinsicTransition::Committed)
+                            } else {
+                                Some(ResolvedIntrinsicTransition::Legacy(outcome))
+                            }
+                        });
+                        if let Some(resolved) = resolved {
+                            if resolved.distribute() {
+                                out.push((oid, resolved));
                             }
                         }
                     }
                     out
                 };
-                for (oid, committed) in fired {
+                for (oid, resolved) in fired {
                     Self::build_and_send_event_notification(
                         &db_intrinsic,
                         &network_intrinsic,
@@ -650,7 +663,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         &server_tsm_intrinsic,
                         &notification_transactions_intrinsic,
                         &oid,
-                        committed,
+                        resolved,
                         intrinsic_retry_ms,
                     )
                     .await;


### PR DESCRIPTION
## Summary

- route all nine built-in analog, binary, and multi-state intrinsic-reporting families through the shared transition commit kernel
- resolve Ack_Required and stage one coherent Device-clock or wrapping-sequence timestamp under the database write guard
- preserve Event_Enable and DCC as distribution-only gates while failed commits remain retryable without sequence consumption

## Standard references

ASHRAE 135-2020 §§13.2.2.1.4 and 13.2.3, Table 13-3, and §21.6.

## Validation

- cargo test -p bacnet-objects --locked
- cargo test -p bacnet-server --locked
- cargo fmt --all -- --check
- cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked
- cargo test --workspace --exclude rusty-bacnet --locked
- cargo check -p rusty-bacnet --tests --locked
- conformance generation check, file-size check, secret scan, and git diff check

Refs #123