### PR TITLE
feat(services): add AuditLogQuery ACK codec

### DIFF
--- a/crates/bacnet-services/src/audit.rs
+++ b/crates/bacnet-services/src/audit.rs
@@ -10,13 +10,15 @@ use bacnet_types::bitstring::AuditOperationFlags;
 use bacnet_types::constructed::{BACnetAddress, BACnetRecipient};
 use bacnet_types::enums::{AuditOperation, ErrorClass, ErrorCode, PropertyIdentifier};
 use bacnet_types::error::Error;
-use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier};
+use bacnet_types::primitives::{BACnetTimeStamp, Date, ObjectIdentifier, Time};
 use bytes::BytesMut;
 
 use crate::common::PropertyReference;
 
 #[path = "audit/notification_codec.rs"]
 mod notification_codec;
+#[path = "audit/query_ack_codec.rs"]
+mod query_ack_codec;
 #[path = "audit/query_codec.rs"]
 mod query_codec;
 
@@ -50,6 +52,44 @@ pub struct BACnetAuditNotification {
     /// Raw, structurally validated `ABSTRACT-SYNTAX.&Type` encoding.
     pub current_value: Option<Vec<u8>>,
     pub result: Option<(ErrorClass, ErrorCode)>,
+}
+
+/// AuditLogQuery-ACK service parameters.
+///
+/// This wire model does not perform storage queries or infer record ordering,
+/// continuity, filtering, or the truth of `no_more_items`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuditLogQueryAck {
+    pub audit_log: ObjectIdentifier,
+    /// Zero or more adjacent record results encoded under context tag `[1]`.
+    pub records: Vec<BACnetAuditLogRecordResult>,
+    pub no_more_items: bool,
+}
+
+/// One result in an [`AuditLogQueryAck`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct BACnetAuditLogRecordResult {
+    pub sequence_number: u64,
+    pub record: BACnetAuditLogRecord,
+}
+
+/// One Audit Log record, distinct from Trend/Event Log record models.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BACnetAuditLogRecord {
+    /// BACnetDateTime encoded as application Date followed by application Time.
+    pub timestamp: (Date, Time),
+    pub datum: BACnetAuditLogDatum,
+}
+
+/// Audit-specific `BACnetAuditLogRecord` datum CHOICE.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BACnetAuditLogDatum {
+    /// Three-bit BACnetLogStatus: log-disabled, buffer-purged, log-interrupted.
+    LogStatus(u8),
+    /// A bare BACnetAuditNotification wrapped by choice tag `[1]`.
+    AuditNotification(BACnetAuditNotification),
+    /// Clock adjustment in seconds, encoded as a four-octet REAL under `[2]`.
+    TimeChange(f32),
 }
 
 /// Typed `BACnetAuditLogQueryParameters` CHOICE.
@@ -166,6 +206,22 @@ impl AuditLogQueryRequest {
     /// Decode a complete payload; trailing bytes are rejected.
     pub fn decode(data: &[u8]) -> Result<Self, Error> {
         query_codec::decode(data)
+    }
+}
+
+impl AuditLogQueryAck {
+    /// Encode after validation, leaving `buf` unchanged on failure.
+    pub fn try_encode(&self, buf: &mut BytesMut) -> Result<(), Error> {
+        query_ack_codec::encode(self, buf)
+    }
+
+    pub fn encode(&self, buf: &mut BytesMut) -> Result<(), Error> {
+        self.try_encode(buf)
+    }
+
+    /// Decode a complete payload; trailing bytes are rejected.
+    pub fn decode(data: &[u8]) -> Result<Self, Error> {
+        query_ack_codec::decode(data)
     }
 }
 

--- a/crates/bacnet-services/src/audit/malformed_tests.rs
+++ b/crates/bacnet-services/src/audit/malformed_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use bacnet_encoding::{constructed::encode_recipient, primitives, tags};
 use bacnet_types::enums::ObjectType;
