### PR TITLE
fix(server): make reliability evaluation object-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reliability evaluation now belongs to each `BACnetObject` through a defaulted
+  opt-in hook. Enabling server fault detection invokes that hook for every
+  object every 10 seconds; stock objects currently make no change. The server
+  no longer treats Analog Input, Analog Output, or Analog Value
+  `Min_Pres_Value` / `Max_Pres_Value` engineering metadata as reliability fault
+  limits, so those bounds cannot synthesize `OVER_RANGE` or `UNDER_RANGE`.
+  Analog Output `OUT_OF_RANGE` intrinsic event reporting is unchanged and
+  remains separate from reliability evaluation. Full Analog Input/Value
+  `FAULT_OUT_OF_RANGE` algorithms remain deferred.
+
 - Correct `NotificationParameters` codecs for complex event values `[6]`,
   AccessEvent credentials and authentication factors `[13]`, rejection of the
   omitted choice `[20]`, and independently optional ChangeOfTimer fields `[22]`

--- a/crates/bacnet-objects/src/analog/input.rs
+++ b/crates/bacnet-objects/src/analog/input.rs
@@ -28,9 +28,9 @@ pub struct AnalogInputObject {
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
     reliability_before_out_of_service: Option<u32>,
-    /// Optional minimum present value for fault detection.
+    /// Optional minimum engineering bound metadata for Present_Value.
     min_pres_value: Option<f32>,
-    /// Optional maximum present value for fault detection.
+    /// Optional maximum engineering bound metadata for Present_Value.
     max_pres_value: Option<f32>,
     pub(crate) event_history: EventHistory,
 }
@@ -72,12 +72,12 @@ impl AnalogInputObject {
         self.description = desc.into();
     }
 
-    /// Set the minimum present value for fault detection.
+    /// Set minimum engineering-bound metadata; this is not a reliability fault limit.
     pub fn set_min_pres_value(&mut self, value: f32) {
         self.min_pres_value = Some(value);
     }
 
-    /// Set the maximum present value for fault detection.
+    /// Set maximum engineering-bound metadata; this is not a reliability fault limit.
     pub fn set_max_pres_value(&mut self, value: f32) {
         self.max_pres_value = Some(value);
     }

--- a/crates/bacnet-objects/src/analog/output.rs
+++ b/crates/bacnet-objects/src/analog/output.rs
@@ -67,12 +67,12 @@ impl AnalogOutputObject {
         self.description = desc.into();
     }
 
-    /// Set the minimum present value for fault detection.
+    /// Set minimum engineering-bound metadata; this is not a reliability fault limit.
     pub fn set_min_pres_value(&mut self, value: f32) {
         self.min_pres_value = Some(value);
     }
 
-    /// Set the maximum present value for fault detection.
+    /// Set maximum engineering-bound metadata; this is not a reliability fault limit.
     pub fn set_max_pres_value(&mut self, value: f32) {
         self.max_pres_value = Some(value);
     }

--- a/crates/bacnet-objects/src/analog/value.rs
+++ b/crates/bacnet-objects/src/analog/value.rs
@@ -79,12 +79,12 @@ impl AnalogValueObject {
         self.description = desc.into();
     }
 
-    /// Set the minimum present value for fault detection.
+    /// Set minimum engineering-bound metadata; this is not a reliability fault limit.
     pub fn set_min_pres_value(&mut self, value: f32) {
         self.min_pres_value = Some(value);
     }
 
-    /// Set the maximum present value for fault detection.
+    /// Set maximum engineering-bound metadata; this is not a reliability fault limit.
     pub fn set_max_pres_value(&mut self, value: f32) {
         self.max_pres_value = Some(value);
     }

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -38,6 +38,20 @@ pub enum LifeSafetyOperationEffect {
     AlreadyApplied,
 }
 
+/// Result of one object-owned reliability evaluation pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReliabilityEvaluation {
+    /// The object made no reliability-related mutation.
+    Unchanged,
+    /// The object successfully mutated its `Reliability` value.
+    Changed {
+        /// Reliability before the successful mutation.
+        old_reliability: u32,
+        /// Reliability after the successful mutation.
+        new_reliability: u32,
+    },
+}
+
 impl WritePropertyRollback {
     /// Wrap object-private rollback state.
     #[doc(hidden)]
@@ -515,6 +529,22 @@ pub trait BACnetObject: Send + Sync {
             class: ErrorClass::OBJECT.to_raw() as u32,
             code: ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw() as u32,
         })
+    }
+
+    /// Evaluate and, when necessary, mutate this object's `Reliability`.
+    ///
+    /// Reliability evaluation is object-owned: an implementation decides
+    /// whether and how its internal conditions affect `Reliability`, performs
+    /// the mutation itself, and returns [`ReliabilityEvaluation::Changed`] only
+    /// after that mutation succeeds. [`ReliabilityEvaluation::Unchanged`] means
+    /// the object made no mutation. Returning `Err` MUST leave all object state
+    /// unchanged.
+    ///
+    /// The default opts out without changing state, preserving source
+    /// compatibility for object implementations that do not own a reliability
+    /// evaluation algorithm.
+    fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {
+        Ok(ReliabilityEvaluation::Unchanged)
     }
 
     /// Apply an internally-derived `Reliability` value.

