### PR TITLE
feat(client): enforce routed path APDU limits

### DIFF
--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -73,7 +73,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         #[cfg(test)]
         let segmented_cleanup_dispatch = Arc::clone(&segmented_cleanup);
         let response_limits = ResponseLimits::from_config(&config);
-        let routed_path_limits = Arc::new(RoutedPathLimits::default());
+        let routed_path_limits = Arc::new(RoutedPathLimits::new(routed_path_quarantine_horizon(
+            &config,
+        )));
         let routed_path_limits_dispatch = Arc::clone(&routed_path_limits);
 
         let dispatch_task = tokio::spawn(async move {

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -42,6 +42,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         options.validate()?;
 
         let mut network = NetworkLayer::new(transport);
+        let mut network_control_rx = network.enable_network_control_receiver()?;
         let mut apdu_rx = network.start().await?;
         config.max_apdu_length = cap_max_apdu_to_transport(
             config.max_apdu_length,
@@ -72,16 +73,29 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         #[cfg(test)]
         let segmented_cleanup_dispatch = Arc::clone(&segmented_cleanup);
         let response_limits = ResponseLimits::from_config(&config);
+        let routed_path_limits = Arc::new(RoutedPathLimits::default());
+        let routed_path_limits_dispatch = Arc::clone(&routed_path_limits);
 
         let dispatch_task = tokio::spawn(async move {
             let mut seg_state: HashMap<SegKey, SegmentedReceiveState> = HashMap::new();
             let mut device_purge_interval = tokio::time::interval(DEVICE_PURGE_INTERVAL);
+            let mut network_control_open = true;
             // Tokio intervals tick immediately; consume that tick so discovery purges
             // run on the configured cadence instead of racing the first APDU.
             device_purge_interval.tick().await;
 
             loop {
                 tokio::select! {
+                    control = network_control_rx.recv(), if network_control_open => {
+                        match control {
+                            Some(control) => {
+                                routed_path_limits_dispatch
+                                    .handle_network_control(&tsm_dispatch, control)
+                                    .await;
+                            }
+                            None => network_control_open = false,
+                        }
+                    }
                     cleanup = cleanup_rx.recv() => {
                         let Some(cleanup) = cleanup else {
                             break;
@@ -175,6 +189,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             #[cfg(test)]
             segmented_cleanup,
             local_mac,
+            routed_path_limits,
         })
     }
     /// Get the client's local MAC address.

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -165,6 +165,7 @@ pub(crate) fn confirmed_response_result(response: TsmResponse) -> Result<Bytes, 
         TsmResponse::Error { class, code } => Err(Error::Protocol { class, code }),
         TsmResponse::Reject { reason } => Err(Error::Reject { reason }),
         TsmResponse::Abort { reason } => Err(Error::Abort { reason }),
+        TsmResponse::NetworkPathTooLong { dnet } => Err(Error::RoutedPathTooLong { dnet }),
     }
 }
 
@@ -428,6 +429,7 @@ pub struct BACnetClient<T: TransportPort> {
     #[cfg(test)]
     segmented_cleanup: Arc<SegmentedCleanupHook>,
     local_mac: MacAddr,
+    routed_path_limits: Arc<RoutedPathLimits>,
 }
 
 impl BACnetClient<BipTransport> {
@@ -789,10 +791,12 @@ mod object_mgmt;
 mod property;
 mod requests;
 mod response_admission;
+mod routed_path_limits;
 mod segmentation;
 mod segmented_request;
 mod transaction_cleanup;
 mod transaction_peer;
+use routed_path_limits::RoutedPathLimits;
 use transaction_peer::response_transaction_peer;
 
 pub use cov_notifications::{
@@ -827,6 +831,8 @@ mod request_timer_tests;
 mod response_correlation_tests;
 #[cfg(test)]
 mod routed_max_apdu_tests;
+#[cfg(test)]
+mod routed_path_limit_tests;
 #[cfg(test)]
 mod routed_reply_tests;
 #[cfg(all(test, feature = "sc-tls"))]

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -796,7 +796,7 @@ mod segmentation;
 mod segmented_request;
 mod transaction_cleanup;
 mod transaction_peer;
-use routed_path_limits::RoutedPathLimits;
+use routed_path_limits::{routed_path_quarantine_horizon, RoutedPathLease, RoutedPathLimits};
 use transaction_peer::response_transaction_peer;
 
 pub use cov_notifications::{

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -175,12 +175,41 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         service_choice: ConfirmedServiceChoice,
         service_data: &[u8],
     ) -> Result<Bytes, Error> {
+        // The lease serializes one active request per (immediate router, DNET)
+        // and remains live through every return path, including cancellation.
+        let path_lease = match target {
+            ConfirmedTarget::Local { .. } => None,
+            ConfirmedTarget::Routed {
+                router_mac,
+                dest_network,
+                ..
+            } => Some(
+                self.routed_path_limits
+                    .acquire(router_mac, dest_network)
+                    .await,
+            ),
+        };
+        let (routed_path_max_apdu, routed_forwarded_npci_len) = match (path_lease.as_ref(), target)
+        {
+            (
+                Some(lease),
+                ConfirmedTarget::Routed {
+                    dest_mac,
+                    dest_network: _,
+                    router_mac: _,
+                },
+            ) => (
+                Some(lease.max_apdu(dest_mac.len(), self.local_mac.len())?),
+                Some(lease.forwarded_npci_len(dest_mac.len(), self.local_mac.len())?),
+            ),
+            _ => (None, None),
+        };
         let transaction_peer = target.transaction_peer();
         let tsm_mac = transaction_peer.tsm_mac;
         let unsegmented_apdu_size = 4 + service_data.len();
         let target_transport_max_apdu = self.target_transport_max_apdu_length(target);
 
-        let (remote_max_apdu, remote_max_segments, advertised, peer_segmentation) = {
+        let (peer_max_apdu, remote_max_segments, advertised, peer_segmentation) = {
             let dt = self.device_table.lock().await;
             // A routed peer is recorded under the router's MAC, so only the
             // SNET/SADR of the NPDU that carried its I-Am identifies it
@@ -208,14 +237,21 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             } else {
                 LengthBoundedBy::LocalConfig(max_apdu)
             };
-            (
-                max_apdu.min(target_transport_max_apdu),
-                max_seg,
-                advertised,
-                peer_segmentation,
-            )
+            (max_apdu, max_seg, advertised, peer_segmentation)
         };
         check_transmittable_length(advertised, target_transport_max_apdu)?;
+        if routed_path_max_apdu.is_some_and(|path_max_apdu| {
+            path_max_apdu < MINIMUM_MESSAGE_SIZE
+                && path_max_apdu <= peer_max_apdu.min(target_transport_max_apdu)
+        }) {
+            let ConfirmedTarget::Routed { dest_network, .. } = target else {
+                unreachable!("a routed path limit exists only for a routed target")
+            };
+            return Err(Error::RoutedPathTooLong { dnet: dest_network });
+        }
+        let remote_max_apdu = peer_max_apdu
+            .min(target_transport_max_apdu)
+            .min(routed_path_max_apdu.unwrap_or(u16::MAX));
         if unsegmented_apdu_size > remote_max_apdu as usize {
             // Clause 12.11: a NO_SEGMENTATION or SEGMENTED_TRANSMIT peer
             // accepts exactly one segment — only unsegmented requests — and
@@ -244,6 +280,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     service_data,
                     remote_max_apdu,
                     remote_max_segments,
+                    routed_forwarded_npci_len,
                 )
                 .await;
         }
@@ -285,6 +322,33 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
 
         let mut buf = BytesMut::with_capacity(6 + service_data.len());
         encode_apdu(&mut buf, &pdu)?;
+
+        if let Some(forwarded_npci_len) = routed_forwarded_npci_len {
+            self.routed_path_limits.install_active(
+                target,
+                tsm_mac.clone(),
+                invoke_id,
+                owner.clone(),
+                forwarded_npci_len,
+            );
+        }
+        if !self.routed_path_limits.authorize_attempt(
+            target,
+            &tsm_mac,
+            invoke_id,
+            &owner,
+            buf.len(),
+        ) {
+            guard.mark_completed();
+            self.tsm
+                .lock()
+                .await
+                .cancel_transaction_for_owner(&tsm_mac, invoke_id, &owner);
+            self.enqueue_transaction_cleanup(&tsm_mac, invoke_id, &owner, false, None);
+            return Err(Error::Encoding(
+                "routed send lost its active path authorization".into(),
+            ));
+        }
 
         if let Err(e) = self.send_confirmed_target_apdu(target, &buf).await {
             guard.mark_completed();
@@ -380,6 +444,17 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     };
                                     retries_sent += 1;
                                     drop(tsm);
+                                    if !self.routed_path_limits.authorize_attempt(
+                                        target,
+                                        tsm_mac,
+                                        invoke_id,
+                                        owner,
+                                        retry_apdu.len(),
+                                    ) {
+                                        return (&mut response_rx).await.map_err(|_| {
+                                            Error::Encoding("TSM response channel closed".into())
+                                        });
+                                    }
                                     let send_result = self
                                         .send_confirmed_target_apdu(target, retry_apdu)
                                         .await;

--- a/crates/bacnet-client/src/client/requests.rs
+++ b/crates/bacnet-client/src/client/requests.rs
@@ -68,61 +68,6 @@ fn check_transmittable_length(peer_or_local: LengthBoundedBy, transport: u16) ->
     )))
 }
 
-#[cfg(test)]
-mod transmittable_length_tests {
-    use super::{check_transmittable_length, LengthBoundedBy};
-
-    #[test]
-    fn conformant_lengths_pass() {
-        for advertised in [50u16, 128, 206, 480, 1024, 1476] {
-            assert!(
-                check_transmittable_length(LengthBoundedBy::DiscoveredPeer(advertised), 1476)
-                    .is_ok(),
-                "{advertised} is at or above MinimumMessageSize"
-            );
-        }
-    }
-
-    /// I-Am carries an Unsigned octet count, not the four-bit code, and Clause
-    /// 20.1.2.5 says the true value "may be larger than indicated in this
-    /// parameter" — so values outside the six encodings are legitimate.
-    #[test]
-    fn lengths_outside_the_encoded_set_are_not_rejected() {
-        for advertised in [51u16, 600, 1500, u16::MAX] {
-            assert!(
-                check_transmittable_length(LengthBoundedBy::DiscoveredPeer(advertised), u16::MAX)
-                    .is_ok(),
-                "{advertised} is conformant even though it is not one of the six encodings"
-            );
-        }
-    }
-
-    /// The error must blame whichever term actually bound the minimum. The peer
-    /// is only sometimes that term: BACnet/SC recomputes its own limit from the
-    /// hub's Connect-Accept, so a transport can fall below the floor while the
-    /// peer is entirely conformant.
-    #[test]
-    fn the_error_names_the_binding_term() {
-        let peer_bound =
-            check_transmittable_length(LengthBoundedBy::DiscoveredPeer(3), 1476).unwrap_err();
-        assert!(
-            peer_bound.to_string().contains("peer's advertised"),
-            "peer is the binding term here, got: {peer_bound}"
-        );
-
-        let transport_bound =
-            check_transmittable_length(LengthBoundedBy::DiscoveredPeer(1476), 48).unwrap_err();
-        assert!(
-            transport_bound.to_string().contains("transport's limit"),
-            "transport is the binding term here and the peer is conformant, got: {transport_bound}"
-        );
-        assert!(
-            !transport_bound.to_string().contains("peer's advertised"),
-            "must not blame a conformant peer for the transport's limit"
-        );
-    }
-}
-
 impl<T: TransportPort + 'static> BACnetClient<T> {
     /// Send a confirmed request and wait for the response.
     ///
@@ -186,7 +131,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             } => Some(
                 self.routed_path_limits
                     .acquire(router_mac, dest_network)
-                    .await,
+                    .await?,
             ),
         };
         let (routed_path_max_apdu, routed_forwarded_npci_len) = match (path_lease.as_ref(), target)
@@ -281,6 +226,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                     remote_max_apdu,
                     remote_max_segments,
                     routed_forwarded_npci_len,
+                    path_lease.as_ref(),
                 )
                 .await;
         }
@@ -330,6 +276,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 invoke_id,
                 owner.clone(),
                 forwarded_npci_len,
+                self.network.network_control_ingress_sequence(),
             );
         }
         if !self.routed_path_limits.authorize_attempt(
@@ -370,6 +317,11 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 Some(&buf),
             )
             .await;
+        if response.is_ok() {
+            if let Some(lease) = path_lease.as_ref() {
+                lease.mark_terminal_observed();
+            }
+        }
         guard.mark_completed();
         response.and_then(Self::confirmed_response_result)
     }
@@ -702,3 +654,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             .await
     }
 }
+
+#[cfg(test)]
+#[path = "requests_tests.rs"]
+mod transmittable_length_tests;

--- a/crates/bacnet-client/src/client/requests_tests.rs
+++ b/crates/bacnet-client/src/client/requests_tests.rs
@@ -1,0 +1,50 @@
+use super::{check_transmittable_length, LengthBoundedBy};
+
+#[test]
+fn conformant_lengths_pass() {
+    for advertised in [50u16, 128, 206, 480, 1024, 1476] {
+        assert!(
+            check_transmittable_length(LengthBoundedBy::DiscoveredPeer(advertised), 1476).is_ok(),
+            "{advertised} is at or above MinimumMessageSize"
+        );
+    }
+}
+
+/// I-Am carries an Unsigned octet count, not the four-bit code, and Clause
+/// 20.1.2.5 says the true value "may be larger than indicated in this
+/// parameter" — so values outside the six encodings are legitimate.
+#[test]
+fn lengths_outside_the_encoded_set_are_not_rejected() {
+    for advertised in [51u16, 600, 1500, u16::MAX] {
+        assert!(
+            check_transmittable_length(LengthBoundedBy::DiscoveredPeer(advertised), u16::MAX)
+                .is_ok(),
+            "{advertised} is conformant even though it is not one of the six encodings"
+        );
+    }
+}
+
+/// The error must blame whichever term actually bound the minimum. The peer
+/// is only sometimes that term: BACnet/SC recomputes its own limit from the
+/// hub's Connect-Accept, so a transport can fall below the floor while the
+/// peer is entirely conformant.
+#[test]
+fn the_error_names_the_binding_term() {
+    let peer_bound =
+        check_transmittable_length(LengthBoundedBy::DiscoveredPeer(3), 1476).unwrap_err();
+    assert!(
+        peer_bound.to_string().contains("peer's advertised"),
+        "peer is the binding term here, got: {peer_bound}"
+    );
+
+    let transport_bound =
+        check_transmittable_length(LengthBoundedBy::DiscoveredPeer(1476), 48).unwrap_err();
+    assert!(
+        transport_bound.to_string().contains("transport's limit"),
+        "transport is the binding term here and the peer is conformant, got: {transport_bound}"
+    );
+    assert!(
+        !transport_bound.to_string().contains("peer's advertised"),
+        "must not blame a conformant peer for the transport's limit"
+    );
+}

--- a/crates/bacnet-client/src/client/routed_path_limit_tests.rs
+++ b/crates/bacnet-client/src/client/routed_path_limit_tests.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 use bacnet_encoding::apdu::{self, encode_apdu, Apdu, SegmentAck, SimpleAck};
 use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu, NpduAddress};
 use bacnet_transport::port::{ReceivedNpdu, TransportPort};
-use bacnet_types::enums::{
-    ConfirmedServiceChoice, NetworkMessageType, NetworkPriority, RejectMessageReason,
-};
+use bacnet_types::enums::{ConfirmedServiceChoice, NetworkMessageType, RejectMessageReason};
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 use bytes::{Bytes, BytesMut};
@@ -13,7 +11,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, timeout, Duration};
 
-use super::{BACnetClient, ClientConfig};
+use super::{routed_path_limits::MAX_ROUTED_PATH_ENTRIES, BACnetClient, ClientConfig};
 
 const DNET: u16 = 100;
 
@@ -333,6 +331,44 @@ async fn subminimum_path_cap_fails_before_registration_or_emission() {
 }
 
 #[tokio::test]
