### PR TITLE
feat(objects): expose recipient lookup outcomes

### DIFF
--- a/crates/bacnet-objects/src/notification_class/mod.rs
+++ b/crates/bacnet-objects/src/notification_class/mod.rs
@@ -405,25 +405,73 @@ pub fn resolve_transition_priority_ack(
     (priority, ack_required)
 }
 
-/// Get notification recipients for a given notification class number and transition.
+/// The complete outcome of looking up and selecting Notification Class recipients.
 ///
-/// Looks up the `NotificationClass` object whose `Notification_Class` property equals
-/// `notification_class`, then filters its `Recipient_List` by day, time, and transition.
+/// Broadcast is not an outcome. It is represented only by an address inside
+/// [`Matched`](Self::Matched), after that configured destination passes the
+/// day, time, and transition filters. Device recipients are also successful
+/// matches here; resolving them to network addresses is a later routing step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecipientLookupOutcome {
+    /// No Notification Class has the requested class number.
+    NotificationClassMissing,
+    /// The class exists, but its recipient-list property could not be read.
+    RecipientListUnavailable,
+    /// The complete recipient-list value could not be decoded.
+    RecipientListInvalid,
+    /// The class contains a valid list with zero configured destinations.
+    NoConfiguredDestinations,
+    /// Destinations are configured, but none is eligible for this selection.
+    NoMatchingDestinations,
+    /// Eligible configured destinations and their delivery settings.
+    Matched(Vec<(BACnetRecipient, u32, bool)>),
+}
+
+/// Look up and select recipients for a Notification Class transition.
 ///
-/// # Parameters
-/// - `db`: the object database containing NotificationClass objects
-/// - `notification_class`: the notification class number to look up
-/// - `transition`: which event transition to filter for
-/// - `today_bit`: bitmask for today's day of week in `valid_days`, using the
-///   `BACnetDaysOfWeek` convention **bit 0 = Monday, …, bit 6 = Sunday**
-///   (i.e. `1 << dow` where `dow = 0` on Monday)
-/// - `current_time`: the current local time for time-window filtering
+/// This is the canonical recipient lookup API and distinguishes configuration
+/// failures from valid empty or ineligible configuration. Selection uses the
+/// configured destination's day mask, local time window, and transition mask.
+/// `today_bit` uses bit 0 for Monday through bit 6 for Sunday.
 ///
