### PR TITLE
fix(server): commit Event Enrollment updates transactionally

### DIFF
--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -10,12 +10,14 @@ use std::borrow::Cow;
 
 use crate::common::{self, read_common_properties};
 use crate::event::history::EventHistory;
+use crate::event::{EventTransitionCommit, EventTransitionCommitError};
 use crate::property_metadata::PropertyMetadata;
 use crate::traits::{BACnetObject, WritePropertyRollback};
 
 mod metadata;
 mod parameters;
 mod state;
+mod transition;
 use state::{AlertEnrollmentWriteRollback, EventEnrollmentWriteRollback};
 pub use state::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource, EventEnrollmentPending};
 
@@ -528,6 +530,8 @@ impl BACnetObject for EventEnrollmentObject {
         }
         Ok(())
     }
+
+    transition::impl_event_enrollment_transition_commit!();
 
     fn capture_write_property_rollback(
         &mut self,

--- a/crates/bacnet-objects/src/event_enrollment/tests/atomic_commit.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/atomic_commit.rs
@@ -1,0 +1,121 @@
+use super::super::*;
+use crate::event::{
+    EventStateChange, EventTransition, EventTransitionCommit, EventTransitionCommitError,
+};
+use bacnet_encoding::primitives::decode_timestamp_choice;
+use bacnet_types::primitives::BACnetTimeStamp;
+
+fn timestamp_at(object: &EventEnrollmentObject, index: u32) -> BACnetTimeStamp {
+    let PropertyValue::ApplicationData(bytes) = object
+        .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(index))
+        .unwrap()
+    else {
+        panic!("Event_Time_Stamps slot must be encoded application data");
+    };
+    let (timestamp, end) = decode_timestamp_choice(&bytes, 0).unwrap();
+    assert_eq!(end, bytes.len());
+    timestamp
+}
+
+fn snapshot(object: &EventEnrollmentObject) -> (PropertyValue, PropertyValue, PropertyValue) {
+    (
+        object
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        object
+            .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+            .unwrap(),
+        object
+            .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
+            .unwrap(),
+    )
+}
+
+#[test]
+fn stock_enrollment_atomically_commits_state_ack_and_exact_history_coordinate() {
+    let mut object = EventEnrollmentObject::new(1, "EE-atomic", 0).unwrap();
+
+    object
+        .commit_event_transition_internal(EventTransitionCommit {
+            change: EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            coordinate: EventTransition::ToOffnormal,
+            ack_required: true,
+            timestamp: BACnetTimeStamp::SequenceNumber(41),
+            message_text: None,
+        })
+        .unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw())
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0x60],
+        }
+    );
+    assert_eq!(
+        timestamp_at(&object, 1),
+        BACnetTimeStamp::SequenceNumber(41)
+    );
+    assert_eq!(timestamp_at(&object, 2), BACnetTimeStamp::SequenceNumber(0));
+    assert_eq!(timestamp_at(&object, 3), BACnetTimeStamp::SequenceNumber(0));
+
+    object
+        .commit_event_transition_internal(EventTransitionCommit {
+            change: EventStateChange {
+                from: EventState::HIGH_LIMIT,
+                to: EventState::HIGH_LIMIT,
+            },
+            coordinate: EventTransition::ToOffnormal,
+            ack_required: false,
+            timestamp: BACnetTimeStamp::SequenceNumber(42),
+            message_text: None,
+        })
+        .unwrap();
+    assert_eq!(
+        timestamp_at(&object, 1),
+        BACnetTimeStamp::SequenceNumber(42)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0xE0],
+        }
+    );
+}
+
+#[test]
+fn rejected_stock_commit_changes_none_of_the_three_properties() {
+    let mut object = EventEnrollmentObject::new(2, "EE-reject", 0).unwrap();
+    let before = snapshot(&object);
+
+    assert_eq!(
+        object.commit_event_transition_internal(EventTransitionCommit {
+            change: EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            coordinate: EventTransition::ToNormal,
+            ack_required: true,
+            timestamp: BACnetTimeStamp::SequenceNumber(99),
+            message_text: None,
+        }),
+        Err(EventTransitionCommitError::CoordinateTargetMismatch {
+            coordinate: EventTransition::ToNormal,
+            target: EventState::HIGH_LIMIT,
+        })
+    );
+    assert_eq!(snapshot(&object), before);
+}

--- a/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
@@ -1,4 +1,5 @@
 mod alert;
+mod atomic_commit;
 mod detection_enable;
 mod enrollment;
 mod fault_parameters;

--- a/crates/bacnet-objects/src/event_enrollment/transition.rs
+++ b/crates/bacnet-objects/src/event_enrollment/transition.rs
@@ -1,0 +1,46 @@
+use crate::event::history::{EventHistory, EventTransitionState};
+use crate::event::{EventTransitionCommit, EventTransitionCommitError};
+use bacnet_types::enums::EventState;
+
+pub(super) fn commit_event_transition(
+    event_state: &mut u32,
+    acked_transitions: &mut u8,
+    event_history: &mut EventHistory,
+    commit: EventTransitionCommit,
+) -> Result<(), EventTransitionCommitError> {
+    // Event Enrollment stores Event_State as its wire enumeration. Stage
+    // typed and cloned locals so validation and kernel mutation complete
+    // before any object-owned field changes.
+    let mut typed_event_state = EventState::from_raw(*event_state);
+    let mut staged_acknowledgments = *acked_transitions;
+    let mut staged_history = event_history.clone();
+    EventTransitionState::new(
+        &mut typed_event_state,
+        &mut staged_acknowledgments,
+        &mut staged_history,
+    )
+    .commit(commit)?;
+
+    *event_state = typed_event_state.to_raw();
+    *acked_transitions = staged_acknowledgments;
+    *event_history = staged_history;
+    Ok(())
+}
+
+macro_rules! impl_event_enrollment_transition_commit {
+    () => {
+        fn commit_event_transition_internal(
+            &mut self,
+            commit: EventTransitionCommit,
+        ) -> Result<(), EventTransitionCommitError> {
+            transition::commit_event_transition(
+                &mut self.event_state,
+                &mut self.acked_transitions,
+                &mut self.event_history,
+                commit,
+            )
+        }
+    };
+}
+
+pub(super) use impl_event_enrollment_transition_commit;