--- a/crates/bacnet-server/src/fault_detection.rs
+++ b/crates/bacnet-server/src/fault_detection.rs
@@ -1,14 +1,14 @@
 //! Fault detection / reliability evaluation.
 //!
-//! The [`FaultDetector`] periodically evaluates each object's reliability,
-//! checking for OVER_RANGE, UNDER_RANGE (analog objects), and optionally
-//! COMMUNICATION_FAILURE (staleness timeout).
+//! The [`FaultDetector`] periodically invokes each object's opt-in,
+//! object-owned reliability evaluation hook.
 
-use bacnet_objects::database::ObjectDatabase;
-use bacnet_types::enums::{ObjectType, PropertyIdentifier, Reliability};
-use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 use std::collections::HashMap;
 use std::sync::Mutex;
+
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_objects::traits::ReliabilityEvaluation;
+use bacnet_types::primitives::ObjectIdentifier;
 
 /// A reliability change detected by the fault detector.
 #[derive(Debug, Clone, PartialEq)]
@@ -23,12 +23,14 @@ pub struct ReliabilityChange {
 
 /// Fault detection engine.
 ///
-/// Call [`FaultDetector::evaluate`] periodically (e.g. every 10 s) against
-/// the object database.  It returns a list of objects whose reliability
-/// changed so the caller can update them.
+/// Call [`FaultDetector::evaluate`] periodically (the bundled server uses a
+/// 10-second interval) against the object database. Every object is visited;
+/// objects opt in by overriding
+/// [`BACnetObject::evaluate_reliability_internal`](bacnet_objects::traits::BACnetObject::evaluate_reliability_internal).
+/// The default object hook is a no-op.
 pub struct FaultDetector {
     /// Timeout after which an object is considered to have a communication
-    /// failure.  Set to `None` to disable communication-failure detection.
+    /// failure. Set to `None` to disable communication-failure detection.
     pub comm_timeout: Option<std::time::Duration>,
     warned_internal_failures: Mutex<HashMap<ObjectIdentifier, String>>,
 }
@@ -73,190 +75,143 @@ impl FaultDetector {
 
     /// Evaluate reliability for all objects in the database.
     ///
-    /// For each analog object (AI, AO, AV) that has `MIN_PRES_VALUE` and
-    /// `MAX_PRES_VALUE` properties, the present value is compared against
-    /// those limits.  If out of range the reliability is set to
-    /// `OVER_RANGE` or `UNDER_RANGE`; otherwise `NO_FAULT_DETECTED`.
+    /// Each object owns both the decision and any mutation. Engineering
+    /// `Min_Pres_Value` / `Max_Pres_Value` metadata is not a reliability fault
+    /// algorithm. Only a successful hook result of
+    /// [`ReliabilityEvaluation::Changed`] produces a [`ReliabilityChange`].
+    /// Hook errors are rate-limited per object and produce no change record.
     ///
-    /// **Objects with `Out_Of_Service` TRUE are skipped entirely** — not compared,
-    /// not written, and not represented in the returned list. While an object is
-    /// out of service the client owns `Reliability`: ASHRAE 135-2020 Clause 12.2(c)
-    /// and 12.3(c) make it writable "to allow simulating specific conditions or for
-    /// testing purposes" (Clause 12.4(b) for Analog Value), and 12.2(b) / 12.3(b)
-    /// decouple it from the physical point. Re-deriving it here would overwrite a
-    /// simulated value within one evaluation interval.
-    ///
-    /// The check is fail-open: an object that does not report `Out_Of_Service`, or
-    /// reports it at an unexpected type, is still evaluated.
-    ///
-    /// Returns a list of changes that were applied to the database.
+    /// Returns a list of changes that object hooks successfully applied.
     pub fn evaluate(&self, db: &mut ObjectDatabase) -> Vec<ReliabilityChange> {
-        let analog_types = [
-            ObjectType::ANALOG_INPUT,
-            ObjectType::ANALOG_OUTPUT,
-            ObjectType::ANALOG_VALUE,
-        ];
-
-        let mut updates: Vec<(ObjectIdentifier, u32, u32)> = Vec::new();
-
-        for &obj_type in &analog_types {
-            let oids = db.find_by_type(obj_type);
-            for oid in oids {
-                if let Some(obj) = db.get(&oid) {
-                    // While the object is out of service the client owns Reliability, so
-                    // re-deriving it here would defeat a behavior the standard mandates.
-                    // The three types ground that differently, so cite them separately:
-                    //
-                    // - Analog Input, Clause 12.2(b) and (c): Reliability "shall be
-                    //   decoupled from the physical input", and it "shall be writable to
-                    //   allow simulating specific conditions or for testing purposes".
-                    // - Analog Output, Clause 12.3(b) and (c): the same two, worded for a
-                    //   physical output.
-                    // - Analog Value, Clause 12.4(b): writability for simulation only.
-                    //   There is no decoupling item, because an Analog Value has no
-                    //   physical point to decouple from.
-                    //
-                    // Note the letters differ between 12.2/12.3 and 12.4 — writability is
-                    // (c) on the first two and (b) on the third.
-                    //
-                    // Deliberately fail-open: an object that does not report Out_Of_Service,
-                    // or reports it at an unexpected type, is still evaluated. That
-                    // preserves prior behavior for anything unusual rather than silently
-                    // disabling fault detection for it.
-                    if matches!(
-                        obj.read_property(PropertyIdentifier::OUT_OF_SERVICE, None),
-                        Ok(PropertyValue::Boolean(true))
-                    ) {
-                        continue;
-                    }
-
-                    let current_reliability =
-                        match obj.read_property(PropertyIdentifier::RELIABILITY, None) {
-                            Ok(PropertyValue::Enumerated(v)) => v,
-                            _ => 0,
-                        };
-
-                    let present_value =
-                        match obj.read_property(PropertyIdentifier::PRESENT_VALUE, None) {
-                            Ok(PropertyValue::Real(v)) => v,
-                            _ => continue,
-                        };
-
-                    let min_pres = obj
-                        .read_property(PropertyIdentifier::MIN_PRES_VALUE, None)
-                        .ok()
-                        .and_then(|v| match v {
-                            PropertyValue::Real(f) => Some(f),
-                            _ => None,
-                        });
-
-                    let max_pres = obj
-                        .read_property(PropertyIdentifier::MAX_PRES_VALUE, None)
-                        .ok()
-                        .and_then(|v| match v {
-                            PropertyValue::Real(f) => Some(f),
-                            _ => None,
-                        });
-
-                    let new_reliability = if let Some(max) = max_pres {
-                        if present_value > max {
-                            Reliability::OVER_RANGE.to_raw()
-                        } else if let Some(min) = min_pres {
-                            if present_value < min {
-                                Reliability::UNDER_RANGE.to_raw()
-                            } else {
-                                Reliability::NO_FAULT_DETECTED.to_raw()
-                            }
-                        } else {
-                            Reliability::NO_FAULT_DETECTED.to_raw()
-                        }
-                    } else if let Some(min) = min_pres {
-                        if present_value < min {
-                            Reliability::UNDER_RANGE.to_raw()
-                        } else {
-                            Reliability::NO_FAULT_DETECTED.to_raw()
-                        }
-                    } else {
-                        continue;
-                    };
-
-                    if new_reliability != current_reliability {
-                        updates.push((oid, current_reliability, new_reliability));
-                    }
-                }
-            }
-        }
-
         let mut changes = Vec::new();
-        for (oid, old_rel, new_rel) in updates {
-            if let Some(obj) = db.get_mut(&oid) {
-                match obj.set_reliability_internal(new_rel) {
-                    Ok(()) => {
-                        self.clear_internal_failure(&oid);
-                        changes.push(ReliabilityChange {
-                            object_id: oid,
-                            old_reliability: old_rel,
-                            new_reliability: new_rel,
-                        });
-                    }
-                    Err(error) => {
-                        let error_text = error.to_string();
-                        if self.should_warn_internal_failure(oid, &error_text) {
-                            tracing::warn!(
-                                object = %oid,
-                                error = %error,
-                                "Fault detection could not apply Reliability through BACnetObject::set_reliability_internal"
-                            );
-                        }
-                    }
+        db.for_each_object_mut(|oid, object| match object.evaluate_reliability_internal() {
+            Ok(ReliabilityEvaluation::Unchanged) => {
+                self.clear_internal_failure(&oid);
+            }
+            Ok(ReliabilityEvaluation::Changed {
+                old_reliability,
+                new_reliability,
+            }) => {
+                self.clear_internal_failure(&oid);
+                changes.push(ReliabilityChange {
+                    object_id: oid,
+                    old_reliability,
+                    new_reliability,
+                });
+            }
+            Err(error) => {
+                let error_text = error.to_string();
+                if self.should_warn_internal_failure(oid, &error_text) {
+                    tracing::warn!(
+                        object = %oid,
+                        error = %error,
+                        "Fault detection object-owned reliability evaluation failed"
+                    );
                 }
             }
-        }
-
+        });
         changes
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use bacnet_objects::analog::{AnalogInputObject, AnalogOutputObject, AnalogValueObject};
-    use bacnet_types::enums::{ErrorClass, ErrorCode, EventState};
-    use bacnet_types::error::Error;
+    use std::borrow::Cow;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
 
-    fn commit_test_proposal(
-        object: &mut dyn bacnet_objects::traits::BACnetObject,
-        outcome: bacnet_objects::event::TransitionOutcome,
-    ) -> bacnet_objects::event::TransitionOutcome {
-        object
-            .commit_event_transition_internal(bacnet_objects::event::EventTransitionCommit {
-                coordinate: outcome.change.transition(),
-                change: outcome.change.clone(),
-                ack_required: false,
-                timestamp: bacnet_types::primitives::BACnetTimeStamp::SequenceNumber(0),
-                message_text: None,
-            })
-            .expect("built-in test proposal must commit");
-        outcome
+    use bacnet_objects::analog::{AnalogInputObject, AnalogOutputObject, AnalogValueObject};
+    use bacnet_objects::traits::BACnetObject;
+    use bacnet_types::enums::{ObjectType, PropertyIdentifier, Reliability};
+    use bacnet_types::error::Error;
+    use bacnet_types::primitives::PropertyValue;
+
+    use super::*;
+
+    const HOOK_ERROR: &str = "test reliability hook failed";
+
+    fn read_reliability(db: &ObjectDatabase, oid: ObjectIdentifier) -> u32 {
+        match db
+            .get(&oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap()
+        {
+            PropertyValue::Enumerated(value) => value,
+            other => panic!("expected Enumerated Reliability, got {other:?}"),
+        }
     }
 
-    /// Helper: build an ObjectDatabase with a single AI that has min/max limits.
-    fn db_with_analog_input(
-        present_value: f32,
-        min_pres: Option<f32>,
-        max_pres: Option<f32>,
-    ) -> ObjectDatabase {
-        let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
-        ai.set_present_value(present_value);
-        if let Some(min) = min_pres {
-            ai.set_min_pres_value(min);
+    struct OptInReliabilityObject {
+        oid: ObjectIdentifier,
+        name: String,
+        reliability: u32,
+        target_reliability: u32,
+        fail: Arc<AtomicBool>,
+    }
+
+    impl OptInReliabilityObject {
+        fn new(instance: u32, name: &str, target_reliability: u32, fail: Arc<AtomicBool>) -> Self {
+            Self {
+                oid: ObjectIdentifier::new(ObjectType::BINARY_INPUT, instance).unwrap(),
+                name: name.to_owned(),
+                reliability: Reliability::NO_FAULT_DETECTED.to_raw(),
+                target_reliability,
+                fail,
+            }
         }
-        if let Some(max) = max_pres {
-            ai.set_max_pres_value(max);
+    }
+
+    impl BACnetObject for OptInReliabilityObject {
+        fn object_identifier(&self) -> ObjectIdentifier {
+            self.oid
         }
-        let mut db = ObjectDatabase::new();
-        db.add(Box::new(ai)).unwrap();
-        db
+
+        fn object_name(&self) -> &str {
+            &self.name
+        }
+
+        fn read_property(
+            &self,
+            property: PropertyIdentifier,
+            _array_index: Option<u32>,
+        ) -> Result<PropertyValue, Error> {
+            if property == PropertyIdentifier::RELIABILITY {
+                Ok(PropertyValue::Enumerated(self.reliability))
+            } else {
+                Err(Error::Encoding("test property is unsupported".into()))
+            }
+        }
+
+        fn write_property(
+            &mut self,
+            _property: PropertyIdentifier,
+            _array_index: Option<u32>,
+            _value: PropertyValue,
+            _priority: Option<u8>,
+        ) -> Result<(), Error> {
+            Err(Error::Encoding("test object is read-only".into()))
+        }
+
+        fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+            Cow::Borrowed(&[PropertyIdentifier::RELIABILITY])
+        }
+
+        fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(Error::Encoding(HOOK_ERROR.into()));
+            }
+            if self.reliability == self.target_reliability {
+                return Ok(ReliabilityEvaluation::Unchanged);
+            }
+
+            let old_reliability = self.reliability;
+            self.reliability = self.target_reliability;
+            Ok(ReliabilityEvaluation::Changed {
+                old_reliability,
+                new_reliability: self.reliability,
+            })
+        }
     }
 
     #[test]
@@ -274,375 +229,174 @@ mod tests {
     }
 
     #[test]
-    fn no_fault_when_in_range() {
-        let mut db = db_with_analog_input(50.0, Some(0.0), Some(100.0));
-        let detector = FaultDetector::default();
-        let changes = detector.evaluate(&mut db);
-        assert!(changes.is_empty(), "no change expected for in-range value");
-    }
+    fn stock_analog_engineering_bounds_never_change_reliability() {
+        let mut db = ObjectDatabase::new();
 
-    #[test]
-    fn over_range_detected() {
-        let mut db = db_with_analog_input(150.0, Some(0.0), Some(100.0));
-        let detector = FaultDetector::default();
-        let changes = detector.evaluate(&mut db);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].new_reliability, Reliability::OVER_RANGE.to_raw());
-        assert_eq!(
-            changes[0].old_reliability,
-            Reliability::NO_FAULT_DETECTED.to_raw()
-        );
-    }
+        let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+        ai.set_min_pres_value(0.0);
+        ai.set_max_pres_value(100.0);
+        ai.set_present_value(200.0);
+        let ai_oid = ai.object_identifier();
+        db.add(Box::new(ai)).unwrap();
 
-    #[test]
-    fn under_range_detected() {
-        let mut db = db_with_analog_input(-10.0, Some(0.0), Some(100.0));
-        let detector = FaultDetector::default();
-        let changes = detector.evaluate(&mut db);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(
-            changes[0].new_reliability,
-            Reliability::UNDER_RANGE.to_raw()
-        );
-    }
-
-    #[test]
-    fn analog_simulation_restores_derived_fault_without_normal_churn() {
-        let mut db = db_with_analog_input(150.0, Some(0.0), Some(100.0));
-        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-        let changes = FaultDetector::default().evaluate(&mut db);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].new_reliability, Reliability::OVER_RANGE.to_raw());
-
-        let obj = db.get_mut(&oid).unwrap();
-        let proposal = obj
-            .evaluate_intrinsic_reporting()
-            .expect("derived Reliability must enter FAULT");
-        let real_fault = commit_test_proposal(obj.as_mut(), proposal);
-        assert_eq!(real_fault.change.to, EventState::FAULT);
-
-        obj.write_property(
-            PropertyIdentifier::OUT_OF_SERVICE,
-            None,
-            PropertyValue::Boolean(true),
-            None,
-        )
-        .unwrap();
-        obj.write_property(
-            PropertyIdentifier::RELIABILITY,
-            None,
-            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
-            None,
-        )
-        .unwrap();
-        let proposal = obj
-            .evaluate_intrinsic_reporting()
-            .expect("different simulated fault must re-enter FAULT");
-        let simulated_fault = commit_test_proposal(obj.as_mut(), proposal);
-        assert_eq!(simulated_fault.change.to, EventState::FAULT);
-
-        obj.write_property(
-            PropertyIdentifier::OUT_OF_SERVICE,
-            None,
-            PropertyValue::Boolean(false),
-            None,
-        )
-        .unwrap();
-        assert_eq!(
-            obj.read_property(PropertyIdentifier::RELIABILITY, None)
-                .unwrap(),
-            PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw())
-        );
-        assert_eq!(
-            obj.read_property(PropertyIdentifier::EVENT_STATE, None)
-                .unwrap(),
-            PropertyValue::Enumerated(EventState::FAULT.to_raw())
-        );
-
-        let proposal = obj
-            .evaluate_intrinsic_reporting()
-            .expect("restored real fault must re-enter FAULT");
-        let restored_fault = commit_test_proposal(obj.as_mut(), proposal);
-        assert_eq!(restored_fault.change.to, EventState::FAULT);
-        assert_eq!(
-            obj.read_property(PropertyIdentifier::EVENT_STATE, None)
-                .unwrap(),
-            PropertyValue::Enumerated(EventState::FAULT.to_raw())
-        );
-    }
-
-    #[test]
-    fn returns_to_no_fault_after_correction() {
-        let mut db = db_with_analog_input(150.0, Some(0.0), Some(100.0));
-        let detector = FaultDetector::default();
-
-        // First evaluation: over-range
-        let changes = detector.evaluate(&mut db);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].new_reliability, Reliability::OVER_RANGE.to_raw());
-
-        // Correct the value back in range
-        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-        let obj = db.get_mut(&oid).unwrap();
-        obj.write_property(
+        let mut ao = AnalogOutputObject::new(1, "AO-1", 62).unwrap();
+        ao.set_min_pres_value(0.0);
+        ao.set_max_pres_value(100.0);
+        ao.write_property(
             PropertyIdentifier::PRESENT_VALUE,
             None,
-            PropertyValue::Real(50.0),
-            None,
+            PropertyValue::Real(150.0),
+            Some(8),
         )
-        // AI write needs out_of_service=true
-        .unwrap_or_else(|_| {
-            obj.write_property(
+        .unwrap();
+        let ao_oid = ao.object_identifier();
+        db.add(Box::new(ao)).unwrap();
+
+        let mut av = AnalogValueObject::new(1, "AV-1", 62).unwrap();
+        av.set_min_pres_value(0.0);
+        av.set_max_pres_value(100.0);
+        av.set_present_value(-10.0);
+        let av_oid = av.object_identifier();
+        db.add(Box::new(av)).unwrap();
+
+        let changes = FaultDetector::default().evaluate(&mut db);
+
+        assert!(changes.is_empty());
+        for oid in [ai_oid, ao_oid, av_oid] {
+            assert_eq!(
+                read_reliability(&db, oid),
+                Reliability::NO_FAULT_DETECTED.to_raw()
+            );
+        }
+        let ao = db.get(&ao_oid).unwrap();
+        assert_eq!(
+            ao.read_property(PropertyIdentifier::PRESENT_VALUE, None)
+                .unwrap(),
+            PropertyValue::Real(150.0)
+        );
+        assert_eq!(
+            ao.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
+                .unwrap(),
+            PropertyValue::Real(150.0)
+        );
+    }
+
+    #[test]
+    fn existing_nonzero_in_service_reliability_is_preserved() {
+        let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+        ai.set_min_pres_value(0.0);
+        ai.set_max_pres_value(100.0);
+        ai.set_present_value(50.0);
+        ai.set_reliability_internal(Reliability::NO_SENSOR.to_raw())
+            .unwrap();
+        let oid = ai.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(ai)).unwrap();
+
+        assert!(FaultDetector::default().evaluate(&mut db).is_empty());
+        assert_eq!(read_reliability(&db, oid), Reliability::NO_SENSOR.to_raw());
+    }
+
+    #[test]
+    fn out_of_service_client_write_and_restore_remain_object_owned() {
+        let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+        ai.set_reliability_internal(Reliability::OVER_RANGE.to_raw())
+            .unwrap();
+        let oid = ai.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(ai)).unwrap();
+
+        let object = db.get_mut(&oid).unwrap();
+        object
+            .write_property(
                 PropertyIdentifier::OUT_OF_SERVICE,
                 None,
                 PropertyValue::Boolean(true),
                 None,
             )
             .unwrap();
-            obj.write_property(
-                PropertyIdentifier::PRESENT_VALUE,
-                None,
-                PropertyValue::Real(50.0),
-                None,
-            )
-            .unwrap();
-        });
-        obj.write_property(
-            PropertyIdentifier::OUT_OF_SERVICE,
-            None,
-            PropertyValue::Boolean(false),
-            None,
-        )
-        .unwrap();
-
-        assert_eq!(
-            obj.read_property(PropertyIdentifier::RELIABILITY, None)
-                .unwrap(),
-            PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw())
-        );
-
-        // Returning to service restores the pre-simulation fault. The detector
-        // then converges it to the corrected physical condition.
-        let changes = detector.evaluate(&mut db);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(
-            changes[0].new_reliability,
-            Reliability::NO_FAULT_DETECTED.to_raw()
-        );
-    }
-
-    #[test]
-    fn no_limits_means_no_evaluation() {
-        // AI without min/max limits — detector should skip it entirely
-        let mut db = db_with_analog_input(999.0, None, None);
-        let detector = FaultDetector::default();
-        let changes = detector.evaluate(&mut db);
-        assert!(changes.is_empty());
-    }
-
-    #[test]
-    fn max_only_over_range() {
-        let mut db = db_with_analog_input(200.0, None, Some(100.0));
-        let detector = FaultDetector::default();
-        let changes = detector.evaluate(&mut db);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].new_reliability, Reliability::OVER_RANGE.to_raw());
-    }
-
-    #[test]
-    fn min_only_under_range() {
-        let mut db = db_with_analog_input(-5.0, Some(0.0), None);
-        let detector = FaultDetector::default();
-        let changes = detector.evaluate(&mut db);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(
-            changes[0].new_reliability,
-            Reliability::UNDER_RANGE.to_raw()
-        );
-    }
-
-    #[test]
-    fn no_change_emitted_when_already_faulted() {
-        let mut db = db_with_analog_input(150.0, Some(0.0), Some(100.0));
-        let detector = FaultDetector::default();
-
-        // First run: change detected
-        let changes = detector.evaluate(&mut db);
-        assert_eq!(changes.len(), 1);
-
-        // Second run: same fault, no new change
-        let changes = detector.evaluate(&mut db);
-        assert!(changes.is_empty());
-    }
-
-    #[test]
-    fn evaluates_multiple_analog_types() {
-        let mut db = ObjectDatabase::new();
-
-        let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
-        ai.set_present_value(200.0);
-        ai.set_max_pres_value(100.0);
-        db.add(Box::new(ai)).unwrap();
-
-        let ao = AnalogOutputObject::new(1, "AO-1", 62).unwrap();
-        // AO starts at 0.0 — in range with no limits, so skipped
-        db.add(Box::new(ao)).unwrap();
-
-        let mut av = AnalogValueObject::new(1, "AV-1", 62).unwrap();
-        av.set_present_value(-10.0);
-        av.set_min_pres_value(0.0);
-        db.add(Box::new(av)).unwrap();
-
-        let detector = FaultDetector::default();
-        let changes = detector.evaluate(&mut db);
-        assert_eq!(changes.len(), 2);
-    }
-
-    #[test]
-    fn out_of_service_preserves_client_written_reliability_without_change_record() {
-        let mut db = db_with_analog_input(50.0, Some(0.0), Some(100.0));
-        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-        let obj = db.get_mut(&oid).unwrap();
-        obj.write_property(
-            PropertyIdentifier::OUT_OF_SERVICE,
-            None,
-            PropertyValue::Boolean(true),
-            None,
-        )
-        .unwrap();
-        obj.write_property(
-            PropertyIdentifier::RELIABILITY,
-            None,
-            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
-            None,
-        )
-        .unwrap();
-
-        let changes = FaultDetector::default().evaluate(&mut db);
-
-        assert!(changes.is_empty());
-        assert_eq!(
-            db.get(&oid)
-                .unwrap()
-                .read_property(PropertyIdentifier::RELIABILITY, None)
-                .unwrap(),
-            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw())
-        );
-    }
-
-    #[test]
-    fn in_service_refuses_client_write_and_recomputes_reliability() {
-        let mut db = db_with_analog_input(50.0, Some(0.0), Some(100.0));
-        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-        let obj = db.get_mut(&oid).unwrap();
-        obj.set_reliability_internal(Reliability::NO_SENSOR.to_raw())
-            .unwrap();
-        let error = obj
+        object
             .write_property(
                 PropertyIdentifier::RELIABILITY,
                 None,
-                PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw()),
+                PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
                 None,
             )