-/// Returns `(recipient, process_identifier, issue_confirmed_notifications)` tuples.
-/// Returns an empty `Vec` if no matching NotificationClass is found or no recipients match.
-/// Compatibility wrapper: a `Recipient_List` that fails to decode yields an
-/// empty list here; routing that must distinguish "no recipients" from
-/// "undecodable list" uses [`get_notification_recipients_strict`].
+/// A malformed complete list returns
+/// [`RecipientListInvalid`](RecipientLookupOutcome::RecipientListInvalid);
+/// no decodable prefix is selected. Every non-matched outcome is fail-closed
+/// and names no implicit destination.
+pub fn lookup_notification_recipients(
+    db: &ObjectDatabase,
+    notification_class: u32,
+    transition: EventTransition,
+    today_bit: u8,
+    current_time: &Time,
+) -> RecipientLookupOutcome {
+    let Some(nc) = find_notification_class(db, notification_class) else {
+        return RecipientLookupOutcome::NotificationClassMissing;
+    };
+    let Ok(recipient_list_value) = nc.read_property(PropertyIdentifier::RECIPIENT_LIST, None)
+    else {
+        return RecipientLookupOutcome::RecipientListUnavailable;
+    };
+    let Ok(destinations) = decode_destination_list_pv(&recipient_list_value) else {
+        return RecipientLookupOutcome::RecipientListInvalid;
+    };
+    if destinations.is_empty() {
+        return RecipientLookupOutcome::NoConfiguredDestinations;
+    }
+
+    let recipients = filter_destinations(destinations, transition, today_bit, current_time);
+    if recipients.is_empty() {
+        RecipientLookupOutcome::NoMatchingDestinations
+    } else {
+        RecipientLookupOutcome::Matched(recipients)
+    }
+}
+
+/// Get notification recipients for a given class number and transition.
+///
+/// This source-compatible wrapper delegates to
+/// [`lookup_notification_recipients`] and returns the matched recipient tuples.
+/// Every other outcome maps to an empty vector, preserving the legacy API.
 pub fn get_notification_recipients(
     db: &ObjectDatabase,
     notification_class: u32,
@@ -431,18 +479,29 @@ pub fn get_notification_recipients(
     today_bit: u8,
     current_time: &Time,
 ) -> Vec<(BACnetRecipient, u32, bool)> {
-    get_notification_recipients_strict(db, notification_class, transition, today_bit, current_time)
-        .unwrap_or_default()
+    match lookup_notification_recipients(
+        db,
+        notification_class,
+        transition,
+        today_bit,
+        current_time,
+    ) {
+        RecipientLookupOutcome::Matched(recipients) => recipients,
+        RecipientLookupOutcome::NotificationClassMissing
+        | RecipientLookupOutcome::RecipientListUnavailable
+        | RecipientLookupOutcome::RecipientListInvalid
+        | RecipientLookupOutcome::NoConfiguredDestinations
+        | RecipientLookupOutcome::NoMatchingDestinations => Vec::new(),
+    }
 }
 
 /// Strict variant of [`get_notification_recipients`] for fail-closed routing.
 ///
-/// - `Some(list)` — no class matched (value `[]`, as before), or the class
-///   was found and its `Recipient_List` decoded; `list` may be empty after
-///   filtering (no recipient viable right now).
-/// - `None` — a NotificationClass matched but its stored `Recipient_List`
-///   FAILED to decode: the configured recipients are unknown, and delivering
-///   to a decodable prefix would notify the wrong set of devices.
+/// This source-compatible wrapper delegates to
+/// [`lookup_notification_recipients`]. It preserves `None` for an invalid or
+/// undecodable complete list and `Some([])` for missing class, property-read
+/// failure, configured empty, and no-match outcomes. Successful matches return
+/// `Some(recipients)`.
 pub fn get_notification_recipients_strict(
     db: &ObjectDatabase,
     notification_class: u32,
@@ -450,19 +509,20 @@ pub fn get_notification_recipients_strict(
     today_bit: u8,
     current_time: &Time,
 ) -> Option<Vec<(BACnetRecipient, u32, bool)>> {
-    let Some(nc) = find_notification_class(db, notification_class) else {
-        return Some(Vec::new());
-    };
-    let Ok(recipient_list_val) = nc.read_property(PropertyIdentifier::RECIPIENT_LIST, None) else {
-        return Some(Vec::new());
-    };
-    let destinations = decode_destination_list_pv(&recipient_list_val).ok()?;
-    Some(filter_destinations(
-        destinations,
+    match lookup_notification_recipients(
+        db,
+        notification_class,
         transition,
         today_bit,
         current_time,
-    ))
+    ) {
+        RecipientLookupOutcome::RecipientListInvalid => None,
+        RecipientLookupOutcome::Matched(recipients) => Some(recipients),
+        RecipientLookupOutcome::NotificationClassMissing
+        | RecipientLookupOutcome::RecipientListUnavailable
+        | RecipientLookupOutcome::NoConfiguredDestinations
+        | RecipientLookupOutcome::NoMatchingDestinations => Some(Vec::new()),
+    }
 }
 
 /// Decode ONE legacy flat `Recipient_List` entry (the pre-#152
@@ -575,7 +635,7 @@ fn decode_destination_list_pv(value: &PropertyValue) -> Result<Vec<BACnetDestina
 
 /// Filter decoded destinations by day, time, and transition — the shared
 /// selection step of [`filter_recipient_list`] and
-/// [`get_notification_recipients_strict`].
+/// [`lookup_notification_recipients`].
 fn filter_destinations(
     destinations: Vec<BACnetDestination>,
     transition: EventTransition,

--- a/crates/bacnet-objects/src/notification_class/tests/lookup.rs
+++ b/crates/bacnet-objects/src/notification_class/tests/lookup.rs
@@ -1,0 +1,272 @@
+use super::super::*;
+use super::{make_dest_device, make_time};
+use std::borrow::Cow;
+
+enum RecipientListBehavior {
+    Unavailable,
+    Invalid,
+}
+
+struct LookupTestNotificationClass {
+    oid: ObjectIdentifier,
+    behavior: RecipientListBehavior,
+}
+
+impl LookupTestNotificationClass {
+    fn new(behavior: RecipientListBehavior) -> Self {
+        Self {
+            oid: ObjectIdentifier::new(ObjectType::NOTIFICATION_CLASS, 1).unwrap(),
+            behavior,
+        }
+    }
+}
+
+impl BACnetObject for LookupTestNotificationClass {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "lookup-test-notification-class"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        match property {
+            p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(1)),
+            p if p == PropertyIdentifier::RECIPIENT_LIST => match self.behavior {
+                RecipientListBehavior::Unavailable => Err(Error::Protocol {
+                    class: bacnet_types::enums::ErrorClass::PROPERTY.to_raw() as u32,
+                    code: bacnet_types::enums::ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+                }),
+                // A malformed complete list with no valid destination prefix.
+                RecipientListBehavior::Invalid => Ok(PropertyValue::ApplicationData(vec![0x5E])),
+            },
+            _ => Err(Error::Protocol {
+                class: bacnet_types::enums::ErrorClass::PROPERTY.to_raw() as u32,
+                code: bacnet_types::enums::ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            }),
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: bacnet_types::enums::ErrorClass::PROPERTY.to_raw() as u32,
+            code: bacnet_types::enums::ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::RECIPIENT_LIST,
+        ])
+    }
+}
+
+fn lookup(db: &ObjectDatabase) -> RecipientLookupOutcome {
+    lookup_notification_recipients(db, 1, EventTransition::ToOffnormal, 0x01, &make_time(12, 0))
+}
+
+#[test]
+fn lookup_distinguishes_missing_notification_class_and_wrappers_remain_empty() {
+    let db = ObjectDatabase::new();
+
+    assert!(matches!(
+        lookup(&db),
+        RecipientLookupOutcome::NotificationClassMissing
+    ));
+    assert!(get_notification_recipients(
+        &db,
+        1,
+        EventTransition::ToOffnormal,
+        0x01,
+        &make_time(12, 0),
+    )
+    .is_empty());
+    assert_eq!(
+        get_notification_recipients_strict(
+            &db,
+            1,
+            EventTransition::ToOffnormal,
+            0x01,
+            &make_time(12, 0),
+        ),
+        Some(Vec::new())
+    );
+}
+
+#[test]
+fn lookup_distinguishes_unavailable_recipient_list_and_preserves_strict_mapping() {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(LookupTestNotificationClass::new(
+        RecipientListBehavior::Unavailable,
+    )))
+    .unwrap();
+
+    assert!(matches!(
+        lookup(&db),
+        RecipientLookupOutcome::RecipientListUnavailable
+    ));
+    assert!(get_notification_recipients(
+        &db,
+        1,
+        EventTransition::ToOffnormal,
+        0x01,
+        &make_time(12, 0),
+    )
+    .is_empty());
+    assert_eq!(
+        get_notification_recipients_strict(
+            &db,
+            1,
+            EventTransition::ToOffnormal,
+            0x01,
+            &make_time(12, 0),
+        ),
+        Some(Vec::new())
+    );
+}
+
+#[test]
+fn lookup_distinguishes_invalid_full_list_without_delivering_a_prefix() {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(LookupTestNotificationClass::new(
+        RecipientListBehavior::Invalid,
+    )))
+    .unwrap();
+
+    assert!(matches!(
+        lookup(&db),
+        RecipientLookupOutcome::RecipientListInvalid
+    ));
+    assert!(get_notification_recipients(
+        &db,
+        1,
+        EventTransition::ToOffnormal,
+        0x01,
+        &make_time(12, 0),
+    )
+    .is_empty());
+    assert_eq!(
+        get_notification_recipients_strict(
+            &db,
+            1,
+            EventTransition::ToOffnormal,
+            0x01,
+            &make_time(12, 0),
+        ),
+        None
+    );
+}
+
+#[test]
+fn lookup_distinguishes_zero_configured_destinations_and_wrappers_remain_empty() {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(NotificationClass::new(1, "NC-1").unwrap()))
+        .unwrap();
+
+    assert!(matches!(
+        lookup(&db),
+        RecipientLookupOutcome::NoConfiguredDestinations
+    ));
+    assert!(get_notification_recipients(
+        &db,
+        1,
+        EventTransition::ToOffnormal,
+        0x01,
+        &make_time(12, 0),
+    )
+    .is_empty());
+    assert_eq!(
+        get_notification_recipients_strict(
+            &db,
+            1,
+            EventTransition::ToOffnormal,
+            0x01,
+            &make_time(12, 0),
+        ),
+        Some(Vec::new())
+    );
+}
+
+#[test]
+fn lookup_distinguishes_configured_but_ineligible_destinations() {
+    let mut nc = NotificationClass::new(1, "NC-1").unwrap();
+    let mut destination = make_dest_device(10);
+    destination.valid_days = 0x02;
+    nc.add_destination(destination);
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(nc)).unwrap();
+
+    assert!(matches!(
+        lookup(&db),
+        RecipientLookupOutcome::NoMatchingDestinations
+    ));
+    assert!(get_notification_recipients(
+        &db,
+        1,
+        EventTransition::ToOffnormal,
+        0x01,
+        &make_time(12, 0),
+    )
+    .is_empty());
+    assert_eq!(
+        get_notification_recipients_strict(
+            &db,
+            1,
+            EventTransition::ToOffnormal,
+            0x01,
+            &make_time(12, 0),
+        ),
+        Some(Vec::new())
+    );
+}
+
+#[test]
+fn lookup_returns_selected_device_recipient_as_a_match_for_both_wrappers() {
+    let destination = make_dest_device(10);
+    let expected = (
+        destination.recipient.clone(),
+        destination.process_identifier,
+        destination.issue_confirmed_notifications,
+    );
+    let mut nc = NotificationClass::new(1, "NC-1").unwrap();
+    nc.add_destination(destination);
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(nc)).unwrap();
+
+    let RecipientLookupOutcome::Matched(recipients) = lookup(&db) else {
+        panic!("eligible device recipient must be a lookup success");
+    };
+    assert_eq!(recipients, vec![expected.clone()]);
+    assert_eq!(
+        get_notification_recipients(
+            &db,
+            1,
+            EventTransition::ToOffnormal,
+            0x01,
+            &make_time(12, 0),
+        ),
+        vec![expected.clone()]
+    );
+    assert_eq!(
+        get_notification_recipients_strict(
+            &db,
+            1,
+            EventTransition::ToOffnormal,
+            0x01,
+            &make_time(12, 0),
+        ),
+        Some(vec![expected])
+    );
+}

