### PR TITLE
feat(audit): execute AuditLogQuery against retained records

### DIFF
--- a/crates/bacnet-objects/src/audit.rs
+++ b/crates/bacnet-objects/src/audit.rs
@@ -5,7 +5,8 @@ use std::collections::VecDeque;
 use std::sync::Arc;
 
 use bacnet_types::constructed::{
-    BACnetAuditLogDatum, BACnetAuditLogRecord, BACnetAuditLogRecordResult,
+    BACnetAuditLogDatum, BACnetAuditLogQueryParameters, BACnetAuditLogRecord,
+    BACnetAuditLogRecordResult, BACnetAuditNotification, BACnetRecipient,
 };
 use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
@@ -20,6 +21,34 @@ use persistence::{validate_record, validate_snapshot};
 pub use persistence::{
     AuditLogPersistence, AuditLogSnapshot, FileAuditLogPersistence, MAX_AUDIT_RECORDS,
 };
+
+/// One owned page returned by an object-level AuditLogQuery capability.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuditLogQueryPage {
+    /// Matching records in newest-first retained insertion order.
+    pub records: Vec<BACnetAuditLogRecordResult>,
+    /// Whether a complete retained-buffer scan found no unreturned match.
+    pub no_more_items: bool,
+}
+
+/// Read-only query capability for an object's retained Audit Log records.
+///
+/// Implementations return owned pages so the server can release its object
+/// database read guard before building and encoding the ComplexACK. This
+/// interface never performs persistence I/O or mutates the log.
+pub trait AuditLogStorage: Send + Sync {
+    /// Filter and page the currently retained in-memory records.
+    ///
+    /// A present start is the existing Clause-21 `Unsigned32` model and admits
+    /// only literal sequence identities below it. This intentionally does not
+    /// add a modular cursor across `u64::MAX -> 1`.
+    fn query(
+        &self,
+        parameters: &BACnetAuditLogQueryParameters,
+        start_at_sequence_number: Option<u32>,
+        requested_count: u16,
+    ) -> AuditLogQueryPage;
+}
 
 // ---------------------------------------------------------------------------
 // AuditLog (type 61)
@@ -231,6 +260,129 @@ fn append_record(snapshot: &mut AuditLogSnapshot, record: BACnetAuditLogRecord) 
     sequence_number
 }
 