--- a/crates/bacnet-server/src/event_enrollment/commit.rs
+++ b/crates/bacnet-server/src/event_enrollment/commit.rs
@@ -1,0 +1,317 @@
+use std::collections::{HashMap, HashSet};
+
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_objects::event::{
+    EventStateChange, EventTransition, EventTransitionCommit, EventTransitionCommitError,
+};
+use bacnet_objects::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource};
+use bacnet_types::enums::{EventState, EventType, PropertyIdentifier};
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+
+use super::EventEnrollmentTransition;
+use crate::server::event_timestamp::{confirm_event_timestamp, stage_event_timestamp};
+
+/// Stage at which an Event Enrollment evaluation result was committed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventEnrollmentEvaluationStage {
+    /// The enrollment produced no mutation or transition proposal.
+    Evaluation,
+    /// Monitored-source ownership was being updated.
+    EvaluationSource,
+    /// Private countdown or baseline state was being updated.
+    EvaluationState,
+    /// The atomic Event_State/Acked_Transitions/Event_Time_Stamps hook ran.
+    EventTransition,
+}
+
+/// Observable result of one Event Enrollment commit stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventEnrollmentEvaluationOutcome {
+    /// Evaluation completed without a transition.
+    NoTransition,
+    /// A pending transition was canceled and its private state was stored.
+    CancellationCommitted,
+    /// A required internal mutation was rejected.
+    Rejected,
+    /// A custom hook returned an error after the target Event_State landed.
+    ///
+    /// This violates the atomic hook contract. The evaluator suppresses the
+    /// transition token, does not consume the staged clockless sequence
+    /// number, and invalidates private evaluation state for a later reset.
+    LandedAfterError,
+}
+
+impl EventEnrollmentEvaluationOutcome {
+    /// Whether this outcome represents a commit failure.
+    pub fn is_failure(self) -> bool {
+        matches!(self, Self::Rejected | Self::LandedAfterError)
+    }
+}
+
+/// One structured Event Enrollment evaluation diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventEnrollmentEvaluationDiagnostic {
+    /// Enrollment whose evaluation produced this diagnostic.
+    pub enrollment_oid: ObjectIdentifier,
+    /// Commit stage that produced the outcome.
+    pub stage: EventEnrollmentEvaluationStage,
+    /// Observable stage outcome.
+    pub outcome: EventEnrollmentEvaluationOutcome,
+}
+
+/// Detailed result of one Event Enrollment evaluation pass.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct EventEnrollmentEvaluationReport {
+    /// Transitions whose complete atomic object commit succeeded.
+    pub transitions: Vec<EventEnrollmentTransition>,
+    /// Non-transition and failure diagnostics in enrollment evaluation order.
+    pub diagnostics: Vec<EventEnrollmentEvaluationDiagnostic>,
+}
+
+pub(crate) fn log_evaluation_failures(report: &EventEnrollmentEvaluationReport) {
+    for diagnostic in report
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.outcome.is_failure())
+    {
+        tracing::warn!(
+            enrollment = %diagnostic.enrollment_oid,
+            stage = ?diagnostic.stage,
+            outcome = ?diagnostic.outcome,
+            "Event enrollment: internal commit failed"
+        );
+    }
+}
+
+/// Coalesced desired mutation for one enrollment and one evaluation pass.
+#[derive(Default)]
+pub(super) struct EnrollmentUpdate {
+    eval_state: Option<EventEnrollmentEvalState>,
+    eval_source: Option<Option<EventEnrollmentMonitoredSource>>,
+    clears_invalidation: bool,
+    fired: Option<FiredTransition>,
+    canceled: bool,
+}
+
+pub(super) struct FiredTransition {
+    pub(super) monitored_oid: ObjectIdentifier,
+    pub(super) event_type_raw: u32,
+    pub(super) from: EventState,
+    pub(super) to: EventState,
+    pub(super) distribute: bool,
+    pub(super) ack_required: bool,
+}
+
+impl EnrollmentUpdate {
+    /// Replace the desired private state with the state reached later in the
+    /// same deterministic phase-1 flow. This is semantic coalescing: reset,
+    /// cancellation, and reseed operations all update one final snapshot.
+    pub(super) fn set_eval_state(&mut self, state: EventEnrollmentEvalState) {
+        self.eval_state = Some(state);
+    }
+
+    pub(super) fn reset_eval_state(&mut self) {
+        self.eval_state = Some(EventEnrollmentEvalState::default());
+        self.clears_invalidation = true;
+    }
+
+    pub(super) fn cancel_pending(&mut self, state: EventEnrollmentEvalState) {
+        self.eval_state = Some(state);
+        self.canceled = true;
+    }
+
+    pub(super) fn set_eval_source(&mut self, source: Option<EventEnrollmentMonitoredSource>) {
+        self.eval_source = Some(source);
+    }
+
+    pub(super) fn fire(&mut self, fired: FiredTransition) {
+        debug_assert!(
+            self.fired.is_none(),
+            "one enrollment fires at most once per pass"
+        );
+        self.fired = Some(fired);
+    }
+}
+
+fn diagnostic(
+    enrollment_oid: ObjectIdentifier,
+    stage: EventEnrollmentEvaluationStage,
+    outcome: EventEnrollmentEvaluationOutcome,
+) -> EventEnrollmentEvaluationDiagnostic {
+    EventEnrollmentEvaluationDiagnostic {
+        enrollment_oid,
+        stage,
+        outcome,
+    }
+}
+
+fn event_state_landed(db: &ObjectDatabase, oid: &ObjectIdentifier, state: EventState) -> bool {
+    matches!(
+        db.get(oid)
+            .and_then(|object| object.read_property(PropertyIdentifier::EVENT_STATE, None).ok()),
+        Some(PropertyValue::Enumerated(raw)) if raw == state.to_raw()
+    )
+}
+
+fn clear_source_ownership(
+    db: &mut ObjectDatabase,
+    oid: ObjectIdentifier,
+    database_eval_sources: &HashSet<ObjectIdentifier>,
+) {
+    if database_eval_sources.contains(&oid) {
+        db.set_enrollment_eval_source(oid, None);
+    } else if let Some(object) = db.get_mut(&oid) {
+        let _ = object.set_enrollment_eval_source_internal(None);
+    }
+}
+
+pub(super) fn apply_updates(
+    db: &mut ObjectDatabase,
+    oids: &[ObjectIdentifier],
+    mut updates: HashMap<ObjectIdentifier, EnrollmentUpdate>,
+    database_eval_sources: &HashSet<ObjectIdentifier>,
+) -> EventEnrollmentEvaluationReport {
+    let mut report = EventEnrollmentEvaluationReport::default();
+
+    for &oid in oids {
+        let Some(update) = updates.remove(&oid) else {
+            report.diagnostics.push(diagnostic(
+                oid,
+                EventEnrollmentEvaluationStage::Evaluation,
+                EventEnrollmentEvaluationOutcome::NoTransition,
+            ));
+            continue;
+        };
+
+        let mut source_failed = false;
+        let mut state_failed = false;
+        if let Some(source) = update.eval_source {
+            if database_eval_sources.contains(&oid) {
+                db.set_enrollment_eval_source(oid, source);
+            } else {
+                let failed = db.get_mut(&oid).is_none_or(|object| {
+                    object.set_enrollment_eval_source_internal(source).is_err()
+                });
+                if failed {
+                    source_failed = true;
+                    report.diagnostics.push(diagnostic(
+                        oid,
+                        EventEnrollmentEvaluationStage::EvaluationSource,
+                        EventEnrollmentEvaluationOutcome::Rejected,
+                    ));
+                }
+            }
+        }
+
+        let mut state_committed = false;
+        if source_failed {
+            // Dependent state cannot retain an owner that failed to land.
+            // This is the single allowed private-state setter call this pass.
+            state_failed = db.get_mut(&oid).is_none_or(|object| {
+                object
+                    .set_enrollment_eval_state_internal(EventEnrollmentEvalState::default())
+                    .is_err()
+            });
+            if state_failed {
+                db.set_enrollment_eval_state_invalidated(oid, true);
+                report.diagnostics.push(diagnostic(
+                    oid,
+                    EventEnrollmentEvaluationStage::EvaluationState,
+                    EventEnrollmentEvaluationOutcome::Rejected,
+                ));
+            } else {
+                state_committed = true;
+            }
+        } else if let Some(state) = update.eval_state {
+            let state_failed = db
+                .get_mut(&oid)
+                .is_none_or(|object| object.set_enrollment_eval_state_internal(state).is_err());
+            if state_failed {
+                clear_source_ownership(db, oid, database_eval_sources);
+                db.set_enrollment_eval_state_invalidated(oid, true);
+                report.diagnostics.push(diagnostic(
+                    oid,
+                    EventEnrollmentEvaluationStage::EvaluationState,
+                    EventEnrollmentEvaluationOutcome::Rejected,
+                ));
+                continue;
+            }
+            state_committed = true;
+            if update.clears_invalidation {
+                db.set_enrollment_eval_state_invalidated(oid, false);
+            }
+        }
+
+        let Some(fired) = update.fired else {
+            report.diagnostics.push(diagnostic(
+                oid,
+                EventEnrollmentEvaluationStage::EvaluationState,
+                if update.canceled && state_committed {
+                    EventEnrollmentEvaluationOutcome::CancellationCommitted
+                } else {
+                    EventEnrollmentEvaluationOutcome::NoTransition
+                },
+            ));
+            continue;
+        };
+
+        if state_failed {
+            continue;
+        }
+
+        // A same-state transition depends on private state to distinguish the
+        // new indication from the previous one. Preserve the established
+        // stateless source-failure behavior only for a changing Event_State.
+        if source_failed && fired.from == fired.to {
+            continue;
+        }
+
+        let coordinate = EventTransition::for_target_state(fired.to);
+        let staged_timestamp = stage_event_timestamp(db);
+        let commit = EventTransitionCommit {
+            change: EventStateChange {
+                from: fired.from,
+                to: fired.to,
+            },
+            coordinate,
+            ack_required: fired.ack_required,
+            timestamp: staged_timestamp.sample.timestamp.clone(),
+            message_text: None,
+        };
+        let commit_result = db
+            .get_mut(&oid)
+            .map_or(Err(EventTransitionCommitError::Unsupported), |object| {
+                object.commit_event_transition_internal(commit)
+            });
+
+        if commit_result.is_err() {
+            let outcome = if fired.from != fired.to && event_state_landed(db, &oid, fired.to) {
+                EventEnrollmentEvaluationOutcome::LandedAfterError
+            } else {
+                EventEnrollmentEvaluationOutcome::Rejected
+            };
+            clear_source_ownership(db, oid, database_eval_sources);
+            db.set_enrollment_eval_state_invalidated(oid, true);
+            report.diagnostics.push(diagnostic(
+                oid,
+                EventEnrollmentEvaluationStage::EventTransition,
+                outcome,
+            ));
+            continue;
+        }
+
+        confirm_event_timestamp(db, staged_timestamp);
+        report.transitions.push(EventEnrollmentTransition {
+            enrollment_oid: oid,
+            monitored_oid: fired.monitored_oid,
+            change: EventStateChange {
+                from: fired.from,
+                to: fired.to,
+            },
+            event_type: EventType::from_raw(fired.event_type_raw),
+            distribute: fired.distribute,
+        });
+    }
+
+    report
+}

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -34,18 +34,24 @@
 //! `Acked_Transitions` bit is set/cleared per the referenced Notification
 //! Class's `Ack_Required` (Clause 13.2.3), and the transition is emitted with
 //! its `Event_Enable`-scoped `distribute` flag. What is NOT here, by design:
-//! `Event_Time_Stamps` / `Event_Message_Texts` are not modeled on the EE
-//! object (tranche E, #264), and no notification is sent (#127, tranche E) —
-//! the lifecycle task only logs the returned transitions.
+//! `Event_Time_Stamps` is committed atomically with `Event_State` and
+//! `Acked_Transitions`; `Event_Message_Texts` remains absent, and no
+//! notification is sent (#127) — the lifecycle task logs committed
+//! transitions and internal commit failures.
 
 mod algorithms;
+mod commit;
 mod reference;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 pub use algorithms::{
     encode_change_of_bitstring_params, encode_change_of_state_params,
     encode_change_of_value_params, encode_floating_limit_params, encode_out_of_range_params,
+};
+pub use commit::{
+    EventEnrollmentEvaluationDiagnostic, EventEnrollmentEvaluationOutcome,
+    EventEnrollmentEvaluationReport, EventEnrollmentEvaluationStage,
 };
 
 use algorithms::{
@@ -53,6 +59,8 @@ use algorithms::{
     eval_floating_limit_struct, eval_legacy_le_arm, eval_out_of_range_struct, extract_bitstring,
     extract_property_state_value, extract_real, ArmEvaluation,
 };
+pub(crate) use commit::log_evaluation_failures;
+use commit::{apply_updates, EnrollmentUpdate, FiredTransition};
 #[cfg(test)]
 use reference::MonitoredReference;
 use reference::{params_fingerprint, read_object_property_ref};
@@ -171,90 +179,38 @@ fn ack_required_for_transition(
     }
 }
 
