### PR TITLE
fix(objects): evaluate analog range reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,13 +125,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reliability evaluation now belongs to each `BACnetObject` through a defaulted
   opt-in hook. Enabling server fault detection invokes that hook for every
-  object every 10 seconds; stock objects currently make no change. The server
-  no longer treats Analog Input, Analog Output, or Analog Value
+  object every 10 seconds; stock objects remain opted out by default. Analog
+  Input and Analog Value may opt in through the atomic Rust
+  `configure_fault_out_of_range(low, high)` API. Configured objects expose the
+  paired, read-only `Fault_Low_Limit` / `Fault_High_Limit` properties and apply
+  strict FAULT_OUT_OF_RANGE evaluation to their resolved `Present_Value`, with
+  first-stage Reliability and Out_Of_Service simulation taking precedence. The
+  server no longer treats Analog Input, Analog Output, or Analog Value
   `Min_Pres_Value` / `Max_Pres_Value` engineering metadata as reliability fault
   limits, so those bounds cannot synthesize `OVER_RANGE` or `UNDER_RANGE`.
   Analog Output `OUT_OF_RANGE` intrinsic event reporting is unchanged and
-  remains separate from reliability evaluation. Full Analog Input/Value
-  `FAULT_OUT_OF_RANGE` algorithms remain deferred.
+  remains separate from reliability evaluation.
 
 - Correct `NotificationParameters` codecs for complex event values `[6]`,
   AccessEvent credentials and authentication factors `[13]`, rejection of the