--- a/crates/bacnet-objects/src/notification_class/tests/mod.rs
+++ b/crates/bacnet-objects/src/notification_class/tests/mod.rs
@@ -1,3 +1,4 @@
+mod lookup;
 mod priority;
 mod properties;
 mod recipient_list;

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -12,6 +12,10 @@ use bacnet_types::primitives::{BACnetTimeStamp, Time};
 
 use crate::event_enrollment::{CommittedEventEnrollmentDelivery, CommittedEventEnrollmentResult};
 
+#[path = "event_recipient_lookup.rs"]
+mod recipient_lookup;
+use recipient_lookup::matched_recipients_or_log;
+
 /// One exact transition-coordinate projection from object-owned event history.
 #[derive(Debug, Clone, PartialEq)]
 struct CommittedHistorySnapshot {
@@ -587,6 +591,20 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 resolve_transition_priority_ack(&db, notification_class, transition);
             let ack_required = ack_required_snapshot.unwrap_or(resolved_ack_required);
 
+            let Some(recipients) = matched_recipients_or_log(
+                lookup_notification_recipients(
+                    &db,
+                    notification_class,
+                    transition,
+                    today_bit,
+                    &current_time,
+                ),
+                notification_class,
+                transition,
+            ) else {
+                return;
+            };
+
             let base_notification = EventNotificationRequest {
                 process_identifier: 0,
                 initiating_device_identifier: device_oid,
@@ -611,29 +629,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 event_values: None,
             };
 
-            let recipients = match get_notification_recipients_strict(
-                &db,
-                notification_class,
-                transition,
-                today_bit,
-                &current_time,
-            ) {
-                Some(recipients) => recipients,
-                None => {
-                    // The NotificationClass's Recipient_List failed to
-                    // decode — its configured recipients are UNKNOWN. Fail
-                    // closed (consistent with the encode-failure branches
-                    // below): deliver this notification to NO ONE rather
-                    // than to a silently-truncated prefix of the configured
-                    // destinations.
-                    warn!(
-                        notification_class,
-                        "Recipient_List failed to decode; skipping event notification delivery"
-                    );
-                    return;
-                }
-            };
-
             (base_notification, recipients)
         };
 
