### PR TITLE
fix(events): source notifications from committed history

### DIFF
--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -1,18 +1,37 @@
 use super::event_timestamp::{
-    confirm_event_timestamp, sample_event_timestamp, stage_event_timestamp, EventTimestampSample,
-    SampledEventClock,
+    confirm_event_timestamp, sample_event_timestamp, stage_event_timestamp, SampledEventClock,
 };
 use super::*;
-use bacnet_objects::event::{EventTransitionCommit, TransitionOutcome};
+use bacnet_encoding::primitives::decode_timestamp_choice;
+use bacnet_objects::event::{EventTransition, EventTransitionCommit, TransitionOutcome};
 use bacnet_objects::notification_class::local_day_and_time;
+use bacnet_objects::traits::BACnetObject;
 use bacnet_types::constructed::BACnetRecipient;
 use bacnet_types::enums::EventType;
-use bacnet_types::primitives::Time;
+use bacnet_types::primitives::{BACnetTimeStamp, Time};
+
+/// One exact transition-coordinate projection from object-owned event history.
+#[derive(Debug, Clone, PartialEq)]
+struct CommittedHistorySnapshot {
+    timestamp: BACnetTimeStamp,
+    message_text: Option<String>,
+}
+
+/// The source boundary for the notification's timestamp and message.
+enum NotificationHistorySource {
+    /// Legacy/default objects sample their timestamp when distribution begins.
+    SendTime,
+    /// Atomic built-ins use the exact history coordinate read after commit.
+    Committed {
+        snapshot: CommittedHistorySnapshot,
+        recipient_clock: SampledEventClock,
+    },
+}
 
 pub(super) struct NotificationTransition {
     change: EventStateChange,
     event_type: EventType,
-    timestamp_sample: Option<EventTimestampSample>,
+    history_source: NotificationHistorySource,
     ack_required: Option<bool>,
 }
 
@@ -21,7 +40,7 @@ impl From<(EventStateChange, EventType)> for NotificationTransition {
         Self {
             change,
             event_type,
-            timestamp_sample: None,
+            history_source: NotificationHistorySource::SendTime,
             ack_required: None,
         }
     }
@@ -32,7 +51,8 @@ pub(super) struct CommittedIntrinsicTransition {
     pub(super) change: EventStateChange,
     pub(super) event_type: EventType,
     pub(super) distribute: bool,
-    timestamp_sample: EventTimestampSample,
+    history_snapshot: CommittedHistorySnapshot,
+    recipient_clock: SampledEventClock,
     ack_required: bool,
 }
 
@@ -41,7 +61,10 @@ impl From<CommittedIntrinsicTransition> for NotificationTransition {
         Self {
             change: committed.change,
             event_type: committed.event_type,
-            timestamp_sample: Some(committed.timestamp_sample),
+            history_source: NotificationHistorySource::Committed {
+                snapshot: committed.history_snapshot,
+                recipient_clock: committed.recipient_clock,
+            },
             ack_required: Some(committed.ack_required),
         }
     }
@@ -104,6 +127,42 @@ fn system_utc_recipient_filter_time(now: Duration) -> (u8, Time) {
     let (today_bit, mut current_time) = local_day_and_time(now.as_secs(), 0);
     current_time.hundredths = (now.subsec_millis() / 10) as u8;
     (today_bit, current_time)
+}
+
+/// Read one exact committed transition coordinate through the object contract.
+///
+/// Both properties are projected while the caller still owns the database
+/// write guard. A malformed or incomplete projection is not equivalent to a
+/// missing message/timestamp: the committed transition remains local, but no
+/// outward frame can be built from an unproven history snapshot.
+fn read_committed_history_snapshot(
+    object: &dyn BACnetObject,
+    coordinate: EventTransition,
+) -> Option<CommittedHistorySnapshot> {
+    let array_index = u32::try_from(coordinate.index() + 1)
+        .expect("three event transition coordinates fit in u32");
+    let PropertyValue::ApplicationData(encoded_timestamp) = object
+        .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(array_index))
+        .ok()?
+    else {
+        return None;
+    };
+    let (timestamp, consumed) = decode_timestamp_choice(&encoded_timestamp, 0).ok()?;
+    if consumed != encoded_timestamp.len() {
+        return None;
+    }
+
+    let PropertyValue::CharacterString(message_text) = object
+        .read_property(PropertyIdentifier::EVENT_MESSAGE_TEXTS, Some(array_index))
+        .ok()?
+    else {
+        return None;
+    };
+
+    Some(CommittedHistorySnapshot {
+        timestamp,
+        message_text: (!message_text.is_empty()).then_some(message_text),
+    })
 }
 
 /// The network destination a Notification Class recipient resolves to.
