### PR TITLE
fix(objects): add multi-state configuration reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Object-owned multi-state configuration Reliability and recovery for
+  Multi-state Input, Output, and Value (#226). The Standard requires
+  `MULTI_STATE_OUT_OF_RANGE` for an invalid retained `Present_Value`, and
+  `CONFIGURATION_ERROR` (with precedence) for invalid retained MSO priority,
+  default, or feedback configuration and MSV priority, default, or alarm
+  configuration. Relevant successful mutations now recompute synchronously;
+  the periodic object hook shares the same owned first-stage evaluator, while
+  intrinsic FAULT/NORMAL reporting remains in the existing event kernel. A new
+  fallible Rust-only `set_number_of_states` API supplies the local count-change
+  path: zero is rejected before mutation, shrink truncates `State_Text`, and
+  growth retains its prefix and appends constructor-style `State {n}` labels.
+  The local API and label policy are product choices; `Number_Of_States` stays
+  read-only through BACnet WP/WPM, PICS, and Python. MSV `Fault_Values` remains
+  unsupported, and no broader conformance claim is made.
+
 - Product-elected `Reliability_Evaluation_Inhibit` support on Analog,
   Binary, and Multi-state Input/Output/Value objects (#232). The optional
   Boolean is present on all nine types, defaults to FALSE, is BACnet-readable

--- a/crates/bacnet-objects/src/multistate/input.rs
+++ b/crates/bacnet-objects/src/multistate/input.rs
@@ -20,6 +20,7 @@ pub struct MultiStateInputObject {
     reliability: u32,
     reliability_before_out_of_service: Option<u32>,
     reliability_inhibit: common::ReliabilityInhibitState,
+    reliability_evaluator: MultiStateReliabilityState,
     state_text: Vec<String>,
     /// CHANGE_OF_STATE event detector.
     event_detector: ChangeOfStateDetector,
@@ -48,6 +49,7 @@ impl MultiStateInputObject {
             reliability: 0,
             reliability_before_out_of_service: None,
             reliability_inhibit: common::ReliabilityInhibitState::default(),
+            reliability_evaluator: MultiStateReliabilityState::default(),
             state_text: (1..=number_of_states)
                 .map(|i| format!("State {i}"))
                 .collect(),
@@ -65,11 +67,40 @@ impl MultiStateInputObject {
     /// Set the present value (used by application to update input state).
     pub fn set_present_value(&mut self, value: u32) {
         self.present_value = value;
+        let _ = self.recompute_reliability();
+    }
+
+    /// Change the locally configured number of states.
+    ///
+    /// The BACnet `Number_Of_States` property remains read-only. A successful
+    /// local change retains the State_Text prefix, truncates its tail on
+    /// shrink, appends constructor-style labels on growth, and immediately
+    /// re-evaluates Reliability without repairing Present_Value.
+    pub fn set_number_of_states(&mut self, number_of_states: u32) -> Result<(), Error> {
+        resize_state_text(
+            &mut self.number_of_states,
+            &mut self.state_text,
+            number_of_states,
+        )?;
+        let _ = self.recompute_reliability();
+        Ok(())
     }
 
     /// Set the description string.
     pub fn set_description(&mut self, desc: impl Into<String>) {
         self.description = desc.into();
+    }
+
+    fn recompute_reliability(&mut self) -> ReliabilityEvaluation {
+        if self.out_of_service || self.reliability_inhibit.enabled() {
+            return ReliabilityEvaluation::Unchanged;
+        }
+        self.reliability_evaluator.evaluate(
+            false,
+            self.present_value,
+            self.number_of_states,
+            &mut self.reliability,
+        )
     }
 }
 
@@ -100,7 +131,8 @@ impl BACnetObject for MultiStateInputObject {
         reliability_inhibit,
         reliability,
         out_of_service,
-        reliability_before_out_of_service
+        reliability_before_out_of_service;
+        reliability_evaluator
     );
 
     fn read_property(
@@ -181,6 +213,7 @@ impl BACnetObject for MultiStateInputObject {
                     return Err(common::value_out_of_range_error());
                 }
                 self.present_value = v as u32;
+                let _ = self.recompute_reliability();
                 return Ok(());
             }
             return Err(common::invalid_data_type_error());
@@ -226,7 +259,9 @@ impl BACnetObject for MultiStateInputObject {
             property,
             &value,
         ) {
-            return result;
+            result?;
+            let _ = self.recompute_reliability();
+            return Ok(());
         }
         if let Some(result) = self.reliability_inhibit.write_out_of_service(
             &mut self.out_of_service,
@@ -235,7 +270,9 @@ impl BACnetObject for MultiStateInputObject {
             property,
             &value,
         ) {
-            return result;
+            result?;
+            let _ = self.recompute_reliability();
+            return Ok(());
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
             return result;
@@ -298,7 +335,12 @@ impl BACnetObject for MultiStateInputObject {
             return Err(common::value_out_of_range_error());
         }
         self.reliability = reliability;
+        self.reliability_evaluator.clear_ownership();
         Ok(())
+    }
+
+    fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {
+        Ok(self.recompute_reliability())
     }
 
     fn reliability_evaluation_inhibited_internal(&self) -> bool {
@@ -378,5 +420,30 @@ mod detection_enable_tests {
             .property_list()
             .contains(&PropertyIdentifier::EVENT_DETECTION_ENABLE));
         assert!(msi.is_writable_property(PropertyIdentifier::EVENT_DETECTION_ENABLE));
+    }
+}
+
+#[cfg(test)]
+mod reliability_safety_net_tests {
+    use super::*;
+    use crate::traits::ReliabilityEvaluation;
+    use bacnet_types::enums::Reliability;
+
+    #[test]
+    fn periodic_hook_repairs_one_stale_bypassed_state_then_is_unchanged() {
+        let mut msi = MultiStateInputObject::new(1, "MSI-stale", 2).unwrap();
+        msi.present_value = 3;
+
+        assert_eq!(
+            msi.evaluate_reliability_internal().unwrap(),
+            ReliabilityEvaluation::Changed {
+                old_reliability: Reliability::NO_FAULT_DETECTED.to_raw(),
+                new_reliability: Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw(),
+            }
+        );
+        assert_eq!(
+            msi.evaluate_reliability_internal().unwrap(),
+            ReliabilityEvaluation::Unchanged
+        );
     }
 }

--- a/crates/bacnet-objects/src/multistate/mod.rs
+++ b/crates/bacnet-objects/src/multistate/mod.rs
@@ -2,7 +2,7 @@
 //! Multi-State Value (type 19) objects per ASHRAE 135-2020 Clauses 12.18,
 //! 12.19, and 12.20.
 
-use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier, Reliability};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;
@@ -12,7 +12,7 @@ use crate::common::{
 };
 use crate::event::{history::EventHistory, ChangeOfStateDetector};
 use crate::rollback::impl_intrinsic_write_rollback;
-use crate::traits::BACnetObject;
+use crate::traits::{BACnetObject, ReliabilityEvaluation};
 
 /// Resource cap consistent with bounded server tables such as
 /// `MAX_COV_SUBSCRIPTIONS`. Recipient_List has the same pre-existing unbounded
@@ -60,6 +60,100 @@ fn require_nonzero_states(number_of_states: u32) -> Result<(), Error> {
         ));
     }
     Ok(())
+}
+
+/// Resize an object's State_Text with the repository's local count-change policy.
+///
+/// Validation precedes mutation. Shrink truncates the tail, while growth keeps
+/// the retained prefix and appends the same `State {n}` labels as construction.
+fn resize_state_text(
+    current_number_of_states: &mut u32,
+    state_text: &mut Vec<String>,
+    number_of_states: u32,
+) -> Result<(), Error> {
+    require_nonzero_states(number_of_states)?;
+    let new_len = number_of_states as usize;
+    if new_len < state_text.len() {
+        state_text.truncate(new_len);
+    } else {
+        state_text.extend((state_text.len() + 1..=new_len).map(|state| format!("State {state}")));
+    }
+    *current_number_of_states = number_of_states;
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OwnedMultiStateFault {
+    ConfigurationError,
+    MultiStateOutOfRange,
+}
+
+impl OwnedMultiStateFault {
+    fn reliability(self) -> u32 {
+        match self {
+            Self::ConfigurationError => Reliability::CONFIGURATION_ERROR.to_raw(),
+            Self::MultiStateOutOfRange => Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw(),
+        }
+    }
+}
+
+/// Private first-stage Reliability ownership shared by MSI, MSO, and MSV.
+#[derive(Debug, Default)]
+struct MultiStateReliabilityState {
+    pub(crate) owned_fault: Option<OwnedMultiStateFault>,
+}
+
+impl MultiStateReliabilityState {
+    fn clear_ownership(&mut self) {
+        self.owned_fault = None;
+    }
+
+    fn evaluate(
+        &mut self,
+        configuration_invalid: bool,
+        present_value: u32,
+        number_of_states: u32,
+        reliability: &mut u32,
+    ) -> ReliabilityEvaluation {
+        let observed_fault = if configuration_invalid {
+            Some(OwnedMultiStateFault::ConfigurationError)
+        } else if !(1..=number_of_states).contains(&present_value) {
+            Some(OwnedMultiStateFault::MultiStateOutOfRange)
+        } else {
+            None
+        };
+
+        let (new_reliability, new_owner) = if self.owned_fault.is_some() {
+            (
+                observed_fault
+                    .map(OwnedMultiStateFault::reliability)
+                    .unwrap_or_else(|| Reliability::NO_FAULT_DETECTED.to_raw()),
+                observed_fault,
+            )
+        } else if *reliability == Reliability::NO_FAULT_DETECTED.to_raw() {
+            let Some(fault) = observed_fault else {
+                return ReliabilityEvaluation::Unchanged;
+            };
+            (fault.reliability(), Some(fault))
+        } else {
+            return ReliabilityEvaluation::Unchanged;
+        };
+
+        // Ownership can change while Reliability is already zero, notably when
+        // inhibit normalized an owned fault and its source recovered before the
+        // gate reopened. Keep the private state current even without a public
+        // Reliability transition.
+        self.owned_fault = new_owner;
+        if new_reliability == *reliability {
+            return ReliabilityEvaluation::Unchanged;
+        }
+        let old_reliability = *reliability;
+        *reliability = new_reliability;
+        ReliabilityEvaluation::Changed {
+            old_reliability,
+            new_reliability,
+        }
+    }
 }
 
 mod input;

--- a/crates/bacnet-objects/src/multistate/output.rs
+++ b/crates/bacnet-objects/src/multistate/output.rs
@@ -24,6 +24,7 @@ pub struct MultiStateOutputObject {
     reliability: u32,
     reliability_before_out_of_service: Option<u32>,
     reliability_inhibit: common::ReliabilityInhibitState,
+    reliability_evaluator: MultiStateReliabilityState,
     event_detection_enable: bool,
     state_text: Vec<String>,
     /// COMMAND_FAILURE event detector.
@@ -55,6 +56,7 @@ impl MultiStateOutputObject {
             reliability: 0,
             reliability_before_out_of_service: None,
             reliability_inhibit: common::ReliabilityInhibitState::default(),
+            reliability_evaluator: MultiStateReliabilityState::default(),
             event_detection_enable: false,
             state_text: (1..=number_of_states)
                 .map(|i| format!("State {i}"))
@@ -73,6 +75,46 @@ impl MultiStateOutputObject {
     fn recalculate_present_value(&mut self) {
         self.present_value =
             common::recalculate_from_priority_array(&self.priority_array, self.relinquish_default);
+        let _ = self.recompute_reliability();
+    }
+
+    fn configuration_invalid(&self) -> bool {
+        let is_invalid = |value: u32| !(1..=self.number_of_states).contains(&value);
+        self.priority_array
+            .iter()
+            .flatten()
+            .copied()
+            .any(is_invalid)
+            || is_invalid(self.relinquish_default)
+            || is_invalid(self.feedback_value)
+    }
+
+    fn recompute_reliability(&mut self) -> ReliabilityEvaluation {
+        if self.out_of_service || self.reliability_inhibit.enabled() {
+            return ReliabilityEvaluation::Unchanged;
+        }
+        let configuration_invalid = self.configuration_invalid();
+        self.reliability_evaluator.evaluate(
+            configuration_invalid,
+            self.present_value,
+            self.number_of_states,
+            &mut self.reliability,
+        )
+    }
+
+    /// Change the locally configured number of states.
+    ///
+    /// The BACnet `Number_Of_States` property remains read-only. A successful
+    /// local change resizes State_Text and immediately re-evaluates Reliability;
+    /// retained commands, defaults, feedback, and Present_Value are not repaired.
+    pub fn set_number_of_states(&mut self, number_of_states: u32) -> Result<(), Error> {
+        resize_state_text(
+            &mut self.number_of_states,
+            &mut self.state_text,
+            number_of_states,
+        )?;
+        let _ = self.recompute_reliability();
+        Ok(())
     }
 
     /// Set the Relinquish_Default (#270).
@@ -85,10 +127,10 @@ impl MultiStateOutputObject {
     /// Number_Of_States shrink interplay: if the state count ever shrinks
     /// below this value, the standard leaves adjustment of Priority_Array,
     /// Relinquish_Default, Present_Value, and Feedback_Value "a local matter"
-    /// (Clause 12.19/12.22 Number_Of_States text). This implementation does
+    /// (Clause 12.19 / Table 12-22 Number_Of_States text). This implementation does
     /// NOT auto-adjust: out-of-range stored values are a configuration
-    /// decision for the application to resolve (Reliability
-    /// CONFIGURATION_ERROR reporting for that condition tracks #226).
+    /// decision for the application to resolve; the object-owned evaluator
+    /// reports CONFIGURATION_ERROR while that retained condition remains.
     pub fn set_relinquish_default(&mut self, value: u32) -> Result<(), Error> {
         if value < 1 || value > self.number_of_states {
             return Err(common::value_out_of_range_error());
@@ -127,7 +169,8 @@ impl BACnetObject for MultiStateOutputObject {
         reliability_inhibit,
         reliability,
         out_of_service,
-        reliability_before_out_of_service
+        reliability_before_out_of_service;
+        reliability_evaluator
     );
 
     fn read_property(
@@ -253,7 +296,7 @@ impl BACnetObject for MultiStateOutputObject {
                 // — not as a value to refuse. Feedback_Value reflects a sensed quantity
                 // whose determination is "a local matter", so it can legitimately fall
                 // outside the configured range; refusing it would make CONFIGURATION_ERROR
-                // unreachable. Setting that reliability is tracked as #226.
+                // unreachable. The object-owned evaluator applies that reliability.
                 //
                 // The u32 conversion is still checked. A BACnet Unsigned decodes from up
                 // to 8 octets, so a bare `as u32` would wrap a large value back into the
@@ -262,6 +305,7 @@ impl BACnetObject for MultiStateOutputObject {
                 // representation limit, not a configuration limit, so it is enforced here
                 // while the state-set range is not.
                 self.feedback_value = common::u64_to_u32(u)?;
+                let _ = self.recompute_reliability();
                 return Ok(());
             }
             return Err(common::invalid_data_type_error());
@@ -302,7 +346,9 @@ impl BACnetObject for MultiStateOutputObject {
             property,
             &value,
         ) {
-            return result;
+            result?;
+            let _ = self.recompute_reliability();
+            return Ok(());
         }
         if let Some(result) = self.reliability_inhibit.write_out_of_service(
             &mut self.out_of_service,
@@ -311,7 +357,9 @@ impl BACnetObject for MultiStateOutputObject {
             property,
             &value,
         ) {
-            return result;
+            result?;
+            let _ = self.recompute_reliability();
+            return Ok(());
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
             return result;
@@ -384,7 +432,12 @@ impl BACnetObject for MultiStateOutputObject {
             return Err(common::value_out_of_range_error());
         }
         self.reliability = reliability;
+        self.reliability_evaluator.clear_ownership();
         Ok(())
+    }
+
+    fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {
+        Ok(self.recompute_reliability())
     }
 
     fn reliability_evaluation_inhibited_internal(&self) -> bool {
@@ -454,7 +507,7 @@ mod command_failure_tests {
     }
 
     /// Clause 12.19 defines an out-of-range Feedback_Value as a reportable condition
-    /// (Reliability CONFIGURATION_ERROR, see #226), not a value to refuse. Refusing it
+    /// (Reliability CONFIGURATION_ERROR), not a value to refuse. Refusing it
     /// would make that reliability unreachable, so the write is accepted even though
     /// Present_Value at the same value would be rejected.
     #[test]
@@ -703,5 +756,43 @@ mod command_failure_tests {
             .property_list()
             .contains(&PropertyIdentifier::EVENT_DETECTION_ENABLE));
         assert!(mso.is_writable_property(PropertyIdentifier::EVENT_DETECTION_ENABLE));
+    }
+}
+
+#[cfg(test)]
+mod reliability_evaluator_tests {
+    use super::*;
+    use bacnet_types::enums::Reliability;
+
+    #[test]
+    fn configuration_error_dominates_bypassed_invalid_present_value() {
+        let mut mso = MultiStateOutputObject::new(1, "MSO-dominance", 2).unwrap();
+        mso.present_value = 3;
+        mso.feedback_value = 3;
+
+        mso.evaluate_reliability_internal().unwrap();
+        assert_eq!(
+            mso.reliability,
+            Reliability::CONFIGURATION_ERROR.to_raw(),
+            "invalid configuration must dominate invalid Present_Value"
+        );
+        mso.feedback_value = 1;
+        mso.evaluate_reliability_internal().unwrap();
+        assert_eq!(
+            mso.reliability,
+            Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw()
+        );
+        mso.write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Unsigned(1),
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            mso.reliability,
+            Reliability::NO_FAULT_DETECTED.to_raw(),
+            "the central priority recalculation must recover synchronously"
+        );
     }
 }

--- a/crates/bacnet-objects/src/multistate/output.rs
+++ b/crates/bacnet-objects/src/multistate/output.rs
@@ -170,7 +170,10 @@ impl BACnetObject for MultiStateOutputObject {
         reliability,
         out_of_service,
         reliability_before_out_of_service;
-        reliability_evaluator
+        reliability_evaluator,
+        priority_array,
+        relinquish_default,
+        present_value
     );
 
     fn read_property(

--- a/crates/bacnet-objects/src/multistate/tests/mod.rs
+++ b/crates/bacnet-objects/src/multistate/tests/mod.rs
@@ -1,4 +1,5 @@
 mod generic_event_properties;
 mod objects;
+mod reliability;
 mod relinquish_default;
 mod state_text;

--- a/crates/bacnet-objects/src/multistate/tests/reliability.rs
+++ b/crates/bacnet-objects/src/multistate/tests/reliability.rs
@@ -1,0 +1,501 @@
+//! Multi-state Number_Of_States configuration and object-owned Reliability.
+
+use super::super::*;
+use crate::traits::ReliabilityEvaluation;
+use bacnet_types::enums::{ErrorClass, ErrorCode, EventState, Reliability};
+
+fn read_reliability(object: &dyn BACnetObject) -> u32 {
+    match object
+        .read_property(PropertyIdentifier::RELIABILITY, None)
+        .unwrap()
+    {
+        PropertyValue::Enumerated(value) => value,
+        other => panic!("expected Enumerated Reliability, got {other:?}"),
+    }
+}
+
+fn read_unsigned(object: &dyn BACnetObject, property: PropertyIdentifier) -> u64 {
+    match object.read_property(property, None).unwrap() {
+        PropertyValue::Unsigned(value) => value,
+        other => panic!("expected Unsigned property, got {other:?}"),
+    }
+}
+
+fn read_state_text(object: &dyn BACnetObject) -> Vec<PropertyValue> {
+    match object
+        .read_property(PropertyIdentifier::STATE_TEXT, None)
+        .unwrap()
+    {
+        PropertyValue::List(values) => values,
+        other => panic!("expected State_Text list, got {other:?}"),
+    }
+}
+
+fn write_bool(object: &mut dyn BACnetObject, property: PropertyIdentifier, value: bool) {
+    object
+        .write_property(property, None, PropertyValue::Boolean(value), None)
+        .unwrap();
+}
+
+fn write_unsigned(object: &mut dyn BACnetObject, property: PropertyIdentifier, value: u64) {
+    object
+        .write_property(property, None, PropertyValue::Unsigned(value), None)
+        .unwrap();
+}
+
+fn assert_unknown_property(result: Result<PropertyValue, Error>) {
+    assert!(matches!(
+        result,
+        Err(Error::Protocol { class, code })
+            if class == ErrorClass::PROPERTY.to_raw() as u32
+                && code == ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32
+    ));
+}
+
+macro_rules! assert_number_of_states_policy {
+    ($object:expr) => {{
+        let mut object = $object;
+        object
+            .write_property(
+                PropertyIdentifier::STATE_TEXT,
+                Some(1),
+                PropertyValue::CharacterString("Retained one".into()),
+                None,
+            )
+            .unwrap();
+        object
+            .write_property(
+                PropertyIdentifier::STATE_TEXT,
+                Some(2),
+                PropertyValue::CharacterString("Retained two".into()),
+                None,
+            )
+            .unwrap();
+        object
+            .write_property(
+                PropertyIdentifier::STATE_TEXT,
+                Some(3),
+                PropertyValue::CharacterString("Discarded three".into()),
+                None,
+            )
+            .unwrap();
+
+        let before_count = read_unsigned(&object, PropertyIdentifier::NUMBER_OF_STATES);
+        let before_text = read_state_text(&object);
+        let before_reliability = read_reliability(&object);
+        assert!(object.set_number_of_states(0).is_err());
+        assert_eq!(
+            read_unsigned(&object, PropertyIdentifier::NUMBER_OF_STATES),
+            before_count
+        );
+        assert_eq!(read_state_text(&object), before_text);
+        assert_eq!(read_reliability(&object), before_reliability);
+
+        object.set_number_of_states(2).unwrap();
+        assert_eq!(
+            read_unsigned(&object, PropertyIdentifier::NUMBER_OF_STATES),
+            2
+        );
+        assert_eq!(
+            read_state_text(&object),
+            vec![
+                PropertyValue::CharacterString("Retained one".into()),
+                PropertyValue::CharacterString("Retained two".into()),
+            ]
+        );
+        assert!(object
+            .read_property(PropertyIdentifier::STATE_TEXT, Some(3))
+            .is_err());
+
+        object.set_number_of_states(4).unwrap();
+        assert_eq!(
+            read_state_text(&object),
+            vec![
+                PropertyValue::CharacterString("Retained one".into()),
+                PropertyValue::CharacterString("Retained two".into()),
+                PropertyValue::CharacterString("State 3".into()),
+                PropertyValue::CharacterString("State 4".into()),
+            ],
+            "growth must append constructor-style labels, not resurrect truncated text"
+        );
+        assert_eq!(
+            object
+                .read_property(PropertyIdentifier::STATE_TEXT, Some(4))
+                .unwrap(),
+            PropertyValue::CharacterString("State 4".into())
+        );
+        assert!(object
+            .read_property(PropertyIdentifier::STATE_TEXT, Some(5))
+            .is_err());
+
+        assert!(object
+            .write_property(
+                PropertyIdentifier::NUMBER_OF_STATES,
+                None,
+                PropertyValue::Unsigned(3),
+                None,
+            )
+            .is_err());
+        assert!(!object.is_writable_property(PropertyIdentifier::NUMBER_OF_STATES));
+        assert_eq!(
+            read_unsigned(&object, PropertyIdentifier::NUMBER_OF_STATES),
+            4,
+            "network denial must leave local configuration unchanged"
+        );
+    }};
+}
+
+#[test]
+fn local_count_setters_are_atomic_and_resize_state_text_with_one_shared_policy() {
+    assert_number_of_states_policy!(MultiStateInputObject::new(1, "MSI-1", 3).unwrap());
+    assert_number_of_states_policy!(MultiStateOutputObject::new(1, "MSO-1", 3).unwrap());
+    assert_number_of_states_policy!(MultiStateValueObject::new(1, "MSV-1", 3).unwrap());
+}
+
+#[test]
+fn msi_recomputes_range_reliability_synchronously_and_recovers() {
+    let mut msi = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
+
+    msi.set_present_value(4);
+    assert_eq!(
+        read_reliability(&msi),
+        Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw()
+    );
+    assert_eq!(
+        msi.evaluate_reliability_internal().unwrap(),
+        ReliabilityEvaluation::Unchanged,
+        "the periodic safety-net hook must normally have nothing left to do"
+    );
+
+    msi.set_number_of_states(4).unwrap();
+    assert_eq!(
+        read_reliability(&msi),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+    msi.set_number_of_states(1).unwrap();
+    assert_eq!(
+        read_reliability(&msi),
+        Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw()
+    );
+    msi.set_present_value(1);
+    assert_eq!(
+        read_reliability(&msi),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+}
+
+#[test]
+fn mso_configuration_sources_are_scanned_and_dominate_invalid_present_value() {
+    let mut priority = MultiStateOutputObject::new(1, "MSO-priority", 3).unwrap();
+    priority
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(16),
+            PropertyValue::Unsigned(3),
+            None,
+        )
+        .unwrap();
+    priority
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(8),
+            PropertyValue::Unsigned(1),
+            None,
+        )
+        .unwrap();
+    priority.set_number_of_states(2).unwrap();
+    assert_eq!(
+        read_reliability(&priority),
+        Reliability::CONFIGURATION_ERROR.to_raw(),
+        "an invalid inactive priority slot is still a configuration error"
+    );
+    priority
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(16),
+            PropertyValue::Unsigned(2),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        read_reliability(&priority),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+
+    let mut default = MultiStateOutputObject::new(2, "MSO-default", 3).unwrap();
+    default.set_relinquish_default(3).unwrap();
+    default
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Unsigned(1),
+            Some(8),
+        )
+        .unwrap();
+    default.set_number_of_states(2).unwrap();
+    assert_eq!(
+        read_reliability(&default),
+        Reliability::CONFIGURATION_ERROR.to_raw()
+    );
+    default.set_relinquish_default(2).unwrap();
+    assert_eq!(
+        read_reliability(&default),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+
+    let mut feedback = MultiStateOutputObject::new(3, "MSO-feedback", 3).unwrap();
+    write_unsigned(&mut feedback, PropertyIdentifier::FEEDBACK_VALUE, 3);
+    feedback.set_number_of_states(2).unwrap();
+    assert_eq!(
+        read_reliability(&feedback),
+        Reliability::CONFIGURATION_ERROR.to_raw()
+    );
+    write_unsigned(&mut feedback, PropertyIdentifier::FEEDBACK_VALUE, 2);
+    assert_eq!(
+        read_reliability(&feedback),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+
+    let mut combined = MultiStateOutputObject::new(4, "MSO-combined", 3).unwrap();
+    combined.set_relinquish_default(3).unwrap();
+    combined.set_number_of_states(2).unwrap();
+    assert_eq!(
+        read_unsigned(&combined, PropertyIdentifier::PRESENT_VALUE),
+        3
+    );
+    assert_eq!(
+        read_reliability(&combined),
+        Reliability::CONFIGURATION_ERROR.to_raw(),
+        "configuration error must dominate an out-of-range Present_Value"
+    );
+    combined.set_number_of_states(3).unwrap();
+    assert_eq!(
+        read_reliability(&combined),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+}
+
+#[test]
+fn msv_configuration_sources_recompute_immediately_and_fault_values_stays_absent() {
+    let mut priority = MultiStateValueObject::new(1, "MSV-priority", 3).unwrap();
+    priority
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(16),
+            PropertyValue::Unsigned(3),
+            None,
+        )
+        .unwrap();
+    priority
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(8),
+            PropertyValue::Unsigned(1),
+            None,
+        )
+        .unwrap();
+    priority.set_number_of_states(2).unwrap();
+    assert_eq!(
+        read_reliability(&priority),
+        Reliability::CONFIGURATION_ERROR.to_raw()
+    );
+    priority
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(16),
+            PropertyValue::Unsigned(2),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        read_reliability(&priority),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+
+    let mut default = MultiStateValueObject::new(2, "MSV-default", 3).unwrap();
+    default.set_relinquish_default(3).unwrap();
+    default
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Unsigned(1),
+            Some(8),
+        )
+        .unwrap();
+    default.set_number_of_states(2).unwrap();
+    assert_eq!(
+        read_reliability(&default),
+        Reliability::CONFIGURATION_ERROR.to_raw()
+    );
+    default.set_relinquish_default(2).unwrap();
+    assert_eq!(
+        read_reliability(&default),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+
+    let mut alarms = MultiStateValueObject::new(3, "MSV-alarms", 3).unwrap();
+    alarms.set_alarm_values(vec![3]);
+    assert_eq!(
+        read_reliability(&alarms),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+    alarms.set_number_of_states(2).unwrap();
+    assert_eq!(
+        read_reliability(&alarms),
+        Reliability::CONFIGURATION_ERROR.to_raw()
+    );
+    alarms.set_alarm_values(vec![2]);
+    assert_eq!(
+        read_reliability(&alarms),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+    alarms
+        .write_property(
+            PropertyIdentifier::ALARM_VALUES,
+            None,
+            PropertyValue::List(vec![PropertyValue::Unsigned(4)]),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        read_reliability(&alarms),
+        Reliability::CONFIGURATION_ERROR.to_raw(),
+        "the list write route must funnel through the same synchronous setter"
+    );
+
+    assert_unknown_property(alarms.read_property(PropertyIdentifier::FAULT_VALUES, None));
+    assert!(!alarms
+        .property_list()
+        .contains(&PropertyIdentifier::FAULT_VALUES));
+    assert!(!alarms.is_writable_property(PropertyIdentifier::FAULT_VALUES));
+}
+
+#[test]
+fn multistate_evaluator_recovers_only_faults_it_owns() {
+    let mut msi = MultiStateInputObject::new(1, "MSI-owner", 2).unwrap();
+    msi.set_reliability_internal(Reliability::NO_SENSOR.to_raw())
+        .unwrap();
+    msi.set_present_value(3);
+    assert_eq!(read_reliability(&msi), Reliability::NO_SENSOR.to_raw());
+
+    msi.set_reliability_internal(Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw())
+        .unwrap();
+    msi.set_present_value(3);
+    msi.set_present_value(1);
+    assert_eq!(
+        read_reliability(&msi),
+        Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw(),
+        "an equal numeric Reliability without ownership must not be claimed or cleared"
+    );
+
+    msi.set_reliability_internal(Reliability::NO_FAULT_DETECTED.to_raw())
+        .unwrap();
+    msi.set_present_value(3);
+    assert_eq!(
+        read_reliability(&msi),
+        Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw()
+    );
+    msi.set_present_value(1);
+    assert_eq!(
+        read_reliability(&msi),
+        Reliability::NO_FAULT_DETECTED.to_raw(),
+        "an evaluator-owned fault must recover"
+    );
+}
+
+#[test]
+fn oos_and_inhibit_suppress_mutations_then_release_current_state_synchronously() {
+    let mut inhibited = MultiStateInputObject::new(1, "MSI-inhibited", 2).unwrap();
+    write_bool(
+        &mut inhibited,
+        PropertyIdentifier::RELIABILITY_EVALUATION_INHIBIT,
+        true,
+    );
+    inhibited.set_present_value(3);
+    assert_eq!(
+        read_reliability(&inhibited),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+    write_bool(
+        &mut inhibited,
+        PropertyIdentifier::RELIABILITY_EVALUATION_INHIBIT,
+        false,
+    );
+    assert_eq!(
+        read_reliability(&inhibited),
+        Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw(),
+        "disabling inhibit must evaluate the current value before returning"
+    );
+    write_bool(
+        &mut inhibited,
+        PropertyIdentifier::RELIABILITY_EVALUATION_INHIBIT,
+        true,
+    );
+    inhibited.set_present_value(1);
+    write_bool(
+        &mut inhibited,
+        PropertyIdentifier::RELIABILITY_EVALUATION_INHIBIT,
+        false,
+    );
+    assert_eq!(
+        read_reliability(&inhibited),
+        Reliability::NO_FAULT_DETECTED.to_raw()
+    );
+
+    let mut oos = MultiStateInputObject::new(2, "MSI-oos", 3).unwrap();
+    write_bool(&mut oos, PropertyIdentifier::OUT_OF_SERVICE, true);
+    write_bool(
+        &mut oos,
+        PropertyIdentifier::RELIABILITY_EVALUATION_INHIBIT,
+        true,
+    );
+    oos.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Unsigned(3),
+        None,
+    )
+    .unwrap();
+    oos.set_number_of_states(1).unwrap();
+    oos.write_property(
+        PropertyIdentifier::RELIABILITY,
+        None,
+        PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+        None,
+    )
+    .unwrap();
+    write_bool(
+        &mut oos,
+        PropertyIdentifier::RELIABILITY_EVALUATION_INHIBIT,
+        false,
+    );
+    assert_eq!(
+        read_reliability(&oos),
+        Reliability::NO_SENSOR.to_raw(),
+        "accepted OOS alternate must remain authoritative while OOS"
+    );
+    write_bool(&mut oos, PropertyIdentifier::OUT_OF_SERVICE, false);
+    assert_eq!(
+        read_reliability(&oos),
+        Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw(),
+        "leaving OOS must restore then evaluate the retained current configuration"
+    );
+}
+
+#[test]
+fn synchronous_reliability_is_observed_by_the_existing_intrinsic_event_kernel() {
+    let mut msi = MultiStateInputObject::new(1, "MSI-events", 2).unwrap();
+    msi.set_present_value(3);
+    let fault = msi
+        .evaluate_intrinsic_reporting()
+        .expect("synchronous Reliability fault must be observable");
+    assert_eq!(fault.change.to, EventState::FAULT);
+    crate::event::commit_test_proposal(&mut msi, fault);
+
+    msi.set_present_value(1);
+    let recovery = msi
+        .evaluate_intrinsic_reporting()
+        .expect("synchronous Reliability recovery must be observable");
+    assert_eq!(recovery.change.from, EventState::FAULT);
+    assert_eq!(recovery.change.to, EventState::NORMAL);
+}

--- a/crates/bacnet-objects/src/multistate/tests/relinquish_default.rs
+++ b/crates/bacnet-objects/src/multistate/tests/relinquish_default.rs
@@ -76,13 +76,12 @@ fn mso_msv_relinquish_default_write_recaptures_present_value() {
     );
 }
 
-/// Number_Of_States-shrink interplay, pinned: clause 12.19/12.22 leave any
+/// Number_Of_States-shrink interplay, pinned: Clause 12.19 / Table 12-22 leave any
 /// adjustment of Priority_Array / Relinquish_Default / Present_Value /
 /// Feedback_Value "a local matter" when the state count shrinks below stored
-/// values, and Number_Of_States is constructor-fixed in this implementation,
-/// so nothing auto-adjusts — a stale Relinquish_Default simply keeps driving
-/// Present_Value until the application resolves the configuration (the
-/// CONFIGURATION_ERROR reporting for that condition tracks #226).
+/// values, so the local count setter does not auto-adjust them — a stale
+/// Relinquish_Default keeps driving Present_Value until the application
+/// resolves the configuration, with CONFIGURATION_ERROR reported meanwhile.
 #[test]
 fn mso_relinquish_default_is_not_range_locked_after_store() {
     let mut mso = MultiStateOutputObject::new(1, "MSO-1", 3).unwrap();
@@ -92,7 +91,22 @@ fn mso_relinquish_default_is_not_range_locked_after_store() {
             .unwrap(),
         PropertyValue::Unsigned(3)
     );
-    // No Number_Of_States write arm exists: a shrink cannot arrive over the
-    // network, and no code path re-validates the stored default.
+    mso.set_number_of_states(2).unwrap();
+    assert_eq!(
+        mso.read_property(PropertyIdentifier::RELINQUISH_DEFAULT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(3)
+    );
+    assert_eq!(
+        mso.read_property(PropertyIdentifier::PRESENT_VALUE, None)
+            .unwrap(),
+        PropertyValue::Unsigned(3)
+    );
+    assert_eq!(
+        mso.read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::CONFIGURATION_ERROR.to_raw())
+    );
+    // The local API does not add a Number_Of_States network write arm.
     assert!(!mso.is_writable_property(PropertyIdentifier::NUMBER_OF_STATES));
 }

--- a/crates/bacnet-objects/src/multistate/value.rs
+++ b/crates/bacnet-objects/src/multistate/value.rs
@@ -178,7 +178,10 @@ impl BACnetObject for MultiStateValueObject {
         reliability,
         out_of_service,
         reliability_before_out_of_service;
-        reliability_evaluator
+        reliability_evaluator,
+        priority_array,
+        relinquish_default,
+        present_value
     );
 
     fn read_property(

--- a/crates/bacnet-objects/src/multistate/value.rs
+++ b/crates/bacnet-objects/src/multistate/value.rs
@@ -22,6 +22,7 @@ pub struct MultiStateValueObject {
     reliability: u32,
     reliability_before_out_of_service: Option<u32>,
     reliability_inhibit: common::ReliabilityInhibitState,
+    reliability_evaluator: MultiStateReliabilityState,
     state_text: Vec<String>,
     /// CHANGE_OF_STATE event detector.
     event_detector: ChangeOfStateDetector,
@@ -54,6 +55,7 @@ impl MultiStateValueObject {
             reliability: 0,
             reliability_before_out_of_service: None,
             reliability_inhibit: common::ReliabilityInhibitState::default(),
+            reliability_evaluator: MultiStateReliabilityState::default(),
             state_text: (1..=number_of_states)
                 .map(|i| format!("State {i}"))
                 .collect(),
@@ -72,6 +74,57 @@ impl MultiStateValueObject {
     fn recalculate_present_value(&mut self) {
         self.present_value =
             common::recalculate_from_priority_array(&self.priority_array, self.relinquish_default);
+        let _ = self.recompute_reliability();
+    }
+
+    fn configuration_invalid(&self) -> bool {
+        let is_invalid = |value: u32| !(1..=self.number_of_states).contains(&value);
+        self.priority_array
+            .iter()
+            .flatten()
+            .copied()
+            .any(is_invalid)
+            || is_invalid(self.relinquish_default)
+            || self
+                .event_detector
+                .alarm_values
+                .iter()
+                .copied()
+                .any(is_invalid)
+    }
+
+    fn recompute_reliability(&mut self) -> ReliabilityEvaluation {
+        if self.out_of_service || self.reliability_inhibit.enabled() {
+            return ReliabilityEvaluation::Unchanged;
+        }
+        let configuration_invalid = self.configuration_invalid();
+        self.reliability_evaluator.evaluate(
+            configuration_invalid,
+            self.present_value,
+            self.number_of_states,
+            &mut self.reliability,
+        )
+    }
+
+    /// Change the locally configured number of states.
+    ///
+    /// The BACnet `Number_Of_States` property remains read-only. A successful
+    /// local change resizes State_Text and immediately re-evaluates Reliability;
+    /// retained commands, defaults, alarms, and Present_Value are not repaired.
+    pub fn set_number_of_states(&mut self, number_of_states: u32) -> Result<(), Error> {
+        resize_state_text(
+            &mut self.number_of_states,
+            &mut self.state_text,
+            number_of_states,
+        )?;
+        let _ = self.recompute_reliability();
+        Ok(())
+    }
+
+    /// Set the alarm values and synchronously re-evaluate configuration Reliability.
+    pub fn set_alarm_values(&mut self, values: Vec<u32>) {
+        self.event_detector.alarm_values = values;
+        let _ = self.recompute_reliability();
     }
 
     /// Set the Relinquish_Default (#270).
@@ -82,12 +135,11 @@ impl MultiStateValueObject {
     /// default immediately.
     ///
     /// Number_Of_States shrink interplay: if the state count ever shrinks
-    /// below this value, the standard leaves adjustment of Priority_Array,
-    /// Relinquish_Default, Present_Value, and Feedback_Value "a local matter"
-    /// (Clause 12.19/12.22 Number_Of_States text). This implementation does
-    /// NOT auto-adjust: out-of-range stored values are a configuration
-    /// decision for the application to resolve (Reliability
-    /// CONFIGURATION_ERROR reporting for that condition tracks #226).
+    /// below this value, retained Priority_Array, Relinquish_Default,
+    /// Present_Value, and Alarm_Values are not auto-adjusted (Clause 12.20 /
+    /// Table 12-23). An out-of-range retained value is a configuration decision
+    /// for the application to resolve; the object-owned evaluator reports
+    /// CONFIGURATION_ERROR while that condition remains.
     pub fn set_relinquish_default(&mut self, value: u32) -> Result<(), Error> {
         if value < 1 || value > self.number_of_states {
             return Err(common::value_out_of_range_error());
@@ -125,7 +177,8 @@ impl BACnetObject for MultiStateValueObject {
         reliability_inhibit,
         reliability,
         out_of_service,
-        reliability_before_out_of_service
+        reliability_before_out_of_service;
+        reliability_evaluator
     );
 
     fn read_property(
@@ -260,7 +313,7 @@ impl BACnetObject for MultiStateValueObject {
         }
         if property == PropertyIdentifier::ALARM_VALUES {
             let values = decode_alarm_values_write(array_index, value)?;
-            self.event_detector.alarm_values = values;
+            self.set_alarm_values(values);
             return Ok(());
         }
         if property == PropertyIdentifier::EVENT_DETECTION_ENABLE {
@@ -286,7 +339,9 @@ impl BACnetObject for MultiStateValueObject {
             property,
             &value,
         ) {
-            return result;
+            result?;
+            let _ = self.recompute_reliability();
+            return Ok(());
         }
         if let Some(result) = self.reliability_inhibit.write_out_of_service(
             &mut self.out_of_service,
@@ -295,7 +350,9 @@ impl BACnetObject for MultiStateValueObject {
             property,
             &value,
         ) {
-            return result;
+            result?;
+            let _ = self.recompute_reliability();
+            return Ok(());
         }
         if let Some(result) = common::write_object_name(&mut self.name, property, &value) {
             return result;
@@ -368,7 +425,12 @@ impl BACnetObject for MultiStateValueObject {
             return Err(common::value_out_of_range_error());
         }
         self.reliability = reliability;
+        self.reliability_evaluator.clear_ownership();
         Ok(())
+    }
+
+    fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {
+        Ok(self.recompute_reliability())
     }
 
     fn reliability_evaluation_inhibited_internal(&self) -> bool {
@@ -454,5 +516,37 @@ mod detection_enable_tests {
             .property_list()
             .contains(&PropertyIdentifier::EVENT_DETECTION_ENABLE));
         assert!(msv.is_writable_property(PropertyIdentifier::EVENT_DETECTION_ENABLE));
+    }
+}
+
+#[cfg(test)]
+mod reliability_evaluator_tests {
+    use super::*;
+    use bacnet_types::enums::Reliability;
+
+    #[test]
+    fn configuration_error_dominates_bypassed_invalid_present_value() {
+        let mut msv = MultiStateValueObject::new(1, "MSV-dominance", 2).unwrap();
+        msv.present_value = 3;
+        msv.event_detector.alarm_values = vec![3];
+
+        msv.evaluate_reliability_internal().unwrap();
+        assert_eq!(
+            msv.reliability,
+            Reliability::CONFIGURATION_ERROR.to_raw(),
+            "invalid configuration must dominate invalid Present_Value"
+        );
+        msv.event_detector.alarm_values = vec![1];
+        msv.evaluate_reliability_internal().unwrap();
+        assert_eq!(
+            msv.reliability,
+            Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw()
+        );
+        msv.set_number_of_states(3).unwrap();
+        assert_eq!(
+            msv.reliability,
+            Reliability::NO_FAULT_DETECTED.to_raw(),
+            "count growth must synchronously recover the retained Present_Value"
+        );
     }
 }

--- a/crates/bacnet-objects/src/rollback.rs
+++ b/crates/bacnet-objects/src/rollback.rs
@@ -24,10 +24,85 @@ pub(crate) enum IntrinsicWriteRollback {
         range_fault_ownership: Option<Option<crate::analog::OwnedRangeFault>>,
         multistate_fault_ownership: Option<Option<crate::multistate::OwnedMultiStateFault>>,
     },
+    MultiStateCommand {
+        priority_array: [Option<u32>; 16],
+        relinquish_default: u32,
+        present_value: u32,
+        reliability: u32,
+        fault_ownership: Option<crate::multistate::OwnedMultiStateFault>,
+    },
 }
 
-/// Preserve event state that the detection-disable reset clears, plus the raw
-/// optional `Time_Delay_Normal` backing value that effective readback hides.
+macro_rules! capture_multistate_command_rollback {
+    (
+        $object:ident,
+        $reliability_field:ident;
+        $fault_field:ident,
+        $priority_array_field:ident,
+        $relinquish_default_field:ident,
+        $present_value_field:ident
+    ) => {
+        Some($crate::traits::WritePropertyRollback::new(
+            $crate::rollback::IntrinsicWriteRollback::MultiStateCommand {
+                priority_array: $object.$priority_array_field,
+                relinquish_default: $object.$relinquish_default_field,
+                present_value: $object.$present_value_field,
+                reliability: $object.$reliability_field,
+                fault_ownership: $object.$fault_field.owned_fault,
+            },
+        ))
+    };
+    ($object:ident, $reliability_field:ident $(; $fault_field:ident)?) => {
+        None
+    };
+}
+
+macro_rules! restore_multistate_command_rollback {
+    (
+        $object:ident,
+        $priority_array:ident,
+        $relinquish_default:ident,
+        $present_value:ident,
+        $reliability:ident,
+        $fault_ownership:ident,
+        $reliability_field:ident;
+        $fault_field:ident,
+        $priority_array_field:ident,
+        $relinquish_default_field:ident,
+        $present_value_field:ident
+    ) => {{
+        $object.$priority_array_field = $priority_array;
+        $object.$relinquish_default_field = $relinquish_default;
+        $object.$present_value_field = $present_value;
+        $object.$reliability_field = $reliability;
+        $object.$fault_field.owned_fault = $fault_ownership;
+        Ok(())
+    }};
+    (
+        $object:ident,
+        $priority_array:ident,
+        $relinquish_default:ident,
+        $present_value:ident,
+        $reliability:ident,
+        $fault_ownership:ident,
+        $reliability_field:ident
+        $(; $fault_field:ident)?
+    ) => {{
+        let _ = (
+            $priority_array,
+            $relinquish_default,
+            $present_value,
+            $reliability,
+            $fault_ownership,
+        );
+        Err(bacnet_types::error::Error::Encoding(
+            "object received an incompatible multi-state command rollback token".into(),
+        ))
+    }};
+}
+
+/// Preserve intrinsic event/inhibit state hidden by property readback and,
+/// when configured, exact retained multi-state command configuration.
 macro_rules! impl_intrinsic_write_rollback {
     (
         $detector_field:ident,
@@ -38,7 +113,11 @@ macro_rules! impl_intrinsic_write_rollback {
         $out_of_service_field:ident,
         $saved_reliability_field:ident
         $(, $range_fault_field:ident)?
-        $(; $multistate_fault_field:ident)?
+        $(; $multistate_fault_field:ident
+            $(, $priority_array_field:ident,
+                $relinquish_default_field:ident,
+                $present_value_field:ident)?
+        )?
     ) => {
         fn capture_write_property_rollback(
             &mut self,
@@ -85,6 +164,18 @@ macro_rules! impl_intrinsic_write_rollback {
                             multistate_fault_ownership,
                         },
                     ))
+                }
+                bacnet_types::enums::PropertyIdentifier::PRIORITY_ARRAY
+                | bacnet_types::enums::PropertyIdentifier::RELINQUISH_DEFAULT => {
+                    $crate::rollback::capture_multistate_command_rollback!(
+                        self,
+                        $reliability_field
+                        $(; $multistate_fault_field
+                            $(, $priority_array_field,
+                                $relinquish_default_field,
+                                $present_value_field)?
+                        )?
+                    )
                 }
                 _ => None,
             }
@@ -162,8 +253,30 @@ macro_rules! impl_intrinsic_write_rollback {
                     let _ = (range_fault_ownership, multistate_fault_ownership);
                     Ok(())
                 }
+                $crate::rollback::IntrinsicWriteRollback::MultiStateCommand {
+                    priority_array,
+                    relinquish_default,
+                    present_value,
+                    reliability,
+                    fault_ownership,
+                } => $crate::rollback::restore_multistate_command_rollback!(
+                    self,
+                    priority_array,
+                    relinquish_default,
+                    present_value,
+                    reliability,
+                    fault_ownership,
+                    $reliability_field
+                    $(; $multistate_fault_field
+                        $(, $priority_array_field,
+                            $relinquish_default_field,
+                            $present_value_field)?
+                    )?
+                ),
             }
         }
     };
 }
+pub(crate) use capture_multistate_command_rollback;
 pub(crate) use impl_intrinsic_write_rollback;
+pub(crate) use restore_multistate_command_rollback;

--- a/crates/bacnet-objects/src/rollback.rs
+++ b/crates/bacnet-objects/src/rollback.rs
@@ -22,6 +22,7 @@ pub(crate) enum IntrinsicWriteRollback {
         out_of_service: bool,
         saved_reliability: Option<u32>,
         range_fault_ownership: Option<Option<crate::analog::OwnedRangeFault>>,
+        multistate_fault_ownership: Option<Option<crate::multistate::OwnedMultiStateFault>>,
     },
 }
 
@@ -37,6 +38,7 @@ macro_rules! impl_intrinsic_write_rollback {
         $out_of_service_field:ident,
         $saved_reliability_field:ident
         $(, $range_fault_field:ident)?
+        $(; $multistate_fault_field:ident)?
     ) => {
         fn capture_write_property_rollback(
             &mut self,
@@ -70,6 +72,9 @@ macro_rules! impl_intrinsic_write_rollback {
                     let range_fault_ownership = None$(.or(Some(
                         self.$range_fault_field.owned_fault,
                     )))?;
+                    let multistate_fault_ownership = None$(.or(Some(
+                        self.$multistate_fault_field.owned_fault,
+                    )))?;
                     Some($crate::traits::WritePropertyRollback::new(
                         $crate::rollback::IntrinsicWriteRollback::ReliabilityInhibit {
                             state: self.$inhibit_field,
@@ -77,6 +82,7 @@ macro_rules! impl_intrinsic_write_rollback {
                             out_of_service: self.$out_of_service_field,
                             saved_reliability: self.$saved_reliability_field,
                             range_fault_ownership,
+                            multistate_fault_ownership,
                         },
                     ))
                 }
@@ -117,6 +123,7 @@ macro_rules! impl_intrinsic_write_rollback {
                     out_of_service,
                     saved_reliability,
                     range_fault_ownership,
+                    multistate_fault_ownership,
                 } => {
                     $(
                         let range_fault_ownership = range_fault_ownership.ok_or_else(|| {
@@ -130,6 +137,18 @@ macro_rules! impl_intrinsic_write_rollback {
                             )
                         })?;
                     )?
+                    $(
+                        let multistate_fault_ownership = multistate_fault_ownership.ok_or_else(|| {
+                            bacnet_types::error::Error::Encoding(
+                                concat!(
+                                    "multi-state rollback token omitted ",
+                                    stringify!($multistate_fault_field),
+                                    " ownership",
+                                )
+                                .into(),
+                            )
+                        })?;
+                    )?
                     self.$inhibit_field = state;
                     self.$reliability_field = reliability;
                     self.$out_of_service_field = out_of_service;
@@ -137,7 +156,10 @@ macro_rules! impl_intrinsic_write_rollback {
                     $(
                         self.$range_fault_field.owned_fault = range_fault_ownership;
                     )?
-                    let _ = range_fault_ownership;
+                    $(
+                        self.$multistate_fault_field.owned_fault = multistate_fault_ownership;
+                    )?
+                    let _ = (range_fault_ownership, multistate_fault_ownership);
                     Ok(())
                 }
             }

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -56,6 +56,7 @@ mod reference_writes;
 mod wpm_create_alarm;
 mod wpm_event_rollback;
 mod wpm_fault_rollback;
+mod wpm_multistate_reliability_rollback;
 mod wpm_parameter_rollback;
 mod wpm_rollback_contract;
 mod write_cov_who;

--- a/crates/bacnet-server/src/handlers/tests/wpm_fault_rollback.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_fault_rollback.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use bacnet_objects::binary::BinaryInputObject;
+use bacnet_objects::multistate::{MultiStateInputObject, MultiStateOutputObject};
 use bacnet_objects::traits::ReliabilityEvaluation;
 use bacnet_services::common::BACnetPropertyValue;
 use bacnet_services::wpm::{WriteAccessSpecification, WritePropertyMultipleRequest};
@@ -389,4 +390,211 @@ fn wpm_rollback_restores_non_range_inhibit_reliability_and_future_oos_state() {
         PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
         "the next OOS cycle must independently save and restore Reliability"
     );
+}
+
+#[test]
+fn multistate_wpm_source_rollback_restores_reliability_and_private_ownership() {
+    let mut db = ObjectDatabase::new();
+    let mut output = MultiStateOutputObject::new(1, "MSO-rollback", 3).unwrap();
+    output
+        .write_property(
+            PropertyIdentifier::FEEDBACK_VALUE,
+            None,
+            PropertyValue::Unsigned(3),
+            None,
+        )
+        .unwrap();
+    output.set_number_of_states(2).unwrap();
+    let oid = output.object_identifier();
+    db.add(Box::new(output)).unwrap();
+
+    let mut repaired_feedback = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_unsigned(&mut repaired_feedback, 2);
+    let mut read_only_value = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_enumerated(&mut read_only_value, 0);
+    let request = WritePropertyMultipleRequest {
+        list_of_write_access_specs: vec![WriteAccessSpecification {
+            object_identifier: oid,
+            list_of_properties: vec![
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::FEEDBACK_VALUE,
+                    property_array_index: None,
+                    value: repaired_feedback.to_vec(),
+                    priority: None,
+                },
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::OBJECT_TYPE,
+                    property_array_index: None,
+                    value: read_only_value.to_vec(),
+                    priority: None,
+                },
+            ],
+        }],
+    };
+    let mut request_bytes = BytesMut::new();
+    request.encode(&mut request_bytes);
+    assert!(handle_write_property_multiple(&mut db, &request_bytes).is_err());
+
+    let object = db.get_mut(&oid).unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::FEEDBACK_VALUE, None)
+            .unwrap(),
+        PropertyValue::Unsigned(3)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::CONFIGURATION_ERROR.to_raw())
+    );
+    object
+        .write_property(
+            PropertyIdentifier::FEEDBACK_VALUE,
+            None,
+            PropertyValue::Unsigned(2),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+        "recovery proves rollback restored the private evaluator owner"
+    );
+}
+
+#[test]
+fn multistate_wpm_gate_release_rollback_restores_saved_and_owned_reliability() {
+    let mut db = ObjectDatabase::new();
+    let mut input = MultiStateInputObject::new(2, "MSI-gate-rollback", 2).unwrap();
+    input.set_present_value(3);
+    input
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    input.set_present_value(1);
+    input
+        .write_property(
+            PropertyIdentifier::RELIABILITY,
+            None,
+            PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw()),
+            None,
+        )
+        .unwrap();
+    let oid = input.object_identifier();
+    db.add(Box::new(input)).unwrap();
+
+    let mut leave_oos = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_boolean(&mut leave_oos, false);
+    let mut read_only_value = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_enumerated(&mut read_only_value, 0);
+    let request = WritePropertyMultipleRequest {
+        list_of_write_access_specs: vec![WriteAccessSpecification {
+            object_identifier: oid,
+            list_of_properties: vec![
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::OUT_OF_SERVICE,
+                    property_array_index: None,
+                    value: leave_oos.to_vec(),
+                    priority: None,
+                },
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::OBJECT_TYPE,
+                    property_array_index: None,
+                    value: read_only_value.to_vec(),
+                    priority: None,
+                },
+            ],
+        }],
+    };
+    let mut request_bytes = BytesMut::new();
+    request.encode(&mut request_bytes);
+    assert!(handle_write_property_multiple(&mut db, &request_bytes).is_err());
+
+    let object = db.get_mut(&oid).unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::OUT_OF_SERVICE, None)
+            .unwrap(),
+        PropertyValue::Boolean(true)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::NO_SENSOR.to_raw())
+    );
+    object
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+        "release recovery proves rollback restored saved Reliability and its private owner"
+    );
+}
+
+#[test]
+fn multistate_number_of_states_stays_wpm_read_only() {
+    for (mut db, oid) in [
+        {
+            let mut db = ObjectDatabase::new();
+            let object = MultiStateInputObject::new(10, "MSI-count", 2).unwrap();
+            let oid = object.object_identifier();
+            db.add(Box::new(object)).unwrap();
+            (db, oid)
+        },
+        {
+            let mut db = ObjectDatabase::new();
+            let object = MultiStateOutputObject::new(10, "MSO-count", 2).unwrap();
+            let oid = object.object_identifier();
+            db.add(Box::new(object)).unwrap();
+            (db, oid)
+        },
+        {
+            let mut db = ObjectDatabase::new();
+            let object =
+                bacnet_objects::multistate::MultiStateValueObject::new(10, "MSV-count", 2).unwrap();
+            let oid = object.object_identifier();
+            db.add(Box::new(object)).unwrap();
+            (db, oid)
+        },
+    ] {
+        let mut count = BytesMut::new();
+        bacnet_encoding::primitives::encode_app_unsigned(&mut count, 3);
+        let request = WritePropertyMultipleRequest {
+            list_of_write_access_specs: vec![WriteAccessSpecification {
+                object_identifier: oid,
+                list_of_properties: vec![BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::NUMBER_OF_STATES,
+                    property_array_index: None,
+                    value: count.to_vec(),
+                    priority: None,
+                }],
+            }],
+        };
+        let mut request_bytes = BytesMut::new();
+        request.encode(&mut request_bytes);
+        assert!(handle_write_property_multiple(&mut db, &request_bytes).is_err());
+        assert_eq!(
+            db.get(&oid)
+                .unwrap()
+                .read_property(PropertyIdentifier::NUMBER_OF_STATES, None)
+                .unwrap(),
+            PropertyValue::Unsigned(2)
+        );
+    }
 }

--- a/crates/bacnet-server/src/handlers/tests/wpm_multistate_reliability_rollback.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_multistate_reliability_rollback.rs
@@ -1,0 +1,271 @@
+//! WPM rollback for retained multi-state command configuration after count shrink.
+
+use super::*;
+use bacnet_objects::multistate::{MultiStateOutputObject, MultiStateValueObject};
+use bacnet_objects::traits::BACnetObject;
+use bacnet_services::common::BACnetPropertyValue;
+use bacnet_services::wpm::{WriteAccessSpecification, WritePropertyMultipleRequest};
+use bacnet_types::enums::Reliability;
+use bytes::BytesMut;
+
+fn failed_wpm_after_unsigned_repair(
+    db: &mut ObjectDatabase,
+    oid: ObjectIdentifier,
+    property: PropertyIdentifier,
+    array_index: Option<u32>,
+    repaired_value: u64,
+) {
+    let mut repair = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_unsigned(&mut repair, repaired_value);
+    let mut read_only_value = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_enumerated(&mut read_only_value, 0);
+    let request = WritePropertyMultipleRequest {
+        list_of_write_access_specs: vec![WriteAccessSpecification {
+            object_identifier: oid,
+            list_of_properties: vec![
+                BACnetPropertyValue {
+                    property_identifier: property,
+                    property_array_index: array_index,
+                    value: repair.to_vec(),
+                    priority: None,
+                },
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::OBJECT_TYPE,
+                    property_array_index: None,
+                    value: read_only_value.to_vec(),
+                    priority: None,
+                },
+            ],
+        }],
+    };
+    let mut request_bytes = BytesMut::new();
+    request.encode(&mut request_bytes);
+
+    assert!(
+        matches!(
+            handle_write_property_multiple(db, &request_bytes),
+            Err(Error::Protocol { class, code })
+                if class == ErrorClass::PROPERTY.to_raw() as u32
+                    && code == ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32
+        ),
+        "rollback must succeed and preserve the later write's protocol error"
+    );
+}
+
+fn assert_invalid_default_restored(mut db: ObjectDatabase, oid: ObjectIdentifier) {
+    let priority_before = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::PRIORITY_ARRAY, None)
+        .unwrap();
+
+    failed_wpm_after_unsigned_repair(
+        &mut db,
+        oid,
+        PropertyIdentifier::RELINQUISH_DEFAULT,
+        None,
+        2,
+    );
+
+    let object = db.get_mut(&oid).unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::PRIORITY_ARRAY, None)
+            .unwrap(),
+        priority_before
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELINQUISH_DEFAULT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(3)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::PRESENT_VALUE, None)
+            .unwrap(),
+        PropertyValue::Unsigned(3)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::CONFIGURATION_ERROR.to_raw())
+    );
+
+    object
+        .write_property(
+            PropertyIdentifier::RELINQUISH_DEFAULT,
+            None,
+            PropertyValue::Unsigned(2),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+        "recovery proves rollback restored configuration-fault ownership"
+    );
+}
+
+fn assert_invalid_inactive_priority_restored(mut db: ObjectDatabase, oid: ObjectIdentifier) {
+    let default_before = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::RELINQUISH_DEFAULT, None)
+        .unwrap();
+
+    failed_wpm_after_unsigned_repair(
+        &mut db,
+        oid,
+        PropertyIdentifier::PRIORITY_ARRAY,
+        Some(16),
+        2,
+    );
+
+    let object = db.get_mut(&oid).unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(8))
+            .unwrap(),
+        PropertyValue::Unsigned(1),
+        "the active command must remain unchanged"
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::PRIORITY_ARRAY, Some(16))
+            .unwrap(),
+        PropertyValue::Unsigned(3),
+        "the invalid inactive command must be restored without client validation"
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELINQUISH_DEFAULT, None)
+            .unwrap(),
+        default_before
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::PRESENT_VALUE, None)
+            .unwrap(),
+        PropertyValue::Unsigned(1)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::CONFIGURATION_ERROR.to_raw())
+    );
+
+    object
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(16),
+            PropertyValue::Unsigned(2),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::RELIABILITY, None)
+            .unwrap(),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+        "recovery proves rollback restored configuration-fault ownership"
+    );
+}
+
+fn mso_with_invalid_default(instance: u32) -> (ObjectDatabase, ObjectIdentifier) {
+    let mut object = MultiStateOutputObject::new(instance, "MSO-default-rollback", 3).unwrap();
+    object.set_relinquish_default(3).unwrap();
+    object.set_number_of_states(2).unwrap();
+    let oid = object.object_identifier();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(object)).unwrap();
+    (db, oid)
+}
+
+fn msv_with_invalid_default(instance: u32) -> (ObjectDatabase, ObjectIdentifier) {
+    let mut object = MultiStateValueObject::new(instance, "MSV-default-rollback", 3).unwrap();
+    object.set_relinquish_default(3).unwrap();
+    object.set_number_of_states(2).unwrap();
+    let oid = object.object_identifier();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(object)).unwrap();
+    (db, oid)
+}
+
+fn mso_with_invalid_inactive_priority(instance: u32) -> (ObjectDatabase, ObjectIdentifier) {
+    let mut object = MultiStateOutputObject::new(instance, "MSO-priority-rollback", 3).unwrap();
+    object
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(16),
+            PropertyValue::Unsigned(3),
+            None,
+        )
+        .unwrap();
+    object
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(8),
+            PropertyValue::Unsigned(1),
+            None,
+        )
+        .unwrap();
+    object.set_number_of_states(2).unwrap();
+    let oid = object.object_identifier();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(object)).unwrap();
+    (db, oid)
+}
+
+fn msv_with_invalid_inactive_priority(instance: u32) -> (ObjectDatabase, ObjectIdentifier) {
+    let mut object = MultiStateValueObject::new(instance, "MSV-priority-rollback", 3).unwrap();
+    object
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(16),
+            PropertyValue::Unsigned(3),
+            None,
+        )
+        .unwrap();
+    object
+        .write_property(
+            PropertyIdentifier::PRIORITY_ARRAY,
+            Some(8),
+            PropertyValue::Unsigned(1),
+            None,
+        )
+        .unwrap();
+    object.set_number_of_states(2).unwrap();
+    let oid = object.object_identifier();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(object)).unwrap();
+    (db, oid)
+}
+
+#[test]
+fn mso_retained_invalid_default_is_restored_after_failed_wpm_repair() {
+    let (db, oid) = mso_with_invalid_default(20);
+    assert_invalid_default_restored(db, oid);
+}
+
+#[test]
+fn msv_retained_invalid_default_is_restored_after_failed_wpm_repair() {
+    let (db, oid) = msv_with_invalid_default(21);
+    assert_invalid_default_restored(db, oid);
+}
+
+#[test]
+fn mso_retained_invalid_inactive_priority_is_restored_after_failed_wpm_repair() {
+    let (db, oid) = mso_with_invalid_inactive_priority(22);
+    assert_invalid_inactive_priority_restored(db, oid);
+}
+
+#[test]
+fn msv_retained_invalid_inactive_priority_is_restored_after_failed_wpm_repair() {
+    let (db, oid) = msv_with_invalid_inactive_priority(23);
+    assert_invalid_inactive_priority_restored(db, oid);
+}