@@ -641,20 +636,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         // Clause 13.2.5.4 sets the NPDU priority from the notification's
         // event priority, on every send of this notification — retries too.
         let network_priority = network_priority_for_event(notification.priority);
-
-        // Clause 13.2.5: "notifications are distributed to the notification-
-        // clients specified by the Recipient_List input". The Recipient_List is
-        // the destination set, so no matching recipient means no notification
-        // is distributed. Broadcasting instead would invent a destination the
-        // configuration never named, and would leak the alarm to every device
-        // on the link.
-        if recipients.is_empty() {
-            debug!(
-                notification_class,
-                "No Recipient_List entry matched this transition; nothing distributed"
-            );
-            return;
-        }
 
         for (recipient, process_id, confirmed) in &recipients {
             let route =

--- a/crates/bacnet-server/src/server/event_recipient_lookup.rs
+++ b/crates/bacnet-server/src/server/event_recipient_lookup.rs
@@ -1,0 +1,55 @@
+use bacnet_objects::event::EventTransition;
+use bacnet_objects::notification_class::RecipientLookupOutcome;
+use bacnet_types::constructed::BACnetRecipient;
+use tracing::{debug, warn};
+
+/// Log a bounded lookup diagnostic and expose only successful selections.
+pub(super) fn matched_recipients_or_log(
+    outcome: RecipientLookupOutcome,
+    notification_class: u32,
+    transition: EventTransition,
+) -> Option<Vec<(BACnetRecipient, u32, bool)>> {
+    match outcome {
+        RecipientLookupOutcome::NotificationClassMissing => {
+            warn!(
+                notification_class,
+                ?transition,
+                "Missing Notification Class; delivery suppressed"
+            );
+            None
+        }
+        RecipientLookupOutcome::RecipientListUnavailable => {
+            warn!(
+                notification_class,
+                ?transition,
+                "Recipient list unavailable; delivery suppressed"
+            );
+            None
+        }
+        RecipientLookupOutcome::RecipientListInvalid => {
+            warn!(
+                notification_class,
+                ?transition,
+                "Recipient list invalid; delivery suppressed"
+            );
+            None
+        }
+        RecipientLookupOutcome::NoConfiguredDestinations => {
+            debug!(
+                notification_class,
+                ?transition,
+                "Recipient list empty; no delivery"
+            );
+            None
+        }
+        RecipientLookupOutcome::NoMatchingDestinations => {
+            debug!(
+                notification_class,
+                ?transition,
+                "No eligible recipient; no delivery"
+            );
+            None
+        }
+        RecipientLookupOutcome::Matched(recipients) => Some(recipients),
+    }
+}

--- a/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
@@ -12,13 +12,14 @@ use super::event_notifications_tests::local_broadcast_destination;
 use super::*;
 use bacnet_objects::analog::AnalogInputObject;
 use bacnet_objects::device::{DeviceConfig, DeviceObject};
-use bacnet_objects::event::EventStateChange;
+use bacnet_objects::event::{EventStateChange, EventTransition};
 use bacnet_objects::notification_class::NotificationClass;
 use bacnet_objects::traits::BACnetObject;
 use bacnet_transport::port::TransportPort;
 use bacnet_types::constructed::{BACnetAddress, BACnetDestination, BACnetRecipient};
 use bacnet_types::enums::{EventState, EventType};
 use bytes::Bytes;
+use std::borrow::Cow;
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
 use tokio::sync::mpsc;
 
@@ -107,13 +108,6 @@ async fn distribute_with_clock_mode(
     destinations: Vec<BACnetDestination>,
     clocked: bool,
 ) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
-    let transport = RoutingTransport::default();
-    let broadcasts = StdArc::clone(&transport.broadcasts);
-    let unicasts = StdArc::clone(&transport.unicasts);
-    let network = Arc::new(NetworkLayer::new(transport));
-    let comm_state = Arc::new(AtomicU8::new(0));
-    let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
-
     let mut db = if clocked {
         clocked_test_database()
     } else {
@@ -125,6 +119,17 @@ async fn distribute_with_clock_mode(
         nc.add_destination(destination);
     }
     db.add(Box::new(nc)).unwrap();
+    distribute_from_database(db).await
+}
+
+async fn distribute_from_database(mut db: ObjectDatabase) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
+    let transport = RoutingTransport::default();
+    let broadcasts = StdArc::clone(&transport.broadcasts);
+    let unicasts = StdArc::clone(&transport.unicasts);
+    let network = Arc::new(NetworkLayer::new(transport));
+    let comm_state = Arc::new(AtomicU8::new(0));
+    let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+
     db.add(Box::new(
         DeviceObject::new(DeviceConfig {
             instance: 1,
@@ -174,6 +179,120 @@ async fn distribute_with_clock_mode(
     let broadcasts = broadcasts.lock().unwrap().clone();
     let unicasts = unicasts.lock().unwrap().clone();
     (broadcasts, unicasts)
+}
+
+enum TestRecipientList {
+    Unavailable,
+    Invalid,
+}
+
+struct TestNotificationClass {
+    oid: ObjectIdentifier,
+    recipient_list: TestRecipientList,
+}
+
+impl TestNotificationClass {
+    fn new(recipient_list: TestRecipientList) -> Self {
+        Self {
+            oid: ObjectIdentifier::new(ObjectType::NOTIFICATION_CLASS, 0).unwrap(),
+            recipient_list,
+        }
+    }
+}
+
+impl BACnetObject for TestNotificationClass {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "recipient-lookup-test-class"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        match property {
+            p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(0)),
+            p if p == PropertyIdentifier::RECIPIENT_LIST => match self.recipient_list {
+                TestRecipientList::Unavailable => Err(Error::Protocol {
+                    class: ErrorClass::PROPERTY.to_raw() as u32,
+                    code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+                }),
+                TestRecipientList::Invalid => Ok(PropertyValue::ApplicationData(vec![0x5E])),
+            },
+            _ => Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            }),
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::RECIPIENT_LIST,
+        ])
+    }
+}
+
+async fn distribute_non_matched_case(case: &str) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
+    let mut db = clocked_test_database();
+    match case {
+        "missing-class" => {}
+        "list-unavailable" => db
+            .add(Box::new(TestNotificationClass::new(
+                TestRecipientList::Unavailable,
+            )))
+            .unwrap(),
+        "list-invalid" => db
+            .add(Box::new(TestNotificationClass::new(
+                TestRecipientList::Invalid,
+            )))
+            .unwrap(),
+        "empty-list" => db
+            .add(Box::new(NotificationClass::new(0, "NC-0").unwrap()))
+            .unwrap(),
+        "no-eligible-destination" => {
+            let mut nc = NotificationClass::new(0, "NC-0").unwrap();
+            let mut destination = destination_for(address_recipient(0, &[]), false);
+            destination.transitions = EventTransition::ToNormal.bit_mask();
+            nc.add_destination(destination);
+            db.add(Box::new(nc)).unwrap();
+        }
+        _ => unreachable!("test case is fixed"),
+    }
+    distribute_from_database(db).await
+}
+
+#[tokio::test]
+async fn every_non_matched_lookup_outcome_emits_no_frame() {
+    for case in [
+        "missing-class",
+        "list-unavailable",
+        "list-invalid",
+        "empty-list",
+        "no-eligible-destination",
+    ] {
+        let (broadcasts, unicasts) = distribute_non_matched_case(case).await;
+        assert!(broadcasts.is_empty(), "{case} must not widen to broadcast");
+        assert!(unicasts.is_empty(), "{case} must not emit a unicast");
+    }
 }
 
 #[tokio::test]

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -30,7 +30,7 @@ use bacnet_network::layer::NetworkLayer;
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_objects::event::EventStateChange;
 use bacnet_objects::notification_class::{
-    get_notification_recipients_strict, resolve_transition_priority_ack,
+    lookup_notification_recipients, resolve_transition_priority_ack,
 };
 use bacnet_services::alarm_event::EventNotificationRequest;
 use bacnet_services::common::BACnetPropertyValue;