@@ -251,12 +310,27 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             return None;
         }
 
-        let timestamp_sample = confirm_event_timestamp(db, staged_timestamp);
+        let recipient_clock = confirm_event_timestamp(db, staged_timestamp).clock;
+        let history_snapshot = match db
+            .get(oid)
+            .and_then(|object| read_committed_history_snapshot(object, coordinate))
+        {
+            Some(snapshot) => snapshot,
+            None => {
+                debug!(
+                    %oid,
+                    ?coordinate,
+                    "Committed intrinsic history projection rejected; suppressing distribution"
+                );
+                return None;
+            }
+        };
         Some(CommittedIntrinsicTransition {
             change: outcome.change,
             event_type: outcome.event_type,
             distribute: outcome.distribute,
-            timestamp_sample,
+            history_snapshot,
+            recipient_clock,
             ack_required,
         })
     }
@@ -353,7 +427,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let NotificationTransition {
             change,
             event_type,
-            timestamp_sample,
+            history_source,
             ack_required: ack_required_snapshot,
         } = transition.into();
         let system_utc = std::time::SystemTime::now()
@@ -362,8 +436,16 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let (notification, recipients) = {
             let mut db = db.write().await;
 
-            let timestamp_sample =
-                timestamp_sample.unwrap_or_else(|| sample_event_timestamp(&mut db));
+            let (timestamp, message_text, recipient_clock) = match history_source {
+                NotificationHistorySource::SendTime => {
+                    let sample = sample_event_timestamp(&mut db);
+                    (sample.timestamp, None, sample.clock)
+                }
+                NotificationHistorySource::Committed {
+                    snapshot,
+                    recipient_clock,
+                } => (snapshot.timestamp, snapshot.message_text, recipient_clock),
+            };
 
             let device_oid = db
                 .list_objects()
@@ -371,7 +453,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 .find(|o| o.object_type() == ObjectType::DEVICE)
                 .unwrap_or_else(|| ObjectIdentifier::new(ObjectType::DEVICE, 0).unwrap());
 
-            let (today_bit, current_time) = match timestamp_sample.clock {
+            let (today_bit, current_time) = match recipient_clock {
                 SampledEventClock::Valid(clock_frame) => (
                     clock_frame
                         .day_of_week_bit()
@@ -427,11 +509,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 process_identifier: 0,
                 initiating_device_identifier: device_oid,
                 event_object_identifier: *oid,
-                timestamp: timestamp_sample.timestamp,
+                timestamp,
                 notification_class,
                 priority,
                 event_type: event_type.to_raw(),
-                message_text: None,
+                message_text,
                 notify_type,
                 // ack_required is only meaningful for ALARM/EVENT notify types
                 // (ACK_NOTIFICATION omits the field on the wire). Per §13.2.1 the

--- a/crates/bacnet-server/src/server/event_notifications_history_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_history_tests.rs
@@ -1,0 +1,438 @@
+use super::*;
+use bacnet_objects::event::{
+    EventStateChange, EventTransitionCommit, EventTransitionCommitError, TransitionOutcome,
+};
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::enums::{EventState, EventType};
+use bacnet_types::primitives::{BACnetTimeStamp, Date, Time};
+
+#[derive(Clone)]
+enum IndexedHistoryRead {
+    Value(PropertyValue),
+    Missing,
+    Unreadable,
+}
+
+struct AtomicHistoryObject {
+    oid: ObjectIdentifier,
+    timestamps: [IndexedHistoryRead; 3],
+    messages: [IndexedHistoryRead; 3],
+}
+
+impl AtomicHistoryObject {
+    fn indexed(
+        values: &[IndexedHistoryRead; 3],
+        array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        let Some(index @ 1..=3) = array_index else {
+            return Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::INVALID_ARRAY_INDEX.to_raw() as u32,
+            });
+        };
+        match &values[index as usize - 1] {
+            IndexedHistoryRead::Value(value) => Ok(value.clone()),
+            IndexedHistoryRead::Missing => Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            }),
+            IndexedHistoryRead::Unreadable => Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::READ_ACCESS_DENIED.to_raw() as u32,
+            }),
+        }
+    }
+}
+
+impl BACnetObject for AtomicHistoryObject {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "atomic-history"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        match property {
+            p if p == PropertyIdentifier::OBJECT_IDENTIFIER => {
+                Ok(PropertyValue::ObjectIdentifier(self.oid))
+            }
+            p if p == PropertyIdentifier::OBJECT_NAME => {
+                Ok(PropertyValue::CharacterString(self.object_name().into()))
+            }
+            p if p == PropertyIdentifier::OBJECT_TYPE => {
+                Ok(PropertyValue::Enumerated(ObjectType::ANALOG_INPUT.to_raw()))
+            }
+            p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(0)),
+            p if p == PropertyIdentifier::NOTIFY_TYPE => {
+                Ok(PropertyValue::Enumerated(NotifyType::ALARM.to_raw()))
+            }
+            p if p == PropertyIdentifier::EVENT_TIME_STAMPS => {
+                Self::indexed(&self.timestamps, array_index)
+            }
+            p if p == PropertyIdentifier::EVENT_MESSAGE_TEXTS => {
+                Self::indexed(&self.messages, array_index)
+            }
+            _ => Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            }),
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> std::borrow::Cow<'static, [PropertyIdentifier]> {
+        std::borrow::Cow::Borrowed(&[
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+            PropertyIdentifier::EVENT_MESSAGE_TEXTS,
+        ])
+    }
+
+    fn intrinsic_reporting_requires_atomic_commit(&self) -> bool {
+        true
+    }
+
+    fn commit_event_transition_internal(
+        &mut self,
+        _commit: EventTransitionCommit,
+    ) -> Result<(), EventTransitionCommitError> {
+        Ok(())
+    }
+}
+
+fn timestamp_read(timestamp: BACnetTimeStamp) -> IndexedHistoryRead {
+    let mut encoded = BytesMut::new();
+    bacnet_encoding::primitives::encode_timestamp_choice(&mut encoded, &timestamp).unwrap();
+    IndexedHistoryRead::Value(PropertyValue::ApplicationData(encoded.to_vec()))
+}
+
+fn empty_message_read() -> IndexedHistoryRead {
+    IndexedHistoryRead::Value(PropertyValue::CharacterString(String::new()))
+}
+
+fn atomic_history_database(
+    timestamps: [IndexedHistoryRead; 3],
+    messages: [IndexedHistoryRead; 3],
+    clocked: bool,
+) -> (Arc<RwLock<ObjectDatabase>>, ObjectIdentifier) {
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 77).unwrap();
+    let mut db = if clocked {
+        clocked_test_database()
+    } else {
+        ObjectDatabase::new()
+    };
+    db.add(Box::new(AtomicHistoryObject {
+        oid,
+        timestamps,
+        messages,
+    }))
+    .unwrap();
+    db.add(Box::new(
+        DeviceObject::new(DeviceConfig {
+            instance: 1,
+            name: "History Device".into(),
+            ..DeviceConfig::default()
+        })
+        .unwrap(),
+    ))
+    .unwrap();
+    db.add(Box::new(notification_class_0_broadcasting()))
+        .unwrap();
+    (Arc::new(RwLock::new(db)), oid)
+}
+
+async fn commit_and_capture_history_notification(
+    timestamps: [IndexedHistoryRead; 3],
+    messages: [IndexedHistoryRead; 3],
+    change: EventStateChange,
+    clocked: bool,
+) -> (Arc<RwLock<ObjectDatabase>>, Vec<bytes::Bytes>) {
+    let (db, oid) = atomic_history_database(timestamps, messages, clocked);
+    let committed = {
+        let mut guard = db.write().await;
+        BACnetServer::<RecordingTransport>::commit_intrinsic_transition(
+            &mut guard,
+            &oid,
+            TransitionOutcome {
+                change,
+                event_type: EventType::OUT_OF_RANGE,
+                distribute: true,
+            },
+        )
+    };
+
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    if let Some(committed) = committed {
+        let network = Arc::new(NetworkLayer::new(RecordingTransport {
+            sent_broadcast: StdArc::clone(&sent),
+            local_mac: vec![127, 0, 0, 1, 0xBA, 0xC0],
+        }));
+        BACnetServer::<RecordingTransport>::build_and_send_event_notification(
+            &db,
+            &network,
+            &Arc::new(AtomicU8::new(0)),
+            &Arc::new(Mutex::new(ServerTsm::new())),
+            &NotificationTransactions::new(),
+            &oid,
+            committed,
+            1000,
+        )
+        .await;
+    }
+
+    let captured = sent.lock().unwrap().clone();
+    (db, captured)
+}
+
+fn repeated_timestamp_reads(timestamp: BACnetTimeStamp) -> [IndexedHistoryRead; 3] {
+    std::array::from_fn(|_| timestamp_read(timestamp.clone()))
+}
+
+fn empty_message_reads() -> [IndexedHistoryRead; 3] {
+    std::array::from_fn(|_| empty_message_read())
+}
+
+#[tokio::test]
+async fn committed_history_preserves_each_timestamp_choice_on_the_wire() {
+    let choices = [
+        BACnetTimeStamp::Time(Time {
+            hour: 4,
+            minute: 5,
+            second: 6,
+            hundredths: 7,
+        }),
+        BACnetTimeStamp::SequenceNumber(44_444),
+        BACnetTimeStamp::DateTime {
+            date: Date {
+                year: 124,
+                month: 2,
+                day: 29,
+                day_of_week: 4,
+            },
+            time: Time {
+                hour: 12,
+                minute: 34,
+                second: 56,
+                hundredths: 78,
+            },
+        },
+    ];
+
+    for expected in choices {
+        let (_, sent) = commit_and_capture_history_notification(
+            repeated_timestamp_reads(expected.clone()),
+            empty_message_reads(),
+            EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            true,
+        )
+        .await;
+        let notification = decode_broadcast_notification(&StdMutex::new(sent));
+        assert_eq!(notification.timestamp, expected);
+        assert_eq!(
+            notification.message_text, None,
+            "empty committed message history must remain absent on the wire"
+        );
+    }
+}
+
+#[tokio::test]
+async fn committed_history_selects_only_the_transition_coordinate() {
+    let timestamps = [
+        timestamp_read(BACnetTimeStamp::SequenceNumber(11)),
+        timestamp_read(BACnetTimeStamp::SequenceNumber(22)),
+        timestamp_read(BACnetTimeStamp::SequenceNumber(33)),
+    ];
+    let cases = [
+        (
+            EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            11,
+        ),
+        (
+            EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::FAULT,
+            },
+            22,
+        ),
+        (
+            EventStateChange {
+                from: EventState::HIGH_LIMIT,
+                to: EventState::NORMAL,
+            },
+            33,
+        ),
+    ];
+
+    for (change, expected) in cases {
+        let (_, sent) = commit_and_capture_history_notification(
+            timestamps.clone(),
+            empty_message_reads(),
+            change,
+            true,
+        )
+        .await;
+        assert_eq!(
+            decode_broadcast_notification(&StdMutex::new(sent)).timestamp,
+            BACnetTimeStamp::SequenceNumber(expected)
+        );
+    }
+}
+
+#[tokio::test]
+async fn committed_history_timestamp_is_distinct_from_the_staged_device_clock_sample() {
+    let expected = BACnetTimeStamp::SequenceNumber(54_321);
+    let (_, sent) = commit_and_capture_history_notification(
+        repeated_timestamp_reads(expected.clone()),
+        empty_message_reads(),
+        EventStateChange {
+            from: EventState::NORMAL,
+            to: EventState::HIGH_LIMIT,
+        },
+        true,
+    )
+    .await;
+
+    assert_eq!(
+        decode_broadcast_notification(&StdMutex::new(sent)).timestamp,
+        expected,
+        "the stored coordinate, not the staged Device DateTime, is wire authority"
+    );
+}
+
+#[tokio::test]
+async fn nonempty_committed_message_is_captured_with_its_timestamp() {
+    let messages = std::array::from_fn(|index| {
+        IndexedHistoryRead::Value(PropertyValue::CharacterString(format!("message-{index}")))
+    });
+    let (_, sent) = commit_and_capture_history_notification(
+        repeated_timestamp_reads(BACnetTimeStamp::SequenceNumber(9)),
+        messages,
+        EventStateChange {
+            from: EventState::NORMAL,
+            to: EventState::FAULT,
+        },
+        true,
+    )
+    .await;
+
+    assert_eq!(
+        decode_broadcast_notification(&StdMutex::new(sent)).message_text,
+        Some("message-1".into())
+    );
+}
+
+#[tokio::test]
+async fn invalid_committed_history_suppresses_emission_after_consuming_sequence() {
+    let mut trailing = BytesMut::new();
+    bacnet_encoding::primitives::encode_timestamp_choice(
+        &mut trailing,
+        &BACnetTimeStamp::SequenceNumber(7),
+    )
+    .unwrap();
+    trailing.extend_from_slice(&[0]);
+
+    let failures = [
+        IndexedHistoryRead::Value(PropertyValue::ApplicationData(vec![0x19])),
+        IndexedHistoryRead::Value(PropertyValue::Unsigned(7)),
+        IndexedHistoryRead::Missing,
+        IndexedHistoryRead::Unreadable,
+        IndexedHistoryRead::Value(PropertyValue::ApplicationData(trailing.to_vec())),
+    ];
+
+    for failure in failures {
+        let timestamps = std::array::from_fn(|index| {
+            if index == 0 {
+                failure.clone()
+            } else {
+                timestamp_read(BACnetTimeStamp::SequenceNumber(index as u16))
+            }
+        });
+        let (db, sent) = commit_and_capture_history_notification(
+            timestamps,
+            empty_message_reads(),
+            EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            false,
+        )
+        .await;
+
+        assert!(
+            sent.is_empty(),
+            "invalid committed history must fail closed"
+        );
+        assert_eq!(
+            db.write().await.reserve_event_sequence_number().number(),
+            1,
+            "a successful commit permanently consumes its staged sequence"
+        );
+    }
+}
+
+#[tokio::test]
+async fn invalid_committed_message_history_suppresses_emission_after_consuming_sequence() {
+    let failures = [
+        IndexedHistoryRead::Value(PropertyValue::Unsigned(7)),
+        IndexedHistoryRead::Missing,
+        IndexedHistoryRead::Unreadable,
+    ];
+
+    for failure in failures {
+        let messages = std::array::from_fn(|index| {
+            if index == 0 {
+                failure.clone()
+            } else {
+                empty_message_read()
+            }
+        });
+        let (db, sent) = commit_and_capture_history_notification(
+            repeated_timestamp_reads(BACnetTimeStamp::SequenceNumber(17)),
+            messages,
+            EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            false,
+        )
+        .await;
+
+        assert!(
+            sent.is_empty(),
+            "invalid committed message history must fail closed"
+        );
+        assert_eq!(
+            db.write().await.reserve_event_sequence_number().number(),
+            1,
+            "a successful commit permanently consumes its staged sequence"
+        );
+    }
+}