+use bacnet_types::primitives::{Date, Time};
 use bacnet_types::MacAddr;
 
 fn device(instance: u32) -> ObjectIdentifier {
@@ -366,4 +367,160 @@ fn decoder_requires_full_service_consumption() {
 
     let wrong_wrapper = [0x1e, 0x1f];
     assert!(AuditNotificationRequest::decode(&wrong_wrapper).is_err());
+}
+
+fn query_ack(datum: BACnetAuditLogDatum) -> AuditLogQueryAck {
+    AuditLogQueryAck {
+        audit_log: ObjectIdentifier::new(ObjectType::AUDIT_LOG, 1).unwrap(),
+        records: vec![BACnetAuditLogRecordResult {
+            sequence_number: 1,
+            record: BACnetAuditLogRecord {
+                timestamp: (
+                    Date {
+                        year: 126,
+                        month: 8,
+                        day: 29,
+                        day_of_week: 6,
+                    },
+                    Time {
+                        hour: 12,
+                        minute: 34,
+                        second: 56,
+                        hundredths: 78,
+                    },
+                ),
+                datum,
+            },
+        }],
+        no_more_items: false,
+    }
+}
+
+fn encode_query_ack(datum: BACnetAuditLogDatum) -> Vec<u8> {
+    let mut encoded = BytesMut::new();
+    query_ack(datum).encode(&mut encoded).unwrap();
+    encoded.to_vec()
+}
+
+#[test]
+fn query_ack_rejects_unsigned_boolean_and_top_level_malformations() {
+    let canonical = encode_query_ack(BACnetAuditLogDatum::LogStatus(0));
+    let sequence = canonical
+        .windows(2)
+        .position(|bytes| bytes == [0x09, 1])
+        .unwrap();
+
+    let mut noncanonical = canonical.clone();
+    noncanonical.splice(sequence..sequence + 2, [0x0a, 0, 1]);
+    assert!(AuditLogQueryAck::decode(&noncanonical).is_err());
+
+    let mut over_wide = canonical.clone();
+    over_wide.splice(sequence..sequence + 2, [0x0d, 9, 1, 0, 0, 0, 0, 0, 0, 0, 0]);
+    assert!(AuditLogQueryAck::decode(&over_wide).is_err());
+
+    let mut non_boolean = canonical.clone();
+    *non_boolean.last_mut().unwrap() = 2;
+    assert!(AuditLogQueryAck::decode(&non_boolean).is_err());
+
+    let mut missing_boolean = canonical.clone();
+    missing_boolean.truncate(missing_boolean.len() - 2);
+    assert!(AuditLogQueryAck::decode(&missing_boolean).is_err());
+
+    let mut trailing = canonical.clone();
+    trailing.push(0);
+    assert!(AuditLogQueryAck::decode(&trailing).is_err());
+
+    let mut wrong_list = canonical.clone();
+    wrong_list[5] = 0x2e;
+    assert!(AuditLogQueryAck::decode(&wrong_list).is_err());
+
+    let mut mismatched_list = canonical;
+    let list_close = mismatched_list.len() - 3;
+    mismatched_list[list_close] = 0x0f;
+    assert!(AuditLogQueryAck::decode(&mismatched_list).is_err());
+}
+
+#[test]
+fn query_ack_rejects_malformed_date_time_and_datum_choices() {
+    let canonical = encode_query_ack(BACnetAuditLogDatum::LogStatus(0b010));
+
+    let date = canonical.iter().position(|byte| *byte == 0xa4).unwrap();
+    let mut invalid_date = canonical.clone();
+    invalid_date[date + 2] = 0;
+    assert!(AuditLogQueryAck::decode(&invalid_date).is_err());
+
+    let time = canonical.iter().position(|byte| *byte == 0xb4).unwrap();
+    let mut invalid_time = canonical.clone();
+    invalid_time[time + 1] = 24;
+    assert!(AuditLogQueryAck::decode(&invalid_time).is_err());
+
+    let status = canonical
+        .windows(3)
+        .position(|bytes| bytes == [0x0a, 5, 0x40])
+        .unwrap();
+    let mut bad_unused = canonical.clone();
+    bad_unused[status + 1] = 4;
+    assert!(AuditLogQueryAck::decode(&bad_unused).is_err());
+
+    let mut bad_padding = canonical.clone();
+    bad_padding[status + 2] |= 1;
+    assert!(AuditLogQueryAck::decode(&bad_padding).is_err());
+
+    let mut wrong_class = canonical;
+    wrong_class[status] = 0x82;
+    assert!(AuditLogQueryAck::decode(&wrong_class).is_err());
+
+    let mut real = encode_query_ack(BACnetAuditLogDatum::TimeChange(1.5));
+    let real_tag = real.iter().position(|byte| *byte == 0x2c).unwrap();
+    real[real_tag] = 0x2b;
+    assert!(AuditLogQueryAck::decode(&real).is_err());
+}
+
+#[test]
+fn query_ack_nested_notification_requires_complete_consumption() {
+    let notification = minimal_notification(AuditOperation::WRITE);
+    let mut encoded = encode_query_ack(BACnetAuditLogDatum::AuditNotification(notification));
+    let target_close = encoded.iter().position(|byte| *byte == 0xaf).unwrap();
+    encoded.insert(target_close + 1, 0x00);
+    assert!(AuditLogQueryAck::decode(&encoded).is_err());
+}
+
+#[test]
+fn query_ack_record_list_accepts_limit_and_rejects_one_more() {
+    let record = BACnetAuditLogRecordResult {
+        sequence_number: 0,
+        record: query_ack(BACnetAuditLogDatum::LogStatus(0))
+            .records
+            .pop()
+            .unwrap()
+            .record,
+    };
+    let at_limit = AuditLogQueryAck {
+        audit_log: ObjectIdentifier::new(ObjectType::AUDIT_LOG, 1).unwrap(),
+        records: vec![record.clone(); crate::common::MAX_DECODED_ITEMS],
+        no_more_items: true,
+    };
+    let mut encoded = BytesMut::new();
+    at_limit.encode(&mut encoded).unwrap();
+    assert_eq!(
+        AuditLogQueryAck::decode(&encoded).unwrap().records.len(),
+        crate::common::MAX_DECODED_ITEMS
+    );
+
+    let item = encoded[6..encoded.len() - 3].to_vec();
+    let mut over_limit = encoded;
+    over_limit.truncate(over_limit.len() - 3);
+    over_limit.extend_from_slice(&item[..item.len() / crate::common::MAX_DECODED_ITEMS]);
+    tags::encode_closing_tag(&mut over_limit, 1);
+    primitives::encode_ctx_boolean(&mut over_limit, 2, true);
+    assert!(AuditLogQueryAck::decode(&over_limit).is_err());
+
+    let over_limit_model = AuditLogQueryAck {
+        audit_log: ObjectIdentifier::new(ObjectType::AUDIT_LOG, 1).unwrap(),
+        records: vec![record; crate::common::MAX_DECODED_ITEMS + 1],
+        no_more_items: false,
+    };
+    let mut output = BytesMut::from(&b"prefix"[..]);
+    assert!(over_limit_model.encode(&mut output).is_err());
+    assert_eq!(output.as_ref(), b"prefix");
 }

--- a/crates/bacnet-services/src/audit/notification_codec.rs
+++ b/crates/bacnet-services/src/audit/notification_codec.rs
@@ -33,7 +33,7 @@ pub(super) fn encode(request: &AuditNotificationRequest, buf: &mut BytesMut) -> 
     Ok(())
 }
 