--- a/crates/bacnet-objects/src/analog/input.rs
+++ b/crates/bacnet-objects/src/analog/input.rs
@@ -28,6 +28,7 @@ pub struct AnalogInputObject {
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
     reliability_before_out_of_service: Option<u32>,
+    fault_out_of_range: FaultOutOfRangeState,
     /// Optional minimum engineering bound metadata for Present_Value.
     min_pres_value: Option<f32>,
     /// Optional maximum engineering bound metadata for Present_Value.
@@ -52,6 +53,7 @@ impl AnalogInputObject {
             event_detection_enable: true,
             reliability: 0,
             reliability_before_out_of_service: None,
+            fault_out_of_range: FaultOutOfRangeState::default(),
             min_pres_value: None,
             max_pres_value: None,
             event_history: EventHistory::default(),
@@ -80,6 +82,15 @@ impl AnalogInputObject {
     /// Set maximum engineering-bound metadata; this is not a reliability fault limit.
     pub fn set_max_pres_value(&mut self, value: f32) {
         self.max_pres_value = Some(value);
+    }
+
+    /// Configure the optional object-owned FAULT_OUT_OF_RANGE algorithm.
+    ///
+    /// Both limits become readable together. Equal limits are valid; non-finite
+    /// limits and a low limit greater than the high limit are rejected without
+    /// changing the prior configuration.
+    pub fn configure_fault_out_of_range(&mut self, low: f32, high: f32) -> Result<(), Error> {
+        self.fault_out_of_range.configure(low, high)
     }
 }
 
@@ -120,6 +131,9 @@ impl BACnetObject for AnalogInputObject {
         }
         if property == PropertyIdentifier::EVENT_DETECTION_ENABLE {
             return Ok(PropertyValue::Boolean(self.event_detection_enable));
+        }
+        if let Some(value) = self.fault_out_of_range.read_limit(property) {
+            return Ok(value);
         }
         match property {
             p if p == PropertyIdentifier::OBJECT_TYPE => {
@@ -247,7 +261,7 @@ impl BACnetObject for AnalogInputObject {
             PropertyIdentifier::EVENT_TIME_STAMPS,
             PropertyIdentifier::EVENT_MESSAGE_TEXTS,
         ];
-        Cow::Borrowed(PROPS)
+        self.fault_out_of_range.property_list(PROPS)
     }
 
     fn supports_cov(&self) -> bool {
@@ -280,7 +294,16 @@ impl BACnetObject for AnalogInputObject {
             return Err(common::value_out_of_range_error());
         }
         self.reliability = reliability;
+        self.fault_out_of_range.clear_ownership();
         Ok(())
+    }
+
+    fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {
+        if self.out_of_service {
+            return Ok(ReliabilityEvaluation::Unchanged);
+        }
+        self.fault_out_of_range
+            .evaluate(self.present_value, &mut self.reliability)
     }
 
     fn is_createable(&self) -> bool {
@@ -521,5 +544,84 @@ mod detection_enable_reset_tests {
             BACnetTimeStamp::SequenceNumber(7)
         );
         assert_eq!(ai.event_history.message_texts[0], "offnormal");
+    }
+}
+
+#[cfg(test)]
+mod fault_out_of_range_non_finite_tests {
+    use super::*;
+    use bacnet_types::enums::{ErrorClass, ErrorCode, Reliability};
+
+    fn assert_value_out_of_range(result: Result<ReliabilityEvaluation, Error>) {
+        assert!(matches!(
+            result,
+            Err(Error::Protocol { class, code })
+                if class == ErrorClass::PROPERTY.to_raw() as u32
+                    && code == ErrorCode::VALUE_OUT_OF_RANGE.to_raw() as u32
+        ));
+    }
+
+    #[test]
+    fn ai_non_finite_monitored_values_preserve_reliability_status_and_ownership() {
+        for non_finite in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let mut normal = AnalogInputObject::new(1, "AI-normal", 62).unwrap();
+            normal.configure_fault_out_of_range(10.0, 20.0).unwrap();
+            let status_before = normal
+                .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+                .unwrap();
+            normal.present_value = non_finite;
+
+            assert_value_out_of_range(normal.evaluate_reliability_internal());
+            assert_eq!(normal.present_value.to_bits(), non_finite.to_bits());
+            assert_eq!(normal.reliability, Reliability::NO_FAULT_DETECTED.to_raw());
+            assert_eq!(
+                normal
+                    .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+                    .unwrap(),
+                status_before
+            );
+            assert!(normal.fault_out_of_range.owned_fault.is_none());
+
+            normal.present_value = 9.0;
+            assert_eq!(
+                normal.evaluate_reliability_internal().unwrap(),
+                ReliabilityEvaluation::Changed {
+                    old_reliability: Reliability::NO_FAULT_DETECTED.to_raw(),
+                    new_reliability: Reliability::UNDER_RANGE.to_raw(),
+                }
+            );
+
+            let mut owned = AnalogInputObject::new(2, "AI-owned", 62).unwrap();
+            owned.configure_fault_out_of_range(10.0, 20.0).unwrap();
+            owned.present_value = 9.0;
+            owned.evaluate_reliability_internal().unwrap();
+            let status_before = owned
+                .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+                .unwrap();
+            owned.present_value = non_finite;
+
+            assert_value_out_of_range(owned.evaluate_reliability_internal());
+            assert_eq!(owned.present_value.to_bits(), non_finite.to_bits());
+            assert_eq!(owned.reliability, Reliability::UNDER_RANGE.to_raw());
+            assert_eq!(
+                owned
+                    .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+                    .unwrap(),
+                status_before
+            );
+            assert!(matches!(
+                owned.fault_out_of_range.owned_fault,
+                Some(OwnedRangeFault::UnderRange)
+            ));
+
+            owned.present_value = 21.0;
+            assert_eq!(
+                owned.evaluate_reliability_internal().unwrap(),
+                ReliabilityEvaluation::Changed {
+                    old_reliability: Reliability::UNDER_RANGE.to_raw(),
+                    new_reliability: Reliability::OVER_RANGE.to_raw(),
+                }
+            );
+        }
     }
 }

--- a/crates/bacnet-objects/src/analog/mod.rs
+++ b/crates/bacnet-objects/src/analog/mod.rs
@@ -1,8 +1,8 @@
 //! Analog Input (type 0), Analog Output (type 1), and Analog Value (type 2) objects.
 //!
-//! Per ASHRAE 135-2020 Clauses 12.1 (AI), 12.2 (AO), and 12.3 (AV).
+//! Per ASHRAE 135-2020 Clauses 12.2 (AI), 12.3 (AO), and 12.4 (AV).
 
-use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{ObjectType, PropertyIdentifier, Reliability};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;
@@ -10,7 +10,122 @@ use std::borrow::Cow;
 use crate::common::{self, read_common_properties};
 use crate::event::{history::EventHistory, OutOfRangeDetector};
 use crate::rollback::impl_intrinsic_write_rollback;
-use crate::traits::BACnetObject;
+use crate::traits::{BACnetObject, ReliabilityEvaluation};
+
+#[derive(Clone, Copy)]
+struct FaultOutOfRangeLimits {
+    low: f32,
+    high: f32,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum OwnedRangeFault {
+    UnderRange,
+    OverRange,
+}
+
+impl OwnedRangeFault {
+    fn reliability(self) -> u32 {
+        match self {
+            Self::UnderRange => Reliability::UNDER_RANGE.to_raw(),
+            Self::OverRange => Reliability::OVER_RANGE.to_raw(),
+        }
+    }
+}
+
+#[derive(Default)]
+struct FaultOutOfRangeState {
+    // Deliberately separate from the intrinsic OutOfRangeDetector: reliability
+    // has strict boundaries, no deadband, and first-stage ownership precedence.
+    limits: Option<FaultOutOfRangeLimits>,
+    owned_fault: Option<OwnedRangeFault>,
+}
+
+impl FaultOutOfRangeState {
+    fn configure(&mut self, low: f32, high: f32) -> Result<(), Error> {
+        if !low.is_finite() || !high.is_finite() || low > high {
+            return Err(common::value_out_of_range_error());
+        }
+        self.limits = Some(FaultOutOfRangeLimits { low, high });
+        Ok(())
+    }
+
+    fn read_limit(&self, property: PropertyIdentifier) -> Option<PropertyValue> {
+        let limits = self.limits?;
+        match property {
+            PropertyIdentifier::FAULT_LOW_LIMIT => Some(PropertyValue::Real(limits.low)),
+            PropertyIdentifier::FAULT_HIGH_LIMIT => Some(PropertyValue::Real(limits.high)),
+            _ => None,
+        }
+    }
+
+    fn property_list(
+        &self,
+        base: &'static [PropertyIdentifier],
+    ) -> Cow<'static, [PropertyIdentifier]> {
+        if self.limits.is_none() {
+            return Cow::Borrowed(base);
+        }
+        let mut properties = Vec::with_capacity(base.len() + 2);
+        properties.extend_from_slice(base);
+        properties.extend([
+            PropertyIdentifier::FAULT_HIGH_LIMIT,
+            PropertyIdentifier::FAULT_LOW_LIMIT,
+        ]);
+        Cow::Owned(properties)
+    }
+
+    fn clear_ownership(&mut self) {
+        self.owned_fault = None;
+    }
+
+    fn evaluate(
+        &mut self,
+        monitored_value: f32,
+        reliability: &mut u32,
+    ) -> Result<ReliabilityEvaluation, Error> {
+        let Some(limits) = self.limits else {
+            return Ok(ReliabilityEvaluation::Unchanged);
+        };
+        if !monitored_value.is_finite() {
+            return Err(common::value_out_of_range_error());
+        }
+        let observed_fault = if monitored_value < limits.low {
+            Some(OwnedRangeFault::UnderRange)
+        } else if monitored_value > limits.high {
+            Some(OwnedRangeFault::OverRange)
+        } else {
+            None
+        };
+
+        let (new_reliability, new_owner) = if self.owned_fault.is_some() {
+            (
+                observed_fault
+                    .map(OwnedRangeFault::reliability)
+                    .unwrap_or_else(|| Reliability::NO_FAULT_DETECTED.to_raw()),
+                observed_fault,
+            )
+        } else if *reliability == Reliability::NO_FAULT_DETECTED.to_raw() {
+            let Some(fault) = observed_fault else {
+                return Ok(ReliabilityEvaluation::Unchanged);
+            };
+            (fault.reliability(), Some(fault))
+        } else {
+            return Ok(ReliabilityEvaluation::Unchanged);
+        };
+
+        if new_reliability == *reliability {
+            return Ok(ReliabilityEvaluation::Unchanged);
+        }
+        let old_reliability = *reliability;
+        *reliability = new_reliability;
+        self.owned_fault = new_owner;
+        Ok(ReliabilityEvaluation::Changed {
+            old_reliability,
+            new_reliability,
+        })
+    }
+}
 
 mod input;
 mod output;

--- a/crates/bacnet-objects/src/analog/tests/fault_out_of_range.rs
+++ b/crates/bacnet-objects/src/analog/tests/fault_out_of_range.rs
@@ -1,0 +1,536 @@
+use super::super::*;
+use crate::traits::{BACnetObject, ReliabilityEvaluation};
+use bacnet_types::enums::{ErrorClass, ErrorCode, Reliability};
+use bacnet_types::primitives::StatusFlags;
+
+fn reliability(object: &dyn BACnetObject) -> u32 {
+    match object
+        .read_property(PropertyIdentifier::RELIABILITY, None)
+        .unwrap()
+    {
+        PropertyValue::Enumerated(value) => value,
+        other => panic!("expected Enumerated Reliability, got {other:?}"),
+    }
+}
+
+fn assert_changed(
+    result: Result<ReliabilityEvaluation, Error>,
+    old_reliability: Reliability,
+    new_reliability: Reliability,
+) {
+    assert_eq!(
+        result.unwrap(),
+        ReliabilityEvaluation::Changed {
+            old_reliability: old_reliability.to_raw(),
+            new_reliability: new_reliability.to_raw(),
+        }
+    );
+}
+
+fn assert_unchanged(result: Result<ReliabilityEvaluation, Error>) {
+    assert_eq!(result.unwrap(), ReliabilityEvaluation::Unchanged);
+}
+
+fn assert_unknown_property(result: Result<PropertyValue, Error>) {
+    assert!(matches!(
+        result,
+        Err(Error::Protocol { class, code })
+            if class == ErrorClass::PROPERTY.to_raw() as u32
+                && code == ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32
+    ));
+}
+
+fn assert_write_denied(result: Result<(), Error>) {
+    assert!(matches!(
+        result,
+        Err(Error::Protocol { class, code })
+            if class == ErrorClass::PROPERTY.to_raw() as u32
+                && code == ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32
+    ));
+}
+
+fn assert_fault_flag(object: &dyn BACnetObject, expected: bool) {
+    let PropertyValue::BitString { unused_bits, data } = object
+        .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+        .unwrap()
+    else {
+        panic!("expected Status_Flags BitString");
+    };
+    assert_eq!(unused_bits, 4);
+    assert_eq!(data[0] & (StatusFlags::FAULT.bits() << 4) != 0, expected);
+}
+
+fn assert_fault_properties(object: &dyn BACnetObject, expected: bool) {
+    for property in [
+        PropertyIdentifier::FAULT_LOW_LIMIT,
+        PropertyIdentifier::FAULT_HIGH_LIMIT,
+    ] {
+        assert_eq!(object.property_list().contains(&property), expected);
+    }
+    let PropertyValue::List(wire_list) = object
+        .read_property(PropertyIdentifier::PROPERTY_LIST, None)
+        .unwrap()
+    else {
+        panic!("expected Property_List List");
+    };
+    for property in [
+        PropertyIdentifier::FAULT_LOW_LIMIT,
+        PropertyIdentifier::FAULT_HIGH_LIMIT,
+    ] {
+        assert_eq!(
+            wire_list.contains(&PropertyValue::Enumerated(property.to_raw())),
+            expected
+        );
+    }
+}
+
+macro_rules! assert_property_surface {
+    ($object:expr) => {{
+        let mut object = $object;
+        assert_unknown_property(object.read_property(PropertyIdentifier::FAULT_LOW_LIMIT, None));
+        assert_unknown_property(object.read_property(PropertyIdentifier::FAULT_HIGH_LIMIT, None));
+        assert_fault_properties(&object, false);
+
+        object.configure_fault_out_of_range(-5.0, 25.0).unwrap();
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::FAULT_LOW_LIMIT, None)
+                .unwrap(),
+            PropertyValue::Real(-5.0)
+        );
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::FAULT_HIGH_LIMIT, None)
+                .unwrap(),
+            PropertyValue::Real(25.0)
+        );
+        assert_fault_properties(&object, true);
+        for property in [
+            PropertyIdentifier::FAULT_LOW_LIMIT,
+            PropertyIdentifier::FAULT_HIGH_LIMIT,
+        ] {
+            assert!(!object.is_writable_property(property));
+            assert_write_denied(object.write_property(
+                property,
+                None,
+                PropertyValue::Real(1.0),
+                None,
+            ));
+        }
+
+        object.configure_fault_out_of_range(3.0, 3.0).unwrap();
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::FAULT_LOW_LIMIT, None)
+                .unwrap(),
+            PropertyValue::Real(3.0)
+        );
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::FAULT_HIGH_LIMIT, None)
+                .unwrap(),
+            PropertyValue::Real(3.0)
+        );
+    }};
+}
+
+#[test]
+fn ai_and_av_fault_limit_properties_are_atomic_optional_and_read_only() {
+    assert_property_surface!(AnalogInputObject::new(1, "AI-1", 62).unwrap());
+    assert_property_surface!(AnalogValueObject::new(1, "AV-1", 62).unwrap());
+}
+
+macro_rules! assert_invalid_configuration_is_atomic {
+    ($object:expr) => {{
+        let mut object = $object;
+        let invalid_limits = [
+            (f32::NAN, 1.0),
+            (1.0, f32::NAN),
+            (f32::INFINITY, 1.0),
+            (f32::NEG_INFINITY, 1.0),
+            (1.0, f32::INFINITY),
+            (1.0, f32::NEG_INFINITY),
+            (2.0, 1.0),
+        ];
+
+        for (low, high) in invalid_limits {
+            assert!(object.configure_fault_out_of_range(low, high).is_err());
+            assert_unknown_property(
+                object.read_property(PropertyIdentifier::FAULT_LOW_LIMIT, None),
+            );
+            assert_unknown_property(
+                object.read_property(PropertyIdentifier::FAULT_HIGH_LIMIT, None),
+            );
+            assert_fault_properties(&object, false);
+            assert_eq!(
+                reliability(&object),
+                Reliability::NO_FAULT_DETECTED.to_raw()
+            );
+        }
+
+        object.configure_fault_out_of_range(10.0, 20.0).unwrap();
+        object.set_present_value(21.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::NO_FAULT_DETECTED,
+            Reliability::OVER_RANGE,
+        );
+        for (low, high) in invalid_limits {
+            assert!(object.configure_fault_out_of_range(low, high).is_err());
+            assert_eq!(
+                object
+                    .read_property(PropertyIdentifier::FAULT_LOW_LIMIT, None)
+                    .unwrap(),
+                PropertyValue::Real(10.0)
+            );
+            assert_eq!(
+                object
+                    .read_property(PropertyIdentifier::FAULT_HIGH_LIMIT, None)
+                    .unwrap(),
+                PropertyValue::Real(20.0)
+            );
+            assert_fault_properties(&object, true);
+            assert_eq!(reliability(&object), Reliability::OVER_RANGE.to_raw());
+        }
+
+        object.set_present_value(20.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::OVER_RANGE,
+            Reliability::NO_FAULT_DETECTED,
+        );
+    }};
+}
+
+#[test]
+fn invalid_ai_and_av_configuration_changes_no_public_or_private_state() {
+    assert_invalid_configuration_is_atomic!(AnalogInputObject::new(1, "AI-1", 62).unwrap());
+    assert_invalid_configuration_is_atomic!(AnalogValueObject::new(1, "AV-1", 62).unwrap());
+}
+
+#[test]
+fn configured_ai_evaluator_enters_under_range_from_no_fault() {
+    let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+    ai.configure_fault_out_of_range(10.0, 20.0).unwrap();
+    ai.set_present_value(9.0);
+
+    assert_changed(
+        ai.evaluate_reliability_internal(),
+        Reliability::NO_FAULT_DETECTED,
+        Reliability::UNDER_RANGE,
+    );
+}
+
+macro_rules! assert_strict_range_transitions {
+    ($object:expr) => {{
+        let mut object = $object;
+        object.configure_fault_out_of_range(10.0, 20.0).unwrap();
+
+        object.set_present_value(10.0);
+        assert_unchanged(object.evaluate_reliability_internal());
+        object.set_present_value(f32::from_bits(10.0f32.to_bits() - 1));
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::NO_FAULT_DETECTED,
+            Reliability::UNDER_RANGE,
+        );
+        assert_fault_flag(&object, true);
+        object.set_present_value(10.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::UNDER_RANGE,
+            Reliability::NO_FAULT_DETECTED,
+        );
+        assert_fault_flag(&object, false);
+
+        object.set_present_value(20.0);
+        assert_unchanged(object.evaluate_reliability_internal());
+        object.set_present_value(f32::from_bits(20.0f32.to_bits() + 1));
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::NO_FAULT_DETECTED,
+            Reliability::OVER_RANGE,
+        );
+        object.set_present_value(20.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::OVER_RANGE,
+            Reliability::NO_FAULT_DETECTED,
+        );
+
+        object.set_present_value(9.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::NO_FAULT_DETECTED,
+            Reliability::UNDER_RANGE,
+        );
+        object.set_present_value(21.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::UNDER_RANGE,
+            Reliability::OVER_RANGE,
+        );
+        object.set_present_value(15.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::OVER_RANGE,
+            Reliability::NO_FAULT_DETECTED,
+        );
+
+        object.configure_fault_out_of_range(10.0, 10.0).unwrap();
+        object.set_present_value(10.0);
+        assert_unchanged(object.evaluate_reliability_internal());
+        object.set_present_value(9.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::NO_FAULT_DETECTED,
+            Reliability::UNDER_RANGE,
+        );
+        object.set_present_value(11.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::UNDER_RANGE,
+            Reliability::OVER_RANGE,
+        );
+        object.set_present_value(10.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::OVER_RANGE,
+            Reliability::NO_FAULT_DETECTED,
+        );
+    }};
+}
+
+#[test]
+fn ai_and_av_use_strict_entry_inclusive_recovery_and_no_deadband() {
+    assert_strict_range_transitions!(AnalogInputObject::new(1, "AI-1", 62).unwrap());
+    assert_strict_range_transitions!(AnalogValueObject::new(1, "AV-1", 62).unwrap());
+}
+
+macro_rules! assert_first_stage_precedence {
+    ($object:expr) => {{
+        let mut object = $object;
+        object.configure_fault_out_of_range(10.0, 20.0).unwrap();
+
+        object.set_present_value(21.0);
+        object
+            .set_reliability_internal(Reliability::NO_SENSOR.to_raw())
+            .unwrap();
+        assert_unchanged(object.evaluate_reliability_internal());
+        assert_eq!(reliability(&object), Reliability::NO_SENSOR.to_raw());
+
+        object
+            .set_reliability_internal(Reliability::UNDER_RANGE.to_raw())
+            .unwrap();
+        assert_unchanged(object.evaluate_reliability_internal());
+        assert_eq!(reliability(&object), Reliability::UNDER_RANGE.to_raw());
+
+        object.set_present_value(9.0);
+        object
+            .set_reliability_internal(Reliability::OVER_RANGE.to_raw())
+            .unwrap();
+        assert_unchanged(object.evaluate_reliability_internal());
+        assert_eq!(reliability(&object), Reliability::OVER_RANGE.to_raw());
+
+        object
+            .set_reliability_internal(Reliability::NO_FAULT_DETECTED.to_raw())
+            .unwrap();
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::NO_FAULT_DETECTED,
+            Reliability::UNDER_RANGE,
+        );
+
+        assert!(object.set_reliability_internal(11).is_err());
+        object.set_present_value(10.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::UNDER_RANGE,
+            Reliability::NO_FAULT_DETECTED,
+        );
+
+        object.set_present_value(21.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::NO_FAULT_DETECTED,
+            Reliability::OVER_RANGE,
+        );
+        object
+            .set_reliability_internal(Reliability::OVER_RANGE.to_raw())
+            .unwrap();
+        object.set_present_value(20.0);
+        assert_unchanged(object.evaluate_reliability_internal());
+        assert_eq!(reliability(&object), Reliability::OVER_RANGE.to_raw());
+
+        object
+            .set_reliability_internal(Reliability::NO_FAULT_DETECTED.to_raw())
+            .unwrap();
+        object.set_present_value(9.0);
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::NO_FAULT_DETECTED,
+            Reliability::UNDER_RANGE,
+        );
+        object.configure_fault_out_of_range(0.0, 5.0).unwrap();
+        assert_changed(
+            object.evaluate_reliability_internal(),
+            Reliability::UNDER_RANGE,
+            Reliability::OVER_RANGE,
+        );
+    }};
+}
+
+#[test]
+fn ai_and_av_preserve_first_stage_values_and_clear_only_owned_faults() {
+    assert_first_stage_precedence!(AnalogInputObject::new(1, "AI-1", 62).unwrap());
+    assert_first_stage_precedence!(AnalogValueObject::new(1, "AV-1", 62).unwrap());
+}
+
+#[test]
+fn ai_out_of_service_simulation_preserves_range_fault_ownership() {
+    let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+    ai.configure_fault_out_of_range(10.0, 20.0).unwrap();
+    ai.set_present_value(21.0);
+    assert_changed(
+        ai.evaluate_reliability_internal(),
+        Reliability::NO_FAULT_DETECTED,
+        Reliability::OVER_RANGE,
+    );
+
+    ai.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    ai.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Real(15.0),
+        None,
+    )
+    .unwrap();
+    ai.write_property(
+        PropertyIdentifier::RELIABILITY,
+        None,
+        PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+        None,
+    )
+    .unwrap();
+
+    assert_unchanged(ai.evaluate_reliability_internal());
+    assert_eq!(reliability(&ai), Reliability::NO_SENSOR.to_raw());
+    assert_eq!(
+        ai.read_property(PropertyIdentifier::PRESENT_VALUE, None)
+            .unwrap(),
+        PropertyValue::Real(15.0)
+    );
+
+    ai.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(false),
+        None,
+    )
+    .unwrap();
+    assert_eq!(reliability(&ai), Reliability::OVER_RANGE.to_raw());
+    assert_changed(
+        ai.evaluate_reliability_internal(),
+        Reliability::OVER_RANGE,
+        Reliability::NO_FAULT_DETECTED,
+    );
+}
+
+#[test]
+fn av_evaluates_resolved_priority_value_without_mutating_priority_array() {
+    let mut av = AnalogValueObject::new(1, "AV-1", 62).unwrap();
+    av.configure_fault_out_of_range(10.0, 20.0).unwrap();
+    av.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Real(5.0),
+        Some(16),
+    )
+    .unwrap();
+    let priority_before = av
+        .read_property(PropertyIdentifier::PRIORITY_ARRAY, None)
+        .unwrap();
+    assert_changed(
+        av.evaluate_reliability_internal(),
+        Reliability::NO_FAULT_DETECTED,
+        Reliability::UNDER_RANGE,
+    );
+    assert_eq!(
+        av.read_property(PropertyIdentifier::PRIORITY_ARRAY, None)
+            .unwrap(),
+        priority_before
+    );
+
+    av.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Real(25.0),
+        Some(8),
+    )
+    .unwrap();
+    let priority_before = av
+        .read_property(PropertyIdentifier::PRIORITY_ARRAY, None)
+        .unwrap();
+    assert_changed(
+        av.evaluate_reliability_internal(),
+        Reliability::UNDER_RANGE,
+        Reliability::OVER_RANGE,
+    );
+    assert_eq!(
+        av.read_property(PropertyIdentifier::PRIORITY_ARRAY, None)
+            .unwrap(),
+        priority_before
+    );
+    assert_eq!(
+        av.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
+            .unwrap(),
+        PropertyValue::Real(25.0)
+    );
+    assert_eq!(
+        av.read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(16))
+            .unwrap(),
+        PropertyValue::Real(5.0)
+    );
+
+    av.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Null,
+        Some(8),
+    )
+    .unwrap();
+    assert_changed(
+        av.evaluate_reliability_internal(),
+        Reliability::OVER_RANGE,
+        Reliability::UNDER_RANGE,
+    );
+}
+
+#[test]
+fn analog_output_has_no_fault_out_of_range_surface_or_evaluator() {
+    let mut ao = AnalogOutputObject::new(1, "AO-1", 62).unwrap();
+    for property in [
+        PropertyIdentifier::FAULT_LOW_LIMIT,
+        PropertyIdentifier::FAULT_HIGH_LIMIT,
+    ] {
+        assert_unknown_property(ao.read_property(property, None));
+        assert!(!ao.property_list().contains(&property));
+        assert!(!ao.is_writable_property(property));
+        assert_write_denied(ao.write_property(property, None, PropertyValue::Real(1.0), None));
+    }
+    ao.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Real(100.0),
+        Some(8),
+    )
+    .unwrap();
+    assert_unchanged(ao.evaluate_reliability_internal());
+    assert_eq!(reliability(&ao), Reliability::NO_FAULT_DETECTED.to_raw());
+}