+fn recipient_matches(
+    actual: &BACnetRecipient,
+    required_identifier: ObjectIdentifier,
+    optional_address: Option<&bacnet_types::constructed::BACnetAddress>,
+) -> bool {
+    match actual {
+        BACnetRecipient::Device(identifier) => *identifier == required_identifier,
+        BACnetRecipient::Address(address) => {
+            optional_address.is_some_and(|filter| address == filter)
+        }
+    }
+}
+
+fn operation_matches(
+    notification: &BACnetAuditNotification,
+    operations: Option<bacnet_types::bitstring::AuditOperationFlags>,
+    successful_actions_only: bool,
+) -> bool {
+    operations.is_none_or(|flags| flags.contains(notification.operation))
+        && (!successful_actions_only || notification.result.is_none())
+}
+
+fn query_matches(
+    notification: &BACnetAuditNotification,
+    parameters: &BACnetAuditLogQueryParameters,
+) -> bool {
+    match parameters {
+        BACnetAuditLogQueryParameters::ByTarget {
+            target_device_identifier,
+            target_device_address,
+            target_object_identifier,
+            target_property_identifier,
+            target_array_index,
+            target_priority,
+            operations,
+            successful_actions_only,
+        } => {
+            recipient_matches(
+                &notification.target_device,
+                *target_device_identifier,
+                target_device_address.as_ref(),
+            ) && target_object_identifier
+                .is_none_or(|filter| notification.target_object == Some(filter))
+                && target_property_identifier.is_none_or(|filter| {
+                    notification.target_property.as_ref().is_some_and(|property| {
+                        property.property_identifier == filter
+                    })
+                })
+                && target_array_index.is_none_or(|filter| {
+                    notification.target_property.as_ref().is_some_and(|property| {
+                        property.property_array_index == Some(filter)
+                    })
+                })
+                // Clause 13.19 says a record without Priority matches any
+                // requested Target Priority.
+                && target_priority.is_none_or(|filter| {
+                    notification
+                        .target_priority
+                        .is_none_or(|priority| priority == filter)
+                })
+                && operation_matches(notification, *operations, *successful_actions_only)
+        }
+        BACnetAuditLogQueryParameters::BySource {
+            source_device_identifier,
+            source_device_address,
+            source_object_identifier,
+            operations,
+            successful_actions_only,
+        } => {
+            recipient_matches(
+                &notification.source_device,
+                *source_device_identifier,
+                source_device_address.as_ref(),
+            ) && source_object_identifier
+                .is_none_or(|filter| notification.source_object == Some(filter))
+                && operation_matches(notification, *operations, *successful_actions_only)
+        }
+    }
+}
+
+impl AuditLogStorage for AuditLogObject {
+    fn query(
+        &self,
+        parameters: &BACnetAuditLogQueryParameters,
+        start_at_sequence_number: Option<u32>,
+        requested_count: u16,
+    ) -> AuditLogQueryPage {
+        let limit = usize::from(requested_count).min(MAX_AUDIT_RECORDS as usize);
+        let mut records = Vec::with_capacity(limit.min(self.buffer.len()));
+        let mut unreturned_match = false;
+
+        // The ring is stored oldest-to-newest. Reverse insertion order is the
+        // query order even across sequence wrap; numeric sorting would turn
+        // retained [MAX, 1] into the wrong chronology.
+        for result in self.buffer.iter().rev() {
+            if start_at_sequence_number
+                .is_some_and(|start| result.sequence_number >= u64::from(start))
+            {
+                continue;
+            }
+            let BACnetAuditLogDatum::AuditNotification(notification) = &result.record.datum else {
+                continue;
+            };
+            if !query_matches(notification, parameters) {
+                continue;
+            }
+            if records.len() < limit {
+                records.push(result.clone());
+            } else {
+                // Keep scanning the complete retained snapshot so a full page
+                // can still truthfully distinguish exhaustion from a later
+                // eligible match. This also defines count=0.
+                unreturned_match = true;
+            }
+        }
+
+        AuditLogQueryPage {
+            records,
+            no_more_items: !unreturned_match,
+        }
+    }
+}
+
 impl BACnetObject for AuditLogObject {
     fn object_identifier(&self) -> ObjectIdentifier {
         self.oid
@@ -357,6 +509,10 @@ impl BACnetObject for AuditLogObject {
 
     fn bind_clock_internal(&mut self, clock: Option<Arc<dyn ClockReader>>) {
         self.clock = clock;
+    }
+
+    fn audit_log_storage_internal(&self) -> Option<&dyn AuditLogStorage> {
+        Some(self)
     }
 
     fn capture_write_property_rollback(
@@ -502,3 +658,7 @@ impl BACnetObject for AuditReporterObject {
 #[cfg(test)]
 #[path = "audit/tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "audit/query_tests.rs"]
+mod query_tests;

--- a/crates/bacnet-objects/src/audit/query_tests.rs
+++ b/crates/bacnet-objects/src/audit/query_tests.rs
@@ -1,0 +1,484 @@
+use std::sync::{Arc, Mutex};
+
+use bacnet_types::bitstring::AuditOperationFlags;
+use bacnet_types::constructed::{
+    AuditPropertyReference, BACnetAddress, BACnetAuditLogDatum, BACnetAuditLogQueryParameters,
+    BACnetAuditLogRecord, BACnetAuditLogRecordResult, BACnetAuditNotification, BACnetRecipient,
+};
+use bacnet_types::enums::{AuditOperation, ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{Date, ObjectIdentifier, Time};
+use bacnet_types::MacAddr;
+
+use crate::traits::BACnetObject;
+
+use super::{AuditLogObject, AuditLogPersistence, AuditLogSnapshot, MAX_AUDIT_RECORDS};
+
+#[derive(Default)]
+struct MemoryPersistence(Mutex<Option<AuditLogSnapshot>>);
+
+impl MemoryPersistence {
+    fn with_snapshot(snapshot: AuditLogSnapshot) -> Self {
+        Self(Mutex::new(Some(snapshot)))
+    }
+}
+
+impl AuditLogPersistence for MemoryPersistence {
+    fn load(&self, _expected_object: ObjectIdentifier) -> Result<Option<AuditLogSnapshot>, Error> {
+        Ok(self.0.lock().unwrap().clone())
+    }
+
+    fn commit(&self, snapshot: &AuditLogSnapshot) -> Result<(), Error> {
+        *self.0.lock().unwrap() = Some(snapshot.clone());
+        Ok(())
+    }
+}
+
+fn device(instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::DEVICE, instance).unwrap()
+}
+
+fn object(object_type: ObjectType, instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(object_type, instance).unwrap()
+}
+
+fn address(network_number: u16, mac: &[u8]) -> BACnetAddress {
+    BACnetAddress {
+        network_number,
+        mac_address: MacAddr::from_slice(mac),
+    }
+}
+
+fn record(sequence_number: u64, datum: BACnetAuditLogDatum) -> BACnetAuditLogRecordResult {
+    BACnetAuditLogRecordResult {
+        sequence_number,
+        record: BACnetAuditLogRecord {
+            timestamp: (
+                Date {
+                    year: 124,
+                    month: 2,
+                    day: 29,
+                    day_of_week: 4,
+                },
+                Time {
+                    hour: 12,
+                    minute: 0,
+                    second: 0,
+                    hundredths: 0,
+                },
+            ),
+            datum,
+        },
+    }
+}
+
+fn notification(
+    source_device: BACnetRecipient,
+    target_device: BACnetRecipient,
+) -> BACnetAuditNotification {
+    BACnetAuditNotification {
+        source_timestamp: None,
+        target_timestamp: None,
+        source_device,
+        source_object: Some(object(ObjectType::ANALOG_INPUT, 10)),
+        operation: AuditOperation::WRITE,
+        source_comment: None,
+        target_comment: None,
+        invoke_id: None,
+        source_user_id: None,
+        source_user_role: None,
+        target_device,
+        target_object: Some(object(ObjectType::ANALOG_VALUE, 20)),
+        target_property: Some(AuditPropertyReference {
+            property_identifier: PropertyIdentifier::PRESENT_VALUE,
+            property_array_index: Some(3),
+        }),
+        target_priority: Some(8),
+        target_value: None,
+        current_value: None,
+        result: None,
+    }
+}
+
+fn log_with_records(records: Vec<BACnetAuditLogRecordResult>) -> AuditLogObject {
+    let total_record_count = records.last().map_or(0, |entry| entry.sequence_number);
+    let capacity = u32::try_from(records.len()).unwrap();
+    let persistence = Arc::new(MemoryPersistence::with_snapshot(AuditLogSnapshot {
+        object_identifier: object(ObjectType::AUDIT_LOG, 1),
+        generation: 1,
+        capacity,
+        log_enable: true,
+        total_record_count,
+        records,
+    }));
+    AuditLogObject::new(1, "Audit-1", capacity, persistence).unwrap()
+}
+
+fn query(
+    log: &AuditLogObject,
+    parameters: &BACnetAuditLogQueryParameters,
+    start: Option<u32>,
+    count: u16,
+) -> super::AuditLogQueryPage {
+    BACnetObject::audit_log_storage_internal(log)
+        .unwrap()
+        .query(parameters, start, count)
+}
+
+fn target_query() -> BACnetAuditLogQueryParameters {
+    let mut operations = AuditOperationFlags::empty();
+    assert!(operations.insert(AuditOperation::WRITE));
+    BACnetAuditLogQueryParameters::ByTarget {
+        target_device_identifier: device(2),
+        target_device_address: Some(address(7, &[0x22])),
+        target_object_identifier: Some(object(ObjectType::ANALOG_VALUE, 20)),
+        target_property_identifier: Some(PropertyIdentifier::PRESENT_VALUE),
+        target_array_index: Some(3),
+        target_priority: Some(8),
+        operations: Some(operations),
+        successful_actions_only: true,
+    }
+}
+
+#[test]
+fn target_filter_matches_every_field_and_device_identifier_or_address() {
+    let by_identifier = notification(
+        BACnetRecipient::Device(device(1)),
+        BACnetRecipient::Device(device(2)),
+    );
+    let by_address = notification(
+        BACnetRecipient::Device(device(1)),
+        BACnetRecipient::Address(address(7, &[0x22])),
+    );
+    let log = log_with_records(vec![
+        record(1, BACnetAuditLogDatum::LogStatus(0)),
+        record(2, BACnetAuditLogDatum::TimeChange(1.5)),
+        record(3, BACnetAuditLogDatum::AuditNotification(by_identifier)),
+        record(4, BACnetAuditLogDatum::AuditNotification(by_address)),
+    ]);
+
+    let page = query(&log, &target_query(), None, 10);
+    assert_eq!(
+        page.records
+            .iter()
+            .map(|entry| entry.sequence_number)
+            .collect::<Vec<_>>(),
+        vec![4, 3]
+    );
+    assert!(page.no_more_items);
+
+    // The index comparison is independent: the service does not reject or
+    // reinterpret a supplied array index merely because the property filter
+    // itself was omitted.
+    let index_without_property = BACnetAuditLogQueryParameters::ByTarget {
+        target_device_identifier: device(2),
+        target_device_address: Some(address(7, &[0x22])),
+        target_object_identifier: None,
+        target_property_identifier: None,
+        target_array_index: Some(3),
+        target_priority: None,
+        operations: None,
+        successful_actions_only: false,
+    };
+    assert_eq!(
+        query(&log, &index_without_property, None, 10).records.len(),
+        2
+    );
+
+    let BACnetAuditLogQueryParameters::ByTarget {
+        target_device_identifier,
+        target_device_address,
+        target_object_identifier,
+        target_property_identifier,
+        target_array_index,
+        target_priority,
+        operations,
+        successful_actions_only,
+    } = target_query()
+    else {
+        unreachable!();
+    };
+
+    let mismatches = [
+        BACnetAuditLogQueryParameters::ByTarget {
+            target_device_identifier: device(99),
+            target_device_address: Some(address(8, &[0x99])),
+            target_object_identifier,
+            target_property_identifier,
+            target_array_index,
+            target_priority,
+            operations,
+            successful_actions_only,
+        },
+        BACnetAuditLogQueryParameters::ByTarget {
+            target_device_identifier,
+            target_device_address: target_device_address.clone(),
+            target_object_identifier: Some(object(ObjectType::ANALOG_VALUE, 99)),
+            target_property_identifier,
+            target_array_index,
+            target_priority,
+            operations,
+            successful_actions_only,
+        },
+        BACnetAuditLogQueryParameters::ByTarget {
+            target_device_identifier,
+            target_device_address: target_device_address.clone(),
+            target_object_identifier,
+            target_property_identifier: Some(PropertyIdentifier::DESCRIPTION),
+            target_array_index,
+            target_priority,
+            operations,
+            successful_actions_only,
+        },
+        BACnetAuditLogQueryParameters::ByTarget {
+            target_device_identifier,
+            target_device_address: target_device_address.clone(),
+            target_object_identifier,
+            target_property_identifier,
+            target_array_index: Some(4),
+            target_priority,
+            operations,
+            successful_actions_only,
+        },
+        BACnetAuditLogQueryParameters::ByTarget {
+            target_device_identifier,
+            target_device_address: target_device_address.clone(),
+            target_object_identifier,
+            target_property_identifier,
+            target_array_index,
+            target_priority: Some(9),
+            operations,
+            successful_actions_only,
+        },
+        BACnetAuditLogQueryParameters::ByTarget {
+            target_device_identifier,
+            target_device_address,
+            target_object_identifier,
+            target_property_identifier,
+            target_array_index,
+            target_priority,
+            operations: Some(AuditOperationFlags::empty()),
+            successful_actions_only,
+        },
+    ];
+    for mismatch in mismatches {
+        assert!(query(&log, &mismatch, None, 10).records.is_empty());
+    }
+}
+
+#[test]
+fn target_optional_values_are_wildcards_and_absent_record_priority_matches() {
+    let mut audit = notification(
+        BACnetRecipient::Device(device(1)),
+        BACnetRecipient::Device(device(2)),
+    );
+    audit.target_object = None;
+    audit.target_property = None;
+    audit.target_priority = None;
+    let log = log_with_records(vec![record(
+        1,
+        BACnetAuditLogDatum::AuditNotification(audit),
+    )]);
+
+    let wildcard = BACnetAuditLogQueryParameters::ByTarget {
+        target_device_identifier: device(2),
+        target_device_address: None,
+        target_object_identifier: None,
+        target_property_identifier: None,
+        target_array_index: None,
+        target_priority: Some(16),
+        operations: None,
+        successful_actions_only: true,
+    };
+    assert_eq!(query(&log, &wildcard, None, 1).records.len(), 1);
+}
+
+#[test]
+fn source_filter_and_success_boolean_follow_the_wire_contract() {
+    let source_address = address(5, &[0x11]);
+    let success = notification(
+        BACnetRecipient::Address(source_address.clone()),
+        BACnetRecipient::Device(device(2)),
+    );
+    let mut failure = success.clone();
+    failure.result = Some((ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED));
+    let log = log_with_records(vec![
+        record(1, BACnetAuditLogDatum::AuditNotification(success)),
+        record(2, BACnetAuditLogDatum::AuditNotification(failure)),
+    ]);
+    let mut operations = AuditOperationFlags::empty();
+    assert!(operations.insert(AuditOperation::WRITE));
+
+    let query_parameters = |successful_actions_only| BACnetAuditLogQueryParameters::BySource {
+        source_device_identifier: device(99),
+        source_device_address: Some(source_address.clone()),
+        source_object_identifier: Some(object(ObjectType::ANALOG_INPUT, 10)),
+        operations: Some(operations),
+        successful_actions_only,
+    };
+    assert_eq!(
+        query(&log, &query_parameters(true), None, 10)
+            .records
+            .iter()
+            .map(|entry| entry.sequence_number)
+            .collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(
+        query(&log, &query_parameters(false), None, 10)
+            .records
+            .iter()
+            .map(|entry| entry.sequence_number)
+            .collect::<Vec<_>>(),
+        vec![2, 1]
+    );
+
+    let wrong_source = BACnetAuditLogQueryParameters::BySource {
+        source_device_identifier: device(98),
+        source_device_address: Some(address(6, &[0x66])),
+        source_object_identifier: None,
+        operations: None,
+        successful_actions_only: false,
+    };
+    assert!(query(&log, &wrong_source, None, 10).records.is_empty());
+
+    let wrong_source_object = BACnetAuditLogQueryParameters::BySource {
+        source_device_identifier: device(99),
+        source_device_address: Some(source_address),
+        source_object_identifier: Some(object(ObjectType::ANALOG_INPUT, 99)),
+        operations: Some(operations),
+        successful_actions_only: false,
+    };
+    assert!(query(&log, &wrong_source_object, None, 10)
+        .records
+        .is_empty());
+}
+
+#[test]
+fn query_uses_insertion_order_literal_start_and_complete_scan_for_no_more_items() {
+    let audit = notification(
+        BACnetRecipient::Device(device(1)),
+        BACnetRecipient::Device(device(2)),
+    );
+    let log = log_with_records(vec![
+        record(
+            u64::MAX,
+            BACnetAuditLogDatum::AuditNotification(audit.clone()),
+        ),
+        record(1, BACnetAuditLogDatum::AuditNotification(audit)),
+    ]);
+    let query_parameters = BACnetAuditLogQueryParameters::ByTarget {
+        target_device_identifier: device(2),
+        target_device_address: None,
+        target_object_identifier: None,
+        target_property_identifier: None,
+        target_array_index: None,
+        target_priority: None,
+        operations: None,
+        successful_actions_only: false,
+    };
+
+    let all = query(&log, &query_parameters, None, 10);
+    assert_eq!(
+        all.records
+            .iter()
+            .map(|entry| entry.sequence_number)
+            .collect::<Vec<_>>(),
+        vec![1, u64::MAX]
+    );
+    assert!(all.no_more_items);
+
+    let after_literal_start = query(&log, &query_parameters, Some(2), 10);
+    assert_eq!(after_literal_start.records[0].sequence_number, 1);
+    assert_eq!(after_literal_start.records.len(), 1);
+    assert!(after_literal_start.no_more_items);
+
+    let truncated = query(&log, &query_parameters, None, 1);
+    assert_eq!(truncated.records[0].sequence_number, 1);
+    assert!(!truncated.no_more_items);
+
+    let zero = query(&log, &query_parameters, None, 0);
+    assert!(zero.records.is_empty());
+    assert!(!zero.no_more_items);
+
+    let mut no_match = query_parameters.clone();
+    let BACnetAuditLogQueryParameters::ByTarget {
+        target_device_identifier,
+        ..
+    } = &mut no_match
+    else {
+        unreachable!();
+    };
+    *target_device_identifier = device(99);
+    let zero_without_match = query(&log, &no_match, None, 0);
+    assert!(zero_without_match.records.is_empty());
+    assert!(zero_without_match.no_more_items);
+}
+
+#[test]
+fn query_observes_retained_ring_eviction_and_newest_first_order() {
+    let audit = notification(
+        BACnetRecipient::Device(device(1)),
+        BACnetRecipient::Device(device(2)),
+    );
+    let mut log = log_with_records(vec![
+        record(1, BACnetAuditLogDatum::AuditNotification(audit.clone())),
+        record(2, BACnetAuditLogDatum::AuditNotification(audit.clone())),
+    ]);
+    let newest = record(3, BACnetAuditLogDatum::AuditNotification(audit)).record;
+    assert_eq!(log.add_record(newest).unwrap(), Some(3));
+
+    let query_parameters = BACnetAuditLogQueryParameters::BySource {
+        source_device_identifier: device(1),
+        source_device_address: None,
+        source_object_identifier: None,
+        operations: None,
+        successful_actions_only: false,
+    };
+    let page = query(&log, &query_parameters, None, 10);
+
+    assert_eq!(
+        page.records
+            .iter()
+            .map(|entry| entry.sequence_number)
+            .collect::<Vec<_>>(),
+        vec![3, 2]
+    );
+    assert!(page.no_more_items);
+}
+
+#[test]
+fn query_never_returns_more_than_the_retained_storage_cap() {
+    let audit = notification(
+        BACnetRecipient::Device(device(1)),
+        BACnetRecipient::Device(device(2)),
+    );
+    let records = (1..=MAX_AUDIT_RECORDS)
+        .map(|sequence_number| {
+            record(
+                u64::from(sequence_number),
+                BACnetAuditLogDatum::AuditNotification(audit.clone()),
+            )
+        })
+        .collect();
+    let log = log_with_records(records);
+    let query_parameters = BACnetAuditLogQueryParameters::BySource {
+        source_device_identifier: device(1),
+        source_device_address: None,
+        source_object_identifier: None,
+        operations: None,
+        successful_actions_only: false,
+    };
+
+    let page = query(&log, &query_parameters, None, u16::MAX);
+    assert_eq!(page.records.len(), MAX_AUDIT_RECORDS as usize);
+    assert_eq!(page.records[0].sequence_number, MAX_AUDIT_RECORDS as u64);
+    assert_eq!(page.records.last().unwrap().sequence_number, 1);
+    assert!(page.no_more_items);
+}
+
+#[test]
+fn non_audit_objects_keep_the_default_capability_absent() {
+    let reporter = super::AuditReporterObject::new(1, "Reporter").unwrap();
+    assert!(reporter.audit_log_storage_internal().is_none());
+}

--- a/crates/bacnet-objects/src/device/mod.rs
+++ b/crates/bacnet-objects/src/device/mod.rs
@@ -58,6 +58,7 @@ pub const EXECUTED_SERVICES: &[ServiceSupported] = &[
     ServiceSupported::SUBSCRIBE_COV_PROPERTY,
     ServiceSupported::GET_EVENT_INFORMATION,
     ServiceSupported::SUBSCRIBE_COV_PROPERTY_MULTIPLE,
+    ServiceSupported::AUDIT_LOG_QUERY,
 ];
 
 /// Number of bits in the `BACnetServicesSupported` production: bits 0..=48

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -11,6 +11,7 @@ use bacnet_types::enums::{
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
+use crate::audit::AuditLogStorage;
 use crate::clock::ClockReader;
 use crate::event::{EventTransitionCommit, EventTransitionCommitError, TransitionOutcome};
 use crate::event_enrollment::{
@@ -533,6 +534,18 @@ pub trait BACnetObject: Send + Sync {
             class: ErrorClass::OBJECT.to_raw() as u32,
             code: ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw() as u32,
         })
+    }
+
+    /// Borrow this object's Audit Log query storage, if it has any.
+    ///
+    /// This read-only, type-erased channel lets the bundled server execute an
+    /// AuditLogQuery against an object's already-loaded retained records. It
+    /// deliberately does not expose persistence, mutation, or object
+    /// downcasting. The **default** returns `None`; an Audit Log object that
+    /// does not opt in is reported as SERVICES /
+    /// OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.
+    fn audit_log_storage_internal(&self) -> Option<&dyn AuditLogStorage> {
+        None
     }
 
     /// Borrow this object's File storage, if it has any.

--- a/crates/bacnet-server/src/handlers/audit_log_query.rs
+++ b/crates/bacnet-server/src/handlers/audit_log_query.rs
@@ -1,0 +1,52 @@
+//! AuditLogQuery service handler (Clause 13.19).
+
+use bacnet_objects::audit::AuditLogQueryPage;
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_services::audit::AuditLogQueryRequest;
+use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::ObjectIdentifier;
+
+fn unknown_object() -> Error {
+    Error::Protocol {
+        class: ErrorClass::OBJECT.to_raw() as u32,
+        code: ErrorCode::UNKNOWN_OBJECT.to_raw() as u32,
+    }
+}
+
+fn optional_functionality_not_supported() -> Error {
+    Error::Protocol {
+        class: ErrorClass::SERVICES.to_raw() as u32,
+        code: ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw() as u32,
+    }
+}
+
+/// Decode and execute one AuditLogQuery against the object's retained state.
+///
+/// Decoding completes before object lookup or capability access. The returned
+/// page owns its records, allowing the dispatcher to release the database read
+/// guard before constructing and encoding the acknowledgment.
+pub fn handle_audit_log_query(
+    db: &ObjectDatabase,
+    service_data: &[u8],
+) -> Result<(ObjectIdentifier, AuditLogQueryPage), Error> {
+    let request = AuditLogQueryRequest::decode(service_data)?;
+
+    // Clause 13.19 specifies OBJECT / UNKNOWN_OBJECT for an Audit Log that
+    // does not exist. A non-Audit identifier cannot designate the requested
+    // Audit Log and follows the same public result instead of exposing an
+    // object-type distinction.
+    if request.audit_log.object_type() != ObjectType::AUDIT_LOG {
+        return Err(unknown_object());
+    }
+    let object = db.get(&request.audit_log).ok_or_else(unknown_object)?;
+    let storage = object
+        .audit_log_storage_internal()
+        .ok_or_else(optional_functionality_not_supported)?;
+    let page = storage.query(
+        &request.query_parameters,
+        request.start_at_sequence_number,
+        request.requested_count,
+    );
+    Ok((request.audit_log, page))
+}

--- a/crates/bacnet-server/src/handlers/mod.rs
+++ b/crates/bacnet-server/src/handlers/mod.rs
@@ -36,6 +36,7 @@ use bytes::BytesMut;
 use crate::cov::{CovNotificationKind, CovSubscription, CovSubscriptionTable};
 
 mod alarm_event;
+mod audit_log_query;
 mod cov;
 mod device_mgmt;
 mod file;
@@ -45,6 +46,7 @@ mod read_property;
 mod write_property;
 
 pub use alarm_event::*;
+pub use audit_log_query::*;
 pub use cov::*;
 pub use device_mgmt::*;
 pub use file::*;

--- a/crates/bacnet-server/src/handlers/tests/audit_log_query.rs
+++ b/crates/bacnet-server/src/handlers/tests/audit_log_query.rs
@@ -1,0 +1,267 @@
+use std::borrow::Cow;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use bacnet_objects::audit::{
+    AuditLogObject, AuditLogPersistence, AuditLogQueryPage, AuditLogSnapshot, AuditLogStorage,
+};
+use bacnet_services::audit::{AuditLogQueryRequest, BACnetAuditLogQueryParameters};
+use bacnet_types::constructed::{
+    BACnetAuditLogDatum, BACnetAuditLogRecord, BACnetAuditNotification, BACnetRecipient,
+};
+use bacnet_types::enums::{AuditOperation, ErrorClass, ErrorCode};
+use bacnet_types::primitives::{Date, Time};
+
+use super::*;
+
+#[derive(Default)]
+struct MemoryPersistence(Mutex<Option<AuditLogSnapshot>>);
+
+impl AuditLogPersistence for MemoryPersistence {
+    fn load(&self, _expected_object: ObjectIdentifier) -> Result<Option<AuditLogSnapshot>, Error> {
+        Ok(self.0.lock().unwrap().clone())
+    }
+
+    fn commit(&self, snapshot: &AuditLogSnapshot) -> Result<(), Error> {
+        *self.0.lock().unwrap() = Some(snapshot.clone());
+        Ok(())
+    }
+}
+
+fn oid(object_type: ObjectType, instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(object_type, instance).unwrap()
+}
+
+fn audit_record(target: ObjectIdentifier) -> BACnetAuditLogRecord {
+    let source = oid(ObjectType::DEVICE, 1);
+    BACnetAuditLogRecord {
+        timestamp: (
+            Date {
+                year: 124,
+                month: 2,
+                day: 29,
+                day_of_week: 4,
+            },
+            Time {
+                hour: 12,
+                minute: 0,
+                second: 0,
+                hundredths: 0,
+            },
+        ),
+        datum: BACnetAuditLogDatum::AuditNotification(BACnetAuditNotification {
+            source_timestamp: None,
+            target_timestamp: None,
+            source_device: BACnetRecipient::Device(source),
+            source_object: None,
+            operation: AuditOperation::READ,
+            source_comment: None,
+            target_comment: None,
+            invoke_id: None,
+            source_user_id: None,
+            source_user_role: None,
+            target_device: BACnetRecipient::Device(target),
+            target_object: None,
+            target_property: None,
+            target_priority: None,
+            target_value: None,
+            current_value: None,
+            result: None,
+        }),
+    }
+}
+
+fn request(audit_log: ObjectIdentifier) -> AuditLogQueryRequest {
+    AuditLogQueryRequest {
+        audit_log,
+        query_parameters: BACnetAuditLogQueryParameters::BySource {
+            source_device_identifier: oid(ObjectType::DEVICE, 1),
+            source_device_address: None,
+            source_object_identifier: None,
+            operations: None,
+            successful_actions_only: false,
+        },
+        start_at_sequence_number: None,
+        requested_count: 10,
+    }
+}
+
+fn encode_request(request: &AuditLogQueryRequest) -> Vec<u8> {
+    let mut encoded = BytesMut::new();
+    request.try_encode(&mut encoded).unwrap();
+    encoded.to_vec()
+}
+
+fn assert_protocol(error: Error, class: ErrorClass, code: ErrorCode) {
+    assert!(matches!(
+        error,
+        Error::Protocol { class: actual_class, code: actual_code }
+            if actual_class == class.to_raw() as u32 && actual_code == code.to_raw() as u32
+    ));
+}
+
+#[test]
+fn handler_decodes_then_returns_an_owned_page_from_real_audit_storage() {
+    let audit_oid = oid(ObjectType::AUDIT_LOG, 7);
+    let target = oid(ObjectType::DEVICE, 2);
+    let mut log =
+        AuditLogObject::new(7, "Audit-7", 4, Arc::new(MemoryPersistence::default())).unwrap();
+    log.add_record(audit_record(target)).unwrap();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(log)).unwrap();
+
+    let (returned_oid, page) =
+        handle_audit_log_query(&db, &encode_request(&request(audit_oid))).unwrap();
+    assert_eq!(returned_oid, audit_oid);
+    assert_eq!(page.records.len(), 1);
+    assert_eq!(page.records[0].sequence_number, 1);
+    assert!(page.no_more_items);
+}
+
+#[test]
+fn missing_or_non_audit_identifiers_map_to_unknown_object() {
+    let db = make_db_with_ai();
+    for requested in [
+        oid(ObjectType::AUDIT_LOG, 99),
+        oid(ObjectType::ANALOG_INPUT, 1),
+    ] {
+        let error = handle_audit_log_query(&db, &encode_request(&request(requested))).unwrap_err();
+        assert_protocol(error, ErrorClass::OBJECT, ErrorCode::UNKNOWN_OBJECT);
+    }
+}
+
+struct AuditWithoutCapability {
+    oid: ObjectIdentifier,
+}
+
+impl BACnetObject for AuditWithoutCapability {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "AuditWithoutCapability"
+    }
+
+    fn read_property(
+        &self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+        })
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[])
+    }
+}
+
+#[test]
+fn audit_typed_object_without_capability_maps_to_optional_functionality() {
+    let audit_oid = oid(ObjectType::AUDIT_LOG, 8);
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(AuditWithoutCapability { oid: audit_oid }))
+        .unwrap();
+
+    let error = handle_audit_log_query(&db, &encode_request(&request(audit_oid))).unwrap_err();
+    assert_protocol(
+        error,
+        ErrorClass::SERVICES,
+        ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+    );
+}
+
+struct SpyAuditStorage {
+    query_count: AtomicUsize,
+}
+
+impl AuditLogStorage for SpyAuditStorage {
+    fn query(
+        &self,
+        _parameters: &BACnetAuditLogQueryParameters,
+        _start_at_sequence_number: Option<u32>,
+        _requested_count: u16,
+    ) -> AuditLogQueryPage {
+        self.query_count.fetch_add(1, Ordering::SeqCst);
+        AuditLogQueryPage {
+            records: Vec::new(),
+            no_more_items: true,
+        }
+    }
+}
+
+struct SpyAuditObject {
+    oid: ObjectIdentifier,
+    storage: Arc<SpyAuditStorage>,
+}
+
+impl BACnetObject for SpyAuditObject {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "SpyAuditObject"
+    }
+
+    fn read_property(
+        &self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        unreachable!("AuditLogQuery must not inspect properties")
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        unreachable!("AuditLogQuery is read-only")
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[])
+    }
+
+    fn audit_log_storage_internal(&self) -> Option<&dyn AuditLogStorage> {
+        Some(self.storage.as_ref())
+    }
+}
+
+#[test]
+fn malformed_payload_fails_before_audit_storage_is_inspected() {
+    let audit_oid = oid(ObjectType::AUDIT_LOG, 9);
+    let storage = Arc::new(SpyAuditStorage {
+        query_count: AtomicUsize::new(0),
+    });
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(SpyAuditObject {
+        oid: audit_oid,
+        storage: Arc::clone(&storage),
+    }))
+    .unwrap();
+    let mut malformed = encode_request(&request(audit_oid));
+    malformed.push(0);
+
+    assert!(handle_audit_log_query(&db, &malformed).is_err());
+    assert_eq!(storage.query_count.load(Ordering::SeqCst), 0);
+}

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -36,6 +36,7 @@ fn make_db_with_device_and_ai() -> ObjectDatabase {
 mod acknowledge_alarm_ee;
 mod array_index_gating;
 mod async_dcc;
+mod audit_log_query;
 mod cov_multiple_parameters;
 mod detection_enable_summary;
 mod device_event;

--- a/crates/bacnet-server/src/handlers/tests/read_rpm.rs
+++ b/crates/bacnet-server/src/handlers/tests/read_rpm.rs
@@ -582,7 +582,7 @@ fn read_property_serves_derived_services_supported() {
     // End-to-end pin for #192: the wire-level BitString a client receives for
     // Protocol_Services_Supported, through the real ReadProperty handler path.
     // Expected bytes derive from device::EXECUTED_SERVICES bits
-    // {0,3-12,14-17,19,20,31-39,41} packed MSB-first over the full production
+    // {0,3-12,14-17,19,20,31-39,41,42} packed MSB-first over the full production
     // range (49 defined bits, 7 octets, 7 unused).
     let db = make_db_with_device_and_ai();
     let oid = ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap();
@@ -605,7 +605,7 @@ fn read_property_serves_derived_services_supported() {
         val,
         bacnet_types::primitives::PropertyValue::BitString {
             unused_bits: 7,
-            data: vec![0x9F, 0xFB, 0xD8, 0x01, 0xFF, 0x40, 0x00],
+            data: vec![0x9F, 0xFB, 0xD8, 0x01, 0xFF, 0x44, 0x00],
         }
     );
 
@@ -615,5 +615,6 @@ fn read_property_serves_derived_services_supported() {
     };
     let ss = bacnet_types::bitstring::ServicesSupported::from_bacnet(&data);
     assert!(ss.contains(bacnet_types::enums::ServiceSupported::WHO_IS));
+    assert!(ss.contains(bacnet_types::enums::ServiceSupported::AUDIT_LOG_QUERY));
     assert!(!ss.contains(bacnet_types::enums::ServiceSupported::I_AM));
 }

--- a/crates/bacnet-server/src/server/audit_log_query_tests.rs
+++ b/crates/bacnet-server/src/server/audit_log_query_tests.rs
@@ -1,0 +1,126 @@
+use std::sync::{Arc, Mutex as StdMutex};
+
+use bacnet_encoding::apdu::decode_apdu;
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_objects::audit::{AuditLogObject, AuditLogPersistence, AuditLogSnapshot};
+use bacnet_services::audit::{
+    AuditLogQueryAck, AuditLogQueryRequest, BACnetAuditLogQueryParameters,
+};
+use bacnet_types::primitives::ObjectIdentifier;
+
+use super::*;
+
+#[derive(Default)]
+struct MemoryPersistence(StdMutex<Option<AuditLogSnapshot>>);
+
+impl AuditLogPersistence for MemoryPersistence {
+    fn load(&self, _expected_object: ObjectIdentifier) -> Result<Option<AuditLogSnapshot>, Error> {
+        Ok(self.0.lock().unwrap().clone())
+    }
+
+    fn commit(&self, snapshot: &AuditLogSnapshot) -> Result<(), Error> {
+        *self.0.lock().unwrap() = Some(snapshot.clone());
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn audit_log_query_dispatch_returns_a_typed_complex_ack() {
+    let audit_log = ObjectIdentifier::new(ObjectType::AUDIT_LOG, 7).unwrap();
+    let target = ObjectIdentifier::new(ObjectType::DEVICE, 2).unwrap();
+    let mut database = ObjectDatabase::new();
+    database
+        .add(Box::new(
+            AuditLogObject::new(7, "Audit-7", 4, Arc::new(MemoryPersistence::default())).unwrap(),
+        ))
+        .unwrap();
+    let db = Arc::new(RwLock::new(database));
+
+    let request = AuditLogQueryRequest {
+        audit_log,
+        query_parameters: BACnetAuditLogQueryParameters::ByTarget {
+            target_device_identifier: target,
+            target_device_address: None,
+            target_object_identifier: None,
+            target_property_identifier: None,
+            target_array_index: None,
+            target_priority: None,
+            operations: None,
+            successful_actions_only: false,
+        },
+        start_at_sequence_number: None,
+        requested_count: 10,
+    };
+    let mut service_request = BytesMut::new();
+    request.try_encode(&mut service_request).unwrap();
+
+    let network = Arc::new(NetworkLayer::new(BipTransport::new(
+        Ipv4Addr::LOCALHOST,
+        0,
+        Ipv4Addr::BROADCAST,
+    )));
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let cov_in_flight = Arc::new(Semaphore::new(1));
+    let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+    let notification_transactions = NotificationTransactions::new();
+    let device_bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
+    let comm_state = Arc::new(AtomicU8::new(0));
+    let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
+    let config = ServerConfig::default();
+    let source_mac = MacAddr::from_slice(&[1]);
+    let routed_source = NpduAddress {
+        network: 100,
+        mac_address: MacAddr::from_slice(&[0x0a, 0x0b]),
+    };
+    let confirmed = ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 480,
+        invoke_id: 0x42,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::AUDIT_LOG_QUERY,
+        service_request: service_request.freeze(),
+    };
+    let (tx, rx) = oneshot::channel();
+
+    BACnetServer::<BipTransport>::handle_confirmed_request(
+        &db,
+        &network,
+        &cov_table,
+        &seg_ack_senders,
+        &seg_send_permits,
+        &cov_in_flight,
+        &server_tsm,
+        &notification_transactions,
+        &device_bindings,
+        &comm_state,
+        &dcc_timer,
+        &config,
+        &source_mac,
+        Some(routed_source.clone()),
+        confirmed,
+        Some(tx),
+    )
+    .await;
+
+    let npdu = decode_npdu(rx.await.expect("query response")).unwrap();
+    assert_eq!(npdu.destination, Some(routed_source));
+    let Apdu::ComplexAck(ack) = decode_apdu(npdu.payload).unwrap() else {
+        panic!("expected AuditLogQuery ComplexAck");
+    };
+    assert_eq!(ack.invoke_id, 0x42);
+    assert_eq!(ack.service_choice, ConfirmedServiceChoice::AUDIT_LOG_QUERY);
+    assert_eq!(
+        AuditLogQueryAck::decode(&ack.service_ack).unwrap(),
+        AuditLogQueryAck {
+            audit_log,
+            records: Vec::new(),
+            no_more_items: true,
+        }
+    );
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -879,6 +879,8 @@ mod segmented_receive;
 mod shutdown;
 
 #[cfg(test)]
+mod audit_log_query_tests;
+#[cfg(test)]
 mod cov_notifications_tests;
 #[cfg(test)]
 mod dcc_event_detection_tests;

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -43,6 +43,7 @@ pub(crate) const EXECUTED_CONFIRMED: &[ConfirmedServiceChoice] = &[
     ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY,
     ConfirmedServiceChoice::GET_EVENT_INFORMATION,
     ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY_MULTIPLE,
+    ConfirmedServiceChoice::AUDIT_LOG_QUERY,
 ];
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
@@ -337,6 +338,28 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let db = db.read().await;
                 match handlers::handle_get_enrollment_summary(&db, &req.service_request, &mut buf) {
                     Ok(()) => complex_ack(buf),
+                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
+                }
+            }
+            s if s == ConfirmedServiceChoice::AUDIT_LOG_QUERY => {
+                // Query under the read guard, then release it before ACK
+                // construction/encoding and the generic segmentation path.
+                let query_result = {
+                    let db = db.read().await;
+                    handlers::handle_audit_log_query(&db, &req.service_request)
+                };
+                match query_result {
+                    Ok((audit_log, page)) => {
+                        let ack = bacnet_services::audit::AuditLogQueryAck {
+                            audit_log,
+                            records: page.records,
+                            no_more_items: page.no_more_items,
+                        };
+                        match ack.try_encode(&mut ack_buf) {
+                            Ok(()) => complex_ack(ack_buf),
+                            Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
+                        }
+                    }
                     Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
                 }
             }

--- a/crates/bacnet-server/src/server/tests.rs
+++ b/crates/bacnet-server/src/server/tests.rs
@@ -640,7 +640,7 @@ async fn reply_tx_response_preserves_routed_npdu_destination() {
         invoke_id: 0x31,
         sequence_number: None,
         proposed_window_size: None,
-        service_choice: ConfirmedServiceChoice::AUDIT_LOG_QUERY,
+        service_choice: ConfirmedServiceChoice::VT_OPEN,
         service_request: Bytes::new(),
     };
     let (tx, rx) = oneshot::channel();

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -832,13 +832,19 @@
    "id": "BACNET-13-AUDIT-WIRE-MODELS",
    "standard_anchor": "Clauses 13.19-13.21; Clause 21.2.1, Clause 21.2.3, Clause 21.3.1, BACnetAuditNotification, BACnetAuditLogQueryParameters, and BACnetAuditOperationFlags productions",
    "priority": "P1",
-   "requirement_summary": "AuditNotification request payloads carry one or more typed BACnetAuditNotification values under context tag 0, while AuditLogQuery requests carry a typed by-target or by-source query alternative. Within the primitive layer's u64 Unsigned domain, the codecs preserve the Clause 21 field order, tags, numeric domains, Boolean encoding, recipient alternatives, standard operation-flag bits 0-15, and proprietary bits 32-63; reject reserved flag bits, trailing or malformed structure; bound notification-list allocation; and leave destination buffers unchanged when model validation fails.",
+   "requirement_summary": "AuditNotification request payloads carry one or more typed BACnetAuditNotification values under context tag 0, while AuditLogQuery requests carry a typed by-target or by-source query alternative and the bundled server can execute those queries against explicitly persisted retained Audit Log records. Within the primitive layer's u64 Unsigned domain, the codecs preserve the Clause 21 field order, tags, numeric domains, Boolean encoding, recipient alternatives, standard operation-flag bits 0-15, and proprietary bits 32-63; reject reserved flag bits, trailing or malformed structure; bound notification/query-result allocation; and leave destination buffers unchanged when model validation fails.",
    "status": "implementation-present-needs-source-review",
    "code_anchors": [
     "crates/bacnet-types/src/bitstring.rs",
     "crates/bacnet-services/src/audit.rs",
     "crates/bacnet-services/src/audit/notification_codec.rs",
     "crates/bacnet-services/src/audit/query_codec.rs",
+    "crates/bacnet-services/src/audit/query_ack_codec.rs",
+    "crates/bacnet-objects/src/audit.rs",
+    "crates/bacnet-objects/src/traits.rs",
+    "crates/bacnet-server/src/handlers/audit_log_query.rs",
+    "crates/bacnet-server/src/server/requests/mod.rs",
+    "crates/bacnet-objects/src/device/mod.rs",
     "crates/rusty-bacnet/src/client/client_methods/vt_audit_time_directed.rs"
    ],
    "positive_tests": [
@@ -849,7 +855,15 @@
     "crates/bacnet-services/src/audit/malformed_tests.rs::minimal_notification_has_no_per_item_sequence_wrapper",
     "crates/bacnet-services/src/audit/tests.rs::by_target_minimum_matches_clause_21_golden",
     "crates/bacnet-services/src/audit/tests.rs::by_source_minimum_and_sequence_number_match_clause_21_golden",
-    "crates/bacnet-services/src/audit/tests.rs::by_target_all_optional_fields_round_trip"
+    "crates/bacnet-services/src/audit/tests.rs::by_target_all_optional_fields_round_trip",
+    "crates/bacnet-objects/src/audit/query_tests.rs::target_filter_matches_every_field_and_device_identifier_or_address",
+    "crates/bacnet-objects/src/audit/query_tests.rs::source_filter_and_success_boolean_follow_the_wire_contract",
+    "crates/bacnet-objects/src/audit/query_tests.rs::query_uses_insertion_order_literal_start_and_complete_scan_for_no_more_items",
+    "crates/bacnet-objects/src/audit/query_tests.rs::query_observes_retained_ring_eviction_and_newest_first_order",
+    "crates/bacnet-objects/src/audit/query_tests.rs::query_never_returns_more_than_the_retained_storage_cap",
+    "crates/bacnet-server/src/handlers/tests/audit_log_query.rs::handler_decodes_then_returns_an_owned_page_from_real_audit_storage",
+    "crates/bacnet-server/src/server/audit_log_query_tests.rs::audit_log_query_dispatch_returns_a_typed_complex_ack",
+    "crates/bacnet-server/src/pics/tests.rs::executed_services_match_dispatch_table"
    ],
    "negative_tests": [
     "crates/bacnet-types/src/bitstring.rs::tests::audit_operation_flags_reject_overlong_and_nonzero_padding",
@@ -865,11 +879,14 @@
     "crates/bacnet-services/src/audit/tests.rs::nested_field_widths_and_priority_range_are_enforced",
     "crates/bacnet-services/src/audit/tests.rs::operation_flags_reject_more_than_64_bits_and_nonzero_padding",
     "crates/bacnet-services/src/audit/tests.rs::every_constructed_level_requires_full_consumption",
-    "crates/bacnet-services/src/audit/tests.rs::invalid_priority_encode_is_atomic"
+    "crates/bacnet-services/src/audit/tests.rs::invalid_priority_encode_is_atomic",
+    "crates/bacnet-server/src/handlers/tests/audit_log_query.rs::missing_or_non_audit_identifiers_map_to_unknown_object",
+    "crates/bacnet-server/src/handlers/tests/audit_log_query.rs::audit_typed_object_without_capability_maps_to_optional_functionality",
+    "crates/bacnet-server/src/handlers/tests/audit_log_query.rs::malformed_payload_fails_before_audit_storage_is_inspected"
    ],
    "benchmarks": [],
    "public_claims": [],
-   "notes": "Wire-model-only evidence for issue #345. The request models follow the Clause 21 field and tag productions within the library's u64 Unsigned implementation limit: start-at-sequence-number is Unsigned32 and successful-actions-only is BOOLEAN. Clause 13.19 instead describes Unsigned64 and the three-state BACnetSuccessFilter, including failures-only; that internal Standard conflict remains unresolved pending authoritative addendum or errata research, so this row stays below supported status. The 10,000-notification bound is an implementation resource cap, not a Standard service cardinality. Raw target/current ANY values receive structural TLV validation only, not property-schema validation. Python exposes all three audit sends as caller-supplied, pre-encoded Clause 21 payload escape hatches. AuditLogQuery acknowledgment/record models, bundled-server execution and persistence, authorization, transport-source provenance, rate limiting, replay/merge policy, error mapping, APDU sizing/segmentation, Device service truth, PICS declarations, and BIBB claims remain unsupported or deferred."
+   "notes": "Partial evidence for issue #345. The request/ACK models follow the Clause 21 field and tag productions within the library's u64 Unsigned implementation limit: start-at-sequence-number is Unsigned32 and successful-actions-only is BOOLEAN. Clause 13.19 instead describes Unsigned64 and the three-state BACnetSuccessFilter, including failures-only; that internal Standard conflict remains unresolved pending authoritative addendum or errata research, so this row stays below supported status. AuditLogQuery executes both alternatives over the explicitly persisted, already-loaded retained snapshot, traverses insertion order newest-first without numeric sorting, applies the literal Unsigned32 start predicate, scans completely for No_More_Items, and returns at most the 10,000-record persistence/ACK cap through the generic ComplexACK sizing and segmentation path. Missing/non-Audit identifiers and absent query capability use the Clause 13.19 business errors; malformed payloads retain the repository's SERVICES/OTHER mapping after decode-first failure. The 10,000 notification/result bounds are implementation resource caps, not Standard service cardinalities. Raw target/current ANY values receive structural TLV validation only, not property-schema validation. Python exposes the three audit sends and query response as caller-supplied/pre-encoded byte escape hatches. AuditNotification ingestion, authorization, transport-source provenance, rate limiting, replay/merge policy, failures-only queries, wrap-safe continuation, and Audit BIBB claims remain unsupported or deferred."
   },
   {
    "id": "BACNET-15-ARRAY-INDEX-GATING",

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -993,9 +993,12 @@ raw = await client.audit_log_query(
 ```
 
 These three methods are generic outbound byte paths. They do not validate the
-payload, provide structured Python audit models, or imply audit-service
-execution by the bundled server; its audit notification and query handlers
-remain unsupported.
+payload or provide structured Python audit models. A bundled server with an
+explicitly persisted Audit Log object can execute the raw AuditLogQuery payload
+against its retained in-memory records and return a raw typed ACK payload. Its
+confirmed and unconfirmed AuditNotification receivers remain unsupported, and
+query authorization, ingestion, and replay policy remain application/follow-up
+work.
 
 ---
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -930,6 +930,7 @@ The server automatically dispatches:
 - GetAlarmSummary, GetEnrollmentSummary
 - ConfirmedTextMessage
 - LifeSafetyOperation (authorized silence/unsilence; built-in reset is unsupported)
+- AuditLogQuery (retained records; no built-in ingestion, authorization, or failures-only mode)
 - ReadRange
 - AtomicReadFile, AtomicWriteFile
 - AddListElement, RemoveListElement

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -233,8 +233,8 @@ use bacnet_services::vt::{VtOpenRequest, VtCloseRequest, VtDataRequest};
 
 ```rust
 use bacnet_services::audit::{
-    AuditLogQueryRequest, AuditNotificationRequest, AuditPropertyReference,
-    BACnetAuditLogQueryParameters, BACnetAuditNotification,
+    AuditLogQueryAck, AuditLogQueryRequest, AuditNotificationRequest,
+    AuditPropertyReference, BACnetAuditLogQueryParameters, BACnetAuditNotification,
 };
 ```
 
@@ -524,7 +524,7 @@ let obj = db.get_mut(&oid);            // Option<&mut Box<dyn BACnetObject>>
 | `TrendLogObject` | `::new(instance, name, buffer_size)` |
 | `TrendLogMultipleObject` | `::new(instance, name, buffer_size)` |
 | `EventLogObject` | `::new(instance, name, buffer_size)` |
-| `AuditLogObject` | `::new(instance, name, buffer_size)` |
+| `AuditLogObject` | `::new(instance, name, buffer_size, persistence)` |
 | `AuditReporterObject` | `::new(instance, name)` |
 
 #### Building Control (7)
@@ -808,7 +808,9 @@ let raw = client.vt_data(&mac, session_id, &data, data_flag).await?;
 ### Audit Services
 
 ```rust
-use bacnet_services::audit::{AuditLogQueryRequest, AuditNotificationRequest};
+use bacnet_services::audit::{
+    AuditLogQueryAck, AuditLogQueryRequest, AuditNotificationRequest,
+};
 use bacnet_types::enums::{ConfirmedServiceChoice, UnconfirmedServiceChoice};
 use bytes::BytesMut;
 
@@ -835,11 +837,17 @@ let raw_ack = client.confirmed_request(
     ConfirmedServiceChoice::AUDIT_LOG_QUERY,
     &query_data,
 ).await?;
+let query_ack = AuditLogQueryAck::decode(&raw_ack)?;
 ```
 
-These are codec plus generic-client examples. `raw_ack` is not yet decoded by
-an AuditLogQuery acknowledgment model, and the bundled server does not execute
-the audit notification or query services. No PICS or BIBB support is implied.
+These remain generic-client examples. The bundled server executes
+AuditLogQuery against the retained in-memory snapshot of an explicitly backed
+`AuditLogObject`, returning newest-first typed records through the existing
+ComplexACK segmentation path. Its confirmed and unconfirmed AuditNotification
+receivers remain unsupported, so records still come from application-owned
+storage/producer policy. Query authorization, replay policy, failures-only
+filtering, and a wrap-safe 64-bit continuation are not provided. No Audit BIBB
+claim is implied.
 
 ---
 


### PR DESCRIPTION
## Summary

- add a defaulted, read-only, type-erased Audit Log query capability that returns an owned page from retained object state
- execute `AuditLogQuery` through the bundled server, construct the typed ACK after releasing the database read guard, and reuse the existing ComplexACK sizing/segmentation path
- align Device executed-service truth and add focused object, handler, runtime, routing, and service-bit tests
- narrowly correct stale Rust/Python API text and retain a qualified conformance-ledger row

## Standard and behavior

Grounded against the local licensed ASHRAE 135-2020 reference at §13.19, §19.6, and the Clause 21 Audit productions.

- supports both by-target and by-source alternatives, required identifier/address OR matching, optional wildcards, operations, priority, and the Boolean successful-actions filter
- traverses the retained ring newest-first by insertion order; a present Clause-21 `Unsigned32` start uses the literal numeric `< start` predicate
- scans the full retained buffer to compute `No_More_Items`, including count-zero and filtered-tail cases
- maps missing/non-Audit identifiers to `OBJECT / UNKNOWN_OBJECT` and an Audit-typed object without the capability to `SERVICES / OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED`
- decodes before object/capability access and never performs query-time persistence I/O or mutation

The existing qualified Clause 13/Clause 21 conflict remains unchanged: failures-only filtering and wrap-safe/full-64-bit continuation are not represented by the current request model.

## Validation

- `cargo test -p bacnet-services audit --locked` — 30 passed
- `cargo test -p bacnet-objects audit --locked` — 22 passed
- `cargo test -p bacnet-server audit_log_query --locked` — 5 passed
- focused Device/routing/services-supported tests — passed
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked` — passed with the existing warning baseline
- `cargo test --workspace --exclude rusty-bacnet --locked` — passed
- `cargo check -p rusty-bacnet --tests --locked` — passed
- `RUSTUP_TOOLCHAIN=1.93 bash .github/scripts/check-msrv.sh` — passed
- Rustfmt, conformance generation, file-size, no-secret, and diff-hygiene checks — passed

## Scope boundaries

This PR does not add AuditNotification ingestion, authorization/replay policy, producer policy, typed client/Python high-level APIs, failures-only filtering, modular cursor semantics, persistence redesign, Event Log integration, new segmentation behavior, or an Audit BIBB/full-support claim.

Base: `f427578fda6d341f0ee64028dfad8ee62a8df7b8`

Head: `e026860428484559a050e7c515c54582957ebd1e`

Refs #345