-            .expect_err("in-service Reliability write must be refused");
+            .unwrap();
 
-        let changes = FaultDetector::default().evaluate(&mut db);
+        assert!(FaultDetector::default().evaluate(&mut db).is_empty());
+        assert_eq!(read_reliability(&db, oid), Reliability::NO_SENSOR.to_raw());
 
-        match error {
-            Error::Protocol { class, code } => {
-                assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
-                assert_eq!(code, ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32);
-            }
-            other => panic!("expected PROPERTY / WRITE_ACCESS_DENIED, got {other:?}"),
-        }
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].object_id, oid);
+        db.get_mut(&oid)
+            .unwrap()
+            .write_property(
+                PropertyIdentifier::OUT_OF_SERVICE,
+                None,
+                PropertyValue::Boolean(false),
+                None,
+            )
+            .unwrap();
+        assert_eq!(read_reliability(&db, oid), Reliability::OVER_RANGE.to_raw());
+    }
+
+    #[test]
+    fn only_hook_returned_changed_creates_a_change_record() {
+        let fail = Arc::new(AtomicBool::new(false));
+        let object =
+            OptInReliabilityObject::new(1, "custom-hook", Reliability::NO_SENSOR.to_raw(), fail);
+        let oid = object.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(object)).unwrap();
+        let detector = FaultDetector::default();
+        assert!(detector.should_warn_internal_failure(oid, HOOK_ERROR));
+
         assert_eq!(
-            changes[0].new_reliability,
+            detector.evaluate(&mut db),
+            vec![ReliabilityChange {
+                object_id: oid,
+                old_reliability: Reliability::NO_FAULT_DETECTED.to_raw(),
+                new_reliability: Reliability::NO_SENSOR.to_raw(),
+            }]
+        );
+        assert_eq!(read_reliability(&db, oid), Reliability::NO_SENSOR.to_raw());
+        assert!(detector.should_warn_internal_failure(oid, HOOK_ERROR));
+        assert!(detector.evaluate(&mut db).is_empty());
+        assert!(detector.should_warn_internal_failure(oid, HOOK_ERROR));
+    }
+
+    #[test]
+    fn failing_hook_is_rate_limited_and_cannot_create_a_change() {
+        let fail = Arc::new(AtomicBool::new(true));
+        let object = OptInReliabilityObject::new(
+            1,
+            "failing-hook",
+            Reliability::NO_FAULT_DETECTED.to_raw(),
+            Arc::clone(&fail),
+        );
+        let oid = object.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(object)).unwrap();
+        let detector = FaultDetector::default();
+        let error_text = Error::Encoding(HOOK_ERROR.into()).to_string();
+
+        assert!(detector.evaluate(&mut db).is_empty());
+        assert_eq!(
+            read_reliability(&db, oid),
             Reliability::NO_FAULT_DETECTED.to_raw()
         );