--- a/crates/bacnet-objects/src/analog/tests/mod.rs
+++ b/crates/bacnet-objects/src/analog/tests/mod.rs
@@ -1,4 +1,5 @@
 mod event_history_read;
+mod fault_out_of_range;
 mod input;
 mod output;
 mod value;

--- a/crates/bacnet-objects/src/analog/value.rs
+++ b/crates/bacnet-objects/src/analog/value.rs
@@ -31,6 +31,7 @@ pub struct AnalogValueObject {
     /// Reliability: 0 = NO_FAULT_DETECTED.
     reliability: u32,
     reliability_before_out_of_service: Option<u32>,
+    fault_out_of_range: FaultOutOfRangeState,
     min_pres_value: Option<f32>,
     max_pres_value: Option<f32>,
     pub(crate) event_history: EventHistory,
@@ -57,6 +58,7 @@ impl AnalogValueObject {
             event_detection_enable: true,
             reliability: 0,
             reliability_before_out_of_service: None,
+            fault_out_of_range: FaultOutOfRangeState::default(),
             min_pres_value: None,
             max_pres_value: None,
             event_history: EventHistory::default(),
@@ -87,6 +89,15 @@ impl AnalogValueObject {
     /// Set maximum engineering-bound metadata; this is not a reliability fault limit.
     pub fn set_max_pres_value(&mut self, value: f32) {
         self.max_pres_value = Some(value);
+    }
+
+    /// Configure the optional object-owned FAULT_OUT_OF_RANGE algorithm.
+    ///
+    /// Both limits become readable together. Equal limits are valid; non-finite
+    /// limits and a low limit greater than the high limit are rejected without
+    /// changing the prior configuration.
+    pub fn configure_fault_out_of_range(&mut self, low: f32, high: f32) -> Result<(), Error> {
+        self.fault_out_of_range.configure(low, high)
     }
 
     /// Recalculate present-value from the priority array.
@@ -144,6 +155,9 @@ impl BACnetObject for AnalogValueObject {
         }
         if property == PropertyIdentifier::EVENT_DETECTION_ENABLE {
             return Ok(PropertyValue::Boolean(self.event_detection_enable));
+        }
+        if let Some(value) = self.fault_out_of_range.read_limit(property) {
+            return Ok(value);
         }
         match property {
             p if p == PropertyIdentifier::OBJECT_TYPE => {
@@ -311,7 +325,7 @@ impl BACnetObject for AnalogValueObject {
             PropertyIdentifier::EVENT_TIME_STAMPS,
             PropertyIdentifier::EVENT_MESSAGE_TEXTS,
         ];
-        Cow::Borrowed(PROPS)
+        self.fault_out_of_range.property_list(PROPS)
     }
 
     fn supports_cov(&self) -> bool {
@@ -344,7 +358,16 @@ impl BACnetObject for AnalogValueObject {
             return Err(common::value_out_of_range_error());
         }
         self.reliability = reliability;
+        self.fault_out_of_range.clear_ownership();
         Ok(())
+    }
+
+    fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {
+        if self.out_of_service {
+            return Ok(ReliabilityEvaluation::Unchanged);
+        }
+        self.fault_out_of_range
+            .evaluate(self.present_value, &mut self.reliability)
     }
 
     /// AnalogValue is NOT createable: `handle_create_object` has no branch for
@@ -425,5 +448,84 @@ mod detection_enable_reset_tests {
             av.event_history.message_texts,
             [String::new(), String::new(), String::new()]
         );
+    }
+}
+
+#[cfg(test)]
+mod fault_out_of_range_non_finite_tests {
+    use super::*;
+    use bacnet_types::enums::{ErrorClass, ErrorCode, Reliability};
+
+    fn assert_value_out_of_range(result: Result<ReliabilityEvaluation, Error>) {
+        assert!(matches!(
+            result,
+            Err(Error::Protocol { class, code })
+                if class == ErrorClass::PROPERTY.to_raw() as u32
+                    && code == ErrorCode::VALUE_OUT_OF_RANGE.to_raw() as u32
+        ));
+    }
+
+    #[test]
+    fn av_non_finite_monitored_values_preserve_reliability_status_and_ownership() {
+        for non_finite in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let mut normal = AnalogValueObject::new(1, "AV-normal", 62).unwrap();
+            normal.configure_fault_out_of_range(10.0, 20.0).unwrap();
+            let status_before = normal
+                .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+                .unwrap();
+            normal.present_value = non_finite;
+
+            assert_value_out_of_range(normal.evaluate_reliability_internal());
+            assert_eq!(normal.present_value.to_bits(), non_finite.to_bits());
+            assert_eq!(normal.reliability, Reliability::NO_FAULT_DETECTED.to_raw());
+            assert_eq!(
+                normal
+                    .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+                    .unwrap(),
+                status_before
+            );
+            assert!(normal.fault_out_of_range.owned_fault.is_none());
+
+            normal.present_value = 9.0;
+            assert_eq!(
+                normal.evaluate_reliability_internal().unwrap(),
+                ReliabilityEvaluation::Changed {
+                    old_reliability: Reliability::NO_FAULT_DETECTED.to_raw(),
+                    new_reliability: Reliability::UNDER_RANGE.to_raw(),
+                }
+            );
+
+            let mut owned = AnalogValueObject::new(2, "AV-owned", 62).unwrap();
+            owned.configure_fault_out_of_range(10.0, 20.0).unwrap();
+            owned.present_value = 9.0;
+            owned.evaluate_reliability_internal().unwrap();
+            let status_before = owned
+                .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+                .unwrap();
+            owned.present_value = non_finite;
+
+            assert_value_out_of_range(owned.evaluate_reliability_internal());
+            assert_eq!(owned.present_value.to_bits(), non_finite.to_bits());
+            assert_eq!(owned.reliability, Reliability::UNDER_RANGE.to_raw());
+            assert_eq!(
+                owned
+                    .read_property(PropertyIdentifier::STATUS_FLAGS, None)
+                    .unwrap(),
+                status_before
+            );
+            assert!(matches!(
+                owned.fault_out_of_range.owned_fault,
+                Some(OwnedRangeFault::UnderRange)
+            ));
+
+            owned.present_value = 21.0;
+            assert_eq!(
+                owned.evaluate_reliability_internal().unwrap(),
+                ReliabilityEvaluation::Changed {
+                    old_reliability: Reliability::UNDER_RANGE.to_raw(),
+                    new_reliability: Reliability::OVER_RANGE.to_raw(),
+                }
+            );
+        }
     }
 }

--- a/crates/bacnet-server/src/fault_detection.rs
+++ b/crates/bacnet-server/src/fault_detection.rs
@@ -122,7 +122,7 @@ mod tests {
 
     use bacnet_objects::analog::{AnalogInputObject, AnalogOutputObject, AnalogValueObject};
     use bacnet_objects::traits::BACnetObject;
-    use bacnet_types::enums::{ObjectType, PropertyIdentifier, Reliability};
+    use bacnet_types::enums::{EventState, ObjectType, PropertyIdentifier, Reliability};
     use bacnet_types::error::Error;
     use bacnet_types::primitives::PropertyValue;
 
@@ -279,6 +279,136 @@ mod tests {
                 .unwrap(),
             PropertyValue::Real(150.0)
         );
+    }
+
+    #[test]
+    fn configured_ai_and_av_changes_are_recorded_and_seen_by_intrinsic_fault_observation() {
+        let mut db = ObjectDatabase::new();
+
+        let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+        ai.configure_fault_out_of_range(10.0, 20.0).unwrap();
+        ai.set_present_value(21.0);
+        let ai_oid = ai.object_identifier();
+        db.add(Box::new(ai)).unwrap();
+
+        let mut av = AnalogValueObject::new(1, "AV-1", 62).unwrap();
+        av.configure_fault_out_of_range(10.0, 20.0).unwrap();
+        av.write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(9.0),
+            Some(8),
+        )
+        .unwrap();
+        let av_oid = av.object_identifier();
+        db.add(Box::new(av)).unwrap();
+
+        let detector = FaultDetector::default();
+        let changes = detector.evaluate(&mut db);
+        assert_eq!(changes.len(), 2);
+        assert!(changes.contains(&ReliabilityChange {
+            object_id: ai_oid,
+            old_reliability: Reliability::NO_FAULT_DETECTED.to_raw(),
+            new_reliability: Reliability::OVER_RANGE.to_raw(),
+        }));
+        assert!(changes.contains(&ReliabilityChange {
+            object_id: av_oid,
+            old_reliability: Reliability::NO_FAULT_DETECTED.to_raw(),
+            new_reliability: Reliability::UNDER_RANGE.to_raw(),
+        }));
+        assert!(detector.evaluate(&mut db).is_empty());
+
+        for oid in [ai_oid, av_oid] {
+            let proposal = db
+                .get_mut(&oid)
+                .unwrap()
+                .evaluate_intrinsic_reporting()
+                .expect("range Reliability must be observed as an intrinsic fault");
+            assert_eq!(proposal.change.from, EventState::NORMAL);
+            assert_eq!(proposal.change.to, EventState::FAULT);
+        }
+    }
+
+    // The public sensor setters intentionally retain their debug assertions.
+    // This release-only test exercises the production path where those setters
+    // can receive non-finite application data without changing their API.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn non_finite_configured_analogs_create_no_change_and_keep_owned_faults() {
+        let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+        ai.configure_fault_out_of_range(10.0, 20.0).unwrap();
+        ai.set_present_value(21.0);
+        ai.evaluate_reliability_internal().unwrap();
+        ai.set_present_value(f32::NAN);
+        let ai_oid = ai.object_identifier();
+
+        let mut av = AnalogValueObject::new(1, "AV-1", 62).unwrap();
+        av.configure_fault_out_of_range(10.0, 20.0).unwrap();
+        av.set_present_value(9.0);
+        av.evaluate_reliability_internal().unwrap();
+        av.set_present_value(f32::INFINITY);
+        let av_oid = av.object_identifier();
+
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(ai)).unwrap();
+        db.add(Box::new(av)).unwrap();
+        let detector = FaultDetector::default();
+
+        assert!(detector.evaluate(&mut db).is_empty());
+        assert!(detector.evaluate(&mut db).is_empty());
+        assert_eq!(
+            read_reliability(&db, ai_oid),
+            Reliability::OVER_RANGE.to_raw()
+        );
+        assert_eq!(
+            read_reliability(&db, av_oid),
+            Reliability::UNDER_RANGE.to_raw()
+        );
+
+        let ai = db.get_mut(&ai_oid).unwrap();
+        ai.write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+        ai.write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(9.0),
+            None,
+        )
+        .unwrap();
+        ai.write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .unwrap();
+        db.get_mut(&av_oid)
+            .unwrap()
+            .write_property(
+                PropertyIdentifier::PRESENT_VALUE,
+                None,
+                PropertyValue::Real(21.0),
+                Some(8),
+            )
+            .unwrap();
+
+        let changes = detector.evaluate(&mut db);
+        assert_eq!(changes.len(), 2);
+        assert!(changes.contains(&ReliabilityChange {
+            object_id: ai_oid,
+            old_reliability: Reliability::OVER_RANGE.to_raw(),
+            new_reliability: Reliability::UNDER_RANGE.to_raw(),
+        }));
+        assert!(changes.contains(&ReliabilityChange {
+            object_id: av_oid,
+            old_reliability: Reliability::UNDER_RANGE.to_raw(),
+            new_reliability: Reliability::OVER_RANGE.to_raw(),
+        }));
     }
 
     #[test]

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -55,6 +55,7 @@ mod read_rpm;
 mod reference_writes;
 mod wpm_create_alarm;
 mod wpm_event_rollback;
