### PR TITLE
Event Enrollment: add atomic Reliability and FAULT evaluation

### DIFF
--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -20,6 +20,7 @@ mod state;
 mod transition;
 use state::{AlertEnrollmentWriteRollback, EventEnrollmentWriteRollback};
 pub use state::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource, EventEnrollmentPending};
+pub use transition::EventEnrollmentReliabilityCommit;
 
 /// BACnet EventEnrollment object.
 ///

--- a/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/mod.rs
@@ -4,6 +4,7 @@ mod detection_enable;
 mod enrollment;
 mod fault_parameters;
 mod object_name;
+mod reliability_commit;
 mod status_flags;
 mod time_delay_normal;
 mod timestamps;

--- a/crates/bacnet-objects/src/event_enrollment/tests/reliability_commit.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/reliability_commit.rs
@@ -1,0 +1,168 @@
+use super::super::*;
+use crate::event::{
+    EventStateChange, EventTransition, EventTransitionCommit, EventTransitionCommitError,
+};
+use bacnet_encoding::primitives::decode_timestamp_choice;
+use bacnet_types::enums::Reliability;
+use bacnet_types::primitives::BACnetTimeStamp;
+
+fn timestamp_at(object: &EventEnrollmentObject, index: u32) -> BACnetTimeStamp {
+    let PropertyValue::ApplicationData(bytes) = object
+        .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(index))
+        .unwrap()
+    else {
+        panic!("Event_Time_Stamps slot must be encoded application data");
+    };
+    let (timestamp, end) = decode_timestamp_choice(&bytes, 0).unwrap();
+    assert_eq!(end, bytes.len());
+    timestamp
+}
+
+fn snapshot(object: &EventEnrollmentObject) -> [PropertyValue; 5] {
+    [
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        object
+            .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+            .unwrap(),
+        object
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        object
+            .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+            .unwrap(),
+        object
+            .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
+            .unwrap(),
+    ]
+}
+
+fn transition(from: EventState, to: EventState, timestamp: u16) -> EventTransitionCommit {
+    EventTransitionCommit {
+        change: EventStateChange { from, to },
+        coordinate: EventTransition::for_target_state(to),
+        ack_required: true,
+        timestamp: BACnetTimeStamp::SequenceNumber(timestamp),
+        message_text: None,
+    }
+}
+
+#[test]
+fn stock_reliability_commit_is_atomic_across_fault_reentry_and_recovery() {
+    let mut object = EventEnrollmentObject::new(31, "EE-reliability", 0).unwrap();
+
+    object
+        .commit_event_enrollment_reliability_internal(EventEnrollmentReliabilityCommit {
+            reliability: Reliability::UNDER_RANGE,
+            transition: Some(transition(EventState::NORMAL, EventState::FAULT, 11)),
+        })
+        .unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::UNDER_RANGE.to_raw())
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 4,
+            data: vec![0xC0],
+        }
+    );
+    assert_eq!(
+        timestamp_at(&object, 2),
+        BACnetTimeStamp::SequenceNumber(11)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0xA0],
+        }
+    );
+
+    object
+        .commit_event_enrollment_reliability_internal(EventEnrollmentReliabilityCommit {
+            reliability: Reliability::OVER_RANGE,
+            transition: Some(transition(EventState::FAULT, EventState::FAULT, 12)),
+        })
+        .unwrap();
+    assert_eq!(
+        timestamp_at(&object, 2),
+        BACnetTimeStamp::SequenceNumber(12)
+    );
+
+    object
+        .commit_event_enrollment_reliability_internal(EventEnrollmentReliabilityCommit {
+            reliability: Reliability::NO_FAULT_DETECTED,
+            transition: Some(transition(EventState::FAULT, EventState::NORMAL, 13)),
+        })
+        .unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 4,
+            data: vec![0],
+        }
+    );
+    assert_eq!(
+        timestamp_at(&object, 3),
+        BACnetTimeStamp::SequenceNumber(13)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+            .unwrap(),
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0x80],
+        }
+    );
+}
+
+#[test]
+fn rejected_stock_reliability_commit_changes_nothing() {
+    let mut object = EventEnrollmentObject::new(32, "EE-reliability-reject", 0).unwrap();
+    let before = snapshot(&object);
+
+    let mut invalid = transition(EventState::NORMAL, EventState::FAULT, 99);
+    invalid.coordinate = EventTransition::ToNormal;
+    assert_eq!(
+        object.commit_event_enrollment_reliability_internal(EventEnrollmentReliabilityCommit {
+            reliability: Reliability::CONFIGURATION_ERROR,
+            transition: Some(invalid),
+        }),
+        Err(EventTransitionCommitError::CoordinateTargetMismatch {
+            coordinate: EventTransition::ToNormal,
+            target: EventState::FAULT,
+        })
+    );
+    assert_eq!(snapshot(&object), before);
+}
+
+#[test]
+fn network_reliability_write_remains_denied() {
+    let mut object = EventEnrollmentObject::new(33, "EE-network-reliability", 0).unwrap();
+    assert!(object
+        .write_property(
+            PropertyIdentifier::RELIABILITY,
+            None,
+            PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
+            None,
+        )
+        .is_err());
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw())
+    );
+}

--- a/crates/bacnet-objects/src/event_enrollment/transition.rs
+++ b/crates/bacnet-objects/src/event_enrollment/transition.rs
@@ -1,6 +1,19 @@
 use crate::event::history::{EventHistory, EventTransitionState};
 use crate::event::{EventTransitionCommit, EventTransitionCommitError};