+        assert!(!detector.should_warn_internal_failure(oid, &error_text));
+        assert!(detector.evaluate(&mut db).is_empty());
         assert_eq!(
-            db.get(&oid)
-                .unwrap()
-                .read_property(PropertyIdentifier::RELIABILITY, None)
-                .unwrap(),
-            PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw())
+            read_reliability(&db, oid),
+            Reliability::NO_FAULT_DETECTED.to_raw()
         );
-    }
 
-    #[test]
-    fn out_of_service_out_of_range_does_not_overwrite_client_reliability() {
-        let mut db = db_with_analog_input(150.0, Some(0.0), Some(100.0));
-        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-        let obj = db.get_mut(&oid).unwrap();
-        obj.write_property(
-            PropertyIdentifier::OUT_OF_SERVICE,
-            None,
-            PropertyValue::Boolean(true),
-            None,
-        )
-        .unwrap();
-        obj.write_property(
-            PropertyIdentifier::RELIABILITY,
-            None,
-            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
-            None,
-        )
-        .unwrap();
-
-        let changes = FaultDetector::default().evaluate(&mut db);
-
-        assert!(changes.is_empty());
+        fail.store(false, Ordering::SeqCst);
+        assert!(detector.evaluate(&mut db).is_empty());
         assert_eq!(
-            db.get(&oid)
-                .unwrap()
-                .read_property(PropertyIdentifier::RELIABILITY, None)
-                .unwrap(),
-            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw())
+            read_reliability(&db, oid),
+            Reliability::NO_FAULT_DETECTED.to_raw()
         );