-/// What phase 1 decided for one enrollment, applied under a mutable borrow in
-/// phase 2 (phase 1 holds immutable database borrows to read monitored
-/// objects, so all mutation is deferred).
-struct EnrollmentUpdate {
-    /// Evaluation state to write back — pending countdown and/or baselines —
-    /// when it changed this pass, even with no transition.
-    eval_state: Option<EventEnrollmentEvalState>,
-    /// Monitored-source ownership update for objects that support the channel.
-    eval_source: Option<Option<EventEnrollmentMonitoredSource>>,
-    /// Clear the database-level reset requirement if this state write lands.
-    clears_invalidation: bool,
-    /// A transition that fired this pass, with everything the transition
-    /// actions need.
-    fired: Option<FiredTransition>,
-}
-
-struct FiredTransition {
-    monitored_oid: ObjectIdentifier,
-    event_type_raw: u32,
-    from: EventState,
-    to: EventState,
-    distribute: bool,
-    transition_bit: u8,
-    ack_required: bool,
-}
-
-impl EnrollmentUpdate {
-    fn eval_state_only(eval_state: EventEnrollmentEvalState) -> Self {
-        Self {
-            eval_state: Some(eval_state),
-            eval_source: None,
-            clears_invalidation: false,
-            fired: None,
-        }
-    }
-
-    fn eval_source_only(source: Option<EventEnrollmentMonitoredSource>) -> Self {
-        Self {
-            eval_state: None,
-            eval_source: Some(source),
-            clears_invalidation: false,
-            fired: None,
-        }
-    }
-
-    fn eval_state_reset() -> Self {
-        Self {
-            eval_state: Some(EventEnrollmentEvalState::default()),
-            eval_source: None,
-            clears_invalidation: true,
-            fired: None,
-        }
-    }
-}
-
 fn queue_eval_state_reset(
-    updates: &mut Vec<(ObjectIdentifier, EnrollmentUpdate)>,
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
     oid: ObjectIdentifier,
     supported: bool,
     state: &EventEnrollmentEvalState,
 ) {
     if supported && *state != EventEnrollmentEvalState::default() {
-        updates.push((oid, EnrollmentUpdate::eval_state_reset()));
+        updates.entry(oid).or_default().reset_eval_state();
     }
 }
 
 fn queue_pending_cancellation(
-    updates: &mut Vec<(ObjectIdentifier, EnrollmentUpdate)>,
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
     oid: ObjectIdentifier,
     supported: bool,
     state: &mut EventEnrollmentEvalState,
 ) {
     if state.pending.take().is_some() && supported {
-        updates.push((oid, EnrollmentUpdate::eval_state_only(state.clone())));
+        updates
+            .entry(oid)
+            .or_default()
+            .cancel_pending(state.clone());
     }
 }
 
 fn queue_eval_source_reset(
-    updates: &mut Vec<(ObjectIdentifier, EnrollmentUpdate)>,
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
     oid: ObjectIdentifier,
     source: Option<Option<EventEnrollmentMonitoredSource>>,
 ) {
     if source.flatten().is_some() {
-        updates.push((oid, EnrollmentUpdate::eval_source_only(None)));
+        updates.entry(oid).or_default().set_eval_source(None);
     }
 }
 