-fn encode_notification(
+pub(super) fn encode_notification(
     notification: &BACnetAuditNotification,
     buf: &mut BytesMut,
 ) -> Result<(), Error> {
@@ -184,7 +184,7 @@ pub(super) fn decode(data: &[u8]) -> Result<AuditNotificationRequest, Error> {
     Ok(AuditNotificationRequest { notifications })
 }
 
-fn decode_notification(
+pub(super) fn decode_notification(
     data: &[u8],
     mut offset: usize,
 ) -> Result<(BACnetAuditNotification, usize), Error> {

--- a/crates/bacnet-services/src/audit/query_ack_codec.rs
+++ b/crates/bacnet-services/src/audit/query_ack_codec.rs
@@ -1,0 +1,306 @@
+use super::{
+    decode_canonical_unsigned, notification_codec, AuditLogQueryAck, BACnetAuditLogDatum,
+    BACnetAuditLogRecord, BACnetAuditLogRecordResult,
+};
+use crate::common::{decode_context, decode_context_bool, MAX_DECODED_ITEMS};
+use bacnet_encoding::{primitives, tags};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{Date, ObjectIdentifier, Time};
+use bytes::BytesMut;
+
+const AUDIT_LOG_TAG: u8 = 0;
+const RECORDS_TAG: u8 = 1;
+const NO_MORE_ITEMS_TAG: u8 = 2;
+
+pub(super) fn encode(ack: &AuditLogQueryAck, buf: &mut BytesMut) -> Result<(), Error> {
+    if ack.records.len() > MAX_DECODED_ITEMS {
+        return Err(Error::OutOfRange(format!(
+            "AuditLogQuery-ACK record count {} exceeds {MAX_DECODED_ITEMS}",
+            ack.records.len()
+        )));
+    }
+
+    // Build the complete payload separately so a later invalid record cannot
+    // leave a partial complex-ACK in the caller's APDU buffer.
+    let mut encoded = BytesMut::new();
+    primitives::encode_ctx_object_id(&mut encoded, AUDIT_LOG_TAG, &ack.audit_log);
+    tags::encode_opening_tag(&mut encoded, RECORDS_TAG);
+    for result in &ack.records {
+        encode_result(result, &mut encoded)?;
+    }
+    tags::encode_closing_tag(&mut encoded, RECORDS_TAG);
+    primitives::encode_ctx_boolean(&mut encoded, NO_MORE_ITEMS_TAG, ack.no_more_items);
+
+    buf.extend_from_slice(&encoded);
+    Ok(())
+}
+
+fn encode_result(result: &BACnetAuditLogRecordResult, buf: &mut BytesMut) -> Result<(), Error> {
+    primitives::encode_ctx_unsigned(buf, 0, result.sequence_number);
+    tags::encode_opening_tag(buf, 1);
+    encode_record(&result.record, buf)?;
+    tags::encode_closing_tag(buf, 1);
+    Ok(())
+}
+
+fn encode_record(record: &BACnetAuditLogRecord, buf: &mut BytesMut) -> Result<(), Error> {
+    validate_date_time(&record.timestamp.0, &record.timestamp.1)?;
+
+    tags::encode_opening_tag(buf, 0);
+    primitives::encode_app_date(buf, &record.timestamp.0);
+    primitives::encode_app_time(buf, &record.timestamp.1);
+    tags::encode_closing_tag(buf, 0);
+
+    tags::encode_opening_tag(buf, 1);
+    match &record.datum {
+        BACnetAuditLogDatum::LogStatus(status) => {
+            if status & !0b111 != 0 {
+                return Err(Error::OutOfRange(format!(
+                    "BACnetAuditLogRecord log-status {status:#010b} exceeds three bits"
+                )));
+            }
+            primitives::encode_ctx_bit_string(buf, 0, 5, &[*status << 5]);
+        }
+        BACnetAuditLogDatum::AuditNotification(notification) => {
+            tags::encode_opening_tag(buf, 1);
+            notification_codec::encode_notification(notification, buf)?;
+            tags::encode_closing_tag(buf, 1);
+        }
+        BACnetAuditLogDatum::TimeChange(change) => {
+            primitives::encode_ctx_real(buf, 2, *change);
+        }
+    }
+    tags::encode_closing_tag(buf, 1);
+    Ok(())
+}
+
+pub(super) fn decode(data: &[u8]) -> Result<AuditLogQueryAck, Error> {
+    let (audit_log_contents, mut offset) =
+        decode_context(data, 0, AUDIT_LOG_TAG, "AuditLogQuery-ACK audit-log")?;
+    let audit_log = ObjectIdentifier::decode(audit_log_contents)?;
+
+    let (records_body, records_end) =
+        decode_constructed_body(data, offset, RECORDS_TAG, "record list")?;
+    let mut records = Vec::new();
+    let mut record_offset = 0;
+    while record_offset < records_body.len() {
+        if records.len() >= MAX_DECODED_ITEMS {
+            return Err(Error::decoding(
+                offset + record_offset,
+                format!("AuditLogQuery-ACK record count exceeds {MAX_DECODED_ITEMS}"),
+            ));
+        }
+        let (result, next) = decode_result(records_body, record_offset)?;
+        if next <= record_offset {
+            return Err(Error::decoding(
+                offset + record_offset,
+                "AuditLogQuery-ACK record decoder made no progress",
+            ));
+        }
+        records.push(result);
+        record_offset = next;
+    }
+    offset = records_end;
+
+    let (no_more_items, end) = decode_context_bool(
+        data,
+        offset,
+        NO_MORE_ITEMS_TAG,
+        "AuditLogQuery-ACK no-more-items",
+    )?;
+    if end != data.len() {
+        return Err(Error::decoding(
+            end,
+            "AuditLogQuery-ACK has trailing service data",
+        ));
+    }
+
+    Ok(AuditLogQueryAck {
+        audit_log,
+        records,
+        no_more_items,
+    })
+}
+
+fn decode_result(data: &[u8], offset: usize) -> Result<(BACnetAuditLogRecordResult, usize), Error> {
+    let (sequence_contents, record_start) =
+        decode_context(data, offset, 0, "AuditLogQuery-ACK record sequence-number")?;
+    if sequence_contents.is_empty() || sequence_contents.len() > 8 {
+        return Err(Error::decoding(
+            offset,
+            "AuditLogQuery-ACK sequence-number must contain one to eight octets",
+        ));
+    }
+    let sequence_number = decode_canonical_unsigned(
+        sequence_contents,
+        offset,
+        "AuditLogQuery-ACK sequence-number",
+    )?;
+
+    let (record_body, next) = decode_constructed_body(data, record_start, 1, "record value")?;
+    let record = decode_record(record_body)?;
+    Ok((
+        BACnetAuditLogRecordResult {
+            sequence_number,
+            record,
+        },
+        next,
+    ))
+}
+
+fn decode_record(data: &[u8]) -> Result<BACnetAuditLogRecord, Error> {
+    let (timestamp_body, datum_start) = decode_constructed_body(data, 0, 0, "record timestamp")?;
+    let timestamp = decode_date_time(timestamp_body)?;
+
+    let (datum_body, end) = decode_constructed_body(data, datum_start, 1, "record datum")?;
+    if end != data.len() {
+        return Err(Error::decoding(
+            end,
+            "BACnetAuditLogRecord has trailing fields",
+        ));
+    }
+    let datum = decode_datum(datum_body)?;
+
+    Ok(BACnetAuditLogRecord { timestamp, datum })
+}
+
+fn decode_date_time(data: &[u8]) -> Result<(Date, Time), Error> {
+    let (date_tag, date_start) = tags::decode_tag(data, 0)?;
+    if date_tag.class != tags::TagClass::Application
+        || date_tag.number != tags::app_tag::DATE
+        || date_tag.is_opening
+        || date_tag.is_closing
+        || date_tag.length != 4
+    {
+        return Err(Error::decoding(
+            0,
+            "BACnetAuditLogRecord timestamp expected four-octet application Date",
+        ));
+    }
+    let date_end = date_start
+        .checked_add(4)
+        .ok_or_else(|| Error::decoding(date_start, "timestamp Date length overflow"))?;
+    if date_end > data.len() {
+        return Err(Error::decoding(date_start, "timestamp Date is truncated"));
+    }
+    let date = Date::decode(&data[date_start..date_end])?;
+
+    let (time_tag, time_start) = tags::decode_tag(data, date_end)?;
+    if time_tag.class != tags::TagClass::Application
+        || time_tag.number != tags::app_tag::TIME
+        || time_tag.is_opening
+        || time_tag.is_closing
+        || time_tag.length != 4
+    {
+        return Err(Error::decoding(
+            date_end,
+            "BACnetAuditLogRecord timestamp expected four-octet application Time",
+        ));
+    }
+    let time_end = time_start
+        .checked_add(4)
+        .ok_or_else(|| Error::decoding(time_start, "timestamp Time length overflow"))?;
+    if time_end > data.len() {
+        return Err(Error::decoding(time_start, "timestamp Time is truncated"));
+    }
+    if time_end != data.len() {
+        return Err(Error::decoding(
+            time_end,
+            "BACnetAuditLogRecord timestamp has trailing fields",
+        ));
+    }
+    let time = Time::decode(&data[time_start..time_end])?;
+    validate_date_time(&date, &time).map_err(|error| {
+        Error::decoding(
+            0,
+            format!("BACnetAuditLogRecord timestamp is malformed: {error}"),
+        )
+    })?;
+    Ok((date, time))
+}
+
+fn decode_datum(data: &[u8]) -> Result<BACnetAuditLogDatum, Error> {
+    let (choice, _) = tags::decode_tag(data, 0)?;
+    if choice.is_context(0) {
+        let (contents, end) = decode_context(data, 0, 0, "BACnetAuditLogRecord log-status")?;
+        if end != data.len() {
+            return Err(Error::decoding(
+                end,
+                "log-status choice has trailing fields",
+            ));
+        }
+        if contents.len() != 2 || contents[0] != 5 || contents[1] & 0x1f != 0 {
+            return Err(Error::decoding(
+                0,
+                "BACnetAuditLogRecord log-status must be a canonical three-bit BitString",
+            ));
+        }
+        Ok(BACnetAuditLogDatum::LogStatus(contents[1] >> 5))
+    } else if choice.is_opening_tag(1) {
+        let (notification_body, end) =
+            decode_constructed_body(data, 0, 1, "AuditNotification choice")?;
+        if end != data.len() {
+            return Err(Error::decoding(
+                end,
+                "AuditNotification choice has trailing fields",
+            ));
+        }
+        let (notification, notification_end) =
+            notification_codec::decode_notification(notification_body, 0)?;
+        if notification_end != notification_body.len() {
+            return Err(Error::decoding(
+                notification_end,
+                "AuditNotification choice has trailing notification fields",
+            ));
+        }
+        Ok(BACnetAuditLogDatum::AuditNotification(notification))
+    } else if choice.is_context(2) {
+        let (contents, end) = decode_context(data, 0, 2, "BACnetAuditLogRecord time-change")?;
+        if end != data.len() {
+            return Err(Error::decoding(
+                end,
+                "time-change choice has trailing fields",
+            ));
+        }
+        Ok(BACnetAuditLogDatum::TimeChange(primitives::decode_real(
+            contents,
+        )?))
+    } else {
+        Err(Error::decoding(
+            0,
+            "BACnetAuditLogRecord datum expected context [0], constructed [1], or context [2]",
+        ))
+    }
+}
+
+fn decode_constructed_body<'a>(
+    data: &'a [u8],
+    offset: usize,
+    tag_number: u8,
+    field: &str,
+) -> Result<(&'a [u8], usize), Error> {
+    let (opening, body_start) = tags::decode_tag(data, offset)?;
+    if !opening.is_opening_tag(tag_number) {
+        return Err(Error::decoding(
+            offset,
+            format!("AuditLogQuery-ACK {field} expected opening tag [{tag_number}]"),
+        ));
+    }
+    tags::extract_context_value(data, body_start, tag_number)
+}
+
+fn validate_date_time(date: &Date, time: &Time) -> Result<(), Error> {
+    let date_valid = (date.month == Date::UNSPECIFIED || (1..=14).contains(&date.month))
+        && (date.day == Date::UNSPECIFIED || (1..=34).contains(&date.day))
+        && (date.day_of_week == Date::UNSPECIFIED || (1..=7).contains(&date.day_of_week));
+    let time_valid = (time.hour == Time::UNSPECIFIED || time.hour <= 23)
+        && (time.minute == Time::UNSPECIFIED || time.minute <= 59)
+        && (time.second == Time::UNSPECIFIED || time.second <= 59)
+        && (time.hundredths == Time::UNSPECIFIED || time.hundredths <= 99);
+    if !date_valid || !time_valid {
+        return Err(Error::Encoding(
+            "BACnetAuditLogRecord timestamp contains an invalid Date or Time component".into(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/bacnet-services/src/audit/tests.rs
+++ b/crates/bacnet-services/src/audit/tests.rs
@@ -1,14 +1,15 @@
 use bacnet_encoding::{primitives, tags};
 use bacnet_types::bitstring::AuditOperationFlags;
 use bacnet_types::constructed::{BACnetAddress, BACnetRecipient};
-use bacnet_types::enums::{AuditOperation, ObjectType, PropertyIdentifier};
-use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::enums::{AuditOperation, ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
+use bacnet_types::primitives::{Date, ObjectIdentifier, Time};
 use bacnet_types::MacAddr;
 use bytes::BytesMut;
 
 use super::{
-    AuditLogQueryRequest, AuditNotificationRequest, AuditPropertyReference,
-    BACnetAuditLogQueryParameters, BACnetAuditNotification,
+    AuditLogQueryAck, AuditLogQueryRequest, AuditNotificationRequest, AuditPropertyReference,
+    BACnetAuditLogDatum, BACnetAuditLogQueryParameters, BACnetAuditLogRecord,
+    BACnetAuditLogRecordResult, BACnetAuditNotification,
 };
 
 fn oid(object_type: ObjectType, instance: u32) -> ObjectIdentifier {
@@ -388,4 +389,163 @@ fn encode_outer_suffix(buf: &mut BytesMut, choice: u8) {
     tags::encode_closing_tag(buf, choice);
     tags::encode_closing_tag(buf, 1);
     primitives::encode_ctx_unsigned(buf, 3, 1);
+}
+
+fn audit_record(datum: BACnetAuditLogDatum) -> BACnetAuditLogRecord {
+    BACnetAuditLogRecord {
+        timestamp: (
+            Date {
+                year: 126,
+                month: 8,
+                day: 29,
+                day_of_week: 6,
+            },
+            Time {
+                hour: 12,
+                minute: 34,
+                second: 56,
+                hundredths: 78,
+            },
+        ),
+        datum,
+    }
+}
+
+fn ack_notification() -> BACnetAuditNotification {
+    BACnetAuditNotification {
+        source_timestamp: None,
+        target_timestamp: None,
+        source_device: BACnetRecipient::Device(oid(ObjectType::DEVICE, 1)),
+        source_object: None,
+        operation: AuditOperation::WRITE,
+        source_comment: None,
+        target_comment: None,
+        invoke_id: None,
+        source_user_id: None,
+        source_user_role: None,
+        target_device: BACnetRecipient::Device(oid(ObjectType::DEVICE, 2)),
+        target_object: None,
+        target_property: None,
+        target_priority: None,
+        target_value: None,
+        current_value: None,
+        result: Some((ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED)),
+    }
+}
+
+#[test]
+fn audit_log_query_ack_empty_matches_clause_21_literal() {
+    let ack = AuditLogQueryAck {
+        audit_log: oid(ObjectType::AUDIT_LOG, 1),
+        records: Vec::new(),
+        no_more_items: true,
+    };
+    let mut encoded = BytesMut::new();
+    ack.try_encode(&mut encoded).unwrap();
+
+    assert_eq!(
+        encoded.as_ref(),
+        &[0x0c, 0x0f, 0x40, 0x00, 0x01, 0x1e, 0x1f, 0x29, 0x01]
+    );
+    assert_eq!(AuditLogQueryAck::decode(&encoded).unwrap(), ack);
+}
+
+#[test]
+fn audit_log_query_ack_log_status_matches_clause_21_literal() {
+    let ack = AuditLogQueryAck {
+        audit_log: oid(ObjectType::AUDIT_LOG, 1),
+        records: vec![BACnetAuditLogRecordResult {
+            sequence_number: 1,
+            record: audit_record(BACnetAuditLogDatum::LogStatus(0b010)),
+        }],
+        no_more_items: false,
+    };
+    let expected = [
+        0x0c, 0x0f, 0x40, 0x00, 0x01, // audit-log [0]
+        0x1e, // list-of-records [1]
+        0x09, 0x01, // sequence-number [0]
+        0x1e, // record [1]
+        0x0e, 0xa4, 126, 8, 29, 6, 0xb4, 12, 34, 56, 78, 0x0f, // timestamp [0]
+        0x1e, 0x0a, 5, 0x40, 0x1f, // datum [1], log-status [0]
+        0x1f, // end record
+        0x1f, // end list
+        0x29, 0x00, // no-more-items [2]
+    ];
+
+    let mut encoded = BytesMut::new();
+    ack.try_encode(&mut encoded).unwrap();
+    assert_eq!(encoded.as_ref(), expected);
+    assert_eq!(AuditLogQueryAck::decode(&expected).unwrap(), ack);
+}
+
+#[test]
+fn audit_log_query_ack_nested_notification_with_error_matches_literal() {
+    let notification = ack_notification();
+    let ack = AuditLogQueryAck {
+        audit_log: oid(ObjectType::AUDIT_LOG, 1),
+        records: vec![BACnetAuditLogRecordResult {
+            sequence_number: 2,
+            record: audit_record(BACnetAuditLogDatum::AuditNotification(notification.clone())),
+        }],
+        no_more_items: true,
+    };
+    let expected = [
+        0x0c, 0x0f, 0x40, 0x00, 0x01, 0x1e, 0x09, 0x02, 0x1e, 0x0e, 0xa4, 126, 8, 29, 6, 0xb4, 12,
+        34, 56, 78, 0x0f, 0x1e, // datum [1]
+        0x1e, // notification alternative [1]
+        0x2e, 0x0c, 0x02, 0x00, 0x00, 0x01, 0x2f, // source-device
+        0x49, 0x01, // WRITE operation
+        0xae, 0x0c, 0x02, 0x00, 0x00, 0x02, 0xaf, // target-device
+        0xfe, 16, 0x91, 0x02, 0x91, 0x28, 0xff, 16, // optional Error [16]
+        0x1f, 0x1f, 0x1f, 0x1f, 0x29, 0x01,
+    ];
+
+    let mut encoded = BytesMut::new();
+    ack.encode(&mut encoded).unwrap();
+    assert_eq!(encoded.as_ref(), expected);
+    assert_eq!(AuditLogQueryAck::decode(&expected).unwrap(), ack);
+}
+
+#[test]
+fn audit_log_query_ack_time_change_and_adjacent_results_match_literal() {
+    let ack = AuditLogQueryAck {
+        audit_log: oid(ObjectType::AUDIT_LOG, 1),
+        records: vec![
+            BACnetAuditLogRecordResult {
+                sequence_number: u64::MAX,
+                record: audit_record(BACnetAuditLogDatum::TimeChange(1.5)),
+            },
+            BACnetAuditLogRecordResult {
+                sequence_number: 0,
+                record: audit_record(BACnetAuditLogDatum::LogStatus(0)),
+            },
+        ],
+        no_more_items: false,
+    };
+    let expected = [
+        0x0c, 0x0f, 0x40, 0x00, 0x01, 0x1e, 0x0d, 0x08, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0x1e, 0x0e, 0xa4, 126, 8, 29, 6, 0xb4, 12, 34, 56, 78, 0x0f, 0x1e, 0x2c, 0x3f, 0xc0,
+        0x00, 0x00, 0x1f, 0x1f, 0x09, 0x00, 0x1e, 0x0e, 0xa4, 126, 8, 29, 6, 0xb4, 12, 34, 56, 78,
+        0x0f, 0x1e, 0x0a, 5, 0x00, 0x1f, 0x1f, 0x1f, 0x29, 0x00,
+    ];
+
+    let mut encoded = BytesMut::new();
+    ack.encode(&mut encoded).unwrap();
+    assert_eq!(encoded.as_ref(), expected);
+    assert_eq!(AuditLogQueryAck::decode(&expected).unwrap(), ack);
+}
+
+#[test]
+fn audit_log_query_ack_encode_is_atomic() {
+    let ack = AuditLogQueryAck {
+        audit_log: oid(ObjectType::AUDIT_LOG, 1),
+        records: vec![BACnetAuditLogRecordResult {
+            sequence_number: 1,
+            record: audit_record(BACnetAuditLogDatum::LogStatus(0b1000)),
+        }],
+        no_more_items: false,
+    };
+    let mut output = BytesMut::from(&b"prefix"[..]);
+    assert!(ack.try_encode(&mut output).is_err());
+    assert_eq!(output.as_ref(), b"prefix");
 }


### PR DESCRIPTION
## Summary

- add typed AuditLogQuery-ACK, BACnetAuditLogRecordResult, BACnetAuditLogRecord, and Audit-specific datum models
- implement exact Clause 21 ACK, result, record, and three-choice datum codecs with atomic encoding and bounded decoding
- add literal golden, malformed, canonical-number, adjacent-result, u64 maximum, and 10,000/10,001 resource-boundary coverage

## Standard grounding

- ANSI/ASHRAE 135-2020 Clauses 13.19-13.21, 19.6, and the corresponding Clause 21 productions
- preserves the existing GATE-0005 decision: request fields retain the formal Clause 21 interpretation and the Clause 13 interoperability qualification
- service errors remain the generic BACnet Error path; the ACK model has no invented error union

## Validation

- cargo test -p bacnet-services audit --locked (30 passed)
- cargo fmt --all -- --check
- cargo clippy -p bacnet-services --all-targets --locked
- cargo test -p bacnet-services --locked (509 passed)
- cargo check -p rusty-bacnet --tests --locked
- git diff --check

## Scope

Wire codecs only. No Audit Log storage or query execution, authorization or replay policy, typed client or Python wiring, documentation expansion, conformance claim, or CI change. Issue 345 remains open for the runtime slices.

Refs #345