### PR TITLE
feat(audit): receive confirmed audit notifications atomically

### DIFF
--- a/crates/bacnet-objects/src/audit.rs
+++ b/crates/bacnet-objects/src/audit.rs
@@ -16,7 +16,9 @@ use crate::clock::ClockReader;
 use crate::common::read_property_list_property;
 use crate::traits::{BACnetObject, WritePropertyRollback};
 
+mod notification;
 mod persistence;
+pub use notification::AuditLogNotificationSink;
 use persistence::{validate_record, validate_snapshot};
 pub use persistence::{
     AuditLogPersistence, AuditLogSnapshot, FileAuditLogPersistence, MAX_AUDIT_RECORDS,
@@ -515,6 +517,12 @@ impl BACnetObject for AuditLogObject {
         Some(self)
     }
 
+    fn audit_log_notification_sink_internal(
+        &mut self,
+    ) -> Option<&mut dyn AuditLogNotificationSink> {
+        Some(self)
+    }
+
     fn capture_write_property_rollback(
         &mut self,
         property: PropertyIdentifier,
@@ -662,3 +670,7 @@ mod tests;
 #[cfg(test)]
 #[path = "audit/query_tests.rs"]
 mod query_tests;
+
+#[cfg(test)]
+#[path = "audit/notification_tests.rs"]
+mod notification_tests;

--- a/crates/bacnet-objects/src/audit/notification.rs
+++ b/crates/bacnet-objects/src/audit/notification.rs
@@ -1,0 +1,274 @@
+use bacnet_types::primitives::{BACnetTimeStamp, Date, Time};
+
+use super::*;
+
+/// Mutable, object-owned receiver for one authorized Audit notification batch.
+///
+/// Implementations must commit the complete prospective state before exposing
+/// any in-memory change. The server uses this type-erased channel instead of
+/// downcasting an Audit Log object or taking ownership of its persistence.
+pub trait AuditLogNotificationSink: Send + Sync {
+    /// Whether this sink currently accepts Audit notifications.
+    fn notification_logging_enabled(&self) -> bool;
+
+    /// Merge or create every notification in wire order as one durable batch.
+    ///
+    /// `apdu_timeout_ms` is the local Device object's configured APDU_Timeout.
+    /// It supplies the Clause 12.64 complementary timestamp window.
+    fn store_notifications(
+        &mut self,
+        notifications: &[BACnetAuditNotification],
+        apdu_timeout_ms: u32,
+    ) -> Result<(), Error>;
+}
+
+impl AuditLogObject {
+    fn store_notification_batch(
+        &mut self,
+        notifications: &[BACnetAuditNotification],
+        apdu_timeout_ms: u32,
+    ) -> Result<(), Error> {
+        if !self.log_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::SERVICES.to_raw() as u32,
+                code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+            });
+        }
+        if notifications.is_empty() {
+            return Err(Error::OutOfRange(
+                "Audit notification batch must not be empty".into(),
+            ));
+        }
+
+        let mut prospective = self.snapshot_for_next_generation()?;
+        let mut changed = false;
+        for notification in notifications {
+            if let Some(index) = matching_record_index(
+                &prospective.records,
+                notification,
+                u64::from(apdu_timeout_ms) * 2,
+            ) {
+                let BACnetAuditLogDatum::AuditNotification(stored) =
+                    &mut prospective.records[index].record.datum
+                else {
+                    unreachable!("matching_record_index only returns Audit notifications");
+                };
+                if stored.source_timestamp.is_some() && stored.target_timestamp.is_some() {
+                    continue;
+                }
+                merge_notification(stored, notification);
+                validate_record(&prospective.records[index].record)?;
+                changed = true;
+            } else {
+                let timestamp = self.valid_timestamp()?;
+                let record = BACnetAuditLogRecord {
+                    timestamp,
+                    datum: BACnetAuditLogDatum::AuditNotification(notification.clone()),
+                };
+                validate_record(&record)?;
+                append_record(&mut prospective, record);
+                changed = true;
+            }
+        }
+        if changed {
+            self.commit_and_apply(prospective)?;
+        }
+        Ok(())
+    }
+}
+
+impl AuditLogNotificationSink for AuditLogObject {
+    fn notification_logging_enabled(&self) -> bool {
+        self.log_enable
+    }
+
+    fn store_notifications(
+        &mut self,
+        notifications: &[BACnetAuditNotification],
+        apdu_timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.store_notification_batch(notifications, apdu_timeout_ms)
+    }
+}
+
+fn matching_record_index(
+    records: &[BACnetAuditLogRecordResult],
+    incoming: &BACnetAuditNotification,
+    window_ms: u64,
+) -> Option<usize> {
+    records.iter().rposition(|result| {
+        let BACnetAuditLogDatum::AuditNotification(stored) = &result.record.datum else {
+            return false;
+        };
+        notification_identity_matches(stored, incoming)
+            && complementary_timestamps_match(stored, incoming, window_ms)
+    })
+}
+
+fn notification_identity_matches(
+    stored: &BACnetAuditNotification,
+    incoming: &BACnetAuditNotification,
+) -> bool {
+    // Clause 12.64 names the exact equality coordinates. Its
+    // "operation-source" is the Clause 19.6 client actor represented by
+    // Source Device; Source Object is optional extra information. Likewise,
+    // Target Property is the BACnetPropertyReference parameter, distinct from
+    // the separately defined Target Object parameter. Source Object and Target
+    // Object are therefore merged when absent but are not match coordinates.
+    stored.source_device == incoming.source_device
+        && stored.operation == incoming.operation
+        && stored.invoke_id == incoming.invoke_id
+        && stored.target_device == incoming.target_device
+        && stored.target_property == incoming.target_property
+        && optional_agrees(&stored.source_user_id, &incoming.source_user_id)
+        && optional_agrees(&stored.source_user_role, &incoming.source_user_role)
+        && optional_agrees(&stored.target_value, &incoming.target_value)
+}
+
+fn optional_agrees<T: PartialEq>(left: &Option<T>, right: &Option<T>) -> bool {
+    match (left, right) {
+        (Some(left), Some(right)) => left == right,
+        _ => true,
+    }
+}
+
+fn complementary_timestamps_match(
+    stored: &BACnetAuditNotification,
+    incoming: &BACnetAuditNotification,
+    window_ms: u64,
+) -> bool {
+    match (
+        stored.source_timestamp.as_ref(),
+        incoming.target_timestamp.as_ref(),
+    ) {
+        (Some(left), Some(right)) if timestamps_within(left, right, window_ms) => true,
+        _ => matches!(
+            (
+                stored.target_timestamp.as_ref(),
+                incoming.source_timestamp.as_ref()
+            ),
+            (Some(left), Some(right)) if timestamps_within(left, right, window_ms)
+        ),
+    }
+}
+
+/// Compare like timestamp variants only. DateTime uses an absolute civil-time
+/// distance, Time uses the shortest circular time-of-day distance (so reports
+/// can straddle midnight), and SequenceNumber has no duration scale and must
+/// therefore be equal. Mixed variants do not match.
+fn timestamps_within(left: &BACnetTimeStamp, right: &BACnetTimeStamp, window_ms: u64) -> bool {
+    let window_centiseconds = window_ms / 10;
+    match (left, right) {
+        (BACnetTimeStamp::Time(left), BACnetTimeStamp::Time(right)) => {
+            let (Some(left), Some(right)) = (time_centiseconds(*left), time_centiseconds(*right))
+            else {
+                return false;
+            };
+            let distance = left.abs_diff(right);
+            distance.min(8_640_000 - distance) <= window_centiseconds
+        }
+        (
+            BACnetTimeStamp::DateTime {
+                date: left_date,
+                time: left_time,
+            },
+            BACnetTimeStamp::DateTime {
+                date: right_date,
+                time: right_time,
+            },
+        ) => {
+            let (Some(left), Some(right)) = (
+                datetime_centiseconds(*left_date, *left_time),
+                datetime_centiseconds(*right_date, *right_time),
+            ) else {
+                return false;
+            };
+            left.abs_diff(right) <= window_centiseconds
+        }
+        (BACnetTimeStamp::SequenceNumber(left), BACnetTimeStamp::SequenceNumber(right)) => {
+            left == right
+        }
+        _ => false,
+    }
+}
+
+fn time_centiseconds(time: Time) -> Option<u64> {
+    (time.hour <= 23 && time.minute <= 59 && time.second <= 59 && time.hundredths <= 99).then(
+        || {
+            (((u64::from(time.hour) * 60 + u64::from(time.minute)) * 60 + u64::from(time.second))
+                * 100)
+                + u64::from(time.hundredths)
+        },
+    )
+}
+
+fn datetime_centiseconds(date: Date, time: Time) -> Option<u64> {
+    let year = date.actual_year()?;
+    if !(1..=12).contains(&date.month) || !(1..=7).contains(&date.day_of_week) {
+        return None;
+    }
+    let max_day = days_in_month(year, date.month);
+    if date.day == 0 || date.day > max_day {
+        return None;
+    }
+    let days = days_from_civil(i64::from(year), i64::from(date.month), i64::from(date.day));
+    let expected_day_of_week = (days + 3).rem_euclid(7) as u8 + 1;
+    if date.day_of_week != expected_day_of_week {
+        return None;
+    }
+    let time = time_centiseconds(time)?;
+    let shifted_days = days.checked_add(719_468)?;
+    u64::try_from(shifted_days)
+        .ok()?
+        .checked_mul(8_640_000)?
+        .checked_add(time)
+}
+
+fn days_in_month(year: u16, month: u8) -> u8 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400)) => {
+            29
+        }
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year = year - i64::from(month <= 2);
+    let era = year.div_euclid(400);
+    let year_of_era = year - era * 400;
+    let month_prime = month + if month > 2 { -3 } else { 9 };
+    let day_of_year = (153 * month_prime + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146_097 + day_of_era - 719_468
+}
+
+fn merge_notification(stored: &mut BACnetAuditNotification, incoming: &BACnetAuditNotification) {
+    let incoming_is_target_report = incoming.target_timestamp.is_some();
+    fill_missing(&mut stored.source_timestamp, &incoming.source_timestamp);
+    fill_missing(&mut stored.target_timestamp, &incoming.target_timestamp);
+    fill_missing(&mut stored.source_object, &incoming.source_object);
+    fill_missing(&mut stored.source_comment, &incoming.source_comment);
+    fill_missing(&mut stored.target_comment, &incoming.target_comment);
+    fill_missing(&mut stored.source_user_id, &incoming.source_user_id);
+    fill_missing(&mut stored.source_user_role, &incoming.source_user_role);
+    fill_missing(&mut stored.target_object, &incoming.target_object);
+    fill_missing(&mut stored.target_property, &incoming.target_property);
+    fill_missing(&mut stored.target_priority, &incoming.target_priority);
+    fill_missing(&mut stored.target_value, &incoming.target_value);
+    fill_missing(&mut stored.result, &incoming.result);
+    if incoming_is_target_report && incoming.current_value.is_some() {
+        stored.current_value.clone_from(&incoming.current_value);
+    } else {
+        fill_missing(&mut stored.current_value, &incoming.current_value);
+    }
+}
+
+fn fill_missing<T: Clone>(stored: &mut Option<T>, incoming: &Option<T>) {
+    if stored.is_none() {
+        stored.clone_from(incoming);
+    }
+}