@@ -289,6 +245,18 @@ pub fn evaluate_event_enrollments(
     db: &mut ObjectDatabase,
     interval_secs: u64,
 ) -> Vec<EventEnrollmentTransition> {
+    evaluate_event_enrollments_report(db, interval_secs).transitions
+}
+
+/// Evaluate all EventEnrollment objects and expose commit diagnostics.
+///
+/// Unlike [`evaluate_event_enrollments`], this detailed API makes rejected
+/// private-state and atomic transition commits observable. Only transitions
+/// whose complete object-owned commit succeeds appear in `transitions`.
+pub fn evaluate_event_enrollments_report(
+    db: &mut ObjectDatabase,
+    interval_secs: u64,
+) -> EventEnrollmentEvaluationReport {
     let interval_secs = interval_secs.max(1);
     let oids = db.find_by_type(ObjectType::EVENT_ENROLLMENT);
     // A qualified reference can identify self only when the containing Device
@@ -299,7 +267,7 @@ pub fn evaluate_event_enrollments(
         _ => None,
     };
 
-    let mut updates: Vec<(ObjectIdentifier, EnrollmentUpdate)> = Vec::new();
+    let mut updates: HashMap<ObjectIdentifier, EnrollmentUpdate> = HashMap::new();
     let mut database_eval_sources = HashSet::new();
 
     for oid in &oids {
@@ -350,7 +318,7 @@ pub fn evaluate_event_enrollments(
             let had_private_state = eval_state != EventEnrollmentEvalState::default();
             eval_state = EventEnrollmentEvalState::default();
             if eval_state_supported && (had_private_state || force_state_reset) {
-                updates.push((*oid, EnrollmentUpdate::eval_state_reset()));
+                updates.entry(*oid).or_default().reset_eval_state();
             }
         }
 
@@ -472,7 +440,10 @@ pub fn evaluate_event_enrollments(
             eval_state.pending = None;
             eval_state_dirty = false;
             if eval_state_supported {
-                updates.push((*oid, EnrollmentUpdate::eval_state_only(eval_state.clone())));
+                updates
+                    .entry(*oid)
+                    .or_default()
+                    .set_eval_state(eval_state.clone());
             }
         }
 
@@ -500,10 +471,10 @@ pub fn evaluate_event_enrollments(
         };
         let event_type = EventType::from_raw(event_type_raw);
         if eval_source.is_some_and(|current| current != Some(monitored_reference)) {
-            updates.push((
-                *oid,
-                EnrollmentUpdate::eval_source_only(Some(monitored_reference)),
-            ));
+            updates
+                .entry(*oid)
+                .or_default()
+                .set_eval_source(Some(monitored_reference));
         }
 
         let (time_delay, arm) = match &params {
@@ -675,7 +646,7 @@ pub fn evaluate_event_enrollments(
                 eval_state_dirty = true;
             }
             if eval_state_dirty && eval_state_supported {
-                updates.push((*oid, EnrollmentUpdate::eval_state_only(eval_state)));
+                updates.entry(*oid).or_default().set_eval_state(eval_state);
             }
             continue;
         };
@@ -728,7 +699,7 @@ pub fn evaluate_event_enrollments(
 
         let Some(fired) = fired else {
             if eval_state_dirty && eval_state_supported {
-                updates.push((*oid, EnrollmentUpdate::eval_state_only(eval_state)));
+                updates.entry(*oid).or_default().set_eval_state(eval_state);
             }
             continue;
         };
@@ -753,149 +724,21 @@ pub fn evaluate_event_enrollments(
         let distribute = event_enable & transition_bit != 0;
         let ack_required = ack_required_for_transition(db, enrollment, transition_bit);
 
-        updates.push((
-            *oid,
-            EnrollmentUpdate {
-                eval_state: (eval_state_dirty && eval_state_supported).then_some(eval_state),
-                eval_source: None,
-                clears_invalidation: false,
-                fired: Some(FiredTransition {
-                    monitored_oid,
-                    event_type_raw,
-                    from: current_state,
-                    to: fired.target,
-                    distribute,
-                    transition_bit,
-                    ack_required,
-                }),
-            },
-        ));
+        let update = updates.entry(*oid).or_default();
+        if eval_state_dirty && eval_state_supported {
+            update.set_eval_state(eval_state);
+        }
+        update.fire(FiredTransition {
+            monitored_oid,
+            event_type_raw,
+            from: current_state,
+            to: fired.target,
+            distribute,
+            ack_required,
+        });
     }
 
-    let mut transitions = Vec::new();
-    let mut source_failures = HashSet::new();
-    let mut state_failures = HashSet::new();
-    let mut invalidation_changes = Vec::new();
-    let mut database_source_changes = Vec::new();
-    for (oid, update) in updates {
-        let source_failed = source_failures.contains(&oid);
-        if state_failures.contains(&oid)
-            || (source_failed && update.eval_source.is_some())
-            || (source_failed && update.fired.is_none() && update.eval_state.is_some())
-        {
-            continue;
-        }
-        let Some(obj) = db.get_mut(&oid) else {
-            continue;
-        };
-        if let Some(source) = update.eval_source {
-            if database_eval_sources.contains(&oid) {
-                database_source_changes.push((oid, source));
-            } else if obj.set_enrollment_eval_source_internal(source).is_err() {
-                // State written later in this pass would have no reliable
-                // owner. Clear it and suppress dependent state updates, while
-                // allowing an immediate stateless transition to proceed.
-                if obj
-                    .set_enrollment_eval_state_internal(EventEnrollmentEvalState::default())
-                    .is_err()
-                {
-                    state_failures.insert(oid);
-                    invalidation_changes.push((oid, true));
-                }
-                source_failures.insert(oid);
-                continue;
-            }
-        }
-        if let Some(fired) = update.fired {
-            // Persist the transition through the internal lifecycle path, not
-            // the network `write_property(EVENT_STATE, …)` route. `Event_State`
-            // is algorithmically derived (ASHRAE 135-2020 Clause 12.12) and
-            // read-only over the network, so the evaluator reaches the field
-            // via `set_event_state_internal` (issue #130). The SPECIFIC
-            // returned state is stored — 13.2.2.1.4 forbids collapsing
-            // HIGH_LIMIT/LOW_LIMIT to OFFNORMAL — and the actions run for
-            // same-state transitions too (`from == to`).
-            if source_failed && fired.from == fired.to {
-                continue;
-            }
-            let mut persisted_eval_state = false;
-            if !source_failed {
-                if let Some(state) = update.eval_state {
-                    if obj.set_enrollment_eval_state_internal(state).is_err() {
-                        if database_eval_sources.contains(&oid) {
-                            database_source_changes.push((oid, None));
-                        } else {
-                            let _ = obj.set_enrollment_eval_source_internal(None);
-                        }
-                        state_failures.insert(oid);
-                        invalidation_changes.push((oid, true));
-                        continue;
-                    }
-                    persisted_eval_state = true;
-                }
-            }
-            let event_state_landed = fired.from == fired.to
-                || obj.set_event_state_internal(fired.to).is_ok()
-                || matches!(
-                    obj.read_property(PropertyIdentifier::EVENT_STATE, None),
-                    Ok(PropertyValue::Enumerated(state)) if state == fired.to.to_raw()
-                );
-            if !event_state_landed {
-                if persisted_eval_state {
-                    if obj
-                        .set_enrollment_eval_state_internal(EventEnrollmentEvalState::default())
-                        .is_err()
-                    {
-                        invalidation_changes.push((oid, true));
-                    }
-                    if database_eval_sources.contains(&oid) {
-                        database_source_changes.push((oid, None));
-                    } else {
-                        let _ = obj.set_enrollment_eval_source_internal(None);
-                    }
-                }
-                continue;
-            }
-            // 13.2.2.1.4's fourth action, alarm-acknowledgment half (13.2.3):
-            // with the transition's Ack_Required bit set, the corresponding
-            // Acked_Transitions bit is cleared (ack now owed); otherwise it is
-            // set. The notification-distribution half is tranche E's #127.
-            let _ = obj.set_acked_transitions_internal(fired.transition_bit, !fired.ack_required);
-            transitions.push(EventEnrollmentTransition {
-                enrollment_oid: oid,
-                monitored_oid: fired.monitored_oid,
-                change: EventStateChange {
-                    from: fired.from,
-                    to: fired.to,
-                },
-                event_type: EventType::from_raw(fired.event_type_raw),
-                distribute: fired.distribute,
-            });
-        } else if let Some(state) = update.eval_state {
-            if obj.set_enrollment_eval_state_internal(state).is_err() {
-                // A later source write must not claim state that failed to
-                // reset.
-                if database_eval_sources.contains(&oid) {
-                    database_source_changes.push((oid, None));
-                } else {
-                    let _ = obj.set_enrollment_eval_source_internal(None);
-                }
-                state_failures.insert(oid);
-                invalidation_changes.push((oid, true));
-            } else if update.clears_invalidation {
-                invalidation_changes.push((oid, false));
-            }
-        }
-    }
-
-    for (oid, source) in database_source_changes {
-        db.set_enrollment_eval_source(oid, source);
-    }
-    for (oid, invalidated) in invalidation_changes {
-        db.set_enrollment_eval_state_invalidated(oid, invalidated);
-    }
-
-    transitions
+    apply_updates(db, &oids, updates, &database_eval_sources)
 }
 
 #[cfg(test)]

--- a/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/custom_state.rs
@@ -504,7 +504,7 @@ fn same_state_transition_does_not_depend_on_rewriting_event_state() {
 }
 
 #[test]
-fn landed_event_state_is_reported_when_its_setter_returns_error() {
+fn mutation_then_error_is_visible_but_never_reports_a_transition() {
     let mut db = ObjectDatabase::new();
     let mut target = AnalogValueObject::new(112, "AV-landed-error", 62).unwrap();
     target
@@ -531,7 +531,17 @@ fn landed_event_state_is_reported_when_its_setter_returns_error() {
     let enrollment_oid = enrollment.object_identifier();
     db.add(Box::new(enrollment)).unwrap();
 
-    assert_eq!(evaluate_event_enrollments(&mut db, 1).len(), 1);
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert!(report.transitions.is_empty());
+    assert!(report
+        .diagnostics
+        .contains(&EventEnrollmentEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentEvaluationStage::EventTransition,
+            outcome: EventEnrollmentEvaluationOutcome::LandedAfterError,
+        }));
+    assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
+    assert_eq!(db.reserve_event_sequence_number().number(), 0);
     assert_eq!(
         db.get(&enrollment_oid)
             .unwrap()

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -9,7 +9,7 @@ use bacnet_objects::event_enrollment::EventEnrollmentObject;
 use bacnet_objects::traits::BACnetObject;
 use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetEventParameter};
 use std::borrow::Cow;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 // ---- Integration: multiple enrollments ----
@@ -217,10 +217,12 @@ pub(super) struct ReferenceValueObject {
     reference: Option<PropertyValue>,
     pub(super) event_parameters_readable: Arc<AtomicBool>,
     pub(super) state_writable: Arc<AtomicBool>,
+    pub(super) state_write_count: Arc<AtomicUsize>,
     pub(super) source_supported: bool,
     pub(super) source_writable: Arc<AtomicBool>,
     pub(super) normal_event_state_writable: bool,
     pub(super) event_state_error_after_write: bool,
+    pub(super) atomic_commit_supported: bool,
 }
 
 impl ReferenceValueObject {
@@ -246,10 +248,12 @@ impl ReferenceValueObject {
             reference,
             event_parameters_readable: Arc::new(AtomicBool::new(true)),
             state_writable: Arc::new(AtomicBool::new(true)),
+            state_write_count: Arc::new(AtomicUsize::new(0)),
             source_supported: true,
             source_writable: Arc::new(AtomicBool::new(true)),
             normal_event_state_writable: true,
             event_state_error_after_write: false,
+            atomic_commit_supported: true,
         }
     }
 }
@@ -313,6 +317,7 @@ impl BACnetObject for ReferenceValueObject {
         &mut self,
         state: bacnet_objects::event_enrollment::EventEnrollmentEvalState,
     ) -> Result<(), bacnet_types::error::Error> {
+        self.state_write_count.fetch_add(1, Ordering::SeqCst);
         if !self.state_writable.load(Ordering::SeqCst) {
             return Err(bacnet_types::error::Error::Encoding(
                 "evaluation state write failed".into(),
@@ -366,6 +371,21 @@ impl BACnetObject for ReferenceValueObject {
     ) -> Result<(), bacnet_types::error::Error> {
         self.inner
             .set_acked_transitions_internal(transition_bit, acknowledged)
+    }
+
+    fn commit_event_transition_internal(
+        &mut self,
+        commit: bacnet_objects::event::EventTransitionCommit,
+    ) -> Result<(), bacnet_objects::event::EventTransitionCommitError> {
+        if !self.atomic_commit_supported {
+            return Err(bacnet_objects::event::EventTransitionCommitError::Unsupported);
+        }
+        self.inner.commit_event_transition_internal(commit)?;
+        if self.event_state_error_after_write {
+            Err(bacnet_objects::event::EventTransitionCommitError::Unsupported)
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/crates/bacnet-server/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/mod.rs
@@ -11,6 +11,7 @@ mod foreign_state;
 mod integration;
 mod out_of_range;
 mod same_state;
+mod transactional_commit;
 
 use super::*;
 use bacnet_objects::analog::AnalogInputObject;

--- a/crates/bacnet-server/src/event_enrollment/tests/transactional_commit.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/transactional_commit.rs
@@ -1,0 +1,428 @@
+use super::integration::{indexed_reference_value, ReferenceValueObject};
+use super::*;
+use bacnet_encoding::primitives::decode_timestamp_choice;
+use bacnet_objects::analog::{AnalogInputObject, AnalogValueObject};
+use bacnet_objects::clock::{ClockFrame, ClockReader};
+use bacnet_objects::event_enrollment::EventEnrollmentObject;
+use bacnet_objects::notification_class::NotificationClass;
+use bacnet_types::constructed::{
+    BACnetDeviceObjectPropertyReference, BACnetEventParameter, ChangeOfValueCriteria,
+};
+use bacnet_types::primitives::{BACnetTimeStamp, Date, Time};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+struct FixedClock(ClockFrame);
+
+impl ClockReader for FixedClock {
+    fn read_clock(&self) -> Option<ClockFrame> {
+        Some(self.0)
+    }
+}
+
+fn timestamp_at(
+    db: &ObjectDatabase,
+    enrollment_oid: &ObjectIdentifier,
+    index: u32,
+) -> BACnetTimeStamp {
+    let PropertyValue::ApplicationData(bytes) = db
+        .get(enrollment_oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(index))
+        .unwrap()
+    else {
+        panic!("Event_Time_Stamps slot must be an encoded timestamp");
+    };
+    let (timestamp, end) = decode_timestamp_choice(&bytes, 0).unwrap();
+    assert_eq!(end, bytes.len());
+    timestamp
+}
+
+#[test]
+fn stock_transition_commits_timestamp_before_report_token_escapes() {
+    let (mut db, enrollment_oid, monitored_oid) = setup_out_of_range(90.0, 80.0, 20.0, 2.0);
+    let mut notification_class = NotificationClass::new(7, "NC-7").unwrap();
+    notification_class.ack_required = [true, false, false];
+    db.add(Box::new(notification_class)).unwrap();
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            None,
+            PropertyValue::Unsigned(7),
+            None,
+        )
+        .unwrap();
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+
+    assert_eq!(report.transitions.len(), 1);
+    assert_eq!(acked_transitions(&db, &enrollment_oid), 0b110);
+    assert_eq!(
+        timestamp_at(&db, &enrollment_oid, 1),
+        BACnetTimeStamp::SequenceNumber(0)
+    );
+    assert_eq!(db.reserve_event_sequence_number().number(), 1);
+
+    let monitored = db.get_mut(&monitored_oid).unwrap();
+    monitored
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    monitored
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(50.0),
+            None,
+        )
+        .unwrap();
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(report.transitions.len(), 1);
+    assert_eq!(report.transitions[0].change.to, EventState::NORMAL);
+    assert_eq!(acked_transitions(&db, &enrollment_oid), 0b110);
+    assert_eq!(
+        timestamp_at(&db, &enrollment_oid, 2),
+        BACnetTimeStamp::SequenceNumber(0)
+    );
+    assert_eq!(
+        timestamp_at(&db, &enrollment_oid, 3),
+        BACnetTimeStamp::SequenceNumber(1)
+    );
+    assert_eq!(db.reserve_event_sequence_number().number(), 2);
+}
+
+#[test]
+fn stock_transition_commits_exact_device_clock_datetime() {
+    let (mut db, enrollment_oid, _) = setup_out_of_range(90.0, 80.0, 20.0, 2.0);
+    let frame = ClockFrame {
+        local_date: Date {
+            year: 124,
+            month: 2,
+            day: 29,
+            day_of_week: 4,
+        },
+        local_time: Time {
+            hour: 12,
+            minute: 34,
+            second: 56,
+            hundredths: 78,
+        },
+        utc_offset: 300,
+        daylight_savings_status: true,
+    };
+    db.set_clock_reader(Some(Arc::new(FixedClock(frame))));
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+
+    assert_eq!(report.transitions.len(), 1);
+    assert_eq!(
+        timestamp_at(&db, &enrollment_oid, 1),
+        BACnetTimeStamp::DateTime {
+            date: frame.local_date,
+            time: frame.local_time,
+        }
+    );
+    assert_eq!(db.reserve_event_sequence_number().number(), 0);
+}
+
+fn acked_transitions(db: &ObjectDatabase, enrollment_oid: &ObjectIdentifier) -> u8 {
+    let PropertyValue::BitString { data, .. } = db
+        .get(enrollment_oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+        .unwrap()
+    else {
+        panic!("Acked_Transitions must be a bit string");
+    };
+    bacnet_types::bitstring::unpack_octet(&data, 3)
+}
+
+#[test]
+fn same_state_transition_still_commits_ack_and_history() {
+    let mut db = ObjectDatabase::new();
+    let mut monitored = AnalogInputObject::new(31, "AI-COV", 62).unwrap();
+    monitored.set_present_value(10.0);
+    let monitored_oid = monitored.object_identifier();
+    db.add(Box::new(monitored)).unwrap();
+
+    let mut enrollment =
+        EventEnrollmentObject::new(31, "EE-COV", EventType::CHANGE_OF_VALUE.to_raw()).unwrap();
+    enrollment.set_object_property_reference(Some(BACnetDeviceObjectPropertyReference::new_local(
+        monitored_oid,
+        PropertyIdentifier::PRESENT_VALUE.to_raw(),
+    )));
+    enrollment.set_event_parameters(BACnetEventParameter::ChangeOfValue {
+        time_delay: 0,
+        criteria: ChangeOfValueCriteria::ReferencedPropertyIncrement(5.0),
+    });
+    enrollment.set_notification_class(31);
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    let mut notification_class = NotificationClass::new(31, "NC-COV").unwrap();
+    notification_class.ack_required = [false, false, true];
+    db.add(Box::new(notification_class)).unwrap();
+
+    assert!(evaluate_event_enrollments_report(&mut db, 1)
+        .transitions
+        .is_empty());
+    let monitored = db.get_mut(&monitored_oid).unwrap();
+    monitored
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    monitored
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(20.0),
+            None,
+        )
+        .unwrap();
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(report.transitions.len(), 1);
+    assert_eq!(
+        report.transitions[0].change,
+        EventStateChange {
+            from: EventState::NORMAL,
+            to: EventState::NORMAL,
+        }
+    );
+    assert_eq!(acked_transitions(&db, &enrollment_oid), 0b011);
+    assert_eq!(
+        timestamp_at(&db, &enrollment_oid, 3),
+        BACnetTimeStamp::SequenceNumber(0)
+    );
+    assert_eq!(db.reserve_event_sequence_number().number(), 1);
+}
+
+fn setup_counted_delayed_enrollment() -> (
+    ObjectDatabase,
+    ObjectIdentifier,
+    ObjectIdentifier,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    let mut db = ObjectDatabase::new();
+    let mut monitored = AnalogValueObject::new(41, "AV-counted", 62).unwrap();
+    for index in [1, 2] {
+        monitored
+            .write_property(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                PropertyValue::Real(90.0),
+                Some(index),
+            )
+            .unwrap();
+    }
+    let monitored_oid = monitored.object_identifier();
+    db.add(Box::new(monitored)).unwrap();
+
+    let enrollment = ReferenceValueObject::new(Some(indexed_reference_value(monitored_oid, 1)));
+    let state_write_count = enrollment.state_write_count.clone();
+    let parameters_readable = enrollment.event_parameters_readable.clone();
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+    (
+        db,
+        enrollment_oid,
+        monitored_oid,
+        state_write_count,
+        parameters_readable,
+    )
+}
+
+#[test]
+fn valid_retarget_coalesces_reset_and_full_delay_reseed_to_one_state_write() {
+    let (mut db, enrollment_oid, monitored_oid, state_write_count, _) =
+        setup_counted_delayed_enrollment();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    state_write_count.store(0, Ordering::SeqCst);
+
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::OBJECT_PROPERTY_REFERENCE,
+            None,
+            indexed_reference_value(monitored_oid, 2),
+            None,
+        )
+        .unwrap();
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+
+    assert!(report.transitions.is_empty());
+    assert_eq!(state_write_count.load(Ordering::SeqCst), 1);
+    let pending = db
+        .get(&enrollment_oid)
+        .unwrap()
+        .enrollment_eval_state_internal()
+        .unwrap()
+        .pending
+        .unwrap();
+    assert_eq!(pending.remaining, 2, "retarget starts the complete delay");
+}
+
+#[test]
+fn later_unusable_input_commits_cancellation_once() {
+    let (mut db, enrollment_oid, _, state_write_count, parameters_readable) =
+        setup_counted_delayed_enrollment();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
+    state_write_count.store(0, Ordering::SeqCst);
+    parameters_readable.store(false, Ordering::SeqCst);
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+
+    assert!(report.transitions.is_empty());
+    assert_eq!(state_write_count.load(Ordering::SeqCst), 1);
+    assert!(db
+        .get(&enrollment_oid)
+        .unwrap()
+        .enrollment_eval_state_internal()
+        .unwrap()
+        .pending
+        .is_none());
+    assert!(report
+        .diagnostics
+        .contains(&EventEnrollmentEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentEvaluationStage::EvaluationState,
+            outcome: EventEnrollmentEvaluationOutcome::CancellationCommitted,
+        }));
+}
+
+#[test]
+fn source_and_state_rejection_never_claims_cancellation_committed() {
+    let mut db = ObjectDatabase::new();
+    let enrollment = ReferenceValueObject::new(None);
+    enrollment.source_writable.store(false, Ordering::SeqCst);
+    enrollment.state_writable.store(false, Ordering::SeqCst);
+    let state_write_count = Arc::clone(&enrollment.state_write_count);
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    let mut update = EnrollmentUpdate::default();
+    update.set_eval_source(Some((
+        ObjectIdentifier::new(ObjectType::ANALOG_VALUE, 9).unwrap(),
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+    )));
+    update.cancel_pending(EventEnrollmentEvalState::default());
+    let mut updates = std::collections::HashMap::new();
+    updates.insert(enrollment_oid, update);
+
+    let report = apply_updates(
+        &mut db,
+        &[enrollment_oid],
+        updates,
+        &std::collections::HashSet::new(),
+    );
+
+    assert!(report.transitions.is_empty());
+    assert_eq!(state_write_count.load(Ordering::SeqCst), 1);
+    assert!(report
+        .diagnostics
+        .contains(&EventEnrollmentEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentEvaluationStage::EvaluationSource,
+            outcome: EventEnrollmentEvaluationOutcome::Rejected,
+        }));
+    assert!(report
+        .diagnostics
+        .contains(&EventEnrollmentEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentEvaluationStage::EvaluationState,
+            outcome: EventEnrollmentEvaluationOutcome::Rejected,
+        }));
+    assert!(!report.diagnostics.iter().any(|diagnostic| {
+        diagnostic.outcome == EventEnrollmentEvaluationOutcome::CancellationCommitted
+    }));
+    assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
+}
+
+#[test]
+fn private_state_failure_is_reported_and_suppresses_transition() {
+    let mut db = ObjectDatabase::new();
+    let mut monitored = AnalogValueObject::new(42, "AV-state-failure", 62).unwrap();
+    monitored
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let monitored_oid = monitored.object_identifier();
+    db.add(Box::new(monitored)).unwrap();
+    let enrollment = ReferenceValueObject::new(Some(indexed_reference_value(monitored_oid, 1)));
+    enrollment.state_writable.store(false, Ordering::SeqCst);
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert!(report.transitions.is_empty());
+    assert!(report
+        .diagnostics
+        .contains(&EventEnrollmentEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentEvaluationStage::EvaluationState,
+            outcome: EventEnrollmentEvaluationOutcome::Rejected,
+        }));
+    assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
+}
+
+#[test]
+fn unsupported_atomic_hook_fails_closed_without_consuming_sequence() {
+    let mut db = ObjectDatabase::new();
+    let mut monitored = AnalogValueObject::new(43, "AV-unsupported-hook", 62).unwrap();
+    monitored
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let monitored_oid = monitored.object_identifier();
+    db.add(Box::new(monitored)).unwrap();
+    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(monitored_oid, 1)));
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::OutOfRange {
+            time_delay: 0,
+            low_limit: 20.0,
+            high_limit: 80.0,
+            deadband: 2.0,
+        });
+    enrollment.atomic_commit_supported = false;
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert!(report.transitions.is_empty());
+    assert!(report
+        .diagnostics
+        .contains(&EventEnrollmentEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentEvaluationStage::EventTransition,
+            outcome: EventEnrollmentEvaluationOutcome::Rejected,
+        }));
+    assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
+    assert_eq!(db.reserve_event_sequence_number().number(), 0);
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        PropertyValue::Enumerated(EventState::NORMAL.to_raw())
+    );
+}