### PR DESCRIPTION
## Summary
- add a canonical typed Notification Class recipient lookup that distinguishes missing, unavailable, invalid, empty, ineligible, and matched outcomes
- retain both existing public lookup signatures as delegating compatibility wrappers
- migrate the shared event sender to exhaustive fail-closed handling with bounded diagnostics; only matched configured recipients reach route resolution

## Scope and compatibility
- empty, unavailable, invalid, and no-match outcomes emit no frame and never infer broadcast
- explicitly configured eligible broadcast destinations continue to work
- selected device recipients remain lookup successes; address binding and unresolved-device handling remain PR-0402/#125
- no Python, payload, Event Log, transport-route, support-claim, dependency, or CI changes
- source obligations and public comments are described generally without direct source identifiers

## Validation
Validation ran from the cargo-clean state established between PRs.

- [x] focused recipient lookup and recipient-list tests
- [x] focused server event-recipient routing and notification tests
- [x] cargo test -p bacnet-objects --locked
- [x] cargo test -p bacnet-server --locked
- [x] cargo fmt --all -- --check
- [x] cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked
- [x] cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls,bacnet-transport/serial,bacnet-transport/ethernet
- [x] cargo check -p rusty-bacnet --tests --locked
- [x] python3 scripts/generate-conformance-docs.py --check
- [x] bash .github/scripts/check-file-size.sh
- [x] bash .github/scripts/check-no-secrets.sh
- [x] git diff --check

Closes #124