--- a/crates/bacnet-objects/src/audit/notification_tests.rs
+++ b/crates/bacnet-objects/src/audit/notification_tests.rs
@@ -1,0 +1,311 @@
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use bacnet_types::constructed::{
+    AuditPropertyReference, BACnetAuditLogDatum, BACnetAuditNotification, BACnetRecipient,
+};
+use bacnet_types::enums::{AuditOperation, ObjectType, PropertyIdentifier};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{BACnetTimeStamp, Date, ObjectIdentifier, Time};
+
+use crate::clock::{ClockFrame, ClockReader};
+use crate::traits::BACnetObject;
+
+use super::{AuditLogNotificationSink, AuditLogObject, AuditLogPersistence, AuditLogSnapshot};
+
+#[derive(Default)]
+struct MemoryPersistence {
+    snapshot: Mutex<Option<AuditLogSnapshot>>,
+    commits: AtomicUsize,
+    fail: AtomicBool,
+}
+
+impl AuditLogPersistence for MemoryPersistence {
+    fn load(&self, _expected_object: ObjectIdentifier) -> Result<Option<AuditLogSnapshot>, Error> {
+        Ok(self.snapshot.lock().unwrap().clone())
+    }
+
+    fn commit(&self, snapshot: &AuditLogSnapshot) -> Result<(), Error> {
+        if self.fail.load(Ordering::Acquire) {
+            return Err(Error::Transport(std::io::Error::other(
+                "injected commit failure",
+            )));
+        }
+        *self.snapshot.lock().unwrap() = Some(snapshot.clone());
+        self.commits.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+}
+
+struct FixedClock(Option<ClockFrame>);
+
+impl ClockReader for FixedClock {
+    fn read_clock(&self) -> Option<ClockFrame> {
+        self.0
+    }
+}
+
+fn oid(object_type: ObjectType, instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(object_type, instance).unwrap()
+}
+
+fn date() -> Date {
+    Date {
+        year: 124,
+        month: 2,
+        day: 29,
+        day_of_week: 4,
+    }
+}
+
+fn time(second: u8) -> Time {
+    Time {
+        hour: 12,
+        minute: 0,
+        second,
+        hundredths: 0,
+    }
+}
+
+fn clock() -> Arc<dyn ClockReader> {
+    Arc::new(FixedClock(Some(ClockFrame {
+        local_date: date(),
+        local_time: time(30),
+        utc_offset: 0,
+        daylight_savings_status: false,
+    })))
+}
+
+fn invalid_clock_frame() -> ClockFrame {
+    ClockFrame {
+        local_date: Date {
+            year: 124,
+            month: 2,
+            day: 30,
+            day_of_week: 5,
+        },
+        local_time: time(30),
+        utc_offset: 0,
+        daylight_savings_status: false,
+    }
+}
+
+fn notification(
+    source: Option<BACnetTimeStamp>,
+    target: Option<BACnetTimeStamp>,
+) -> BACnetAuditNotification {
+    BACnetAuditNotification {
+        source_timestamp: source,
+        target_timestamp: target,
+        source_device: BACnetRecipient::Device(oid(ObjectType::DEVICE, 1)),
+        source_object: Some(oid(ObjectType::ANALOG_INPUT, 1)),
+        operation: AuditOperation::WRITE,
+        source_comment: None,
+        target_comment: None,
+        invoke_id: Some(7),
+        source_user_id: Some(9),
+        source_user_role: Some(2),
+        target_device: BACnetRecipient::Device(oid(ObjectType::DEVICE, 2)),
+        target_object: Some(oid(ObjectType::ANALOG_VALUE, 3)),
+        target_property: Some(AuditPropertyReference {
+            property_identifier: PropertyIdentifier::PRESENT_VALUE,
+            property_array_index: None,
+        }),
+        target_priority: Some(8),
+        target_value: Some(vec![0x21, 0x05]),
+        current_value: None,
+        result: None,
+    }
+}
+
+fn log(capacity: u32) -> (AuditLogObject, Arc<MemoryPersistence>) {
+    let persistence = Arc::new(MemoryPersistence::default());
+    let mut log = AuditLogObject::new(1, "audit", capacity, persistence.clone()).unwrap();
+    log.bind_clock_internal(Some(clock()));
+    (log, persistence)
+}
+
+#[test]
+fn complementary_batch_merges_once_and_target_current_value_wins() {
+    let (mut log, persistence) = log(10);
+    let mut source = notification(Some(BACnetTimeStamp::Time(time(0))), None);
+    source.current_value = Some(vec![0x21, 0x01]);
+    let mut target = notification(None, Some(BACnetTimeStamp::Time(time(4))));
+    target.current_value = Some(vec![0x21, 0x02]);
+
+    log.store_notifications(&[source, target], 2_000).unwrap();
+
+    assert_eq!(persistence.commits.load(Ordering::Acquire), 2); // initialization + batch
+    assert_eq!(log.total_record_count(), 1);
+    assert_eq!(log.records().len(), 1);
+    let result = log.records().front().unwrap();
+    assert_eq!(result.sequence_number, 1);
+    assert_eq!(result.record.timestamp, (date(), time(30)));
+    let BACnetAuditLogDatum::AuditNotification(stored) = &result.record.datum else {
+        panic!("expected notification")
+    };
+    assert!(stored.source_timestamp.is_some());
+    assert!(stored.target_timestamp.is_some());
+    assert_eq!(stored.current_value, Some(vec![0x21, 0x02]));
+}
+
+#[test]
+fn completed_match_is_dropped_and_merge_preserves_record_identity() {
+    let (mut log, persistence) = log(10);
+    let source = notification(Some(BACnetTimeStamp::Time(time(0))), None);
+    log.store_notifications(&[source], 2_000).unwrap();
+    let identity = log.records().front().unwrap().clone();
+    let target = notification(None, Some(BACnetTimeStamp::Time(time(3))));
+    log.store_notifications(std::slice::from_ref(&target), 2_000)
+        .unwrap();
+    assert_eq!(log.total_record_count(), 1);
+    assert_eq!(
+        log.records().front().unwrap().sequence_number,
+        identity.sequence_number
+    );
+    assert_eq!(
+        log.records().front().unwrap().record.timestamp,
+        identity.record.timestamp
+    );
+    let generation = log.generation();
+    let commits = persistence.commits.load(Ordering::Acquire);
+
+    log.store_notifications(&[target], 2_000).unwrap();
+    assert_eq!(log.generation(), generation);
+    assert_eq!(persistence.commits.load(Ordering::Acquire), commits);
+    assert_eq!(log.total_record_count(), 1);
+}
+
+#[test]
+fn match_identity_excludes_the_separate_source_and_target_object_parameters() {
+    let (mut log, _) = log(10);
+    let source = notification(Some(BACnetTimeStamp::Time(time(0))), None);
+    let source_object = source.source_object;
+    let target_object = source.target_object;
+    let mut target = notification(None, Some(BACnetTimeStamp::Time(time(2))));
+    target.source_object = Some(oid(ObjectType::ANALOG_INPUT, 99));
+    target.target_object = Some(oid(ObjectType::ANALOG_VALUE, 99));
+
+    log.store_notifications(&[source, target], 2_000).unwrap();
+
+    assert_eq!(log.total_record_count(), 1);
+    let BACnetAuditLogDatum::AuditNotification(stored) =
+        &log.records().front().unwrap().record.datum
+    else {
+        panic!("expected notification")
+    };
+    assert_eq!(stored.source_object, source_object);
+    assert_eq!(stored.target_object, target_object);
+    assert!(stored.source_timestamp.is_some());
+    assert!(stored.target_timestamp.is_some());
+}
+
+#[test]
+fn timestamp_variants_use_configured_window_and_never_cross_compare() {
+    let cases = [
+        (
+            BACnetTimeStamp::DateTime {
+                date: date(),
+                time: time(0),
+            },
+            BACnetTimeStamp::DateTime {
+                date: date(),
+                time: time(5),
+            },
+            2_500,
+            1,
+        ),
+        (
+            BACnetTimeStamp::SequenceNumber(7),
+            BACnetTimeStamp::SequenceNumber(7),
+            1,
+            1,
+        ),
+        (
+            BACnetTimeStamp::SequenceNumber(7),
+            BACnetTimeStamp::SequenceNumber(8),
+            60_000,
+            2,
+        ),
+        (
+            BACnetTimeStamp::Time(time(0)),
+            BACnetTimeStamp::SequenceNumber(0),
+            60_000,
+            2,
+        ),
+    ];
+    for (source_timestamp, target_timestamp, timeout, expected_count) in cases {
+        let (mut log, _) = log(10);
+        log.store_notifications(
+            &[
+                notification(Some(source_timestamp), None),
+                notification(None, Some(target_timestamp)),
+            ],
+            timeout,
+        )
+        .unwrap();
+        assert_eq!(log.total_record_count(), expected_count);
+    }
+}
+
+#[test]
+fn commit_and_clock_failures_leave_memory_and_durable_snapshot_unchanged() {
+    let (mut log, persistence) = log(10);
+    let before = persistence.snapshot.lock().unwrap().clone().unwrap();
+    persistence.fail.store(true, Ordering::Release);
+    assert!(log
+        .store_notifications(
+            &[notification(Some(BACnetTimeStamp::Time(time(0))), None)],
+            2_000
+        )
+        .is_err());
+    assert_eq!(log.total_record_count(), 0);
+    assert_eq!(*persistence.snapshot.lock().unwrap(), Some(before));
+
+    persistence.fail.store(false, Ordering::Release);
+    for frame in [None, Some(invalid_clock_frame())] {
+        log.bind_clock_internal(Some(Arc::new(FixedClock(frame))));
+        let durable = persistence.snapshot.lock().unwrap().clone();
+        let error = log
+            .store_notifications(
+                &[notification(Some(BACnetTimeStamp::Time(time(0))), None)],
+                2_000,
+            )
+            .unwrap_err();
+        assert!(matches!(error, Error::Protocol { class, code }
+            if class == bacnet_types::enums::ErrorClass::DEVICE.to_raw() as u32
+                && code == bacnet_types::enums::ErrorCode::OPERATIONAL_PROBLEM.to_raw() as u32));
+        assert_eq!(log.total_record_count(), 0);
+        assert_eq!(*persistence.snapshot.lock().unwrap(), durable);
+    }
+}
+
+#[test]
+fn disabled_sink_denies_before_clock_or_persistence_change() {
+    let (mut log, persistence) = log(10);
+    log.write_property(
+        bacnet_types::enums::PropertyIdentifier::LOG_ENABLE,
+        None,
+        bacnet_types::primitives::PropertyValue::Boolean(false),
+        None,
+    )
+    .unwrap();
+    let generation = log.generation();
+    let error = log
+        .store_notifications(&[notification(None, None)], 2_000)
+        .unwrap_err();
+    assert!(matches!(error, Error::Protocol { class, code }
+        if class == bacnet_types::enums::ErrorClass::SERVICES.to_raw() as u32
+            && code == bacnet_types::enums::ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32));
+    assert_eq!(log.generation(), generation);
+    assert_eq!(
+        persistence
+            .snapshot
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .generation,
+        generation
+    );
+}

--- a/crates/bacnet-objects/src/device/mod.rs
+++ b/crates/bacnet-objects/src/device/mod.rs
@@ -58,6 +58,7 @@ pub const EXECUTED_SERVICES: &[ServiceSupported] = &[
     ServiceSupported::SUBSCRIBE_COV_PROPERTY,
     ServiceSupported::GET_EVENT_INFORMATION,
     ServiceSupported::SUBSCRIBE_COV_PROPERTY_MULTIPLE,
+    ServiceSupported::CONFIRMED_AUDIT_NOTIFICATION,
     ServiceSupported::AUDIT_LOG_QUERY,
 ];
 

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -11,7 +11,7 @@ use bacnet_types::enums::{
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
-use crate::audit::AuditLogStorage;
+use crate::audit::{AuditLogNotificationSink, AuditLogStorage};
 use crate::clock::ClockReader;
 use crate::event::{EventTransitionCommit, EventTransitionCommitError, TransitionOutcome};
 use crate::event_enrollment::{
@@ -545,6 +545,16 @@ pub trait BACnetObject: Send + Sync {
     /// does not opt in is reported as SERVICES /
     /// OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.
     fn audit_log_storage_internal(&self) -> Option<&dyn AuditLogStorage> {
+        None
+    }
+
+    /// Mutably borrow this object's Audit notification receiver capability.
+    ///
+    /// The default opts out. Implementations own their persistence transaction
+    /// and must leave memory unchanged when the batch cannot be committed.
+    fn audit_log_notification_sink_internal(
+        &mut self,
+    ) -> Option<&mut dyn AuditLogNotificationSink> {
         None
     }
 

--- a/crates/bacnet-server/src/audit_notification.rs
+++ b/crates/bacnet-server/src/audit_notification.rs
@@ -1,0 +1,365 @@
+//! Receiver policy and bounded duplicate detection for ConfirmedAuditNotification.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use bacnet_encoding::npdu::NpduAddress;
+use bacnet_services::audit::AuditNotificationRequest;
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+use bytes::Bytes;
+
+/// Local maximum accepted ConfirmedAuditNotification service payload.
+pub const MAX_AUDIT_NOTIFICATION_BYTES: usize = 64 * 1024;
+/// Local maximum number of notifications in one accepted request.
+pub const MAX_AUDIT_NOTIFICATIONS: usize = 256;
+const DUPLICATE_WINDOW: Duration = Duration::from_secs(60);
+const MAX_DUPLICATE_ENTRIES: usize = 256;
+
+/// Transport provenance and decoded content supplied to the Audit authorizer.
+///
+/// The source/target identities inside `request` are peer-reported audit data,
+/// not authenticated transport provenance. Policy should use `source_network`
+/// for a usable routed origin and `source_mac` for the immediate data-link peer.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuditNotificationAuthorizationContext {
+    /// Immediate data-link peer (normally a router for routed traffic).
+    pub source_mac: MacAddr,
+    /// Originating NPDU source when one was present.
+    pub source_network: Option<NpduAddress>,
+    /// Outer Confirmed-Request invoke identifier.
+    pub invoke_id: u8,
+    /// Explicitly configured local Audit Log sink.
+    pub audit_log_sink: ObjectIdentifier,
+    /// Decoded peer-reported notification list, preserved verbatim.
+    pub request: AuditNotificationRequest,
+}
+
+/// Fast, nonblocking authorization callback for ConfirmedAuditNotification.
+///
+/// Absence, `false`, or a panic denies the request before storage mutation.
+pub type AuditNotificationAuthorizer =
+    Arc<dyn Fn(&AuditNotificationAuthorizationContext) -> bool + Send + Sync>;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum CanonicalPeer {
+    Direct(MacAddr),
+    Routed(NpduAddress),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum EntryState {
+    Pending,
+    Completed,
+}
+
+struct Entry {
+    id: u64,
+    peer: CanonicalPeer,
+    invoke_id: u8,
+    request: Bytes,
+    expires_at: Option<Instant>,
+    state: EntryState,
+}
+
+#[derive(Default)]
+struct TrackerState {
+    next_id: u64,
+    entries: VecDeque<Entry>,
+}
+
+/// Bounded process-local exact-request duplicate tracker.
+///
+/// This tracker retains request bytes for collision-free equality. It never
+/// caches or replays responses; detected pending and completed duplicates are
+/// silently discarded. Expiry or restart permits normal service again.
+#[derive(Default)]
+pub(crate) struct AuditNotificationTracker {
+    state: Mutex<TrackerState>,
+}
+
+pub(crate) enum DuplicateAdmission {
+    Duplicate,
+    New(PendingAuditNotification),
+}
+
+pub(crate) struct PendingAuditNotification {
+    tracker: Arc<AuditNotificationTracker>,
+    id: Option<u64>,
+    completed: bool,
+}
+
+impl AuditNotificationTracker {
+    pub(crate) fn begin(
+        self: &Arc<Self>,
+        source_mac: &[u8],
+        source_network: Option<&NpduAddress>,
+        invoke_id: u8,
+        request: Bytes,
+    ) -> DuplicateAdmission {
+        self.begin_at(
+            source_mac,
+            source_network,
+            invoke_id,
+            request,
+            Instant::now(),
+        )
+    }
+
+    fn begin_at(
+        self: &Arc<Self>,
+        source_mac: &[u8],
+        source_network: Option<&NpduAddress>,
+        invoke_id: u8,
+        request: Bytes,
+        now: Instant,
+    ) -> DuplicateAdmission {
+        let peer = canonical_peer(source_mac, source_network);
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.entries.retain(|entry| match entry.state {
+            EntryState::Pending => true,
+            EntryState::Completed => entry.expires_at.is_some_and(|expires_at| expires_at > now),
+        });
+        if state.entries.iter().any(|entry| {
+            entry.peer == peer && entry.invoke_id == invoke_id && entry.request == request
+        }) {
+            return DuplicateAdmission::Duplicate;
+        }
+
+        if state.entries.len() >= MAX_DUPLICATE_ENTRIES {
+            if let Some(index) = state
+                .entries
+                .iter()
+                .position(|entry| entry.state == EntryState::Completed)
+            {
+                state.entries.remove(index);
+            } else {
+                // If every bounded slot is pending, this request cannot be
+                // distinguished safely. Clause 5 permits servicing normally.
+                return DuplicateAdmission::New(PendingAuditNotification {
+                    tracker: Arc::clone(self),
+                    id: None,
+                    completed: false,
+                });
+            }
+        }
+
+        let id = state.next_id;
+        state.next_id = state.next_id.wrapping_add(1);
+        state.entries.push_back(Entry {
+            id,
+            peer,
+            invoke_id,
+            request,
+            expires_at: None,
+            state: EntryState::Pending,
+        });
+        DuplicateAdmission::New(PendingAuditNotification {
+            tracker: Arc::clone(self),
+            id: Some(id),
+            completed: false,
+        })
+    }
+}
+
+impl PendingAuditNotification {
+    /// Mark the request completed, regardless of service success or failure.
+    /// A byte-exact retransmission is then still a detected duplicate.
+    pub(crate) fn complete(self) {
+        self.complete_at(Instant::now());
+    }
+
+    fn complete_at(mut self, now: Instant) {
+        if let Some(id) = self.id {
+            let mut state = self
+                .tracker
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some(entry) = state.entries.iter_mut().find(|entry| entry.id == id) {
+                entry.state = EntryState::Completed;
+                entry.expires_at = Some(now + DUPLICATE_WINDOW);
+            }
+        }
+        self.completed = true;
+    }
+}
+
+impl Drop for PendingAuditNotification {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        if let Some(id) = self.id {
+            let mut state = self
+                .tracker
+                .state
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            state.entries.retain(|entry| entry.id != id);
+        }
+    }
+}
+
+fn canonical_peer(source_mac: &[u8], source_network: Option<&NpduAddress>) -> CanonicalPeer {
+    source_network
+        .filter(|source| (1..=0xfffe).contains(&source.network) && !source.mac_address.is_empty())
+        .cloned()
+        .map(CanonicalPeer::Routed)
+        .unwrap_or_else(|| CanonicalPeer::Direct(MacAddr::from_slice(source_mac)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn routed(network: u16, mac: &[u8]) -> NpduAddress {
+        NpduAddress {
+            network,
+            mac_address: MacAddr::from_slice(mac),
+        }
+    }
+
+    #[test]
+    fn exact_pending_completed_and_invoke_reuse_are_distinguished() {
+        let tracker = Arc::new(AuditNotificationTracker::default());
+        let now = Instant::now();
+        let pending = match tracker.begin_at(b"a", None, 1, Bytes::from_static(b"one"), now) {
+            DuplicateAdmission::New(pending) => pending,
+            DuplicateAdmission::Duplicate => panic!("first request was duplicate"),
+        };
+        assert!(matches!(
+            tracker.begin_at(b"a", None, 1, Bytes::from_static(b"one"), now),
+            DuplicateAdmission::Duplicate
+        ));
+        pending.complete();
+        assert!(matches!(
+            tracker.begin_at(b"a", None, 1, Bytes::from_static(b"one"), now),
+            DuplicateAdmission::Duplicate
+        ));
+        assert!(matches!(
+            tracker.begin_at(b"a", None, 1, Bytes::from_static(b"two"), now),
+            DuplicateAdmission::New(_)
+        ));
+    }
+
+    #[test]
+    fn expiry_capacity_and_canonical_routed_peer_are_bounded() {
+        let tracker = Arc::new(AuditNotificationTracker::default());
+        let now = Instant::now();
+        let first = match tracker.begin_at(
+            b"router-a",
+            Some(&routed(5, b"origin")),
+            1,
+            Bytes::from_static(b"x"),
+            now,
+        ) {
+            DuplicateAdmission::New(pending) => pending,
+            DuplicateAdmission::Duplicate => unreachable!(),
+        };
+        first.complete_at(now);
+        assert!(matches!(
+            tracker.begin_at(
+                b"router-b",
+                Some(&routed(5, b"origin")),
+                1,
+                Bytes::from_static(b"x"),
+                now
+            ),
+            DuplicateAdmission::Duplicate
+        ));
+        assert!(matches!(
+            tracker.begin_at(
+                b"router-b",
+                Some(&routed(6, b"origin")),
+                1,
+                Bytes::from_static(b"x"),
+                now
+            ),
+            DuplicateAdmission::New(_)
+        ));
+        assert!(matches!(
+            tracker.begin_at(
+                b"router-a",
+                Some(&routed(5, b"origin")),
+                1,
+                Bytes::from_static(b"x"),
+                now + DUPLICATE_WINDOW
+            ),
+            DuplicateAdmission::New(_)
+        ));
+
+        let tracker = Arc::new(AuditNotificationTracker::default());
+        for invoke in 0..MAX_DUPLICATE_ENTRIES {
+            let pending = match tracker.begin_at(
+                b"a",
+                None,
+                invoke as u8,
+                Bytes::from(vec![invoke as u8, (invoke >> 8) as u8]),
+                now,
+            ) {
+                DuplicateAdmission::New(pending) => pending,
+                DuplicateAdmission::Duplicate => unreachable!(),
+            };
+            pending.complete_at(now);
+        }
+        let newest = match tracker.begin_at(b"a", None, 1, Bytes::from_static(b"new"), now) {
+            DuplicateAdmission::New(pending) => pending,
+            DuplicateAdmission::Duplicate => unreachable!(),
+        };
+        newest.complete_at(now);
+        assert_eq!(
+            tracker.state.lock().unwrap().entries.len(),
+            MAX_DUPLICATE_ENTRIES
+        );
+    }
+
+    #[test]
+    fn pending_never_expires_and_completed_window_starts_at_completion() {
+        let tracker = Arc::new(AuditNotificationTracker::default());
+        let started_at = Instant::now();
+        let pending =
+            match tracker.begin_at(b"peer", None, 1, Bytes::from_static(b"request"), started_at) {
+                DuplicateAdmission::New(pending) => pending,
+                DuplicateAdmission::Duplicate => unreachable!(),
+            };
+
+        let completed_at = started_at + DUPLICATE_WINDOW + Duration::from_secs(30);
+        assert!(matches!(
+            tracker.begin_at(
+                b"peer",
+                None,
+                1,
+                Bytes::from_static(b"request"),
+                completed_at
+            ),
+            DuplicateAdmission::Duplicate
+        ));
+
+        pending.complete_at(completed_at);
+        assert!(matches!(
+            tracker.begin_at(
+                b"peer",
+                None,
+                1,
+                Bytes::from_static(b"request"),
+                completed_at + DUPLICATE_WINDOW - Duration::from_millis(1)
+            ),
+            DuplicateAdmission::Duplicate
+        ));
+        assert!(matches!(
+            tracker.begin_at(
+                b"peer",
+                None,
+                1,
+                Bytes::from_static(b"request"),
+                completed_at + DUPLICATE_WINDOW
+            ),
+            DuplicateAdmission::New(_)
+        ));
+    }
+}

--- a/crates/bacnet-server/src/handlers/audit_notification.rs
+++ b/crates/bacnet-server/src/handlers/audit_notification.rs
@@ -1,0 +1,74 @@
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_services::audit::AuditNotificationRequest;
+use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+
+/// Store one decoded and authorized notification batch in its explicit sink.
+///
+/// Persistence is synchronous under the database writer in this bounded
+/// receiver foundation. That limits availability to the configured backend's
+/// commit latency, but keeps the durable commit and memory apply atomic.
+pub fn handle_confirmed_audit_notification(
+    db: &mut ObjectDatabase,
+    sink: ObjectIdentifier,
+    request: &AuditNotificationRequest,
+) -> Result<(), Error> {
+    if sink.object_type() != ObjectType::AUDIT_LOG {
+        return Err(service_request_denied());
+    }
+    {
+        let object = db.get_mut(&sink).ok_or_else(service_request_denied)?;
+        let storage = object
+            .audit_log_notification_sink_internal()
+            .ok_or_else(service_request_denied)?;
+        if !storage.notification_logging_enabled() {
+            return Err(service_request_denied());
+        }
+    }
+    let apdu_timeout_ms = configured_apdu_timeout(db)?;
+    let object = db
+        .get_mut(&sink)
+        .expect("sink existence was checked before Device timeout lookup");
+    let storage = object
+        .audit_log_notification_sink_internal()
+        .expect("sink capability was checked before Device timeout lookup");
+    storage.store_notifications(&request.notifications, apdu_timeout_ms)
+}
+
+fn configured_apdu_timeout(db: &ObjectDatabase) -> Result<u32, Error> {
+    let devices: Vec<_> = db
+        .list_objects()
+        .into_iter()
+        .filter(|oid| oid.object_type() == ObjectType::DEVICE)
+        .collect();
+    let [device_oid] = devices.as_slice() else {
+        return Err(operational_problem());
+    };
+    let Some(device) = db.get(device_oid) else {
+        return Err(operational_problem());
+    };
+    let Ok(PropertyValue::Unsigned(timeout)) =
+        device.read_property(PropertyIdentifier::APDU_TIMEOUT, None)
+    else {
+        return Err(operational_problem());
+    };
+    u32::try_from(timeout)
+        .ok()
+        .filter(|timeout| *timeout != 0)
+        .ok_or_else(operational_problem)
+}
+
+fn service_request_denied() -> Error {
+    Error::Protocol {
+        class: ErrorClass::SERVICES.to_raw() as u32,
+        code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+    }
+}
+
+fn operational_problem() -> Error {
+    Error::Protocol {
+        class: ErrorClass::DEVICE.to_raw() as u32,
+        code: ErrorCode::OPERATIONAL_PROBLEM.to_raw() as u32,
+    }
+}

--- a/crates/bacnet-server/src/handlers/mod.rs
+++ b/crates/bacnet-server/src/handlers/mod.rs
@@ -37,6 +37,7 @@ use crate::cov::{CovNotificationKind, CovSubscription, CovSubscriptionTable};
 
 mod alarm_event;
 mod audit_log_query;
+mod audit_notification;
 mod cov;
 mod device_mgmt;
 mod file;
@@ -47,6 +48,7 @@ mod write_property;
 
 pub use alarm_event::*;
 pub use audit_log_query::*;
+pub use audit_notification::*;
 pub use cov::*;
 pub use device_mgmt::*;
 pub use file::*;

--- a/crates/bacnet-server/src/handlers/tests/read_rpm.rs
+++ b/crates/bacnet-server/src/handlers/tests/read_rpm.rs
@@ -582,8 +582,8 @@ fn read_property_serves_derived_services_supported() {
     // End-to-end pin for #192: the wire-level BitString a client receives for
     // Protocol_Services_Supported, through the real ReadProperty handler path.
     // Expected bytes derive from device::EXECUTED_SERVICES bits
-    // {0,3-12,14-17,19,20,31-39,41,42} packed MSB-first over the full production
-    // range (49 defined bits, 7 octets, 7 unused).
+    // {0,3-12,14-17,19,20,31-39,41,42,44} packed MSB-first over the full
+    // production range (49 defined bits, 7 octets, 7 unused).
     let db = make_db_with_device_and_ai();
     let oid = ObjectIdentifier::new(ObjectType::DEVICE, 1).unwrap();
 
@@ -605,7 +605,7 @@ fn read_property_serves_derived_services_supported() {
         val,
         bacnet_types::primitives::PropertyValue::BitString {
             unused_bits: 7,
-            data: vec![0x9F, 0xFB, 0xD8, 0x01, 0xFF, 0x44, 0x00],
+            data: vec![0x9F, 0xFB, 0xD8, 0x01, 0xFF, 0x4C, 0x00],
         }
     );
 
@@ -615,6 +615,7 @@ fn read_property_serves_derived_services_supported() {
     };
     let ss = bacnet_types::bitstring::ServicesSupported::from_bacnet(&data);
     assert!(ss.contains(bacnet_types::enums::ServiceSupported::WHO_IS));
+    assert!(ss.contains(bacnet_types::enums::ServiceSupported::CONFIRMED_AUDIT_NOTIFICATION));
     assert!(ss.contains(bacnet_types::enums::ServiceSupported::AUDIT_LOG_QUERY));
     assert!(!ss.contains(bacnet_types::enums::ServiceSupported::I_AM));
 }

--- a/crates/bacnet-server/src/lib.rs
+++ b/crates/bacnet-server/src/lib.rs
@@ -1,5 +1,6 @@
 //! BACnet server: APDU dispatch and service handlers.
 
+pub mod audit_notification;
 pub mod cov;
 pub mod event_enrollment;
 pub mod fault_detection;

--- a/crates/bacnet-server/src/server/audit_notification_tests.rs
+++ b/crates/bacnet-server/src/server/audit_notification_tests.rs
@@ -1,0 +1,538 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use bacnet_encoding::apdu::decode_apdu;
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_objects::audit::{AuditLogObject, AuditLogPersistence, AuditLogSnapshot};
+use bacnet_objects::clock::{ClockFrame, ClockReader};
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_services::audit::AuditNotificationRequest;
+use bacnet_types::constructed::{BACnetAuditNotification, BACnetRecipient};
+use bacnet_types::enums::{AuditOperation, ServiceSupported};
+use bacnet_types::primitives::{BACnetTimeStamp, Date, ObjectIdentifier, PropertyValue, Time};
+
+use super::*;
+
+#[derive(Default)]
+struct MemoryPersistence {
+    snapshot: StdMutex<Option<AuditLogSnapshot>>,
+    fail: AtomicBool,
+}
+
+impl AuditLogPersistence for MemoryPersistence {
+    fn load(&self, _expected_object: ObjectIdentifier) -> Result<Option<AuditLogSnapshot>, Error> {
+        Ok(self.snapshot.lock().unwrap().clone())
+    }
+
+    fn commit(&self, snapshot: &AuditLogSnapshot) -> Result<(), Error> {
+        if self.fail.load(Ordering::Acquire) {
+            return Err(Error::Transport(std::io::Error::other(
+                "injected persistence failure",
+            )));
+        }
+        *self.snapshot.lock().unwrap() = Some(snapshot.clone());
+        Ok(())
+    }
+}
+
+struct FixedClock;
+
+impl ClockReader for FixedClock {
+    fn read_clock(&self) -> Option<ClockFrame> {
+        Some(ClockFrame {
+            local_date: Date {
+                year: 124,
+                month: 2,
+                day: 29,
+                day_of_week: 4,
+            },
+            local_time: Time {
+                hour: 12,
+                minute: 0,
+                second: 30,
+                hundredths: 0,
+            },
+            utc_offset: 0,
+            daylight_savings_status: false,
+        })
+    }
+}
+
+fn oid(object_type: ObjectType, instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(object_type, instance).unwrap()
+}
+
+fn notification(operation: AuditOperation) -> BACnetAuditNotification {
+    BACnetAuditNotification {
+        source_timestamp: Some(BACnetTimeStamp::Time(Time {
+            hour: 12,
+            minute: 0,
+            second: 0,
+            hundredths: 0,
+        })),
+        target_timestamp: None,
+        // Deliberately conflicts with transport provenance. The server must
+        // preserve it as peer-reported payload, never rewrite or authenticate it.
+        source_device: BACnetRecipient::Device(oid(ObjectType::DEVICE, 999)),
+        source_object: None,
+        operation,
+        source_comment: None,
+        target_comment: None,
+        invoke_id: Some(200),
+        source_user_id: None,
+        source_user_role: None,
+        target_device: BACnetRecipient::Device(oid(ObjectType::DEVICE, 2)),
+        target_object: None,
+        target_property: None,
+        target_priority: None,
+        target_value: None,
+        current_value: None,
+        result: None,
+    }
+}
+
+fn request_bytes(notifications: Vec<BACnetAuditNotification>) -> Bytes {
+    let mut bytes = BytesMut::new();
+    AuditNotificationRequest { notifications }
+        .try_encode(&mut bytes)
+        .unwrap();
+    bytes.freeze()
+}
+
+fn database(
+    persistence: Arc<MemoryPersistence>,
+    sink_instance: u32,
+) -> Arc<RwLock<ObjectDatabase>> {
+    database_with_device(persistence, sink_instance, Some(DeviceConfig::default()))
+}
+
+fn database_with_device(
+    persistence: Arc<MemoryPersistence>,
+    sink_instance: u32,
+    device_config: Option<DeviceConfig>,
+) -> Arc<RwLock<ObjectDatabase>> {
+    let mut db = ObjectDatabase::new();
+    db.set_clock_reader(Some(Arc::new(FixedClock)));
+    if let Some(device_config) = device_config {
+        db.add(Box::new(DeviceObject::new(device_config).unwrap()))
+            .unwrap();
+    }
+    db.add(Box::new(
+        AuditLogObject::new(sink_instance, "audit", 16, persistence).unwrap(),
+    ))
+    .unwrap();
+    Arc::new(RwLock::new(db))
+}
+
+async fn dispatch(
+    db: &Arc<RwLock<ObjectDatabase>>,
+    config: &ServerConfig,
+    notification_transactions: &Arc<NotificationTransactions>,
+    invoke_id: u8,
+    source_mac: &[u8],
+    source_network: Option<NpduAddress>,
+    service_request: Bytes,
+) -> Result<Apdu, tokio::sync::oneshot::error::RecvError> {
+    let network = Arc::new(NetworkLayer::new(BipTransport::new(
+        Ipv4Addr::LOCALHOST,
+        0,
+        Ipv4Addr::BROADCAST,
+    )));
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let cov_in_flight = Arc::new(Semaphore::new(1));
+    let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+    let device_bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
+    let comm_state = Arc::new(AtomicU8::new(0));
+    let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
+    let confirmed = ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 1476,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::CONFIRMED_AUDIT_NOTIFICATION,
+        service_request,
+    };
+    let (tx, rx) = oneshot::channel();
+    BACnetServer::<BipTransport>::handle_confirmed_request(
+        db,
+        &network,
+        &cov_table,
+        &seg_ack_senders,
+        &seg_send_permits,
+        &cov_in_flight,
+        &server_tsm,
+        notification_transactions,
+        &device_bindings,
+        &comm_state,
+        &dcc_timer,
+        config,
+        source_mac,
+        source_network,
+        confirmed,
+        Some(tx),
+    )
+    .await;
+    rx.await
+        .map(|bytes| decode_apdu(decode_npdu(bytes).unwrap().payload).unwrap())
+}
+
+async fn count(db: &Arc<RwLock<ObjectDatabase>>, sink: ObjectIdentifier) -> (u64, u64) {
+    let db = db.read().await;
+    let object = db.get(&sink).unwrap();
+    let PropertyValue::Unsigned(records) = object
+        .read_property(PropertyIdentifier::RECORD_COUNT, None)
+        .unwrap()
+    else {
+        unreachable!()
+    };
+    let PropertyValue::Unsigned(total) = object
+        .read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+        .unwrap()
+    else {
+        unreachable!()
+    };
+    (records, total)
+}
+
+#[tokio::test]
+async fn authorized_routed_request_preserves_provenance_and_duplicate_is_silent() {
+    let persistence = Arc::new(MemoryPersistence::default());
+    let sink = oid(ObjectType::AUDIT_LOG, 7);
+    let db = database(persistence.clone(), 7);
+    let contexts = Arc::new(StdMutex::new(Vec::new()));
+    let observed = contexts.clone();
+    let mut config = ServerConfig {
+        audit_notification_sink: Some(sink),
+        ..ServerConfig::default()
+    };
+    config.audit_notification_authorizer = Some(Arc::new(move |context| {
+        observed.lock().unwrap().push(context.clone());
+        true
+    }));
+    let notification_transactions = NotificationTransactions::new();
+    let routed = NpduAddress {
+        network: 55,
+        mac_address: MacAddr::from_slice(&[0xaa]),
+    };
+    let source_report = notification(AuditOperation::WRITE);
+    let mut target_report = source_report.clone();
+    target_report.source_timestamp = None;
+    target_report.target_timestamp = Some(BACnetTimeStamp::Time(Time {
+        hour: 12,
+        minute: 0,
+        second: 4,
+        hundredths: 0,
+    }));
+    let bytes = request_bytes(vec![source_report, target_report]);
+
+    let response = dispatch(
+        &db,
+        &config,
+        &notification_transactions,
+        9,
+        &[0x10],
+        Some(routed.clone()),
+        bytes.clone(),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(response, Apdu::SimpleAck(_)));
+    assert_eq!(count(&db, sink).await, (1, 1));
+    let context = contexts.lock().unwrap().first().unwrap().clone();
+    assert_eq!(context.source_mac, MacAddr::from_slice(&[0x10]));
+    assert_eq!(context.source_network, Some(routed));
+    assert_eq!(context.invoke_id, 9);
+    assert_eq!(context.audit_log_sink, sink);
+    assert_eq!(
+        context.request.notifications[0].source_device,
+        BACnetRecipient::Device(oid(ObjectType::DEVICE, 999))
+    );
+
+    assert!(dispatch(
+        &db,
+        &config,
+        &notification_transactions,
+        9,
+        &[0x10],
+        context.source_network,
+        bytes
+    )
+    .await
+    .is_err());
+    assert_eq!(count(&db, sink).await, (1, 1));
+    assert_eq!(contexts.lock().unwrap().len(), 1);
+
+    let response = dispatch(
+        &db,
+        &config,
+        &notification_transactions,
+        9,
+        &[0x10],
+        None,
+        request_bytes(vec![notification(AuditOperation::READ)]),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(response, Apdu::SimpleAck(_)));
+    assert_eq!(count(&db, sink).await, (2, 2));
+    let contexts = contexts.lock().unwrap();
+    assert_eq!(
+        contexts.last().unwrap().source_mac,
+        MacAddr::from_slice(&[0x10])
+    );
+    assert_eq!(contexts.last().unwrap().source_network, None);
+}
+
+#[tokio::test]
+async fn policy_decode_bounds_sink_and_persistence_fail_before_success_ack() {
+    let sink = oid(ObjectType::AUDIT_LOG, 7);
+    for authorizer in [
+        None,
+        Some(Arc::new(|_: &AuditNotificationAuthorizationContext| false)
+            as AuditNotificationAuthorizer),
+        Some(
+            Arc::new(|_: &AuditNotificationAuthorizationContext| -> bool { panic!("denied panic") })
+                as AuditNotificationAuthorizer,
+        ),
+    ] {
+        let persistence = Arc::new(MemoryPersistence::default());
+        let db = database(persistence, 7);
+        let config = ServerConfig {
+            audit_notification_sink: Some(sink),
+            audit_notification_authorizer: authorizer,
+            ..ServerConfig::default()
+        };
+        let response = dispatch(
+            &db,
+            &config,
+            &NotificationTransactions::new(),
+            1,
+            &[1],
+            None,
+            request_bytes(vec![notification(AuditOperation::WRITE)]),
+        )
+        .await
+        .unwrap();
+        let Apdu::Error(error) = response else {
+            panic!("expected error")
+        };
+        assert_eq!(error.error_class, ErrorClass::SERVICES);
+        assert_eq!(error.error_code, ErrorCode::SERVICE_REQUEST_DENIED);
+        assert_eq!(count(&db, sink).await, (0, 0));
+    }
+
+    let persistence = Arc::new(MemoryPersistence::default());
+    let db = database(persistence.clone(), 7);
+    persistence.fail.store(true, Ordering::Release);
+    let config = ServerConfig {
+        audit_notification_sink: Some(sink),
+        audit_notification_authorizer: Some(Arc::new(|_| true)),
+        ..ServerConfig::default()
+    };
+    let response = dispatch(
+        &db,
+        &config,
+        &NotificationTransactions::new(),
+        2,
+        &[1],
+        None,
+        request_bytes(vec![notification(AuditOperation::WRITE)]),
+    )
+    .await
+    .unwrap();
+    assert!(matches!(response, Apdu::Error(_)));
+    assert_eq!(count(&db, sink).await, (0, 0));
+
+    for malformed in [
+        Bytes::from_static(b"bad"),
+        Bytes::from(vec![0; MAX_AUDIT_NOTIFICATION_BYTES + 1]),
+    ] {
+        let response = dispatch(
+            &db,
+            &config,
+            &NotificationTransactions::new(),
+            3,
+            &[1],
+            None,
+            malformed,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(response, Apdu::Error(_)));
+        assert_eq!(count(&db, sink).await, (0, 0));
+    }
+
+    let too_many = request_bytes(
+        (0..=MAX_AUDIT_NOTIFICATIONS)
+            .map(|_| notification(AuditOperation::WRITE))
+            .collect(),
+    );
+    let response = dispatch(
+        &db,
+        &config,
+        &NotificationTransactions::new(),
+        4,
+        &[1],
+        None,
+        too_many,
+    )
+    .await
+    .unwrap();
+    assert!(matches!(response, Apdu::Error(_)));
+    assert_eq!(count(&db, sink).await, (0, 0));
+
+    for configured_sink in [
+        None,
+        Some(oid(ObjectType::ANALOG_INPUT, 7)),
+        Some(oid(ObjectType::AUDIT_LOG, 99)),
+    ] {
+        let config = ServerConfig {
+            audit_notification_sink: configured_sink,
+            audit_notification_authorizer: Some(Arc::new(|_| true)),
+            ..ServerConfig::default()
+        };
+        let response = dispatch(
+            &db,
+            &config,
+            &NotificationTransactions::new(),
+            5,
+            &[1],
+            None,
+            request_bytes(vec![notification(AuditOperation::READ)]),
+        )
+        .await
+        .unwrap();
+        let Apdu::Error(error) = response else {
+            panic!("expected error")
+        };
+        assert_eq!(error.error_class, ErrorClass::SERVICES);
+        assert_eq!(error.error_code, ErrorCode::SERVICE_REQUEST_DENIED);
+        assert_eq!(count(&db, sink).await, (0, 0));
+    }
+}
+
+#[tokio::test]
+async fn disabled_sink_returns_service_request_denied_without_receiver_mutation() {
+    let persistence = Arc::new(MemoryPersistence::default());
+    let sink = oid(ObjectType::AUDIT_LOG, 7);
+    let db = database(persistence, 7);
+    {
+        let mut db = db.write().await;
+        db.get_mut(&sink)
+            .unwrap()
+            .write_property(
+                PropertyIdentifier::LOG_ENABLE,
+                None,
+                PropertyValue::Boolean(false),
+                None,
+            )
+            .unwrap();
+    }
+    let before = count(&db, sink).await;
+    let config = ServerConfig {
+        audit_notification_sink: Some(sink),
+        audit_notification_authorizer: Some(Arc::new(|_| true)),
+        ..ServerConfig::default()
+    };
+    let response = dispatch(
+        &db,
+        &config,
+        &NotificationTransactions::new(),
+        6,
+        &[1],
+        None,
+        request_bytes(vec![notification(AuditOperation::WRITE)]),
+    )
+    .await
+    .unwrap();
+    let Apdu::Error(error) = response else {
+        panic!("expected error")
+    };
+    assert_eq!(error.error_class, ErrorClass::SERVICES);
+    assert_eq!(error.error_code, ErrorCode::SERVICE_REQUEST_DENIED);
+    assert_eq!(count(&db, sink).await, before);
+}
+
+#[tokio::test]
+async fn missing_or_invalid_device_apdu_timeout_is_operational_problem_without_mutation() {
+    let sink = oid(ObjectType::AUDIT_LOG, 7);
+    for device_config in [
+        None,
+        Some(DeviceConfig {
+            apdu_timeout: 0,
+            ..DeviceConfig::default()
+        }),
+    ] {
+        let persistence = Arc::new(MemoryPersistence::default());
+        let db = database_with_device(persistence, 7, device_config);
+        let config = ServerConfig {
+            audit_notification_sink: Some(sink),
+            audit_notification_authorizer: Some(Arc::new(|_| true)),
+            ..ServerConfig::default()
+        };
+        let response = dispatch(
+            &db,
+            &config,
+            &NotificationTransactions::new(),
+            7,
+            &[1],
+            None,
+            request_bytes(vec![notification(AuditOperation::WRITE)]),
+        )
+        .await
+        .unwrap();
+        let Apdu::Error(error) = response else {
+            panic!("expected error")
+        };
+        assert_eq!(error.error_class, ErrorClass::DEVICE);
+        assert_eq!(error.error_code, ErrorCode::OPERATIONAL_PROBLEM);
+        assert_eq!(count(&db, sink).await, (0, 0));
+    }
+}
+
+#[test]
+fn executed_service_truth_is_confirmed_only() {
+    assert!(EXECUTED_CONFIRMED.contains(&ConfirmedServiceChoice::CONFIRMED_AUDIT_NOTIFICATION));
+    assert!(
+        !EXECUTED_UNCONFIRMED.contains(&UnconfirmedServiceChoice::UNCONFIRMED_AUDIT_NOTIFICATION)
+    );
+    assert!(bacnet_objects::device::EXECUTED_SERVICES
+        .contains(&ServiceSupported::CONFIRMED_AUDIT_NOTIFICATION));
+    assert!(!bacnet_objects::device::EXECUTED_SERVICES
+        .contains(&ServiceSupported::UNCONFIRMED_AUDIT_NOTIFICATION));
+}
+
+#[test]
+fn generic_and_bip_builders_store_the_same_explicit_receiver_policy() {
+    let sink = oid(ObjectType::AUDIT_LOG, 7);
+    let generic = BACnetServer::<BipTransport>::generic_builder()
+        .audit_notification_sink(sink)
+        .audit_notification_authorizer(|_| true);
+    assert_eq!(generic.config.audit_notification_sink, Some(sink));
+    assert!(generic.config.audit_notification_authorizer.is_some());
+
+    let bip = BACnetServer::<BipTransport>::bip_builder()
+        .audit_notification_sink(sink)
+        .audit_notification_authorizer(|_| true);
+    assert_eq!(bip.config.audit_notification_sink, Some(sink));
+    assert!(bip.config.audit_notification_authorizer.is_some());
+}
+
+#[cfg(feature = "sc-tls")]
+#[test]
+fn sc_builder_exposes_the_same_explicit_receiver_policy() {
+    let sink = oid(ObjectType::AUDIT_LOG, 7);
+    let sc = BACnetServer::<
+        bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>,
+    >::sc_builder()
+    .audit_notification_sink(sink)
+    .audit_notification_authorizer(|_| true);
+    assert_eq!(sc.config.audit_notification_sink, Some(sink));
+    assert!(sc.config.audit_notification_authorizer.is_some());
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -50,6 +50,10 @@ use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 use bacnet_types::MacAddr;
 
+use crate::audit_notification::{
+    AuditNotificationAuthorizationContext, AuditNotificationAuthorizer, DuplicateAdmission,
+    MAX_AUDIT_NOTIFICATIONS, MAX_AUDIT_NOTIFICATION_BYTES,
+};
 use crate::cov::{CovNotificationKind, CovSubscription, CovSubscriptionTable};
 use crate::handlers;
 use crate::life_safety::{LifeSafetyOperationAuthorizationContext, LifeSafetyOperationAuthorizer};
@@ -293,6 +297,15 @@ pub struct ServerConfig {
     /// Absence is fail-closed: requests receive SERVICES /
     /// SERVICE_REQUEST_DENIED before object mutation.
     pub life_safety_operation_authorizer: Option<LifeSafetyOperationAuthorizer>,
+    /// Exactly one explicitly configured Audit Log notification sink.
+    ///
+    /// Absence is fail-closed; the server never selects a sink by database
+    /// iteration order.
+    pub audit_notification_sink: Option<ObjectIdentifier>,
+    /// Optional fast, nonblocking ConfirmedAuditNotification authorizer.
+    ///
+    /// Absence, `false`, or a panic denies the request before mutation.
+    pub audit_notification_authorizer: Option<AuditNotificationAuthorizer>,
     /// Optional password required for DeviceCommunicationControl.
     pub dcc_password: Option<String>,
     /// Optional password required for ReinitializeDevice.
@@ -364,6 +377,14 @@ impl std::fmt::Debug for ServerConfig {
                     .as_ref()
                     .map(|_| "<callback>"),
             )
+            .field("audit_notification_sink", &self.audit_notification_sink)
+            .field(
+                "audit_notification_authorizer",
+                &self
+                    .audit_notification_authorizer
+                    .as_ref()
+                    .map(|_| "<callback>"),
+            )
             .field("dcc_password", &self.dcc_password.as_ref().map(|_| "***"))
             .field(
                 "reinit_password",
@@ -391,6 +412,8 @@ impl Default for ServerConfig {
             cov_retry_timeout_ms: 3000,
             on_time_sync: None,
             life_safety_operation_authorizer: None,
+            audit_notification_sink: None,
+            audit_notification_authorizer: None,
             dcc_password: None,
             reinit_password: None,
             enable_fault_detection: false,
@@ -445,6 +468,21 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
         F: Fn(&LifeSafetyOperationAuthorizationContext) -> bool + Send + Sync + 'static,
     {
         self.config.life_safety_operation_authorizer = Some(Arc::new(authorizer));
+        self
+    }
+
+    /// Select the only local Audit Log that receives authorized notifications.
+    pub fn audit_notification_sink(mut self, sink: ObjectIdentifier) -> Self {
+        self.config.audit_notification_sink = Some(sink);
+        self
+    }
+
+    /// Set the fail-closed ConfirmedAuditNotification authorization policy.
+    pub fn audit_notification_authorizer<F>(mut self, authorizer: F) -> Self
+    where
+        F: Fn(&AuditNotificationAuthorizationContext) -> bool + Send + Sync + 'static,
+    {
+        self.config.audit_notification_authorizer = Some(Arc::new(authorizer));
         self
     }
 
@@ -559,6 +597,21 @@ impl BipServerBuilder {
         F: Fn(&LifeSafetyOperationAuthorizationContext) -> bool + Send + Sync + 'static,
     {
         self.config.life_safety_operation_authorizer = Some(Arc::new(authorizer));
+        self
+    }
+
+    /// Select the only local Audit Log that receives authorized notifications.
+    pub fn audit_notification_sink(mut self, sink: ObjectIdentifier) -> Self {
+        self.config.audit_notification_sink = Some(sink);
+        self
+    }
+
+    /// Set the fail-closed ConfirmedAuditNotification authorization policy.
+    pub fn audit_notification_authorizer<F>(mut self, authorizer: F) -> Self
+    where
+        F: Fn(&AuditNotificationAuthorizationContext) -> bool + Send + Sync + 'static,
+    {
+        self.config.audit_notification_authorizer = Some(Arc::new(authorizer));
         self
     }
 
@@ -871,6 +924,8 @@ mod requests;
 mod sc_builder;
 #[cfg(test)]
 pub(crate) use requests::{EXECUTED_CONFIRMED, EXECUTED_UNCONFIRMED};
+#[cfg(test)]
+mod audit_notification_tests;
 #[cfg(feature = "sc-tls")]
 pub use sc_builder::ScServerBuilder;
 mod responses;

--- a/crates/bacnet-server/src/server/notification_transactions.rs
+++ b/crates/bacnet-server/src/server/notification_transactions.rs
@@ -14,6 +14,7 @@ use tokio::sync::oneshot;
 use tokio::time::Duration;
 
 use super::CovAckResult;
+use crate::audit_notification::AuditNotificationTracker;
 
 #[derive(Debug)]
 pub(super) enum NotificationReserveError {
@@ -50,6 +51,10 @@ struct NotificationState {
 pub(super) struct NotificationTransactions {
     coordinator: Arc<OutboundTransactionCoordinator>,
     state: Mutex<NotificationState>,
+    /// Physical server-lifetime anchor only. Inbound Audit duplicate state,
+    /// keys, expiry, admission, and cleanup are independent of outbound
+    /// notification correlation and are not changed by `close`.
+    audit_notification_tracker: Arc<AuditNotificationTracker>,
 }
 
 impl NotificationTransactions {
@@ -64,7 +69,12 @@ impl NotificationTransactions {
                 closed: false,
                 pending: HashMap::new(),
             }),
+            audit_notification_tracker: Arc::new(AuditNotificationTracker::default()),
         })
+    }
+
+    pub(super) fn audit_notification_tracker(&self) -> &Arc<AuditNotificationTracker> {
+        &self.audit_notification_tracker
     }
 
     pub(super) fn reserve(

--- a/crates/bacnet-server/src/server/requests/audit_notification.rs
+++ b/crates/bacnet-server/src/server/requests/audit_notification.rs
@@ -1,0 +1,79 @@
+use super::*;
+
+/// Decode, authorize, and durably store one confirmed Audit request.
+///
+/// `None` means an exact pending/completed duplicate was detected and must be
+/// silently discarded. Every other request returns its service result.
+pub(super) async fn receive_confirmed_audit_notification(
+    db: &Arc<RwLock<ObjectDatabase>>,
+    notification_transactions: &Arc<NotificationTransactions>,
+    config: &ServerConfig,
+    source_mac: &[u8],
+    source_network: Option<&NpduAddress>,
+    invoke_id: u8,
+    service_request: &Bytes,
+) -> Option<Result<(), Error>> {
+    if service_request.len() > MAX_AUDIT_NOTIFICATION_BYTES {
+        return Some(Err(Error::OutOfRange(format!(
+            "ConfirmedAuditNotification payload exceeds {MAX_AUDIT_NOTIFICATION_BYTES} bytes"
+        ))));
+    }
+
+    let pending = match notification_transactions
+        .audit_notification_tracker()
+        .begin(
+            source_mac,
+            source_network,
+            invoke_id,
+            service_request.clone(),
+        ) {
+        DuplicateAdmission::Duplicate => return None,
+        DuplicateAdmission::New(pending) => pending,
+    };
+    let decoded = bacnet_services::audit::AuditNotificationRequest::decode(service_request);
+    let execution = match decoded {
+        Err(error) => Err(error),
+        Ok(request) if request.notifications.len() > MAX_AUDIT_NOTIFICATIONS => {
+            Err(Error::OutOfRange(format!(
+                "ConfirmedAuditNotification list exceeds {MAX_AUDIT_NOTIFICATIONS} items"
+            )))
+        }
+        Ok(request) => match config.audit_notification_sink {
+            None => Err(request_denied()),
+            Some(sink) => {
+                let context = AuditNotificationAuthorizationContext {
+                    source_mac: MacAddr::from_slice(source_mac),
+                    source_network: source_network.cloned(),
+                    invoke_id,
+                    audit_log_sink: sink,
+                    request: request.clone(),
+                };
+                let authorized =
+                    config
+                        .audit_notification_authorizer
+                        .as_ref()
+                        .is_some_and(|authorizer| {
+                            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                authorizer(&context)
+                            }))
+                            .unwrap_or(false)
+                        });
+                if !authorized {
+                    Err(request_denied())
+                } else {
+                    let mut db = db.write().await;
+                    handlers::handle_confirmed_audit_notification(&mut db, sink, &request)
+                }
+            }
+        },
+    };
+    pending.complete();
+    Some(execution)
+}
+
+fn request_denied() -> Error {
+    Error::Protocol {
+        class: ErrorClass::SERVICES.to_raw() as u32,
+        code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+    }
+}

--- a/crates/bacnet-server/src/server/requests/executed.rs
+++ b/crates/bacnet-server/src/server/requests/executed.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+/// Every confirmed service choice with an inbound execution arm in
+/// `handle_confirmed_request`. Keep in lockstep with the dispatch match; the
+/// PICS synchronization test maps this list through `ServiceSupported` and
+/// compares it with `bacnet_objects::device::EXECUTED_SERVICES`.
+pub(crate) const EXECUTED_CONFIRMED: &[ConfirmedServiceChoice] = &[
+    ConfirmedServiceChoice::ACKNOWLEDGE_ALARM,
+    ConfirmedServiceChoice::GET_ALARM_SUMMARY,
+    ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY,
+    ConfirmedServiceChoice::SUBSCRIBE_COV,
+    ConfirmedServiceChoice::ATOMIC_READ_FILE,
+    ConfirmedServiceChoice::ATOMIC_WRITE_FILE,
+    ConfirmedServiceChoice::ADD_LIST_ELEMENT,
+    ConfirmedServiceChoice::REMOVE_LIST_ELEMENT,
+    ConfirmedServiceChoice::CREATE_OBJECT,
+    ConfirmedServiceChoice::DELETE_OBJECT,
+    ConfirmedServiceChoice::READ_PROPERTY,
+    ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+    ConfirmedServiceChoice::WRITE_PROPERTY,
+    ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE,
+    ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+    ConfirmedServiceChoice::CONFIRMED_TEXT_MESSAGE,
+    ConfirmedServiceChoice::REINITIALIZE_DEVICE,
+    ConfirmedServiceChoice::READ_RANGE,
+    ConfirmedServiceChoice::LIFE_SAFETY_OPERATION,
+    ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY,
+    ConfirmedServiceChoice::GET_EVENT_INFORMATION,
+    ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY_MULTIPLE,
+    ConfirmedServiceChoice::CONFIRMED_AUDIT_NOTIFICATION,
+    ConfirmedServiceChoice::AUDIT_LOG_QUERY,
+];

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -1,50 +1,20 @@
 use super::*;
 
+mod audit_notification;
 mod confirmed_response;
 mod endpoint_responder;
 #[cfg(test)]
 #[path = "endpoint_shared_runtime_tests.rs"]
 mod endpoint_shared_runtime_tests;
+#[cfg(test)]
+mod executed;
 mod unconfirmed;
 #[cfg(test)]
 mod unconfirmed_tests;
 #[cfg(test)]
-pub(crate) use unconfirmed::EXECUTED_UNCONFIRMED;
-
+pub(crate) use executed::EXECUTED_CONFIRMED;
 #[cfg(test)]
-/// Every confirmed service choice with an inbound execution arm in
-/// `handle_confirmed_request` below. Keep in lockstep with the `match` —
-/// the `executed_services_match_dispatch_table` test compares this list
-/// (mapped through [`ServiceSupported::from_confirmed_choice`]) against
-/// [`bacnet_objects::device::EXECUTED_SERVICES`], which is what the Device
-/// object advertises in `Protocol_Services_Supported`.
-///
-/// [`ServiceSupported::from_confirmed_choice`]: bacnet_types::enums::ServiceSupported::from_confirmed_choice
-pub(crate) const EXECUTED_CONFIRMED: &[ConfirmedServiceChoice] = &[
-    ConfirmedServiceChoice::ACKNOWLEDGE_ALARM,
-    ConfirmedServiceChoice::GET_ALARM_SUMMARY,
-    ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY,
-    ConfirmedServiceChoice::SUBSCRIBE_COV,
-    ConfirmedServiceChoice::ATOMIC_READ_FILE,
-    ConfirmedServiceChoice::ATOMIC_WRITE_FILE,
-    ConfirmedServiceChoice::ADD_LIST_ELEMENT,
-    ConfirmedServiceChoice::REMOVE_LIST_ELEMENT,
-    ConfirmedServiceChoice::CREATE_OBJECT,
-    ConfirmedServiceChoice::DELETE_OBJECT,
-    ConfirmedServiceChoice::READ_PROPERTY,
-    ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
-    ConfirmedServiceChoice::WRITE_PROPERTY,
-    ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE,
-    ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
-    ConfirmedServiceChoice::CONFIRMED_TEXT_MESSAGE,
-    ConfirmedServiceChoice::REINITIALIZE_DEVICE,
-    ConfirmedServiceChoice::READ_RANGE,
-    ConfirmedServiceChoice::LIFE_SAFETY_OPERATION,
-    ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY,
-    ConfirmedServiceChoice::GET_EVENT_INFORMATION,
-    ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY_MULTIPLE,
-    ConfirmedServiceChoice::AUDIT_LOG_QUERY,
-];
+pub(crate) use unconfirmed::EXECUTED_UNCONFIRMED;
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Handle a confirmed request.
@@ -361,6 +331,25 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         }
                     }
                     Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
+                }
+            }
+            s if s == ConfirmedServiceChoice::CONFIRMED_AUDIT_NOTIFICATION => {
+                match audit_notification::receive_confirmed_audit_notification(
+                    db,
+                    notification_transactions,
+                    config,
+                    source_mac,
+                    source_network.as_ref(),
+                    invoke_id,
+                    &req.service_request,
+                )
+                .await
+                {
+                    None => return,
+                    Some(Ok(())) => simple_ack(),
+                    Some(Err(error)) => {
+                        Self::error_apdu_from_error(invoke_id, service_choice, &error)
+                    }
                 }
             }
             s if s == ConfirmedServiceChoice::CONFIRMED_TEXT_MESSAGE => {

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -111,6 +111,21 @@ impl ScServerBuilder {
         self
     }
 
+    /// Select the only local Audit Log that receives authorized notifications.
+    pub fn audit_notification_sink(mut self, sink: ObjectIdentifier) -> Self {
+        self.config.audit_notification_sink = Some(sink);
+        self
+    }
+
+    /// Set the fail-closed ConfirmedAuditNotification authorization policy.
+    pub fn audit_notification_authorizer<F>(mut self, authorizer: F) -> Self
+    where
+        F: Fn(&AuditNotificationAuthorizationContext) -> bool + Send + Sync + 'static,
+    {
+        self.config.audit_notification_authorizer = Some(Arc::new(authorizer));
+        self
+    }
+
     /// Enable periodic fault detection / reliability evaluation.
     pub fn enable_fault_detection(mut self, enabled: bool) -> Self {
         self.config.enable_fault_detection = enabled;

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -832,7 +832,7 @@
    "id": "BACNET-13-AUDIT-WIRE-MODELS",
    "standard_anchor": "Clauses 13.19-13.21; Clause 21.2.1, Clause 21.2.3, Clause 21.3.1, BACnetAuditNotification, BACnetAuditLogQueryParameters, and BACnetAuditOperationFlags productions",
    "priority": "P1",
-   "requirement_summary": "AuditNotification request payloads carry one or more typed BACnetAuditNotification values under context tag 0, while AuditLogQuery requests carry a typed by-target or by-source query alternative and the bundled server can execute those queries against explicitly persisted retained Audit Log records. Within the primitive layer's u64 Unsigned domain, the codecs preserve the Clause 21 field order, tags, numeric domains, Boolean encoding, recipient alternatives, standard operation-flag bits 0-15, and proprietary bits 32-63; reject reserved flag bits, trailing or malformed structure; bound notification/query-result allocation; and leave destination buffers unchanged when model validation fails.",
+   "requirement_summary": "AuditNotification request payloads carry one or more typed BACnetAuditNotification values under context tag 0, while AuditLogQuery requests carry a typed by-target or by-source query alternative. The bundled server executes queries over explicitly persisted retained records and receives ConfirmedAuditNotification only through one explicit sink plus fail-closed transport-provenance authorization, bounded duplicate detection, and atomic durable merge-or-create. Within the primitive layer's u64 Unsigned domain, the codecs preserve the Clause 21 field order, tags, numeric domains, Boolean encoding, recipient alternatives, standard operation-flag bits 0-15, and proprietary bits 32-63; reject reserved flag bits, trailing or malformed structure; bound allocation; and leave destination buffers unchanged when validation fails.",
    "status": "implementation-present-needs-source-review",
    "code_anchors": [
     "crates/bacnet-types/src/bitstring.rs",
@@ -841,8 +841,12 @@
     "crates/bacnet-services/src/audit/query_codec.rs",
     "crates/bacnet-services/src/audit/query_ack_codec.rs",
     "crates/bacnet-objects/src/audit.rs",
+    "crates/bacnet-objects/src/audit/notification.rs",
     "crates/bacnet-objects/src/traits.rs",
     "crates/bacnet-server/src/handlers/audit_log_query.rs",
+    "crates/bacnet-server/src/handlers/audit_notification.rs",
+    "crates/bacnet-server/src/audit_notification.rs",
+    "crates/bacnet-server/src/server/requests/audit_notification.rs",
     "crates/bacnet-server/src/server/requests/mod.rs",
     "crates/bacnet-objects/src/device/mod.rs",
     "crates/rusty-bacnet/src/client/client_methods/vt_audit_time_directed.rs"
@@ -863,6 +867,10 @@
     "crates/bacnet-objects/src/audit/query_tests.rs::query_never_returns_more_than_the_retained_storage_cap",
     "crates/bacnet-server/src/handlers/tests/audit_log_query.rs::handler_decodes_then_returns_an_owned_page_from_real_audit_storage",
     "crates/bacnet-server/src/server/audit_log_query_tests.rs::audit_log_query_dispatch_returns_a_typed_complex_ack",
+    "crates/bacnet-objects/src/audit/notification_tests.rs::complementary_batch_merges_once_and_target_current_value_wins",
+    "crates/bacnet-objects/src/audit/notification_tests.rs::completed_match_is_dropped_and_merge_preserves_record_identity",
+    "crates/bacnet-server/src/server/audit_notification_tests.rs::authorized_routed_request_preserves_provenance_and_duplicate_is_silent",
+    "crates/bacnet-server/src/server/audit_notification_tests.rs::executed_service_truth_is_confirmed_only",
     "crates/bacnet-server/src/pics/tests.rs::executed_services_match_dispatch_table"
    ],
    "negative_tests": [
@@ -882,11 +890,13 @@
     "crates/bacnet-services/src/audit/tests.rs::invalid_priority_encode_is_atomic",
     "crates/bacnet-server/src/handlers/tests/audit_log_query.rs::missing_or_non_audit_identifiers_map_to_unknown_object",
     "crates/bacnet-server/src/handlers/tests/audit_log_query.rs::audit_typed_object_without_capability_maps_to_optional_functionality",
-    "crates/bacnet-server/src/handlers/tests/audit_log_query.rs::malformed_payload_fails_before_audit_storage_is_inspected"
+    "crates/bacnet-server/src/handlers/tests/audit_log_query.rs::malformed_payload_fails_before_audit_storage_is_inspected",
+    "crates/bacnet-objects/src/audit/notification_tests.rs::commit_and_clock_failures_leave_memory_and_durable_snapshot_unchanged",
+    "crates/bacnet-server/src/server/audit_notification_tests.rs::policy_decode_bounds_sink_and_persistence_fail_before_success_ack"
    ],
    "benchmarks": [],
    "public_claims": [],
-   "notes": "Partial evidence for issue #345. The request/ACK models follow the Clause 21 field and tag productions within the library's u64 Unsigned implementation limit: start-at-sequence-number is Unsigned32 and successful-actions-only is BOOLEAN. Clause 13.19 instead describes Unsigned64 and the three-state BACnetSuccessFilter, including failures-only; that internal Standard conflict remains unresolved pending authoritative addendum or errata research, so this row stays below supported status. AuditLogQuery executes both alternatives over the explicitly persisted, already-loaded retained snapshot, traverses insertion order newest-first without numeric sorting, applies the literal Unsigned32 start predicate, scans completely for No_More_Items, and returns at most the 10,000-record persistence/ACK cap through the generic ComplexACK sizing and segmentation path. Missing/non-Audit identifiers and absent query capability use the Clause 13.19 business errors; malformed payloads retain the repository's SERVICES/OTHER mapping after decode-first failure. The 10,000 notification/result bounds are implementation resource caps, not Standard service cardinalities. Raw target/current ANY values receive structural TLV validation only, not property-schema validation. Python exposes the three audit sends and query response as caller-supplied/pre-encoded byte escape hatches. AuditNotification ingestion, authorization, transport-source provenance, rate limiting, replay/merge policy, failures-only queries, wrap-safe continuation, and Audit BIBB claims remain unsupported or deferred."
+   "notes": "Partial evidence for issue #345. The request/ACK models follow the Clause 21 field and tag productions within the library's u64 Unsigned implementation limit: start-at-sequence-number is Unsigned32 and successful-actions-only is BOOLEAN. Clause 13.19 instead describes Unsigned64 and the three-state BACnetSuccessFilter, including failures-only; that internal Standard conflict remains unresolved pending authoritative addendum or errata research, so this row stays below supported status. AuditLogQuery executes both alternatives over the explicitly persisted, already-loaded retained snapshot, traverses insertion order newest-first without numeric sorting, applies the literal Unsigned32 start predicate, scans completely for No_More_Items, and returns at most the 10,000-record persistence/ACK cap through the generic ComplexACK sizing and segmentation path. ConfirmedAuditNotification now decodes before policy/storage, requires one explicit Audit Log sink and a fail-closed fast authorizer, keeps immediate/routed transport provenance separate from peer-reported payload identity, and applies each accepted list in wire order through one prospective snapshot and durable commit. Complementary matching uses twice the configured Device APDU_Timeout as its window; like Time/DateTime variants compare temporal distance while SequenceNumber requires equality and mixed variants do not match. Exact pending/completed duplicates are silently discarded by a bounded 60-second, 256-entry process-local tracker; responses are not replayed and expiry/restart permits service again. Receiver payload/list caps of 64 KiB/256 are repository resource policy. Synchronous persistence under the database writer limits availability. Missing/non-Audit identifiers and absent query capability use the Clause 13.19 query errors; malformed payloads retain SERVICES/OTHER mapping. Raw target/current ANY values receive structural TLV validation only, not property-schema validation. Python exposes outbound Audit calls as byte escape hatches and no inbound builder. Unconfirmed AuditNotification, query authorization, sustained rate limiting, durable provenance/idempotency, failures-only queries, wrap-safe continuation, producer/forwarding policy, and Audit BIBB claims remain unsupported or deferred."
   },
   {
    "id": "BACNET-15-ARRAY-INDEX-GATING",

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -995,10 +995,12 @@ raw = await client.audit_log_query(
 These three methods are generic outbound byte paths. They do not validate the
 payload or provide structured Python audit models. A bundled server with an
 explicitly persisted Audit Log object can execute the raw AuditLogQuery payload
-against its retained in-memory records and return a raw typed ACK payload. Its
-confirmed and unconfirmed AuditNotification receivers remain unsupported, and
-query authorization, ingestion, and replay policy remain application/follow-up
-work.
+against its retained in-memory records and return a raw typed ACK payload. The
+Rust server API can also receive ConfirmedAuditNotification when an application
+explicitly configures one sink and a fail-closed authorizer; this release adds
+no Python builder for that receiver. Unconfirmed receipt, query authorization,
+durable idempotency, and a high-level structured Python Audit API remain
+unsupported.
 
 ---
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -843,11 +843,18 @@ let query_ack = AuditLogQueryAck::decode(&raw_ack)?;
 These remain generic-client examples. The bundled server executes
 AuditLogQuery against the retained in-memory snapshot of an explicitly backed
 `AuditLogObject`, returning newest-first typed records through the existing
-ComplexACK segmentation path. Its confirmed and unconfirmed AuditNotification
-receivers remain unsupported, so records still come from application-owned
-storage/producer policy. Query authorization, replay policy, failures-only
-filtering, and a wrap-safe 64-bit continuation are not provided. No Audit BIBB
-claim is implied.
+ComplexACK segmentation path. ConfirmedAuditNotification receipt is available
+only when the server is configured with exactly one `audit_notification_sink`
+and a fast `audit_notification_authorizer`; missing, false, or panicking policy
+fails closed. Accepted lists merge or create records atomically through the
+sink's durable backend. Transport provenance is passed to policy separately
+from the preserved, peer-reported payload. Duplicate detection is bounded and
+process-local (60 seconds / 256 exact requests) and silently discards detected
+retransmissions rather than replaying responses. Synchronous persistence under
+the database writer is an intentional availability limitation. Unconfirmed
+receipt, query authorization, sustained rate limiting, durable idempotency,
+failures-only filtering, and a wrap-safe 64-bit continuation are not provided.
+No Audit BIBB claim is implied.
 
 ---
 
@@ -930,7 +937,8 @@ The server automatically dispatches:
 - GetAlarmSummary, GetEnrollmentSummary
 - ConfirmedTextMessage
 - LifeSafetyOperation (authorized silence/unsilence; built-in reset is unsupported)
-- AuditLogQuery (retained records; no built-in ingestion, authorization, or failures-only mode)
+- ConfirmedAuditNotification (explicit sink and fail-closed authorizer; process-local duplicate detection)
+- AuditLogQuery (retained records; no query authorization or failures-only mode)
 - ReadRange
 - AtomicReadFile, AtomicWriteFile
 - AddListElement, RemoveListElement


### PR DESCRIPTION
## Summary

- receive `ConfirmedAuditNotification` through one explicitly configured Audit Log sink and a fail-closed, provenance-aware authorizer
- merge or create each accepted notification list in wire order as one object-owned durable transaction, with local insertion timestamps and target `Current_Value` precedence
- silently discard detected pending/completed duplicates through a bounded, exact-byte, process-local tracker; never replay cached responses
- advertise confirmed execution only and keep UnconfirmedAuditNotification, producers/forwarding, Python receiver configuration, durable idempotency, and Audit BIBB claims out of scope

## Standard grounding

- ASHRAE 135-2020 §13.20 and Clause 21: strict confirmed request decoding, explicit logger configuration, and payloadless success
- §12.64: complementary source/target matching, merge-or-create behavior, complete-record drop, local insertion time, and `2 × APDU_Timeout` matching window
- §5.3.5.3: detected duplicate Confirmed-Requests are discarded rather than answered from a response cache
- §19.6: payload identities remain reported audit content; transport-observed provenance is supplied separately to application authorization

## Validation

- `cargo test -p bacnet-objects audit --locked` — 28 passed
- `cargo test -p bacnet-server audit_notification --locked` — 9 passed
- `cargo test -p bacnet-server audit_notification --all-features --locked` — 10 passed, including BACnet/SC builder coverage
- `cargo test -p bacnet-server --locked` — 663 unit + 3 integration passed
- `cargo test --workspace --exclude rusty-bacnet --locked` — passed
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked` — passed with pre-existing warnings only
- `cargo check -p rusty-bacnet --tests --locked` — passed
- formatting, conformance generation/JSON, file-size, no-secret, and diff-hygiene checks — passed

## Compatibility and limits

- the new `BACnetObject` capability is defaulted; builder methods are additive
- two new public `ServerConfig` fields affect callers using exhaustive struct literals
- persistence remains synchronous under the database writer
- duplicate retention is bounded to 256 exact requests for 60 seconds after completion and resets on restart
- a single readable local Device object with a nonzero `APDU_Timeout` is required
- no UnconfirmedAuditNotification receiver or Audit BIBB claim is added

Refs #345