-    }
-
-    #[test]
-    fn mixed_service_states_evaluate_only_in_service_object() {
-        let mut db = ObjectDatabase::new();
-        let mut in_service = AnalogInputObject::new(1, "AI-1", 62).unwrap();
-        in_service.set_present_value(150.0);
-        in_service.set_max_pres_value(100.0);
-        db.add(Box::new(in_service)).unwrap();
-
-        let mut out_of_service = AnalogInputObject::new(2, "AI-2", 62).unwrap();
-        out_of_service.set_present_value(150.0);
-        out_of_service.set_max_pres_value(100.0);
-        let out_of_service_oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 2).unwrap();
-        db.add(Box::new(out_of_service)).unwrap();
-        let obj = db.get_mut(&out_of_service_oid).unwrap();
-        obj.write_property(
-            PropertyIdentifier::OUT_OF_SERVICE,
-            None,
-            PropertyValue::Boolean(true),
-            None,
-        )
-        .unwrap();
-        obj.write_property(
-            PropertyIdentifier::RELIABILITY,
-            None,
-            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
-            None,
-        )
-        .unwrap();
-
-        let changes = FaultDetector::default().evaluate(&mut db);
-
-        let in_service_oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].object_id, in_service_oid);
-        assert_eq!(changes[0].new_reliability, Reliability::OVER_RANGE.to_raw());
-        assert_eq!(
-            db.get(&out_of_service_oid)
-                .unwrap()
-                .read_property(PropertyIdentifier::RELIABILITY, None)
-                .unwrap(),
-            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw())
-        );
+        assert!(detector.should_warn_internal_failure(oid, &error_text));
     }
 }

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -582,13 +582,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         // It is also what carries Reliability into event-state-detection. Per
         // Clause 13.2.2 the FAULT determination is a standing condition, so each
         // tick re-derives it from the object's current `Reliability` rather than