--- a/crates/bacnet-server/src/server/event_timestamp.rs
+++ b/crates/bacnet-server/src/server/event_timestamp.rs
@@ -3,26 +3,26 @@ use bacnet_objects::database::{EventSequenceReservation, ObjectDatabase};
 use bacnet_types::primitives::BACnetTimeStamp;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum SampledEventClock {
+pub(crate) enum SampledEventClock {
     Valid(ClockFrame),
     Unavailable,
     Invalid,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(super) struct EventTimestampSample {
-    pub(super) timestamp: BACnetTimeStamp,
-    pub(super) clock: SampledEventClock,
+pub(crate) struct EventTimestampSample {
+    pub(crate) timestamp: BACnetTimeStamp,
+    pub(crate) clock: SampledEventClock,
 }
 
 /// A timestamp selected without consuming the clockless sequence source.
-pub(super) struct StagedEventTimestamp {
-    pub(super) sample: EventTimestampSample,
+pub(crate) struct StagedEventTimestamp {
+    pub(crate) sample: EventTimestampSample,
     sequence: Option<EventSequenceReservation>,
 }
 
 /// Select a timestamp while leaving a clockless sequence retryable.
-pub(super) fn stage_event_timestamp(db: &ObjectDatabase) -> StagedEventTimestamp {
+pub(crate) fn stage_event_timestamp(db: &ObjectDatabase) -> StagedEventTimestamp {
     match db.clock_frame() {
         Some(frame) if frame.is_valid_actual_datetime() => StagedEventTimestamp {
             sample: EventTimestampSample {
@@ -52,7 +52,7 @@ pub(super) fn stage_event_timestamp(db: &ObjectDatabase) -> StagedEventTimestamp
 }
 
 /// Confirm staged sequence consumption after the transition commit succeeds.
-pub(super) fn confirm_event_timestamp(
+pub(crate) fn confirm_event_timestamp(
     db: &mut ObjectDatabase,
     staged: StagedEventTimestamp,
 ) -> EventTimestampSample {

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -534,11 +534,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 loop {
                     interval.tick().await;
                     let mut db_guard = db_ee.write().await;
-                    let transitions = crate::event_enrollment::evaluate_event_enrollments(
+                    let report = crate::event_enrollment::evaluate_event_enrollments_report(
                         &mut db_guard,
                         ee_interval_secs,
                     );
-                    for t in &transitions {
+                    for t in &report.transitions {
                         // `distribute` is logged rather than acted on: this task
                         // records Event_State but does not yet emit
                         // EventNotifications (#127). Surfacing it keeps an
@@ -554,6 +554,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             "Event enrollment: state changed"
                         );
                     }
+                    crate::event_enrollment::log_evaluation_failures(&report);
                 }
             }))
         } else {

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -1000,7 +1000,7 @@ mod cov_clock;
 mod cov_notifications;
 mod dispatch;
 mod event_notifications;
-mod event_timestamp;
+pub(crate) mod event_timestamp;
 mod lifecycle;
 mod notification_transactions;
 mod requests;


### PR DESCRIPTION
## Summary

- coalesce each Event Enrollment object to one final private evaluator update per pass while retaining the existing transition-vector API and adding a diagnostic report API
- atomically commit Event_State, Acked_Transitions, and Event_Time_Stamps through the object transition hook
- fail closed and surface lifecycle warnings when custom object hooks reject or violate the atomic contract

## Standard references

ASHRAE Standard 135-2020 §12.12, §13.2.2.1.4, §13.2.3, and §13.3.

## Validation

- cargo test -p bacnet-server event_enrollment::tests::transactional_commit
- cargo test -p bacnet-objects event_enrollment::tests::atomic_commit
- cargo test -p bacnet-server --locked
- cargo test -p bacnet-objects --locked
- cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls,bacnet-transport/serial,bacnet-transport/ethernet
- cargo check -p rusty-bacnet --tests --locked
- cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked
- cargo fmt --all -- --check
- repository conformance, file-size, no-secret, and diff checks

Closes #303
Closes #304