--- a/crates/bacnet-server/src/pics/tests.rs
+++ b/crates/bacnet-server/src/pics/tests.rs
@@ -667,18 +667,19 @@ fn pics_state_text_writable_on_multistate_types() {
 }
 
 #[test]
-fn pics_universal_readonly_properties_never_writable() {
+fn pics_fixed_readonly_properties_never_writable() {
     let db = make_real_objects_db();
     let pics = generate_pics(&db, &ServerConfig::default(), &make_pics_config());
 
-    // OBJECT_IDENTIFIER, OBJECT_TYPE, PROPERTY_LIST, STATUS_FLAGS are never
-    // writable on any object type.
+    // The universal identifiers below are never writable. Number_Of_States is
+    // likewise fixed on every object type that exposes it.
     for ot in pics.supported_object_types.iter() {
         for pid in [
             PropertyIdentifier::OBJECT_IDENTIFIER,
             PropertyIdentifier::OBJECT_TYPE,
             PropertyIdentifier::PROPERTY_LIST,
             PropertyIdentifier::STATUS_FLAGS,
+            PropertyIdentifier::NUMBER_OF_STATES,
         ] {
             if ot.supported_properties.iter().any(|p| p.property_id == pid) {
                 assert!(


### PR DESCRIPTION
## Summary
- add object-owned Multi-state reliability evaluation for MSI, MSO, and MSV
- report `MULTI_STATE_OUT_OF_RANGE` for invalid effective values and `CONFIGURATION_ERROR` for retained invalid MSO/MSV configuration
- recompute synchronously after relevant mutations while retaining the periodic reliability hook as a safety net
- preserve first-stage/external Reliability, OOS/inhibit authority, intrinsic event flow, and WPM rollback
- add fallible local `set_number_of_states` setters with one atomic State_Text resize policy

## Standard traceability
| ANSI/ASHRAE 135-2020 source | Implemented behavior |
|---|---|
| §12.18 Multi-state Input | Effective Present_Value outside `1..=Number_Of_States` produces `MULTI_STATE_OUT_OF_RANGE` unless Out_Of_Service. |
| §12.19 Multi-state Output | Invalid retained Priority_Array entries, Relinquish_Default, or Feedback_Value produce `CONFIGURATION_ERROR`; otherwise an invalid effective Present_Value produces `MULTI_STATE_OUT_OF_RANGE`. |
| §12.20 Multi-state Value | Invalid retained Priority_Array entries, Relinquish_Default, or Alarm_Values produce `CONFIGURATION_ERROR`; otherwise an invalid effective Present_Value produces `MULTI_STATE_OUT_OF_RANGE`. |

Configuration errors take precedence over an invalid effective Present_Value. Evaluation releases only Reliability values owned by this evaluator.

## Owner decisions
- `Number_Of_States` remains network/PICS read-only; this PR adds only a fallible local Rust setter.
- `Fault_Values` remains unsupported and is deferred.
- State_Text preserves retained entries, truncates on shrink, and appends `State {n}` labels on growth.

## Validation
- focused red-first Multi-state reliability tests
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-server --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

## Deferred
- Multi-state `Fault_Values`
- BACnet/Python writes for `Number_Of_States`
- Event Enrollment or event-kernel redesign
- changes to existing direct Priority_Array command semantics
- broad support/conformance claims

Closes #226