-        // reacting to a change event. That is why the fault detector below can
+        // reacting to a change event. That is why the fault detector above can
         // keep merely *logging* its `ReliabilityChange` records: whoever writes
-        // Reliability — that detector, a local write, or a network write —
-        // reaches detection through this tick, and no route needs to notify
-        // anything. `enable_fault_detection` therefore governs only whether
-        // Reliability is *derived* from limits, never whether a Reliability that
-        // exists is honored.
+        // Reliability — an object's opt-in evaluation hook, a local write, or a
+        // network write — reaches detection through this tick, and no route
+        // needs to notify anything. `enable_fault_detection` therefore governs
+        // only whether those object-owned hooks run every 10 seconds, never
+        // whether an existing Reliability is honored.
         //
         // Six of the nine wired object types have no route that can set
         // Reliability, so the fault path is correct but inert on them (#218).

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -316,8 +316,9 @@ pub struct ServerConfig {
     /// Optional password required for ReinitializeDevice.
     pub reinit_password: Option<String>,
     /// Enable periodic fault detection / reliability evaluation.
-    /// When true, the server evaluates analog objects every 10 s for
-    /// OVER_RANGE / UNDER_RANGE faults.
+    /// When true, the server invokes every object's opt-in, object-owned
+    /// reliability evaluation hook every 10 seconds. Stock objects currently
+    /// inherit the no-op default.
     ///
     /// This governs reliability evaluation only. Event Enrollment evaluation
     /// is configured separately via [`enable_event_enrollment`](Self::enable_event_enrollment).
@@ -510,6 +511,9 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
 
     /// Enable periodic fault detection / reliability evaluation.
     ///
+    /// When enabled, every object's opt-in reliability hook runs every 10
+    /// seconds; the default hook is a no-op.
+    ///
     /// Reliability evaluation only; Event Enrollment evaluation is configured
     /// by [`enable_event_enrollment`](Self::enable_event_enrollment).
     pub fn enable_fault_detection(mut self, enabled: bool) -> Self {
@@ -647,6 +651,9 @@ impl BipServerBuilder {
     }
 
     /// Enable periodic fault detection / reliability evaluation.
+    ///
+    /// When enabled, every object's opt-in reliability hook runs every 10
+    /// seconds; the default hook is a no-op.
     ///
     /// Reliability evaluation only; Event Enrollment evaluation is configured
     /// by [`enable_event_enrollment`](Self::enable_event_enrollment).

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -136,6 +136,9 @@ impl ScServerBuilder {
     }
 
     /// Enable periodic fault detection / reliability evaluation.
+    ///
+    /// When enabled, every object's opt-in reliability hook runs every 10
+    /// seconds; the default hook is a no-op.
     pub fn enable_fault_detection(mut self, enabled: bool) -> Self {
         self.config.enable_fault_detection = enabled;
         self


### PR DESCRIPTION
## Summary
- add a default, object-owned reliability evaluation hook to `BACnetObject`
- replace the server's generic AI/AO/AV `Min_Pres_Value` / `Max_Pres_Value` sweep with all-object hook dispatch
- keep stock objects opted out while preserving OOS, intrinsic reporting, AO priority-array behavior, and public server configuration
- clarify engineering-bound documentation and the unreleased changelog

## Source-to-behavior traceability
| Standard 135-2020 source | Implemented behavior |
|---|---|
| §12.1; §§12.2 and 12.4; §12.3; §13.4.7 | Generic scheduling invokes object-owned reliability hooks only; engineering Min/Max metadata never derives Reliability; AI/AV Fault_High/Low `FAULT_OUT_OF_RANGE` remains deferred; AO `OUT_OF_RANGE` intrinsic reporting remains separate and unchanged. |

The roadmap packet's §13.4.8 navigation anchor is stale for Standard 135-2020; the algorithm appears at §13.4.7.

## Validation
- `cargo fmt --all -- --check`
- focused fault-detector, intrinsic fault/recovery, AO priority/intrinsic, and `CHANGE_OF_RELIABILITY` tests
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-types --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

The owner-approved replan uses repository CI-native equivalents instead of two baseline-incompatible raw workspace commands: strict workspace clippy reaches pre-existing `bacnet-types` missing-doc warnings, and raw workspace tests hit unchanged macOS PyO3 linker symbols.

## Deferred
- AI/AV `FAULT_OUT_OF_RANGE`, Fault High/Low storage, deadband, inhibit, and algorithm state
- AO reliability fault evaluation
- Event Enrollment or intrinsic event changes

Refs #231