+async fn configured_capacity_exhaustion_fails_before_registration_or_emission() {
+    let (transport, _inbound, mut outbound) = harness(&[1; 6], 1490);
+    let mut client = BACnetClient::generic_builder()
+        .transport(transport)
+        .build()
+        .await
+        .unwrap();
+
+    for path in 1..=MAX_ROUTED_PATH_ENTRIES {
+        let path = u16::try_from(path).unwrap();
+        client
+            .configure_routed_path_max_npdu(&path.to_be_bytes(), path, 1497)
+            .await
+            .unwrap();
+    }
+
+    let result = client
+        .confirmed_request_routed(
+            &[0xff, 0xfe],
+            u16::try_from(MAX_ROUTED_PATH_ENTRIES + 1).unwrap(),
+            &[3],
+            ConfirmedServiceChoice::READ_PROPERTY,
+            &[0x0c],
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(Error::RoutedPathCapacityExceeded {
+            capacity: MAX_ROUTED_PATH_ENTRIES
+        })
+    ));
+    assert!(outbound.try_recv().is_err());
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn reason_4_completes_exact_caller_learns_bound_and_does_not_retry() {
     let router = vec![2];
     let dadr = vec![3];
@@ -584,6 +620,94 @@ async fn same_path_serializes_while_a_second_router_remains_concurrent() {
 }
 
 #[tokio::test]
+async fn cancelled_generation_quarantines_delayed_reason_4_before_next_send() {
+    let router = vec![2];
+    let dadr = vec![3];
+    let (transport, inbound, mut outbound) = harness(&[1], 1486);
+    let client = Arc::new(
+        BACnetClient::start(
+            ClientConfig {
+                apdu_timeout_ms: 100,
+                apdu_retries: 0,
+                ..ClientConfig::default()
+            },
+            transport,
+        )
+        .await
+        .unwrap(),
+    );
+    client
+        .configure_routed_path_max_npdu(&router, DNET, 1497)
+        .await
+        .unwrap();
+
+    let cancelled = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x61; 300],
+    );
+    let _cancelled_request = confirmed_request(outbound.recv().await.unwrap(), &router);
+    cancelled.abort();
+    assert!(cancelled.await.unwrap_err().is_cancelled());
+
+    let next = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x62; 300],
+    );
+    assert!(
+        timeout(Duration::from_millis(20), outbound.recv())
+            .await
+            .is_err(),
+        "same-path request became active before the stale-control quarantine"
+    );
+
+    // This control belongs to the cancelled generation. It reaches network
+    // ingress while the next request is waiting, and must be drained without
+    // completing or teaching the next generation.
+    inject_reason_4(&inbound, &router, DNET).await;
+    sleep(Duration::from_millis(10)).await;
+    assert!(!next.is_finished());
+
+    let next_request = confirmed_request(
+        timeout(Duration::from_millis(200), outbound.recv())
+            .await
+            .expect("quarantine did not release the next request")
+            .unwrap(),
+        &router,
+    );
+    assert!(
+        !next_request.segmented,
+        "delayed reason-4 must not poison the waiting generation"
+    );
+    inject_simple_ack(&inbound, &router, DNET, &dadr, next_request.invoke_id).await;
+    assert!(next.await.unwrap().unwrap().is_empty());
+
+    let proof = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x63; 300],
+    );
+    let proof_request = confirmed_request(outbound.recv().await.unwrap(), &router);
+    assert!(
+        !proof_request.segmented,
+        "stale control changed learned policy"
+    );
+    inject_simple_ack(&inbound, &router, DNET, &dadr, proof_request.invoke_id).await;
+    assert!(proof.await.unwrap().unwrap().is_empty());
+
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    let mut client = Arc::try_unwrap(client).ok().unwrap();
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
 async fn reason_4_during_segmented_send_prevents_window_retransmission() {
     let router = vec![2];
     let dadr = vec![3];
@@ -628,11 +752,4 @@ async fn reason_4_during_segmented_send_prevents_window_retransmission() {
 
     let mut client = Arc::try_unwrap(client).ok().unwrap();
     client.stop().await.unwrap();
-}
-
-#[test]
-fn network_control_message_type_constant_remains_standard_value() {
-    assert_eq!(NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw(), 0x03);
-    assert_eq!(RejectMessageReason::MESSAGE_TOO_LONG.to_raw(), 4);
-    assert_eq!(NetworkPriority::NORMAL.to_raw(), 0);
 }

--- a/crates/bacnet-client/src/client/routed_path_limit_tests.rs
+++ b/crates/bacnet-client/src/client/routed_path_limit_tests.rs
@@ -1,0 +1,638 @@
+use std::sync::Arc;
+
+use bacnet_encoding::apdu::{self, encode_apdu, Apdu, SegmentAck, SimpleAck};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu, NpduAddress};
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_types::enums::{
+    ConfirmedServiceChoice, NetworkMessageType, NetworkPriority, RejectMessageReason,
+};
+use bacnet_types::error::Error;
+use bacnet_types::MacAddr;
+use bytes::{Bytes, BytesMut};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::{sleep, timeout, Duration};
+
+use super::{BACnetClient, ClientConfig};
+
+const DNET: u16 = 100;
+
+struct SentFrame {
+    npdu: Bytes,
+    destination: MacAddr,
+}
+
+struct CaptureTransport {
+    local_mac: MacAddr,
+    inbound_rx: Option<mpsc::Receiver<ReceivedNpdu>>,
+    outbound_tx: mpsc::UnboundedSender<SentFrame>,
+    max_apdu: u16,
+}
+
+impl TransportPort for CaptureTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        self.inbound_rx
+            .take()
+            .ok_or_else(|| Error::Encoding("capture transport already started".into()))
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
+        self.outbound_tx
+            .send(SentFrame {
+                npdu: Bytes::copy_from_slice(npdu),
+                destination: MacAddr::from_slice(mac),
+            })
+            .map_err(|_| Error::Encoding("capture observer closed".into()))
+    }
+
+    async fn send_broadcast(&self, npdu: &[u8]) -> Result<(), Error> {
+        self.send_unicast(npdu, &[]).await
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &self.local_mac
+    }
+
+    fn max_apdu_length(&self) -> u16 {
+        self.max_apdu
+    }
+}
+
+fn harness(
+    local_mac: &[u8],
+    max_apdu: u16,
+) -> (
+    CaptureTransport,
+    mpsc::Sender<ReceivedNpdu>,
+    mpsc::UnboundedReceiver<SentFrame>,
+) {
+    let (inbound_tx, inbound_rx) = mpsc::channel(64);
+    let (outbound_tx, outbound_rx) = mpsc::unbounded_channel();
+    (
+        CaptureTransport {
+            local_mac: MacAddr::from_slice(local_mac),
+            inbound_rx: Some(inbound_rx),
+            outbound_tx,
+            max_apdu,
+        },
+        inbound_tx,
+        outbound_rx,
+    )
+}
+
+fn routed_request(
+    client: Arc<BACnetClient<CaptureTransport>>,
+    router: Vec<u8>,
+    dnet: u16,
+    dadr: Vec<u8>,
+    service_data: Vec<u8>,
+) -> JoinHandle<Result<Bytes, Error>> {
+    tokio::spawn(async move {
+        client
+            .confirmed_request_routed(
+                &router,
+                dnet,
+                &dadr,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &service_data,
+            )
+            .await
+    })
+}
+
+fn confirmed_request(frame: SentFrame, expected_router: &[u8]) -> apdu::ConfirmedRequest {
+    assert_eq!(frame.destination.as_slice(), expected_router);
+    let npdu = decode_npdu(frame.npdu).unwrap();
+    let Apdu::ConfirmedRequest(request) = apdu::decode_apdu(npdu.payload).unwrap() else {
+        panic!("expected ConfirmedRequest")
+    };
+    request
+}
+
+async fn inject_apdu(
+    inbound: &mpsc::Sender<ReceivedNpdu>,
+    immediate_source: &[u8],
+    routed_source: Option<(u16, &[u8])>,
+    apdu: Apdu,
+) {
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &apdu).unwrap();
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(
+        &mut npdu_buf,
+        &Npdu {
+            source: routed_source.map(|(network, mac)| NpduAddress {
+                network,
+                mac_address: MacAddr::from_slice(mac),
+            }),
+            payload: apdu_buf.freeze(),
+            ..Npdu::default()
+        },
+    )
+    .unwrap();
+    inbound
+        .send(ReceivedNpdu {
+            npdu: npdu_buf.freeze(),
+            source_mac: MacAddr::from_slice(immediate_source),
+            link_layer_group: false,
+            data_attributes: Vec::new(),
+            reply_tx: None,
+        })
+        .await
+        .unwrap();
+}
+
+async fn inject_control(
+    inbound: &mpsc::Sender<ReceivedNpdu>,
+    immediate_source: &[u8],
+    message_type: u8,
+    payload: &[u8],
+) {
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(
+        &mut npdu_buf,
+        &Npdu {
+            is_network_message: true,
+            message_type: Some(message_type),
+            payload: Bytes::copy_from_slice(payload),
+            ..Npdu::default()
+        },
+    )
+    .unwrap();
+    inbound
+        .send(ReceivedNpdu {
+            npdu: npdu_buf.freeze(),
+            source_mac: MacAddr::from_slice(immediate_source),
+            link_layer_group: false,
+            data_attributes: Vec::new(),
+            reply_tx: None,
+        })
+        .await
+        .unwrap();
+}
+
+async fn inject_reason_4(inbound: &mpsc::Sender<ReceivedNpdu>, immediate_source: &[u8], dnet: u16) {
+    inject_control(
+        inbound,
+        immediate_source,
+        NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw(),
+        &[
+            RejectMessageReason::MESSAGE_TOO_LONG.to_raw(),
+            (dnet >> 8) as u8,
+            dnet as u8,
+        ],
+    )
+    .await;
+}
+
+async fn inject_simple_ack(
+    inbound: &mpsc::Sender<ReceivedNpdu>,
+    router: &[u8],
+    dnet: u16,
+    dadr: &[u8],
+    invoke_id: u8,
+) {
+    inject_apdu(
+        inbound,
+        router,
+        Some((dnet, dadr)),
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+}
+
+async fn finish_segmented(
+    inbound: &mpsc::Sender<ReceivedNpdu>,
+    outbound: &mut mpsc::UnboundedReceiver<SentFrame>,
+    router: &[u8],
+    dnet: u16,
+    dadr: &[u8],
+    first: apdu::ConfirmedRequest,
+    max_apdu: u16,
+) {
+    let mut request = first;
+    loop {
+        assert!(request.segmented);
+        assert!(6 + request.service_request.len() <= usize::from(max_apdu));
+        let seq = request.sequence_number.unwrap();
+        inject_apdu(
+            inbound,
+            router,
+            Some((dnet, dadr)),
+            Apdu::SegmentAck(SegmentAck {
+                negative_ack: false,
+                sent_by_server: true,
+                invoke_id: request.invoke_id,
+                sequence_number: seq,
+                actual_window_size: 1,
+            }),
+        )
+        .await;
+        if !request.more_follows {
+            inject_simple_ack(inbound, router, dnet, dadr, request.invoke_id).await;
+            return;
+        }
+        request = confirmed_request(
+            timeout(Duration::from_secs(1), outbound.recv())
+                .await
+                .unwrap()
+                .unwrap(),
+            router,
+        );
+    }
+}
+
+#[tokio::test]
+async fn routed_sizing_uses_conservative_and_configured_forwarded_envelopes() {
+    let local = vec![1, 2, 3, 4, 5, 6];
+    let router = vec![11, 12, 13, 14, 15, 16];
+    let dadr = vec![21, 22, 23, 24, 25, 26];
+    let (transport, inbound, mut outbound) = harness(&local, 1490);
+    let client = Arc::new(
+        BACnetClient::generic_builder()
+            .transport(transport)
+            .apdu_timeout_ms(1000)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    // 228 NPDU - (9 + 6-byte DADR + 6-byte forwarded source) = 207 APDU.
+    let first_task = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x55; 204],
+    );
+    let first = confirmed_request(outbound.recv().await.unwrap(), &router);
+    assert!(first.segmented);
+    finish_segmented(&inbound, &mut outbound, &router, DNET, &dadr, first, 207).await;
+    assert!(first_task.await.unwrap().unwrap().is_empty());
+
+    client
+        .configure_routed_path_max_npdu(&router, DNET, 1497)
+        .await
+        .unwrap();
+    let configured_task = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x66; 1472],
+    );
+    let configured = confirmed_request(outbound.recv().await.unwrap(), &router);
+    assert!(!configured.segmented);
+    assert_eq!(4 + configured.service_request.len(), 1476);
+    inject_simple_ack(&inbound, &router, DNET, &dadr, configured.invoke_id).await;
+    assert!(configured_task.await.unwrap().unwrap().is_empty());
+
+    let mut client = Arc::try_unwrap(client).ok().unwrap();
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn subminimum_path_cap_fails_before_registration_or_emission() {
+    let router = vec![2; 6];
+    let dadr = vec![3; 6];
+    let (transport, _inbound, mut outbound) = harness(&[1; 6], 1490);
+    let mut client = BACnetClient::generic_builder()
+        .transport(transport)
+        .build()
+        .await
+        .unwrap();
+    client
+        .configure_routed_path_max_npdu(&router, DNET, 70)
+        .await
+        .unwrap();
+
+    let result = client
+        .confirmed_request_routed(
+            &router,
+            DNET,
+            &dadr,
+            ConfirmedServiceChoice::READ_PROPERTY,
+            &[0x0c],
+        )
+        .await;
+    assert!(matches!(
+        result,
+        Err(Error::RoutedPathTooLong { dnet: DNET })
+    ));
+    assert!(outbound.try_recv().is_err());
+    assert_eq!(client.tsm.lock().await.pending_count(), 0);
+    assert_eq!(client.tsm.lock().await.coordinated_active_count(), 0);
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn reason_4_completes_exact_caller_learns_bound_and_does_not_retry() {
+    let router = vec![2];
+    let dadr = vec![3];
+    let (transport, inbound, mut outbound) = harness(&[1], 1486);
+    let client = Arc::new(
+        BACnetClient::start(
+            ClientConfig {
+                apdu_timeout_ms: 40,
+                apdu_retries: 3,
+                ..ClientConfig::default()
+            },
+            transport,
+        )
+        .await
+        .unwrap(),
+    );
+    client
+        .configure_routed_path_max_npdu(&router, DNET, 1497)
+        .await
+        .unwrap();
+
+    let rejected_task = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x44; 300],
+    );
+    let rejected = confirmed_request(outbound.recv().await.unwrap(), &router);
+    assert!(!rejected.segmented);
+    assert_eq!(4 + rejected.service_request.len(), 304);
+    inject_reason_4(&inbound, &router, DNET).await;
+    assert!(matches!(
+        timeout(Duration::from_millis(100), rejected_task)
+            .await
+            .unwrap()
+            .unwrap(),
+        Err(Error::RoutedPathTooLong { dnet: DNET })
+    ));
+    assert!(timeout(Duration::from_millis(150), outbound.recv())
+        .await
+        .is_err());
+
+    // The rejected 315-octet forwarded NPDU is an exclusive upper bound,
+    // leaving 303 APDU octets for the next request.
+    let learned_task = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x45; 300],
+    );
+    let learned = confirmed_request(outbound.recv().await.unwrap(), &router);
+    assert!(learned.segmented);
+    finish_segmented(&inbound, &mut outbound, &router, DNET, &dadr, learned, 303).await;
+    assert!(learned_task.await.unwrap().unwrap().is_empty());
+
+    // An explicit override deliberately resets learned negative evidence.
+    client
+        .configure_routed_path_max_npdu(&router, DNET, 1497)
+        .await
+        .unwrap();
+    let reset_task = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x46; 300],
+    );
+    let reset = confirmed_request(outbound.recv().await.unwrap(), &router);
+    assert!(!reset.segmented);
+    inject_simple_ack(&inbound, &router, DNET, &dadr, reset.invoke_id).await;
+    assert!(reset_task.await.unwrap().unwrap().is_empty());
+
+    let mut client = Arc::try_unwrap(client).ok().unwrap();
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn unmatched_controls_and_direct_requests_do_not_change_path_policy() {
+    let router = vec![2];
+    let wrong_router = vec![9];
+    let dadr = vec![3];
+    let (transport, inbound, mut outbound) = harness(&[1], 1486);
+    let client = Arc::new(
+        BACnetClient::generic_builder()
+            .transport(transport)
+            .apdu_timeout_ms(1000)
+            .build()
+            .await
+            .unwrap(),
+    );
+    client
+        .configure_routed_path_max_npdu(&router, DNET, 1497)
+        .await
+        .unwrap();
+
+    let task = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x31; 300],
+    );
+    let request = confirmed_request(outbound.recv().await.unwrap(), &router);
+    inject_reason_4(&inbound, &wrong_router, DNET).await;
+    inject_reason_4(&inbound, &router, DNET + 1).await;
+    inject_control(
+        &inbound,
+        &router,
+        NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw(),
+        &[RejectMessageReason::ROUTER_BUSY.to_raw(), 0, DNET as u8],
+    )
+    .await;
+    inject_control(
+        &inbound,
+        &router,
+        NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw(),
+        &[RejectMessageReason::MESSAGE_TOO_LONG.to_raw(), 0],
+    )
+    .await;
+    inject_control(
+        &inbound,
+        &router,
+        NetworkMessageType::ROUTER_BUSY_TO_NETWORK.to_raw(),
+        &[
+            RejectMessageReason::MESSAGE_TOO_LONG.to_raw(),
+            0,
+            DNET as u8,
+        ],
+    )
+    .await;
+    sleep(Duration::from_millis(25)).await;
+    assert!(!task.is_finished());
+    inject_simple_ack(&inbound, &router, DNET, &dadr, request.invoke_id).await;
+    assert!(task.await.unwrap().unwrap().is_empty());
+
+    // A stale matching control with no active path has no effect either.
+    inject_reason_4(&inbound, &router, DNET).await;
+    sleep(Duration::from_millis(25)).await;
+    let next_task = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x32; 300],
+    );
+    let next = confirmed_request(outbound.recv().await.unwrap(), &router);
+    assert!(!next.segmented, "unmatched controls must not learn a bound");
+    inject_simple_ack(&inbound, &router, DNET, &dadr, next.invoke_id).await;
+    assert!(next_task.await.unwrap().unwrap().is_empty());
+
+    let direct_mac = vec![7];
+    let direct_client = Arc::clone(&client);
+    let direct_target = direct_mac.clone();
+    let direct_task = tokio::spawn(async move {
+        direct_client
+            .confirmed_request(
+                &direct_target,
+                ConfirmedServiceChoice::WRITE_PROPERTY,
+                &[0x0c],
+            )
+            .await
+    });
+    let direct = confirmed_request(outbound.recv().await.unwrap(), &direct_mac);
+    inject_reason_4(&inbound, &router, DNET).await;
+    sleep(Duration::from_millis(25)).await;
+    assert!(!direct_task.is_finished());
+    inject_apdu(
+        &inbound,
+        &direct_mac,
+        None,
+        Apdu::SimpleAck(SimpleAck {
+            invoke_id: direct.invoke_id,
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        }),
+    )
+    .await;
+    assert!(direct_task.await.unwrap().unwrap().is_empty());
+
+    let mut client = Arc::try_unwrap(client).ok().unwrap();
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn same_path_serializes_while_a_second_router_remains_concurrent() {
+    let router_a = vec![2];
+    let router_b = vec![8];
+    let dadr_a = vec![3];
+    let dadr_b = vec![4];
+    let (transport, inbound, mut outbound) = harness(&[1], 1486);
+    let client = Arc::new(
+        BACnetClient::generic_builder()
+            .transport(transport)
+            .apdu_timeout_ms(1000)
+            .build()
+            .await
+            .unwrap(),
+    );
+
+    let first_task = routed_request(
+        Arc::clone(&client),
+        router_a.clone(),
+        DNET,
+        dadr_a.clone(),
+        vec![1],
+    );
+    let first = confirmed_request(outbound.recv().await.unwrap(), &router_a);
+    let blocked_task = routed_request(
+        Arc::clone(&client),
+        router_a.clone(),
+        DNET,
+        dadr_b.clone(),
+        vec![2],
+    );
+    let concurrent_task = routed_request(
+        Arc::clone(&client),
+        router_b.clone(),
+        DNET,
+        dadr_b.clone(),
+        vec![3],
+    );
+
+    let concurrent = confirmed_request(
+        timeout(Duration::from_millis(100), outbound.recv())
+            .await
+            .expect("different router path should remain concurrent")
+            .unwrap(),
+        &router_b,
+    );
+    assert!(!blocked_task.is_finished());
+    inject_simple_ack(&inbound, &router_b, DNET, &dadr_b, concurrent.invoke_id).await;
+    assert!(concurrent_task.await.unwrap().unwrap().is_empty());
+
+    inject_simple_ack(&inbound, &router_a, DNET, &dadr_a, first.invoke_id).await;
+    assert!(first_task.await.unwrap().unwrap().is_empty());
+    let blocked = confirmed_request(
+        timeout(Duration::from_millis(100), outbound.recv())
+            .await
+            .expect("same-path waiter did not resume")
+            .unwrap(),
+        &router_a,
+    );
+    inject_simple_ack(&inbound, &router_a, DNET, &dadr_b, blocked.invoke_id).await;
+    assert!(blocked_task.await.unwrap().unwrap().is_empty());
+
+    let mut client = Arc::try_unwrap(client).ok().unwrap();
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn reason_4_during_segmented_send_prevents_window_retransmission() {
+    let router = vec![2];
+    let dadr = vec![3];
+    let (transport, inbound, mut outbound) = harness(&[1], 1486);
+    let client = Arc::new(
+        BACnetClient::start(
+            ClientConfig {
+                apdu_timeout_ms: 40,
+                apdu_retries: 3,
+                ..ClientConfig::default()
+            },
+            transport,
+        )
+        .await
+        .unwrap(),
+    );
+    client
+        .configure_routed_path_max_npdu(&router, DNET, 128)
+        .await
+        .unwrap();
+
+    let task = routed_request(
+        Arc::clone(&client),
+        router.clone(),
+        DNET,
+        dadr.clone(),
+        vec![0x77; 300],
+    );
+    let first = confirmed_request(outbound.recv().await.unwrap(), &router);
+    assert!(first.segmented);
+    inject_reason_4(&inbound, &router, DNET).await;
+    assert!(matches!(
+        timeout(Duration::from_millis(100), task)
+            .await
+            .unwrap()
+            .unwrap(),
+        Err(Error::RoutedPathTooLong { dnet: DNET })
+    ));
+    assert!(timeout(Duration::from_millis(150), outbound.recv())
+        .await
+        .is_err());
+
+    let mut client = Arc::try_unwrap(client).ok().unwrap();
+    client.stop().await.unwrap();
+}
+
+#[test]
+fn network_control_message_type_constant_remains_standard_value() {
+    assert_eq!(NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw(), 0x03);
+    assert_eq!(RejectMessageReason::MESSAGE_TOO_LONG.to_raw(), 4);
+    assert_eq!(NetworkPriority::NORMAL.to_raw(), 0);
+}

--- a/crates/bacnet-client/src/client/routed_path_limits.rs
+++ b/crates/bacnet-client/src/client/routed_path_limits.rs
@@ -1,0 +1,440 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard};
+use std::time::Instant;
+
+use bacnet_encoding::npdu::decode_reject_message_to_network;
+use bacnet_network::layer::ReceivedNetworkControl;
+use bacnet_types::enums::{NetworkMessageType, RejectMessageReason};
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+use super::*;
+use crate::tsm::CompletionOutcome;
+
+/// Smallest routed NPDU envelope required across the standard data links.
+const CONSERVATIVE_ROUTED_PATH_MAX_NPDU: u16 = 228;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct RoutedPathKey {
+    immediate_router_mac: MacAddr,
+    dnet: u16,
+}
+
+impl RoutedPathKey {
+    fn new(immediate_router_mac: &[u8], dnet: u16) -> Self {
+        Self {
+            immediate_router_mac: MacAddr::from_slice(immediate_router_mac),
+            dnet,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ConfiguredLimitProvenance {
+    ExplicitApi,
+}
+
+struct ConfiguredPathLimit {
+    max_npdu: u16,
+    provenance: ConfiguredLimitProvenance,
+    observed_at: Instant,
+}
+
+struct LearnedPathLimit {
+    exclusive_max_npdu: u16,
+    observed_at: Instant,
+}
+
+struct ActiveRoutedSend {
+    path: RoutedPathKey,
+    tsm_mac: MacAddr,
+    invoke_id: u8,
+    owner: TransactionOwner,
+    forwarded_npci_len: u16,
+    outgoing_apdu_len: Option<u16>,
+}
+
+struct RoutedPathEntry {
+    gate: Arc<AsyncMutex<()>>,
+    configured: Option<ConfiguredPathLimit>,
+    learned: Option<LearnedPathLimit>,
+    active: Option<ActiveRoutedSend>,
+}
+
+impl Default for RoutedPathEntry {
+    fn default() -> Self {
+        Self {
+            gate: Arc::new(AsyncMutex::new(())),
+            configured: None,
+            learned: None,
+            active: None,
+        }
+    }
+}
+
+#[derive(Default)]
+pub(super) struct RoutedPathLimits {
+    entries: StdMutex<HashMap<RoutedPathKey, RoutedPathEntry>>,
+}
+
+impl RoutedPathLimits {
+    fn entries(&self) -> StdMutexGuard<'_, HashMap<RoutedPathKey, RoutedPathEntry>> {
+        self.entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    pub(super) async fn acquire(self: &Arc<Self>, router_mac: &[u8], dnet: u16) -> RoutedPathLease {
+        let key = RoutedPathKey::new(router_mac, dnet);
+        let gate = {
+            let mut entries = self.entries();
+            Arc::clone(&entries.entry(key.clone()).or_default().gate)
+        };
+        let gate = gate.lock_owned().await;
+        RoutedPathLease {
+            limits: Arc::clone(self),
+            key,
+            _gate: gate,
+        }
+    }
+
+    pub(super) fn install_active(
+        &self,
+        target: ConfirmedTarget<'_>,
+        tsm_mac: MacAddr,
+        invoke_id: u8,
+        owner: TransactionOwner,
+        forwarded_npci_len: u16,
+    ) {
+        let ConfirmedTarget::Routed {
+            router_mac,
+            dest_network,
+            ..
+        } = target
+        else {
+            return;
+        };
+        let key = RoutedPathKey::new(router_mac, dest_network);
+        let mut entries = self.entries();
+        let entry = entries.entry(key.clone()).or_default();
+        debug_assert!(
+            entry.active.is_none(),
+            "the per-path gate permits only one active routed request"
+        );
+        entry.active = Some(ActiveRoutedSend {
+            path: key,
+            tsm_mac,
+            invoke_id,
+            owner,
+            forwarded_npci_len,
+            outgoing_apdu_len: None,
+        });
+    }
+
+    pub(super) fn authorize_attempt(
+        &self,
+        target: ConfirmedTarget<'_>,
+        tsm_mac: &MacAddr,
+        invoke_id: u8,
+        owner: &TransactionOwner,
+        outgoing_apdu_len: usize,
+    ) -> bool {
+        let ConfirmedTarget::Routed {
+            router_mac,
+            dest_network,
+            ..
+        } = target
+        else {
+            return true;
+        };
+        let Ok(outgoing_apdu_len) = u16::try_from(outgoing_apdu_len) else {
+            return false;
+        };
+        let key = RoutedPathKey::new(router_mac, dest_network);
+        let mut entries = self.entries();
+        let Some(active) = entries
+            .get_mut(&key)
+            .and_then(|entry| entry.active.as_mut())
+        else {
+            return false;
+        };
+        if active.tsm_mac != *tsm_mac
+            || active.invoke_id != invoke_id
+            || !active.owner.same_as(owner)
+        {
+            return false;
+        }
+        active.outgoing_apdu_len = Some(outgoing_apdu_len);
+        true
+    }
+
+    pub(super) async fn handle_network_control(
+        &self,
+        tsm: &Arc<Mutex<Tsm>>,
+        control: ReceivedNetworkControl,
+    ) {
+        if control.npdu.message_type != Some(NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw())
+        {
+            return;
+        }
+        let Ok(reject) = decode_reject_message_to_network(&control.npdu.payload) else {
+            return;
+        };
+        if reject.reason != RejectMessageReason::MESSAGE_TOO_LONG {
+            return;
+        }
+
+        let Some(active) = self.claim_active(&control.source_mac, reject.dnet) else {
+            return;
+        };
+        let outcome = tsm.lock().await.complete_network_path_too_long_for_owner(
+            &active.tsm_mac,
+            active.invoke_id,
+            &active.owner,
+            reject.dnet,
+        );
+        if outcome == CompletionOutcome::Delivered {
+            self.commit_learned_limit(active);
+        }
+    }
+
+    fn claim_active(&self, router_mac: &[u8], dnet: u16) -> Option<ActiveRoutedSend> {
+        let key = RoutedPathKey::new(router_mac, dnet);
+        let mut entries = self.entries();
+        let entry = entries.get_mut(&key)?;
+        if entry
+            .active
+            .as_ref()
+            .is_none_or(|active| active.outgoing_apdu_len.is_none() || active.path != key)
+        {
+            return None;
+        }
+        entry.active.take()
+    }
+
+    fn commit_learned_limit(&self, active: ActiveRoutedSend) {
+        let Some(attempted_npdu) = active
+            .outgoing_apdu_len
+            .and_then(|apdu| active.forwarded_npci_len.checked_add(apdu))
+        else {
+            return;
+        };
+        let mut entries = self.entries();
+        let entry = entries.entry(active.path).or_default();
+        let exclusive_max_npdu = entry.learned.as_ref().map_or(attempted_npdu, |learned| {
+            learned.exclusive_max_npdu.min(attempted_npdu)
+        });
+        entry.learned = Some(LearnedPathLimit {
+            exclusive_max_npdu,
+            observed_at: Instant::now(),
+        });
+    }
+}
+
+pub(super) struct RoutedPathLease {
+    limits: Arc<RoutedPathLimits>,
+    key: RoutedPathKey,
+    _gate: OwnedMutexGuard<()>,
+}
+
+impl RoutedPathLease {
+    pub(super) fn max_apdu(
+        &self,
+        dadr_len: usize,
+        local_source_mac_len: usize,
+    ) -> Result<u16, Error> {
+        let forwarded_npci_len = forwarded_npci_len(dadr_len, local_source_mac_len)?;
+        let entries = self.limits.entries();
+        let entry = entries
+            .get(&self.key)
+            .expect("path entry remains present while its gate is held");
+        let configured_or_conservative =
+            entry
+                .configured
+                .as_ref()
+                .map_or(CONSERVATIVE_ROUTED_PATH_MAX_NPDU, |configured| {
+                    tracing::trace!(
+                        max_npdu = configured.max_npdu,
+                        provenance = ?configured.provenance,
+                        age = ?configured.observed_at.elapsed(),
+                        "Using configured routed-path NPDU limit"
+                    );
+                    configured.max_npdu
+                });
+        let effective_npdu = entry
+            .learned
+            .as_ref()
+            .map_or(configured_or_conservative, |learned| {
+                tracing::trace!(
+                    exclusive_max_npdu = learned.exclusive_max_npdu,
+                    age = ?learned.observed_at.elapsed(),
+                    "Applying learned routed-path upper bound"
+                );
+                configured_or_conservative
+                    .min(learned.exclusive_max_npdu.checked_sub(1).unwrap_or(0))
+            });
+        Ok(effective_npdu.checked_sub(forwarded_npci_len).unwrap_or(0))
+    }
+
+    pub(super) fn forwarded_npci_len(
+        &self,
+        dadr_len: usize,
+        local_source_mac_len: usize,
+    ) -> Result<u16, Error> {
+        forwarded_npci_len(dadr_len, local_source_mac_len)
+    }
+
+    fn configure(&self, max_npdu: u16) {
+        let mut entries = self.limits.entries();
+        let entry = entries
+            .get_mut(&self.key)
+            .expect("path entry remains present while its gate is held");
+        entry.configured = Some(ConfiguredPathLimit {
+            max_npdu,
+            provenance: ConfiguredLimitProvenance::ExplicitApi,
+            observed_at: Instant::now(),
+        });
+        entry.learned = None;
+    }
+
+    fn clear(&self) {
+        let mut entries = self.limits.entries();
+        let entry = entries
+            .get_mut(&self.key)
+            .expect("path entry remains present while its gate is held");
+        entry.configured = None;
+        entry.learned = None;
+    }
+}
+
+impl Drop for RoutedPathLease {
+    fn drop(&mut self) {
+        let mut entries = self.limits.entries();
+        if let Some(entry) = entries.get_mut(&self.key) {
+            entry.active = None;
+        }
+    }
+}
+
+fn forwarded_npci_len(dadr_len: usize, local_source_mac_len: usize) -> Result<u16, Error> {
+    if dadr_len > u8::MAX as usize {
+        return Err(Error::Encoding(
+            "routed destination MAC address exceeds 255 bytes".into(),
+        ));
+    }
+    if local_source_mac_len == 0 || local_source_mac_len > u8::MAX as usize {
+        return Err(Error::Encoding(
+            "local source MAC address for routed forwarding must contain 1..=255 bytes".into(),
+        ));
+    }
+    u16::try_from(9usize + dadr_len + local_source_mac_len)
+        .map_err(|_| Error::Encoding("forwarded routed NPCI length exceeds u16".into()))
+}
+
+impl<T: TransportPort + 'static> BACnetClient<T> {
+    /// Configure the maximum NPDU for one immediate-router/DNET path.
+    ///
+    /// The update waits for any request already active on the same path. It
+    /// replaces the previous configured value and deliberately clears learned
+    /// reason-4 evidence for that path.
+    pub async fn configure_routed_path_max_npdu(
+        &self,
+        router_mac: &[u8],
+        dnet: u16,
+        max_npdu: u16,
+    ) -> Result<(), Error> {
+        validate_public_path(router_mac, dnet)?;
+        let lease = self.routed_path_limits.acquire(router_mac, dnet).await;
+        lease.configure(max_npdu);
+        Ok(())
+    }
+
+    /// Restore one immediate-router/DNET path to the conservative default.
+    ///
+    /// The update waits for an active request and clears both configured and
+    /// learned reason-4 evidence. Later requests therefore use the 228-octet
+    /// conservative routed NPDU envelope until new evidence is supplied.
+    pub async fn clear_routed_path_limit(&self, router_mac: &[u8], dnet: u16) -> Result<(), Error> {
+        validate_public_path(router_mac, dnet)?;
+        let lease = self.routed_path_limits.acquire(router_mac, dnet).await;
+        lease.clear();
+        Ok(())
+    }
+}
+
+fn validate_public_path(router_mac: &[u8], dnet: u16) -> Result<(), Error> {
+    if router_mac.is_empty() || router_mac.len() > u8::MAX as usize {
+        return Err(Error::Encoding(
+            "immediate router MAC address must contain 1..=255 bytes".into(),
+        ));
+    }
+    if dnet == 0 || dnet == 0xffff {
+        return Err(Error::Encoding(
+            "routed path DNET must be in 1..=65534".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bacnet_types::enums::ConfirmedServiceChoice;
+
+    #[test]
+    fn conservative_and_configured_npdu_envelopes_use_forwarded_source() {
+        let header = forwarded_npci_len(6, 6).unwrap();
+        assert_eq!(header, 21);
+        assert_eq!(CONSERVATIVE_ROUTED_PATH_MAX_NPDU - header, 207);
+        assert_eq!(1497 - header, 1476);
+
+        assert_eq!(forwarded_npci_len(1, 1).unwrap(), 11);
+        assert_eq!(forwarded_npci_len(4, 6).unwrap(), 19);
+    }
+
+    #[test]
+    fn forwarded_npci_rejects_unrepresentable_addresses() {
+        assert!(forwarded_npci_len(256, 6).is_err());
+        assert!(forwarded_npci_len(6, 0).is_err());
+        assert!(forwarded_npci_len(6, 256).is_err());
+    }
+
+    #[test]
+    fn claimed_control_cannot_complete_reused_invoke_id_for_new_owner() {
+        let limits = RoutedPathLimits::default();
+        let router = [2];
+        let dadr = [3];
+        let target = ConfirmedTarget::Routed {
+            router_mac: &router,
+            dest_network: 100,
+            dest_mac: &dadr,
+        };
+        let tsm_mac = target.transaction_peer().tsm_mac;
+        let mut tsm = Tsm::new(TsmConfig::default());
+        let old = tsm.register_transaction_with_progress(
+            tsm_mac.clone(),
+            7,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+        limits.install_active(target, tsm_mac.clone(), 7, old.owner.clone(), 11);
+        assert!(limits.authorize_attempt(target, &tsm_mac, 7, &old.owner, 100));
+        let claimed = limits.claim_active(&router, 100).unwrap();
+
+        assert!(tsm.cancel_transaction_for_owner(&tsm_mac, 7, &old.owner));
+        let replacement = tsm.register_transaction_with_progress(
+            tsm_mac.clone(),
+            7,
+            ConfirmedServiceChoice::READ_PROPERTY,
+        );
+        assert_eq!(
+            tsm.complete_network_path_too_long_for_owner(
+                &claimed.tsm_mac,
+                claimed.invoke_id,
+                &claimed.owner,
+                100,
+            ),
+            CompletionOutcome::NoTransaction
+        );
+        assert!(tsm.owner_is_current(&tsm_mac, 7, &replacement.owner));
+        assert_eq!(tsm.pending_count(), 1);
+    }
+}

--- a/crates/bacnet-client/src/client/routed_path_limits.rs
+++ b/crates/bacnet-client/src/client/routed_path_limits.rs
@@ -1,19 +1,22 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex as StdMutex, MutexGuard as StdMutexGuard};
-use std::time::Instant;
+use std::time::{Duration, Instant as StdInstant};
 
 use bacnet_encoding::npdu::decode_reject_message_to_network;
 use bacnet_network::layer::ReceivedNetworkControl;
 use bacnet_types::enums::{NetworkMessageType, RejectMessageReason};
 use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+use tokio::time::Instant as TokioInstant;
 
 use super::*;
 use crate::tsm::CompletionOutcome;
 
 /// Smallest routed NPDU envelope required across the standard data links.
 const CONSERVATIVE_ROUTED_PATH_MAX_NPDU: u16 = 228;
+/// Hard bound covering gates, configured evidence, and learned evidence.
+pub(super) const MAX_ROUTED_PATH_ENTRIES: usize = 256;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct RoutedPathKey {
     immediate_router_mac: MacAddr,
     dnet: u16,
@@ -36,12 +39,12 @@ enum ConfiguredLimitProvenance {
 struct ConfiguredPathLimit {
     max_npdu: u16,
     provenance: ConfiguredLimitProvenance,
-    observed_at: Instant,
+    observed_at: StdInstant,
 }
 
 struct LearnedPathLimit {
     exclusive_max_npdu: u16,
-    observed_at: Instant,
+    observed_at: StdInstant,
 }
 
 struct ActiveRoutedSend {
@@ -51,6 +54,7 @@ struct ActiveRoutedSend {
     owner: TransactionOwner,
     forwarded_npci_len: u16,
     outgoing_apdu_len: Option<u16>,
+    ingress_floor: u64,
 }
 
 struct RoutedPathEntry {
@@ -58,42 +62,156 @@ struct RoutedPathEntry {
     configured: Option<ConfiguredPathLimit>,
     learned: Option<LearnedPathLimit>,
     active: Option<ActiveRoutedSend>,
+    last_used: u64,
+    quarantine_started: Option<TokioInstant>,
+    generation_attempts: u32,
+    generation_terminal_observed: bool,
 }
 
-impl Default for RoutedPathEntry {
-    fn default() -> Self {
+impl RoutedPathEntry {
+    fn new(last_used: u64) -> Self {
         Self {
             gate: Arc::new(AsyncMutex::new(())),
             configured: None,
             learned: None,
             active: None,
+            last_used,
+            quarantine_started: None,
+            generation_attempts: 0,
+            generation_terminal_observed: false,
         }
     }
 }
 
-#[derive(Default)]
+struct RoutedPathState {
+    entries: HashMap<RoutedPathKey, RoutedPathEntry>,
+    next_use: u64,
+    capacity: usize,
+}
+
 pub(super) struct RoutedPathLimits {
-    entries: StdMutex<HashMap<RoutedPathKey, RoutedPathEntry>>,
+    state: StdMutex<RoutedPathState>,
+    quarantine_horizon: Duration,
 }
 
 impl RoutedPathLimits {
-    fn entries(&self) -> StdMutexGuard<'_, HashMap<RoutedPathKey, RoutedPathEntry>> {
-        self.entries
+    pub(super) fn new(quarantine_horizon: Duration) -> Self {
+        Self::with_capacity(MAX_ROUTED_PATH_ENTRIES, quarantine_horizon)
+    }
+
+    fn with_capacity(capacity: usize, quarantine_horizon: Duration) -> Self {
+        assert!(capacity > 0, "routed path capacity must be nonzero");
+        Self {
+            state: StdMutex::new(RoutedPathState {
+                entries: HashMap::new(),
+                next_use: 0,
+                capacity,
+            }),
+            quarantine_horizon,
+        }
+    }
+
+    fn state(&self) -> StdMutexGuard<'_, RoutedPathState> {
+        self.state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    pub(super) async fn acquire(self: &Arc<Self>, router_mac: &[u8], dnet: u16) -> RoutedPathLease {
+    pub(super) async fn acquire(
+        self: &Arc<Self>,
+        router_mac: &[u8],
+        dnet: u16,
+    ) -> Result<RoutedPathLease, Error> {
         let key = RoutedPathKey::new(router_mac, dnet);
-        let gate = {
-            let mut entries = self.entries();
-            Arc::clone(&entries.entry(key.clone()).or_default().gate)
-        };
+        let gate = self.reserve_gate(&key)?;
         let gate = gate.lock_owned().await;
-        RoutedPathLease {
+        self.wait_for_quarantine(&key).await;
+        Ok(RoutedPathLease {
             limits: Arc::clone(self),
             key,
             _gate: gate,
+        })
+    }
+
+    fn reserve_gate(&self, key: &RoutedPathKey) -> Result<Arc<AsyncMutex<()>>, Error> {
+        let mut state = self.state();
+        let last_used = bump_use(&mut state);
+        if let Some(entry) = state.entries.get_mut(key) {
+            entry.last_used = last_used;
+            return Ok(Arc::clone(&entry.gate));
+        }
+
+        if state.entries.len() >= state.capacity {
+            let reclaim = state
+                .entries
+                .iter()
+                .filter(|(_, entry)| self.is_safely_reclaimable(entry))
+                .min_by(|(key_a, entry_a), (key_b, entry_b)| {
+                    entry_a
+                        .last_used
+                        .cmp(&entry_b.last_used)
+                        .then_with(|| key_a.cmp(key_b))
+                })
+                .map(|(key, _)| key.clone());
+            if let Some(reclaim) = reclaim {
+                state.entries.remove(&reclaim);
+            }
+        }
+        if state.entries.len() >= state.capacity {
+            return Err(Error::RoutedPathCapacityExceeded {
+                capacity: state.capacity,
+            });
+        }
+
+        let entry = RoutedPathEntry::new(last_used);
+        let gate = Arc::clone(&entry.gate);
+        state.entries.insert(key.clone(), entry);
+        Ok(gate)
+    }
+
+    fn is_safely_reclaimable(&self, entry: &RoutedPathEntry) -> bool {
+        entry.configured.is_none()
+            && entry.learned.is_none()
+            && entry.active.is_none()
+            && Arc::strong_count(&entry.gate) == 1
+            && entry
+                .quarantine_started
+                .is_none_or(|started| started.elapsed() >= self.quarantine_horizon)
+    }
+
+    async fn wait_for_quarantine(&self, key: &RoutedPathKey) {
+        loop {
+            let remaining = {
+                let mut state = self.state();
+                let last_used = bump_use(&mut state);
+                let entry = state
+                    .entries
+                    .get_mut(key)
+                    .expect("a held or waiting gate keeps its path entry resident");
+                entry.last_used = last_used;
+                match entry.quarantine_started {
+                    Some(started) => {
+                        let remaining = self.quarantine_horizon.saturating_sub(started.elapsed());
+                        if remaining.is_zero() {
+                            entry.quarantine_started = None;
+                            entry.generation_attempts = 0;
+                            entry.generation_terminal_observed = false;
+                            None
+                        } else {
+                            Some(remaining)
+                        }
+                    }
+                    None => {
+                        entry.generation_attempts = 0;
+                        entry.generation_terminal_observed = false;
+                        None
+                    }
+                }
+            };
+            let Some(remaining) = remaining else {
+                return;
+            };
+            tokio::time::sleep(remaining).await;
         }
     }
 
@@ -104,6 +222,7 @@ impl RoutedPathLimits {
         invoke_id: u8,
         owner: TransactionOwner,
         forwarded_npci_len: u16,
+        ingress_floor: u64,
     ) {
         let ConfirmedTarget::Routed {
             router_mac,
@@ -114,8 +233,11 @@ impl RoutedPathLimits {
             return;
         };
         let key = RoutedPathKey::new(router_mac, dest_network);
-        let mut entries = self.entries();
-        let entry = entries.entry(key.clone()).or_default();
+        let mut state = self.state();
+        let entry = state
+            .entries
+            .get_mut(&key)
+            .expect("the routed path lease keeps its entry resident");
         debug_assert!(
             entry.active.is_none(),
             "the per-path gate permits only one active routed request"
@@ -127,6 +249,7 @@ impl RoutedPathLimits {
             owner,
             forwarded_npci_len,
             outgoing_apdu_len: None,
+            ingress_floor,
         });
     }
 
@@ -150,11 +273,11 @@ impl RoutedPathLimits {
             return false;
         };
         let key = RoutedPathKey::new(router_mac, dest_network);
-        let mut entries = self.entries();
-        let Some(active) = entries
-            .get_mut(&key)
-            .and_then(|entry| entry.active.as_mut())
-        else {
+        let mut state = self.state();
+        let Some(entry) = state.entries.get_mut(&key) else {
+            return false;
+        };
+        let Some(active) = entry.active.as_mut() else {
             return false;
         };
         if active.tsm_mac != *tsm_mac
@@ -164,6 +287,7 @@ impl RoutedPathLimits {
             return false;
         }
         active.outgoing_apdu_len = Some(outgoing_apdu_len);
+        entry.generation_attempts = entry.generation_attempts.saturating_add(1);
         true
     }
 
@@ -183,7 +307,9 @@ impl RoutedPathLimits {
             return;
         }
 
-        let Some(active) = self.claim_active(&control.source_mac, reject.dnet) else {
+        let Some(active) =
+            self.claim_active(&control.source_mac, reject.dnet, control.ingress_sequence)
+        else {
             return;
         };
         let outcome = tsm.lock().await.complete_network_path_too_long_for_owner(
@@ -197,15 +323,20 @@ impl RoutedPathLimits {
         }
     }
 
-    fn claim_active(&self, router_mac: &[u8], dnet: u16) -> Option<ActiveRoutedSend> {
+    fn claim_active(
+        &self,
+        router_mac: &[u8],
+        dnet: u16,
+        ingress_sequence: u64,
+    ) -> Option<ActiveRoutedSend> {
         let key = RoutedPathKey::new(router_mac, dnet);
-        let mut entries = self.entries();
-        let entry = entries.get_mut(&key)?;
-        if entry
-            .active
-            .as_ref()
-            .is_none_or(|active| active.outgoing_apdu_len.is_none() || active.path != key)
-        {
+        let mut state = self.state();
+        let entry = state.entries.get_mut(&key)?;
+        if entry.active.as_ref().is_none_or(|active| {
+            active.outgoing_apdu_len.is_none()
+                || active.path != key
+                || ingress_sequence <= active.ingress_floor
+        }) {
             return None;
         }
         entry.active.take()
@@ -218,14 +349,17 @@ impl RoutedPathLimits {
         else {
             return;
         };
-        let mut entries = self.entries();
-        let entry = entries.entry(active.path).or_default();
+        let mut state = self.state();
+        let entry = state
+            .entries
+            .get_mut(&active.path)
+            .expect("the reason-4 claimant still holds its routed path gate");
         let exclusive_max_npdu = entry.learned.as_ref().map_or(attempted_npdu, |learned| {
             learned.exclusive_max_npdu.min(attempted_npdu)
         });
         entry.learned = Some(LearnedPathLimit {
             exclusive_max_npdu,
-            observed_at: Instant::now(),
+            observed_at: StdInstant::now(),
         });
     }
 }
@@ -243,8 +377,9 @@ impl RoutedPathLease {
         local_source_mac_len: usize,
     ) -> Result<u16, Error> {
         let forwarded_npci_len = forwarded_npci_len(dadr_len, local_source_mac_len)?;
-        let entries = self.limits.entries();
-        let entry = entries
+        let state = self.limits.state();
+        let entry = state
+            .entries
             .get(&self.key)
             .expect("path entry remains present while its gate is held");
         let configured_or_conservative =
@@ -283,22 +418,37 @@ impl RoutedPathLease {
         forwarded_npci_len(dadr_len, local_source_mac_len)
     }
 
+    /// Mark a source-correlated terminal response for the current generation.
+    /// One attempted frame plus its terminal response proves there cannot be a
+    /// second reason-4 still in flight for that generation. Multi-frame or
+    /// retried generations remain ambiguous and are quarantined on drop.
+    pub(super) fn mark_terminal_observed(&self) {
+        let mut state = self.limits.state();
+        let entry = state
+            .entries
+            .get_mut(&self.key)
+            .expect("path entry remains present while its gate is held");
+        entry.generation_terminal_observed = entry.generation_attempts == 1;
+    }
+
     fn configure(&self, max_npdu: u16) {
-        let mut entries = self.limits.entries();
-        let entry = entries
+        let mut state = self.limits.state();
+        let entry = state
+            .entries
             .get_mut(&self.key)
             .expect("path entry remains present while its gate is held");
         entry.configured = Some(ConfiguredPathLimit {
             max_npdu,
             provenance: ConfiguredLimitProvenance::ExplicitApi,
-            observed_at: Instant::now(),
+            observed_at: StdInstant::now(),
         });
         entry.learned = None;
     }
 
     fn clear(&self) {
-        let mut entries = self.limits.entries();
-        let entry = entries
+        let mut state = self.limits.state();
+        let entry = state
+            .entries
             .get_mut(&self.key)
             .expect("path entry remains present while its gate is held");
         entry.configured = None;
@@ -308,11 +458,30 @@ impl RoutedPathLease {
 
 impl Drop for RoutedPathLease {
     fn drop(&mut self) {
-        let mut entries = self.limits.entries();
-        if let Some(entry) = entries.get_mut(&self.key) {
+        let mut state = self.limits.state();
+        if let Some(entry) = state.entries.get_mut(&self.key) {
             entry.active = None;
+            if entry.generation_attempts > 0 && !entry.generation_terminal_observed {
+                entry.quarantine_started = Some(TokioInstant::now());
+            }
+            entry.generation_attempts = 0;
+            entry.generation_terminal_observed = false;
         }
     }
+}
+
+fn bump_use(state: &mut RoutedPathState) -> u64 {
+    state.next_use = state.next_use.saturating_add(1);
+    state.next_use
+}
+
+pub(super) fn routed_path_quarantine_horizon(config: &ClientConfig) -> Duration {
+    // Reuse the configured complete request/retry horizon instead of adding a
+    // separate arbitrary stale-control timer. A zero timeout still receives
+    // one millisecond, the existing configuration's millisecond granularity,
+    // so ambiguous generations never skip quarantine entirely.
+    let attempts = u64::from(config.apdu_retries).saturating_add(1);
+    Duration::from_millis(config.apdu_timeout_ms.saturating_mul(attempts).max(1))
 }
 
 fn forwarded_npci_len(dadr_len: usize, local_source_mac_len: usize) -> Result<u16, Error> {
@@ -343,7 +512,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         max_npdu: u16,
     ) -> Result<(), Error> {
         validate_public_path(router_mac, dnet)?;
-        let lease = self.routed_path_limits.acquire(router_mac, dnet).await;
+        let lease = self.routed_path_limits.acquire(router_mac, dnet).await?;
         lease.configure(max_npdu);
         Ok(())
     }
@@ -355,7 +524,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     /// conservative routed NPDU envelope until new evidence is supplied.
     pub async fn clear_routed_path_limit(&self, router_mac: &[u8], dnet: u16) -> Result<(), Error> {
         validate_public_path(router_mac, dnet)?;
-        let lease = self.routed_path_limits.acquire(router_mac, dnet).await;
+        let lease = self.routed_path_limits.acquire(router_mac, dnet).await?;
         lease.clear();
         Ok(())
     }
@@ -376,65 +545,5 @@ fn validate_public_path(router_mac: &[u8], dnet: u16) -> Result<(), Error> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use bacnet_types::enums::ConfirmedServiceChoice;
-
-    #[test]
-    fn conservative_and_configured_npdu_envelopes_use_forwarded_source() {
-        let header = forwarded_npci_len(6, 6).unwrap();
-        assert_eq!(header, 21);
-        assert_eq!(CONSERVATIVE_ROUTED_PATH_MAX_NPDU - header, 207);
-        assert_eq!(1497 - header, 1476);
-
-        assert_eq!(forwarded_npci_len(1, 1).unwrap(), 11);
-        assert_eq!(forwarded_npci_len(4, 6).unwrap(), 19);
-    }
-
-    #[test]
-    fn forwarded_npci_rejects_unrepresentable_addresses() {
-        assert!(forwarded_npci_len(256, 6).is_err());
-        assert!(forwarded_npci_len(6, 0).is_err());
-        assert!(forwarded_npci_len(6, 256).is_err());
-    }
-
-    #[test]
-    fn claimed_control_cannot_complete_reused_invoke_id_for_new_owner() {
-        let limits = RoutedPathLimits::default();
-        let router = [2];
-        let dadr = [3];
-        let target = ConfirmedTarget::Routed {
-            router_mac: &router,
-            dest_network: 100,
-            dest_mac: &dadr,
-        };
-        let tsm_mac = target.transaction_peer().tsm_mac;
-        let mut tsm = Tsm::new(TsmConfig::default());
-        let old = tsm.register_transaction_with_progress(
-            tsm_mac.clone(),
-            7,
-            ConfirmedServiceChoice::READ_PROPERTY,
-        );
-        limits.install_active(target, tsm_mac.clone(), 7, old.owner.clone(), 11);
-        assert!(limits.authorize_attempt(target, &tsm_mac, 7, &old.owner, 100));
-        let claimed = limits.claim_active(&router, 100).unwrap();
-
-        assert!(tsm.cancel_transaction_for_owner(&tsm_mac, 7, &old.owner));
-        let replacement = tsm.register_transaction_with_progress(
-            tsm_mac.clone(),
-            7,
-            ConfirmedServiceChoice::READ_PROPERTY,
-        );
-        assert_eq!(
-            tsm.complete_network_path_too_long_for_owner(
-                &claimed.tsm_mac,
-                claimed.invoke_id,
-                &claimed.owner,
-                100,
-            ),
-            CompletionOutcome::NoTransaction
-        );
-        assert!(tsm.owner_is_current(&tsm_mac, 7, &replacement.owner));
-        assert_eq!(tsm.pending_count(), 1);
-    }
-}
+#[path = "routed_path_limits_tests.rs"]
+mod tests;

--- a/crates/bacnet-client/src/client/routed_path_limits_tests.rs
+++ b/crates/bacnet-client/src/client/routed_path_limits_tests.rs
@@ -1,0 +1,234 @@
+use super::*;
+use bacnet_encoding::npdu::Npdu;
+use bacnet_network::layer::ReceivedNetworkControl;
+use bacnet_types::enums::ConfirmedServiceChoice;
+use bytes::Bytes;
+
+#[test]
+fn conservative_and_configured_npdu_envelopes_use_forwarded_source() {
+    let header = forwarded_npci_len(6, 6).unwrap();
+    assert_eq!(header, 21);
+    assert_eq!(CONSERVATIVE_ROUTED_PATH_MAX_NPDU - header, 207);
+    assert_eq!(1497 - header, 1476);
+    assert_eq!(forwarded_npci_len(1, 1).unwrap(), 11);
+    assert_eq!(forwarded_npci_len(4, 6).unwrap(), 19);
+}
+
+#[test]
+fn forwarded_npci_rejects_unrepresentable_addresses() {
+    assert!(forwarded_npci_len(256, 6).is_err());
+    assert!(forwarded_npci_len(6, 0).is_err());
+    assert!(forwarded_npci_len(6, 256).is_err());
+}
+
+#[tokio::test]
+async fn claimed_control_cannot_complete_reused_invoke_id_for_new_owner() {
+    let limits = Arc::new(RoutedPathLimits::with_capacity(
+        4,
+        Duration::from_millis(10),
+    ));
+    let router = [2];
+    let dadr = [3];
+    let target = ConfirmedTarget::Routed {
+        router_mac: &router,
+        dest_network: 100,
+        dest_mac: &dadr,
+    };
+    let _lease = limits.acquire(&router, 100).await.unwrap();
+    let tsm_mac = target.transaction_peer().tsm_mac;
+    let mut tsm = Tsm::new(TsmConfig::default());
+    let old = tsm.register_transaction_with_progress(
+        tsm_mac.clone(),
+        7,
+        ConfirmedServiceChoice::READ_PROPERTY,
+    );
+    limits.install_active(target, tsm_mac.clone(), 7, old.owner.clone(), 11, 0);
+    assert!(limits.authorize_attempt(target, &tsm_mac, 7, &old.owner, 100));
+    let claimed = limits.claim_active(&router, 100, 1).unwrap();
+
+    assert!(tsm.cancel_transaction_for_owner(&tsm_mac, 7, &old.owner));
+    let replacement = tsm.register_transaction_with_progress(
+        tsm_mac.clone(),
+        7,
+        ConfirmedServiceChoice::READ_PROPERTY,
+    );
+    assert_eq!(
+        tsm.complete_network_path_too_long_for_owner(
+            &claimed.tsm_mac,
+            claimed.invoke_id,
+            &claimed.owner,
+            100,
+        ),
+        CompletionOutcome::NoTransaction
+    );
+    assert!(tsm.owner_is_current(&tsm_mac, 7, &replacement.owner));
+    assert_eq!(tsm.pending_count(), 1);
+}
+
+#[tokio::test]
+async fn hostile_pre_tsm_paths_reclaim_idle_entries_at_capacity() {
+    let limits = Arc::new(RoutedPathLimits::with_capacity(
+        3,
+        Duration::from_millis(10),
+    ));
+    for path in 1..=40u16 {
+        let lease = limits.acquire(&path.to_be_bytes(), path).await.unwrap();
+        assert_eq!(lease.max_apdu(255, 255).unwrap(), 0);
+        drop(lease);
+        assert!(limits.state().entries.len() <= 3);
+    }
+    assert_eq!(limits.state().entries.len(), 3);
+}
+
+#[tokio::test]
+async fn configured_and_learned_evidence_are_never_evicted_for_capacity() {
+    let limits = Arc::new(RoutedPathLimits::with_capacity(
+        2,
+        Duration::from_millis(10),
+    ));
+    let configured_key = RoutedPathKey::new(&[1], 100);
+    let learned_key = RoutedPathKey::new(&[2], 200);
+
+    let configured = limits.acquire(&[1], 100).await.unwrap();
+    configured.configure(1497);
+    drop(configured);
+
+    let learned = limits.acquire(&[2], 200).await.unwrap();
+    limits
+        .state()
+        .entries
+        .get_mut(&learned_key)
+        .unwrap()
+        .learned = Some(LearnedPathLimit {
+        exclusive_max_npdu: 300,
+        observed_at: StdInstant::now(),
+    });
+    drop(learned);
+
+    assert!(matches!(
+        limits.acquire(&[3], 300).await,
+        Err(Error::RoutedPathCapacityExceeded { capacity: 2 })
+    ));
+    let state = limits.state();
+    assert_eq!(state.entries.len(), 2);
+    assert_eq!(
+        state.entries[&configured_key]
+            .configured
+            .as_ref()
+            .unwrap()
+            .max_npdu,
+        1497
+    );
+    assert_eq!(
+        state.entries[&learned_key]
+            .learned
+            .as_ref()
+            .unwrap()
+            .exclusive_max_npdu,
+        300
+    );
+}
+
+#[tokio::test]
+async fn capacity_cleanup_never_splits_a_held_or_waiting_same_path_gate() {
+    let limits = Arc::new(RoutedPathLimits::with_capacity(
+        2,
+        Duration::from_millis(10),
+    ));
+    let held = limits.acquire(&[1], 100).await.unwrap();
+    drop(limits.acquire(&[2], 200).await.unwrap());
+
+    let waiter_limits = Arc::clone(&limits);
+    let (acquired_tx, mut acquired_rx) = tokio::sync::mpsc::unbounded_channel();
+    let waiter = tokio::spawn(async move {
+        let _lease = waiter_limits.acquire(&[1], 100).await.unwrap();
+        acquired_tx.send(()).unwrap();
+    });
+    tokio::task::yield_now().await;
+
+    let replacement = limits.acquire(&[3], 300).await.unwrap();
+    {
+        let state = limits.state();
+        assert!(state.entries.contains_key(&RoutedPathKey::new(&[1], 100)));
+        assert!(!state.entries.contains_key(&RoutedPathKey::new(&[2], 200)));
+    }
+    assert!(acquired_rx.try_recv().is_err());
+
+    drop(replacement);
+    drop(held);
+    tokio::time::timeout(Duration::from_millis(100), acquired_rx.recv())
+        .await
+        .expect("same-path waiter remained blocked")
+        .expect("same-path waiter exited without acquiring the original gate");
+    waiter.await.unwrap();
+}
+
+fn reason_4_control(router: &[u8], dnet: u16, ingress_sequence: u64) -> ReceivedNetworkControl {
+    ReceivedNetworkControl {
+        npdu: Npdu {
+            is_network_message: true,
+            message_type: Some(NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw()),
+            payload: Bytes::from(vec![
+                RejectMessageReason::MESSAGE_TOO_LONG.to_raw(),
+                (dnet >> 8) as u8,
+                dnet as u8,
+            ]),
+            ..Npdu::default()
+        },
+        source_mac: MacAddr::from_slice(router),
+        link_layer_group: false,
+        data_attributes: Vec::new(),
+        ingress_sequence,
+    }
+}
+
+#[tokio::test]
+async fn control_queued_before_activation_cannot_claim_the_new_generation() {
+    let limits = Arc::new(RoutedPathLimits::with_capacity(
+        2,
+        Duration::from_millis(10),
+    ));
+    let router = [2];
+    let dadr = [3];
+    let target = ConfirmedTarget::Routed {
+        router_mac: &router,
+        dest_network: 100,
+        dest_mac: &dadr,
+    };
+    let lease = limits.acquire(&router, 100).await.unwrap();
+    let tsm_mac = target.transaction_peer().tsm_mac;
+    let mut tsm = Tsm::new(TsmConfig::default());
+    let mut registration = tsm.register_transaction_with_progress(
+        tsm_mac.clone(),
+        9,
+        ConfirmedServiceChoice::READ_PROPERTY,
+    );
+    let tsm = Arc::new(Mutex::new(tsm));
+    limits.install_active(
+        target,
+        tsm_mac.clone(),
+        9,
+        registration.owner.clone(),
+        11,
+        5,
+    );
+    assert!(limits.authorize_attempt(target, &tsm_mac, 9, &registration.owner, 100));
+
+    limits
+        .handle_network_control(&tsm, reason_4_control(&router, 100, 5))
+        .await;
+    assert!(tsm
+        .lock()
+        .await
+        .owner_is_current(&tsm_mac, 9, &registration.owner));
+    assert!(registration.response.try_recv().is_err());
+
+    limits
+        .handle_network_control(&tsm, reason_4_control(&router, 100, 6))
+        .await;
+    assert!(matches!(
+        registration.response.await.unwrap(),
+        TsmResponse::NetworkPathTooLong { dnet: 100 }
+    ));
+    lease.mark_terminal_observed();
+}

--- a/crates/bacnet-client/src/client/sc_max_apdu_tests.rs
+++ b/crates/bacnet-client/src/client/sc_max_apdu_tests.rs
@@ -266,6 +266,10 @@ async fn client_routed_unsegmented_request_accounts_for_npdu_overhead_bucket() {
         .unwrap();
     assert_eq!(client.transport_max_apdu_length(), 1024);
     assert_eq!(client.max_apdu_length(), 1024);
+    client
+        .configure_routed_path_max_npdu(&router_mac, remote_network, 1497)
+        .await
+        .unwrap();
 
     let service_data: Vec<u8> = (0..900).map(|i| (i % 251) as u8).collect();
     let request_future = client.confirmed_request_routed(

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -476,6 +476,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         remote_max_apdu: u16,
         remote_max_segments: Option<u32>,
         routed_forwarded_npci_len: Option<u16>,
+        routed_path_lease: Option<&RoutedPathLease>,
     ) -> Result<Bytes, Error> {
         let transaction_peer = target.transaction_peer();
         let tsm_mac = transaction_peer.tsm_mac;
@@ -520,6 +521,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                 invoke_id,
                 owner.clone(),
                 forwarded_npci_len,
+                self.network.network_control_ingress_sequence(),
             );
         }
         let mut guard = TransactionGuard::new(
@@ -812,6 +814,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             }
         };
 
+        if let Some(lease) = routed_path_lease {
+            lease.mark_terminal_observed();
+        }
         guard.mark_completed();
         Self::confirmed_response_result(response)
     }

--- a/crates/bacnet-client/src/client/segmentation.rs
+++ b/crates/bacnet-client/src/client/segmentation.rs
@@ -475,6 +475,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         service_data: &[u8],
         remote_max_apdu: u16,
         remote_max_segments: Option<u32>,
+        routed_forwarded_npci_len: Option<u16>,
     ) -> Result<Bytes, Error> {
         let transaction_peer = target.transaction_peer();
         let tsm_mac = transaction_peer.tsm_mac;
@@ -512,6 +513,15 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         };
 
         let owner = registration.owner.clone();
+        if let Some(forwarded_npci_len) = routed_forwarded_npci_len {
+            self.routed_path_limits.install_active(
+                target,
+                tsm_mac.clone(),
+                invoke_id,
+                owner.clone(),
+                forwarded_npci_len,
+            );
+        }
         let mut guard = TransactionGuard::new(
             Arc::clone(&self.tsm),
             self.cleanup_tx.clone(),

--- a/crates/bacnet-client/src/client/segmented_request.rs
+++ b/crates/bacnet-client/src/client/segmented_request.rs
@@ -45,6 +45,18 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         });
         let mut buf = BytesMut::with_capacity(context.remote_max_apdu as usize);
         encode_apdu(&mut buf, &pdu)?;
+        if !self.routed_path_limits.authorize_attempt(
+            context.target,
+            context.tsm_mac,
+            context.invoke_id,
+            context.owner,
+            buf.len(),
+        ) {
+            return response_rx
+                .await
+                .map(OutgoingSegmentSend::Terminal)
+                .map_err(|_| Error::Encoding("TSM response channel closed".into()));
+        }
         let send = self.send_confirmed_target_apdu(context.target, &buf);
         tokio::pin!(send);
 

--- a/crates/bacnet-client/src/tsm.rs
+++ b/crates/bacnet-client/src/tsm.rs
@@ -6,7 +6,6 @@
 use bacnet_types::enums::{AbortReason, ConfirmedServiceChoice};
 use bacnet_types::MacAddr;
 use bytes::Bytes;
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{oneshot, watch};
@@ -17,6 +16,7 @@ pub(crate) use final_segment::{
 };
 mod segmented_response;
 pub(crate) use segmented_response::SegmentedResponseAdmission;
+mod completion;
 mod coordinated;
 pub(crate) use coordinated::{CoordinatedCompletion, CoordinatedTerminalPhase};
 use coordinated::{PendingLease, PendingRelease};
@@ -59,6 +59,11 @@ pub enum TsmResponse {
     Reject { reason: u8 },
     /// Abort PDU.
     Abort { reason: u8 },
+    /// A router rejected the active message as too long for its routed path.
+    NetworkPathTooLong {
+        /// Destination network named by the network-layer rejection.
+        dnet: u16,
+    },
 }
 
 /// Invoke ID allocator scoped to a single destination MAC.
@@ -653,133 +658,6 @@ impl Tsm {
         self.pending
             .get(&key)
             .is_some_and(|pending| pending.owner.same_as(owner))
-    }
-
-    /// Deliver a response to a pending transaction.
-    ///
-    /// `observed_service_choice` is the service the response claims to answer,
-    /// or `None` for PDUs that carry no service choice at all — Reject and
-    /// Abort (Clauses 20.1.8 and 20.1.9), which can only be correlated by
-    /// invoke ID.
-    ///
-    /// A mismatch leaves the transaction pending and the invoke ID allocated.
-    /// Completing it would hand the caller a payload belonging to a different
-    /// service and free the ID for reuse while the real response is still in
-    /// flight.
-    pub fn complete_transaction(
-        &mut self,
-        source_mac: &[u8],
-        invoke_id: u8,
-        observed_service_choice: Option<ConfirmedServiceChoice>,
-        response: TsmResponse,
-    ) -> CompletionOutcome {
-        self.complete_transaction_inner(
-            source_mac,
-            invoke_id,
-            None,
-            observed_service_choice,
-            response,
-            PendingRelease::Complete,
-        )
-    }
-
-    pub(crate) fn complete_transaction_for_owner(
-        &mut self,
-        source_mac: &[u8],
-        invoke_id: u8,
-        owner: &TransactionOwner,
-        observed_service_choice: Option<ConfirmedServiceChoice>,
-        response: TsmResponse,
-    ) -> CompletionOutcome {
-        self.complete_transaction_inner(
-            source_mac,
-            invoke_id,
-            Some(owner),
-            observed_service_choice,
-            response,
-            PendingRelease::Release,
-        )
-    }
-
-    pub(crate) fn complete_admitted_transaction_for_owner(
-        &mut self,
-        source_mac: &[u8],
-        invoke_id: u8,
-        owner: &TransactionOwner,
-        observed_service_choice: Option<ConfirmedServiceChoice>,
-        response: TsmResponse,
-    ) -> CompletionOutcome {
-        self.complete_transaction_inner(
-            source_mac,
-            invoke_id,
-            Some(owner),
-            observed_service_choice,
-            response,
-            PendingRelease::Complete,
-        )
-    }
-
-    fn complete_transaction_inner(
-        &mut self,
-        source_mac: &[u8],
-        invoke_id: u8,
-        owner: Option<&TransactionOwner>,
-        observed_service_choice: Option<ConfirmedServiceChoice>,
-        response: TsmResponse,
-        release: PendingRelease,
-    ) -> CompletionOutcome {
-        let key = (MacAddr::from_slice(source_mac), invoke_id);
-        let Entry::Occupied(entry) = self.pending.entry(key) else {
-            return CompletionOutcome::NoTransaction;
-        };
-        if owner.is_some_and(|owner| !entry.get().owner.same_as(owner)) {
-            return CompletionOutcome::NoTransaction;
-        }
-        let requires_sent_all_segments = matches!(
-            &response,
-            TsmResponse::SimpleAck | TsmResponse::ComplexAck { .. } | TsmResponse::Error { .. }
-        );
-        if requires_sent_all_segments
-            && matches!(
-                entry.get().phase,
-                TransactionPhase::SegmentedRequest {
-                    sent_all_segments: false
-                }
-            )
-        {
-            let pending = entry.remove();
-            self.abort_pending_invalid_state(source_mac, invoke_id, pending);
-            return CompletionOutcome::Delivered;
-        }
-        let expected = entry.get().expected_service_choice;
-        if let Some(observed) = observed_service_choice {
-            if observed != expected {
-                return CompletionOutcome::ServiceChoiceMismatch { expected, observed };
-            }
-        }
-        let pending = entry.remove();
-        let responder = pending.responder;
-        self.release_pending_lease(source_mac, invoke_id, pending.lease, release);
-        let _ = responder.send(response);
-        CompletionOutcome::Delivered
-    }
-
-    fn abort_pending_invalid_state(
-        &mut self,
-        source_mac: &[u8],
-        invoke_id: u8,
-        pending: PendingTransaction,
-    ) {
-        let responder = pending.responder;
-        self.release_pending_lease(
-            source_mac,
-            invoke_id,
-            pending.lease,
-            PendingRelease::Release,
-        );
-        let _ = responder.send(TsmResponse::Abort {
-            reason: AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw(),
-        });
     }
 
     fn abort_invalid_apdu_in_current_state(

--- a/crates/bacnet-client/src/tsm/completion.rs
+++ b/crates/bacnet-client/src/tsm/completion.rs
@@ -1,0 +1,153 @@
+use super::{
+    CompletionOutcome, PendingRelease, PendingTransaction, TransactionOwner, TransactionPhase, Tsm,
+    TsmResponse,
+};
+use bacnet_types::enums::{AbortReason, ConfirmedServiceChoice};
+use bacnet_types::MacAddr;
+use std::collections::hash_map::Entry;
+
+impl Tsm {
+    /// Deliver a response to a pending transaction.
+    ///
+    /// `observed_service_choice` is the service the response claims to answer,
+    /// or `None` for PDUs that carry no service choice at all — Reject and
+    /// Abort (Clauses 20.1.8 and 20.1.9), which can only be correlated by
+    /// invoke ID.
+    ///
+    /// A mismatch leaves the transaction pending and the invoke ID allocated.
+    /// Completing it would hand the caller a payload belonging to a different
+    /// service and free the ID for reuse while the real response is still in
+    /// flight.
+    pub fn complete_transaction(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        observed_service_choice: Option<ConfirmedServiceChoice>,
+        response: TsmResponse,
+    ) -> CompletionOutcome {
+        self.complete_transaction_inner(
+            source_mac,
+            invoke_id,
+            None,
+            observed_service_choice,
+            response,
+            PendingRelease::Complete,
+        )
+    }
+
+    pub(crate) fn complete_transaction_for_owner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+        observed_service_choice: Option<ConfirmedServiceChoice>,
+        response: TsmResponse,
+    ) -> CompletionOutcome {
+        self.complete_transaction_inner(
+            source_mac,
+            invoke_id,
+            Some(owner),
+            observed_service_choice,
+            response,
+            PendingRelease::Release,
+        )
+    }
+
+    pub(crate) fn complete_network_path_too_long_for_owner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+        dnet: u16,
+    ) -> CompletionOutcome {
+        self.complete_transaction_inner(
+            source_mac,
+            invoke_id,
+            Some(owner),
+            None,
+            TsmResponse::NetworkPathTooLong { dnet },
+            PendingRelease::Complete,
+        )
+    }
+
+    pub(crate) fn complete_admitted_transaction_for_owner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: &TransactionOwner,
+        observed_service_choice: Option<ConfirmedServiceChoice>,
+        response: TsmResponse,
+    ) -> CompletionOutcome {
+        self.complete_transaction_inner(
+            source_mac,
+            invoke_id,
+            Some(owner),
+            observed_service_choice,
+            response,
+            PendingRelease::Complete,
+        )
+    }
+
+    pub(super) fn complete_transaction_inner(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        owner: Option<&TransactionOwner>,
+        observed_service_choice: Option<ConfirmedServiceChoice>,
+        response: TsmResponse,
+        release: PendingRelease,
+    ) -> CompletionOutcome {
+        let key = (MacAddr::from_slice(source_mac), invoke_id);
+        let Entry::Occupied(entry) = self.pending.entry(key) else {
+            return CompletionOutcome::NoTransaction;
+        };
+        if owner.is_some_and(|owner| !entry.get().owner.same_as(owner)) {
+            return CompletionOutcome::NoTransaction;
+        }
+        let requires_sent_all_segments = matches!(
+            &response,
+            TsmResponse::SimpleAck | TsmResponse::ComplexAck { .. } | TsmResponse::Error { .. }
+        );
+        if requires_sent_all_segments
+            && matches!(
+                entry.get().phase,
+                TransactionPhase::SegmentedRequest {
+                    sent_all_segments: false
+                }
+            )
+        {
+            let pending = entry.remove();
+            self.abort_pending_invalid_state(source_mac, invoke_id, pending);
+            return CompletionOutcome::Delivered;
+        }
+        let expected = entry.get().expected_service_choice;
+        if let Some(observed) = observed_service_choice {
+            if observed != expected {
+                return CompletionOutcome::ServiceChoiceMismatch { expected, observed };
+            }
+        }
+        let pending = entry.remove();
+        let responder = pending.responder;
+        self.release_pending_lease(source_mac, invoke_id, pending.lease, release);
+        let _ = responder.send(response);
+        CompletionOutcome::Delivered
+    }
+
+    fn abort_pending_invalid_state(
+        &mut self,
+        source_mac: &[u8],
+        invoke_id: u8,
+        pending: PendingTransaction,
+    ) {
+        let responder = pending.responder;
+        self.release_pending_lease(
+            source_mac,
+            invoke_id,
+            pending.lease,
+            PendingRelease::Release,
+        );
+        let _ = responder.send(TsmResponse::Abort {
+            reason: AbortReason::INVALID_APDU_IN_THIS_STATE.to_raw(),
+        });
+    }
+}

--- a/crates/bacnet-encoding/src/npdu.rs
+++ b/crates/bacnet-encoding/src/npdu.rs
@@ -4,7 +4,7 @@
 //! or a network-layer message, with optional source/destination routing
 //! information for multi-hop BACnet internetworks.
 
-use bacnet_types::enums::NetworkPriority;
+use bacnet_types::enums::{NetworkPriority, RejectMessageReason};
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 use bytes::{BufMut, Bytes, BytesMut};
@@ -52,6 +52,18 @@ pub struct Npdu {
     pub vendor_id: Option<u16>,
     /// Payload: either APDU bytes or network message data.
     pub payload: Bytes,
+}
+
+/// Decoded payload of a Reject-Message-To-Network control message.
+///
+/// The enclosing NPDU identifies the network-message type; this type models
+/// only the fixed reason/DNET payload used by that message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RejectMessageToNetwork {
+    /// Why the router rejected the message.
+    pub reason: RejectMessageReason,
+    /// Destination network named by the rejection.
+    pub dnet: u16,
 }
 
 impl Default for Npdu {
@@ -309,6 +321,27 @@ pub fn decode_npdu(data: Bytes) -> Result<Npdu, Error> {
     })
 }
 
+/// Decode the fixed three-octet Reject-Message-To-Network payload.
+///
+/// The payload is rejected unless it contains exactly one reason octet and
+/// one two-octet destination network. Callers remain responsible for checking
+/// that the enclosing NPDU is the standard Reject-Message-To-Network type.
+pub fn decode_reject_message_to_network(payload: &[u8]) -> Result<RejectMessageToNetwork, Error> {
+    if payload.len() != 3 {
+        return Err(Error::decoding(
+            0,
+            format!(
+                "Reject-Message-To-Network payload must be exactly 3 octets, got {}",
+                payload.len()
+            ),
+        ));
+    }
+    Ok(RejectMessageToNetwork {
+        reason: RejectMessageReason::from_raw(payload[0]),
+        dnet: u16::from_be_bytes([payload[1], payload[2]]),
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -467,6 +500,25 @@ mod tests {
         assert_eq!(encoded[1] & 0x80, 0x80);
         let decoded = decode_npdu(Bytes::from(encoded)).unwrap();
         assert_eq!(decoded, npdu);
+    }
+
+    #[test]
+    fn reject_message_to_network_payload_decodes_typed_reason_and_dnet() {
+        let decoded = decode_reject_message_to_network(&[
+            RejectMessageReason::MESSAGE_TOO_LONG.to_raw(),
+            0x12,
+            0x34,
+        ])
+        .unwrap();
+        assert_eq!(decoded.reason, RejectMessageReason::MESSAGE_TOO_LONG);
+        assert_eq!(decoded.dnet, 0x1234);
+    }
+
+    #[test]
+    fn reject_message_to_network_payload_requires_exact_length() {
+        for payload in [&[][..], &[4, 0][..], &[4, 0, 1, 2][..]] {
+            assert!(decode_reject_message_to_network(payload).is_err());
+        }
     }
 
     #[test]

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -11,6 +11,8 @@ use bacnet_types::enums::NetworkPriority;
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 use bytes::{Bytes, BytesMut};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
@@ -54,6 +56,12 @@ pub struct ReceivedNetworkControl {
     pub link_layer_group: bool,
     /// Data-link attributes supplied by the transport.
     pub data_attributes: Vec<DataAttribute>,
+    /// Monotonic decoded-ingress sequence assigned before channel delivery.
+    ///
+    /// A consumer can compare this with [`NetworkLayer::network_control_ingress_sequence`]
+    /// when activating state so controls already queued at that point cannot
+    /// be mistaken for feedback about the new state.
+    pub ingress_sequence: u64,
 }
 
 impl Clone for ReceivedApdu {
@@ -101,6 +109,7 @@ pub struct NetworkLayer<T: TransportPort> {
     transport: T,
     dispatch_task: Option<JoinHandle<()>>,
     network_control_tx: Option<mpsc::Sender<ReceivedNetworkControl>>,
+    network_control_ingress_sequence: Arc<AtomicU64>,
 }
 
 impl<T: TransportPort + 'static> NetworkLayer<T> {
@@ -110,6 +119,7 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
             transport,
             dispatch_task: None,
             network_control_tx: None,
+            network_control_ingress_sequence: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -143,6 +153,7 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     pub async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedApdu>, Error> {
         let mut npdu_rx = self.transport.start().await?;
         let mut network_control_tx = self.network_control_tx.take();
+        let network_control_ingress_sequence = Arc::clone(&self.network_control_ingress_sequence);
 
         let (apdu_tx, apdu_rx) = mpsc::channel(256);
 
@@ -152,11 +163,15 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
                     Ok(npdu) => {
                         if npdu.is_network_message {
                             if let Some(tx) = network_control_tx.as_ref() {
+                                let ingress_sequence = next_ingress_sequence(
+                                    network_control_ingress_sequence.as_ref(),
+                                );
                                 let control = ReceivedNetworkControl {
                                     npdu,
                                     source_mac: received.source_mac,
                                     link_layer_group: received.link_layer_group,
                                     data_attributes: received.data_attributes,
+                                    ingress_sequence,
                                 };
                                 if tx.send(control).await.is_err() {
                                     network_control_tx = None;
@@ -490,6 +505,15 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
         self.transport.local_mac()
     }
 
+    /// Sequence assigned to the most recently decoded network-control ingress.
+    ///
+    /// The value is updated before the control is queued for its opt-in
+    /// consumer. At counter exhaustion it remains at `u64::MAX`, which makes
+    /// sequence-based consumers fail closed rather than accepting an alias.
+    pub fn network_control_ingress_sequence(&self) -> u64 {
+        self.network_control_ingress_sequence.load(Ordering::SeqCst)
+    }
+
     /// Encode an APDU into an NPDU whose destination is `dest_network` /
     /// `dest_mac`, ready for whichever link send the caller chooses.
     fn encode_routed_npdu_buf(
@@ -524,6 +548,15 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
         }
         self.transport.stop().await
     }
+}
+
+fn next_ingress_sequence(sequence: &AtomicU64) -> u64 {
+    let previous = sequence
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |value| {
+            value.checked_add(1)
+        })
+        .unwrap_or(u64::MAX);
+    previous.saturating_add(1)
 }
 
 impl<T: TransportPort> NetworkLayer<T> {

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -39,6 +39,23 @@ pub struct ReceivedApdu {
     pub reply_tx: Option<oneshot::Sender<Bytes>>,
 }
 
+/// A decoded network-layer control message received from a transport peer.
+///
+/// Non-router users opt in to this stream before [`NetworkLayer::start`].
+/// Without that opt-in, network messages retain their historical discard/log
+/// behavior.
+#[derive(Debug, Clone)]
+pub struct ReceivedNetworkControl {
+    /// Decoded NPDU, including network-message type and typed-address fields.
+    pub npdu: Npdu,
+    /// Immediate transport peer that sent the message.
+    pub source_mac: MacAddr,
+    /// Whether the data-link delivery was multicast or broadcast.
+    pub link_layer_group: bool,
+    /// Data-link attributes supplied by the transport.
+    pub data_attributes: Vec<DataAttribute>,
+}
+
 impl Clone for ReceivedApdu {
     fn clone(&self) -> Self {
         Self {
@@ -83,6 +100,7 @@ pub(crate) fn is_group_delivery(link_layer_group: bool, destination: Option<&Npd
 pub struct NetworkLayer<T: TransportPort> {
     transport: T,
     dispatch_task: Option<JoinHandle<()>>,
+    network_control_tx: Option<mpsc::Sender<ReceivedNetworkControl>>,
 }
 
 impl<T: TransportPort + 'static> NetworkLayer<T> {
@@ -91,7 +109,31 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
         Self {
             transport,
             dispatch_task: None,
+            network_control_tx: None,
         }
+    }
+
+    /// Enable the one-consumer decoded network-control stream.
+    ///
+    /// This must be called before [`Self::start`] and at most once. Dropping
+    /// the returned receiver disables control delivery without affecting APDU
+    /// ingress.
+    pub fn enable_network_control_receiver(
+        &mut self,
+    ) -> Result<mpsc::Receiver<ReceivedNetworkControl>, Error> {
+        if self.dispatch_task.is_some() {
+            return Err(Error::Encoding(
+                "network-control receiver must be enabled before NetworkLayer::start".into(),
+            ));
+        }
+        if self.network_control_tx.is_some() {
+            return Err(Error::Encoding(
+                "network-control receiver is already enabled".into(),
+            ));
+        }
+        let (tx, rx) = mpsc::channel(256);
+        self.network_control_tx = Some(tx);
+        Ok(rx)
     }
 
     /// Start the network layer. Returns a receiver for incoming APDUs.
@@ -100,6 +142,7 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     /// decodes incoming NPDUs and extracts APDUs.
     pub async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedApdu>, Error> {
         let mut npdu_rx = self.transport.start().await?;
+        let mut network_control_tx = self.network_control_tx.take();
 
         let (apdu_tx, apdu_rx) = mpsc::channel(256);
 
@@ -108,10 +151,23 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
                 match decode_npdu(received.npdu.clone()) {
                     Ok(npdu) => {
                         if npdu.is_network_message {
-                            debug!(
-                                message_type = npdu.message_type,
-                                "Ignoring network layer message (non-router mode)"
-                            );
+                            if let Some(tx) = network_control_tx.as_ref() {
+                                let control = ReceivedNetworkControl {
+                                    npdu,
+                                    source_mac: received.source_mac,
+                                    link_layer_group: received.link_layer_group,
+                                    data_attributes: received.data_attributes,
+                                };
+                                if tx.send(control).await.is_err() {
+                                    network_control_tx = None;
+                                    debug!("Network-control receiver closed; resuming discard behavior");
+                                }
+                            } else {
+                                debug!(
+                                    message_type = npdu.message_type,
+                                    "Ignoring network layer message (non-router mode)"
+                                );
+                            }
                             continue;
                         }
 
@@ -491,7 +547,7 @@ mod tests {
     use bacnet_transport::bip::BipTransport;
     use bacnet_transport::sc::{LoopbackWebSocket, ScTransport, WebSocketPort};
     use bacnet_transport::sc_frame::{
-        decode_sc_message, encode_sc_message, ScFunction, ScMessage, ScOption, Vmac,
+        decode_sc_message, encode_sc_message, ScFunction, ScMessage, Vmac,
     };
     use std::net::Ipv4Addr;
     use tokio::time::{timeout, Duration};
@@ -555,76 +611,6 @@ mod tests {
             ws_hub.send(&buf).await.is_err(),
             "{context} must reject post-drop Heartbeat-Request on the closed socket"
         );
-    }
-
-    #[tokio::test]
-    async fn sc_data_options_reach_received_apdu_data_attributes() {
-        let (ws_client, ws_hub) = LoopbackWebSocket::pair();
-        let hub_vmac = [0x10; 6];
-        let mut net = NetworkLayer::new(ScTransport::new(ws_client, [0x01; 6]));
-
-        let hub_accept_task = tokio::spawn(async move {
-            sc_hub_accept(&ws_hub, hub_vmac).await;
-            ws_hub
-        });
-
-        let mut rx = net.start().await.unwrap();
-        let ws_hub = hub_accept_task.await.unwrap();
-
-        let apdu = Bytes::from_static(&[0x10, 0x08]);
-        let npdu = Npdu {
-            is_network_message: false,
-            expecting_reply: false,
-            priority: NetworkPriority::NORMAL,
-            destination: None,
-            source: None,
-            payload: apdu.clone(),
-            ..Npdu::default()
-        };
-        let mut npdu_buf = BytesMut::new();
-        encode_npdu(&mut npdu_buf, &npdu).unwrap();
-
-        let msg = ScMessage {
-            function: ScFunction::EncapsulatedNpdu,
-            message_id: 0x2345,
-            originating_vmac: Some(hub_vmac),
-            destination_vmac: None,
-            dest_options: Vec::new(),
-            data_options: vec![
-                ScOption {
-                    option_type: 1,
-                    must_understand: true,
-                    data: Vec::new(),
-                },
-                ScOption {
-                    option_type: 31,
-                    must_understand: false,
-                    data: vec![0x12, 0x34, 0x56],
-                },
-            ],
-            payload: npdu_buf.freeze(),
-        };
-        let mut sc_buf = BytesMut::new();
-        encode_sc_message(&mut sc_buf, &msg);
-        ws_hub.send(&sc_buf).await.unwrap();
-
-        let received = timeout(Duration::from_secs(1), rx.recv())
-            .await
-            .expect("timed out waiting for APDU")
-            .expect("APDU channel closed");
-
-        assert_eq!(received.apdu, apdu);
-        assert_eq!(received.source_mac.as_slice(), hub_vmac);
-        assert!(received.source_network.is_none());
-        assert_eq!(received.data_attributes.len(), 2);
-        assert_eq!(received.data_attributes[0].option_type, 1);
-        assert!(received.data_attributes[0].must_understand);
-        assert!(received.data_attributes[0].data.is_empty());
-        assert_eq!(received.data_attributes[1].option_type, 31);
-        assert!(!received.data_attributes[1].must_understand);
-        assert_eq!(received.data_attributes[1].data, vec![0x12, 0x34, 0x56]);
-
-        net.stop().await.unwrap();
     }
 
     #[tokio::test]
@@ -845,3 +831,7 @@ mod tests {
 #[cfg(test)]
 #[path = "layer_delivery_tests.rs"]
 mod delivery_tests;
+
+#[cfg(test)]
+#[path = "layer_sc_data_options_tests.rs"]
+mod sc_data_options_tests;

--- a/crates/bacnet-network/src/layer_delivery_tests.rs
+++ b/crates/bacnet-network/src/layer_delivery_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use bacnet_transport::bip::BipTransport;
 use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_types::enums::{NetworkMessageType, RejectMessageReason};
 use std::net::Ipv4Addr;
 use tokio::time::{timeout, Duration};
 
@@ -78,6 +79,83 @@ fn encoded_npdu(destination: Option<NpduAddress>) -> Bytes {
     let mut buffer = BytesMut::new();
     encode_npdu(&mut buffer, &npdu).unwrap();
     buffer.freeze()
+}
+
+fn encoded_reject_message_to_network(reason: RejectMessageReason, dnet: u16) -> Bytes {
+    let npdu = Npdu {
+        is_network_message: true,
+        message_type: Some(NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw()),
+        payload: Bytes::from(vec![reason.to_raw(), (dnet >> 8) as u8, dnet as u8]),
+        ..Npdu::default()
+    };
+    let mut buffer = BytesMut::new();
+    encode_npdu(&mut buffer, &npdu).unwrap();
+    buffer.freeze()
+}
+
+#[tokio::test]
+async fn opted_in_network_control_stream_preserves_start_apdu_receiver() {
+    let (transport, mut peer) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let mut network = NetworkLayer::new(transport);
+    let mut controls = network.enable_network_control_receiver().unwrap();
+    assert!(network.enable_network_control_receiver().is_err());
+    let mut apdus = network.start().await.unwrap();
+
+    peer.send_unicast(
+        &encoded_reject_message_to_network(RejectMessageReason::MESSAGE_TOO_LONG, 100),
+        &[0x01],
+    )
+    .await
+    .unwrap();
+
+    let received = timeout(Duration::from_secs(1), controls.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.source_mac.as_slice(), &[0x02]);
+    assert_eq!(
+        received.npdu.message_type,
+        Some(NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw())
+    );
+    assert!(timeout(Duration::from_millis(25), apdus.recv())
+        .await
+        .is_err());
+    assert!(network.enable_network_control_receiver().is_err());
+
+    network.stop().await.unwrap();
+    peer.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn network_controls_without_opt_in_are_discarded_without_stopping_apdu_ingress() {
+    let (transport, mut peer) = LoopbackTransport::pair(vec![0x01], vec![0x02]);
+    let mut network = NetworkLayer::new(transport);
+    let mut apdus = network.start().await.unwrap();
+
+    peer.send_unicast(
+        &encoded_reject_message_to_network(RejectMessageReason::MESSAGE_TOO_LONG, 100),
+        &[0x01],
+    )
+    .await
+    .unwrap();
+    assert!(timeout(Duration::from_millis(25), apdus.recv())
+        .await
+        .is_err());
+
+    peer.send_unicast(&encoded_npdu(None), &[0x01])
+        .await
+        .unwrap();
+    assert_eq!(
+        timeout(Duration::from_secs(1), apdus.recv())
+            .await
+            .unwrap()
+            .unwrap()
+            .apdu,
+        Bytes::from_static(&[0x10, 0x08])
+    );
+
+    network.stop().await.unwrap();
+    peer.stop().await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/bacnet-network/src/layer_delivery_tests.rs
+++ b/crates/bacnet-network/src/layer_delivery_tests.rs
@@ -113,6 +113,8 @@ async fn opted_in_network_control_stream_preserves_start_apdu_receiver() {
         .unwrap()
         .unwrap();
     assert_eq!(received.source_mac.as_slice(), &[0x02]);
+    assert_eq!(received.ingress_sequence, 1);
+    assert_eq!(network.network_control_ingress_sequence(), 1);
     assert_eq!(
         received.npdu.message_type,
         Some(NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw())

--- a/crates/bacnet-network/src/layer_sc_data_options_tests.rs
+++ b/crates/bacnet-network/src/layer_sc_data_options_tests.rs
@@ -1,0 +1,104 @@
+use super::NetworkLayer;
+use bacnet_encoding::npdu::{encode_npdu, Npdu};
+use bacnet_transport::sc::{LoopbackWebSocket, ScTransport, WebSocketPort};
+use bacnet_transport::sc_frame::{
+    decode_sc_message, encode_sc_message, ScFunction, ScMessage, ScOption, Vmac,
+};
+use bacnet_types::enums::NetworkPriority;
+use bytes::{Bytes, BytesMut};
+use tokio::time::{timeout, Duration};
+
+async fn sc_hub_accept(ws_hub: &LoopbackWebSocket, hub_vmac: Vmac) {
+    let data = ws_hub.recv().await.unwrap();
+    let req = decode_sc_message(&data).unwrap();
+    assert_eq!(req.function, ScFunction::ConnectRequest);
+
+    let mut accept_payload = Vec::with_capacity(26);
+    accept_payload.extend_from_slice(&hub_vmac);
+    accept_payload.extend_from_slice(&[0u8; 16]);
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+    accept_payload.extend_from_slice(&1476u16.to_be_bytes());
+
+    let accept = ScMessage {
+        function: ScFunction::ConnectAccept,
+        message_id: req.message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(accept_payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &accept);
+    ws_hub.send(&buf).await.unwrap();
+}
+
+#[tokio::test]
+async fn sc_data_options_reach_received_apdu_data_attributes() {
+    let (ws_client, ws_hub) = LoopbackWebSocket::pair();
+    let hub_vmac = [0x10; 6];
+    let mut net = NetworkLayer::new(ScTransport::new(ws_client, [0x01; 6]));
+
+    let hub_accept_task = tokio::spawn(async move {
+        sc_hub_accept(&ws_hub, hub_vmac).await;
+        ws_hub
+    });
+
+    let mut rx = net.start().await.unwrap();
+    let ws_hub = hub_accept_task.await.unwrap();
+
+    let apdu = Bytes::from_static(&[0x10, 0x08]);
+    let npdu = Npdu {
+        is_network_message: false,
+        expecting_reply: false,
+        priority: NetworkPriority::NORMAL,
+        destination: None,
+        source: None,
+        payload: apdu.clone(),
+        ..Npdu::default()
+    };
+    let mut npdu_buf = BytesMut::new();
+    encode_npdu(&mut npdu_buf, &npdu).unwrap();
+
+    let msg = ScMessage {
+        function: ScFunction::EncapsulatedNpdu,
+        message_id: 0x2345,
+        originating_vmac: Some(hub_vmac),
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: vec![
+            ScOption {
+                option_type: 1,
+                must_understand: true,
+                data: Vec::new(),
+            },
+            ScOption {
+                option_type: 31,
+                must_understand: false,
+                data: vec![0x12, 0x34, 0x56],
+            },
+        ],
+        payload: npdu_buf.freeze(),
+    };
+    let mut sc_buf = BytesMut::new();
+    encode_sc_message(&mut sc_buf, &msg);
+    ws_hub.send(&sc_buf).await.unwrap();
+
+    let received = timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("timed out waiting for APDU")
+        .expect("APDU channel closed");
+
+    assert_eq!(received.apdu, apdu);
+    assert_eq!(received.source_mac.as_slice(), hub_vmac);
+    assert!(received.source_network.is_none());
+    assert_eq!(received.data_attributes.len(), 2);
+    assert_eq!(received.data_attributes[0].option_type, 1);
+    assert!(received.data_attributes[0].must_understand);
+    assert!(received.data_attributes[0].data.is_empty());
+    assert_eq!(received.data_attributes[1].option_type, 31);
+    assert!(!received.data_attributes[1].must_understand);
+    assert_eq!(received.data_attributes[1].data, vec![0x12, 0x34, 0x56]);
+
+    net.stop().await.unwrap();
+}

--- a/crates/bacnet-types/src/error.rs
+++ b/crates/bacnet-types/src/error.rs
@@ -62,6 +62,13 @@ pub enum Error {
         dnet: u16,
     },
 
+    /// The client cannot safely allocate state for another routed path.
+    #[error("routed path state capacity of {capacity} entries is exhausted")]
+    RoutedPathCapacityExceeded {
+        /// Maximum number of immediate-router/DNET path entries retained.
+        capacity: usize,
+    },
+
     /// Error encoding a PDU.
     #[error("encoding error: {0}")]
     Encoding(String),
@@ -169,5 +176,11 @@ mod tests {
     fn routed_path_too_long_display_preserves_dnet() {
         let err = Error::RoutedPathTooLong { dnet: 1234 };
         assert!(err.to_string().contains("1234"));
+    }
+
+    #[test]
+    fn routed_path_capacity_display_preserves_bound() {
+        let err = Error::RoutedPathCapacityExceeded { capacity: 256 };
+        assert!(err.to_string().contains("256"));
     }
 }

--- a/crates/bacnet-types/src/error.rs
+++ b/crates/bacnet-types/src/error.rs
@@ -55,6 +55,13 @@ pub enum Error {
         reason: u8,
     },
 
+    /// A router reported that the active message was too long for a routed path.
+    #[error("message is too long for routed path to DNET {dnet}")]
+    RoutedPathTooLong {
+        /// Destination network rejected by the router.
+        dnet: u16,
+    },
+
     /// Error encoding a PDU.
     #[error("encoding error: {0}")]
     Encoding(String),
@@ -156,5 +163,11 @@ mod tests {
     fn timeout_error_display() {
         let err = Error::Timeout(Duration::from_secs(3));
         assert!(err.to_string().contains("3s"));
+    }
+
+    #[test]
+    fn routed_path_too_long_display_preserves_dnet() {
+        let err = Error::RoutedPathTooLong { dnet: 1234 };
+        assert!(err.to_string().contains("1234"));
     }
 }

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -200,23 +200,28 @@
    "positive_tests": [
     "crates/bacnet-encoding/src/npdu.rs::tests::reject_message_to_network_payload_decodes_typed_reason_and_dnet",
     "crates/bacnet-network/src/layer_delivery_tests.rs::opted_in_network_control_stream_preserves_start_apdu_receiver",
-    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::routed_sizing_uses_conservative_and_configured_forwarded_envelopes",
-    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::reason_4_completes_exact_caller_learns_bound_and_does_not_retry",
-    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::same_path_serializes_while_a_second_router_remains_concurrent"
+     "crates/bacnet-client/src/client/routed_path_limit_tests.rs::routed_sizing_uses_conservative_and_configured_forwarded_envelopes",
+     "crates/bacnet-client/src/client/routed_path_limit_tests.rs::reason_4_completes_exact_caller_learns_bound_and_does_not_retry",
+     "crates/bacnet-client/src/client/routed_path_limit_tests.rs::same_path_serializes_while_a_second_router_remains_concurrent",
+     "crates/bacnet-client/src/client/routed_path_limits_tests.rs::capacity_cleanup_never_splits_a_held_or_waiting_same_path_gate"
    ],
    "negative_tests": [
     "crates/bacnet-encoding/src/npdu.rs::tests::reject_message_to_network_payload_requires_exact_length",
     "crates/bacnet-network/src/layer_delivery_tests.rs::network_controls_without_opt_in_are_discarded_without_stopping_apdu_ingress",
     "crates/bacnet-client/src/client/routed_path_limit_tests.rs::subminimum_path_cap_fails_before_registration_or_emission",
-    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::unmatched_controls_and_direct_requests_do_not_change_path_policy",
-    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::reason_4_during_segmented_send_prevents_window_retransmission",
-    "crates/bacnet-client/src/client/routed_path_limits.rs::tests::claimed_control_cannot_complete_reused_invoke_id_for_new_owner"
+     "crates/bacnet-client/src/client/routed_path_limit_tests.rs::unmatched_controls_and_direct_requests_do_not_change_path_policy",
+     "crates/bacnet-client/src/client/routed_path_limit_tests.rs::reason_4_during_segmented_send_prevents_window_retransmission",
+     "crates/bacnet-client/src/client/routed_path_limit_tests.rs::configured_capacity_exhaustion_fails_before_registration_or_emission",
+     "crates/bacnet-client/src/client/routed_path_limit_tests.rs::cancelled_generation_quarantines_delayed_reason_4_before_next_send",
+     "crates/bacnet-client/src/client/routed_path_limits_tests.rs::configured_and_learned_evidence_are_never_evicted_for_capacity",
+     "crates/bacnet-client/src/client/routed_path_limits_tests.rs::control_queued_before_activation_cannot_claim_the_new_generation",
+     "crates/bacnet-client/src/client/routed_path_limits_tests.rs::claimed_control_cannot_complete_reused_invoke_id_for_new_owner"
    ],
    "benchmarks": [],
    "public_claims": [
     "docs/rust-api.md routed confirmed-request limits"
    ],
-   "notes": "The path key is immediate-router MAC plus DNET, separate from discovery state. Unknown paths use a 228-octet NPDU envelope; the forwarded NPCI allowance includes destination and source fields using the client's local transport MAC, so six-octet addresses leave 207 APDU octets and an explicitly configured 1497-octet path leaves 1476 before peer or local-link constraints. Configured evidence and process-lifetime learned exclusive upper bounds combine by minimum. One active owner per path makes reason-4 completion owner-qualified; learning occurs only when that completion wins, and retry/window retransmission stops afterward. Malformed, unmatched, stale, wrong-router, wrong-DNET, other-reason, and direct traffic do not mutate policy. Full active probing, persistent cache, router enforcement, and unconfirmed-traffic changes remain deferred. Third-party conformance evidence is still required."
+    "notes": "The path key is immediate-router MAC plus DNET, separate from discovery state. Unknown paths use a 228-octet NPDU envelope; the forwarded NPCI allowance includes destination and source fields using the client's local transport MAC, so six-octet addresses leave 207 APDU octets and an explicitly configured 1497-octet path leaves 1476 before peer or local-link constraints. Configured evidence and process-lifetime learned exclusive upper bounds combine by minimum. One active owner per path makes reason-4 completion owner-qualified; learning occurs only when that completion wins, and retry/window retransmission stops afterward. Path state is capped at 256 entries; deterministic idle reclamation never removes configured/learned evidence or a gate with an owner/waiter, and exhaustion fails before TSM registration. Ambiguous termination holds the same-path gate through a configuration-derived stale-control quarantine, while monotonic network-ingress sequencing prevents controls queued before activation from claiming a later generation. Malformed, unmatched, stale, wrong-router, wrong-DNET, other-reason, and direct traffic do not mutate policy. Full active probing, persistent cache, router enforcement, and unconfirmed-traffic changes remain deferred. Third-party conformance evidence is still required."
   },
   {
    "id": "BACNET-6-NPDU-CONTROL",

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -183,6 +183,42 @@
     "notes": "Receive-side client SEGMENTED_CONF and server SEGMENTED_REQUEST now use the Clause 5.4.2.2 predicate corrected by Addendum 135-2020ch, with modulo-256 unit vectors. Per-session DuplicateCount uses ActualWindowSize as Ndup: exactly Ndup in-window duplicates are discarded silently, the next is NAKed, and true out-of-order segments are NAKed immediately. Focused tests cover window one, windows greater than one, client/server baseline resets, ACK roles and fields, and byte-exact payload survival. The row remains below supported status pending multi-segment send-window behavior, full-transfer modulo-256 wrap evidence, max APDU/max segment boundaries, and broader TSM transition coverage."
   },
   {
+   "id": "BACNET-5-ROUTED-PATH-LIMIT",
+   "standard_anchor": "Clauses 5.2.1.2, 6.4.4, and 19.4",
+   "priority": "P1",
+   "requirement_summary": "Confirmed routed APDU sizing combines peer, local transport, and path NPDU evidence, while an exactly correlated too-long network rejection terminates the active owner and narrows later sends.",
+   "status": "implementation-present-needs-conformance-tests",
+   "code_anchors": [
+    "crates/bacnet-encoding/src/npdu.rs",
+    "crates/bacnet-network/src/layer.rs",
+    "crates/bacnet-client/src/client/routed_path_limits.rs",
+    "crates/bacnet-client/src/client/requests.rs",
+    "crates/bacnet-client/src/client/segmented_request.rs",
+    "crates/bacnet-client/src/client/segmentation.rs",
+    "crates/bacnet-client/src/tsm.rs"
+   ],
+   "positive_tests": [
+    "crates/bacnet-encoding/src/npdu.rs::tests::reject_message_to_network_payload_decodes_typed_reason_and_dnet",
+    "crates/bacnet-network/src/layer_delivery_tests.rs::opted_in_network_control_stream_preserves_start_apdu_receiver",
+    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::routed_sizing_uses_conservative_and_configured_forwarded_envelopes",
+    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::reason_4_completes_exact_caller_learns_bound_and_does_not_retry",
+    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::same_path_serializes_while_a_second_router_remains_concurrent"
+   ],
+   "negative_tests": [
+    "crates/bacnet-encoding/src/npdu.rs::tests::reject_message_to_network_payload_requires_exact_length",
+    "crates/bacnet-network/src/layer_delivery_tests.rs::network_controls_without_opt_in_are_discarded_without_stopping_apdu_ingress",
+    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::subminimum_path_cap_fails_before_registration_or_emission",
+    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::unmatched_controls_and_direct_requests_do_not_change_path_policy",
+    "crates/bacnet-client/src/client/routed_path_limit_tests.rs::reason_4_during_segmented_send_prevents_window_retransmission",
+    "crates/bacnet-client/src/client/routed_path_limits.rs::tests::claimed_control_cannot_complete_reused_invoke_id_for_new_owner"
+   ],
+   "benchmarks": [],
+   "public_claims": [
+    "docs/rust-api.md routed confirmed-request limits"
+   ],
+   "notes": "The path key is immediate-router MAC plus DNET, separate from discovery state. Unknown paths use a 228-octet NPDU envelope; the forwarded NPCI allowance includes destination and source fields using the client's local transport MAC, so six-octet addresses leave 207 APDU octets and an explicitly configured 1497-octet path leaves 1476 before peer or local-link constraints. Configured evidence and process-lifetime learned exclusive upper bounds combine by minimum. One active owner per path makes reason-4 completion owner-qualified; learning occurs only when that completion wins, and retry/window retransmission stops afterward. Malformed, unmatched, stale, wrong-router, wrong-DNET, other-reason, and direct traffic do not mutate policy. Full active probing, persistent cache, router enforcement, and unconfirmed-traffic changes remain deferred. Third-party conformance evidence is still required."
+  },
+  {
    "id": "BACNET-6-NPDU-CONTROL",
    "standard_anchor": "Clause 6.2",
    "priority": "P1",

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -13,11 +13,11 @@
 | Dimension | Value | Count |
 |---|---|---|
 | Priority | P0 | 16 |
-| Priority | P1 | 35 |
+| Priority | P1 | 36 |
 | Priority | P2 | 5 |
 | Priority | P3 | 4 |
 | Status | deferred-pending-owner-decision | 2 |
-| Status | implementation-present-needs-conformance-tests | 14 |
+| Status | implementation-present-needs-conformance-tests | 15 |
 | Status | implementation-present-needs-negative-tests | 6 |
 | Status | implementation-present-needs-platform-tests | 1 |
 | Status | implementation-present-needs-security-tests | 1 |
@@ -38,6 +38,7 @@
 | `BACNET-5-TSM-CLIENT` | Clause 5.4.4 | P1 | implementation-present-needs-state-machine-audit | 2 |
 | `BACNET-5-TSM-SERVER` | Clause 5.4.5 | P1 | implementation-present-needs-state-machine-audit | 1 |
 | `BACNET-5-SEGMENTATION-WINDOW` | Clauses 5.2-5.4 | P1 | implementation-present-needs-window-tests | 1 |
+| `BACNET-5-ROUTED-PATH-LIMIT` | Clauses 5.2.1.2, 6.4.4, and 19.4 | P1 | implementation-present-needs-conformance-tests | 1 |
 | `BACNET-6-NPDU-CONTROL` | Clause 6.2 | P1 | implementation-present-needs-negative-tests | 1 |
 | `BACNET-6-ROUTER-MESSAGES` | Clauses 6.4-6.6 | P1 | implementation-present-needs-conformance-tests | 1 |
 | `BACNET-7-ETHERNET-LLC` | Clause 7 | P2 | implementation-present-needs-platform-tests | 2 |

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -60,13 +60,17 @@ use bacnet_types::error::Error;
 // Protocol error from a remote device
 let e = Error::Protocol { class: 2, code: 31 }; // ErrorClass(2)=PROPERTY, ErrorCode(31)=UNKNOWN_PROPERTY
 
-// Other variants: Timeout, Reject, Abort, RoutedPathTooLong, Encoding, etc.
+// Other variants: Timeout, Reject, Abort, RoutedPathTooLong,
+// RoutedPathCapacityExceeded, Encoding, etc.
 ```
 
 `Error::RoutedPathTooLong { dnet }` identifies the destination network from a
 matching network-layer rejection; it does not claim an exact supported length.
-`Error` is a public enum, so this added variant can require a new arm in
-downstream exhaustive matches. Matchers with a wildcard arm are unaffected.
+`Error::RoutedPathCapacityExceeded { capacity }` reports that all bounded path
+state is protected by a held/waiting gate or configured/learned evidence, so a
+new path was rejected before transaction registration or frame emission.
+`Error` is a public enum, so these variants can require new arms in downstream
+exhaustive matches. Matchers with a wildcard arm are unaffected.
 
 ---
 
@@ -691,6 +695,23 @@ configuring replaces the prior value and deliberately resets learned evidence,
 while clearing removes configured and learned evidence. Active Clause 19.4
 path probing and cache persistence across process restarts are not provided.
 
+The client retains at most 256 routed-path entries. At capacity it
+deterministically reclaims the least-recently-used entry only when it has no
+configured or learned evidence and its gate has neither an owner nor waiters.
+Configured and learned safety evidence is never silently evicted. If no entry
+is safely reclaimable, the operation returns
+`Error::RoutedPathCapacityExceeded { capacity: 256 }` before TSM registration
+or frame emission.
+
+An ambiguously terminated send (including cancellation, timeout, or send
+failure) quarantines its path for the configured APDU timeout multiplied by
+the configured attempt count. The same-path gate remains exclusive during
+that interval, and network controls already observed at ingress before the
+next generation activates are discarded using a monotonic ingress sequence.
+A source-correlated terminal response after one attempted frame can end the
+generation without quarantine; multi-frame or retried generations remain
+conservative.
+
 ### Property Access
 
 ```rust
@@ -1019,6 +1040,7 @@ All async operations return `Result<T, bacnet_types::error::Error>`. Key variant
 | `Error::Reject { reason }` | Remote device rejected request |
 | `Error::Abort { reason }` | Remote device aborted request |
 | `Error::RoutedPathTooLong { dnet }` | Router rejected the active message as too long for DNET |
+| `Error::RoutedPathCapacityExceeded { capacity }` | No routed-path entry can be allocated without discarding protected safety state |
 | `Error::Encoding(msg)` | Malformed packet |
 | `Error::Io(io_error)` | Transport I/O failure |
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -60,8 +60,13 @@ use bacnet_types::error::Error;
 // Protocol error from a remote device
 let e = Error::Protocol { class: 2, code: 31 }; // ErrorClass(2)=PROPERTY, ErrorCode(31)=UNKNOWN_PROPERTY
 
-// Other variants: Timeout, Reject, Abort, Io, Encoding, InvalidState, etc.
+// Other variants: Timeout, Reject, Abort, RoutedPathTooLong, Encoding, etc.
 ```
+
+`Error::RoutedPathTooLong { dnet }` identifies the destination network from a
+matching network-layer rejection; it does not claim an exact supported length.
+`Error` is a public enum, so this added variant can require a new arm in
+downstream exhaustive matches. Matchers with a wildcard arm are unaffected.
 
 ---
 
@@ -652,6 +657,40 @@ let client = BACnetClient::sc_builder()
 
 `BACnetClient::builder()` is an alias for `bip_builder()`.
 
+### Routed Confirmed-Request Limits
+
+Routed confirmed requests size each outgoing APDU to the smallest applicable
+peer, local-transport, and routed-path allowance before registering a
+transaction or emitting a frame. The local allowance retains the transport's
+live maximum and the current routed destination-header cost. The routed-path
+allowance is an NPDU limit: an unknown path starts from a conservative
+228-octet NPDU envelope, then subtracts the forwarded header containing both
+the destination address and the client's actual local source MAC. For example,
+six-octet destination and source addresses leave 207 APDU octets.
+
+Applications with path-specific evidence can configure the NPDU envelope
+without changing `ClientConfig`:
+
+```rust
+client
+    .configure_routed_path_max_npdu(&router_mac, dnet, 1497)
+    .await?;
+
+// Restore the conservative unknown-path policy.
+client.clear_routed_path_limit(&router_mac, dnet).await?;
+```
+
+State is keyed by the immediate router MAC together with DNET. One confirmed
+request at a time owns that path; requests through a different router or to a
+different DNET remain independent, and direct requests bypass this state. A
+matching Reject-Message-To-Network reason 4 completes only the active owner as
+`Error::RoutedPathTooLong { dnet }` and records the attempted NPDU length as an
+exclusive upper bound. Learned negative evidence lasts for the client lifetime
+and has no widening TTL. Both configuration methods wait for an active owner;
+configuring replaces the prior value and deliberately resets learned evidence,
+while clearing removes configured and learned evidence. Active Clause 19.4
+path probing and cache persistence across process restarts are not provided.
+
 ### Property Access
 
 ```rust
@@ -979,6 +1018,7 @@ All async operations return `Result<T, bacnet_types::error::Error>`. Key variant
 | `Error::Timeout(msg)` | APDU retry exhausted |
 | `Error::Reject { reason }` | Remote device rejected request |
 | `Error::Abort { reason }` | Remote device aborted request |
+| `Error::RoutedPathTooLong { dnet }` | Router rejected the active message as too long for DNET |
 | `Error::Encoding(msg)` | Malformed packet |
 | `Error::Io(io_error)` | Transport I/O failure |
 


### PR DESCRIPTION
## Summary
- size routed confirmed APDUs from peer, live local transport, and configured/learned/conservative path NPDU bounds
- serialize one active confirmed request per immediate-router+DNET path so reason-4 feedback completes the exact TSM owner
- bound path state at 256 entries with safe evidence-preserving reclamation and fail-closed capacity errors
- quarantine ambiguous generations and use ingress sequencing so stale reason-4 controls cannot claim later requests
- surface typed `RoutedPathTooLong` and `RoutedPathCapacityExceeded` errors while preserving direct/unconfirmed behavior
- add opt-in decoded network-control ingress without changing `NetworkLayer::start()`

## Standards and policy
Grounded against Standard 135-2020 §5.2.1.2, Clause 6/Table 6-1, §6.4.4, and §19.4. Unknown paths use the 228-octet routed NPDU baseline minus the actual forwarded destination+source NPCI envelope. Full active probing and persistent cache are deferred.

The new public `Error` variants can require downstream exhaustive matches to add arms; this is documented in `docs/rust-api.md`.

Closes #370

## Validation
- `cargo test -p bacnet-encoding --locked`
- `cargo test -p bacnet-network --locked`
- `cargo test -p bacnet-client --locked`
- `cargo test -p bacnet-client --all-features --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

Cycle 1 findings RP469-M01 and DF-001 were repaired in one batch and both independent final review lanes passed at `acdfafa98eb3f014718f66d689c594a29d2c2187`.