### PR TITLE
feat(server): resolve device recipient bindings

### DIFF
--- a/crates/bacnet-server/src/server/clock.rs
+++ b/crates/bacnet-server/src/server/clock.rs
@@ -55,6 +55,16 @@ impl Default for ClockConfig {
 }
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
+    pub(super) async fn start_with_clock_mode(
+        config: ServerConfig,
+        db: ObjectDatabase,
+        transport: T,
+        clock_config: Option<ClockConfig>,
+    ) -> Result<Self, Error> {
+        Self::start_with_clock_mode_and_bindings(config, db, transport, clock_config, Vec::new())
+            .await
+    }
+
     /// Start with the default system-UTC Device clock.
     pub async fn start(
         config: ServerConfig,

--- a/crates/bacnet-server/src/server/device_bindings.rs
+++ b/crates/bacnet-server/src/server/device_bindings.rs
@@ -1,0 +1,304 @@
+use super::*;
+
+/// Maximum number of configured and observed device bindings held by a server.
+pub(super) const MAX_DEVICE_BINDINGS: usize = 4096;
+
+/// Freshness window for passively observed I-Am bindings.
+pub(super) const OBSERVED_BINDING_TTL: Duration = Duration::from_secs(10 * 60);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DeviceBindingTarget {
+    Local {
+        peer_mac: MacAddr,
+    },
+    Routed {
+        network: u16,
+        final_mac: MacAddr,
+        router_mac: MacAddr,
+    },
+}
+
+/// One explicitly configured unicast route to a Device object.
+///
+/// Constructed values are transport-neutral. A builder performs the remaining
+/// concrete data-link broadcast check before the transport is started.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeviceBinding {
+    device: ObjectIdentifier,
+    target: DeviceBindingTarget,
+}
+
+impl DeviceBinding {
+    /// Create a binding to a peer on the server's local network.
+    pub fn local(device: ObjectIdentifier, peer_mac: impl AsRef<[u8]>) -> Result<Self, Error> {
+        validate_device_identifier(device)?;
+        let peer_mac = MacAddr::from_slice(peer_mac.as_ref());
+        if peer_mac.is_empty() {
+            return Err(binding_error("local peer MAC must be non-empty"));
+        }
+        Ok(Self {
+            device,
+            target: DeviceBindingTarget::Local { peer_mac },
+        })
+    }
+
+    /// Create a routed binding with a final network/address and local router.
+    pub fn routed(
+        device: ObjectIdentifier,
+        network: u16,
+        final_mac: impl AsRef<[u8]>,
+        router_mac: impl AsRef<[u8]>,
+    ) -> Result<Self, Error> {
+        validate_device_identifier(device)?;
+        if !(1..=0xFFFE).contains(&network) {
+            return Err(binding_error("routed network must be in 1..=65534"));
+        }
+        let final_mac = MacAddr::from_slice(final_mac.as_ref());
+        if final_mac.is_empty() {
+            return Err(binding_error("routed final MAC must be non-empty"));
+        }
+        let router_mac = MacAddr::from_slice(router_mac.as_ref());
+        if router_mac.is_empty() {
+            return Err(binding_error("routed router MAC must be non-empty"));
+        }
+        Ok(Self {
+            device,
+            target: DeviceBindingTarget::Routed {
+                network,
+                final_mac,
+                router_mac,
+            },
+        })
+    }
+}
+
+fn binding_error(message: &str) -> Error {
+    Error::Encoding(format!("invalid device binding: {message}"))
+}
+
+fn validate_device_identifier(device: ObjectIdentifier) -> Result<(), Error> {
+    if device.object_type() != ObjectType::DEVICE {
+        return Err(binding_error("identifier must name a Device object"));
+    }
+    Ok(())
+}
+
+pub(super) fn register_configured_binding(
+    bindings: &mut Vec<DeviceBinding>,
+    binding: DeviceBinding,
+) -> Result<(), Error> {
+    if bindings.len() >= MAX_DEVICE_BINDINGS {
+        return Err(binding_error("configured binding capacity exceeded"));
+    }
+    if bindings
+        .iter()
+        .any(|configured| configured.device == binding.device)
+    {
+        return Err(binding_error("duplicate configured Device identifier"));
+    }
+    bindings.push(binding);
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum DeviceResolution {
+    ResolvedLocal {
+        peer_mac: MacAddr,
+    },
+    ResolvedRouted {
+        network: u16,
+        final_mac: MacAddr,
+        router_mac: MacAddr,
+    },
+    Unknown,
+    Stale,
+    Invalid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ObservationOutcome {
+    Inserted,
+    Refreshed,
+    ConfiguredPreserved,
+    RejectedInvalid,
+    RejectedCapacity,
+}
+
+#[derive(Debug, Clone)]
+enum BindingEntry {
+    Configured(DeviceBindingTarget),
+    Observed {
+        target: DeviceBindingTarget,
+        observed_at: Instant,
+    },
+}
+
+#[derive(Debug, Default)]
+pub(super) struct DeviceBindingTable {
+    entries: HashMap<ObjectIdentifier, BindingEntry>,
+}
+
+impl DeviceBindingTable {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(super) fn from_configured(
+        bindings: Vec<DeviceBinding>,
+        is_broadcast: impl Fn(&[u8]) -> bool,
+    ) -> Result<Self, Error> {
+        let mut table = Self::new();
+        for binding in bindings {
+            table.insert_configured(binding, &is_broadcast)?;
+        }
+        Ok(table)
+    }
+
+    #[cfg(test)]
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(super) fn insert_configured(
+        &mut self,
+        binding: DeviceBinding,
+        is_broadcast: impl Fn(&[u8]) -> bool,
+    ) -> Result<(), Error> {
+        validate_device_identifier(binding.device)?;
+        if !target_is_usable(&binding.target, &is_broadcast) {
+            return Err(binding_error(
+                "local peer or next-hop router is a broadcast address",
+            ));
+        }
+        if self.entries.contains_key(&binding.device) {
+            return Err(binding_error("duplicate configured Device identifier"));
+        }
+        if self.entries.len() >= MAX_DEVICE_BINDINGS {
+            return Err(binding_error("configured binding capacity exceeded"));
+        }
+        self.entries
+            .insert(binding.device, BindingEntry::Configured(binding.target));
+        Ok(())
+    }
+
+    pub(super) fn observe_i_am_at(
+        &mut self,
+        device: ObjectIdentifier,
+        source_mac: &[u8],
+        source_network: Option<&NpduAddress>,
+        now: Instant,
+        is_broadcast: impl Fn(&[u8]) -> bool,
+    ) -> ObservationOutcome {
+        if validate_device_identifier(device).is_err() {
+            return ObservationOutcome::RejectedInvalid;
+        }
+        let target = match source_network {
+            None => DeviceBindingTarget::Local {
+                peer_mac: MacAddr::from_slice(source_mac),
+            },
+            Some(source)
+                if (1..=0xFFFE).contains(&source.network) && !source.mac_address.is_empty() =>
+            {
+                DeviceBindingTarget::Routed {
+                    network: source.network,
+                    final_mac: source.mac_address.clone(),
+                    router_mac: MacAddr::from_slice(source_mac),
+                }
+            }
+            Some(_) => return ObservationOutcome::RejectedInvalid,
+        };
+        if !target_is_usable(&target, &is_broadcast) {
+            return ObservationOutcome::RejectedInvalid;
+        }
+
+        match self.entries.get_mut(&device) {
+            Some(BindingEntry::Configured(_)) => ObservationOutcome::ConfiguredPreserved,
+            Some(BindingEntry::Observed {
+                target: observed,
+                observed_at,
+            }) => {
+                *observed = target;
+                *observed_at = now;
+                ObservationOutcome::Refreshed
+            }
+            None => {
+                if self.entries.len() >= MAX_DEVICE_BINDINGS {
+                    self.entries.retain(|_, entry| match entry {
+                        BindingEntry::Configured(_) => true,
+                        BindingEntry::Observed { observed_at, .. } => {
+                            now.saturating_duration_since(*observed_at) < OBSERVED_BINDING_TTL
+                        }
+                    });
+                }
+                if self.entries.len() >= MAX_DEVICE_BINDINGS {
+                    return ObservationOutcome::RejectedCapacity;
+                }
+                self.entries.insert(
+                    device,
+                    BindingEntry::Observed {
+                        target,
+                        observed_at: now,
+                    },
+                );
+                ObservationOutcome::Inserted
+            }
+        }
+    }
+
+    pub(super) fn resolve_at(
+        &self,
+        device: &ObjectIdentifier,
+        now: Instant,
+        is_broadcast: impl Fn(&[u8]) -> bool,
+    ) -> DeviceResolution {
+        if device.object_type() != ObjectType::DEVICE {
+            return DeviceResolution::Invalid;
+        }
+        let target = match self.entries.get(device) {
+            Some(BindingEntry::Configured(target)) => target,
+            Some(BindingEntry::Observed {
+                target,
+                observed_at,
+            }) => {
+                if now.saturating_duration_since(*observed_at) >= OBSERVED_BINDING_TTL {
+                    return DeviceResolution::Stale;
+                }
+                target
+            }
+            None => return DeviceResolution::Unknown,
+        };
+        if !target_is_usable(target, is_broadcast) {
+            return DeviceResolution::Invalid;
+        }
+        match target {
+            DeviceBindingTarget::Local { peer_mac } => DeviceResolution::ResolvedLocal {
+                peer_mac: peer_mac.clone(),
+            },
+            DeviceBindingTarget::Routed {
+                network,
+                final_mac,
+                router_mac,
+            } => DeviceResolution::ResolvedRouted {
+                network: *network,
+                final_mac: final_mac.clone(),
+                router_mac: router_mac.clone(),
+            },
+        }
+    }
+}
+
+fn target_is_usable(target: &DeviceBindingTarget, is_broadcast: impl Fn(&[u8]) -> bool) -> bool {
+    match target {
+        DeviceBindingTarget::Local { peer_mac } => !peer_mac.is_empty() && !is_broadcast(peer_mac),
+        DeviceBindingTarget::Routed {
+            network,
+            final_mac,
+            router_mac,
+        } => {
+            (1..=0xFFFE).contains(network)
+                && !final_mac.is_empty()
+                && !router_mac.is_empty()
+                && !is_broadcast(router_mac)
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/device_bindings.rs
+++ b/crates/bacnet-server/src/server/device_bindings.rs
@@ -104,15 +104,32 @@ pub(super) fn register_configured_binding(
 pub(super) enum DeviceResolution {
     ResolvedLocal {
         peer_mac: MacAddr,
+        freshness: BindingFreshness,
     },
     ResolvedRouted {
         network: u16,
         final_mac: MacAddr,
         router_mac: MacAddr,
+        freshness: BindingFreshness,
     },
     Unknown,
     Stale,
     Invalid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BindingFreshness {
+    Configured,
+    ObservedUntil(tokio::time::Instant),
+}
+
+impl BindingFreshness {
+    pub(super) fn permits_attempt_at(self, now: tokio::time::Instant) -> bool {
+        match self {
+            Self::Configured => true,
+            Self::ObservedUntil(deadline) => now < deadline,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -254,8 +271,8 @@ impl DeviceBindingTable {
         if device.object_type() != ObjectType::DEVICE {
             return DeviceResolution::Invalid;
         }
-        let target = match self.entries.get(device) {
-            Some(BindingEntry::Configured(target)) => target,
+        let (target, freshness) = match self.entries.get(device) {
+            Some(BindingEntry::Configured(target)) => (target, BindingFreshness::Configured),
             Some(BindingEntry::Observed {
                 target,
                 observed_at,
@@ -263,7 +280,12 @@ impl DeviceBindingTable {
                 if now.saturating_duration_since(*observed_at) >= OBSERVED_BINDING_TTL {
                     return DeviceResolution::Stale;
                 }
-                target
+                (
+                    target,
+                    BindingFreshness::ObservedUntil(tokio::time::Instant::from_std(
+                        *observed_at + OBSERVED_BINDING_TTL,
+                    )),
+                )
             }
             None => return DeviceResolution::Unknown,
         };
@@ -273,6 +295,7 @@ impl DeviceBindingTable {
         match target {
             DeviceBindingTarget::Local { peer_mac } => DeviceResolution::ResolvedLocal {
                 peer_mac: peer_mac.clone(),
+                freshness,
             },
             DeviceBindingTarget::Routed {
                 network,
@@ -282,6 +305,7 @@ impl DeviceBindingTable {
                 network: *network,
                 final_mac: final_mac.clone(),
                 router_mac: router_mac.clone(),
+                freshness,
             },
         }
     }

--- a/crates/bacnet-server/src/server/device_bindings_tests.rs
+++ b/crates/bacnet-server/src/server/device_bindings_tests.rs
@@ -1,0 +1,477 @@
+use super::device_bindings::{
+    DeviceBindingTable, DeviceResolution, ObservationOutcome, MAX_DEVICE_BINDINGS,
+    OBSERVED_BINDING_TTL,
+};
+use super::*;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bytes::Bytes;
+use tokio::sync::mpsc;
+
+const LOCAL_PEER: &[u8] = &[0x10, 0x11];
+const UPDATED_PEER: &[u8] = &[0x20, 0x21];
+const ROUTER: &[u8] = &[0x30, 0x31];
+const FINAL_PEER: &[u8] = &[0x40, 0x41, 0x42];
+const BROADCAST: &[u8] = &[0xFF, 0xFF];
+
+fn device(instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::DEVICE, instance).unwrap()
+}
+
+fn no_broadcast(_: &[u8]) -> bool {
+    false
+}
+
+fn test_broadcast(mac: &[u8]) -> bool {
+    mac == BROADCAST
+}
+
+#[test]
+fn configured_binding_validation_and_duplicate_rejection_are_pre_mutation() {
+    let not_device = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 7).unwrap();
+    assert!(DeviceBinding::local(not_device, LOCAL_PEER).is_err());
+    assert!(DeviceBinding::local(device(1), []).is_err());
+    assert!(DeviceBinding::routed(device(1), 0, FINAL_PEER, ROUTER).is_err());
+    assert!(DeviceBinding::routed(device(1), 0xFFFF, FINAL_PEER, ROUTER).is_err());
+    assert!(DeviceBinding::routed(device(1), 100, [], ROUTER).is_err());
+    assert!(DeviceBinding::routed(device(1), 100, FINAL_PEER, []).is_err());
+
+    let mut table = DeviceBindingTable::new();
+    let configured = DeviceBinding::local(device(1), LOCAL_PEER).unwrap();
+    table
+        .insert_configured(configured.clone(), no_broadcast)
+        .unwrap();
+    let before = table.len();
+    assert!(table.insert_configured(configured, no_broadcast).is_err());
+    assert_eq!(table.len(), before);
+
+    let broadcast = DeviceBinding::local(device(2), BROADCAST).unwrap();
+    assert!(table.insert_configured(broadcast, test_broadcast).is_err());
+    assert_eq!(table.len(), before);
+}
+
+#[test]
+fn configured_registration_rejects_entry_beyond_capacity_without_mutation() {
+    let mut configured = Vec::new();
+    for instance in 0..MAX_DEVICE_BINDINGS as u32 {
+        super::device_bindings::register_configured_binding(
+            &mut configured,
+            DeviceBinding::local(device(instance), LOCAL_PEER).unwrap(),
+        )
+        .unwrap();
+    }
+    assert_eq!(configured.len(), MAX_DEVICE_BINDINGS);
+    assert!(super::device_bindings::register_configured_binding(
+        &mut configured,
+        DeviceBinding::local(device(MAX_DEVICE_BINDINGS as u32), LOCAL_PEER).unwrap(),
+    )
+    .is_err());
+    assert_eq!(configured.len(), MAX_DEVICE_BINDINGS);
+}
+
+#[test]
+fn configured_precedence_and_observed_refresh_expiry_are_deterministic() {
+    let now = Instant::now();
+    let configured_device = device(10);
+    let observed_device = device(11);
+    let mut table = DeviceBindingTable::new();
+    table
+        .insert_configured(
+            DeviceBinding::local(configured_device, LOCAL_PEER).unwrap(),
+            no_broadcast,
+        )
+        .unwrap();
+
+    assert_eq!(
+        table.observe_i_am_at(configured_device, UPDATED_PEER, None, now, no_broadcast,),
+        ObservationOutcome::ConfiguredPreserved
+    );
+    assert_eq!(
+        table.resolve_at(&configured_device, now, no_broadcast),
+        DeviceResolution::ResolvedLocal {
+            peer_mac: MacAddr::from_slice(LOCAL_PEER),
+        }
+    );
+
+    assert_eq!(
+        table.observe_i_am_at(observed_device, LOCAL_PEER, None, now, no_broadcast),
+        ObservationOutcome::Inserted
+    );
+    let refreshed_at = now + Duration::from_secs(30);
+    assert_eq!(
+        table.observe_i_am_at(
+            observed_device,
+            UPDATED_PEER,
+            None,
+            refreshed_at,
+            no_broadcast,
+        ),
+        ObservationOutcome::Refreshed
+    );
+    assert_eq!(
+        table.resolve_at(
+            &observed_device,
+            refreshed_at + OBSERVED_BINDING_TTL - Duration::from_nanos(1),
+            no_broadcast,
+        ),
+        DeviceResolution::ResolvedLocal {
+            peer_mac: MacAddr::from_slice(UPDATED_PEER),
+        }
+    );
+    assert_eq!(
+        table.resolve_at(
+            &observed_device,
+            refreshed_at + OBSERVED_BINDING_TTL,
+            no_broadcast,
+        ),
+        DeviceResolution::Stale
+    );
+}
+
+#[test]
+fn malformed_invalid_identity_and_broadcast_observations_do_not_mutate() {
+    let now = Instant::now();
+    let mut table = DeviceBindingTable::new();
+    let invalid_device = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let invalid_sources = [
+        (invalid_device, LOCAL_PEER, None),
+        (device(1), &[][..], None),
+        (device(2), BROADCAST, None),
+    ];
+    for (identifier, source, routed) in invalid_sources {
+        assert_eq!(
+            table.observe_i_am_at(identifier, source, routed, now, test_broadcast),
+            ObservationOutcome::RejectedInvalid
+        );
+    }
+
+    for source_network in [
+        NpduAddress {
+            network: 0,
+            mac_address: MacAddr::from_slice(FINAL_PEER),
+        },
+        NpduAddress {
+            network: 0xFFFF,
+            mac_address: MacAddr::from_slice(FINAL_PEER),
+        },
+        NpduAddress {
+            network: 100,
+            mac_address: MacAddr::new(),
+        },
+    ] {
+        assert_eq!(
+            table.observe_i_am_at(
+                device(3),
+                ROUTER,
+                Some(&source_network),
+                now,
+                test_broadcast,
+            ),
+            ObservationOutcome::RejectedInvalid
+        );
+    }
+    let routed = NpduAddress {
+        network: 100,
+        mac_address: MacAddr::from_slice(FINAL_PEER),
+    };
+    assert_eq!(
+        table.observe_i_am_at(device(4), BROADCAST, Some(&routed), now, test_broadcast,),
+        ObservationOutcome::RejectedInvalid
+    );
+    assert_eq!(table.len(), 0);
+
+    table
+        .insert_configured(
+            DeviceBinding::local(device(5), BROADCAST).unwrap(),
+            no_broadcast,
+        )
+        .unwrap();
+    assert_eq!(
+        table.resolve_at(&device(5), now, test_broadcast),
+        DeviceResolution::Invalid
+    );
+}
+
+#[test]
+fn capacity_rejection_stale_reclamation_and_configured_retention_are_bounded() {
+    let now = Instant::now();
+    let mut full = DeviceBindingTable::new();
+    for instance in 0..MAX_DEVICE_BINDINGS as u32 {
+        assert_eq!(
+            full.observe_i_am_at(device(instance), LOCAL_PEER, None, now, no_broadcast),
+            ObservationOutcome::Inserted
+        );
+    }
+    assert_eq!(full.len(), MAX_DEVICE_BINDINGS);
+    let rejected = device(MAX_DEVICE_BINDINGS as u32);
+    assert_eq!(
+        full.observe_i_am_at(rejected, LOCAL_PEER, None, now, no_broadcast),
+        ObservationOutcome::RejectedCapacity
+    );
+    assert_eq!(full.len(), MAX_DEVICE_BINDINGS);
+    assert_eq!(
+        full.resolve_at(&rejected, now, no_broadcast),
+        DeviceResolution::Unknown
+    );
+
+    let configured_device = device(0);
+    let mut reclaiming = DeviceBindingTable::new();
+    reclaiming
+        .insert_configured(
+            DeviceBinding::local(configured_device, UPDATED_PEER).unwrap(),
+            no_broadcast,
+        )
+        .unwrap();
+    for instance in 1..MAX_DEVICE_BINDINGS as u32 {
+        assert_eq!(
+            reclaiming.observe_i_am_at(device(instance), LOCAL_PEER, None, now, no_broadcast,),
+            ObservationOutcome::Inserted
+        );
+    }
+    let after_expiry = now + OBSERVED_BINDING_TTL;
+    assert_eq!(
+        reclaiming.observe_i_am_at(
+            device(MAX_DEVICE_BINDINGS as u32 + 1),
+            LOCAL_PEER,
+            None,
+            after_expiry,
+            no_broadcast,
+        ),
+        ObservationOutcome::Inserted
+    );
+    assert_eq!(reclaiming.len(), 2, "stale observed rows are reclaimed");
+    assert_eq!(
+        reclaiming.resolve_at(&configured_device, after_expiry, no_broadcast),
+        DeviceResolution::ResolvedLocal {
+            peer_mac: MacAddr::from_slice(UPDATED_PEER),
+        },
+        "configured rows never expire or get evicted"
+    );
+}
+
+#[derive(Default)]
+struct PassiveTransport;
+
+impl TransportPort for PassiveTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        let (_tx, rx) = mpsc::channel(1);
+        Ok(rx)
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, _npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        LOCAL_PEER
+    }
+
+    fn is_broadcast_mac(&self, mac: &[u8]) -> bool {
+        test_broadcast(mac)
+    }
+}
+
+fn i_am_request(identifier: ObjectIdentifier) -> UnconfirmedRequestPdu {
+    let i_am = IAmRequest {
+        object_identifier: identifier,
+        max_apdu_length: 1476,
+        segmentation_supported: Segmentation::NONE,
+        vendor_id: 1,
+    };
+    let mut service_request = BytesMut::new();
+    i_am.encode(&mut service_request);
+    UnconfirmedRequestPdu {
+        service_choice: UnconfirmedServiceChoice::I_AM,
+        service_request: service_request.freeze(),
+    }
+}
+
+fn received(
+    source_mac: &[u8],
+    source_network: Option<NpduAddress>,
+) -> bacnet_network::layer::ReceivedApdu {
+    bacnet_network::layer::ReceivedApdu {
+        apdu: Bytes::new(),
+        source_mac: MacAddr::from_slice(source_mac),
+        source_network,
+        link_layer_group: false,
+        is_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
+#[tokio::test]
+async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_blocks_refresh() {
+    let db = Arc::new(RwLock::new(ObjectDatabase::new()));
+    let network = Arc::new(NetworkLayer::new(PassiveTransport));
+    let config = ServerConfig::default();
+    let comm_state = Arc::new(AtomicU8::new(0));
+    let bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
+    let local_device = device(100);
+    let routed_device = device(101);
+
+    BACnetServer::<PassiveTransport>::handle_unconfirmed_request(
+        &db,
+        &network,
+        &config,
+        None,
+        &comm_state,
+        &bindings,
+        i_am_request(local_device),
+        &received(LOCAL_PEER, None),
+    )
+    .await;
+    BACnetServer::<PassiveTransport>::handle_unconfirmed_request(
+        &db,
+        &network,
+        &config,
+        None,
+        &comm_state,
+        &bindings,
+        i_am_request(routed_device),
+        &received(
+            ROUTER,
+            Some(NpduAddress {
+                network: 200,
+                mac_address: MacAddr::from_slice(FINAL_PEER),
+            }),
+        ),
+    )
+    .await;
+
+    let now = Instant::now();
+    let table = bindings.read().await;
+    assert_eq!(
+        table.resolve_at(&local_device, now, test_broadcast),
+        DeviceResolution::ResolvedLocal {
+            peer_mac: MacAddr::from_slice(LOCAL_PEER),
+        }
+    );
+    assert_eq!(
+        table.resolve_at(&routed_device, now, test_broadcast),
+        DeviceResolution::ResolvedRouted {
+            network: 200,
+            final_mac: MacAddr::from_slice(FINAL_PEER),
+            router_mac: MacAddr::from_slice(ROUTER),
+        }
+    );
+    drop(table);
+
+    BACnetServer::<PassiveTransport>::handle_unconfirmed_request(
+        &db,
+        &network,
+        &config,
+        None,
+        &comm_state,
+        &bindings,
+        i_am_request(ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap()),
+        &received(LOCAL_PEER, None),
+    )
+    .await;
+    BACnetServer::<PassiveTransport>::handle_unconfirmed_request(
+        &db,
+        &network,
+        &config,
+        None,
+        &comm_state,
+        &bindings,
+        UnconfirmedRequestPdu {
+            service_choice: UnconfirmedServiceChoice::I_AM,
+            service_request: Bytes::from_static(&[0xFF]),
+        },
+        &received(LOCAL_PEER, None),
+    )
+    .await;
+    assert_eq!(bindings.read().await.len(), 2);
+
+    comm_state.store(1, Ordering::Release);
+    BACnetServer::<PassiveTransport>::handle_unconfirmed_request(
+        &db,
+        &network,
+        &config,
+        None,
+        &comm_state,
+        &bindings,
+        i_am_request(local_device),
+        &received(UPDATED_PEER, None),
+    )
+    .await;
+    BACnetServer::<PassiveTransport>::handle_unconfirmed_request(
+        &db,
+        &network,
+        &config,
+        None,
+        &comm_state,
+        &bindings,
+        i_am_request(device(102)),
+        &received(LOCAL_PEER, None),
+    )
+    .await;
+    assert_eq!(bindings.read().await.len(), 2, "DCC also blocks insertion");
+    assert_eq!(
+        bindings
+            .read()
+            .await
+            .resolve_at(&local_device, Instant::now(), test_broadcast),
+        DeviceResolution::ResolvedLocal {
+            peer_mac: MacAddr::from_slice(LOCAL_PEER),
+        },
+        "DCC-disabled traffic cannot refresh the observed row"
+    );
+}
+
+#[derive(Clone)]
+struct StartTrackingTransport {
+    started: Arc<AtomicBool>,
+}
+
+impl TransportPort for StartTrackingTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        self.started.store(true, Ordering::Release);
+        let (_tx, rx) = mpsc::channel(1);
+        Ok(rx)
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, _npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        LOCAL_PEER
+    }
+
+    fn is_broadcast_mac(&self, mac: &[u8]) -> bool {
+        test_broadcast(mac)
+    }
+}
+
+#[tokio::test]
+async fn concrete_broadcast_validation_rejects_before_transport_start() {
+    let started = Arc::new(AtomicBool::new(false));
+    let transport = StartTrackingTransport {
+        started: Arc::clone(&started),
+    };
+    let builder = BACnetServer::<StartTrackingTransport>::generic_builder()
+        .transport(transport)
+        .device_binding(DeviceBinding::local(device(200), BROADCAST).unwrap())
+        .unwrap();
+
+    assert!(builder.build().await.is_err());
+    assert!(!started.load(Ordering::Acquire));
+}

--- a/crates/bacnet-server/src/server/device_bindings_tests.rs
+++ b/crates/bacnet-server/src/server/device_bindings_tests.rs
@@ -1,6 +1,6 @@
 use super::device_bindings::{
-    DeviceBindingTable, DeviceResolution, ObservationOutcome, MAX_DEVICE_BINDINGS,
-    OBSERVED_BINDING_TTL,
+    BindingFreshness, DeviceBindingTable, DeviceResolution, ObservationOutcome,
+    MAX_DEVICE_BINDINGS, OBSERVED_BINDING_TTL,
 };
 use super::*;
 use bacnet_transport::port::{ReceivedNpdu, TransportPort};
@@ -89,6 +89,7 @@ fn configured_precedence_and_observed_refresh_expiry_are_deterministic() {
         table.resolve_at(&configured_device, now, no_broadcast),
         DeviceResolution::ResolvedLocal {
             peer_mac: MacAddr::from_slice(LOCAL_PEER),
+            freshness: BindingFreshness::Configured,
         }
     );
 
@@ -115,6 +116,9 @@ fn configured_precedence_and_observed_refresh_expiry_are_deterministic() {
         ),
         DeviceResolution::ResolvedLocal {
             peer_mac: MacAddr::from_slice(UPDATED_PEER),
+            freshness: BindingFreshness::ObservedUntil(tokio::time::Instant::from_std(
+                refreshed_at + OBSERVED_BINDING_TTL,
+            )),
         }
     );
     assert_eq!(
@@ -243,6 +247,7 @@ fn capacity_rejection_stale_reclamation_and_configured_retention_are_bounded() {
         reclaiming.resolve_at(&configured_device, after_expiry, no_broadcast),
         DeviceResolution::ResolvedLocal {
             peer_mac: MacAddr::from_slice(UPDATED_PEER),
+            freshness: BindingFreshness::Configured,
         },
         "configured rows never expire or get evicted"
     );
@@ -349,20 +354,22 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
 
     let now = Instant::now();
     let table = bindings.read().await;
-    assert_eq!(
+    assert!(matches!(
         table.resolve_at(&local_device, now, test_broadcast),
         DeviceResolution::ResolvedLocal {
-            peer_mac: MacAddr::from_slice(LOCAL_PEER),
-        }
-    );
-    assert_eq!(
+            peer_mac,
+            freshness: BindingFreshness::ObservedUntil(_),
+        } if peer_mac.as_slice() == LOCAL_PEER
+    ));
+    assert!(matches!(
         table.resolve_at(&routed_device, now, test_broadcast),
         DeviceResolution::ResolvedRouted {
             network: 200,
-            final_mac: MacAddr::from_slice(FINAL_PEER),
-            router_mac: MacAddr::from_slice(ROUTER),
-        }
-    );
+            final_mac,
+            router_mac,
+            freshness: BindingFreshness::ObservedUntil(_),
+        } if final_mac.as_slice() == FINAL_PEER && router_mac.as_slice() == ROUTER
+    ));
     drop(table);
 
     BACnetServer::<PassiveTransport>::handle_unconfirmed_request(
@@ -416,16 +423,16 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
     )
     .await;
     assert_eq!(bindings.read().await.len(), 2, "DCC also blocks insertion");
-    assert_eq!(
+    assert!(matches!(
         bindings
             .read()
             .await
             .resolve_at(&local_device, Instant::now(), test_broadcast),
         DeviceResolution::ResolvedLocal {
-            peer_mac: MacAddr::from_slice(LOCAL_PEER),
-        },
-        "DCC-disabled traffic cannot refresh the observed row"
-    );
+            peer_mac,
+            freshness: BindingFreshness::ObservedUntil(_),
+        } if peer_mac.as_slice() == LOCAL_PEER
+    ));
 }
 
 #[derive(Clone)]

--- a/crates/bacnet-server/src/server/device_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/device_recipient_routing_tests.rs
@@ -1,0 +1,166 @@
+use super::device_bindings::{
+    DeviceBindingTable, ObservationOutcome, MAX_DEVICE_BINDINGS, OBSERVED_BINDING_TTL,
+};
+use super::event_recipient_routing_tests::{
+    destination_for, distribute_from_database_with_bindings, npdu_destination,
+    LITERAL_BROADCAST_MAC,
+};
+use super::*;
+use bacnet_objects::analog::AnalogInputObject;
+use bacnet_objects::notification_class::NotificationClass;
+use bacnet_types::constructed::BACnetRecipient;
+
+const LOCAL_PEER: &[u8] = &[127, 0, 0, 2, 0xBA, 0xC0];
+const ROUTER: &[u8] = &[127, 0, 0, 3, 0xBA, 0xC0];
+const FINAL_PEER: &[u8] = &[0x33, 0x44, 0x55];
+
+fn device(instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::DEVICE, instance).unwrap()
+}
+
+fn binding_database(recipients: &[(ObjectIdentifier, bool)]) -> ObjectDatabase {
+    let mut db = clocked_test_database();
+    let mut class = NotificationClass::new(0, "NC-0").unwrap();
+    for (identifier, confirmed) in recipients {
+        class.add_destination(destination_for(
+            BACnetRecipient::Device(*identifier),
+            *confirmed,
+        ));
+    }
+    db.add(Box::new(class)).unwrap();
+    db.add(Box::new(AnalogInputObject::new(1, "AI-1", 0).unwrap()))
+        .unwrap();
+    db
+}
+
+async fn distribute(
+    recipients: &[(ObjectIdentifier, bool)],
+    table: DeviceBindingTable,
+) -> (Vec<bytes::Bytes>, Vec<(Vec<u8>, bytes::Bytes)>) {
+    distribute_from_database_with_bindings(
+        binding_database(recipients),
+        Arc::new(RwLock::new(table)),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn configured_local_device_recipient_is_direct_unicast_confirmed_and_unconfirmed() {
+    for confirmed in [false, true] {
+        let identifier = device(20 + u32::from(confirmed));
+        let mut table = DeviceBindingTable::new();
+        table
+            .insert_configured(
+                DeviceBinding::local(identifier, LOCAL_PEER).unwrap(),
+                |_| false,
+            )
+            .unwrap();
+        let (broadcasts, unicasts) = distribute(&[(identifier, confirmed)], table).await;
+        assert!(broadcasts.is_empty(), "Device unicast never broadcasts");
+        assert_eq!(unicasts.len(), 1);
+        assert_eq!(unicasts[0].0.as_slice(), LOCAL_PEER);
+        assert_eq!(npdu_destination(&unicasts[0].1), None);
+    }
+}
+
+#[tokio::test]
+async fn configured_and_observed_routed_device_recipients_use_exact_router_and_final_address() {
+    for configured in [true, false] {
+        let identifier = device(30 + u32::from(configured));
+        let mut table = DeviceBindingTable::new();
+        if configured {
+            table
+                .insert_configured(
+                    DeviceBinding::routed(identifier, 700, FINAL_PEER, ROUTER).unwrap(),
+                    |_| false,
+                )
+                .unwrap();
+        } else {
+            assert_eq!(
+                table.observe_i_am_at(
+                    identifier,
+                    ROUTER,
+                    Some(&NpduAddress {
+                        network: 700,
+                        mac_address: MacAddr::from_slice(FINAL_PEER),
+                    }),
+                    Instant::now(),
+                    |_| false,
+                ),
+                ObservationOutcome::Inserted
+            );
+        }
+
+        let (broadcasts, unicasts) = distribute(&[(identifier, false)], table).await;
+        assert!(broadcasts.is_empty());
+        assert_eq!(unicasts.len(), 1);
+        assert_eq!(unicasts[0].0.as_slice(), ROUTER);
+        assert_eq!(
+            npdu_destination(&unicasts[0].1),
+            Some((700, FINAL_PEER.to_vec()))
+        );
+    }
+}
+
+#[tokio::test]
+async fn unknown_stale_invalid_and_capacity_rejected_devices_emit_zero_frames() {
+    let now = Instant::now();
+    let stale = device(40);
+    let invalid = device(41);
+    let unknown = device(42);
+    let rejected = device(900_000);
+    let mut table = DeviceBindingTable::new();
+    assert_eq!(
+        table.observe_i_am_at(stale, LOCAL_PEER, None, now, |_| false),
+        ObservationOutcome::Inserted
+    );
+    table
+        .insert_configured(
+            DeviceBinding::local(invalid, LITERAL_BROADCAST_MAC).unwrap(),
+            |_| false,
+        )
+        .unwrap();
+    for instance in 1000..1000 + MAX_DEVICE_BINDINGS as u32 - 2 {
+        assert_eq!(
+            table.observe_i_am_at(device(instance), LOCAL_PEER, None, now, |_| false),
+            ObservationOutcome::Inserted
+        );
+    }
+    assert_eq!(table.len(), MAX_DEVICE_BINDINGS);
+    assert_eq!(
+        table.observe_i_am_at(rejected, LOCAL_PEER, None, now, |_| false),
+        ObservationOutcome::RejectedCapacity
+    );
+    assert_eq!(
+        table.observe_i_am_at(stale, LOCAL_PEER, None, now - OBSERVED_BINDING_TTL, |_| {
+            false
+        },),
+        ObservationOutcome::Refreshed
+    );
+
+    let (broadcasts, unicasts) = distribute(
+        &[
+            (unknown, false),
+            (stale, false),
+            (invalid, false),
+            (rejected, false),
+        ],
+        table,
+    )
+    .await;
+    assert!(broadcasts.is_empty());
+    assert!(unicasts.is_empty());
+}
+
+#[tokio::test]
+async fn mixed_valid_and_unresolved_device_recipients_preserve_valid_delivery() {
+    let valid = device(50);
+    let mut table = DeviceBindingTable::new();
+    table
+        .insert_configured(DeviceBinding::local(valid, LOCAL_PEER).unwrap(), |_| false)
+        .unwrap();
+    let (broadcasts, unicasts) = distribute(&[(device(51), false), (valid, false)], table).await;
+    assert!(broadcasts.is_empty());
+    assert_eq!(unicasts.len(), 1);
+    assert_eq!(unicasts[0].0.as_slice(), LOCAL_PEER);
+}

--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -88,6 +88,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         cov_in_flight: &Arc<Semaphore>,
         server_tsm: &Arc<Mutex<ServerTsm>>,
         notification_transactions: &Arc<NotificationTransactions>,
+        device_bindings: &Arc<RwLock<DeviceBindingTable>>,
         comm_state: &Arc<AtomicU8>,
         dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
         config: &Arc<ServerConfig>,
@@ -107,6 +108,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let cov_in_flight = Arc::clone(cov_in_flight);
                 let server_tsm = Arc::clone(server_tsm);
                 let notification_transactions = Arc::clone(notification_transactions);
+                let device_bindings = Arc::clone(device_bindings);
                 let comm_state = Arc::clone(comm_state);
                 let dcc_timer = Arc::clone(dcc_timer);
                 let config = Arc::clone(config);
@@ -122,6 +124,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         &cov_in_flight,
                         &server_tsm,
                         &notification_transactions,
+                        &device_bindings,
                         &comm_state,
                         &dcc_timer,
                         &config,
@@ -139,6 +142,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let config = Arc::clone(config);
                 let clock = clock.clone();
                 let comm_state = Arc::clone(comm_state);
+                let device_bindings = Arc::clone(device_bindings);
                 tokio::spawn(async move {
                     Self::handle_unconfirmed_request(
                         &db,
@@ -146,6 +150,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         &config,
                         clock.as_ref(),
                         &comm_state,
+                        &device_bindings,
                         req,
                         &received,
                     )

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -12,7 +12,7 @@
 //! The tests drive the real distribution path over a recording transport and
 //! feed acks through the same correlation entry point the dispatch loop uses.
 
-use super::device_bindings::DeviceBindingTable;
+use super::device_bindings::{DeviceBindingTable, OBSERVED_BINDING_TTL};
 use super::event_notifications_tests::local_broadcast_destination;
 use super::event_recipient_routing_tests::{address_recipient, destination_for};
 use super::*;
@@ -282,6 +282,41 @@ async fn configured_routed_device_retries_unicast_to_router_and_correlates_by_fi
             .await,
         "terminal correlation uses the final routed peer identity"
     );
+}
+
+#[tokio::test(start_paused = true)]
+async fn observed_routed_device_stops_emitting_when_retry_reaches_expiry() {
+    let identifier = ObjectIdentifier::new(ObjectType::DEVICE, 91).unwrap();
+    let mut bindings = DeviceBindingTable::new();
+    let observed_at = Instant::now() - OBSERVED_BINDING_TTL + Duration::from_millis(500);
+    let source = NpduAddress {
+        network: 1001,
+        mac_address: MacAddr::from_slice(RECIPIENT),
+    };
+    assert_eq!(
+        bindings.observe_i_am_at(identifier, ROUTER_A, Some(&source), observed_at, |_| false),
+        super::device_bindings::ObservationOutcome::Inserted
+    );
+    let harness = Harness::new_with_bindings(
+        vec![destination_for(BACnetRecipient::Device(identifier), true)],
+        1_000,
+        bindings,
+    )
+    .await;
+    harness.distribute().await;
+
+    assert_eq!(harness.unicast_frames().len(), 1);
+    tokio::time::advance(Duration::from_secs(1)).await;
+    for _ in 0..16 {
+        tokio::task::yield_now().await;
+    }
+
+    assert_eq!(
+        harness.unicast_frames().len(),
+        1,
+        "an observed route cannot emit at or after its expiry boundary"
+    );
+    assert!(harness.broadcast_frames().is_empty());
 }
 
 /// Decode a captured frame into its NPDU and the confirmed request inside.

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -12,6 +12,7 @@
 //! The tests drive the real distribution path over a recording transport and
 //! feed acks through the same correlation entry point the dispatch loop uses.
 
+use super::device_bindings::DeviceBindingTable;
 use super::event_notifications_tests::local_broadcast_destination;
 use super::event_recipient_routing_tests::{address_recipient, destination_for};
 use super::*;
@@ -21,7 +22,7 @@ use bacnet_objects::event::EventStateChange;
 use bacnet_objects::notification_class::NotificationClass;
 use bacnet_objects::traits::BACnetObject;
 use bacnet_transport::port::TransportPort;
-use bacnet_types::constructed::BACnetDestination;
+use bacnet_types::constructed::{BACnetDestination, BACnetRecipient};
 use bacnet_types::enums::{EventState, EventType};
 use bytes::Bytes;
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
@@ -69,6 +70,7 @@ struct Harness {
     network: Arc<NetworkLayer<RecordingTransport>>,
     server_tsm: Arc<Mutex<ServerTsm>>,
     notification_transactions: Arc<NotificationTransactions>,
+    device_bindings: Arc<RwLock<DeviceBindingTable>>,
     comm_state: Arc<AtomicU8>,
     broadcasts: StdArc<StdMutex<Vec<Bytes>>>,
     unicasts: StdArc<StdMutex<Vec<(Vec<u8>, Bytes)>>>,
@@ -77,6 +79,14 @@ struct Harness {
 
 impl Harness {
     async fn new(destinations: Vec<BACnetDestination>, retry_timeout_ms: u64) -> Self {
+        Self::new_with_bindings(destinations, retry_timeout_ms, DeviceBindingTable::new()).await
+    }
+
+    async fn new_with_bindings(
+        destinations: Vec<BACnetDestination>,
+        retry_timeout_ms: u64,
+        device_bindings: DeviceBindingTable,
+    ) -> Self {
         let transport = RecordingTransport::default();
         let broadcasts = StdArc::clone(&transport.broadcasts);
         let unicasts = StdArc::clone(&transport.unicasts);
@@ -116,6 +126,7 @@ impl Harness {
             network,
             server_tsm,
             notification_transactions,
+            device_bindings: Arc::new(RwLock::new(device_bindings)),
             comm_state,
             broadcasts,
             unicasts,
@@ -125,12 +136,13 @@ impl Harness {
 
     async fn distribute(&self) {
         let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-        BACnetServer::<RecordingTransport>::build_and_send_event_notification(
+        BACnetServer::<RecordingTransport>::build_and_send_event_notification_with_bindings(
             &self.db,
             &self.network,
             &self.comm_state,
             &self.server_tsm,
             &self.notification_transactions,
+            &self.device_bindings,
             &oid,
             (
                 EventStateChange {
@@ -197,6 +209,7 @@ impl Harness {
             &Arc::new(Semaphore::new(255)),
             &self.server_tsm,
             &self.notification_transactions,
+            &self.device_bindings,
             &self.comm_state,
             &Arc::new(Mutex::new(None::<JoinHandle<()>>)),
             &Arc::new(ServerConfig::default()),
@@ -219,6 +232,56 @@ impl Harness {
         }
         self.notification_transactions.active_count() < active_before
     }
+}
+
+#[tokio::test]
+async fn configured_routed_device_retries_unicast_to_router_and_correlates_by_final_peer() {
+    let identifier = ObjectIdentifier::new(ObjectType::DEVICE, 90).unwrap();
+    let mut bindings = DeviceBindingTable::new();
+    bindings
+        .insert_configured(
+            DeviceBinding::routed(identifier, 1000, RECIPIENT, ROUTER_A).unwrap(),
+            |_| false,
+        )
+        .unwrap();
+    let harness = Harness::new_with_bindings(
+        vec![destination_for(BACnetRecipient::Device(identifier), true)],
+        75,
+        bindings,
+    )
+    .await;
+    harness.distribute().await;
+
+    assert!(harness.broadcast_frames().is_empty());
+    let first = harness.unicast_frames();
+    assert_eq!(first.len(), 1);
+    assert_eq!(first[0].0.as_slice(), ROUTER_A);
+    let (npdu, request) = decode_confirmed(&first[0].1);
+    let destination = npdu.destination.unwrap();
+    assert_eq!(destination.network, 1000);
+    assert_eq!(destination.mac_address.as_ref() as &[u8], RECIPIENT);
+
+    tokio::time::sleep(Duration::from_millis(190)).await;
+    let retried = harness.unicast_frames();
+    assert!(retried.len() >= 2, "silence triggers a retry");
+    for (router, frame) in &retried {
+        assert_eq!(router.as_slice(), ROUTER_A, "every attempt uses the router");
+        let (npdu, retry) = decode_confirmed(frame);
+        let destination = npdu.destination.unwrap();
+        assert_eq!(destination.network, 1000);
+        assert_eq!(destination.mac_address.as_ref() as &[u8], RECIPIENT);
+        assert_eq!(retry.invoke_id, request.invoke_id);
+    }
+    assert!(
+        harness.broadcast_frames().is_empty(),
+        "retries never broadcast"
+    );
+    assert!(
+        harness
+            .ack_routed(ROUTER_A, 1000, RECIPIENT, request.invoke_id)
+            .await,
+        "terminal correlation uses the final routed peer identity"
+    );
 }
 
 /// Decode a captured frame into its NPDU and the confirmed request inside.

--- a/crates/bacnet-server/src/server/event_enrollment_lifecycle.rs
+++ b/crates/bacnet-server/src/server/event_enrollment_lifecycle.rs
@@ -7,6 +7,7 @@ pub(super) fn spawn_event_enrollment_task<T: TransportPort + 'static>(
     comm_state: Arc<AtomicU8>,
     server_tsm: Arc<Mutex<ServerTsm>>,
     notification_transactions: Arc<NotificationTransactions>,
+    device_bindings: Arc<RwLock<DeviceBindingTable>>,
     period: Duration,
     retry_ms: u64,
 ) -> JoinHandle<()> {
@@ -52,12 +53,13 @@ pub(super) fn spawn_event_enrollment_task<T: TransportPort + 'static>(
             }
             crate::event_enrollment::log_evaluation_report(&report);
             for (oid, transition) in outbound {
-                BACnetServer::<T>::build_and_send_event_notification(
+                BACnetServer::<T>::build_and_send_event_notification_with_bindings(
                     &db,
                     &network,
                     &comm_state,
                     &server_tsm,
                     &notification_transactions,
+                    &device_bindings,
                     &oid,
                     transition,
                     retry_ms,

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -1,4 +1,4 @@
-use super::event_recipient_route::RecipientRoute;
+use super::event_recipient_route::{ConfirmedRecipientRoute, RecipientRoute};
 use super::event_timestamp::{
     confirm_event_timestamp, sample_event_timestamp, stage_event_timestamp, SampledEventClock,
 };
@@ -619,39 +619,20 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let service_bytes = service_buf.freeze();
 
             if *confirmed {
-                // `permits_confirmed` above admits only unicast route shapes.
-                // If that predicate ever widens without this arm
-                // learning the new route, fail loudly instead of dropping
-                // the notification with no diagnostic.
-                //
-                let (canonical_peer, local_target, remote) = match &route {
-                    RecipientRoute::LocalUnicast(target_mac) => (
-                        canonical_direct_peer(target_mac),
-                        Some(target_mac.clone()),
-                        None,
-                    ),
-                    RecipientRoute::RemoteUnicast { network, mac } => (
-                        canonical_routed_peer(*network, mac),
-                        None,
-                        Some((*network, mac.clone(), None)),
-                    ),
-                    RecipientRoute::BoundRoutedUnicast {
-                        network,
-                        mac,
-                        router,
-                    } => (
-                        canonical_routed_peer(*network, mac),
-                        None,
-                        Some((*network, mac.clone(), Some(router.clone()))),
-                    ),
-                    _ => {
-                        warn!(
-                            notification_class,
-                            "Confirmed notification reached the send path on a \
-                             non-unicast route; dropping"
-                        );
-                        continue;
-                    }
+                // Convert only the unicast route shapes admitted above and
+                // fail closed if the route classification changes.
+                let Some(ConfirmedRecipientRoute {
+                    canonical_peer,
+                    local_target,
+                    remote,
+                    freshness,
+                }) = route.into_confirmed()
+                else {
+                    warn!(
+                        notification_class,
+                        "Confirmed notification route is unusable"
+                    );
+                    continue;
                 };
                 let (operation, result_rx) = match notification_transactions.reserve(
                     canonical_peer,
@@ -698,6 +679,16 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             let local_target = local_target.clone();
                             let remote = remote.clone();
                             async move {
+                                if freshness.is_some_and(|freshness| {
+                                    !freshness.permits_attempt_at(tokio::time::Instant::now())
+                                }) {
+                                    debug!(
+                                        invoke_id = id,
+                                        attempt,
+                                        "Observed Device binding expired before notification attempt"
+                                    );
+                                    return Err(());
+                                }
                                 let send_result = match (local_target, remote) {
                                     (Some(target), None) => {
                                         network
@@ -705,9 +696,9 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                             .await
                                     }
                                     (None, Some((dnet, dadr, configured_router))) => {
-                                        // A configured Device route keeps its fixed
-                                        // next hop for every attempt. Address recipients
-                                        // retain the learned-router/broadcast behavior.
+                                        // A Device binding keeps its fixed next hop for
+                                        // each permitted attempt. Address recipients retain
+                                        // the learned-router/broadcast behavior.
                                         let router = match configured_router {
                                             Some(router) => Some(router),
                                             None if attempt == 0 => {
@@ -753,7 +744,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                         attempt, "Confirmed EventNotification send failed"
                                     ),
                                 }
-                                send_result
+                                send_result.map_err(|_| ())
                             }
                         },
                     )
@@ -783,6 +774,9 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
                 let send_result = match &route {
                     RecipientRoute::LocalUnicast(mac) => {
+                        network.send_apdu(&buf, mac, false, network_priority).await
+                    }
+                    RecipientRoute::BoundLocalUnicast { mac, .. } => {
                         network.send_apdu(&buf, mac, false, network_priority).await
                     }
                     RecipientRoute::LocalBroadcast => {
@@ -821,6 +815,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         network: net,
                         mac,
                         router,
+                        ..
                     } => {
                         network
                             .send_apdu_routed(&buf, *net, mac, router, false, network_priority)

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -1,3 +1,4 @@
+use super::event_recipient_route::RecipientRoute;
 use super::event_timestamp::{
     confirm_event_timestamp, sample_event_timestamp, stage_event_timestamp, SampledEventClock,
 };
@@ -110,9 +111,6 @@ impl From<ResolvedIntrinsicTransition> for NotificationTransition {
         }
     }
 }
-
-/// The DNET reserved for a global broadcast (Clause 6.3).
-const GLOBAL_BROADCAST_NETWORK: u16 = 0xFFFF;
 
 /// Project an alarm/event priority onto the NPDU Network Priority.
 ///
@@ -248,119 +246,6 @@ pub(super) fn resolve_committed_event_enrollment_transition(
     ))
 }
 
-/// The network destination a Notification Class recipient resolves to.
-///
-/// Clause 21's `BACnetAddress` gives a recipient two independent knobs —
-/// `network-number`, where "A value of 0 indicates the local network", and
-/// `mac-address`, where "A string of length 0 indicates a broadcast" — and
-/// Clause 6.3 reserves network 65535 for the global broadcast. Their
-/// combinations are distinct sends rather than one unicast with edge cases,
-/// which is why this is resolved once up front rather than decided at each
-/// send site.
-enum RecipientRoute {
-    /// Network 0 with an explicit MAC: unicast on the local network.
-    LocalUnicast(MacAddr),
-    /// Network 0 with a zero-length MAC. Clause 12.21 prescribes exactly this
-    /// recipient for a device whose `Recipient_List` is not writable and which
-    /// uses no local Notification Forwarder objects.
-    LocalBroadcast,
-    /// A zero-length MAC on a remote network. Clause 6.3: "DNET shall specify
-    /// the network number of the remote network and DLEN shall be set to zero".
-    RemoteBroadcast(u16),
-    /// A zero-length MAC on network 65535. Clause 6.3: "A global broadcast,
-    /// indicated by a DNET of X'FFFF', is sent to all networks through all
-    /// routers" — a destination of its own, not a remote network that happens
-    /// to be numbered 65535. `broadcast_to_network` rejects 0xFFFF outright,
-    /// so routing it as one would drop the notification.
-    GlobalBroadcast,
-    /// A unicast MAC on a remote network. The NPDU names the recipient via
-    /// DNET/DADR; with no router table in this non-routing device, the link
-    /// DA is the local broadcast, exactly as Clause 6.5.3 prescribes when
-    /// "the address of the router is initially unknown".
-    RemoteUnicast { network: u16, mac: MacAddr },
-    /// A unicast MAC alongside network 65535, which is self-contradictory: a
-    /// global broadcast requires DLEN zero.
-    ContradictoryGlobal,
-    /// A device-instance recipient. Resolving it needs a device-to-address
-    /// binding this device does not maintain. Tracked by #125.
-    UnresolvedDevice(ObjectIdentifier),
-}
-
-impl RecipientRoute {
-    fn resolve(recipient: &BACnetRecipient, is_link_broadcast: impl Fn(&[u8]) -> bool) -> Self {
-        match recipient {
-            BACnetRecipient::Device(oid) => Self::UnresolvedDevice(*oid),
-            BACnetRecipient::Address(addr) => {
-                match (addr.network_number, addr.mac_address.is_empty()) {
-                    (0, true) => Self::LocalBroadcast,
-                    // The data-link spelling of a broadcast (#360): Clause 6.3
-                    // names the medium's literal broadcast MAC alongside the
-                    // zero-length form, and both name the same destination.
-                    (0, false) if is_link_broadcast(&addr.mac_address) => Self::LocalBroadcast,
-                    (0, false) => Self::LocalUnicast(addr.mac_address.clone()),
-                    (GLOBAL_BROADCAST_NETWORK, true) => Self::GlobalBroadcast,
-                    (net, true) => Self::RemoteBroadcast(net),
-                    (GLOBAL_BROADCAST_NETWORK, false) => Self::ContradictoryGlobal,
-                    (net, false) => Self::RemoteUnicast {
-                        network: net,
-                        mac: addr.mac_address.clone(),
-                    },
-                }
-            }
-        }
-    }
-
-    /// Whether a ConfirmedEventNotification may be sent to this destination.
-    ///
-    /// Clause 6.3: "Of the BACnet APDUs, only the BACnet-Unconfirmed-Request-PDU
-    /// may be transmitted using a multicast or broadcast network layer address".
-    /// A confirmed notification also has nowhere to return its SimpleACK from.
-    ///
-    /// Both spellings of a broadcast land here as non-unicast routes: the
-    /// zero-length `mac-address` (Clause 21), and the data link's literal
-    /// broadcast MAC, which `resolve` folds into `LocalBroadcast` via the
-    /// transport's own knowledge of its spelling.
-    ///
-    /// `RemoteUnicast` is admitted: Clause 6.3 permits sending it confirmed
-    /// (the DNET/DADR restricts the destination to one device), and the
-    /// server TSM correlates the acknowledgment by routed identity even when
-    /// it arrives through a router whose MAC was unknown at send time (#375).
-    fn permits_confirmed(&self) -> bool {
-        matches!(self, Self::LocalUnicast(_) | Self::RemoteUnicast { .. })
-    }
-
-    /// Whether this destination can be sent to at all, logging why not when it
-    /// cannot. The two failures are reported separately because they are
-    /// separate operator problems: a self-contradictory address is a
-    /// configuration error, while an unbound device instance is a recipient
-    /// this device cannot address at all.
-    fn is_deliverable(&self, notification_class: u32) -> bool {
-        match self {
-            Self::LocalUnicast(_)
-            | Self::LocalBroadcast
-            | Self::RemoteBroadcast(_)
-            | Self::GlobalBroadcast
-            | Self::RemoteUnicast { .. } => true,
-            Self::ContradictoryGlobal => {
-                warn!(
-                    notification_class,
-                    "Skipping recipient: network 65535 with a unicast MAC is \
-                     self-contradictory (a global broadcast requires DLEN zero)"
-                );
-                false
-            }
-            Self::UnresolvedDevice(device) => {
-                warn!(
-                    notification_class,
-                    %device,
-                    "Skipping recipient: no address binding for this device instance"
-                );
-                false
-            }
-        }
-    }
-}
-
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Resolve policy and atomically commit one intrinsic proposal.
     pub(super) fn commit_intrinsic_transition(
@@ -432,12 +317,36 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     /// seeds a pending transition (returning `None`, so no notification is
     /// sent here) and the one-second [`intrinsic_reporting_task`](Self::start)
     /// advances the countdown and sends the notification on expiry.
+    #[cfg(test)]
     pub(super) async fn fire_event_notifications(
         db: &Arc<RwLock<ObjectDatabase>>,
         network: &Arc<NetworkLayer<T>>,
         comm_state: &Arc<AtomicU8>,
         server_tsm: &Arc<Mutex<ServerTsm>>,
         notification_transactions: &Arc<NotificationTransactions>,
+        oid: &ObjectIdentifier,
+        retry_timeout_ms: u64,
+    ) {
+        Self::fire_event_notifications_with_bindings(
+            db,
+            network,
+            comm_state,
+            server_tsm,
+            notification_transactions,
+            &Arc::new(RwLock::new(DeviceBindingTable::new())),
+            oid,
+            retry_timeout_ms,
+        )
+        .await;
+    }
+
+    pub(super) async fn fire_event_notifications_with_bindings(
+        db: &Arc<RwLock<ObjectDatabase>>,
+        network: &Arc<NetworkLayer<T>>,
+        comm_state: &Arc<AtomicU8>,
+        server_tsm: &Arc<Mutex<ServerTsm>>,
+        notification_transactions: &Arc<NotificationTransactions>,
+        device_bindings: &Arc<RwLock<DeviceBindingTable>>,
         oid: &ObjectIdentifier,
         retry_timeout_ms: u64,
     ) {
@@ -473,12 +382,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         // text is intentionally absent for this built-in path.
         if let Some(resolved) = resolved {
             if resolved.distribute() {
-                Self::build_and_send_event_notification(
+                Self::build_and_send_event_notification_with_bindings(
                     db,
                     network,
                     comm_state,
                     server_tsm,
                     notification_transactions,
+                    device_bindings,
                     oid,
                     resolved,
                     retry_timeout_ms,
@@ -491,17 +401,43 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Build an `EventNotificationRequest` for a pre-computed transition and
     /// send it to the recipients the object's NotificationClass names.
     ///
-    /// Shared by the per-write path ([`fire_event_notifications`]) and the
+    /// Shared by the per-write path and the
     /// periodic `Time_Delay` confirmation path, so both emit identical
     /// notifications. Skipped when DCC is active (comm_state >= 1). Re-reads
     /// `Notification_Class` / `Notify_Type` under a brief `db.write()` guard,
     /// then drops the lock before any network send.
+    #[cfg(test)]
     pub(super) async fn build_and_send_event_notification(
         db: &Arc<RwLock<ObjectDatabase>>,
         network: &Arc<NetworkLayer<T>>,
         comm_state: &Arc<AtomicU8>,
         server_tsm: &Arc<Mutex<ServerTsm>>,
         notification_transactions: &Arc<NotificationTransactions>,
+        oid: &ObjectIdentifier,
+        transition: impl Into<NotificationTransition>,
+        retry_timeout_ms: u64,
+    ) {
+        Self::build_and_send_event_notification_with_bindings(
+            db,
+            network,
+            comm_state,
+            server_tsm,
+            notification_transactions,
+            &Arc::new(RwLock::new(DeviceBindingTable::new())),
+            oid,
+            transition,
+            retry_timeout_ms,
+        )
+        .await;
+    }
+
+    pub(super) async fn build_and_send_event_notification_with_bindings(
+        db: &Arc<RwLock<ObjectDatabase>>,
+        network: &Arc<NetworkLayer<T>>,
+        comm_state: &Arc<AtomicU8>,
+        server_tsm: &Arc<Mutex<ServerTsm>>,
+        notification_transactions: &Arc<NotificationTransactions>,
+        device_bindings: &Arc<RwLock<DeviceBindingTable>>,
         oid: &ObjectIdentifier,
         transition: impl Into<NotificationTransition>,
         retry_timeout_ms: u64,
@@ -638,8 +574,22 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let network_priority = network_priority_for_event(notification.priority);
 
         for (recipient, process_id, confirmed) in &recipients {
-            let route =
-                RecipientRoute::resolve(recipient, |mac| network.transport().is_broadcast_mac(mac));
+            let route = match recipient {
+                BACnetRecipient::Address(address) => {
+                    RecipientRoute::resolve_address(address, |mac| {
+                        network.transport().is_broadcast_mac(mac)
+                    })
+                }
+                BACnetRecipient::Device(identifier) => {
+                    let resolution = {
+                        let table = device_bindings.read().await;
+                        table.resolve_at(identifier, Instant::now(), |mac| {
+                            network.transport().is_broadcast_mac(mac)
+                        })
+                    };
+                    RecipientRoute::from_device_resolution(resolution)
+                }
+            };
 
             if !route.is_deliverable(notification_class) {
                 continue;
@@ -669,8 +619,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let service_bytes = service_buf.freeze();
 
             if *confirmed {
-                // `permits_confirmed` above admits exactly these two route
-                // shapes. If that predicate ever widens without this arm
+                // `permits_confirmed` above admits only unicast route shapes.
+                // If that predicate ever widens without this arm
                 // learning the new route, fail loudly instead of dropping
                 // the notification with no diagnostic.
                 //
@@ -683,7 +633,16 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     RecipientRoute::RemoteUnicast { network, mac } => (
                         canonical_routed_peer(*network, mac),
                         None,
-                        Some((*network, mac.clone())),
+                        Some((*network, mac.clone(), None)),
+                    ),
+                    RecipientRoute::BoundRoutedUnicast {
+                        network,
+                        mac,
+                        router,
+                    } => (
+                        canonical_routed_peer(*network, mac),
+                        None,
+                        Some((*network, mac.clone(), Some(router.clone()))),
                     ),
                     _ => {
                         warn!(
@@ -745,13 +704,16 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                             .send_apdu(&buf, &target, true, network_priority)
                                             .await
                                     }
-                                    (None, Some((dnet, dadr))) => {
-                                        // Retry through the local broadcast if a learned
-                                        // router stops answering.
-                                        let router = if attempt == 0 {
-                                            tsm.lock().await.cached_router(dnet)
-                                        } else {
-                                            None
+                                    (None, Some((dnet, dadr, configured_router))) => {
+                                        // A configured Device route keeps its fixed
+                                        // next hop for every attempt. Address recipients
+                                        // retain the learned-router/broadcast behavior.
+                                        let router = match configured_router {
+                                            Some(router) => Some(router),
+                                            None if attempt == 0 => {
+                                                tsm.lock().await.cached_router(dnet)
+                                            }
+                                            None => None,
                                         };
                                         match router {
                                             Some(router_mac) => {
@@ -855,10 +817,20 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             )
                             .await
                     }
-                    // Filtered out by `RecipientRoute::is_deliverable` above.
-                    RecipientRoute::ContradictoryGlobal | RecipientRoute::UnresolvedDevice(_) => {
-                        continue
+                    RecipientRoute::BoundRoutedUnicast {
+                        network: net,
+                        mac,
+                        router,
+                    } => {
+                        network
+                            .send_apdu_routed(&buf, *net, mac, router, false, network_priority)
+                            .await
                     }
+                    // Filtered out by `RecipientRoute::is_deliverable` above.
+                    RecipientRoute::ContradictoryGlobal
+                    | RecipientRoute::UnknownDevice
+                    | RecipientRoute::StaleDevice
+                    | RecipientRoute::InvalidDevice => continue,
                 };
 
                 if let Err(e) = send_result {

--- a/crates/bacnet-server/src/server/event_recipient_route.rs
+++ b/crates/bacnet-server/src/server/event_recipient_route.rs
@@ -1,0 +1,117 @@
+use super::device_bindings::DeviceResolution;
+use super::*;
+use bacnet_types::constructed::BACnetAddress;
+
+const GLOBAL_BROADCAST_NETWORK: u16 = 0xFFFF;
+
+/// The transport action selected for one matched Notification Class recipient.
+pub(super) enum RecipientRoute {
+    LocalUnicast(MacAddr),
+    LocalBroadcast,
+    RemoteBroadcast(u16),
+    GlobalBroadcast,
+    /// An address recipient whose next hop is selected by existing route policy.
+    RemoteUnicast {
+        network: u16,
+        mac: MacAddr,
+    },
+    /// A Device binding with a fixed local next-hop router.
+    BoundRoutedUnicast {
+        network: u16,
+        mac: MacAddr,
+        router: MacAddr,
+    },
+    ContradictoryGlobal,
+    UnknownDevice,
+    StaleDevice,
+    InvalidDevice,
+}
+
+impl RecipientRoute {
+    /// Preserve the pre-existing address-recipient route distinctions.
+    pub(super) fn resolve_address(
+        address: &BACnetAddress,
+        is_link_broadcast: impl Fn(&[u8]) -> bool,
+    ) -> Self {
+        match (address.network_number, address.mac_address.is_empty()) {
+            (0, true) => Self::LocalBroadcast,
+            (0, false) if is_link_broadcast(&address.mac_address) => Self::LocalBroadcast,
+            (0, false) => Self::LocalUnicast(address.mac_address.clone()),
+            (GLOBAL_BROADCAST_NETWORK, true) => Self::GlobalBroadcast,
+            (network, true) => Self::RemoteBroadcast(network),
+            (GLOBAL_BROADCAST_NETWORK, false) => Self::ContradictoryGlobal,
+            (network, false) => Self::RemoteUnicast {
+                network,
+                mac: address.mac_address.clone(),
+            },
+        }
+    }
+
+    pub(super) fn from_device_resolution(resolution: DeviceResolution) -> Self {
+        match resolution {
+            DeviceResolution::ResolvedLocal { peer_mac } => Self::LocalUnicast(peer_mac),
+            DeviceResolution::ResolvedRouted {
+                network,
+                final_mac,
+                router_mac,
+            } => Self::BoundRoutedUnicast {
+                network,
+                mac: final_mac,
+                router: router_mac,
+            },
+            DeviceResolution::Unknown => Self::UnknownDevice,
+            DeviceResolution::Stale => Self::StaleDevice,
+            DeviceResolution::Invalid => Self::InvalidDevice,
+        }
+    }
+
+    pub(super) fn permits_confirmed(&self) -> bool {
+        matches!(
+            self,
+            Self::LocalUnicast(_) | Self::RemoteUnicast { .. } | Self::BoundRoutedUnicast { .. }
+        )
+    }
+
+    /// Log only bounded classification data for unusable recipients.
+    pub(super) fn is_deliverable(&self, notification_class: u32) -> bool {
+        match self {
+            Self::LocalUnicast(_)
+            | Self::LocalBroadcast
+            | Self::RemoteBroadcast(_)
+            | Self::GlobalBroadcast
+            | Self::RemoteUnicast { .. }
+            | Self::BoundRoutedUnicast { .. } => true,
+            Self::ContradictoryGlobal => {
+                warn!(
+                    notification_class,
+                    "Skipping recipient: global broadcast network has a unicast address"
+                );
+                false
+            }
+            Self::UnknownDevice => {
+                warn!(
+                    notification_class,
+                    reason = "unknown",
+                    "Skipping Device recipient: binding is unusable"
+                );
+                false
+            }
+            Self::StaleDevice => {
+                warn!(
+                    notification_class,
+                    reason = "stale",
+                    "Skipping Device recipient: binding is unusable"
+                );
+                false
+            }
+            Self::InvalidDevice => {
+                warn!(
+                    notification_class,
+                    reason = "invalid",
+                    "Skipping Device recipient: binding is unusable"
+                );
+                false
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/event_recipient_route.rs
+++ b/crates/bacnet-server/src/server/event_recipient_route.rs
@@ -1,4 +1,4 @@
-use super::device_bindings::DeviceResolution;
+use super::device_bindings::{BindingFreshness, DeviceResolution};
 use super::*;
 use bacnet_types::constructed::BACnetAddress;
 
@@ -7,6 +7,10 @@ const GLOBAL_BROADCAST_NETWORK: u16 = 0xFFFF;
 /// The transport action selected for one matched Notification Class recipient.
 pub(super) enum RecipientRoute {
     LocalUnicast(MacAddr),
+    BoundLocalUnicast {
+        mac: MacAddr,
+        freshness: BindingFreshness,
+    },
     LocalBroadcast,
     RemoteBroadcast(u16),
     GlobalBroadcast,
@@ -20,11 +24,19 @@ pub(super) enum RecipientRoute {
         network: u16,
         mac: MacAddr,
         router: MacAddr,
+        freshness: BindingFreshness,
     },
     ContradictoryGlobal,
     UnknownDevice,
     StaleDevice,
     InvalidDevice,
+}
+
+pub(super) struct ConfirmedRecipientRoute {
+    pub(super) canonical_peer: bacnet_endpoint_core::coordinator::CanonicalPeer,
+    pub(super) local_target: Option<MacAddr>,
+    pub(super) remote: Option<(u16, MacAddr, Option<MacAddr>)>,
+    pub(super) freshness: Option<BindingFreshness>,
 }
 
 impl RecipientRoute {
@@ -49,15 +61,23 @@ impl RecipientRoute {
 
     pub(super) fn from_device_resolution(resolution: DeviceResolution) -> Self {
         match resolution {
-            DeviceResolution::ResolvedLocal { peer_mac } => Self::LocalUnicast(peer_mac),
+            DeviceResolution::ResolvedLocal {
+                peer_mac,
+                freshness,
+            } => Self::BoundLocalUnicast {
+                mac: peer_mac,
+                freshness,
+            },
             DeviceResolution::ResolvedRouted {
                 network,
                 final_mac,
                 router_mac,
+                freshness,
             } => Self::BoundRoutedUnicast {
                 network,
                 mac: final_mac,
                 router: router_mac,
+                freshness,
             },
             DeviceResolution::Unknown => Self::UnknownDevice,
             DeviceResolution::Stale => Self::StaleDevice,
@@ -68,14 +88,54 @@ impl RecipientRoute {
     pub(super) fn permits_confirmed(&self) -> bool {
         matches!(
             self,
-            Self::LocalUnicast(_) | Self::RemoteUnicast { .. } | Self::BoundRoutedUnicast { .. }
+            Self::LocalUnicast(_)
+                | Self::BoundLocalUnicast { .. }
+                | Self::RemoteUnicast { .. }
+                | Self::BoundRoutedUnicast { .. }
         )
+    }
+
+    pub(super) fn into_confirmed(self) -> Option<ConfirmedRecipientRoute> {
+        let (canonical_peer, local_target, remote, freshness) = match self {
+            Self::LocalUnicast(mac) => (canonical_direct_peer(&mac), Some(mac), None, None),
+            Self::BoundLocalUnicast { mac, freshness } => (
+                canonical_direct_peer(&mac),
+                Some(mac),
+                None,
+                Some(freshness),
+            ),
+            Self::RemoteUnicast { network, mac } => (
+                canonical_routed_peer(network, &mac),
+                None,
+                Some((network, mac, None)),
+                None,
+            ),
+            Self::BoundRoutedUnicast {
+                network,
+                mac,
+                router,
+                freshness,
+            } => (
+                canonical_routed_peer(network, &mac),
+                None,
+                Some((network, mac, Some(router))),
+                Some(freshness),
+            ),
+            _ => return None,
+        };
+        Some(ConfirmedRecipientRoute {
+            canonical_peer,
+            local_target,
+            remote,
+            freshness,
+        })
     }
 
     /// Log only bounded classification data for unusable recipients.
     pub(super) fn is_deliverable(&self, notification_class: u32) -> bool {
         match self {
             Self::LocalUnicast(_)
+            | Self::BoundLocalUnicast { .. }
             | Self::LocalBroadcast
             | Self::RemoteBroadcast(_)
             | Self::GlobalBroadcast

--- a/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
@@ -28,7 +28,7 @@ use tokio::sync::mpsc;
 /// local unicast reaches whichever device happens to hold that MAC on this link,
 /// which is the failure this module exists to catch.
 #[derive(Clone, Default)]
-struct RoutingTransport {
+pub(super) struct RoutingTransport {
     broadcasts: StdArc<StdMutex<Vec<Bytes>>>,
     unicasts: StdArc<StdMutex<Vec<(Vec<u8>, Bytes)>>>,
 }
@@ -122,7 +122,20 @@ async fn distribute_with_clock_mode(
     distribute_from_database(db).await
 }
 
-async fn distribute_from_database(mut db: ObjectDatabase) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
+async fn distribute_from_database(db: ObjectDatabase) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
+    distribute_from_database_with_bindings(
+        db,
+        Arc::new(RwLock::new(
+            super::device_bindings::DeviceBindingTable::new(),
+        )),
+    )
+    .await
+}
+
+pub(super) async fn distribute_from_database_with_bindings(
+    mut db: ObjectDatabase,
+    device_bindings: Arc<RwLock<super::device_bindings::DeviceBindingTable>>,
+) -> (Vec<Bytes>, Vec<(Vec<u8>, Bytes)>) {
     let transport = RoutingTransport::default();
     let broadcasts = StdArc::clone(&transport.broadcasts);
     let unicasts = StdArc::clone(&transport.unicasts);
@@ -151,12 +164,13 @@ async fn distribute_from_database(mut db: ObjectDatabase) -> (Vec<Bytes>, Vec<(V
 
     let db = Arc::new(RwLock::new(db));
     let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-    BACnetServer::<RoutingTransport>::build_and_send_event_notification(
+    BACnetServer::<RoutingTransport>::build_and_send_event_notification_with_bindings(
         &db,
         &network,
         &comm_state,
         &server_tsm,
         &NotificationTransactions::new(),
+        &device_bindings,
         &oid,
         (
             EventStateChange {

--- a/crates/bacnet-server/src/server/life_safety_operation_tests.rs
+++ b/crates/bacnet-server/src/server/life_safety_operation_tests.rs
@@ -43,6 +43,7 @@ async fn dispatch_life_safety_operation(
     let cov_in_flight = Arc::new(Semaphore::new(1));
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
     let notification_transactions = NotificationTransactions::new();
+    let device_bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
     let comm_state = Arc::new(AtomicU8::new(0));
     let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
     let mut service_request = BytesMut::new();
@@ -70,6 +71,7 @@ async fn dispatch_life_safety_operation(
         &cov_in_flight,
         &server_tsm,
         &notification_transactions,
+        &device_bindings,
         &comm_state,
         &dcc_timer,
         &config,

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -21,12 +21,19 @@ pub(super) fn event_enrollment_period(secs: u64) -> Duration {
 }
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
-    pub(super) async fn start_with_clock_mode(
+    pub(super) async fn start_with_clock_mode_and_bindings(
         mut config: ServerConfig,
         mut db: ObjectDatabase,
         transport: T,
         clock_config: Option<ClockConfig>,
+        configured_device_bindings: Vec<DeviceBinding>,
     ) -> Result<Self, Error> {
+        // Validate every configured route against the concrete transport before
+        // mutating the database or starting network work.
+        let device_bindings =
+            DeviceBindingTable::from_configured(configured_device_bindings, |mac| {
+                transport.is_broadcast_mac(mac)
+            })?;
         let transport_max = transport.max_apdu_length() as u32;
         config.max_apdu_length = config.max_apdu_length.min(transport_max);
         let max_apdu = u16::try_from(config.max_apdu_length).map_err(|_| {
@@ -61,6 +68,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let cov_in_flight = Arc::new(Semaphore::new(255));
         let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
         let notification_transactions = NotificationTransactions::new();
+        let device_bindings = Arc::new(RwLock::new(device_bindings));
         let comm_state = Arc::new(AtomicU8::new(0)); // 0 = Enable (default)
         let dcc_timer: Arc<Mutex<Option<JoinHandle<()>>>> = Arc::new(Mutex::new(None));
 
@@ -72,6 +80,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let cov_in_flight_dispatch = Arc::clone(&cov_in_flight);
         let server_tsm_dispatch = Arc::clone(&server_tsm);
         let notification_transactions_dispatch = Arc::clone(&notification_transactions);
+        let device_bindings_dispatch = Arc::clone(&device_bindings);
         let comm_state_dispatch = Arc::clone(&comm_state);
         let dcc_timer_dispatch = Arc::clone(&dcc_timer);
         let config_dispatch = Arc::new(config.clone());
@@ -404,7 +413,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                     &seg_send_permits_dispatch,
                                     &cov_in_flight_dispatch,
                                     &server_tsm_dispatch,
-                                    &notification_transactions_dispatch,
+                                                    &notification_transactions_dispatch,
+	                                                    &device_bindings_dispatch,
 	                                                    &comm_state_dispatch,
 	                                                    &dcc_timer_dispatch,
 	                                                    &config_dispatch,
@@ -454,6 +464,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 &cov_in_flight_dispatch,
                                 &server_tsm_dispatch,
                                 &notification_transactions_dispatch,
+                                &device_bindings_dispatch,
                                 &comm_state_dispatch,
                                 &dcc_timer_dispatch,
                                 &config_dispatch,
@@ -531,6 +542,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     Arc::clone(&comm_state),
                     Arc::clone(&server_tsm),
                     Arc::clone(&notification_transactions),
+                    Arc::clone(&device_bindings),
                     ee_period,
                     config.cov_retry_timeout_ms,
                 ),
@@ -585,6 +597,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let comm_state_intrinsic = Arc::clone(&comm_state);
         let server_tsm_intrinsic = Arc::clone(&server_tsm);
         let notification_transactions_intrinsic = Arc::clone(&notification_transactions);
+        let device_bindings_intrinsic = Arc::clone(&device_bindings);
         let intrinsic_retry_ms = config.cov_retry_timeout_ms;
         let intrinsic_reporting_task = Some(tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(1));
@@ -635,12 +648,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     out
                 };
                 for (oid, resolved) in fired {
-                    Self::build_and_send_event_notification(
+                    Self::build_and_send_event_notification_with_bindings(
                         &db_intrinsic,
                         &network_intrinsic,
                         &comm_state_intrinsic,
                         &server_tsm_intrinsic,
                         &notification_transactions_intrinsic,
+                        &device_bindings_intrinsic,
                         &oid,
                         resolved,
                         intrinsic_retry_ms,
@@ -661,6 +675,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             cov_in_flight,
             server_tsm,
             notification_transactions,
+            device_bindings,
             comm_state,
             dcc_timer,
             dispatch_task: Some(dispatch_task),
@@ -794,12 +809,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         }
 
         // Post-write COV/event trigger, mirroring the network handler's loop.
-        Self::fire_event_notifications(
+        Self::fire_event_notifications_with_bindings(
             &self.db,
             &self.network,
             &self.comm_state,
             &self.server_tsm,
             &self.notification_transactions,
+            &self.device_bindings,
             oid,
             self.config.cov_retry_timeout_ms,
         )

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -53,6 +53,8 @@ use bacnet_types::MacAddr;
 use crate::cov::{CovNotificationKind, CovSubscription, CovSubscriptionTable};
 use crate::handlers;
 use crate::life_safety::{LifeSafetyOperationAuthorizationContext, LifeSafetyOperationAuthorizer};
+pub use device_bindings::DeviceBinding;
+use device_bindings::{register_configured_binding, DeviceBindingTable};
 use notification_transactions::{
     canonical_direct_peer, canonical_routed_peer, run_notification_worker,
     NotificationTransactions, NotificationWorkerResult,
@@ -403,6 +405,7 @@ pub struct ServerBuilder<T: TransportPort> {
     config: ServerConfig,
     db: ObjectDatabase,
     transport: Option<T>,
+    configured_device_bindings: Vec<DeviceBinding>,
 }
 
 impl<T: TransportPort + 'static> ServerBuilder<T> {
@@ -416,6 +419,12 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
     pub fn transport(mut self, transport: T) -> Self {
         self.transport = Some(transport);
         self
+    }
+
+    /// Register one explicit unicast route for a Device recipient.
+    pub fn device_binding(mut self, binding: DeviceBinding) -> Result<Self, Error> {
+        register_configured_binding(&mut self.configured_device_bindings, binding)?;
+        Ok(self)
     }
 
     /// Set the password required for DeviceCommunicationControl requests.
@@ -483,7 +492,14 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
         let transport = self
             .transport
             .ok_or_else(|| Error::Encoding("transport not set on ServerBuilder".into()))?;
-        BACnetServer::start(self.config, self.db, transport).await
+        BACnetServer::start_with_clock_mode_and_bindings(
+            self.config,
+            self.db,
+            transport,
+            Some(ClockConfig::default()),
+            self.configured_device_bindings,
+        )
+        .await
     }
 }
 
@@ -491,6 +507,7 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
 pub struct BipServerBuilder {
     config: ServerConfig,
     db: ObjectDatabase,
+    configured_device_bindings: Vec<DeviceBinding>,
 }
 
 impl BipServerBuilder {
@@ -516,6 +533,12 @@ impl BipServerBuilder {
     pub fn database(mut self, db: ObjectDatabase) -> Self {
         self.db = db;
         self
+    }
+
+    /// Register one explicit unicast route for a Device recipient.
+    pub fn device_binding(mut self, binding: DeviceBinding) -> Result<Self, Error> {
+        register_configured_binding(&mut self.configured_device_bindings, binding)?;
+        Ok(self)
     }
 
     /// Set the password required for DeviceCommunicationControl requests.
@@ -585,7 +608,14 @@ impl BipServerBuilder {
             self.config.port,
             self.config.broadcast_address,
         );
-        BACnetServer::start(self.config, self.db, transport).await
+        BACnetServer::start_with_clock_mode_and_bindings(
+            self.config,
+            self.db,
+            transport,
+            Some(ClockConfig::default()),
+            self.configured_device_bindings,
+        )
+        .await
     }
 }
 
@@ -767,6 +797,8 @@ pub struct BACnetServer<T: TransportPort> {
     server_tsm: Arc<Mutex<ServerTsm>>,
     /// Invoke-ID ownership and terminal admission for confirmed notifications.
     notification_transactions: Arc<NotificationTransactions>,
+    /// Shared configured and passively observed Device recipient authority.
+    device_bindings: Arc<RwLock<DeviceBindingTable>>,
     /// Communication state: 0 = Enable, 1 = Disable, 2 = DisableInitiation.
     comm_state: Arc<AtomicU8>,
     /// Handle for the DCC auto-re-enable timer. A new DCC request aborts
@@ -807,184 +839,13 @@ impl BACnetServer<BipTransport> {
         BipServerBuilder {
             config: ServerConfig::default(),
             db: ObjectDatabase::new(),
+            configured_device_bindings: Vec::new(),
         }
     }
 
     /// Create a BIP-specific builder (alias for backward compatibility).
     pub fn builder() -> BipServerBuilder {
         Self::bip_builder()
-    }
-}
-
-#[cfg(feature = "sc-tls")]
-impl BACnetServer<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>> {
-    /// Create an SC-specific builder that connects to a BACnet/SC hub.
-    pub fn sc_builder() -> ScServerBuilder {
-        ScServerBuilder {
-            config: ServerConfig::default(),
-            db: ObjectDatabase::new(),
-            hub_url: String::new(),
-            tls_config: None,
-            vmac: [0; 6],
-            heartbeat_interval_ms: 30_000,
-            heartbeat_timeout_ms: 60_000,
-            reconnect: None,
-        }
-    }
-}
-
-/// SC-specific server builder.
-///
-/// Created by [`BACnetServer::sc_builder()`].  Requires the `sc-tls` feature.
-#[cfg(feature = "sc-tls")]
-pub struct ScServerBuilder {
-    config: ServerConfig,
-    db: ObjectDatabase,
-    hub_url: String,
-    tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ClientConfig>>,
-    vmac: bacnet_transport::sc_frame::Vmac,
-    heartbeat_interval_ms: u64,
-    heartbeat_timeout_ms: u64,
-    reconnect: Option<bacnet_transport::sc::ScReconnectConfig>,
-}
-
-#[cfg(feature = "sc-tls")]
-impl ScServerBuilder {
-    /// Set the hub WebSocket URL (e.g. `wss://hub.example.com/bacnet`).
-    pub fn hub_url(mut self, url: &str) -> Self {
-        self.hub_url = url.to_string();
-        self
-    }
-
-    /// Set the segmentation support this device advertises and enforces.
-    ///
-    /// The dispatch loop honors the advertisement (Clause 5.4.5.1): inbound
-    /// segmented requests are reassembled only under `BOTH` or `RECEIVE`, and
-    /// draw a SEGMENTATION_NOT_SUPPORTED Abort otherwise. The default is
-    /// `NONE`.
-    pub fn segmentation_supported(mut self, segmentation: Segmentation) -> Self {
-        self.config.segmentation_supported = segmentation;
-        self
-    }
-
-    /// Set the TLS client configuration.
-    pub fn tls_config(
-        mut self,
-        config: std::sync::Arc<tokio_rustls::rustls::ClientConfig>,
-    ) -> Self {
-        self.tls_config = Some(config);
-        self
-    }
-
-    /// Set the local VMAC address.
-    pub fn vmac(mut self, vmac: [u8; 6]) -> Self {
-        self.vmac = vmac;
-        self
-    }
-
-    /// Set the object database (transfers ownership).
-    pub fn database(mut self, db: ObjectDatabase) -> Self {
-        self.db = db;
-        self
-    }
-
-    /// Set the heartbeat interval in milliseconds (default 30 000).
-    pub fn heartbeat_interval_ms(mut self, ms: u64) -> Self {
-        self.heartbeat_interval_ms = ms;
-        self
-    }
-
-    /// Set the heartbeat timeout in milliseconds (default 60 000).
-    pub fn heartbeat_timeout_ms(mut self, ms: u64) -> Self {
-        self.heartbeat_timeout_ms = ms;
-        self
-    }
-
-    /// Enable automatic reconnection with the given configuration.
-    pub fn reconnect(mut self, config: bacnet_transport::sc::ScReconnectConfig) -> Self {
-        self.reconnect = Some(config);
-        self
-    }
-
-    /// Set the password required for DeviceCommunicationControl requests.
-    pub fn dcc_password(mut self, password: impl Into<String>) -> Self {
-        self.config.dcc_password = Some(password.into());
-        self
-    }
-
-    /// Set the password required for ReinitializeDevice requests.
-    pub fn reinit_password(mut self, password: impl Into<String>) -> Self {
-        self.config.reinit_password = Some(password.into());
-        self
-    }
-
-    /// Set the policy that authorizes inbound LifeSafetyOperation requests.
-    pub fn life_safety_operation_authorizer<F>(mut self, authorizer: F) -> Self
-    where
-        F: Fn(&LifeSafetyOperationAuthorizationContext) -> bool + Send + Sync + 'static,
-    {
-        self.config.life_safety_operation_authorizer = Some(Arc::new(authorizer));
-        self
-    }
-
-    /// Enable periodic fault detection / reliability evaluation.
-    ///
-    /// Reliability evaluation only; Event Enrollment evaluation is configured
-    /// by [`enable_event_enrollment`](Self::enable_event_enrollment).
-    pub fn enable_fault_detection(mut self, enabled: bool) -> Self {
-        self.config.enable_fault_detection = enabled;
-        self
-    }
-
-    /// Enable periodic Event Enrollment evaluation (default `true`).
-    pub fn enable_event_enrollment(mut self, enabled: bool) -> Self {
-        self.config.enable_event_enrollment = enabled;
-        self
-    }
-
-    /// Set the interval in seconds between Event Enrollment evaluation passes
-    /// (default 10).
-    pub fn event_enrollment_interval_secs(mut self, secs: u64) -> Self {
-        self.config.event_enrollment_interval_secs = secs;
-        self
-    }
-
-    /// Connect to the hub and start the server.
-    pub async fn build(
-        self,
-    ) -> Result<
-        BACnetServer<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>>,
-        Error,
-    > {
-        let tls_config = self
-            .tls_config
-            .ok_or_else(|| Error::Encoding("SC server builder: tls_config is required".into()))?;
-
-        let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
-            .await?;
-
-        let mut transport = bacnet_transport::sc::ScTransport::new(ws, self.vmac)
-            .with_heartbeat_interval_ms(self.heartbeat_interval_ms)
-            .with_heartbeat_timeout_ms(self.heartbeat_timeout_ms);
-        if let Some(rc) = self.reconnect {
-            let hub_url = self.hub_url.clone();
-            let tls_config = tls_config.clone();
-            #[allow(deprecated)]
-            {
-                transport = transport
-                    .with_connector(move || {
-                        let hub_url = hub_url.clone();
-                        let tls_config = tls_config.clone();
-                        async move {
-                            bacnet_transport::sc_tls::TlsWebSocket::connect(&hub_url, tls_config)
-                                .await
-                        }
-                    })
-                    .with_reconnect(rc);
-            }
-        }
-
-        BACnetServer::start(self.config, self.db, transport).await
     }
 }
 
@@ -995,15 +856,21 @@ pub use clock::ClockConfig;
 use clock::ServerClock;
 mod cov_clock;
 mod cov_notifications;
+mod device_bindings;
 mod dispatch;
 mod event_enrollment_lifecycle;
 mod event_notifications;
+mod event_recipient_route;
 pub(crate) mod event_timestamp;
 mod lifecycle;
 mod notification_transactions;
 mod requests;
+#[cfg(feature = "sc-tls")]
+mod sc_builder;
 #[cfg(test)]
 pub(crate) use requests::{EXECUTED_CONFIRMED, EXECUTED_UNCONFIRMED};
+#[cfg(feature = "sc-tls")]
+pub use sc_builder::ScServerBuilder;
 mod responses;
 mod segmentation;
 mod segmented_receive;
@@ -1013,6 +880,10 @@ mod shutdown;
 mod cov_notifications_tests;
 #[cfg(test)]
 mod dcc_event_detection_tests;
+#[cfg(test)]
+mod device_bindings_tests;
+#[cfg(test)]
+mod device_recipient_routing_tests;
 #[cfg(test)]
 mod event_confirmed_routing_tests;
 #[cfg(test)]
@@ -1040,6 +911,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             config: ServerConfig::default(),
             db: ObjectDatabase::new(),
             transport: None,
+            configured_device_bindings: Vec::new(),
         }
     }
 }

--- a/crates/bacnet-server/src/server/notification_transactions_tests.rs
+++ b/crates/bacnet-server/src/server/notification_transactions_tests.rs
@@ -377,6 +377,7 @@ async fn dispatch_keeps_segment_and_complex_acks_out_of_notification_completion(
     let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
     let cov_in_flight = Arc::new(Semaphore::new(255));
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+    let device_bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
     let comm_state = Arc::new(AtomicU8::new(0));
     let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
     let config = Arc::new(ServerConfig::default());
@@ -396,6 +397,7 @@ async fn dispatch_keeps_segment_and_complex_acks_out_of_notification_completion(
             &cov_in_flight,
             &server_tsm,
             &transactions,
+            &device_bindings,
             &comm_state,
             &dcc_timer,
             &config,

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -57,6 +57,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         cov_in_flight: &Arc<Semaphore>,
         server_tsm: &Arc<Mutex<ServerTsm>>,
         notification_transactions: &Arc<NotificationTransactions>,
+        device_bindings: &Arc<RwLock<DeviceBindingTable>>,
         comm_state: &Arc<AtomicU8>,
         dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
         config: &ServerConfig,
@@ -502,12 +503,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 }
 
                 for oid in &written_oids {
-                    Self::fire_event_notifications(
+                    Self::fire_event_notifications_with_bindings(
                         db,
                         network,
                         comm_state,
                         server_tsm,
                         notification_transactions,
+                        device_bindings,
                         oid,
                         config.cov_retry_timeout_ms,
                     )
@@ -602,12 +604,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         }
 
         for oid in &written_oids {
-            Self::fire_event_notifications(
+            Self::fire_event_notifications_with_bindings(
                 db,
                 network,
                 comm_state,
                 server_tsm,
                 notification_transactions,
+                device_bindings,
                 oid,
                 config.cov_retry_timeout_ms,
             )

--- a/crates/bacnet-server/src/server/requests/unconfirmed.rs
+++ b/crates/bacnet-server/src/server/requests/unconfirmed.rs
@@ -27,6 +27,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         config: &ServerConfig,
         clock: Option<&Arc<ServerClock>>,
         comm_state: &Arc<AtomicU8>,
+        device_bindings: &Arc<RwLock<DeviceBindingTable>>,
         req: UnconfirmedRequestPdu,
         received: &bacnet_network::layer::ReceivedApdu,
     ) {
@@ -36,7 +37,33 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             return;
         }
 
-        if req.service_choice == UnconfirmedServiceChoice::WHO_IS {
+        if req.service_choice == UnconfirmedServiceChoice::I_AM {
+            let i_am = match IAmRequest::decode(&req.service_request) {
+                Ok(request) => request,
+                Err(_) => {
+                    debug!("Ignoring malformed I-Am observation");
+                    return;
+                }
+            };
+            let outcome = device_bindings.write().await.observe_i_am_at(
+                i_am.object_identifier,
+                &received.source_mac,
+                received.source_network.as_ref(),
+                Instant::now(),
+                |mac| network.transport().is_broadcast_mac(mac),
+            );
+            match outcome {
+                device_bindings::ObservationOutcome::RejectedInvalid => {
+                    debug!("Ignoring unusable I-Am observation");
+                }
+                device_bindings::ObservationOutcome::RejectedCapacity => {
+                    warn!("Device binding capacity reached; I-Am observation ignored");
+                }
+                device_bindings::ObservationOutcome::Inserted
+                | device_bindings::ObservationOutcome::Refreshed
+                | device_bindings::ObservationOutcome::ConfiguredPreserved => {}
+            }
+        } else if req.service_choice == UnconfirmedServiceChoice::WHO_IS {
             let who_is = match WhoIsRequest::decode(&req.service_request) {
                 Ok(r) => r,
                 Err(e) => {

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -136,6 +136,10 @@ impl ScServerBuilder {
         BACnetServer<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>>,
         Error,
     > {
+        DeviceBindingTable::from_configured(self.configured_device_bindings.clone(), |mac| {
+            mac == bacnet_transport::sc_frame::BROADCAST_VMAC
+        })?;
+
         let tls_config = self
             .tls_config
             .ok_or_else(|| Error::Encoding("SC server builder: tls_config is required".into()))?;

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -1,0 +1,176 @@
+use super::*;
+
+impl BACnetServer<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>> {
+    /// Create an SC-specific builder that connects to a BACnet/SC hub.
+    pub fn sc_builder() -> ScServerBuilder {
+        ScServerBuilder {
+            config: ServerConfig::default(),
+            db: ObjectDatabase::new(),
+            configured_device_bindings: Vec::new(),
+            hub_url: String::new(),
+            tls_config: None,
+            vmac: [0; 6],
+            heartbeat_interval_ms: 30_000,
+            heartbeat_timeout_ms: 60_000,
+            reconnect: None,
+        }
+    }
+}
+
+/// SC-specific server builder.
+///
+/// Created by [`BACnetServer::sc_builder()`]. Requires the `sc-tls` feature.
+pub struct ScServerBuilder {
+    pub(super) config: ServerConfig,
+    db: ObjectDatabase,
+    pub(super) configured_device_bindings: Vec<DeviceBinding>,
+    hub_url: String,
+    tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ClientConfig>>,
+    vmac: bacnet_transport::sc_frame::Vmac,
+    heartbeat_interval_ms: u64,
+    heartbeat_timeout_ms: u64,
+    reconnect: Option<bacnet_transport::sc::ScReconnectConfig>,
+}
+
+impl ScServerBuilder {
+    /// Set the hub WebSocket URL (e.g. `wss://hub.example.com/bacnet`).
+    pub fn hub_url(mut self, url: &str) -> Self {
+        self.hub_url = url.to_string();
+        self
+    }
+
+    /// Set the segmentation support this device advertises and enforces.
+    pub fn segmentation_supported(mut self, segmentation: Segmentation) -> Self {
+        self.config.segmentation_supported = segmentation;
+        self
+    }
+
+    /// Set the TLS client configuration.
+    pub fn tls_config(
+        mut self,
+        config: std::sync::Arc<tokio_rustls::rustls::ClientConfig>,
+    ) -> Self {
+        self.tls_config = Some(config);
+        self
+    }
+
+    /// Set the local VMAC address.
+    pub fn vmac(mut self, vmac: [u8; 6]) -> Self {
+        self.vmac = vmac;
+        self
+    }
+
+    /// Set the object database (transfers ownership).
+    pub fn database(mut self, db: ObjectDatabase) -> Self {
+        self.db = db;
+        self
+    }
+
+    /// Register one explicit unicast route for a Device recipient.
+    pub fn device_binding(mut self, binding: DeviceBinding) -> Result<Self, Error> {
+        register_configured_binding(&mut self.configured_device_bindings, binding)?;
+        Ok(self)
+    }
+
+    /// Set the heartbeat interval in milliseconds (default 30 000).
+    pub fn heartbeat_interval_ms(mut self, ms: u64) -> Self {
+        self.heartbeat_interval_ms = ms;
+        self
+    }
+
+    /// Set the heartbeat timeout in milliseconds (default 60 000).
+    pub fn heartbeat_timeout_ms(mut self, ms: u64) -> Self {
+        self.heartbeat_timeout_ms = ms;
+        self
+    }
+
+    /// Enable automatic reconnection with the given configuration.
+    pub fn reconnect(mut self, config: bacnet_transport::sc::ScReconnectConfig) -> Self {
+        self.reconnect = Some(config);
+        self
+    }
+
+    /// Set the password required for DeviceCommunicationControl requests.
+    pub fn dcc_password(mut self, password: impl Into<String>) -> Self {
+        self.config.dcc_password = Some(password.into());
+        self
+    }
+
+    /// Set the password required for ReinitializeDevice requests.
+    pub fn reinit_password(mut self, password: impl Into<String>) -> Self {
+        self.config.reinit_password = Some(password.into());
+        self
+    }
+
+    /// Set the policy that authorizes inbound LifeSafetyOperation requests.
+    pub fn life_safety_operation_authorizer<F>(mut self, authorizer: F) -> Self
+    where
+        F: Fn(&LifeSafetyOperationAuthorizationContext) -> bool + Send + Sync + 'static,
+    {
+        self.config.life_safety_operation_authorizer = Some(Arc::new(authorizer));
+        self
+    }
+
+    /// Enable periodic fault detection / reliability evaluation.
+    pub fn enable_fault_detection(mut self, enabled: bool) -> Self {
+        self.config.enable_fault_detection = enabled;
+        self
+    }
+
+    /// Enable periodic Event Enrollment evaluation (default `true`).
+    pub fn enable_event_enrollment(mut self, enabled: bool) -> Self {
+        self.config.enable_event_enrollment = enabled;
+        self
+    }
+
+    /// Set the interval in seconds between Event Enrollment evaluation passes.
+    pub fn event_enrollment_interval_secs(mut self, secs: u64) -> Self {
+        self.config.event_enrollment_interval_secs = secs;
+        self
+    }
+
+    /// Connect to the hub and start the server.
+    pub async fn build(
+        self,
+    ) -> Result<
+        BACnetServer<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>>,
+        Error,
+    > {
+        let tls_config = self
+            .tls_config
+            .ok_or_else(|| Error::Encoding("SC server builder: tls_config is required".into()))?;
+
+        let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
+            .await?;
+
+        let mut transport = bacnet_transport::sc::ScTransport::new(ws, self.vmac)
+            .with_heartbeat_interval_ms(self.heartbeat_interval_ms)
+            .with_heartbeat_timeout_ms(self.heartbeat_timeout_ms);
+        if let Some(rc) = self.reconnect {
+            let hub_url = self.hub_url.clone();
+            let tls_config = tls_config.clone();
+            #[allow(deprecated)]
+            {
+                transport = transport
+                    .with_connector(move || {
+                        let hub_url = hub_url.clone();
+                        let tls_config = tls_config.clone();
+                        async move {
+                            bacnet_transport::sc_tls::TlsWebSocket::connect(&hub_url, tls_config)
+                                .await
+                        }
+                    })
+                    .with_reconnect(rc);
+            }
+        }
+
+        BACnetServer::start_with_clock_mode_and_bindings(
+            self.config,
+            self.db,
+            transport,
+            Some(ClockConfig::default()),
+            self.configured_device_bindings,
+        )
+        .await
+    }
+}

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -272,6 +272,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
     let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
     let notification_transactions = NotificationTransactions::new();
+    let device_bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
     let comm_state = Arc::new(AtomicU8::new(0));
     let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
     let config = Arc::new(ServerConfig::default());
@@ -285,6 +286,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
         &cov_in_flight,
         &server_tsm,
         &notification_transactions,
+        &device_bindings,
         &comm_state,
         &dcc_timer,
         &config,

--- a/crates/bacnet-server/src/server/tests.rs
+++ b/crates/bacnet-server/src/server/tests.rs
@@ -98,6 +98,38 @@ fn all_builders_assign_life_safety_operation_authorizer() {
     }
 }
 
+#[test]
+fn all_builders_register_the_same_validated_device_binding_surface() {
+    let identifier = ObjectIdentifier::new(ObjectType::DEVICE, 44).unwrap();
+    let binding = DeviceBinding::local(identifier, [1, 2, 3]).unwrap();
+
+    let generic = BACnetServer::<BipTransport>::generic_builder()
+        .device_binding(binding.clone())
+        .unwrap();
+    assert_eq!(generic.configured_device_bindings.len(), 1);
+
+    let bip = BACnetServer::<BipTransport>::bip_builder()
+        .device_binding(binding.clone())
+        .unwrap();
+    assert_eq!(bip.configured_device_bindings.len(), 1);
+
+    #[cfg(feature = "sc-tls")]
+    {
+        let sc = BACnetServer::sc_builder().device_binding(binding).unwrap();
+        assert_eq!(sc.configured_device_bindings.len(), 1);
+    }
+}
+
+#[test]
+fn builder_rejects_duplicate_configured_device_before_start() {
+    let identifier = ObjectIdentifier::new(ObjectType::DEVICE, 45).unwrap();
+    let binding = DeviceBinding::local(identifier, [1, 2, 3]).unwrap();
+    let builder = BACnetServer::<BipTransport>::generic_builder()
+        .device_binding(binding.clone())
+        .unwrap();
+    assert!(builder.device_binding(binding).is_err());
+}
+
 // -----------------------------------------------------------------------
 // Event Enrollment lifecycle configuration (issue #133)
 // -----------------------------------------------------------------------
@@ -573,6 +605,7 @@ async fn reply_tx_response_preserves_routed_npdu_destination() {
     let cov_in_flight = Arc::new(Semaphore::new(1));
     let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
     let notification_transactions = NotificationTransactions::new();
+    let device_bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
     let comm_state = Arc::new(AtomicU8::new(0));
     let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
     let config = ServerConfig::default();
@@ -604,6 +637,7 @@ async fn reply_tx_response_preserves_routed_npdu_destination() {
         &cov_in_flight,
         &server_tsm,
         &notification_transactions,
+        &device_bindings,
         &comm_state,
         &dcc_timer,
         &config,

--- a/crates/bacnet-server/src/server/tests.rs
+++ b/crates/bacnet-server/src/server/tests.rs
@@ -130,6 +130,23 @@ fn builder_rejects_duplicate_configured_device_before_start() {
     assert!(builder.device_binding(binding).is_err());
 }
 
+#[cfg(feature = "sc-tls")]
+#[tokio::test]
+async fn sc_builder_rejects_broadcast_binding_before_tls_prerequisites() {
+    let identifier = ObjectIdentifier::new(ObjectType::DEVICE, 46).unwrap();
+    let binding =
+        DeviceBinding::local(identifier, bacnet_transport::sc_frame::BROADCAST_VMAC).unwrap();
+    let builder = BACnetServer::sc_builder().device_binding(binding).unwrap();
+
+    let Err(error) = builder.build().await else {
+        panic!("invalid SC binding unexpectedly started a server");
+    };
+    assert!(
+        error.to_string().contains("broadcast address"),
+        "binding validation must precede TLS prerequisites: {error}"
+    );
+}
+
 // -----------------------------------------------------------------------
 // Event Enrollment lifecycle configuration (issue #133)
 // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a bounded server-owned Device recipient binding authority with explicit builder configuration and passive inbound I-Am learning
- route local and remote Device recipients by unicast while preserving final routed identity and the configured next hop
- keep configured entries authoritative, expire observed entries deterministically, and fail closed for unknown, stale, invalid, or capacity-rejected bindings
- preserve existing address-recipient behavior and public start/configuration compatibility

## Scope
This is an intermediate notification-distribution slice. Active discovery, pending delivery, persistence, and retry/backoff policy for unresolved recipients remain deferred.

## Validation
- `cargo fmt --all -- --check`
- focused `bacnet-server` binding and Device-recipient tests
- `cargo test -p bacnet-server --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- workspace feature test matrix
- root crate test check
- conformance-doc generation check
- file-size, secret, and diff checks

Refs #125