+mod wpm_fault_rollback;
 mod wpm_parameter_rollback;
 mod wpm_rollback_contract;
 mod write_cov_who;

--- a/crates/bacnet-server/src/handlers/tests/wpm_fault_rollback.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_fault_rollback.rs
@@ -1,0 +1,89 @@
+//! WPM rollback coverage for object-owned analog reliability state.
+
+use super::*;
+use bacnet_objects::traits::ReliabilityEvaluation;
+use bacnet_services::common::BACnetPropertyValue;
+use bacnet_services::wpm::{WriteAccessSpecification, WritePropertyMultipleRequest};
+use bacnet_types::enums::Reliability;
+use bytes::BytesMut;
+
+#[test]
+fn wpm_out_of_service_rollback_preserves_range_fault_ownership() {
+    let mut db = ObjectDatabase::new();
+    let mut input = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+    input.configure_fault_out_of_range(10.0, 20.0).unwrap();
+    input.set_present_value(21.0);
+    assert_eq!(
+        input.evaluate_reliability_internal().unwrap(),
+        ReliabilityEvaluation::Changed {
+            old_reliability: Reliability::NO_FAULT_DETECTED.to_raw(),
+            new_reliability: Reliability::OVER_RANGE.to_raw(),
+        }
+    );
+    input.set_present_value(15.0);
+    let oid = input.object_identifier();
+    db.add(Box::new(input)).unwrap();
+
+    let mut out_of_service = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_boolean(&mut out_of_service, true);
+    let mut simulated_reliability = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_enumerated(
+        &mut simulated_reliability,
+        Reliability::NO_SENSOR.to_raw(),
+    );
+    let mut read_only_value = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_enumerated(&mut read_only_value, 0);
+    let request = WritePropertyMultipleRequest {
+        list_of_write_access_specs: vec![WriteAccessSpecification {
+            object_identifier: oid,
+            list_of_properties: vec![
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::OUT_OF_SERVICE,
+                    property_array_index: None,
+                    value: out_of_service.to_vec(),
+                    priority: None,
+                },
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::RELIABILITY,
+                    property_array_index: None,
+                    value: simulated_reliability.to_vec(),
+                    priority: None,
+                },
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::OBJECT_TYPE,
+                    property_array_index: None,
+                    value: read_only_value.to_vec(),
+                    priority: None,
+                },
+            ],
+        }],
+    };
+    let mut request_bytes = BytesMut::new();
+    request.encode(&mut request_bytes);
+    assert!(handle_write_property_multiple(&mut db, &request_bytes).is_err());
+
+    let object = db.get(&oid).unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::OUT_OF_SERVICE, None)
+            .unwrap(),
+        PropertyValue::Boolean(false)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::OVER_RANGE.to_raw())
+    );
+    assert_eq!(
+        db.get_mut(&oid)
+            .unwrap()
+            .evaluate_reliability_internal()
+            .unwrap(),
+        ReliabilityEvaluation::Changed {
+            old_reliability: Reliability::OVER_RANGE.to_raw(),
+            new_reliability: Reliability::NO_FAULT_DETECTED.to_raw(),
+        },
+        "successful rollback must preserve the private owner needed for recovery"
+    );
+}


### PR DESCRIPTION
## Summary
- add opt-in, object-owned `FAULT_OUT_OF_RANGE` reliability evaluation for Analog Input and Analog Value
- expose paired `Fault_Low_Limit` / `Fault_High_Limit` properties as optional and read-only
- preserve first-stage reliability precedence, out-of-service simulation, rollback ownership, and AV priority resolution
- keep Analog Output reliability evaluation unchanged

## Standard traceability
- ASHRAE 135-2020 §§12.1, 12.2, 12.4 and 13.4.7
- strict `< low` / `> high` entry and inclusive recovery; no deadband

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-server --release --locked non_finite_configured_analogs_create_no_change_and_keep_owned_faults`
- `cargo test -p bacnet-types --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- conformance-doc, file-size, no-secret, and diff checks

Advances #231.