-use bacnet_types::enums::EventState;
+use bacnet_types::enums::{EventState, Reliability};
+
+/// All object-owned values needed to commit Event Enrollment Reliability.
+///
+/// A transition is present whenever a Reliability observation indicates a
+/// FAULT entry, re-entry, or recovery. Keeping it optional also permits an
+/// idempotent Reliability-only commit without fabricating event history.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EventEnrollmentReliabilityCommit {
+    /// Desired value of the Event Enrollment object's Reliability property.
+    pub reliability: Reliability,
+    /// Event transition to commit atomically with Reliability, when indicated.
+    pub transition: Option<EventTransitionCommit>,
+}
 
 pub(super) fn commit_event_transition(
     event_state: &mut u32,
@@ -27,6 +40,36 @@ pub(super) fn commit_event_transition(
     Ok(())
 }
 
+pub(super) fn commit_reliability(
+    reliability: &mut u32,
+    event_state: &mut u32,
+    acked_transitions: &mut u8,
+    event_history: &mut EventHistory,
+    commit: EventEnrollmentReliabilityCommit,
+) -> Result<(), EventTransitionCommitError> {
+    // Reliability is staged alongside the three event-transition stores. A
+    // rejected transition therefore leaves all four properties unchanged.
+    let staged_reliability = commit.reliability.to_raw();
+    let mut typed_event_state = EventState::from_raw(*event_state);
+    let mut staged_acknowledgments = *acked_transitions;
+    let mut staged_history = event_history.clone();
+
+    if let Some(transition) = commit.transition {
+        EventTransitionState::new(
+            &mut typed_event_state,
+            &mut staged_acknowledgments,
+            &mut staged_history,
+        )
+        .commit(transition)?;
+    }
+
+    *reliability = staged_reliability;
+    *event_state = typed_event_state.to_raw();
+    *acked_transitions = staged_acknowledgments;
+    *event_history = staged_history;
+    Ok(())
+}
+
 macro_rules! impl_event_enrollment_transition_commit {
     () => {
         fn commit_event_transition_internal(
@@ -34,6 +77,19 @@ macro_rules! impl_event_enrollment_transition_commit {
             commit: EventTransitionCommit,
         ) -> Result<(), EventTransitionCommitError> {
             transition::commit_event_transition(
+                &mut self.event_state,
+                &mut self.acked_transitions,
+                &mut self.event_history,
+                commit,
+            )
+        }
+
+        fn commit_event_enrollment_reliability_internal(
+            &mut self,
+            commit: $crate::event_enrollment::EventEnrollmentReliabilityCommit,
+        ) -> Result<(), EventTransitionCommitError> {
+            transition::commit_reliability(
+                &mut self.reliability,
                 &mut self.event_state,
                 &mut self.acked_transitions,
                 &mut self.event_history,

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -13,7 +13,9 @@ use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
 use crate::clock::ClockReader;
 use crate::event::{EventTransitionCommit, EventTransitionCommitError, TransitionOutcome};
-use crate::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource};
+use crate::event_enrollment::{
+    EventEnrollmentEvalState, EventEnrollmentMonitoredSource, EventEnrollmentReliabilityCommit,
+};
 use crate::file::FileStorage;
 
 /// Object-owned state that cannot be reconstructed from property readback.
@@ -312,6 +314,22 @@ pub trait BACnetObject: Send + Sync {
     fn commit_event_transition_internal(
         &mut self,
         _commit: EventTransitionCommit,
+    ) -> Result<(), EventTransitionCommitError> {
+        Err(EventTransitionCommitError::Unsupported)
+    }
+
+    /// Atomically commit Event Enrollment Reliability and transition state.
+    ///
+    /// This Event Enrollment-specific channel joins `Reliability` to the
+    /// existing atomic `Event_State`, `Acked_Transitions`, and
+    /// `Event_Time_Stamps` commit. Implementations must stage every supplied
+    /// value before assigning object-owned fields and leave them unchanged on
+    /// error. The default fails closed for custom objects that have not adopted
+    /// the stronger contract.
+    #[doc(hidden)]
+    fn commit_event_enrollment_reliability_internal(
+        &mut self,
+        _commit: EventEnrollmentReliabilityCommit,
     ) -> Result<(), EventTransitionCommitError> {
         Err(EventTransitionCommitError::Unsupported)
     }

--- a/crates/bacnet-server/src/event_enrollment/commit.rs
+++ b/crates/bacnet-server/src/event_enrollment/commit.rs
@@ -21,8 +21,6 @@ pub enum EventEnrollmentEvaluationStage {
     EvaluationSource,
     /// Private countdown or baseline state was being updated.
     EvaluationState,
-    /// Reliability observation or the combined Reliability transition hook ran.
-    Reliability,
     /// The atomic Event_State/Acked_Transitions/Event_Time_Stamps hook ran.
     EventTransition,
 }
@@ -34,10 +32,6 @@ pub enum EventEnrollmentEvaluationOutcome {
     NoTransition,
     /// A pending transition was canceled and its private state was stored.
     CancellationCommitted,
-    /// A required local or remote observation was temporarily unavailable.
-    ///
-    /// No Reliability, event, history, or private evaluator state is changed.
-    ObservationUnavailable,
     /// A required internal mutation was rejected.
     Rejected,
     /// A custom hook returned an error after the target Event_State landed.
@@ -64,6 +58,60 @@ pub struct EventEnrollmentEvaluationDiagnostic {
     pub stage: EventEnrollmentEvaluationStage,
     /// Observable stage outcome.
     pub outcome: EventEnrollmentEvaluationOutcome,
+}
+
+/// Stage exposed by the additive detailed Event Enrollment evaluator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventEnrollmentDetailedEvaluationStage {
+    /// The enrollment produced no mutation or transition proposal.
+    Evaluation,
+    /// Monitored-source ownership was being updated.
+    EvaluationSource,
+    /// Private countdown or baseline state was being updated.
+    EvaluationState,
+    /// Reliability observation or the combined Reliability transition hook ran.
+    Reliability,
+    /// The atomic Event_State/Acked_Transitions/Event_Time_Stamps hook ran.
+    EventTransition,
+}
+
+/// Outcome exposed by the additive detailed Event Enrollment evaluator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventEnrollmentDetailedEvaluationOutcome {
+    /// Evaluation completed without a transition.
+    NoTransition,
+    /// A pending transition was canceled and its private state was stored.
+    CancellationCommitted,
+    /// A required local or remote observation was temporarily unavailable.
+    ///
+    /// No Reliability, event, history, or private evaluator state is changed.
+    ObservationUnavailable,
+    /// A required internal mutation was rejected.
+    Rejected,
+    /// A custom hook returned an error after Reliability or Event_State landed.
+    ///
+    /// This violates the atomic hook contract. The evaluator suppresses the
+    /// result token, does not consume the staged clockless sequence number,
+    /// and invalidates private evaluation state for a later reset.
+    LandedAfterError,
+}
+
+impl EventEnrollmentDetailedEvaluationOutcome {
+    /// Whether this outcome represents a commit failure.
+    pub fn is_failure(self) -> bool {
+        matches!(self, Self::Rejected | Self::LandedAfterError)
+    }
+}
+
+/// One diagnostic from the additive detailed Event Enrollment evaluator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EventEnrollmentDetailedEvaluationDiagnostic {
+    /// Enrollment whose evaluation produced this diagnostic.
+    pub enrollment_oid: ObjectIdentifier,
+    /// Evaluation or commit stage that produced the outcome.
+    pub stage: EventEnrollmentDetailedEvaluationStage,
+    /// Observable stage outcome.
+    pub outcome: EventEnrollmentDetailedEvaluationOutcome,
 }
 
 /// Precedence source that selected a committed Event Enrollment Reliability.
@@ -96,18 +144,86 @@ pub struct EventEnrollmentReliabilityResult {
     pub cause: EventEnrollmentReliabilityCause,
 }
 
-/// Detailed result of one Event Enrollment evaluation pass.
+/// Legacy result of one Event Enrollment evaluation pass.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct EventEnrollmentEvaluationReport {
     /// Transitions whose complete atomic object commit succeeded.
     pub transitions: Vec<EventEnrollmentTransition>,
-    /// Reliability results whose complete combined object commit succeeded.
-    pub reliability_results: Vec<EventEnrollmentReliabilityResult>,
     /// Non-transition and failure diagnostics in enrollment evaluation order.
     pub diagnostics: Vec<EventEnrollmentEvaluationDiagnostic>,
 }
 
-pub(crate) fn log_evaluation_report(report: &EventEnrollmentEvaluationReport) {
+/// Additive detailed result of one Event Enrollment evaluation pass.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct EventEnrollmentDetailedEvaluationReport {
+    /// Transitions whose complete atomic object commit succeeded.
+    pub transitions: Vec<EventEnrollmentTransition>,
+    /// Reliability results whose complete combined object commit succeeded.
+    pub reliability_results: Vec<EventEnrollmentReliabilityResult>,
+    /// Every detailed evaluation, observation, and commit diagnostic.
+    pub diagnostics: Vec<EventEnrollmentDetailedEvaluationDiagnostic>,
+}
+
+impl EventEnrollmentDetailedEvaluationReport {
+    pub(super) fn into_legacy(self) -> EventEnrollmentEvaluationReport {
+        let diagnostics = self
+            .diagnostics
+            .into_iter()
+            .map(|diagnostic| {
+                let stage = match (diagnostic.stage, diagnostic.outcome) {
+                    (
+                        EventEnrollmentDetailedEvaluationStage::Reliability,
+                        EventEnrollmentDetailedEvaluationOutcome::ObservationUnavailable
+                        | EventEnrollmentDetailedEvaluationOutcome::NoTransition,
+                    ) => EventEnrollmentEvaluationStage::Evaluation,
+                    (EventEnrollmentDetailedEvaluationStage::Reliability, _) => {
+                        EventEnrollmentEvaluationStage::EventTransition
+                    }
+                    (EventEnrollmentDetailedEvaluationStage::Evaluation, _) => {
+                        EventEnrollmentEvaluationStage::Evaluation
+                    }
+                    (EventEnrollmentDetailedEvaluationStage::EvaluationSource, _) => {
+                        EventEnrollmentEvaluationStage::EvaluationSource
+                    }
+                    (EventEnrollmentDetailedEvaluationStage::EvaluationState, _) => {
+                        EventEnrollmentEvaluationStage::EvaluationState
+                    }
+                    (EventEnrollmentDetailedEvaluationStage::EventTransition, _) => {
+                        EventEnrollmentEvaluationStage::EventTransition
+                    }
+                };
+                let outcome = match diagnostic.outcome {
+                    EventEnrollmentDetailedEvaluationOutcome::ObservationUnavailable => {
+                        EventEnrollmentEvaluationOutcome::NoTransition
+                    }
+                    EventEnrollmentDetailedEvaluationOutcome::NoTransition => {
+                        EventEnrollmentEvaluationOutcome::NoTransition
+                    }
+                    EventEnrollmentDetailedEvaluationOutcome::CancellationCommitted => {
+                        EventEnrollmentEvaluationOutcome::CancellationCommitted
+                    }
+                    EventEnrollmentDetailedEvaluationOutcome::Rejected => {
+                        EventEnrollmentEvaluationOutcome::Rejected
+                    }
+                    EventEnrollmentDetailedEvaluationOutcome::LandedAfterError => {
+                        EventEnrollmentEvaluationOutcome::LandedAfterError
+                    }
+                };
+                EventEnrollmentEvaluationDiagnostic {
+                    enrollment_oid: diagnostic.enrollment_oid,
+                    stage,
+                    outcome,
+                }
+            })
+            .collect();
+        EventEnrollmentEvaluationReport {
+            transitions: self.transitions,
+            diagnostics,
+        }
+    }
+}
+
+pub(crate) fn log_evaluation_report(report: &EventEnrollmentDetailedEvaluationReport) {
     for result in &report.reliability_results {
         tracing::debug!(
             enrollment = %result.enrollment_oid,
@@ -211,10 +327,10 @@ impl EnrollmentUpdate {
 
 fn diagnostic(
     enrollment_oid: ObjectIdentifier,
-    stage: EventEnrollmentEvaluationStage,
-    outcome: EventEnrollmentEvaluationOutcome,
-) -> EventEnrollmentEvaluationDiagnostic {
-    EventEnrollmentEvaluationDiagnostic {
+    stage: EventEnrollmentDetailedEvaluationStage,
+    outcome: EventEnrollmentDetailedEvaluationOutcome,
+) -> EventEnrollmentDetailedEvaluationDiagnostic {
+    EventEnrollmentDetailedEvaluationDiagnostic {
         enrollment_oid,
         stage,
         outcome,
@@ -267,15 +383,15 @@ pub(super) fn apply_updates(
     oids: &[ObjectIdentifier],
     mut updates: HashMap<ObjectIdentifier, EnrollmentUpdate>,
     database_eval_sources: &HashSet<ObjectIdentifier>,
-) -> EventEnrollmentEvaluationReport {
-    let mut report = EventEnrollmentEvaluationReport::default();
+) -> EventEnrollmentDetailedEvaluationReport {
+    let mut report = EventEnrollmentDetailedEvaluationReport::default();
 
     for &oid in oids {
         let Some(update) = updates.remove(&oid) else {
             report.diagnostics.push(diagnostic(
                 oid,
-                EventEnrollmentEvaluationStage::Evaluation,
-                EventEnrollmentEvaluationOutcome::NoTransition,
+                EventEnrollmentDetailedEvaluationStage::Evaluation,
+                EventEnrollmentDetailedEvaluationOutcome::NoTransition,
             ));
             continue;
         };
@@ -283,8 +399,8 @@ pub(super) fn apply_updates(
         if update.observation_unavailable {
             report.diagnostics.push(diagnostic(
                 oid,
-                EventEnrollmentEvaluationStage::Reliability,
-                EventEnrollmentEvaluationOutcome::ObservationUnavailable,
+                EventEnrollmentDetailedEvaluationStage::Reliability,
+                EventEnrollmentDetailedEvaluationOutcome::ObservationUnavailable,
             ));
             continue;
         }
@@ -302,8 +418,8 @@ pub(super) fn apply_updates(
                     source_failed = true;
                     report.diagnostics.push(diagnostic(
                         oid,
-                        EventEnrollmentEvaluationStage::EvaluationSource,
-                        EventEnrollmentEvaluationOutcome::Rejected,
+                        EventEnrollmentDetailedEvaluationStage::EvaluationSource,
+                        EventEnrollmentDetailedEvaluationOutcome::Rejected,
                     ));
                 }
             }
@@ -322,8 +438,8 @@ pub(super) fn apply_updates(
                 db.set_enrollment_eval_state_invalidated(oid, true);
                 report.diagnostics.push(diagnostic(
                     oid,
-                    EventEnrollmentEvaluationStage::EvaluationState,
-                    EventEnrollmentEvaluationOutcome::Rejected,
+                    EventEnrollmentDetailedEvaluationStage::EvaluationState,
+                    EventEnrollmentDetailedEvaluationOutcome::Rejected,
                 ));
             } else {
                 state_committed = true;
@@ -337,8 +453,8 @@ pub(super) fn apply_updates(
                 db.set_enrollment_eval_state_invalidated(oid, true);
                 report.diagnostics.push(diagnostic(
                     oid,
-                    EventEnrollmentEvaluationStage::EvaluationState,
-                    EventEnrollmentEvaluationOutcome::Rejected,
+                    EventEnrollmentDetailedEvaluationStage::EvaluationState,
+                    EventEnrollmentDetailedEvaluationOutcome::Rejected,
                 ));
                 continue;
             }
@@ -349,7 +465,7 @@ pub(super) fn apply_updates(
         }
 
         if let Some(reliability) = update.reliability {
-            if state_failed || (source_failed && reliability.from == reliability.to) {
+            if state_failed {
                 continue;
             }
 
@@ -378,15 +494,15 @@ pub(super) fn apply_updates(
 
             if commit_result.is_err() {
                 let outcome = if reliability_or_state_landed(db, &oid, &reliability) {
-                    EventEnrollmentEvaluationOutcome::LandedAfterError
+                    EventEnrollmentDetailedEvaluationOutcome::LandedAfterError
                 } else {
-                    EventEnrollmentEvaluationOutcome::Rejected
+                    EventEnrollmentDetailedEvaluationOutcome::Rejected
                 };
                 clear_source_ownership(db, oid, database_eval_sources);
                 db.set_enrollment_eval_state_invalidated(oid, true);
                 report.diagnostics.push(diagnostic(
                     oid,
-                    EventEnrollmentEvaluationStage::Reliability,
+                    EventEnrollmentDetailedEvaluationStage::Reliability,
                     outcome,
                 ));
                 continue;
@@ -410,11 +526,11 @@ pub(super) fn apply_updates(
         let Some(fired) = update.fired else {
             report.diagnostics.push(diagnostic(
                 oid,
-                EventEnrollmentEvaluationStage::EvaluationState,
+                EventEnrollmentDetailedEvaluationStage::EvaluationState,
                 if update.canceled && state_committed {
-                    EventEnrollmentEvaluationOutcome::CancellationCommitted
+                    EventEnrollmentDetailedEvaluationOutcome::CancellationCommitted
                 } else {
-                    EventEnrollmentEvaluationOutcome::NoTransition
+                    EventEnrollmentDetailedEvaluationOutcome::NoTransition
                 },
             ));
             continue;
@@ -424,9 +540,10 @@ pub(super) fn apply_updates(
             continue;
         }
 
-        // A same-state transition depends on private state to distinguish the
-        // new indication from the previous one. Preserve the established
-        // stateless source-failure behavior only for a changing Event_State.
+        // A same-state normal-event transition depends on private source
+        // ownership to distinguish the new indication from the previous one.
+        // Reliability re-entry is independently distinguished by its changed
+        // Reliability value and therefore is not suppressed by source failure.
         if source_failed && fired.from == fired.to {
             continue;
         }
@@ -451,15 +568,15 @@ pub(super) fn apply_updates(
 
         if commit_result.is_err() {
             let outcome = if fired.from != fired.to && event_state_landed(db, &oid, fired.to) {
-                EventEnrollmentEvaluationOutcome::LandedAfterError
+                EventEnrollmentDetailedEvaluationOutcome::LandedAfterError
             } else {
-                EventEnrollmentEvaluationOutcome::Rejected
+                EventEnrollmentDetailedEvaluationOutcome::Rejected
             };
             clear_source_ownership(db, oid, database_eval_sources);
             db.set_enrollment_eval_state_invalidated(oid, true);
             report.diagnostics.push(diagnostic(
                 oid,
-                EventEnrollmentEvaluationStage::EventTransition,
+                EventEnrollmentDetailedEvaluationStage::EventTransition,
                 outcome,
             ));
             continue;

--- a/crates/bacnet-server/src/event_enrollment/commit.rs
+++ b/crates/bacnet-server/src/event_enrollment/commit.rs
@@ -4,8 +4,9 @@ use bacnet_objects::database::ObjectDatabase;
 use bacnet_objects::event::{
     EventStateChange, EventTransition, EventTransitionCommit, EventTransitionCommitError,
 };
+use bacnet_objects::event_enrollment::EventEnrollmentReliabilityCommit;
 use bacnet_objects::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource};
-use bacnet_types::enums::{EventState, EventType, PropertyIdentifier};
+use bacnet_types::enums::{EventState, EventType, PropertyIdentifier, Reliability};
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
 use super::EventEnrollmentTransition;
@@ -20,6 +21,8 @@ pub enum EventEnrollmentEvaluationStage {
     EvaluationSource,
     /// Private countdown or baseline state was being updated.
     EvaluationState,
+    /// Reliability observation or the combined Reliability transition hook ran.
+    Reliability,
     /// The atomic Event_State/Acked_Transitions/Event_Time_Stamps hook ran.
     EventTransition,
 }
@@ -31,6 +34,10 @@ pub enum EventEnrollmentEvaluationOutcome {
     NoTransition,
     /// A pending transition was canceled and its private state was stored.
     CancellationCommitted,
+    /// A required local or remote observation was temporarily unavailable.
+    ///
+    /// No Reliability, event, history, or private evaluator state is changed.
+    ObservationUnavailable,
     /// A required internal mutation was rejected.
     Rejected,
     /// A custom hook returned an error after the target Event_State landed.
@@ -59,16 +66,60 @@ pub struct EventEnrollmentEvaluationDiagnostic {
     pub outcome: EventEnrollmentEvaluationOutcome,
 }
 
+/// Precedence source that selected a committed Event Enrollment Reliability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventEnrollmentReliabilityCause {
+    /// A definitive local configuration defect selected CONFIGURATION_ERROR.
+    Configuration,
+    /// The monitored object's nonzero Reliability selected MONITORED_OBJECT_FAULT.
+    MonitoredObject,
+    /// A supported configured fault algorithm selected the value or recovery.
+    FaultAlgorithm,
+}
+
+/// One successfully committed Event Enrollment Reliability result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventEnrollmentReliabilityResult {
+    /// Event Enrollment object whose atomic commit succeeded.
+    pub enrollment_oid: ObjectIdentifier,
+    /// Configured monitored object, absent for a malformed/missing reference.
+    pub monitored_oid: Option<ObjectIdentifier>,
+    /// Reliability value read before the commit.
+    pub previous_reliability: Reliability,
+    /// Reliability value stored by the commit.
+    pub new_reliability: Reliability,
+    /// FAULT entry, re-entry, or recovery committed with Reliability.
+    pub state_change: Option<EventStateChange>,
+    /// Whether Event_Enable permits distribution for the transition coordinate.
+    pub distribute: bool,
+    /// Precedence source that selected `new_reliability`.
+    pub cause: EventEnrollmentReliabilityCause,
+}
+
 /// Detailed result of one Event Enrollment evaluation pass.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct EventEnrollmentEvaluationReport {
     /// Transitions whose complete atomic object commit succeeded.
     pub transitions: Vec<EventEnrollmentTransition>,
+    /// Reliability results whose complete combined object commit succeeded.
+    pub reliability_results: Vec<EventEnrollmentReliabilityResult>,
     /// Non-transition and failure diagnostics in enrollment evaluation order.
     pub diagnostics: Vec<EventEnrollmentEvaluationDiagnostic>,
 }
 
-pub(crate) fn log_evaluation_failures(report: &EventEnrollmentEvaluationReport) {
+pub(crate) fn log_evaluation_report(report: &EventEnrollmentEvaluationReport) {
+    for result in &report.reliability_results {
+        tracing::debug!(
+            enrollment = %result.enrollment_oid,
+            monitored = ?result.monitored_oid,
+            previous = ?result.previous_reliability,
+            new = ?result.new_reliability,
+            state_change = ?result.state_change,
+            distribute = result.distribute,
+            cause = ?result.cause,
+            "Event enrollment: reliability committed"
+        );
+    }
     for diagnostic in report
         .diagnostics
         .iter()
@@ -90,6 +141,8 @@ pub(super) struct EnrollmentUpdate {
     eval_source: Option<Option<EventEnrollmentMonitoredSource>>,
     clears_invalidation: bool,
     fired: Option<FiredTransition>,
+    reliability: Option<ReliabilityUpdate>,
+    observation_unavailable: bool,
     canceled: bool,
 }
 
@@ -100,6 +153,17 @@ pub(super) struct FiredTransition {
     pub(super) to: EventState,
     pub(super) distribute: bool,
     pub(super) ack_required: bool,
+}
+
+pub(super) struct ReliabilityUpdate {
+    pub(super) monitored_oid: Option<ObjectIdentifier>,
+    pub(super) previous: Reliability,
+    pub(super) desired: Reliability,
+    pub(super) from: EventState,
+    pub(super) to: EventState,
+    pub(super) distribute: bool,
+    pub(super) ack_required: bool,
+    pub(super) cause: EventEnrollmentReliabilityCause,
 }
 
 impl EnrollmentUpdate {
@@ -131,6 +195,18 @@ impl EnrollmentUpdate {
         );
         self.fired = Some(fired);
     }
+
+    pub(super) fn set_reliability(&mut self, reliability: ReliabilityUpdate) {
+        debug_assert!(
+            self.reliability.is_none() && self.fired.is_none(),
+            "one enrollment commits one transition family per pass"
+        );
+        self.reliability = Some(reliability);
+    }
+
+    pub(super) fn observation_unavailable(&mut self) {
+        self.observation_unavailable = true;
+    }
 }
 
 fn diagnostic(
@@ -151,6 +227,27 @@ fn event_state_landed(db: &ObjectDatabase, oid: &ObjectIdentifier, state: EventS
             .and_then(|object| object.read_property(PropertyIdentifier::EVENT_STATE, None).ok()),
         Some(PropertyValue::Enumerated(raw)) if raw == state.to_raw()
     )
+}
+
+fn reliability_or_state_landed(
+    db: &ObjectDatabase,
+    oid: &ObjectIdentifier,
+    update: &ReliabilityUpdate,
+) -> bool {
+    let Some(object) = db.get(oid) else {
+        return false;
+    };
+    let reliability_landed = update.previous != update.desired
+        && matches!(
+            object.read_property(PropertyIdentifier::RELIABILITY, None),
+            Ok(PropertyValue::Enumerated(raw)) if raw == update.desired.to_raw()
+        );
+    let state_landed = update.from != update.to
+        && matches!(
+            object.read_property(PropertyIdentifier::EVENT_STATE, None),
+            Ok(PropertyValue::Enumerated(raw)) if raw == update.to.to_raw()
+        );
+    reliability_landed || state_landed
 }
 
 fn clear_source_ownership(
@@ -182,6 +279,15 @@ pub(super) fn apply_updates(
             ));
             continue;
         };
+
+        if update.observation_unavailable {
+            report.diagnostics.push(diagnostic(
+                oid,
+                EventEnrollmentEvaluationStage::Reliability,
+                EventEnrollmentEvaluationOutcome::ObservationUnavailable,
+            ));
+            continue;
+        }
 
         let mut source_failed = false;
         let mut state_failed = false;
@@ -240,6 +346,65 @@ pub(super) fn apply_updates(
             if update.clears_invalidation {
                 db.set_enrollment_eval_state_invalidated(oid, false);
             }
+        }
+
+        if let Some(reliability) = update.reliability {
+            if state_failed || (source_failed && reliability.from == reliability.to) {
+                continue;
+            }
+
+            let coordinate = EventTransition::for_target_state(reliability.to);
+            let staged_timestamp = stage_event_timestamp(db);
+            let change = EventStateChange {
+                from: reliability.from,
+                to: reliability.to,
+            };
+            let transition = EventTransitionCommit {
+                change: change.clone(),
+                coordinate,
+                ack_required: reliability.ack_required,
+                timestamp: staged_timestamp.sample.timestamp.clone(),
+                message_text: None,
+            };
+            let commit = EventEnrollmentReliabilityCommit {
+                reliability: reliability.desired,
+                transition: Some(transition),
+            };
+            let commit_result = db
+                .get_mut(&oid)
+                .map_or(Err(EventTransitionCommitError::Unsupported), |object| {
+                    object.commit_event_enrollment_reliability_internal(commit)
+                });
+
+            if commit_result.is_err() {
+                let outcome = if reliability_or_state_landed(db, &oid, &reliability) {
+                    EventEnrollmentEvaluationOutcome::LandedAfterError
+                } else {
+                    EventEnrollmentEvaluationOutcome::Rejected
+                };
+                clear_source_ownership(db, oid, database_eval_sources);
+                db.set_enrollment_eval_state_invalidated(oid, true);
+                report.diagnostics.push(diagnostic(
+                    oid,
+                    EventEnrollmentEvaluationStage::Reliability,
+                    outcome,
+                ));
+                continue;
+            }
+
+            confirm_event_timestamp(db, staged_timestamp);
+            report
+                .reliability_results
+                .push(EventEnrollmentReliabilityResult {
+                    enrollment_oid: oid,
+                    monitored_oid: reliability.monitored_oid,
+                    previous_reliability: reliability.previous,
+                    new_reliability: reliability.desired,
+                    state_change: Some(change),
+                    distribute: reliability.distribute,
+                    cause: reliability.cause,
+                });
+            continue;
         }
 
         let Some(fired) = update.fired else {

--- a/crates/bacnet-server/src/event_enrollment/fault.rs
+++ b/crates/bacnet-server/src/event_enrollment/fault.rs
@@ -1,0 +1,181 @@
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::constructed::{BACnetEventParameter, FaultParameters};
+use bacnet_types::enums::{ErrorClass, ErrorCode, PropertyIdentifier, Reliability};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+
+use super::support::classify_required_property_read_error;
+use super::LocalConfigurationReadError;
+
+/// Fault algorithms intentionally implemented by the Event Enrollment core.
+///
+/// `FaultOutOfRange` operates on the repository's normalized numeric `f64`
+/// representation; it does not claim the full datatype-dependent model in
+/// ASHRAE 135-2020 Clause 13.4.7.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) enum SupportedFaultAlgorithm {
+    None,
+    StatusFlags { object_identifier: ObjectIdentifier },
+    OutOfRange { min_normal: f64, max_normal: f64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum MonitoredReliability {
+    Absent,
+    Value(Reliability),
+    ConfigurationError,
+    ObservationUnavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FaultAlgorithmEvaluation {
+    Healthy,
+    Fault(Reliability),
+    ConfigurationError,
+    ObservationUnavailable,
+}
+
+pub(super) fn read_event_parameters(
+    enrollment: &dyn BACnetObject,
+) -> Result<BACnetEventParameter, LocalConfigurationReadError> {
+    match enrollment.read_property(PropertyIdentifier::EVENT_PARAMETERS, None) {
+        Ok(PropertyValue::ApplicationData(bytes)) => {
+            match bacnet_encoding::constructed::decode_event_parameter(&bytes, 0) {
+                Ok((parameters, consumed)) if consumed == bytes.len() => Ok(parameters),
+                _ => Err(LocalConfigurationReadError::Malformed),
+            }
+        }
+        Ok(value) => {
+            BACnetEventParameter::decode(&value).map_err(|_| LocalConfigurationReadError::Malformed)
+        }
+        Err(error) => Err(classify_required_property_read_error(&error)),
+    }
+}
+
+pub(super) fn read_fault_algorithm(
+    enrollment: &dyn BACnetObject,
+    local_device_oid: Option<ObjectIdentifier>,
+) -> Result<SupportedFaultAlgorithm, LocalConfigurationReadError> {
+    let parameters = match enrollment.read_property(PropertyIdentifier::FAULT_PARAMETERS, None) {
+        Ok(PropertyValue::ApplicationData(bytes)) => {
+            match bacnet_encoding::constructed::decode_fault_parameters(&bytes, 0) {
+                Ok((parameters, consumed)) if consumed == bytes.len() => parameters,
+                _ => return Err(LocalConfigurationReadError::Malformed),
+            }
+        }
+        Ok(value) => FaultParameters::decode_property_value(&value)
+            .map_err(|_| LocalConfigurationReadError::Malformed)?,
+        Err(error) if optional_property_absent(&error) => {
+            return Ok(SupportedFaultAlgorithm::None);
+        }
+        Err(error) => return Err(classify_required_property_read_error(&error)),
+    };
+
+    match parameters {
+        FaultParameters::FaultNone => Ok(SupportedFaultAlgorithm::None),
+        FaultParameters::FaultStatusFlags { reference } => {
+            let local = reference
+                .device_identifier
+                .is_none_or(|device| Some(device) == local_device_oid);
+            if !local
+                || reference.property_identifier != PropertyIdentifier::STATUS_FLAGS.to_raw()
+                || reference.property_array_index.is_some()
+            {
+                return Err(LocalConfigurationReadError::Malformed);
+            }
+            Ok(SupportedFaultAlgorithm::StatusFlags {
+                object_identifier: reference.object_identifier,
+            })
+        }
+        FaultParameters::FaultOutOfRange {
+            min_normal,
+            max_normal,
+        } if min_normal.is_finite() && max_normal.is_finite() && min_normal <= max_normal => {
+            Ok(SupportedFaultAlgorithm::OutOfRange {
+                min_normal,
+                max_normal,
+            })
+        }
+        // These alternatives round-trip at the object boundary, but their
+        // state models are deliberately deferred. Treating them as healthy
+        // would silently disable a configured fault algorithm.
+        _ => Err(LocalConfigurationReadError::Malformed),
+    }
+}
+
+pub(super) fn read_monitored_reliability(object: &dyn BACnetObject) -> MonitoredReliability {
+    match object.read_property(PropertyIdentifier::RELIABILITY, None) {
+        Ok(PropertyValue::Enumerated(value)) => {
+            MonitoredReliability::Value(Reliability::from_raw(value))
+        }
+        Ok(_) => MonitoredReliability::ConfigurationError,
+        Err(error) if optional_property_absent(&error) => MonitoredReliability::Absent,
+        Err(_) => MonitoredReliability::ObservationUnavailable,
+    }
+}
+
+pub(super) fn evaluate_fault_algorithm(
+    db: &ObjectDatabase,
+    algorithm: &SupportedFaultAlgorithm,
+    monitored_value: Option<&PropertyValue>,
+) -> FaultAlgorithmEvaluation {
+    match algorithm {
+        SupportedFaultAlgorithm::None => FaultAlgorithmEvaluation::Healthy,
+        SupportedFaultAlgorithm::StatusFlags { object_identifier } => {
+            let Some(object) = db.get(object_identifier) else {
+                return FaultAlgorithmEvaluation::ObservationUnavailable;
+            };
+            match object.read_property(PropertyIdentifier::STATUS_FLAGS, None) {
+                Ok(PropertyValue::BitString {
+                    unused_bits: 4,
+                    data,
+                }) if data.len() == 1 => {
+                    if data[0] & 0x40 != 0 {
+                        FaultAlgorithmEvaluation::Fault(Reliability::MEMBER_FAULT)
+                    } else {
+                        FaultAlgorithmEvaluation::Healthy
+                    }
+                }
+                Ok(_) => FaultAlgorithmEvaluation::ConfigurationError,
+                Err(_) => FaultAlgorithmEvaluation::ObservationUnavailable,
+            }
+        }
+        SupportedFaultAlgorithm::OutOfRange {
+            min_normal,
+            max_normal,
+        } => {
+            let Some(value) = monitored_value.and_then(numeric_f64) else {
+                return FaultAlgorithmEvaluation::ConfigurationError;
+            };
+            if !value.is_finite() {
+                FaultAlgorithmEvaluation::ConfigurationError
+            } else if value < *min_normal {
+                FaultAlgorithmEvaluation::Fault(Reliability::UNDER_RANGE)
+            } else if value > *max_normal {
+                FaultAlgorithmEvaluation::Fault(Reliability::OVER_RANGE)
+            } else {
+                FaultAlgorithmEvaluation::Healthy
+            }
+        }
+    }
+}
+
+fn numeric_f64(value: &PropertyValue) -> Option<f64> {
+    match value {
+        PropertyValue::Real(value) => Some(f64::from(*value)),
+        PropertyValue::Double(value) => Some(*value),
+        PropertyValue::Unsigned(value) => Some(*value as f64),
+        PropertyValue::Signed(value) => Some(*value as f64),
+        _ => None,
+    }
+}
+
+fn optional_property_absent(error: &Error) -> bool {
+    matches!(
+        error,
+        Error::Protocol { class, code }
+            if *class == ErrorClass::PROPERTY.to_raw() as u32
+                && *code == ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32
+    )
+}

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -41,7 +41,9 @@
 
 mod algorithms;
 mod commit;
+mod fault;
 mod reference;
+mod support;
 
 use std::collections::{HashMap, HashSet};
 
@@ -52,6 +54,7 @@ pub use algorithms::{
 pub use commit::{
     EventEnrollmentEvaluationDiagnostic, EventEnrollmentEvaluationOutcome,
     EventEnrollmentEvaluationReport, EventEnrollmentEvaluationStage,
+    EventEnrollmentReliabilityCause, EventEnrollmentReliabilityResult,
 };
 
 use algorithms::{
@@ -59,23 +62,31 @@ use algorithms::{
     eval_floating_limit_struct, eval_legacy_le_arm, eval_out_of_range_struct, extract_bitstring,
     extract_property_state_value, extract_real, ArmEvaluation,
 };
-pub(crate) use commit::log_evaluation_failures;
+pub(crate) use commit::log_evaluation_report;
 use commit::{apply_updates, EnrollmentUpdate, FiredTransition};
+use fault::{
+    evaluate_fault_algorithm, read_event_parameters, read_fault_algorithm,
+    read_monitored_reliability, FaultAlgorithmEvaluation, MonitoredReliability,
+    SupportedFaultAlgorithm,
+};
 #[cfg(test)]
 use reference::MonitoredReference;
 use reference::{params_fingerprint, read_object_property_ref};
+use support::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalConfigurationReadError {
+    Malformed,
+    Unavailable,
+}
 
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_objects::event::{EventStateChange, EventTransition};
-use bacnet_objects::event_enrollment::{
-    EventEnrollmentEvalState, EventEnrollmentMonitoredSource, EventEnrollmentPending,
-};
+use bacnet_objects::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentPending};
+#[cfg(test)]
 use bacnet_objects::traits::BACnetObject;
 use bacnet_types::constructed::BACnetEventParameter;
-use bacnet_types::enums::{
-    ErrorClass, ErrorCode, EventState, EventType, ObjectType, PropertyIdentifier,
-};
-use bacnet_types::error::Error;
+use bacnet_types::enums::{EventState, EventType, ObjectType, PropertyIdentifier, Reliability};
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
 /// A state transition detected during event enrollment evaluation.
@@ -96,136 +107,6 @@ pub struct EventEnrollmentTransition {
     /// either way; a cleared bit suppresses only the outbound notification
     /// (ASHRAE 135-2020 Clause 12.12).
     pub distribute: bool,
-}
-
-enum SetpointRead {
-    Value(f32),
-    Unusable,
-    Transient,
-}
-
-fn read_setpoint(
-    db: &ObjectDatabase,
-    reference: &bacnet_types::constructed::BACnetDeviceObjectPropertyReference,
-) -> SetpointRead {
-    // Remote-device setpoint references are not resolvable from a local DB.
-    if reference.device_identifier.is_some() {
-        return SetpointRead::Transient;
-    }
-    let Some(obj) = db.get(&reference.object_identifier) else {
-        return SetpointRead::Transient;
-    };
-    let prop = PropertyIdentifier::from_raw(reference.property_identifier);
-    if reference.property_array_index.is_some() && !obj.is_array_property(prop) {
-        return SetpointRead::Unusable;
-    }
-    match obj.read_property(prop, reference.property_array_index) {
-        Ok(value) => extract_real(&value)
-            .map(SetpointRead::Value)
-            .unwrap_or(SetpointRead::Unusable),
-        Err(error)
-            if reference.property_array_index.is_some() && invalid_indexed_target_error(&error) =>
-        {
-            SetpointRead::Unusable
-        }
-        Err(_) => SetpointRead::Transient,
-    }
-}
-
-/// Convert a seconds delay to pending passes with never-fire-early ceiling
-/// semantics: `ceil(delay_secs / interval_secs)`. At the default 10s
-/// interval a 5s delay seeds 1 pass (fires when that pass elapses, ~10s
-/// later); a 15s delay seeds 2 (~20s). Callers never pass `delay_secs == 0`
-/// — a zero delay fires without seeding.
-fn passes_for_delay(delay_secs: u32, interval_secs: u64) -> u32 {
-    let passes = (delay_secs as u64).div_ceil(interval_secs.max(1));
-    u32::try_from(passes).unwrap_or(u32::MAX)
-}
-
-/// Resolve whether the Notification Class referenced by an enrollment
-/// requires acknowledgment of `transition_bit`.
-///
-/// Clause 13.2.3: "Whether or not an acknowledgment is required is determined
-/// by the Ack_Required property from the referenced Notification Class
-/// object." A missing or unreadable Notification Class resolves to
-/// not-required — the standard's fallback for an absent parameter is the
-/// "otherwise it is set" half of the same sentence, which leaves
-/// `Acked_Transitions` alone-equals-acknowledged rather than stranding a
-/// transition permanently unacknowledged for want of a class object.
-fn ack_required_for_transition(
-    db: &ObjectDatabase,
-    enrollment: &dyn BACnetObject,
-    transition_bit: u8,
-) -> bool {
-    let Ok(PropertyValue::Unsigned(nc_instance)) =
-        enrollment.read_property(PropertyIdentifier::NOTIFICATION_CLASS, None)
-    else {
-        return false;
-    };
-    let Ok(nc_oid) = ObjectIdentifier::new(
-        ObjectType::NOTIFICATION_CLASS,
-        u32::try_from(nc_instance).unwrap_or(u32::MAX),
-    ) else {
-        return false;
-    };
-    let Some(nc) = db.get(&nc_oid) else {
-        return false;
-    };
-    match nc.read_property(PropertyIdentifier::ACK_REQUIRED, None) {
-        Ok(PropertyValue::BitString { data, .. }) => {
-            bacnet_types::bitstring::unpack_octet(&data, 3) & transition_bit != 0
-        }
-        _ => false,
-    }
-}
-
-fn queue_eval_state_reset(
-    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
-    oid: ObjectIdentifier,
-    supported: bool,
-    state: &EventEnrollmentEvalState,
-) {
-    if supported && *state != EventEnrollmentEvalState::default() {
-        updates.entry(oid).or_default().reset_eval_state();
-    }
-}
-
-fn queue_pending_cancellation(
-    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
-    oid: ObjectIdentifier,
-    supported: bool,
-    state: &mut EventEnrollmentEvalState,
-) {
-    if state.pending.take().is_some() && supported {
-        updates
-            .entry(oid)
-            .or_default()
-            .cancel_pending(state.clone());
-    }
-}
-
-fn queue_eval_source_reset(
-    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
-    oid: ObjectIdentifier,
-    source: Option<Option<EventEnrollmentMonitoredSource>>,
-) {
-    if source.flatten().is_some() {
-        updates.entry(oid).or_default().set_eval_source(None);
-    }
-}
-
-fn invalid_indexed_target_error(error: &Error) -> bool {
-    matches!(
-        error,
-        Error::Protocol { class, code }
-            if *class == ErrorClass::PROPERTY.to_raw() as u32
-                && matches!(
-                    *code,
-                    code if code == ErrorCode::INVALID_ARRAY_INDEX.to_raw() as u32
-                        || code == ErrorCode::PROPERTY_IS_NOT_AN_ARRAY.to_raw() as u32
-                        || code == ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32
-                )
-    )
 }
 
 /// Evaluate all EventEnrollment objects in the database.
@@ -291,36 +172,6 @@ pub fn evaluate_event_enrollments_report(
             None => None,
         };
         let force_state_reset = db.enrollment_eval_state_invalidated(oid);
-        let reference = match read_object_property_ref(enrollment) {
-            Ok(reference) => reference,
-            Err(()) => continue,
-        };
-        let Some(monitored) = reference.filter(|reference| {
-            reference
-                .device_identifier
-                .is_none_or(|oid| Some(oid) == local_device_oid)
-        }) else {
-            queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
-            queue_eval_source_reset(&mut updates, *oid, eval_source);
-            continue;
-        };
-        let monitored_oid = monitored.object_identifier;
-        let monitored_prop = monitored.property_identifier;
-        let monitored_reference = (monitored_oid, monitored_prop, monitored.array_index);
-        // Private evaluation state belongs to one exact monitored source. A
-        // nonempty ownerless state cannot be adopted safely.
-        let source_changed = match eval_source {
-            Some(Some(current)) => current != monitored_reference,
-            Some(None) => eval_state != EventEnrollmentEvalState::default(),
-            None => false,
-        };
-        if source_changed || force_state_reset {
-            let had_private_state = eval_state != EventEnrollmentEvalState::default();
-            eval_state = EventEnrollmentEvalState::default();
-            if eval_state_supported && (had_private_state || force_state_reset) {
-                updates.entry(*oid).or_default().reset_eval_state();
-            }
-        }
 
         if let Ok(PropertyValue::Boolean(true)) =
             enrollment.read_property(PropertyIdentifier::OUT_OF_SERVICE, None)
@@ -364,53 +215,338 @@ pub fn evaluate_event_enrollments_report(
             _ => 0,
         };
 
-        let params = match enrollment.read_property(PropertyIdentifier::EVENT_PARAMETERS, None) {
-            // Framed wire form (the EventEnrollment object's read arm emits
-            // full ASN.1 CHOICE framing).
-            Ok(PropertyValue::ApplicationData(bytes)) => {
-                match bacnet_encoding::constructed::decode_event_parameter(&bytes, 0) {
-                    Ok((ep, consumed)) if consumed == bytes.len() => ep,
-                    _ => {
-                        queue_pending_cancellation(
-                            &mut updates,
-                            *oid,
-                            eval_state_supported,
-                            &mut eval_state,
-                        );
-                        continue;
-                    }
-                }
-            }
-            // Legacy flat application-tagged form (downstream/custom object
-            // types that have not migrated to the framed read arm).
-            Ok(v) => match BACnetEventParameter::decode(&v) {
-                Ok(ep) => ep,
-                Err(_) => {
-                    queue_pending_cancellation(
-                        &mut updates,
-                        *oid,
-                        eval_state_supported,
-                        &mut eval_state,
-                    );
+        let current_reliability =
+            match enrollment.read_property(PropertyIdentifier::RELIABILITY, None) {
+                Ok(PropertyValue::Enumerated(value)) => Reliability::from_raw(value),
+                _ => {
+                    queue_observation_unavailable(&mut updates, *oid);
                     continue;
                 }
-            },
-            Err(_) => {
-                queue_pending_cancellation(
+            };
+
+        // Local configuration is resolved before any target observation. A
+        // malformed/missing required reference, malformed parameters, or an
+        // unsupported configured fault alternative therefore wins the
+        // Reliability precedence chain deterministically.
+        let reference = read_object_property_ref(enrollment);
+        let params = read_event_parameters(enrollment);
+        let fault_algorithm = read_fault_algorithm(enrollment, local_device_oid);
+        if matches!(reference, Err(LocalConfigurationReadError::Malformed))
+            || matches!(params, Err(LocalConfigurationReadError::Malformed))
+            || matches!(fault_algorithm, Err(LocalConfigurationReadError::Malformed))
+        {
+            let monitored_oid = reference
+                .as_ref()
+                .ok()
+                .map(|reference| reference.object_identifier);
+            queue_eval_state_reset(
+                &mut updates,
+                *oid,
+                eval_state_supported,
+                &eval_state,
+                force_state_reset,
+            );
+            if matches!(reference, Err(LocalConfigurationReadError::Malformed)) {
+                queue_eval_source_reset(&mut updates, *oid, eval_source);
+            }
+            queue_reliability_transition(
+                db,
+                enrollment,
+                &mut updates,
+                *oid,
+                monitored_oid,
+                current_reliability,
+                Reliability::CONFIGURATION_ERROR,
+                current_state,
+                event_enable,
+                EventEnrollmentReliabilityCause::Configuration,
+            );
+            continue;
+        }
+
+        if matches!(reference, Err(LocalConfigurationReadError::Unavailable)) {
+            queue_observation_unavailable(&mut updates, *oid);
+            continue;
+        }
+        if matches!(params, Err(LocalConfigurationReadError::Unavailable)) {
+            queue_pending_cancellation(&mut updates, *oid, eval_state_supported, &mut eval_state);
+            continue;
+        }
+        if matches!(
+            fault_algorithm,
+            Err(LocalConfigurationReadError::Unavailable)
+        ) {
+            queue_observation_unavailable(&mut updates, *oid);
+            continue;
+        }
+
+        let monitored = reference.expect("validated reference");
+        let params = params.expect("validated Event_Parameters");
+        let fault_algorithm = fault_algorithm.expect("validated Fault_Parameters");
+
+        // A well-formed remote target is temporarily unobservable in this
+        // local-only slice. It is not rewritten into persistent target-loss
+        // policy; PR-0303 owns that behavior.
+        if monitored
+            .device_identifier
+            .is_some_and(|device| Some(device) != local_device_oid)
+        {
+            queue_observation_unavailable(&mut updates, *oid);
+            continue;
+        }
+
+        let monitored_oid = monitored.object_identifier;
+        let monitored_prop = monitored.property_identifier;
+        let monitored_reference = (monitored_oid, monitored_prop, monitored.array_index);
+        // Private evaluation state belongs to one exact monitored source. A
+        // nonempty ownerless state cannot be adopted safely. Defer the actual
+        // setter until all required observations succeed, so an unavailable
+        // observation mutates nothing.
+        let source_changed = match eval_source {
+            Some(Some(current)) => current != monitored_reference,
+            Some(None) => eval_state != EventEnrollmentEvalState::default(),
+            None => false,
+        };
+        let reset_evaluation_state = source_changed || force_state_reset;
+        if reset_evaluation_state {
+            eval_state = EventEnrollmentEvalState::default();
+        }
+
+        let Some(monitored_obj) = db.get(&monitored_oid) else {
+            queue_observation_unavailable(&mut updates, *oid);
+            continue;
+        };
+        if monitored.array_index.is_some() && !monitored_obj.is_array_property(monitored_prop) {
+            queue_invalid_reference(&mut updates, *oid, eval_state_supported, eval_source);
+            queue_reliability_transition(
+                db,
+                enrollment,
+                &mut updates,
+                *oid,
+                Some(monitored_oid),
+                current_reliability,
+                Reliability::CONFIGURATION_ERROR,
+                current_state,
+                event_enable,
+                EventEnrollmentReliabilityCause::Configuration,
+            );
+            continue;
+        }
+
+        match read_monitored_reliability(monitored_obj) {
+            MonitoredReliability::ConfigurationError => {
+                queue_evaluation_ownership(
                     &mut updates,
                     *oid,
                     eval_state_supported,
-                    &mut eval_state,
+                    reset_evaluation_state,
+                    eval_source,
+                    monitored_reference,
+                );
+                queue_reliability_transition(
+                    db,
+                    enrollment,
+                    &mut updates,
+                    *oid,
+                    Some(monitored_oid),
+                    current_reliability,
+                    Reliability::CONFIGURATION_ERROR,
+                    current_state,
+                    event_enable,
+                    EventEnrollmentReliabilityCause::Configuration,
                 );
                 continue;
             }
+            MonitoredReliability::ObservationUnavailable => {
+                queue_observation_unavailable(&mut updates, *oid);
+                continue;
+            }
+            MonitoredReliability::Value(reliability)
+                if reliability != Reliability::NO_FAULT_DETECTED =>
+            {
+                queue_evaluation_ownership(
+                    &mut updates,
+                    *oid,
+                    eval_state_supported,
+                    reset_evaluation_state,
+                    eval_source,
+                    monitored_reference,
+                );
+                queue_reliability_transition(
+                    db,
+                    enrollment,
+                    &mut updates,
+                    *oid,
+                    Some(monitored_oid),
+                    current_reliability,
+                    Reliability::MONITORED_OBJECT_FAULT,
+                    current_state,
+                    event_enable,
+                    EventEnrollmentReliabilityCause::MonitoredObject,
+                );
+                continue;
+            }
+            MonitoredReliability::Absent | MonitoredReliability::Value(_) => {}
+        }
+
+        let mut monitored_value = None;
+        if matches!(fault_algorithm, SupportedFaultAlgorithm::OutOfRange { .. }) {
+            match monitored_obj.read_property(monitored_prop, monitored.array_index) {
+                Ok(value) => monitored_value = Some(value),
+                Err(error)
+                    if monitored.array_index.is_some() && invalid_indexed_target_error(&error) =>
+                {
+                    queue_invalid_reference(&mut updates, *oid, eval_state_supported, eval_source);
+                    queue_reliability_transition(
+                        db,
+                        enrollment,
+                        &mut updates,
+                        *oid,
+                        Some(monitored_oid),
+                        current_reliability,
+                        Reliability::CONFIGURATION_ERROR,
+                        current_state,
+                        event_enable,
+                        EventEnrollmentReliabilityCause::Configuration,
+                    );
+                    continue;
+                }
+                Err(_) => {
+                    queue_observation_unavailable(&mut updates, *oid);
+                    continue;
+                }
+            }
+        }
+
+        match evaluate_fault_algorithm(db, &fault_algorithm, monitored_value.as_ref()) {
+            FaultAlgorithmEvaluation::ConfigurationError => {
+                queue_evaluation_ownership(
+                    &mut updates,
+                    *oid,
+                    eval_state_supported,
+                    reset_evaluation_state,
+                    eval_source,
+                    monitored_reference,
+                );
+                queue_reliability_transition(
+                    db,
+                    enrollment,
+                    &mut updates,
+                    *oid,
+                    Some(monitored_oid),
+                    current_reliability,
+                    Reliability::CONFIGURATION_ERROR,
+                    current_state,
+                    event_enable,
+                    EventEnrollmentReliabilityCause::Configuration,
+                );
+                continue;
+            }
+            FaultAlgorithmEvaluation::ObservationUnavailable => {
+                queue_observation_unavailable(&mut updates, *oid);
+                continue;
+            }
+            FaultAlgorithmEvaluation::Fault(reliability) => {
+                queue_evaluation_ownership(
+                    &mut updates,
+                    *oid,
+                    eval_state_supported,
+                    reset_evaluation_state,
+                    eval_source,
+                    monitored_reference,
+                );
+                queue_reliability_transition(
+                    db,
+                    enrollment,
+                    &mut updates,
+                    *oid,
+                    Some(monitored_oid),
+                    current_reliability,
+                    reliability,
+                    current_state,
+                    event_enable,
+                    EventEnrollmentReliabilityCause::FaultAlgorithm,
+                );
+                continue;
+            }
+            FaultAlgorithmEvaluation::Healthy => {}
+        }
+
+        if current_reliability != Reliability::NO_FAULT_DETECTED
+            || current_state == EventState::FAULT
+        {
+            eval_state = EventEnrollmentEvalState::default();
+            queue_evaluation_ownership(
+                &mut updates,
+                *oid,
+                eval_state_supported,
+                true,
+                eval_source,
+                monitored_reference,
+            );
+            let cause = if current_reliability == Reliability::CONFIGURATION_ERROR {
+                EventEnrollmentReliabilityCause::Configuration
+            } else if current_reliability == Reliability::MONITORED_OBJECT_FAULT {
+                EventEnrollmentReliabilityCause::MonitoredObject
+            } else {
+                EventEnrollmentReliabilityCause::FaultAlgorithm
+            };
+            queue_reliability_transition(
+                db,
+                enrollment,
+                &mut updates,
+                *oid,
+                Some(monitored_oid),
+                current_reliability,
+                Reliability::NO_FAULT_DETECTED,
+                current_state,
+                event_enable,
+                cause,
+            );
+            continue;
+        }
+
+        let monitored_value = match monitored_value {
+            Some(value) => value,
+            None => match monitored_obj.read_property(monitored_prop, monitored.array_index) {
+                Ok(value) => value,
+                Err(error)
+                    if monitored.array_index.is_some() && invalid_indexed_target_error(&error) =>
+                {
+                    queue_invalid_reference(&mut updates, *oid, eval_state_supported, eval_source);
+                    queue_reliability_transition(
+                        db,
+                        enrollment,
+                        &mut updates,
+                        *oid,
+                        Some(monitored_oid),
+                        current_reliability,
+                        Reliability::CONFIGURATION_ERROR,
+                        current_state,
+                        event_enable,
+                        EventEnrollmentReliabilityCause::Configuration,
+                    );
+                    continue;
+                }
+                Err(_) => {
+                    queue_observation_unavailable(&mut updates, *oid);
+                    continue;
+                }
+            },
         };
+
+        queue_evaluation_ownership(
+            &mut updates,
+            *oid,
+            eval_state_supported,
+            reset_evaluation_state,
+            eval_source,
+            monitored_reference,
+        );
 
         // The effective normal-direction delay: the EE object's read arm
         // applies the Clause 13.3 fallback (Time_Delay_Normal absent → the
         // Event_Parameters Time_Delay), so this read IS pTimeDelayNormal.
-        // Unreadable (custom object without the property) degrades to 0,
-        // the pre-#163 immediate-transition behavior.
         let normal_delay =
             match enrollment.read_property(PropertyIdentifier::TIME_DELAY_NORMAL, None) {
                 Ok(PropertyValue::Unsigned(v)) => u32::try_from(v).unwrap_or(u32::MAX),
@@ -423,9 +559,7 @@ pub fn evaluate_event_enrollments_report(
 
         // A parameter (or reference) change mid-pending cancels the countdown
         // and re-gates from the current parameters; no partial countdown is
-        // resumed. The cancellation is flushed BEFORE any later exit — a
-        // dropped write-back here is what let a params round-trip A→B→A
-        // resume a stale countdown.
+        // resumed.
         let Ok(fingerprint) =
             params_fingerprint(&params, normal_delay as u64, event_type_raw, &monitored)
         else {
@@ -438,7 +572,6 @@ pub fn evaluate_event_enrollments_report(
             .is_some_and(|p| p.params_fingerprint != fingerprint)
         {
             eval_state.pending = None;
-            eval_state_dirty = false;
             if eval_state_supported {
                 updates
                     .entry(*oid)
@@ -447,35 +580,7 @@ pub fn evaluate_event_enrollments_report(
             }
         }
 
-        let Some(monitored_obj) = db.get(&monitored_oid) else {
-            continue;
-        };
-        if monitored.array_index.is_some() && !monitored_obj.is_array_property(monitored_prop) {
-            queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
-            queue_eval_source_reset(&mut updates, *oid, eval_source);
-            continue;
-        }
-        let monitored_value = match monitored_obj
-            .read_property(monitored_prop, monitored.array_index)
-        {
-            Ok(v) => v,
-            Err(error) => {
-                if monitored.array_index.is_some() && invalid_indexed_target_error(&error) {
-                    // A definitive indexed-target error is not a request to
-                    // retry the whole property.
-                    queue_eval_state_reset(&mut updates, *oid, eval_state_supported, &eval_state);
-                    queue_eval_source_reset(&mut updates, *oid, eval_source);
-                }
-                continue;
-            }
-        };
         let event_type = EventType::from_raw(event_type_raw);
-        if eval_source.is_some_and(|current| current != Some(monitored_reference)) {
-            updates
-                .entry(*oid)
-                .or_default()
-                .set_eval_source(Some(monitored_reference));
-        }
 
         let (time_delay, arm) = match &params {
             BACnetEventParameter::OutOfRange {
@@ -531,7 +636,10 @@ pub fn evaluate_event_enrollments_report(
                         );
                         continue;
                     }
-                    SetpointRead::Transient => continue,
+                    SetpointRead::Transient => {
+                        queue_observation_unavailable(&mut updates, *oid);
+                        continue;
+                    }
                 };
                 (
                     *time_delay,

--- a/crates/bacnet-server/src/event_enrollment/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/mod.rs
@@ -52,6 +52,8 @@ pub use algorithms::{
     encode_change_of_value_params, encode_floating_limit_params, encode_out_of_range_params,
 };
 pub use commit::{
+    EventEnrollmentDetailedEvaluationDiagnostic, EventEnrollmentDetailedEvaluationOutcome,
+    EventEnrollmentDetailedEvaluationReport, EventEnrollmentDetailedEvaluationStage,
     EventEnrollmentEvaluationDiagnostic, EventEnrollmentEvaluationOutcome,
     EventEnrollmentEvaluationReport, EventEnrollmentEvaluationStage,
     EventEnrollmentReliabilityCause, EventEnrollmentReliabilityResult,
@@ -129,15 +131,28 @@ pub fn evaluate_event_enrollments(
     evaluate_event_enrollments_report(db, interval_secs).transitions
 }
 
-/// Evaluate all EventEnrollment objects and expose commit diagnostics.
+/// Evaluate all EventEnrollment objects and expose legacy commit diagnostics.
 ///
-/// Unlike [`evaluate_event_enrollments`], this detailed API makes rejected
-/// private-state and atomic transition commits observable. Only transitions
-/// whose complete object-owned commit succeeds appear in `transitions`.
+/// This preserves the original report shape. Reliability results and typed
+/// observation diagnostics are available from
+/// [`evaluate_event_enrollments_detailed_report`].
 pub fn evaluate_event_enrollments_report(
     db: &mut ObjectDatabase,
     interval_secs: u64,
 ) -> EventEnrollmentEvaluationReport {
+    evaluate_event_enrollments_detailed_report(db, interval_secs).into_legacy()
+}
+
+/// Evaluate all EventEnrollment objects and expose every detailed result.
+///
+/// Unlike [`evaluate_event_enrollments_report`], this additive API includes
+/// committed Reliability results plus typed Reliability and observation
+/// diagnostics. Only results whose complete object-owned commit succeeds
+/// appear in `transitions` or `reliability_results`.
+pub fn evaluate_event_enrollments_detailed_report(
+    db: &mut ObjectDatabase,
+    interval_secs: u64,
+) -> EventEnrollmentDetailedEvaluationReport {
     let interval_secs = interval_secs.max(1);
     let oids = db.find_by_type(ObjectType::EVENT_ENROLLMENT);
     // A qualified reference can identify self only when the containing Device

--- a/crates/bacnet-server/src/event_enrollment/reference.rs
+++ b/crates/bacnet-server/src/event_enrollment/reference.rs
@@ -3,6 +3,9 @@ use bacnet_types::constructed::BACnetEventParameter;
 use bacnet_types::enums::PropertyIdentifier;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
+use super::support::classify_required_property_read_error;
+use super::LocalConfigurationReadError;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) struct MonitoredReference {
     pub(super) object_identifier: ObjectIdentifier,
@@ -29,49 +32,49 @@ impl MonitoredReference {
 
 /// Read the object-property reference from an Event Enrollment object.
 ///
-/// `Err` means the property could not be read; `Ok(None)` means it was read but
-/// does not contain a usable local reference shape.
+/// `Malformed` means the required property is absent or does not contain a
+/// usable reference shape. Other read failures remain temporarily unavailable.
 pub(super) fn read_object_property_ref(
     enrollment: &dyn BACnetObject,
-) -> Result<Option<MonitoredReference>, ()> {
+) -> Result<MonitoredReference, LocalConfigurationReadError> {
     match enrollment.read_property(PropertyIdentifier::OBJECT_PROPERTY_REFERENCE, None) {
         Ok(PropertyValue::List(ref items)) if (2..=4).contains(&items.len()) => {
             let object_identifier = match &items[0] {
                 PropertyValue::ObjectIdentifier(oid) => *oid,
-                _ => return Ok(None),
+                _ => return Err(LocalConfigurationReadError::Malformed),
             };
             let PropertyValue::Unsigned(property_identifier) = &items[1] else {
-                return Ok(None);
+                return Err(LocalConfigurationReadError::Malformed);
             };
             let Ok(property_identifier) = u32::try_from(*property_identifier) else {
-                return Ok(None);
+                return Err(LocalConfigurationReadError::Malformed);
             };
             if property_identifier > 0x3F_FFFF {
-                return Ok(None);
+                return Err(LocalConfigurationReadError::Malformed);
             }
             let property_identifier = PropertyIdentifier::from_raw(property_identifier);
             let array_index = match items.get(2) {
                 None | Some(PropertyValue::Null) => None,
                 Some(PropertyValue::Unsigned(index)) => match u32::try_from(*index) {
                     Ok(index) => Some(index),
-                    Err(_) => return Ok(None),
+                    Err(_) => return Err(LocalConfigurationReadError::Malformed),
                 },
-                Some(_) => return Ok(None),
+                Some(_) => return Err(LocalConfigurationReadError::Malformed),
             };
             let device_identifier = match items.get(3) {
                 None | Some(PropertyValue::Null) => None,
                 Some(PropertyValue::ObjectIdentifier(oid)) => Some(*oid),
-                Some(_) => return Ok(None),
+                Some(_) => return Err(LocalConfigurationReadError::Malformed),
             };
-            Ok(Some(MonitoredReference {
+            Ok(MonitoredReference {
                 object_identifier,
                 property_identifier,
                 array_index,
                 device_identifier,
-            }))
+            })
         }
-        Ok(_) => Ok(None),
-        Err(_) => Err(()),
+        Ok(_) => Err(LocalConfigurationReadError::Malformed),
+        Err(error) => Err(classify_required_property_read_error(&error)),
     }
 }
 

--- a/crates/bacnet-server/src/event_enrollment/support.rs
+++ b/crates/bacnet-server/src/event_enrollment/support.rs
@@ -1,0 +1,219 @@
+use std::collections::HashMap;
+
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_objects::event::EventTransition;
+use bacnet_objects::event_enrollment::{EventEnrollmentEvalState, EventEnrollmentMonitoredSource};
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::enums::{
+    ErrorClass, ErrorCode, EventState, ObjectType, PropertyIdentifier, Reliability,
+};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+
+use super::algorithms::extract_real;
+use super::commit::{EnrollmentUpdate, ReliabilityUpdate};
+use super::EventEnrollmentReliabilityCause;
+use super::LocalConfigurationReadError;
+
+pub(super) enum SetpointRead {
+    Value(f32),
+    Unusable,
+    Transient,
+}
+
+pub(super) fn read_setpoint(
+    db: &ObjectDatabase,
+    reference: &bacnet_types::constructed::BACnetDeviceObjectPropertyReference,
+) -> SetpointRead {
+    if reference.device_identifier.is_some() {
+        return SetpointRead::Transient;
+    }
+    let Some(object) = db.get(&reference.object_identifier) else {
+        return SetpointRead::Transient;
+    };
+    let property = PropertyIdentifier::from_raw(reference.property_identifier);
+    if reference.property_array_index.is_some() && !object.is_array_property(property) {
+        return SetpointRead::Unusable;
+    }
+    match object.read_property(property, reference.property_array_index) {
+        Ok(value) => extract_real(&value)
+            .map(SetpointRead::Value)
+            .unwrap_or(SetpointRead::Unusable),
+        Err(error)
+            if reference.property_array_index.is_some() && invalid_indexed_target_error(&error) =>
+        {
+            SetpointRead::Unusable
+        }
+        Err(_) => SetpointRead::Transient,
+    }
+}
+
+pub(super) fn passes_for_delay(delay_secs: u32, interval_secs: u64) -> u32 {
+    let passes = (delay_secs as u64).div_ceil(interval_secs.max(1));
+    u32::try_from(passes).unwrap_or(u32::MAX)
+}
+
+pub(super) fn ack_required_for_transition(
+    db: &ObjectDatabase,
+    enrollment: &dyn BACnetObject,
+    transition_bit: u8,
+) -> bool {
+    let Ok(PropertyValue::Unsigned(instance)) =
+        enrollment.read_property(PropertyIdentifier::NOTIFICATION_CLASS, None)
+    else {
+        return false;
+    };
+    let Ok(oid) = ObjectIdentifier::new(
+        ObjectType::NOTIFICATION_CLASS,
+        u32::try_from(instance).unwrap_or(u32::MAX),
+    ) else {
+        return false;
+    };
+    let Some(notification_class) = db.get(&oid) else {
+        return false;
+    };
+    match notification_class.read_property(PropertyIdentifier::ACK_REQUIRED, None) {
+        Ok(PropertyValue::BitString { data, .. }) => {
+            bacnet_types::bitstring::unpack_octet(&data, 3) & transition_bit != 0
+        }
+        _ => false,
+    }
+}
+
+pub(super) fn queue_eval_state_reset(
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
+    oid: ObjectIdentifier,
+    supported: bool,
+    state: &EventEnrollmentEvalState,
+    force: bool,
+) {
+    if supported && (force || *state != EventEnrollmentEvalState::default()) {
+        updates.entry(oid).or_default().reset_eval_state();
+    }
+}
+
+pub(super) fn queue_pending_cancellation(
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
+    oid: ObjectIdentifier,
+    supported: bool,
+    state: &mut EventEnrollmentEvalState,
+) {
+    if state.pending.take().is_some() && supported {
+        updates
+            .entry(oid)
+            .or_default()
+            .cancel_pending(state.clone());
+    }
+}
+
+pub(super) fn queue_eval_source_reset(
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
+    oid: ObjectIdentifier,
+    source: Option<Option<EventEnrollmentMonitoredSource>>,
+) {
+    if source.flatten().is_some() {
+        updates.entry(oid).or_default().set_eval_source(None);
+    }
+}
+
+pub(super) fn queue_invalid_reference(
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
+    oid: ObjectIdentifier,
+    eval_state_supported: bool,
+    eval_source: Option<Option<EventEnrollmentMonitoredSource>>,
+) {
+    if eval_state_supported {
+        updates.entry(oid).or_default().reset_eval_state();
+    }
+    queue_eval_source_reset(updates, oid, eval_source);
+}
+
+pub(super) fn invalid_indexed_target_error(error: &Error) -> bool {
+    matches!(
+        error,
+        Error::Protocol { class, code }
+            if *class == ErrorClass::PROPERTY.to_raw() as u32
+                && matches!(
+                    *code,
+                    code if code == ErrorCode::INVALID_ARRAY_INDEX.to_raw() as u32
+                        || code == ErrorCode::PROPERTY_IS_NOT_AN_ARRAY.to_raw() as u32
+                        || code == ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32
+                )
+    )
+}
+
+pub(super) fn classify_required_property_read_error(error: &Error) -> LocalConfigurationReadError {
+    if matches!(
+        error,
+        Error::Protocol { class, code }
+            if *class == ErrorClass::PROPERTY.to_raw() as u32
+                && *code == ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32
+    ) {
+        LocalConfigurationReadError::Malformed
+    } else {
+        LocalConfigurationReadError::Unavailable
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn queue_reliability_transition(
+    db: &ObjectDatabase,
+    enrollment: &dyn BACnetObject,
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
+    enrollment_oid: ObjectIdentifier,
+    monitored_oid: Option<ObjectIdentifier>,
+    previous: Reliability,
+    desired: Reliability,
+    current_state: EventState,
+    event_enable: u8,
+    cause: EventEnrollmentReliabilityCause,
+) {
+    let target = if desired == Reliability::NO_FAULT_DETECTED {
+        EventState::NORMAL
+    } else {
+        EventState::FAULT
+    };
+    if previous == desired && current_state == target {
+        return;
+    }
+    let transition_bit = EventTransition::for_target_state(target).bit_mask();
+    updates
+        .entry(enrollment_oid)
+        .or_default()
+        .set_reliability(ReliabilityUpdate {
+            monitored_oid,
+            previous,
+            desired,
+            from: current_state,
+            to: target,
+            distribute: event_enable & transition_bit != 0,
+            ack_required: ack_required_for_transition(db, enrollment, transition_bit),
+            cause,
+        });
+}
+
+pub(super) fn queue_observation_unavailable(
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
+    oid: ObjectIdentifier,
+) {
+    updates.entry(oid).or_default().observation_unavailable();
+}
+
+pub(super) fn queue_evaluation_ownership(
+    updates: &mut HashMap<ObjectIdentifier, EnrollmentUpdate>,
+    oid: ObjectIdentifier,
+    eval_state_supported: bool,
+    reset_state: bool,
+    eval_source: Option<Option<EventEnrollmentMonitoredSource>>,
+    monitored_reference: EventEnrollmentMonitoredSource,
+) {
+    if eval_state_supported && reset_state {
+        updates.entry(oid).or_default().reset_eval_state();
+    }
+    if eval_source.is_some_and(|current| current != Some(monitored_reference)) {
+        updates
+            .entry(oid)
+            .or_default()
+            .set_eval_source(Some(monitored_reference));
+    }
+}

--- a/crates/bacnet-server/src/event_enrollment/tests/compat.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/compat.rs
@@ -184,6 +184,17 @@ fn change_of_value_bitmask_criteria() {
     let mut target = EventEnrollmentObject::new(96, "Tgt", EventType::NONE.to_raw()).unwrap();
     target.set_event_enable(0x07); // internal 0x07 -> wire 0xE0 (MSB-first)
     let target_oid = target.object_identifier();
+    // Keep this Event Enrollment target itself healthy now that Reliability
+    // evaluation applies to every Event Enrollment object in the database.
+    target.set_object_property_reference(Some(BACnetDeviceObjectPropertyReference::new_local(
+        target_oid,
+        PropertyIdentifier::EVENT_ENABLE.to_raw(),
+    )));
+    target.set_event_parameters(BACnetEventParameter::Extended {
+        vendor_id: 42,
+        extended_event_type: 1,
+        parameters: Vec::new(),
+    });
     db.add(Box::new(target)).unwrap();
 
     let mut ee =

--- a/crates/bacnet-server/src/event_enrollment/tests/floating_limit.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/floating_limit.rs
@@ -142,16 +142,16 @@ fn unavailable_setpoint_discards_queued_evaluator_ownership_atomically() {
         .unwrap();
     let before_sequence = db.reserve_event_sequence_number().number();
 
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
 
     assert!(report.transitions.is_empty());
     assert!(report.reliability_results.is_empty());
     assert!(report
         .diagnostics
-        .contains(&EventEnrollmentEvaluationDiagnostic {
+        .contains(&EventEnrollmentDetailedEvaluationDiagnostic {
             enrollment_oid,
-            stage: EventEnrollmentEvaluationStage::Reliability,
-            outcome: EventEnrollmentEvaluationOutcome::ObservationUnavailable,
+            stage: EventEnrollmentDetailedEvaluationStage::Reliability,
+            outcome: EventEnrollmentDetailedEvaluationOutcome::ObservationUnavailable,
         }));
     let enrollment = db.get(&enrollment_oid).unwrap();
     assert_eq!(

--- a/crates/bacnet-server/src/event_enrollment/tests/floating_limit.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/floating_limit.rs
@@ -75,3 +75,110 @@ fn floating_limit_deadband_hysteresis() {
     assert_eq!(transitions.len(), 1);
     assert_eq!(transitions[0].change.to, EventState::NORMAL);
 }
+
+#[test]
+fn unavailable_setpoint_discards_queued_evaluator_ownership_atomically() {
+    let mut db = ObjectDatabase::new();
+    let mut monitored = AnalogInputObject::new(4, "AI-floating-monitored", 62).unwrap();
+    monitored.set_present_value(65.0);
+    let monitored_oid = monitored.object_identifier();
+    db.add(Box::new(monitored)).unwrap();
+
+    let missing_setpoint_oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 404).unwrap();
+    let mut enrollment = EventEnrollmentObject::new(
+        4,
+        "EE-floating-unavailable",
+        EventType::FLOATING_LIMIT.to_raw(),
+    )
+    .unwrap();
+    enrollment.set_object_property_reference(Some(BACnetDeviceObjectPropertyReference::new_local(
+        monitored_oid,
+        PropertyIdentifier::PRESENT_VALUE.to_raw(),
+    )));
+    enrollment.set_event_parameters(BACnetEventParameter::FloatingLimit {
+        time_delay: 2,
+        setpoint_reference: BACnetDeviceObjectPropertyReference::new_local(
+            missing_setpoint_oid,
+            PropertyIdentifier::PRESENT_VALUE.to_raw(),
+        ),
+        low_diff_limit: 10.0,
+        high_diff_limit: 10.0,
+        deadband: 2.0,
+    });
+    let stale_state = EventEnrollmentEvalState {
+        pending: Some(EventEnrollmentPending {
+            state: EventState::HIGH_LIMIT,
+            remaining: 1,
+            condition: 1,
+            params_fingerprint: 7,
+        }),
+        cov_baseline: Some(PropertyValue::Real(33.0)),
+        last_offnormal_value: Some(2),
+    };
+    let stale_source = (monitored_oid, PropertyIdentifier::DESCRIPTION, None);
+    enrollment
+        .set_enrollment_eval_state_internal(stale_state.clone())
+        .unwrap();
+    enrollment
+        .set_enrollment_eval_source_internal(Some(stale_source))
+        .unwrap();
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    let before_reliability = db
+        .get(&enrollment_oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::RELIABILITY, None)
+        .unwrap();
+    let before_state = db
+        .get(&enrollment_oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::EVENT_STATE, None)
+        .unwrap();
+    let before_timestamps = db
+        .get(&enrollment_oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
+        .unwrap();
+    let before_sequence = db.reserve_event_sequence_number().number();
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+
+    assert!(report.transitions.is_empty());
+    assert!(report.reliability_results.is_empty());
+    assert!(report
+        .diagnostics
+        .contains(&EventEnrollmentEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentEvaluationStage::Reliability,
+            outcome: EventEnrollmentEvaluationOutcome::ObservationUnavailable,
+        }));
+    let enrollment = db.get(&enrollment_oid).unwrap();
+    assert_eq!(
+        enrollment.enrollment_eval_state_internal(),
+        Some(stale_state)
+    );
+    assert_eq!(
+        enrollment.enrollment_eval_source_internal(),
+        Some(Some(stale_source))
+    );
+    assert_eq!(
+        enrollment
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        before_reliability
+    );
+    assert_eq!(
+        enrollment
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        before_state
+    );
+    assert_eq!(
+        enrollment
+            .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
+            .unwrap(),
+        before_timestamps
+    );
+    assert_eq!(db.reserve_event_sequence_number().number(), before_sequence);
+}

--- a/crates/bacnet-server/src/event_enrollment/tests/integration.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/integration.rs
@@ -184,22 +184,21 @@ fn qualified_reference_requires_one_containing_device() {
 }
 
 #[test]
-fn unresolvable_reference_clears_private_evaluator_state() {
+fn remote_reference_is_unavailable_and_retains_private_evaluator_state() {
     let (mut db, ee_oid, _) = setup_qualified_reference(&[100], 200);
+    let stale = bacnet_objects::event_enrollment::EventEnrollmentEvalState {
+        pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
+            state: EventState::HIGH_LIMIT,
+            remaining: 1,
+            condition: 0,
+            params_fingerprint: 1,
+        }),
+        cov_baseline: Some(PropertyValue::Real(90.0)),
+        last_offnormal_value: Some(1),
+    };
     db.get_mut(&ee_oid)
         .unwrap()
-        .set_enrollment_eval_state_internal(
-            bacnet_objects::event_enrollment::EventEnrollmentEvalState {
-                pending: Some(bacnet_objects::event_enrollment::EventEnrollmentPending {
-                    state: EventState::HIGH_LIMIT,
-                    remaining: 1,
-                    condition: 0,
-                    params_fingerprint: 1,
-                }),
-                cov_baseline: Some(PropertyValue::Real(90.0)),
-                last_offnormal_value: Some(1),
-            },
-        )
+        .set_enrollment_eval_state_internal(stale.clone())
         .unwrap();
 
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
@@ -208,7 +207,7 @@ fn unresolvable_reference_clears_private_evaluator_state() {
             .unwrap()
             .enrollment_eval_state_internal()
             .unwrap(),
-        bacnet_objects::event_enrollment::EventEnrollmentEvalState::default()
+        stale
     );
 }
 
@@ -216,6 +215,7 @@ pub(super) struct ReferenceValueObject {
     pub(super) inner: EventEnrollmentObject,
     reference: Option<PropertyValue>,
     pub(super) event_parameters_readable: Arc<AtomicBool>,
+    pub(super) fault_parameters_supported: bool,
     pub(super) state_writable: Arc<AtomicBool>,
     pub(super) state_write_count: Arc<AtomicUsize>,
     pub(super) source_supported: bool,
@@ -223,6 +223,8 @@ pub(super) struct ReferenceValueObject {
     pub(super) normal_event_state_writable: bool,
     pub(super) event_state_error_after_write: bool,
     pub(super) atomic_commit_supported: bool,
+    pub(super) reliability_commit_supported: bool,
+    pub(super) reliability_error_after_write: bool,
 }
 
 impl ReferenceValueObject {
@@ -247,6 +249,7 @@ impl ReferenceValueObject {
             inner,
             reference,
             event_parameters_readable: Arc::new(AtomicBool::new(true)),
+            fault_parameters_supported: true,
             state_writable: Arc::new(AtomicBool::new(true)),
             state_write_count: Arc::new(AtomicUsize::new(0)),
             source_supported: true,
@@ -254,6 +257,8 @@ impl ReferenceValueObject {
             normal_event_state_writable: true,
             event_state_error_after_write: false,
             atomic_commit_supported: true,
+            reliability_commit_supported: true,
+            reliability_error_after_write: false,
         }
     }
 }
@@ -276,6 +281,13 @@ impl BACnetObject for ReferenceValueObject {
             self.reference
                 .clone()
                 .ok_or_else(|| bacnet_types::error::Error::Encoding("reference read failed".into()))
+        } else if property == PropertyIdentifier::FAULT_PARAMETERS
+            && !self.fault_parameters_supported
+        {
+            Err(bacnet_types::error::Error::Protocol {
+                class: bacnet_types::enums::ErrorClass::PROPERTY.to_raw() as u32,
+                code: bacnet_types::enums::ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            })
         } else if property == PropertyIdentifier::EVENT_PARAMETERS
             && !self.event_parameters_readable.load(Ordering::SeqCst)
         {
@@ -382,6 +394,22 @@ impl BACnetObject for ReferenceValueObject {
         }
         self.inner.commit_event_transition_internal(commit)?;
         if self.event_state_error_after_write {
+            Err(bacnet_objects::event::EventTransitionCommitError::Unsupported)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn commit_event_enrollment_reliability_internal(
+        &mut self,
+        commit: bacnet_objects::event_enrollment::EventEnrollmentReliabilityCommit,
+    ) -> Result<(), bacnet_objects::event::EventTransitionCommitError> {
+        if !self.reliability_commit_supported {
+            return Err(bacnet_objects::event::EventTransitionCommitError::Unsupported);
+        }
+        self.inner
+            .commit_event_enrollment_reliability_internal(commit)?;
+        if self.reliability_error_after_write {
             Err(bacnet_objects::event::EventTransitionCommitError::Unsupported)
         } else {
             Ok(())
@@ -573,7 +601,7 @@ fn malformed_reference_shapes_do_not_become_local() {
         let enrollment = ReferenceValueObject::new(Some(PropertyValue::List(items)));
         assert!(matches!(
             super::super::read_object_property_ref(&enrollment),
-            Ok(None)
+            Err(super::super::LocalConfigurationReadError::Malformed)
         ));
     }
 
@@ -583,9 +611,9 @@ fn malformed_reference_shapes_do_not_become_local() {
     ])));
     assert_eq!(
         super::super::read_object_property_ref(&legacy),
-        Ok(Some(super::super::MonitoredReference::local(
+        Ok(super::super::MonitoredReference::local(
             target, property, None
-        )))
+        ))
     );
 }
 
@@ -654,6 +682,7 @@ fn malformed_retarget_does_not_resume_stale_countdown() {
             None,
         )
         .unwrap();
+    assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
     assert!(evaluate_event_enrollments(&mut db, 1).is_empty());
     assert_eq!(

--- a/crates/bacnet-server/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/mod.rs
@@ -10,6 +10,7 @@ mod floating_limit;
 mod foreign_state;
 mod integration;
 mod out_of_range;
+mod reliability;
 mod same_state;
 mod transactional_commit;
 

--- a/crates/bacnet-server/src/event_enrollment/tests/mod.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/mod.rs
@@ -11,6 +11,7 @@ mod foreign_state;
 mod integration;
 mod out_of_range;
 mod reliability;
+mod reliability_dataflow;
 mod same_state;
 mod transactional_commit;
 

--- a/crates/bacnet-server/src/event_enrollment/tests/reliability.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/reliability.rs
@@ -1,0 +1,745 @@
+use super::integration::{indexed_reference_value, ReferenceValueObject};
+use super::*;
+use bacnet_encoding::primitives::decode_timestamp_choice;
+use bacnet_objects::analog::{AnalogInputObject, AnalogValueObject};
+use bacnet_objects::event_enrollment::EventEnrollmentObject;
+use bacnet_types::constructed::{
+    BACnetDeviceObjectPropertyReference, BACnetEventParameter, BACnetPropertyStates,
+    FaultParameters,
+};
+use bacnet_types::enums::{ErrorClass, ErrorCode, Reliability};
+use bacnet_types::primitives::BACnetTimeStamp;
+use std::borrow::Cow;
+use std::sync::atomic::Ordering;
+
+struct OptionalReliabilityTarget {
+    oid: ObjectIdentifier,
+    malformed_reliability: bool,
+}
+
+impl OptionalReliabilityTarget {
+    fn new(instance: u32, malformed_reliability: bool) -> Self {
+        Self {
+            oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap(),
+            malformed_reliability,
+        }
+    }
+}
+
+impl BACnetObject for OptionalReliabilityTarget {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "optional-reliability-target"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, bacnet_types::error::Error> {
+        if property == PropertyIdentifier::PRESENT_VALUE {
+            Ok(PropertyValue::Real(90.0))
+        } else if property == PropertyIdentifier::RELIABILITY && self.malformed_reliability {
+            Ok(PropertyValue::Real(0.0))
+        } else {
+            Err(bacnet_types::error::Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            })
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), bacnet_types::error::Error> {
+        Err(bacnet_types::error::Error::Encoding(
+            "read-only test target".into(),
+        ))
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[])
+    }
+}
+
+fn setup(
+    present_value: f32,
+    fault_parameters: FaultParameters,
+) -> (ObjectDatabase, ObjectIdentifier, ObjectIdentifier) {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogInputObject::new(301, "AI-fault-target", 62).unwrap();
+    target.set_present_value(present_value);
+    target
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment =
+        EventEnrollmentObject::new(301, "EE-fault", EventType::OUT_OF_RANGE.to_raw()).unwrap();
+    enrollment.set_object_property_reference(Some(BACnetDeviceObjectPropertyReference::new_local(
+        target_oid,
+        PropertyIdentifier::PRESENT_VALUE.to_raw(),
+    )));
+    enrollment.set_event_parameters(BACnetEventParameter::OutOfRange {
+        time_delay: 0,
+        low_limit: 20.0,
+        high_limit: 80.0,
+        deadband: 2.0,
+    });
+    enrollment.set_fault_parameters(Some(fault_parameters));
+    enrollment.set_event_enable(0x07);
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+    (db, enrollment_oid, target_oid)
+}
+
+fn write_target(
+    db: &mut ObjectDatabase,
+    target_oid: ObjectIdentifier,
+    property: PropertyIdentifier,
+    value: PropertyValue,
+) {
+    db.get_mut(&target_oid)
+        .unwrap()
+        .write_property(property, None, value, None)
+        .unwrap();
+}
+
+fn reliability(db: &ObjectDatabase, oid: ObjectIdentifier) -> Reliability {
+    let PropertyValue::Enumerated(raw) = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::RELIABILITY, None)
+        .unwrap()
+    else {
+        panic!("Reliability must be Enumerated");
+    };
+    Reliability::from_raw(raw)
+}
+
+fn event_state(db: &ObjectDatabase, oid: ObjectIdentifier) -> EventState {
+    let PropertyValue::Enumerated(raw) = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::EVENT_STATE, None)
+        .unwrap()
+    else {
+        panic!("Event_State must be Enumerated");
+    };
+    EventState::from_raw(raw)
+}
+
+fn timestamp_at(db: &ObjectDatabase, oid: ObjectIdentifier, index: u32) -> BACnetTimeStamp {
+    let PropertyValue::ApplicationData(bytes) = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(index))
+        .unwrap()
+    else {
+        panic!("Event_Time_Stamps slot must be encoded application data");
+    };
+    let (timestamp, end) = decode_timestamp_choice(&bytes, 0).unwrap();
+    assert_eq!(end, bytes.len());
+    timestamp
+}
+
+#[test]
+fn configuration_precedes_monitored_reliability_and_monitored_precedes_algorithm() {
+    let (mut db, enrollment_oid, target_oid) = setup(
+        -1.0,
+        FaultParameters::FaultCharacterString {
+            fault_values: vec!["unsupported".into()],
+        },
+    );
+    write_target(
+        &mut db,
+        target_oid,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
+    );
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(report.reliability_results.len(), 1);
+    assert_eq!(
+        report.reliability_results[0].new_reliability,
+        Reliability::CONFIGURATION_ERROR
+    );
+    assert_eq!(
+        report.reliability_results[0].cause,
+        EventEnrollmentReliabilityCause::Configuration
+    );
+    assert_eq!(event_state(&db, enrollment_oid), EventState::FAULT);
+    assert_eq!(
+        timestamp_at(&db, enrollment_oid, 2),
+        BACnetTimeStamp::SequenceNumber(0)
+    );
+
+    write_target(
+        &mut db,
+        target_oid,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+    );
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::FAULT_PARAMETERS,
+            None,
+            FaultParameters::FaultNone.encode_property_value(),
+            None,
+        )
+        .unwrap();
+    let recovery = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(recovery.reliability_results.len(), 1);
+    assert_eq!(
+        recovery.reliability_results[0].new_reliability,
+        Reliability::NO_FAULT_DETECTED
+    );
+    assert_eq!(
+        recovery.reliability_results[0].cause,
+        EventEnrollmentReliabilityCause::Configuration
+    );
+    assert_eq!(event_state(&db, enrollment_oid), EventState::NORMAL);
+    assert_eq!(
+        timestamp_at(&db, enrollment_oid, 3),
+        BACnetTimeStamp::SequenceNumber(1)
+    );
+
+    let (mut db, enrollment_oid, target_oid) = setup(
+        -1.0,
+        FaultParameters::FaultOutOfRange {
+            min_normal: 0.0,
+            max_normal: 10.0,
+        },
+    );
+    write_target(
+        &mut db,
+        target_oid,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
+    );
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(
+        report.reliability_results[0].new_reliability,
+        Reliability::MONITORED_OBJECT_FAULT
+    );
+    assert_eq!(
+        report.reliability_results[0].cause,
+        EventEnrollmentReliabilityCause::MonitoredObject
+    );
+
+    write_target(
+        &mut db,
+        target_oid,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+    );
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(report.reliability_results.len(), 1);
+    assert_eq!(
+        report.reliability_results[0].new_reliability,
+        Reliability::UNDER_RANGE
+    );
+    assert_eq!(
+        report.reliability_results[0].state_change,
+        Some(EventStateChange {
+            from: EventState::FAULT,
+            to: EventState::FAULT,
+        })
+    );
+    assert_eq!(reliability(&db, enrollment_oid), Reliability::UNDER_RANGE);
+}
+
+#[test]
+fn every_deferred_fault_alternative_commits_configuration_error() {
+    let reference = BACnetDeviceObjectPropertyReference::new_local(
+        ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 301).unwrap(),
+        PropertyIdentifier::PRESENT_VALUE.to_raw(),
+    );
+    let alternatives = [
+        FaultParameters::FaultCharacterString {
+            fault_values: vec!["unsupported".into()],
+        },
+        FaultParameters::FaultExtended {
+            vendor_id: 1,
+            extended_fault_type: 2,
+            parameters: vec![0x21, 0x03],
+        },
+        FaultParameters::FaultLifeSafety {
+            fault_values: vec![1],
+            mode_for_reference: reference.clone(),
+        },
+        FaultParameters::FaultState {
+            fault_values: vec![BACnetPropertyStates::BooleanValue(true)],
+        },
+        FaultParameters::FaultListed { reference },
+    ];
+
+    for parameters in alternatives {
+        let (mut db, enrollment_oid, _) = setup(50.0, parameters);
+        let report = evaluate_event_enrollments_report(&mut db, 1);
+
+        assert_eq!(report.reliability_results.len(), 1);
+        assert_eq!(
+            report.reliability_results[0].new_reliability,
+            Reliability::CONFIGURATION_ERROR
+        );
+        assert_eq!(
+            report.reliability_results[0].cause,
+            EventEnrollmentReliabilityCause::Configuration
+        );
+        assert_eq!(event_state(&db, enrollment_oid), EventState::FAULT);
+    }
+}
+
+#[test]
+fn fault_none_falls_through_to_the_normal_event_algorithm() {
+    let (mut db, enrollment_oid, _) = setup(90.0, FaultParameters::FaultNone);
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+
+    assert!(report.reliability_results.is_empty());
+    assert_eq!(report.transitions.len(), 1);
+    assert_eq!(report.transitions[0].change.to, EventState::HIGH_LIMIT);
+    assert_eq!(
+        reliability(&db, enrollment_oid),
+        Reliability::NO_FAULT_DETECTED
+    );
+}
+
+#[test]
+fn absent_optional_fault_parameters_preserves_custom_normal_event_evaluation() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(321, "AV-no-fault-parameters", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    enrollment.fault_parameters_supported = false;
+    enrollment
+        .inner
+        .set_event_parameters(BACnetEventParameter::OutOfRange {
+            time_delay: 0,
+            low_limit: 20.0,
+            high_limit: 80.0,
+            deadband: 2.0,
+        });
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+
+    assert!(report.reliability_results.is_empty());
+    assert_eq!(report.transitions.len(), 1);
+    assert_eq!(report.transitions[0].change.to, EventState::HIGH_LIMIT);
+    assert_eq!(
+        reliability(&db, enrollment_oid),
+        Reliability::NO_FAULT_DETECTED
+    );
+}
+
+#[test]
+fn absent_optional_target_reliability_falls_through_but_malformed_type_is_configuration_error() {
+    for malformed in [false, true] {
+        let mut db = ObjectDatabase::new();
+        let target = OptionalReliabilityTarget::new(320 + u32::from(malformed), malformed);
+        let target_oid = target.object_identifier();
+        db.add(Box::new(target)).unwrap();
+
+        let mut enrollment = EventEnrollmentObject::new(
+            320 + u32::from(malformed),
+            "EE-optional-reliability",
+            EventType::OUT_OF_RANGE.to_raw(),
+        )
+        .unwrap();
+        enrollment.set_object_property_reference(Some(
+            BACnetDeviceObjectPropertyReference::new_local(
+                target_oid,
+                PropertyIdentifier::PRESENT_VALUE.to_raw(),
+            ),
+        ));
+        enrollment.set_event_parameters(BACnetEventParameter::OutOfRange {
+            time_delay: 0,
+            low_limit: 20.0,
+            high_limit: 80.0,
+            deadband: 2.0,
+        });
+        enrollment.set_fault_parameters(Some(FaultParameters::FaultNone));
+        let enrollment_oid = enrollment.object_identifier();
+        db.add(Box::new(enrollment)).unwrap();
+
+        let report = evaluate_event_enrollments_report(&mut db, 1);
+        if malformed {
+            assert_eq!(
+                report.reliability_results[0].new_reliability,
+                Reliability::CONFIGURATION_ERROR
+            );
+        } else {
+            assert!(report.reliability_results.is_empty());
+            assert_eq!(report.transitions.len(), 1);
+            assert_eq!(event_state(&db, enrollment_oid), EventState::HIGH_LIMIT);
+        }
+    }
+}
+
+#[test]
+fn local_status_flags_fault_enters_member_fault_and_recovers() {
+    let mut status_source = AnalogInputObject::new(302, "AI-status-source", 62).unwrap();
+    status_source
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    status_source
+        .write_property(
+            PropertyIdentifier::RELIABILITY,
+            None,
+            PropertyValue::Enumerated(Reliability::PROCESS_ERROR.to_raw()),
+            None,
+        )
+        .unwrap();
+    let status_oid = status_source.object_identifier();
+
+    let (mut db, enrollment_oid, _) = setup(
+        50.0,
+        FaultParameters::FaultStatusFlags {
+            reference: BACnetDeviceObjectPropertyReference::new_local(
+                status_oid,
+                PropertyIdentifier::STATUS_FLAGS.to_raw(),
+            ),
+        },
+    );
+    db.add(Box::new(status_source)).unwrap();
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(
+        report.reliability_results[0].new_reliability,
+        Reliability::MEMBER_FAULT
+    );
+    assert_eq!(event_state(&db, enrollment_oid), EventState::FAULT);
+
+    write_target(
+        &mut db,
+        status_oid,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+    );
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(
+        report.reliability_results[0].new_reliability,
+        Reliability::NO_FAULT_DETECTED
+    );
+    assert_eq!(event_state(&db, enrollment_oid), EventState::NORMAL);
+}
+
+#[test]
+fn normalized_out_of_range_holds_reindicates_changed_cause_and_recovers() {
+    let (mut db, enrollment_oid, target_oid) = setup(
+        -1.0,
+        FaultParameters::FaultOutOfRange {
+            min_normal: 0.0,
+            max_normal: 10.0,
+        },
+    );
+
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(
+        report.reliability_results[0].new_reliability,
+        Reliability::UNDER_RANGE
+    );
+    assert_eq!(
+        timestamp_at(&db, enrollment_oid, 2),
+        BACnetTimeStamp::SequenceNumber(0)
+    );
+    assert!(evaluate_event_enrollments_report(&mut db, 1)
+        .reliability_results
+        .is_empty());
+    assert_eq!(db.reserve_event_sequence_number().number(), 1);
+
+    write_target(
+        &mut db,
+        target_oid,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Real(11.0),
+    );
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(
+        report.reliability_results[0].state_change,
+        Some(EventStateChange {
+            from: EventState::FAULT,
+            to: EventState::FAULT,
+        })
+    );
+    assert_eq!(
+        report.reliability_results[0].new_reliability,
+        Reliability::OVER_RANGE
+    );
+    assert_eq!(
+        timestamp_at(&db, enrollment_oid, 2),
+        BACnetTimeStamp::SequenceNumber(1)
+    );
+
+    write_target(
+        &mut db,
+        target_oid,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Real(5.0),
+    );
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(
+        report.reliability_results[0].new_reliability,
+        Reliability::NO_FAULT_DETECTED
+    );
+    assert_eq!(
+        timestamp_at(&db, enrollment_oid, 3),
+        BACnetTimeStamp::SequenceNumber(2)
+    );
+}
+
+#[test]
+fn missing_target_is_observation_unavailable_without_mutation() {
+    let mut db = ObjectDatabase::new();
+    let missing_oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 999).unwrap();
+    let mut enrollment =
+        EventEnrollmentObject::new(303, "EE-missing", EventType::OUT_OF_RANGE.to_raw()).unwrap();
+    enrollment.set_object_property_reference(Some(BACnetDeviceObjectPropertyReference::new_local(
+        missing_oid,
+        PropertyIdentifier::PRESENT_VALUE.to_raw(),
+    )));
+    enrollment.set_event_parameters(BACnetEventParameter::OutOfRange {
+        time_delay: 0,
+        low_limit: 0.0,
+        high_limit: 10.0,
+        deadband: 1.0,
+    });
+    enrollment.set_fault_parameters(Some(FaultParameters::FaultNone));
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    let before_timestamp = timestamp_at(&db, enrollment_oid, 2);
+    let report = evaluate_event_enrollments_report(&mut db, 1);
+
+    assert!(report.reliability_results.is_empty());
+    assert!(report.transitions.is_empty());
+    assert!(report
+        .diagnostics
+        .contains(&EventEnrollmentEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentEvaluationStage::Reliability,
+            outcome: EventEnrollmentEvaluationOutcome::ObservationUnavailable,
+        }));
+    assert_eq!(
+        reliability(&db, enrollment_oid),
+        Reliability::NO_FAULT_DETECTED
+    );
+    assert_eq!(event_state(&db, enrollment_oid), EventState::NORMAL);
+    assert_eq!(timestamp_at(&db, enrollment_oid, 2), before_timestamp);
+}
+
+#[test]
+fn fault_recovery_resets_cached_event_state_once_and_restarts_full_delay_next_pass() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(304, "AV-recovery", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(90.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    let state_writes = enrollment.state_write_count.clone();
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+    assert!(evaluate_event_enrollments_report(&mut db, 1)
+        .transitions
+        .is_empty());
+
+    write_target(
+        &mut db,
+        target_oid,
+        PropertyIdentifier::OUT_OF_SERVICE,
+        PropertyValue::Boolean(true),
+    );
+    write_target(
+        &mut db,
+        target_oid,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
+    );
+    assert_eq!(
+        evaluate_event_enrollments_report(&mut db, 1).reliability_results[0].new_reliability,
+        Reliability::MONITORED_OBJECT_FAULT
+    );
+
+    write_target(
+        &mut db,
+        target_oid,
+        PropertyIdentifier::RELIABILITY,
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+    );
+    state_writes.store(0, Ordering::SeqCst);
+    let recovery = evaluate_event_enrollments_report(&mut db, 1);
+    assert_eq!(recovery.reliability_results.len(), 1);
+    assert_eq!(state_writes.load(Ordering::SeqCst), 1);
+    assert!(db
+        .get(&enrollment_oid)
+        .unwrap()
+        .enrollment_eval_state_internal()
+        .unwrap()
+        .pending
+        .is_none());
+
+    let next = evaluate_event_enrollments_report(&mut db, 1);
+    assert!(next.transitions.is_empty());
+    assert!(next.reliability_results.is_empty());
+    assert_eq!(
+        db.get(&enrollment_oid)
+            .unwrap()
+            .enrollment_eval_state_internal()
+            .unwrap()
+            .pending
+            .unwrap()
+            .remaining,
+        2
+    );
+}
+
+#[test]
+fn rejected_and_mutating_custom_hooks_do_not_escape_tokens_or_consume_sequences() {
+    for mutate_then_error in [false, true] {
+        let mut db = ObjectDatabase::new();
+        let mut target = AnalogValueObject::new(305, "AV-hook", 62).unwrap();
+        target
+            .write_property(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                PropertyValue::Real(90.0),
+                Some(1),
+            )
+            .unwrap();
+        target
+            .write_property(
+                PropertyIdentifier::OUT_OF_SERVICE,
+                None,
+                PropertyValue::Boolean(true),
+                None,
+            )
+            .unwrap();
+        target
+            .write_property(
+                PropertyIdentifier::RELIABILITY,
+                None,
+                PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
+                None,
+            )
+            .unwrap();
+        let target_oid = target.object_identifier();
+        db.add(Box::new(target)).unwrap();
+
+        let mut enrollment =
+            ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+        enrollment.reliability_commit_supported = mutate_then_error;
+        enrollment.reliability_error_after_write = mutate_then_error;
+        let enrollment_oid = enrollment.object_identifier();
+        db.add(Box::new(enrollment)).unwrap();
+
+        let report = evaluate_event_enrollments_report(&mut db, 1);
+        assert!(report.reliability_results.is_empty());
+        assert!(report.transitions.is_empty());
+        assert!(report
+            .diagnostics
+            .contains(&EventEnrollmentEvaluationDiagnostic {
+                enrollment_oid,
+                stage: EventEnrollmentEvaluationStage::Reliability,
+                outcome: if mutate_then_error {
+                    EventEnrollmentEvaluationOutcome::LandedAfterError
+                } else {
+                    EventEnrollmentEvaluationOutcome::Rejected
+                },
+            }));
+        assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
+        assert_eq!(db.reserve_event_sequence_number().number(), 0);
+    }
+}
+
+#[test]
+fn held_configuration_error_clears_landed_after_error_invalidation_once() {
+    let mut db = ObjectDatabase::new();
+    let mut target = AnalogValueObject::new(306, "AV-held-config", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(50.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    enrollment
+        .inner
+        .set_fault_parameters(Some(FaultParameters::FaultCharacterString {
+            fault_values: vec!["unsupported".into()],
+        }));
+    enrollment.reliability_error_after_write = true;
+    let state_writes = enrollment.state_write_count.clone();
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    let first = evaluate_event_enrollments_report(&mut db, 1);
+    assert!(first
+        .diagnostics
+        .contains(&EventEnrollmentEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentEvaluationStage::Reliability,
+            outcome: EventEnrollmentEvaluationOutcome::LandedAfterError,
+        }));
+    assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
+    assert_eq!(
+        reliability(&db, enrollment_oid),
+        Reliability::CONFIGURATION_ERROR
+    );
+    assert_eq!(event_state(&db, enrollment_oid), EventState::FAULT);
+
+    state_writes.store(0, Ordering::SeqCst);
+    let held = evaluate_event_enrollments_report(&mut db, 1);
+    assert!(held.reliability_results.is_empty());
+    assert_eq!(state_writes.load(Ordering::SeqCst), 1);
+    assert!(!db.enrollment_eval_state_invalidated(&enrollment_oid));
+
+    let held_again = evaluate_event_enrollments_report(&mut db, 1);
+    assert!(held_again.reliability_results.is_empty());
+    assert_eq!(state_writes.load(Ordering::SeqCst), 1);
+    assert!(!db.enrollment_eval_state_invalidated(&enrollment_oid));
+}

--- a/crates/bacnet-server/src/event_enrollment/tests/reliability.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/reliability.rs
@@ -171,7 +171,7 @@ fn configuration_precedes_monitored_reliability_and_monitored_precedes_algorithm
         PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
     );
 
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(report.reliability_results.len(), 1);
     assert_eq!(
         report.reliability_results[0].new_reliability,
@@ -202,7 +202,7 @@ fn configuration_precedes_monitored_reliability_and_monitored_precedes_algorithm
             None,
         )
         .unwrap();
-    let recovery = evaluate_event_enrollments_report(&mut db, 1);
+    let recovery = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(recovery.reliability_results.len(), 1);
     assert_eq!(
         recovery.reliability_results[0].new_reliability,
@@ -231,7 +231,7 @@ fn configuration_precedes_monitored_reliability_and_monitored_precedes_algorithm
         PropertyIdentifier::RELIABILITY,
         PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
     );
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(
         report.reliability_results[0].new_reliability,
         Reliability::MONITORED_OBJECT_FAULT
@@ -247,7 +247,7 @@ fn configuration_precedes_monitored_reliability_and_monitored_precedes_algorithm
         PropertyIdentifier::RELIABILITY,
         PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
     );
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(report.reliability_results.len(), 1);
     assert_eq!(
         report.reliability_results[0].new_reliability,
@@ -290,7 +290,7 @@ fn every_deferred_fault_alternative_commits_configuration_error() {
 
     for parameters in alternatives {
         let (mut db, enrollment_oid, _) = setup(50.0, parameters);
-        let report = evaluate_event_enrollments_report(&mut db, 1);
+        let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
 
         assert_eq!(report.reliability_results.len(), 1);
         assert_eq!(
@@ -309,7 +309,7 @@ fn every_deferred_fault_alternative_commits_configuration_error() {
 fn fault_none_falls_through_to_the_normal_event_algorithm() {
     let (mut db, enrollment_oid, _) = setup(90.0, FaultParameters::FaultNone);
 
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
 
     assert!(report.reliability_results.is_empty());
     assert_eq!(report.transitions.len(), 1);
@@ -348,7 +348,7 @@ fn absent_optional_fault_parameters_preserves_custom_normal_event_evaluation() {
     let enrollment_oid = enrollment.object_identifier();
     db.add(Box::new(enrollment)).unwrap();
 
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
 
     assert!(report.reliability_results.is_empty());
     assert_eq!(report.transitions.len(), 1);
@@ -389,7 +389,7 @@ fn absent_optional_target_reliability_falls_through_but_malformed_type_is_config
         let enrollment_oid = enrollment.object_identifier();
         db.add(Box::new(enrollment)).unwrap();
 
-        let report = evaluate_event_enrollments_report(&mut db, 1);
+        let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
         if malformed {
             assert_eq!(
                 report.reliability_results[0].new_reliability,
@@ -435,7 +435,7 @@ fn local_status_flags_fault_enters_member_fault_and_recovers() {
     );
     db.add(Box::new(status_source)).unwrap();
 
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(
         report.reliability_results[0].new_reliability,
         Reliability::MEMBER_FAULT
@@ -448,7 +448,7 @@ fn local_status_flags_fault_enters_member_fault_and_recovers() {
         PropertyIdentifier::RELIABILITY,
         PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
     );
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(
         report.reliability_results[0].new_reliability,
         Reliability::NO_FAULT_DETECTED
@@ -466,7 +466,7 @@ fn normalized_out_of_range_holds_reindicates_changed_cause_and_recovers() {
         },
     );
 
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(
         report.reliability_results[0].new_reliability,
         Reliability::UNDER_RANGE
@@ -475,7 +475,7 @@ fn normalized_out_of_range_holds_reindicates_changed_cause_and_recovers() {
         timestamp_at(&db, enrollment_oid, 2),
         BACnetTimeStamp::SequenceNumber(0)
     );
-    assert!(evaluate_event_enrollments_report(&mut db, 1)
+    assert!(evaluate_event_enrollments_detailed_report(&mut db, 1)
         .reliability_results
         .is_empty());
     assert_eq!(db.reserve_event_sequence_number().number(), 1);
@@ -486,7 +486,7 @@ fn normalized_out_of_range_holds_reindicates_changed_cause_and_recovers() {
         PropertyIdentifier::PRESENT_VALUE,
         PropertyValue::Real(11.0),
     );
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(
         report.reliability_results[0].state_change,
         Some(EventStateChange {
@@ -509,7 +509,7 @@ fn normalized_out_of_range_holds_reindicates_changed_cause_and_recovers() {
         PropertyIdentifier::PRESENT_VALUE,
         PropertyValue::Real(5.0),
     );
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(
         report.reliability_results[0].new_reliability,
         Reliability::NO_FAULT_DETECTED
@@ -541,16 +541,16 @@ fn missing_target_is_observation_unavailable_without_mutation() {
     db.add(Box::new(enrollment)).unwrap();
 
     let before_timestamp = timestamp_at(&db, enrollment_oid, 2);
-    let report = evaluate_event_enrollments_report(&mut db, 1);
+    let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
 
     assert!(report.reliability_results.is_empty());
     assert!(report.transitions.is_empty());
     assert!(report
         .diagnostics
-        .contains(&EventEnrollmentEvaluationDiagnostic {
+        .contains(&EventEnrollmentDetailedEvaluationDiagnostic {
             enrollment_oid,
-            stage: EventEnrollmentEvaluationStage::Reliability,
-            outcome: EventEnrollmentEvaluationOutcome::ObservationUnavailable,
+            stage: EventEnrollmentDetailedEvaluationStage::Reliability,
+            outcome: EventEnrollmentDetailedEvaluationOutcome::ObservationUnavailable,
         }));
     assert_eq!(
         reliability(&db, enrollment_oid),
@@ -579,7 +579,7 @@ fn fault_recovery_resets_cached_event_state_once_and_restarts_full_delay_next_pa
     let state_writes = enrollment.state_write_count.clone();
     let enrollment_oid = enrollment.object_identifier();
     db.add(Box::new(enrollment)).unwrap();
-    assert!(evaluate_event_enrollments_report(&mut db, 1)
+    assert!(evaluate_event_enrollments_detailed_report(&mut db, 1)
         .transitions
         .is_empty());
 
@@ -596,7 +596,8 @@ fn fault_recovery_resets_cached_event_state_once_and_restarts_full_delay_next_pa
         PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
     );
     assert_eq!(
-        evaluate_event_enrollments_report(&mut db, 1).reliability_results[0].new_reliability,
+        evaluate_event_enrollments_detailed_report(&mut db, 1).reliability_results[0]
+            .new_reliability,
         Reliability::MONITORED_OBJECT_FAULT
     );
 
@@ -607,7 +608,7 @@ fn fault_recovery_resets_cached_event_state_once_and_restarts_full_delay_next_pa
         PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
     );
     state_writes.store(0, Ordering::SeqCst);
-    let recovery = evaluate_event_enrollments_report(&mut db, 1);
+    let recovery = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert_eq!(recovery.reliability_results.len(), 1);
     assert_eq!(state_writes.load(Ordering::SeqCst), 1);
     assert!(db
@@ -618,7 +619,7 @@ fn fault_recovery_resets_cached_event_state_once_and_restarts_full_delay_next_pa
         .pending
         .is_none());
 
-    let next = evaluate_event_enrollments_report(&mut db, 1);
+    let next = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert!(next.transitions.is_empty());
     assert!(next.reliability_results.is_empty());
     assert_eq!(
@@ -672,18 +673,18 @@ fn rejected_and_mutating_custom_hooks_do_not_escape_tokens_or_consume_sequences(
         let enrollment_oid = enrollment.object_identifier();
         db.add(Box::new(enrollment)).unwrap();
 
-        let report = evaluate_event_enrollments_report(&mut db, 1);
+        let report = evaluate_event_enrollments_detailed_report(&mut db, 1);
         assert!(report.reliability_results.is_empty());
         assert!(report.transitions.is_empty());
         assert!(report
             .diagnostics
-            .contains(&EventEnrollmentEvaluationDiagnostic {
+            .contains(&EventEnrollmentDetailedEvaluationDiagnostic {
                 enrollment_oid,
-                stage: EventEnrollmentEvaluationStage::Reliability,
+                stage: EventEnrollmentDetailedEvaluationStage::Reliability,
                 outcome: if mutate_then_error {
-                    EventEnrollmentEvaluationOutcome::LandedAfterError
+                    EventEnrollmentDetailedEvaluationOutcome::LandedAfterError
                 } else {
-                    EventEnrollmentEvaluationOutcome::Rejected
+                    EventEnrollmentDetailedEvaluationOutcome::Rejected
                 },
             }));
         assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
@@ -717,13 +718,13 @@ fn held_configuration_error_clears_landed_after_error_invalidation_once() {
     let enrollment_oid = enrollment.object_identifier();
     db.add(Box::new(enrollment)).unwrap();
 
-    let first = evaluate_event_enrollments_report(&mut db, 1);
+    let first = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert!(first
         .diagnostics
-        .contains(&EventEnrollmentEvaluationDiagnostic {
+        .contains(&EventEnrollmentDetailedEvaluationDiagnostic {
             enrollment_oid,
-            stage: EventEnrollmentEvaluationStage::Reliability,
-            outcome: EventEnrollmentEvaluationOutcome::LandedAfterError,
+            stage: EventEnrollmentDetailedEvaluationStage::Reliability,
+            outcome: EventEnrollmentDetailedEvaluationOutcome::LandedAfterError,
         }));
     assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
     assert_eq!(
@@ -733,12 +734,12 @@ fn held_configuration_error_clears_landed_after_error_invalidation_once() {
     assert_eq!(event_state(&db, enrollment_oid), EventState::FAULT);
 
     state_writes.store(0, Ordering::SeqCst);
-    let held = evaluate_event_enrollments_report(&mut db, 1);
+    let held = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert!(held.reliability_results.is_empty());
     assert_eq!(state_writes.load(Ordering::SeqCst), 1);
     assert!(!db.enrollment_eval_state_invalidated(&enrollment_oid));
 
-    let held_again = evaluate_event_enrollments_report(&mut db, 1);
+    let held_again = evaluate_event_enrollments_detailed_report(&mut db, 1);
     assert!(held_again.reliability_results.is_empty());
     assert_eq!(state_writes.load(Ordering::SeqCst), 1);
     assert!(!db.enrollment_eval_state_invalidated(&enrollment_oid));

--- a/crates/bacnet-server/src/event_enrollment/tests/reliability_dataflow.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/reliability_dataflow.rs
@@ -1,0 +1,152 @@
+use super::integration::{indexed_reference_value, ReferenceValueObject};
+use super::*;
+use bacnet_encoding::primitives::decode_timestamp_choice;
+use bacnet_objects::analog::AnalogValueObject;
+use bacnet_objects::notification_class::NotificationClass;
+use bacnet_types::constructed::FaultParameters;
+use bacnet_types::enums::Reliability;
+use bacnet_types::primitives::BACnetTimeStamp;
+use std::sync::atomic::Ordering;
+
+fn reliability(db: &ObjectDatabase, oid: ObjectIdentifier) -> Reliability {
+    let PropertyValue::Enumerated(raw) = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::RELIABILITY, None)
+        .unwrap()
+    else {
+        panic!("Reliability must be Enumerated");
+    };
+    Reliability::from_raw(raw)
+}
+
+fn timestamp_at(db: &ObjectDatabase, oid: ObjectIdentifier, index: u32) -> BACnetTimeStamp {
+    let PropertyValue::ApplicationData(bytes) = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, Some(index))
+        .unwrap()
+    else {
+        panic!("Event_Time_Stamps slot must be encoded application data");
+    };
+    let (timestamp, end) = decode_timestamp_choice(&bytes, 0).unwrap();
+    assert_eq!(end, bytes.len());
+    timestamp
+}
+
+fn acked_transitions(db: &ObjectDatabase, oid: ObjectIdentifier) -> u8 {
+    let PropertyValue::BitString { data, .. } = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+        .unwrap()
+    else {
+        panic!("Acked_Transitions must be BitString");
+    };
+    bacnet_types::bitstring::unpack_octet(&data, 3)
+}
+
+#[test]
+fn source_rejection_does_not_suppress_changed_reliability_fault_reentry() {
+    let mut db = ObjectDatabase::new();
+    let mut notification_class = NotificationClass::new(32, "NC-reliability-source").unwrap();
+    notification_class.ack_required = [false, true, false];
+    db.add(Box::new(notification_class)).unwrap();
+
+    let mut target = AnalogValueObject::new(307, "AV-reliability-source", 62).unwrap();
+    target
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(-1.0),
+            Some(1),
+        )
+        .unwrap();
+    let target_oid = target.object_identifier();
+    db.add(Box::new(target)).unwrap();
+
+    let mut enrollment = ReferenceValueObject::new(Some(indexed_reference_value(target_oid, 1)));
+    enrollment.source_writable.store(false, Ordering::SeqCst);
+    enrollment
+        .inner
+        .set_fault_parameters(Some(FaultParameters::FaultOutOfRange {
+            min_normal: 0.0,
+            max_normal: 10.0,
+        }));
+    enrollment
+        .inner
+        .write_property(
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            None,
+            PropertyValue::Unsigned(32),
+            None,
+        )
+        .unwrap();
+    let enrollment_oid = enrollment.object_identifier();
+    db.add(Box::new(enrollment)).unwrap();
+
+    let first = evaluate_event_enrollments_detailed_report(&mut db, 1);
+    assert_eq!(first.reliability_results.len(), 1);
+    assert_eq!(
+        first.reliability_results[0].new_reliability,
+        Reliability::UNDER_RANGE
+    );
+    assert!(first
+        .diagnostics
+        .contains(&EventEnrollmentDetailedEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentDetailedEvaluationStage::EvaluationSource,
+            outcome: EventEnrollmentDetailedEvaluationOutcome::Rejected,
+        }));
+    assert_eq!(
+        timestamp_at(&db, enrollment_oid, 2),
+        BACnetTimeStamp::SequenceNumber(0)
+    );
+    assert_eq!(acked_transitions(&db, enrollment_oid), 0b101);
+
+    db.get_mut(&enrollment_oid)
+        .unwrap()
+        .set_acked_transitions_internal(0x02, true)
+        .unwrap();
+    db.get_mut(&target_oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(11.0),
+            Some(1),
+        )
+        .unwrap();
+
+    let second = evaluate_event_enrollments_detailed_report(&mut db, 1);
+    assert_eq!(second.reliability_results.len(), 1);
+    assert_eq!(
+        second.reliability_results[0].previous_reliability,
+        Reliability::UNDER_RANGE
+    );
+    assert_eq!(
+        second.reliability_results[0].new_reliability,
+        Reliability::OVER_RANGE
+    );
+    assert_eq!(
+        second.reliability_results[0].state_change,
+        Some(EventStateChange {
+            from: EventState::FAULT,
+            to: EventState::FAULT,
+        })
+    );
+    assert!(second
+        .diagnostics
+        .contains(&EventEnrollmentDetailedEvaluationDiagnostic {
+            enrollment_oid,
+            stage: EventEnrollmentDetailedEvaluationStage::EvaluationSource,
+            outcome: EventEnrollmentDetailedEvaluationOutcome::Rejected,
+        }));
+    assert_eq!(reliability(&db, enrollment_oid), Reliability::OVER_RANGE);
+    assert_eq!(
+        timestamp_at(&db, enrollment_oid, 2),
+        BACnetTimeStamp::SequenceNumber(1)
+    );
+    assert_eq!(acked_transitions(&db, enrollment_oid), 0b101);
+    assert_eq!(db.reserve_event_sequence_number().number(), 2);
+}

--- a/crates/bacnet-server/src/event_enrollment/tests/transactional_commit.rs
+++ b/crates/bacnet-server/src/event_enrollment/tests/transactional_commit.rs
@@ -331,20 +331,20 @@ fn source_and_state_rejection_never_claims_cancellation_committed() {
     assert_eq!(state_write_count.load(Ordering::SeqCst), 1);
     assert!(report
         .diagnostics
-        .contains(&EventEnrollmentEvaluationDiagnostic {
+        .contains(&EventEnrollmentDetailedEvaluationDiagnostic {
             enrollment_oid,
-            stage: EventEnrollmentEvaluationStage::EvaluationSource,
-            outcome: EventEnrollmentEvaluationOutcome::Rejected,
+            stage: EventEnrollmentDetailedEvaluationStage::EvaluationSource,
+            outcome: EventEnrollmentDetailedEvaluationOutcome::Rejected,
         }));
     assert!(report
         .diagnostics
-        .contains(&EventEnrollmentEvaluationDiagnostic {
+        .contains(&EventEnrollmentDetailedEvaluationDiagnostic {
             enrollment_oid,
-            stage: EventEnrollmentEvaluationStage::EvaluationState,
-            outcome: EventEnrollmentEvaluationOutcome::Rejected,
+            stage: EventEnrollmentDetailedEvaluationStage::EvaluationState,
+            outcome: EventEnrollmentDetailedEvaluationOutcome::Rejected,
         }));
     assert!(!report.diagnostics.iter().any(|diagnostic| {
-        diagnostic.outcome == EventEnrollmentEvaluationOutcome::CancellationCommitted
+        diagnostic.outcome == EventEnrollmentDetailedEvaluationOutcome::CancellationCommitted
     }));
     assert!(db.enrollment_eval_state_invalidated(&enrollment_oid));
 }

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -554,7 +554,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             "Event enrollment: state changed"
                         );
                     }
-                    crate::event_enrollment::log_evaluation_failures(&report);
+                    crate::event_enrollment::log_evaluation_report(&report);
                 }
             }))
         } else {

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -534,10 +534,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 loop {
                     interval.tick().await;
                     let mut db_guard = db_ee.write().await;
-                    let report = crate::event_enrollment::evaluate_event_enrollments_report(
-                        &mut db_guard,
-                        ee_interval_secs,
-                    );
+                    let report =
+                        crate::event_enrollment::evaluate_event_enrollments_detailed_report(
+                            &mut db_guard,
+                            ee_interval_secs,
+                        );
                     for t in &report.transitions {
                         // `distribute` is logged rather than acted on: this task
                         // records Event_State but does not yet emit

--- a/crates/bacnet-server/tests/event_enrollment_report_compat.rs
+++ b/crates/bacnet-server/tests/event_enrollment_report_compat.rs
@@ -1,0 +1,43 @@
+//! Public source-compatibility regressions for the legacy evaluation report.
+
+use bacnet_server::event_enrollment::{
+    EventEnrollmentEvaluationOutcome, EventEnrollmentEvaluationReport,
+    EventEnrollmentEvaluationStage,
+};
+
+fn legacy_stage_is_exhaustive(stage: EventEnrollmentEvaluationStage) -> u8 {
+    match stage {
+        EventEnrollmentEvaluationStage::Evaluation => 0,
+        EventEnrollmentEvaluationStage::EvaluationSource => 1,
+        EventEnrollmentEvaluationStage::EvaluationState => 2,
+        EventEnrollmentEvaluationStage::EventTransition => 3,
+    }
+}
+
+fn legacy_outcome_is_exhaustive(outcome: EventEnrollmentEvaluationOutcome) -> u8 {
+    match outcome {
+        EventEnrollmentEvaluationOutcome::NoTransition => 0,
+        EventEnrollmentEvaluationOutcome::CancellationCommitted => 1,
+        EventEnrollmentEvaluationOutcome::Rejected => 2,
+        EventEnrollmentEvaluationOutcome::LandedAfterError => 3,
+    }
+}
+
+#[test]
+fn legacy_report_remains_constructible_with_its_original_fields() {
+    let report = EventEnrollmentEvaluationReport {
+        transitions: vec![],
+        diagnostics: vec![],
+    };
+
+    assert!(report.transitions.is_empty());
+    assert!(report.diagnostics.is_empty());
+    assert_eq!(
+        legacy_stage_is_exhaustive(EventEnrollmentEvaluationStage::Evaluation),
+        0
+    );
+    assert_eq!(
+        legacy_outcome_is_exhaustive(EventEnrollmentEvaluationOutcome::NoTransition),
+        0
+    );
+}


### PR DESCRIPTION
## Summary

- enforce Event Enrollment Reliability precedence across configuration, monitored-object Reliability, supported fault algorithms, and normal event evaluation
- atomically commit Reliability with Event_State, Acked_Transitions, and the matching Event_Time_Stamps coordinate
- execute FaultNone, local FaultStatusFlags, and normalized-number FaultOutOfRange; surface deferred alternatives as CONFIGURATION_ERROR
- report non-mutating unavailable observations and committed Reliability results without adding notification routing

## Standard anchors

ASHRAE 135-2020 Clauses 12.12, 13.2.2-13.2.3, 13.4.6, and 13.4.7.

## Validation

- focused Event Enrollment tests: 130 passed
- full bacnet-server: 596 passed
- full bacnet-objects: 1055 passed
- exact workspace feature-matrix tests passed
- rustfmt, clippy, root-package check, conformance generation, file-size, no-secret, and diff checks passed

## Limitations

FaultOutOfRange uses the repository normalized f64 model, not full source-datatype semantics. CharacterString, Extended, LifeSafety, State, and Listed fault families remain deferred. Remote target-loss persistence and notification routing remain later slices.

Refs #181