### PR TITLE
fix(objects): give log records stable identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Stable in-memory record identity for Event Log, Trend Log, and Trend Log
+  Multiple (#134, #339). Each accepted append now owns a nonzero Unsigned32
+  sequence (wrapping MAX to 1) plus its record Date/Time; FIFO eviction and
+  normal clear do not renumber survivors or reset the live total, and failed
+  WPM clears restore the exact payload/identity view. The additive
+  `LogRecordIdentity` and defaulted `BACnetObject` identity hook preserve the
+  existing public `records()` and `add_record()` signatures. Trend Log projects
+  a present optional record StatusFlags bitstring; Event Log and Trend Log
+  Multiple retain the legacy raw Rust field but do not put it on the wire.
+  ReadRange sequence/time selection, First Sequence Number, persistence,
+  formal Event Log notification records, and purge records remain deferred.
+
 - Object-owned multi-state configuration Reliability and recovery for
   Multi-state Input, Output, and Value (#226). The Standard requires
   `MULTI_STATE_OUT_OF_RANGE` for an invalid retained `Present_Value`, and

--- a/crates/bacnet-objects/src/event_log.rs
+++ b/crates/bacnet-objects/src/event_log.rs
@@ -3,23 +3,26 @@
 use std::borrow::Cow;
 use std::collections::VecDeque;
 
-use bacnet_types::constructed::{BACnetLogRecord, LogDatum};
+use bacnet_types::constructed::BACnetLogRecord;
 use bacnet_types::enums::{ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
 
 use crate::common::{self, read_common_properties};
+use crate::log_buffer::{
+    LogRecordBuffer, LogRecordBufferRecords, LogRecordIdentity, LogRecordProfile,
+};
 use crate::traits::{BACnetObject, WritePropertyRollback};
 
 struct EventLogWriteRollback {
-    buffer: VecDeque<BACnetLogRecord>,
+    records: LogRecordBufferRecords,
 }
 
 /// BACnet EventLog object.
 ///
 /// Ring buffer of timestamped event log records. The application calls
-/// `add_record()` to log event data. Uses the same `BACnetLogRecord`
-/// encoding as TrendLog.
+/// `add_record()` to log event data. Resident records retain the legacy shared
+/// Rust `BACnetLogRecord` shape; Event Log projection remains family-specific.
 pub struct EventLogObject {
     oid: ObjectIdentifier,
     name: String,
@@ -28,8 +31,7 @@ pub struct EventLogObject {
     log_interval: u32,
     stop_when_full: bool,
     buffer_size: u32,
-    buffer: VecDeque<BACnetLogRecord>,
-    total_record_count: u64,
+    log_buffer: LogRecordBuffer,
     status_flags: StatusFlags,
     event_state: u32,
     out_of_service: bool,
@@ -48,8 +50,7 @@ impl EventLogObject {
             log_interval: 0,
             stop_when_full: false,
             buffer_size,
-            buffer: VecDeque::new(),
-            total_record_count: 0,
+            log_buffer: LogRecordBuffer::new(buffer_size),
             status_flags: StatusFlags::empty(),
             event_state: 0,
             out_of_service: false,
@@ -59,69 +60,23 @@ impl EventLogObject {
 
     /// Add a BACnetLogRecord to the event log buffer.
     pub fn add_record(&mut self, record: BACnetLogRecord) {
-        if !self.log_enable {
-            return;
-        }
-        if self.buffer.len() >= self.buffer_size as usize {
-            if self.stop_when_full {
-                return;
-            }
-            self.buffer.pop_front();
-        }
-        self.buffer.push_back(record);
-        self.total_record_count += 1;
+        self.log_buffer
+            .append(record, self.log_enable, self.stop_when_full);
     }
 
     /// Get the current buffer contents.
     pub fn records(&self) -> &VecDeque<BACnetLogRecord> {
-        &self.buffer
+        self.log_buffer.records()
     }
 
     /// Clear the buffer.
     pub fn clear(&mut self) {
-        self.buffer.clear();
+        self.log_buffer.clear();
     }
 
     /// Set the description string.
     pub fn set_description(&mut self, desc: impl Into<String>) {
         self.description = desc.into();
-    }
-
-    fn encode_log_buffer(&self) -> PropertyValue {
-        let records = self
-            .buffer
-            .iter()
-            .map(|record| {
-                let datum_value = match &record.log_datum {
-                    LogDatum::LogStatus(v) => PropertyValue::Unsigned(*v as u64),
-                    LogDatum::BooleanValue(v) => PropertyValue::Boolean(*v),
-                    LogDatum::RealValue(v) => PropertyValue::Real(*v),
-                    LogDatum::EnumValue(v) => PropertyValue::Enumerated(*v),
-                    LogDatum::UnsignedValue(v) => PropertyValue::Unsigned(*v),
-                    LogDatum::SignedValue(v) => PropertyValue::Signed(*v as i32),
-                    LogDatum::BitstringValue { unused_bits, data } => PropertyValue::BitString {
-                        unused_bits: *unused_bits,
-                        data: data.clone(),
-                    },
-                    LogDatum::NullValue => PropertyValue::Null,
-                    LogDatum::Failure {
-                        error_class,
-                        error_code,
-                    } => PropertyValue::List(vec![
-                        PropertyValue::Unsigned(*error_class as u64),
-                        PropertyValue::Unsigned(*error_code as u64),
-                    ]),
-                    LogDatum::TimeChange(v) => PropertyValue::Real(*v),
-                    LogDatum::AnyValue(bytes) => PropertyValue::OctetString(bytes.clone()),
-                };
-                PropertyValue::List(vec![
-                    PropertyValue::Date(record.date),
-                    PropertyValue::Time(record.time),
-                    datum_value,
-                ])
-            })
-            .collect();
-        PropertyValue::List(records)
     }
 }
 
@@ -156,13 +111,15 @@ impl BACnetObject for EventLogObject {
             p if p == PropertyIdentifier::BUFFER_SIZE => {
                 Ok(PropertyValue::Unsigned(self.buffer_size as u64))
             }
-            p if p == PropertyIdentifier::LOG_BUFFER => Ok(self.encode_log_buffer()),
+            p if p == PropertyIdentifier::LOG_BUFFER => {
+                Ok(self.log_buffer.project(LogRecordProfile::Event))
+            }
             p if p == PropertyIdentifier::RECORD_COUNT => {
-                Ok(PropertyValue::Unsigned(self.buffer.len() as u64))
+                Ok(PropertyValue::Unsigned(self.records().len() as u64))
             }
-            p if p == PropertyIdentifier::TOTAL_RECORD_COUNT => {
-                Ok(PropertyValue::Unsigned(self.total_record_count))
-            }
+            p if p == PropertyIdentifier::TOTAL_RECORD_COUNT => Ok(PropertyValue::Unsigned(
+                self.log_buffer.total_record_count() as u64,
+            )),
             p if p == PropertyIdentifier::EVENT_STATE => {
                 Ok(PropertyValue::Enumerated(self.event_state))
             }
@@ -201,7 +158,7 @@ impl BACnetObject for EventLogObject {
         if property == PropertyIdentifier::RECORD_COUNT {
             // Writing 0 clears the buffer
             if let PropertyValue::Unsigned(0) = value {
-                self.buffer.clear();
+                self.clear();
                 return Ok(());
             }
             return Err(common::invalid_data_type_error());
@@ -247,7 +204,7 @@ impl BACnetObject for EventLogObject {
             && matches!(value, PropertyValue::Unsigned(0)))
         .then(|| {
             WritePropertyRollback::new(EventLogWriteRollback {
-                buffer: std::mem::take(&mut self.buffer),
+                records: self.log_buffer.take_records(),
             })
         })
     }
@@ -256,8 +213,13 @@ impl BACnetObject for EventLogObject {
         &mut self,
         rollback: WritePropertyRollback,
     ) -> Result<(), Error> {
-        self.buffer = rollback.downcast::<EventLogWriteRollback>()?.buffer;
+        self.log_buffer
+            .restore_records(rollback.downcast::<EventLogWriteRollback>()?.records);
         Ok(())
+    }
+
+    fn log_record_identities_internal(&self) -> Option<Vec<LogRecordIdentity>> {
+        Some(self.log_buffer.identities())
     }
 }
 

--- a/crates/bacnet-objects/src/event_log/tests.rs
+++ b/crates/bacnet-objects/src/event_log/tests.rs
@@ -134,7 +134,11 @@ fn stop_when_full() {
         el.add_record(make_record(i, i as f32));
     }
     assert_eq!(el.records().len(), 2);
-    assert_eq!(el.total_record_count, 2); // Only 2 accepted
+    assert_eq!(
+        el.read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(2)
+    ); // Only 2 accepted
 }
 
 #[test]
@@ -268,4 +272,151 @@ fn log_buffer_various_datum_types() {
     } else {
         panic!("Expected List for LOG_BUFFER");
     }
+}
+
+#[test]
+fn event_log_identities_align_after_eviction_and_differ_from_position() {
+    let mut el = EventLogObject::new(1, "EL-1", 2).unwrap();
+    for hour in 1..=3 {
+        el.add_record(make_record(hour, hour as f32));
+    }
+
+    let identities = el.log_record_identities_internal().unwrap();
+    let projected = match el
+        .read_property(PropertyIdentifier::LOG_BUFFER, None)
+        .unwrap()
+    {
+        PropertyValue::List(records) => records,
+        other => panic!("expected projected log list, got {other:?}"),
+    };
+    assert_eq!(identities.len(), el.records().len());
+    assert_eq!(identities.len(), projected.len());
+    assert_eq!(identities[0].sequence_number(), 2);
+    assert_ne!(identities[0].sequence_number(), 1);
+    for ((identity, raw), wire) in identities.iter().zip(el.records()).zip(projected) {
+        assert_eq!(identity.date(), raw.date);
+        assert_eq!(identity.time(), raw.time);
+        assert_eq!(
+            wire,
+            PropertyValue::List(vec![
+                PropertyValue::Date(raw.date),
+                PropertyValue::Time(raw.time),
+                PropertyValue::Real(raw.time.hour as f32),
+            ])
+        );
+    }
+}
+
+#[test]
+fn event_log_clear_preserves_total_and_next_identity() {
+    let mut el = EventLogObject::new(1, "EL-1", 2).unwrap();
+    assert_eq!(
+        el.read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(0)
+    );
+    el.add_record(make_record(1, 1.0));
+    el.add_record(make_record(1, 2.0));
+    assert_eq!(
+        el.log_record_identities_internal()
+            .unwrap()
+            .iter()
+            .map(|identity| identity.sequence_number())
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+
+    el.clear();
+    assert!(el.log_record_identities_internal().unwrap().is_empty());
+    assert_eq!(
+        el.read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(2)
+    );
+    el.add_record(make_record(1, 3.0));
+    assert_eq!(
+        el.log_record_identities_internal().unwrap()[0].sequence_number(),
+        3
+    );
+}
+
+#[test]
+fn event_log_rejections_do_not_consume_identity() {
+    let mut el = EventLogObject::new(1, "EL-1", 1).unwrap();
+    el.write_property(
+        PropertyIdentifier::LOG_ENABLE,
+        None,
+        PropertyValue::Boolean(false),
+        None,
+    )
+    .unwrap();
+    el.add_record(make_record(1, 1.0));
+    el.write_property(
+        PropertyIdentifier::LOG_ENABLE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    el.write_property(
+        PropertyIdentifier::STOP_WHEN_FULL,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    el.add_record(make_record(2, 2.0));
+    el.add_record(make_record(3, 3.0));
+
+    assert_eq!(
+        el.log_record_identities_internal().unwrap()[0].sequence_number(),
+        1
+    );
+    assert_eq!(
+        el.read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(1)
+    );
+}
+
+#[test]
+fn event_log_total_record_count_is_u32_and_wraps_max_to_one() {
+    let mut el = EventLogObject::new(1, "EL-1", 1).unwrap();
+    el.log_buffer.set_total_record_count_for_test(u32::MAX);
+    assert_eq!(
+        el.read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(u32::MAX as u64)
+    );
+    el.add_record(make_record(1, 1.0));
+    assert_eq!(
+        el.read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(1)
+    );
+    assert_eq!(
+        el.log_record_identities_internal().unwrap()[0].sequence_number(),
+        1
+    );
+}
+
+#[test]
+fn event_log_retains_raw_flags_but_projects_no_status_or_sequence() {
+    let mut el = EventLogObject::new(1, "EL-1", 1).unwrap();
+    let mut record = make_record(1, 42.0);
+    record.status_flags = Some(0b0100);
+    el.add_record(record);
+
+    assert_eq!(el.records()[0].status_flags, Some(0b0100));
+    let PropertyValue::List(records) = el
+        .read_property(PropertyIdentifier::LOG_BUFFER, None)
+        .unwrap()
+    else {
+        panic!("expected projected log list");
+    };
+    let PropertyValue::List(fields) = &records[0] else {
+        panic!("expected projected record fields");
+    };
+    assert_eq!(fields.len(), 3);
+    assert_eq!(fields[2], PropertyValue::Real(42.0));
 }

--- a/crates/bacnet-objects/src/lib.rs
+++ b/crates/bacnet-objects/src/lib.rs
@@ -21,6 +21,7 @@ pub mod group;
 pub mod life_safety;
 pub mod lighting;
 pub mod load_control;
+pub mod log_buffer;
 pub mod loop_obj;
 pub mod multistate;
 pub mod network_port;

--- a/crates/bacnet-objects/src/log_buffer.rs
+++ b/crates/bacnet-objects/src/log_buffer.rs
@@ -1,0 +1,383 @@
+//! Shared resident storage and identity projection for BACnet log objects.
+
+use std::collections::VecDeque;
+
+use bacnet_types::constructed::{BACnetLogRecord, LogDatum};
+use bacnet_types::primitives::{Date, PropertyValue, Time};
+
+/// Stable object-owned identity for one resident log record.
+///
+/// Identity views returned by [`crate::traits::BACnetObject::log_record_identities_internal`]
+/// are ordered oldest-to-newest and align element-for-element with the owning
+/// object's resident records and `LOG_BUFFER` projection. Sequence numbers are
+/// always nonzero; after `u32::MAX`, the next accepted record uses 1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LogRecordIdentity {
+    sequence_number: u32,
+    date: Date,
+    time: Time,
+}
+
+impl LogRecordIdentity {
+    /// Construct an identity, rejecting zero as an invalid record sequence.
+    pub fn new(sequence_number: u32, date: Date, time: Time) -> Option<Self> {
+        (sequence_number != 0).then_some(Self {
+            sequence_number,
+            date,
+            time,
+        })
+    }
+
+    /// Return this record's nonzero Unsigned32 sequence number.
+    pub fn sequence_number(&self) -> u32 {
+        self.sequence_number
+    }
+
+    /// Return the date owned by this record.
+    pub fn date(&self) -> Date {
+        self.date
+    }
+
+    /// Return the time owned by this record.
+    pub fn time(&self) -> Time {
+        self.time
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum LogRecordProfile {
+    Event,
+    Trend,
+    TrendMultiple,
+}
+
+pub(crate) struct LogRecordBufferRecords(VecDeque<BACnetLogRecord>);
+
+pub(crate) struct LogRecordBuffer {
+    capacity: u32,
+    records: VecDeque<BACnetLogRecord>,
+    total_record_count: u32,
+}
+
+impl LogRecordBuffer {
+    pub(crate) fn new(capacity: u32) -> Self {
+        Self {
+            capacity,
+            records: VecDeque::new(),
+            total_record_count: 0,
+        }
+    }
+
+    pub(crate) fn append(
+        &mut self,
+        record: BACnetLogRecord,
+        enabled: bool,
+        stop_when_full: bool,
+    ) -> bool {
+        let full = self.records.len() >= self.capacity as usize;
+        if !enabled || (full && stop_when_full) {
+            return false;
+        }
+
+        let sequence_number = next_sequence(self.total_record_count);
+        self.total_record_count = sequence_number;
+        if full {
+            self.records.pop_front();
+        }
+        self.records.push_back(record);
+        true
+    }
+
+    pub(crate) fn records(&self) -> &VecDeque<BACnetLogRecord> {
+        &self.records
+    }
+
+    pub(crate) fn total_record_count(&self) -> u32 {
+        self.total_record_count
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.records.clear();
+    }
+
+    pub(crate) fn identities(&self) -> Vec<LogRecordIdentity> {
+        if self.records.is_empty() {
+            return Vec::new();
+        }
+
+        debug_assert_ne!(self.total_record_count, 0);
+        let mut sequence_number = self.total_record_count;
+        for _ in 1..self.records.len() {
+            sequence_number = previous_sequence(sequence_number);
+        }
+
+        self.records
+            .iter()
+            .map(|record| {
+                let identity = LogRecordIdentity {
+                    sequence_number,
+                    date: record.date,
+                    time: record.time,
+                };
+                sequence_number = next_sequence(sequence_number);
+                identity
+            })
+            .collect()
+    }
+
+    pub(crate) fn project(&self, profile: LogRecordProfile) -> PropertyValue {
+        PropertyValue::List(
+            self.records
+                .iter()
+                .map(|record| project_record(record, profile))
+                .collect(),
+        )
+    }
+
+    pub(crate) fn take_records(&mut self) -> LogRecordBufferRecords {
+        LogRecordBufferRecords(std::mem::take(&mut self.records))
+    }
+
+    pub(crate) fn restore_records(&mut self, records: LogRecordBufferRecords) {
+        debug_assert!(self.records.is_empty());
+        self.records = records.0;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_total_record_count_for_test(&mut self, total_record_count: u32) {
+        debug_assert!(self.records.is_empty());
+        self.total_record_count = total_record_count;
+    }
+}
+
+fn next_sequence(sequence_number: u32) -> u32 {
+    if sequence_number == u32::MAX {
+        1
+    } else {
+        sequence_number + 1
+    }
+}
+
+fn previous_sequence(sequence_number: u32) -> u32 {
+    if sequence_number == 1 {
+        u32::MAX
+    } else {
+        sequence_number - 1
+    }
+}
+
+fn project_record(record: &BACnetLogRecord, profile: LogRecordProfile) -> PropertyValue {
+    let mut fields = vec![
+        PropertyValue::Date(record.date),
+        PropertyValue::Time(record.time),
+        project_datum(&record.log_datum),
+    ];
+    if let (LogRecordProfile::Trend, Some(status_flags)) = (profile, record.status_flags) {
+        fields.push(PropertyValue::BitString {
+            unused_bits: 4,
+            data: vec![status_flags << 4],
+        });
+    }
+    PropertyValue::List(fields)
+}
+
+fn project_datum(datum: &LogDatum) -> PropertyValue {
+    match datum {
+        LogDatum::LogStatus(value) => PropertyValue::Unsigned(*value as u64),
+        LogDatum::BooleanValue(value) => PropertyValue::Boolean(*value),
+        LogDatum::RealValue(value) => PropertyValue::Real(*value),
+        LogDatum::EnumValue(value) => PropertyValue::Enumerated(*value),
+        LogDatum::UnsignedValue(value) => PropertyValue::Unsigned(*value),
+        LogDatum::SignedValue(value) => PropertyValue::Signed(*value as i32),
+        LogDatum::BitstringValue { unused_bits, data } => PropertyValue::BitString {
+            unused_bits: *unused_bits,
+            data: data.clone(),
+        },
+        LogDatum::NullValue => PropertyValue::Null,
+        LogDatum::Failure {
+            error_class,
+            error_code,
+        } => PropertyValue::List(vec![
+            PropertyValue::Unsigned(*error_class as u64),
+            PropertyValue::Unsigned(*error_code as u64),
+        ]),
+        LogDatum::TimeChange(value) => PropertyValue::Real(*value),
+        LogDatum::AnyValue(bytes) => PropertyValue::OctetString(bytes.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bacnet_types::constructed::{BACnetLogRecord, LogDatum};
+    use bacnet_types::primitives::{Date, Time};
+
+    fn record(hour: u8) -> BACnetLogRecord {
+        BACnetLogRecord {
+            date: Date {
+                year: 126,
+                month: 8,
+                day: 31,
+                day_of_week: 1,
+            },
+            time: Time {
+                hour,
+                minute: 0,
+                second: 0,
+                hundredths: 0,
+            },
+            log_datum: LogDatum::UnsignedValue(hour as u64),
+            status_flags: None,
+        }
+    }
+
+    #[test]
+    fn log_buffer_assigns_one_and_wraps_max_without_zero() {
+        let mut buffer = LogRecordBuffer::new(2);
+        assert_eq!(buffer.total_record_count(), 0);
+        assert!(LogRecordIdentity::new(0, record(0).date, record(0).time).is_none());
+
+        assert!(buffer.append(record(1), true, false));
+        assert_eq!(buffer.identities()[0].sequence_number(), 1);
+
+        buffer.clear();
+        buffer.set_total_record_count_for_test(u32::MAX);
+        assert!(buffer.append(record(2), true, false));
+        assert_eq!(buffer.total_record_count(), 1);
+        assert_eq!(buffer.identities()[0].sequence_number(), 1);
+    }
+
+    #[test]
+    fn log_buffer_rejections_do_not_consume_sequence() {
+        let mut buffer = LogRecordBuffer::new(1);
+        assert!(!buffer.append(record(1), false, false));
+        assert_eq!(buffer.total_record_count(), 0);
+
+        assert!(buffer.append(record(2), true, true));
+        assert!(!buffer.append(record(3), true, true));
+        assert_eq!(buffer.total_record_count(), 1);
+        assert_eq!(buffer.identities()[0].sequence_number(), 1);
+    }
+
+    #[test]
+    fn log_buffer_preserves_zero_capacity_runtime_behavior() {
+        let mut ring = LogRecordBuffer::new(0);
+        assert!(ring.append(record(1), true, false));
+        assert!(ring.append(record(2), true, false));
+        assert_eq!(ring.records().len(), 1);
+        assert_eq!(ring.records()[0].time.hour, 2);
+        assert_eq!(ring.total_record_count(), 2);
+
+        let mut stop_when_full = LogRecordBuffer::new(0);
+        assert!(!stop_when_full.append(record(1), true, true));
+        assert!(stop_when_full.records().is_empty());
+        assert_eq!(stop_when_full.total_record_count(), 0);
+    }
+
+    #[test]
+    fn log_buffer_fifo_eviction_keeps_survivor_identity_and_alignment() {
+        let mut buffer = LogRecordBuffer::new(2);
+        assert!(buffer.append(record(1), true, false));
+        assert!(buffer.append(record(2), true, false));
+        let survivor = buffer.identities()[1];
+        assert!(buffer.append(record(3), true, false));
+
+        let identities = buffer.identities();
+        assert_eq!(
+            identities,
+            vec![
+                survivor,
+                LogRecordIdentity::new(3, record(3).date, record(3).time).unwrap()
+            ]
+        );
+        assert_eq!(identities[0].sequence_number(), 2);
+        assert_ne!(identities[0].sequence_number(), 1);
+        for (record, identity) in buffer.records().iter().zip(&identities) {
+            assert_eq!(identity.date(), record.date);
+            assert_eq!(identity.time(), record.time);
+        }
+    }
+
+    #[test]
+    fn log_buffer_wrap_and_eviction_keep_modular_fifo_alignment() {
+        let mut buffer = LogRecordBuffer::new(3);
+        buffer.set_total_record_count_for_test(u32::MAX - 1);
+        assert!(buffer.append(record(1), true, false));
+        assert!(buffer.append(record(2), true, false));
+        assert!(buffer.append(record(3), true, false));
+        assert_eq!(
+            buffer
+                .identities()
+                .iter()
+                .map(LogRecordIdentity::sequence_number)
+                .collect::<Vec<_>>(),
+            vec![u32::MAX, 1, 2]
+        );
+
+        assert!(buffer.append(record(4), true, false));
+        assert_eq!(
+            buffer
+                .identities()
+                .iter()
+                .map(LogRecordIdentity::sequence_number)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(
+            buffer
+                .records()
+                .iter()
+                .map(|record| record.time.hour)
+                .collect::<Vec<_>>(),
+            vec![2, 3, 4]
+        );
+    }
+
+    #[test]
+    fn log_buffer_clear_preserves_counter_and_constructor_resets_it() {
+        let mut buffer = LogRecordBuffer::new(2);
+        assert!(buffer.append(record(1), true, false));
+        assert!(buffer.append(record(2), true, false));
+        buffer.clear();
+
+        assert!(buffer.records().is_empty());
+        assert!(buffer.identities().is_empty());
+        assert_eq!(buffer.total_record_count(), 2);
+        assert!(buffer.append(record(3), true, false));
+        assert_eq!(buffer.identities()[0].sequence_number(), 3);
+        assert_eq!(LogRecordBuffer::new(2).total_record_count(), 0);
+    }
+
+    #[test]
+    fn log_buffer_duplicate_timestamps_keep_distinct_sequences() {
+        let mut buffer = LogRecordBuffer::new(2);
+        let duplicate = record(4);
+        assert!(buffer.append(duplicate.clone(), true, false));
+        assert!(buffer.append(duplicate, true, false));
+
+        let identities = buffer.identities();
+        assert_eq!(identities[0].date(), identities[1].date());
+        assert_eq!(identities[0].time(), identities[1].time());
+        assert_eq!(identities[0].sequence_number(), 1);
+        assert_eq!(identities[1].sequence_number(), 2);
+    }
+
+    #[test]
+    fn log_buffer_move_restore_preserves_payloads_and_derived_identities() {
+        let mut buffer = LogRecordBuffer::new(2);
+        assert!(buffer.append(record(1), true, false));
+        assert!(buffer.append(record(2), true, false));
+        let records = buffer.records().clone();
+        let identities = buffer.identities();
+        let total = buffer.total_record_count();
+
+        let moved = buffer.take_records();
+        assert!(buffer.records().is_empty());
+        assert_eq!(buffer.total_record_count(), total);
+        buffer.restore_records(moved);
+
+        assert_eq!(buffer.records(), &records);
+        assert_eq!(buffer.identities(), identities);
+        assert_eq!(buffer.total_record_count(), total);
+    }
+}

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use bacnet_types::constructed::BACnetLogRecord;
 use bacnet_types::enums::{
-    ErrorClass, ErrorCode, EventState, LifeSafetyOperation, ObjectType, PropertyIdentifier,
+    ErrorClass, ErrorCode, EventState, LifeSafetyOperation, PropertyIdentifier,
 };
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
@@ -18,6 +18,10 @@ use crate::event_enrollment::{
     EventEnrollmentEvalState, EventEnrollmentMonitoredSource, EventEnrollmentReliabilityCommit,
 };
 use crate::file::FileStorage;
+use crate::log_buffer::LogRecordIdentity;
+
+mod defaults;
+use defaults::{array_property_default, historical_writable_default};
 
 /// Object-owned state that cannot be reconstructed from property readback.
 ///
@@ -631,122 +635,18 @@ pub trait BACnetObject: Send + Sync {
         None
     }
 
+    /// Return stable identities aligned with this object's resident log records.
+    ///
+    /// Implementing log objects return identities oldest-to-newest, in the
+    /// same order as their public resident-record view and `LOG_BUFFER`
+    /// projection. Sequence numbers are object-owned metadata and never part
+    /// of a projected BACnet record payload. Non-log objects return `None`.
+    fn log_record_identities_internal(&self) -> Option<Vec<LogRecordIdentity>> {
+        None
+    }
+
     /// Add a trend log record (only meaningful for TrendLog / TrendLogMultiple).
     ///
     /// Default is a no-op. TrendLog objects override to append to their buffer.
     fn add_trend_record(&mut self, _record: BACnetLogRecord) {}
-}
-
-/// The default array/list classification behind
-/// [`BACnetObject::is_array_property`], keyed by the Clause 12 property
-/// tables. Three identifier classes:
-///
-/// - **Identifier-stable BACnetARRAY** properties admit an index on every
-///   object type that defines them: OBJECT_LIST (Table 12-13), PROPERTY_LIST
-///   (every table), STATE_TEXT (Tables 12-21/12-22/12-23), PRIORITY
-///   (Table 12-24), WEEKLY_SCHEDULE / EXCEPTION_SCHEDULE (Table 12-28),
-///   EVENT_TIME_STAMPS / EVENT_MESSAGE_TEXTS (Table 12-2 family),
-///   PRIORITY_ARRAY (the commandable family), TAGS (Annex Y),
-///   SUBORDINATE_LIST / SUBORDINATE_ANNOTATIONS (Table 12-34),
-///   GROUP_MEMBERS / GROUP_MEMBER_NAMES (Table 12-57; Elevator/Lift also type
-///   GROUP_MEMBERS BACnetARRAY), ACTION (Table 12-12), and STAGES /
-///   STAGE_NAMES / TARGET_REFERENCES (Table 12-80).
-/// - **Type-dependent** identifiers classify by `object_type`: ALARM_VALUES /
-///   FAULT_VALUES are BACnetARRAY[N] on CharacterString Value (Table 12-44)
-///   and BitString Value (Table 12-47) but BACnetLIST on the multi-state,
-///   life-safety, and access families; LIST_OF_OBJECT_PROPERTY_REFERENCES is
-///   BACnetARRAY[N] on Channel (Table 12-62) but BACnetLIST on Schedule
-///   (Table 12-28) and Timer (Table 12-75); PRESENT_VALUE is
-///   BACnetARRAY[N] of BACnetPropertyAccessResult on Global Group
-///   (Table 12-57) but scalar elsewhere.
-/// - **Everything else** — scalars and the identifier-stable BACnetLIST
-///   properties DATE_LIST (Table 12-11), LIST_OF_GROUP_MEMBERS
-///   (Table 12-17), RECIPIENT_LIST (Table 12-24), LOG_BUFFER
-///   (Tables 12-29/12-31), DEVICE_ADDRESS_BINDING and
-///   ACTIVE_COV_SUBSCRIPTIONS (Table 12-13) — takes no index: Clause 12.1.5.2
-///   makes ReadRange the only positional access to a BACnetLIST. Array-typed
-///   identifiers whose object types are not modeled in-tree (e.g.
-///   ACTION_TEXT, EVENT_MESSAGE_TEXTS_CONFIG, VALUE_SOURCE_ARRAY) stay
-///   rejected until their object-side modeling lands.
-///
-/// Like [`historical_writable_default`] this is a free function (not a
-/// per-object override) so the default trait method can delegate to it
-/// without requiring `Self: Sized` (which would break `dyn BACnetObject`
-/// dispatch).
-#[inline]
-pub(crate) fn array_property_default(
-    object_type: ObjectType,
-    property: PropertyIdentifier,
-) -> bool {
-    match property {
-        PropertyIdentifier::OBJECT_LIST
-        | PropertyIdentifier::PROPERTY_LIST
-        | PropertyIdentifier::STATE_TEXT
-        | PropertyIdentifier::PRIORITY
-        | PropertyIdentifier::WEEKLY_SCHEDULE
-        | PropertyIdentifier::EXCEPTION_SCHEDULE
-        | PropertyIdentifier::EVENT_TIME_STAMPS
-        | PropertyIdentifier::EVENT_MESSAGE_TEXTS
-        | PropertyIdentifier::PRIORITY_ARRAY
-        | PropertyIdentifier::TAGS
-        | PropertyIdentifier::SUBORDINATE_LIST
-        | PropertyIdentifier::SUBORDINATE_ANNOTATIONS
-        | PropertyIdentifier::GROUP_MEMBERS
-        | PropertyIdentifier::GROUP_MEMBER_NAMES
-        | PropertyIdentifier::ACTION
-        | PropertyIdentifier::STAGES
-        | PropertyIdentifier::STAGE_NAMES
-        | PropertyIdentifier::TARGET_REFERENCES => true,
-        PropertyIdentifier::ALARM_VALUES | PropertyIdentifier::FAULT_VALUES => matches!(
-            object_type,
-            ObjectType::CHARACTERSTRING_VALUE | ObjectType::BITSTRING_VALUE
-        ),
-        PropertyIdentifier::LIST_OF_OBJECT_PROPERTY_REFERENCES => {
-            object_type == ObjectType::CHANNEL
-        }
-        PropertyIdentifier::PRESENT_VALUE => object_type == ObjectType::GLOBAL_GROUP,
-        _ => false,
-    }
-}
-
-/// The historical PICS writable-property heuristic, used by the default
-/// [`BACnetObject::is_writable_property`] so unmigrated object types keep
-/// their current PICS output.
-///
-/// This is a free function (not a per-object override) so the default trait
-/// method can delegate to it without requiring `Self: Sized` (which would
-/// break `dyn BACnetObject` dispatch). Object implementations should override
-/// [`BACnetObject::is_writable_property`] to mirror their real `write_property`
-/// arms exactly rather than calling this.
-#[inline]
-pub(crate) fn historical_writable_default(
-    object_type: ObjectType,
-    property: PropertyIdentifier,
-) -> bool {
-    // Universal read-only properties.
-    if property == PropertyIdentifier::OBJECT_IDENTIFIER
-        || property == PropertyIdentifier::OBJECT_TYPE
-        || property == PropertyIdentifier::PROPERTY_LIST
-        || property == PropertyIdentifier::STATUS_FLAGS
-    {
-        return false;
-    }
-
-    if property == PropertyIdentifier::OBJECT_NAME {
-        return true;
-    }
-
-    if property == PropertyIdentifier::PRESENT_VALUE {
-        return object_type != ObjectType::ANALOG_INPUT
-            && object_type != ObjectType::BINARY_INPUT
-            && object_type != ObjectType::MULTI_STATE_INPUT;
-    }
-
-    property == PropertyIdentifier::DESCRIPTION
-        || property == PropertyIdentifier::OUT_OF_SERVICE
-        || property == PropertyIdentifier::COV_INCREMENT
-        || property == PropertyIdentifier::HIGH_LIMIT
-        || property == PropertyIdentifier::LOW_LIMIT
-        || property == PropertyIdentifier::DEADBAND
-        || property == PropertyIdentifier::NOTIFICATION_CLASS
 }

--- a/crates/bacnet-objects/src/traits/defaults.rs
+++ b/crates/bacnet-objects/src/traits/defaults.rs
@@ -1,0 +1,115 @@
+use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+
+/// The default array/list classification behind
+/// [`super::BACnetObject::is_array_property`], keyed by the Clause 12 property
+/// tables. Three identifier classes:
+///
+/// - **Identifier-stable BACnetARRAY** properties admit an index on every
+///   object type that defines them: OBJECT_LIST (Table 12-13), PROPERTY_LIST
+///   (every table), STATE_TEXT (Tables 12-21/12-22/12-23), PRIORITY
+///   (Table 12-24), WEEKLY_SCHEDULE / EXCEPTION_SCHEDULE (Table 12-28),
+///   EVENT_TIME_STAMPS / EVENT_MESSAGE_TEXTS (Table 12-2 family),
+///   PRIORITY_ARRAY (the commandable family), TAGS (Annex Y),
+///   SUBORDINATE_LIST / SUBORDINATE_ANNOTATIONS (Table 12-34),
+///   GROUP_MEMBERS / GROUP_MEMBER_NAMES (Table 12-57; Elevator/Lift also type
+///   GROUP_MEMBERS BACnetARRAY), ACTION (Table 12-12), and STAGES /
+///   STAGE_NAMES / TARGET_REFERENCES (Table 12-80).
+/// - **Type-dependent** identifiers classify by `object_type`: ALARM_VALUES /
+///   FAULT_VALUES are BACnetARRAY[N] on CharacterString Value (Table 12-44)
+///   and BitString Value (Table 12-47) but BACnetLIST on the multi-state,
+///   life-safety, and access families; LIST_OF_OBJECT_PROPERTY_REFERENCES is
+///   BACnetARRAY[N] on Channel (Table 12-62) but BACnetLIST on Schedule
+///   (Table 12-28) and Timer (Table 12-75); PRESENT_VALUE is
+///   BACnetARRAY[N] of BACnetPropertyAccessResult on Global Group
+///   (Table 12-57) but scalar elsewhere.
+/// - **Everything else** — scalars and the identifier-stable BACnetLIST
+///   properties DATE_LIST (Table 12-11), LIST_OF_GROUP_MEMBERS
+///   (Table 12-17), RECIPIENT_LIST (Table 12-24), LOG_BUFFER
+///   (Tables 12-29/12-31), DEVICE_ADDRESS_BINDING and
+///   ACTIVE_COV_SUBSCRIPTIONS (Table 12-13) — takes no index: Clause 12.1.5.2
+///   makes ReadRange the only positional access to a BACnetLIST. Array-typed
+///   identifiers whose object types are not modeled in-tree (e.g.
+///   ACTION_TEXT, EVENT_MESSAGE_TEXTS_CONFIG, VALUE_SOURCE_ARRAY) stay
+///   rejected until their object-side modeling lands.
+///
+/// Like [`historical_writable_default`] this is a free function (not a
+/// per-object override) so the default trait method can delegate to it
+/// without requiring `Self: Sized` (which would break `dyn BACnetObject`
+/// dispatch).
+#[inline]
+pub(super) fn array_property_default(
+    object_type: ObjectType,
+    property: PropertyIdentifier,
+) -> bool {
+    match property {
+        PropertyIdentifier::OBJECT_LIST
+        | PropertyIdentifier::PROPERTY_LIST
+        | PropertyIdentifier::STATE_TEXT
+        | PropertyIdentifier::PRIORITY
+        | PropertyIdentifier::WEEKLY_SCHEDULE
+        | PropertyIdentifier::EXCEPTION_SCHEDULE
+        | PropertyIdentifier::EVENT_TIME_STAMPS
+        | PropertyIdentifier::EVENT_MESSAGE_TEXTS
+        | PropertyIdentifier::PRIORITY_ARRAY
+        | PropertyIdentifier::TAGS
+        | PropertyIdentifier::SUBORDINATE_LIST
+        | PropertyIdentifier::SUBORDINATE_ANNOTATIONS
+        | PropertyIdentifier::GROUP_MEMBERS
+        | PropertyIdentifier::GROUP_MEMBER_NAMES
+        | PropertyIdentifier::ACTION
+        | PropertyIdentifier::STAGES
+        | PropertyIdentifier::STAGE_NAMES
+        | PropertyIdentifier::TARGET_REFERENCES => true,
+        PropertyIdentifier::ALARM_VALUES | PropertyIdentifier::FAULT_VALUES => matches!(
+            object_type,
+            ObjectType::CHARACTERSTRING_VALUE | ObjectType::BITSTRING_VALUE
+        ),
+        PropertyIdentifier::LIST_OF_OBJECT_PROPERTY_REFERENCES => {
+            object_type == ObjectType::CHANNEL
+        }
+        PropertyIdentifier::PRESENT_VALUE => object_type == ObjectType::GLOBAL_GROUP,
+        _ => false,
+    }
+}
+
+/// The historical PICS writable-property heuristic, used by the default
+/// [`super::BACnetObject::is_writable_property`] so unmigrated object types keep
+/// their current PICS output.
+///
+/// This is a free function (not a per-object override) so the default trait
+/// method can delegate to it without requiring `Self: Sized` (which would
+/// break `dyn BACnetObject` dispatch). Object implementations should override
+/// [`super::BACnetObject::is_writable_property`] to mirror their real
+/// `write_property` arms exactly rather than calling this.
+#[inline]
+pub(super) fn historical_writable_default(
+    object_type: ObjectType,
+    property: PropertyIdentifier,
+) -> bool {
+    // Universal read-only properties.
+    if property == PropertyIdentifier::OBJECT_IDENTIFIER
+        || property == PropertyIdentifier::OBJECT_TYPE
+        || property == PropertyIdentifier::PROPERTY_LIST
+        || property == PropertyIdentifier::STATUS_FLAGS
+    {
+        return false;
+    }
+
+    if property == PropertyIdentifier::OBJECT_NAME {
+        return true;
+    }
+
+    if property == PropertyIdentifier::PRESENT_VALUE {
+        return object_type != ObjectType::ANALOG_INPUT
+            && object_type != ObjectType::BINARY_INPUT
+            && object_type != ObjectType::MULTI_STATE_INPUT;
+    }
+
+    property == PropertyIdentifier::DESCRIPTION
+        || property == PropertyIdentifier::OUT_OF_SERVICE
+        || property == PropertyIdentifier::COV_INCREMENT
+        || property == PropertyIdentifier::HIGH_LIMIT
+        || property == PropertyIdentifier::LOW_LIMIT
+        || property == PropertyIdentifier::DEADBAND
+        || property == PropertyIdentifier::NOTIFICATION_CLASS
+}

--- a/crates/bacnet-objects/src/trend/log_record_tests.rs
+++ b/crates/bacnet-objects/src/trend/log_record_tests.rs
@@ -1,0 +1,106 @@
+use super::*;
+use bacnet_types::constructed::LogDatum;
+use bacnet_types::primitives::{Date, Time};
+
+fn record(hour: u8, value: f32, status_flags: Option<u8>) -> BACnetLogRecord {
+    BACnetLogRecord {
+        date: Date {
+            year: 126,
+            month: 8,
+            day: 31,
+            day_of_week: 1,
+        },
+        time: Time {
+            hour,
+            minute: 0,
+            second: 0,
+            hundredths: 0,
+        },
+        log_datum: LogDatum::RealValue(value),
+        status_flags,
+    }
+}
+
+fn projected_records(object: &dyn BACnetObject) -> Vec<PropertyValue> {
+    match object
+        .read_property(PropertyIdentifier::LOG_BUFFER, None)
+        .unwrap()
+    {
+        PropertyValue::List(records) => records,
+        other => panic!("expected projected log list, got {other:?}"),
+    }
+}
+
+#[test]
+fn trend_log_projects_only_present_status_flags_as_fourth_field() {
+    let mut trend = TrendLogObject::new(1, "TL-1", 2).unwrap();
+    trend.add_record(record(1, 10.0, Some(0b0100)));
+    trend.add_record(record(1, 20.0, None));
+
+    let identities = trend.log_record_identities_internal().unwrap();
+    assert_eq!(identities[0].sequence_number(), 1);
+    assert_eq!(identities[1].sequence_number(), 2);
+    assert_eq!(identities[0].date(), identities[1].date());
+    assert_eq!(identities[0].time(), identities[1].time());
+    assert_eq!(trend.records()[0].status_flags, Some(0b0100));
+
+    let projected = projected_records(&trend);
+    let PropertyValue::List(with_status) = &projected[0] else {
+        panic!("expected projected record fields");
+    };
+    assert_eq!(with_status.len(), 4);
+    assert_eq!(with_status[2], PropertyValue::Real(10.0));
+    assert_eq!(
+        with_status[3],
+        PropertyValue::BitString {
+            unused_bits: 4,
+            data: vec![0b0100_0000],
+        }
+    );
+    let PropertyValue::List(without_status) = &projected[1] else {
+        panic!("expected projected record fields");
+    };
+    assert_eq!(without_status.len(), 3);
+    assert_eq!(without_status[2], PropertyValue::Real(20.0));
+}
+
+#[test]
+fn trend_multiple_retains_raw_flags_but_projects_three_fields() {
+    let mut trend = TrendLogMultipleObject::new(1, "TLM-1", 1).unwrap();
+    trend.add_record(record(1, 10.0, Some(0b0100)));
+
+    assert_eq!(trend.records()[0].status_flags, Some(0b0100));
+    let projected = projected_records(&trend);
+    let PropertyValue::List(fields) = &projected[0] else {
+        panic!("expected projected record fields");
+    };
+    assert_eq!(fields.len(), 3);
+    assert_eq!(fields[2], PropertyValue::Real(10.0));
+}
+
+#[test]
+fn trend_family_identity_raw_and_projection_views_stay_fifo_aligned() {
+    let mut trend = TrendLogObject::new(1, "TL-1", 2).unwrap();
+    let mut multiple = TrendLogMultipleObject::new(1, "TLM-1", 2).unwrap();
+    for hour in 1..=3 {
+        trend.add_record(record(hour, hour as f32, None));
+        multiple.add_record(record(hour, hour as f32, Some(0b0001)));
+    }
+
+    for object in [&trend as &dyn BACnetObject, &multiple as &dyn BACnetObject] {
+        let identities = object.log_record_identities_internal().unwrap();
+        let projected = projected_records(object);
+        assert_eq!(identities.len(), 2);
+        assert_eq!(identities.len(), projected.len());
+        assert_eq!(identities[0].sequence_number(), 2);
+        assert_eq!(identities[1].sequence_number(), 3);
+        for (identity, wire) in identities.iter().zip(projected) {
+            let PropertyValue::List(fields) = wire else {
+                panic!("expected projected record fields");
+            };
+            assert_eq!(fields[0], PropertyValue::Date(identity.date()));
+            assert_eq!(fields[1], PropertyValue::Time(identity.time()));
+            assert_eq!(fields.len(), 3);
+        }
+    }
+}

--- a/crates/bacnet-objects/src/trend/mod.rs
+++ b/crates/bacnet-objects/src/trend/mod.rs
@@ -3,20 +3,23 @@
 use std::borrow::Cow;
 use std::collections::VecDeque;
 
-use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetLogRecord, LogDatum};
+use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetLogRecord};
 use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
 
 use crate::common::{self, read_property_list_property};
+use crate::log_buffer::{
+    LogRecordBuffer, LogRecordBufferRecords, LogRecordIdentity, LogRecordProfile,
+};
 use crate::traits::{BACnetObject, WritePropertyRollback};
 
 struct TrendLogWriteRollback {
-    buffer: VecDeque<BACnetLogRecord>,
+    records: LogRecordBufferRecords,
 }
 
 struct TrendLogMultipleWriteRollback {
-    buffer: VecDeque<BACnetLogRecord>,
+    records: LogRecordBufferRecords,
 }
 
 /// BACnet TrendLog object.
@@ -31,8 +34,7 @@ pub struct TrendLogObject {
     log_interval: u32,
     stop_when_full: bool,
     buffer_size: u32,
-    buffer: VecDeque<BACnetLogRecord>,
-    total_record_count: u64,
+    log_buffer: LogRecordBuffer,
     out_of_service: bool,
     reliability: u32,
     status_flags: StatusFlags,
@@ -51,8 +53,7 @@ impl TrendLogObject {
             log_interval: 0,
             stop_when_full: false,
             buffer_size,
-            buffer: VecDeque::new(),
-            total_record_count: 0,
+            log_buffer: LogRecordBuffer::new(buffer_size),
             out_of_service: false,
             reliability: 0,
             status_flags: StatusFlags::empty(),
@@ -63,27 +64,18 @@ impl TrendLogObject {
 
     /// Add a BACnetLogRecord to the trend log buffer.
     pub fn add_record(&mut self, record: BACnetLogRecord) {
-        if !self.log_enable {
-            return;
-        }
-        if self.buffer.len() >= self.buffer_size as usize {
-            if self.stop_when_full {
-                return;
-            }
-            self.buffer.pop_front();
-        }
-        self.buffer.push_back(record);
-        self.total_record_count += 1;
+        self.log_buffer
+            .append(record, self.log_enable, self.stop_when_full);
     }
 
     /// Get the current buffer contents.
     pub fn records(&self) -> &VecDeque<BACnetLogRecord> {
-        &self.buffer
+        self.log_buffer.records()
     }
 
     /// Clear the buffer.
     pub fn clear(&mut self) {
-        self.buffer.clear();
+        self.log_buffer.clear();
     }
 
     /// Set the description string.
@@ -143,11 +135,11 @@ impl BACnetObject for TrendLogObject {
                 Ok(PropertyValue::Unsigned(self.buffer_size as u64))
             }
             p if p == PropertyIdentifier::RECORD_COUNT => {
-                Ok(PropertyValue::Unsigned(self.buffer.len() as u64))
+                Ok(PropertyValue::Unsigned(self.records().len() as u64))
             }
-            p if p == PropertyIdentifier::TOTAL_RECORD_COUNT => {
-                Ok(PropertyValue::Unsigned(self.total_record_count))
-            }
+            p if p == PropertyIdentifier::TOTAL_RECORD_COUNT => Ok(PropertyValue::Unsigned(
+                self.log_buffer.total_record_count() as u64,
+            )),
             p if p == PropertyIdentifier::STATUS_FLAGS => Ok(PropertyValue::BitString {
                 unused_bits: 4,
                 data: vec![self.status_flags.bits() << 4],
@@ -160,42 +152,7 @@ impl BACnetObject for TrendLogObject {
                 Ok(PropertyValue::Boolean(self.out_of_service))
             }
             p if p == PropertyIdentifier::LOG_BUFFER => {
-                let records = self
-                    .buffer
-                    .iter()
-                    .map(|record| {
-                        let datum_value = match &record.log_datum {
-                            LogDatum::LogStatus(v) => PropertyValue::Unsigned(*v as u64),
-                            LogDatum::BooleanValue(v) => PropertyValue::Boolean(*v),
-                            LogDatum::RealValue(v) => PropertyValue::Real(*v),
-                            LogDatum::EnumValue(v) => PropertyValue::Enumerated(*v),
-                            LogDatum::UnsignedValue(v) => PropertyValue::Unsigned(*v),
-                            LogDatum::SignedValue(v) => PropertyValue::Signed(*v as i32),
-                            LogDatum::BitstringValue { unused_bits, data } => {
-                                PropertyValue::BitString {
-                                    unused_bits: *unused_bits,
-                                    data: data.clone(),
-                                }
-                            }
-                            LogDatum::NullValue => PropertyValue::Null,
-                            LogDatum::Failure {
-                                error_class,
-                                error_code,
-                            } => PropertyValue::List(vec![
-                                PropertyValue::Unsigned(*error_class as u64),
-                                PropertyValue::Unsigned(*error_code as u64),
-                            ]),
-                            LogDatum::TimeChange(v) => PropertyValue::Real(*v),
-                            LogDatum::AnyValue(bytes) => PropertyValue::OctetString(bytes.clone()),
-                        };
-                        PropertyValue::List(vec![
-                            PropertyValue::Date(record.date),
-                            PropertyValue::Time(record.time),
-                            datum_value,
-                        ])
-                    })
-                    .collect();
-                Ok(PropertyValue::List(records))
+                Ok(self.log_buffer.project(LogRecordProfile::Trend))
             }
             p if p == PropertyIdentifier::LOGGING_TYPE => {
                 Ok(PropertyValue::Enumerated(self.logging_type))
@@ -267,7 +224,7 @@ impl BACnetObject for TrendLogObject {
         if property == PropertyIdentifier::RECORD_COUNT {
             // Writing 0 clears the buffer
             if let PropertyValue::Unsigned(0) = value {
-                self.buffer.clear();
+                self.clear();
                 return Ok(());
             }
             return Err(Error::Protocol {
@@ -347,7 +304,7 @@ impl BACnetObject for TrendLogObject {
             && matches!(value, PropertyValue::Unsigned(0)))
         .then(|| {
             WritePropertyRollback::new(TrendLogWriteRollback {
-                buffer: std::mem::take(&mut self.buffer),
+                records: self.log_buffer.take_records(),
             })
         })
     }
@@ -356,8 +313,13 @@ impl BACnetObject for TrendLogObject {
         &mut self,
         rollback: WritePropertyRollback,
     ) -> Result<(), Error> {
-        self.buffer = rollback.downcast::<TrendLogWriteRollback>()?.buffer;
+        self.log_buffer
+            .restore_records(rollback.downcast::<TrendLogWriteRollback>()?.records);
         Ok(())
+    }
+
+    fn log_record_identities_internal(&self) -> Option<Vec<LogRecordIdentity>> {
+        Some(self.log_buffer.identities())
     }
 
     fn add_trend_record(&mut self, record: BACnetLogRecord) {
@@ -382,8 +344,7 @@ pub struct TrendLogMultipleObject {
     log_interval: u32,
     stop_when_full: bool,
     buffer_size: u32,
-    buffer: VecDeque<BACnetLogRecord>,
-    total_record_count: u64,
+    log_buffer: LogRecordBuffer,
     status_flags: StatusFlags,
     log_device_object_property: Vec<BACnetDeviceObjectPropertyReference>,
     logging_type: u32, // 0=polled, 1=cov, 2=triggered
@@ -402,8 +363,7 @@ impl TrendLogMultipleObject {
             log_interval: 0,
             stop_when_full: false,
             buffer_size,
-            buffer: VecDeque::new(),
-            total_record_count: 0,
+            log_buffer: LogRecordBuffer::new(buffer_size),
             status_flags: StatusFlags::empty(),
             log_device_object_property: Vec::new(),
             logging_type: 0,
@@ -414,17 +374,8 @@ impl TrendLogMultipleObject {
 
     /// Add a BACnetLogRecord to the trend log buffer.
     pub fn add_record(&mut self, record: BACnetLogRecord) {
-        if !self.log_enable {
-            return;
-        }
-        if self.buffer.len() >= self.buffer_size as usize {
-            if self.stop_when_full {
-                return;
-            }
-            self.buffer.pop_front();
-        }
-        self.buffer.push_back(record);
-        self.total_record_count += 1;
+        self.log_buffer
+            .append(record, self.log_enable, self.stop_when_full);
     }
 
     /// Add a property reference to the monitored list.
@@ -434,12 +385,12 @@ impl TrendLogMultipleObject {
 
     /// Get the current buffer contents.
     pub fn records(&self) -> &VecDeque<BACnetLogRecord> {
-        &self.buffer
+        self.log_buffer.records()
     }
 
     /// Clear the buffer.
     pub fn clear(&mut self) {
-        self.buffer.clear();
+        self.log_buffer.clear();
     }
 
     /// Set the description string.
@@ -491,11 +442,11 @@ impl BACnetObject for TrendLogMultipleObject {
                 Ok(PropertyValue::Unsigned(self.buffer_size as u64))
             }
             p if p == PropertyIdentifier::RECORD_COUNT => {
-                Ok(PropertyValue::Unsigned(self.buffer.len() as u64))
+                Ok(PropertyValue::Unsigned(self.records().len() as u64))
             }
-            p if p == PropertyIdentifier::TOTAL_RECORD_COUNT => {
-                Ok(PropertyValue::Unsigned(self.total_record_count))
-            }
+            p if p == PropertyIdentifier::TOTAL_RECORD_COUNT => Ok(PropertyValue::Unsigned(
+                self.log_buffer.total_record_count() as u64,
+            )),
             p if p == PropertyIdentifier::STATUS_FLAGS => Ok(PropertyValue::BitString {
                 unused_bits: 4,
                 data: vec![self.status_flags.bits() << 4],
@@ -508,42 +459,7 @@ impl BACnetObject for TrendLogMultipleObject {
                 Ok(PropertyValue::Enumerated(self.reliability))
             }
             p if p == PropertyIdentifier::LOG_BUFFER => {
-                let records = self
-                    .buffer
-                    .iter()
-                    .map(|record| {
-                        let datum_value = match &record.log_datum {
-                            LogDatum::LogStatus(v) => PropertyValue::Unsigned(*v as u64),
-                            LogDatum::BooleanValue(v) => PropertyValue::Boolean(*v),
-                            LogDatum::RealValue(v) => PropertyValue::Real(*v),
-                            LogDatum::EnumValue(v) => PropertyValue::Enumerated(*v),
-                            LogDatum::UnsignedValue(v) => PropertyValue::Unsigned(*v),
-                            LogDatum::SignedValue(v) => PropertyValue::Signed(*v as i32),
-                            LogDatum::BitstringValue { unused_bits, data } => {
-                                PropertyValue::BitString {
-                                    unused_bits: *unused_bits,
-                                    data: data.clone(),
-                                }
-                            }
-                            LogDatum::NullValue => PropertyValue::Null,
-                            LogDatum::Failure {
-                                error_class,
-                                error_code,
-                            } => PropertyValue::List(vec![
-                                PropertyValue::Unsigned(*error_class as u64),
-                                PropertyValue::Unsigned(*error_code as u64),
-                            ]),
-                            LogDatum::TimeChange(v) => PropertyValue::Real(*v),
-                            LogDatum::AnyValue(bytes) => PropertyValue::OctetString(bytes.clone()),
-                        };
-                        PropertyValue::List(vec![
-                            PropertyValue::Date(record.date),
-                            PropertyValue::Time(record.time),
-                            datum_value,
-                        ])
-                    })
-                    .collect();
-                Ok(PropertyValue::List(records))
+                Ok(self.log_buffer.project(LogRecordProfile::TrendMultiple))
             }
             p if p == PropertyIdentifier::LOGGING_TYPE => {
                 Ok(PropertyValue::Enumerated(self.logging_type))
@@ -619,7 +535,7 @@ impl BACnetObject for TrendLogMultipleObject {
         if property == PropertyIdentifier::RECORD_COUNT {
             // Writing 0 clears the buffer
             if let PropertyValue::Unsigned(0) = value {
-                self.buffer.clear();
+                self.clear();
                 return Ok(());
             }
             return Err(Error::Protocol {
@@ -675,7 +591,7 @@ impl BACnetObject for TrendLogMultipleObject {
             && matches!(value, PropertyValue::Unsigned(0)))
         .then(|| {
             WritePropertyRollback::new(TrendLogMultipleWriteRollback {
-                buffer: std::mem::take(&mut self.buffer),
+                records: self.log_buffer.take_records(),
             })
         })
     }
@@ -684,14 +600,25 @@ impl BACnetObject for TrendLogMultipleObject {
         &mut self,
         rollback: WritePropertyRollback,
     ) -> Result<(), Error> {
-        self.buffer = rollback.downcast::<TrendLogMultipleWriteRollback>()?.buffer;
+        self.log_buffer.restore_records(
+            rollback
+                .downcast::<TrendLogMultipleWriteRollback>()?
+                .records,
+        );
         Ok(())
+    }
+
+    fn log_record_identities_internal(&self) -> Option<Vec<LogRecordIdentity>> {
+        Some(self.log_buffer.identities())
     }
 
     fn add_trend_record(&mut self, record: BACnetLogRecord) {
         self.add_record(record);
     }
 }
+
+#[cfg(test)]
+mod log_record_tests;
 
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-objects/src/trend/tests.rs
+++ b/crates/bacnet-objects/src/trend/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use bacnet_types::constructed::LogDatum;
 use bacnet_types::primitives::{Date, Time};
 
 fn make_record(hour: u8, value: f32) -> BACnetLogRecord {
@@ -80,7 +81,11 @@ fn trendlog_stop_when_full() {
         tl.add_record(make_record(i, i as f32));
     }
     assert_eq!(tl.records().len(), 2);
-    assert_eq!(tl.total_record_count, 2); // Only 2 accepted
+    assert_eq!(
+        tl.read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(2)
+    ); // Only 2 accepted
 }
 
 #[test]

--- a/crates/bacnet-server/src/handlers/tests/wpm_rollback_contract.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_rollback_contract.rs
@@ -411,15 +411,18 @@ fn log_record_count_rollback_restores_cleared_buffers() {
     let mut db = ObjectDatabase::new();
     let mut trend = TrendLogObject::new(1, "TL-1", 10).unwrap();
     trend.add_record(log_record());
+    trend.add_record(log_record());
     let trend_oid = trend.object_identifier();
     db.add(Box::new(trend)).unwrap();
 
     let mut trend_multiple = TrendLogMultipleObject::new(1, "TLM-1", 10).unwrap();
     trend_multiple.add_record(log_record());
+    trend_multiple.add_record(log_record());
     let trend_multiple_oid = trend_multiple.object_identifier();
     db.add(Box::new(trend_multiple)).unwrap();
 
     let mut event = EventLogObject::new(1, "EL-1", 10).unwrap();
+    event.add_record(log_record());
     event.add_record(log_record());
     let event_oid = event.object_identifier();
     db.add(Box::new(event)).unwrap();
@@ -435,6 +438,15 @@ fn log_record_count_rollback_restores_cleared_buffers() {
         let before_total = object
             .read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
             .unwrap();
+        let before_identities = object.log_record_identities_internal().unwrap();
+        assert_eq!(
+            before_identities
+                .iter()
+                .map(|identity| identity.sequence_number())
+                .collect::<Vec<_>>(),
+            vec![1, 2],
+            "{oid:?}"
+        );
         let mut clear = BytesMut::new();
         bacnet_encoding::primitives::encode_app_unsigned(&mut clear, 0);
 
@@ -454,6 +466,14 @@ fn log_record_count_rollback_restores_cleared_buffers() {
                 .read_property(PropertyIdentifier::RECORD_COUNT, None)
                 .unwrap(),
             before,
+            "{oid:?}"
+        );
+        assert_eq!(
+            db.get(&oid)
+                .unwrap()
+                .log_record_identities_internal()
+                .unwrap(),
+            before_identities,
             "{oid:?}"
         );
         if let Some(before_buffer) = before_buffer {

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -374,6 +374,37 @@
    "notes": "Initial family row only; later work should split high-claim services and object families into detailed rows."
   },
   {
+   "id": "BACNET-12-LOG-RECORD-IDENTITY",
+   "standard_anchor": "Clause 12.25 (p. 319), Clause 12.27 (p. 337), Clause 12.30 (p. 361); Clause 15.8 (pp. 745-750); Clause 21.6 (pp. 902-914)",
+   "priority": "P1",
+   "requirement_summary": "Event Log, Trend Log, and Trend Log Multiple resident records have stable object-owned Unsigned32 sequence and Date/Time identity across accepted append, FIFO overwrite, MAX-to-1 wrap, normal clear, and failed WritePropertyMultiple clear rollback. Record payload projection remains family-specific.",
+   "status": "in-progress",
+   "code_anchors": [
+    "crates/bacnet-objects/src/log_buffer.rs::LogRecordIdentity",
+    "crates/bacnet-objects/src/log_buffer.rs::LogRecordBuffer",
+    "crates/bacnet-objects/src/traits.rs::BACnetObject::log_record_identities_internal",
+    "crates/bacnet-objects/src/event_log.rs::EventLogObject",
+    "crates/bacnet-objects/src/trend/mod.rs::TrendLogObject",
+    "crates/bacnet-objects/src/trend/mod.rs::TrendLogMultipleObject"
+   ],
+   "positive_tests": [
+    "crates/bacnet-objects/src/log_buffer.rs::tests::log_buffer_assigns_one_and_wraps_max_without_zero",
+    "crates/bacnet-objects/src/log_buffer.rs::tests::log_buffer_wrap_and_eviction_keep_modular_fifo_alignment",
+    "crates/bacnet-objects/src/log_buffer.rs::tests::log_buffer_clear_preserves_counter_and_constructor_resets_it",
+    "crates/bacnet-objects/src/event_log/tests.rs::event_log_identities_align_after_eviction_and_differ_from_position",
+    "crates/bacnet-objects/src/event_log/tests.rs::event_log_total_record_count_is_u32_and_wraps_max_to_one",
+    "crates/bacnet-objects/src/trend/log_record_tests.rs::trend_log_projects_only_present_status_flags_as_fourth_field",
+    "crates/bacnet-objects/src/trend/log_record_tests.rs::trend_multiple_retains_raw_flags_but_projects_three_fields"
+   ],
+   "negative_tests": [
+    "crates/bacnet-objects/src/log_buffer.rs::tests::log_buffer_rejections_do_not_consume_sequence",
+    "crates/bacnet-server/src/handlers/tests/wpm_rollback_contract.rs::log_record_count_rollback_restores_cleared_buffers"
+   ],
+   "benchmarks": [],
+   "public_claims": [],
+   "notes": "In-memory storage/model foundation only; this row makes no public support claim. Sequence identity is object metadata and is never serialized in LOG_BUFFER. Trend Log alone projects a present legacy BACnetLogRecord.status_flags value as its formal optional fourth StatusFlags bitstring; Event Log and Trend Log Multiple retain that raw shared-Rust field for source compatibility but always project only Date, Time, and datum. ReadRange By-Sequence/By-Time behavior, First Sequence Number, restart durability/persistence, formal EventLog notification-record modeling, and mandatory purge/status records remain deferred."
+  },
+  {
    "id": "BACNET-12-PROPERTY-METADATA-CORE",
    "standard_anchor": "Clause 12.6, Table 12-6 (pp. 189-190); Clause 12.42, Table 12-49 (pp. 444-445); Clause 15.7.3.1 (p. 743); Annex A (pp. 964-965)",
    "priority": "P1",

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -13,7 +13,7 @@
 | Dimension | Value | Count |
 |---|---|---|
 | Priority | P0 | 16 |
-| Priority | P1 | 36 |
+| Priority | P1 | 37 |
 | Priority | P2 | 5 |
 | Priority | P3 | 4 |
 | Status | deferred-pending-owner-decision | 2 |
@@ -25,7 +25,7 @@
 | Status | implementation-present-needs-state-machine-audit | 4 |
 | Status | implementation-present-needs-timeout-tests | 1 |
 | Status | implementation-present-needs-window-tests | 1 |
-| Status | in-progress | 5 |
+| Status | in-progress | 6 |
 | Status | supported-with-clause-evidence | 15 |
 | Status | unknown-pending-source-review | 4 |
 | Status | unsupported-by-design | 3 |
@@ -47,6 +47,7 @@
 | `BACNET-10-PTP` | Clause 10 | P3 | unknown-pending-source-review | 0 |
 | `BACNET-11-LONTALK` | Clause 11 | P3 | unknown-pending-source-review | 0 |
 | `BACNET-12-OBJECT-MODEL` | Clauses 12-19 | P1 | implementation-present-needs-conformance-tests | 3 |
+| `BACNET-12-LOG-RECORD-IDENTITY` | Clause 12.25 (p. 319), Clause 12.27 (p. 337), Clause 12.30 (p. 361); Clause 15.8 (pp. 745-750); Clause 21.6 (pp. 902-914) | P1 | in-progress | 0 |
 | `BACNET-12-PROPERTY-METADATA-CORE` | Clause 12.6, Table 12-6 (pp. 189-190); Clause 12.42, Table 12-49 (pp. 444-445); Clause 15.7.3.1 (p. 743); Annex A (pp. 964-965) | P1 | in-progress | 1 |
 | `BACNET-12-ESCALATOR-STATUS-WRITABILITY` | Clause 12 general property conformance rules; Clause 12.60 Table 12-78 and Out_Of_Service; Clause 15.9.1.3; Clause 21 BACnetEscalatorMode, BACnetEscalatorOperationDirection, and BACnetEscalatorFault; Clause 23.1 | P1 | supported-with-clause-evidence | 0 |
 | `BACNET-12-DEVICE-MAX-SEGMENTS` | Clause 12.11, Table 12-13 | P1 | implementation-present-needs-conformance-tests | 0 |


### PR DESCRIPTION
## Summary
- add object-owned, nonzero Unsigned32 sequence and Date/Time identity for resident Event Log, Trend Log, and Trend Log Multiple records
- preserve identity through FIFO eviction, MAX-to-1 wrap, normal clear, rejected appends, and failed WritePropertyMultiple clear rollback
- keep existing `records()` and `add_record(BACnetLogRecord)` APIs while exposing an additive defaulted identity hook
- project optional per-record StatusFlags only for Trend Log; Event Log and Trend Log Multiple retain the legacy shared Rust field without wire projection
- add an in-progress conformance-ledger row without promoting public support

## Source traceability
| Standard 135-2020 source | Implemented behavior |
|---|---|
| §§12.25, 12.27, 12.30 | Each accepted record receives the adjusted `Total_Record_Count` as a nonzero Unsigned32 sequence; MAX wraps to 1; FIFO eviction and normal clear do not renumber surviving records or reset the live total. |
| §21.6 | Sequence identity remains object metadata and is not serialized in `LOG_BUFFER`; only Trend Log projects a present optional record StatusFlags value. |
| §15.8 | Establishes the future sequence/time selection identity contract only; ReadRange behavior remains deferred. |

## Validation
- `cargo fmt --all -- --check`
- focused log-buffer, Event Log, Trend Log, and WPM rollback tests
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-server --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- repository CI-native workspace tests
- `python3 scripts/generate-conformance-docs.py --check`
- file-size cap, no-secret scan, and `git diff --check`

## Deferred
- ReadRange By-Sequence and By-Time handling
- First Sequence Number
- restart durability/persistence
- mandatory purge/status records and formal Event Log notification-record modeling
- AuditLog, Python, client/service changes, and public support promotion

Refs #134
Refs #339