### PR TITLE
deps: update h2 to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

- update the locked h2 package from 0.4.15 to patched 0.4.16
- resolve RUSTSEC-2026-0258, a low-severity denial-of-service advisory involving unbounded empty DATA frames
- preserve every other package version, checksum, and dependency edge

Primary evidence:
- https://rustsec.org/advisories/RUSTSEC-2026-0258.html
- https://github.com/hyperium/h2/releases/tag/v0.4.16

## Scope

Cargo.lock only: two insertions and two deletions. No manifest, source, test, CI, or public API changes.

The initial Cargo-generated update also normalized four unrelated dependency edges. Those changes were removed, and cargo metadata --locked accepted the narrowed lock without mutation.

## Validation

- cargo metadata --locked --all-features --format-version 1: pass
- cargo tree --workspace --all-features -i h2@0.4.16 --locked: pass
- cargo audit: pass, zero vulnerabilities; existing allowed yanked chacha20 0.10.1 warning remains
- cargo deny check: pass
- cargo check -p bacnet-benchmarks --all-features --locked: pass
- RUSTUP_TOOLCHAIN=1.93 bash .github/scripts/check-msrv.sh: pass across the ten canonical publishable crates
- git diff --check: pass

A direct Rust 1.93 benchmark check remains unavailable because the pre-existing sysinfo 0.39.6 benchmark dependency requires Rust 1.95; the repository canonical MSRV gate passes and h2 0.4.16 itself declares an older MSRV.

This is the immediate security follow-up authorized after PR #458.