--- a/crates/bacnet-server/src/server/event_notifications_tests.rs
+++ b/crates/bacnet-server/src/server/event_notifications_tests.rs
@@ -12,6 +12,9 @@ use tokio::sync::mpsc;
 #[path = "event_notifications_commit_tests.rs"]
 mod commit_tests;
 
+#[path = "event_notifications_history_tests.rs"]
+mod history_tests;
+
 /// A transport that records every broadcast NPDU it is asked to send and
 /// discards unicasts. Used to capture the EventNotification a server
 /// actually puts on the wire.


### PR DESCRIPTION
## Summary

- read the exact committed transition-coordinate timestamp and stored message boundary under the object database write guard
- use committed history as built-in intrinsic EventNotification wire authority while preserving commit-time Ack_Required and recipient-filter clock metadata
- fail closed without resampling when committed history is unreadable or malformed; keep legacy/default objects on their send-time path

## Standard references

ASHRAE 135-2020 §§13.2.2.1.4, 13.2.3, and 13.2.5.2/Table 13-3; §13.8.1.1; §21.6.

## Validation

- cargo test -p bacnet-server --locked
- cargo fmt --all -- --check
- cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked
- cargo test --workspace --exclude rusty-bacnet --locked
- cargo check -p rusty-bacnet --tests --locked
- conformance generation check, file-size check, secret scan, and git diff check

Closes #169
Refs #123