### PR TITLE
fix(objects): emit mandatory log status records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Mandatory `BACnetLogStatus` lifecycle records for Event Log, Trend Log, and
+  Trend Log Multiple (#189). `Record_Count=0`, effective Enable transitions,
+  and Stop_When_Full now share one non-recursive state machine that validates
+  the database clock before mutation, emits canonical three-bit status values,
+  preserves exact WPM rollback, and counts accepted records without retaining
+  them at zero capacity. The existing infallible Rust `add_record` and raw
+  `clear` APIs remain source-compatible; the server poller uses an additive
+  defaulted fallible hook so mandatory timestamp failures remain retryable.
+  Time-window transitions, `LOG_INTERRUPTED`, writable
+  `Log_DeviceObjectProperty` purge routes, formal Event Log notification
+  payloads, ReadRange, persistence, and full log conformance remain deferred.
+
 - Stable in-memory record identity for Event Log, Trend Log, and Trend Log
   Multiple (#134, #339). Each accepted append now owns a nonzero Unsigned32
   sequence (wrapping MAX to 1) plus its record Date/Time; FIFO eviction and
@@ -19,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a present optional record StatusFlags bitstring; Event Log and Trend Log
   Multiple retain the legacy raw Rust field but do not put it on the wire.
   ReadRange sequence/time selection, First Sequence Number, persistence,
-  formal Event Log notification records, and purge records remain deferred.
+  and formal Event Log notification records remain deferred.
 
 - Object-owned multi-state configuration Reliability and recovery for
   Multi-state Input, Output, and Value (#226). The Standard requires

--- a/crates/bacnet-objects/src/event_log.rs
+++ b/crates/bacnet-objects/src/event_log.rs
@@ -1,22 +1,19 @@
-//! EventLog (type 25) object per ASHRAE 135-2020 Clause 12.28.
+//! EventLog (type 25) object per ASHRAE 135-2020 Clause 12.27.
 
 use std::borrow::Cow;
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use bacnet_types::constructed::BACnetLogRecord;
 use bacnet_types::enums::{ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
 
+use crate::clock::ClockReader;
 use crate::common::{self, read_common_properties};
-use crate::log_buffer::{
-    LogRecordBuffer, LogRecordBufferRecords, LogRecordIdentity, LogRecordProfile,
-};
+use crate::log_buffer::{LogRecordBuffer, LogRecordIdentity, LogRecordProfile};
+use crate::log_lifecycle::{LogLifecycle, LogLifecycleSnapshot};
 use crate::traits::{BACnetObject, WritePropertyRollback};
-
-struct EventLogWriteRollback {
-    records: LogRecordBufferRecords,
-}
 
 /// BACnet EventLog object.
 ///
@@ -36,6 +33,7 @@ pub struct EventLogObject {
     event_state: u32,
     out_of_service: bool,
     reliability: u32,
+    clock: Option<Arc<dyn ClockReader>>,
 }
 
 impl EventLogObject {
@@ -55,13 +53,13 @@ impl EventLogObject {
             event_state: 0,
             out_of_service: false,
             reliability: 0,
+            clock: None,
         })
     }
 
     /// Add a BACnetLogRecord to the event log buffer.
     pub fn add_record(&mut self, record: BACnetLogRecord) {
-        self.log_buffer
-            .append(record, self.log_enable, self.stop_when_full);
+        let _ = self.try_add_record_internal(record);
     }
 
     /// Get the current buffer contents.
@@ -77,6 +75,19 @@ impl EventLogObject {
     /// Set the description string.
     pub fn set_description(&mut self, desc: impl Into<String>) {
         self.description = desc.into();
+    }
+
+    fn try_add_record_internal(&mut self, record: BACnetLogRecord) -> Result<(), Error> {
+        self.lifecycle().try_add_ordinary(record).map(|_| ())
+    }
+
+    fn lifecycle(&mut self) -> LogLifecycle<'_> {
+        LogLifecycle::new(
+            &mut self.log_buffer,
+            &mut self.log_enable,
+            &mut self.stop_when_full,
+            self.clock.as_ref(),
+        )
     }
 }
 
@@ -136,8 +147,7 @@ impl BACnetObject for EventLogObject {
     ) -> Result<(), Error> {
         if property == PropertyIdentifier::LOG_ENABLE {
             if let PropertyValue::Boolean(v) = value {
-                self.log_enable = v;
-                return Ok(());
+                return self.lifecycle().write_enable(v);
             }
             return Err(common::invalid_data_type_error());
         }
@@ -150,16 +160,13 @@ impl BACnetObject for EventLogObject {
         }
         if property == PropertyIdentifier::STOP_WHEN_FULL {
             if let PropertyValue::Boolean(v) = value {
-                self.stop_when_full = v;
-                return Ok(());
+                return self.lifecycle().write_stop_when_full(v);
             }
             return Err(common::invalid_data_type_error());
         }
         if property == PropertyIdentifier::RECORD_COUNT {
-            // Writing 0 clears the buffer
             if let PropertyValue::Unsigned(0) = value {
-                self.clear();
-                return Ok(());
+                return self.lifecycle().purge();
             }
             return Err(common::invalid_data_type_error());
         }
@@ -195,17 +202,39 @@ impl BACnetObject for EventLogObject {
         Cow::Borrowed(PROPS)
     }
 
+    fn bind_clock_internal(&mut self, clock: Option<Arc<dyn ClockReader>>) {
+        self.clock = clock;
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        matches!(
+            property,
+            PropertyIdentifier::LOG_ENABLE
+                | PropertyIdentifier::LOG_INTERVAL
+                | PropertyIdentifier::STOP_WHEN_FULL
+                | PropertyIdentifier::RECORD_COUNT
+                | PropertyIdentifier::OUT_OF_SERVICE
+                | PropertyIdentifier::DESCRIPTION
+        )
+    }
+
     fn capture_write_property_rollback(
         &mut self,
         property: PropertyIdentifier,
         value: &PropertyValue,
     ) -> Option<WritePropertyRollback> {
-        (property == PropertyIdentifier::RECORD_COUNT
+        ((property == PropertyIdentifier::RECORD_COUNT
             && matches!(value, PropertyValue::Unsigned(0)))
+            || (matches!(
+                property,
+                PropertyIdentifier::LOG_ENABLE | PropertyIdentifier::STOP_WHEN_FULL
+            ) && matches!(value, PropertyValue::Boolean(_))))
         .then(|| {
-            WritePropertyRollback::new(EventLogWriteRollback {
-                records: self.log_buffer.take_records(),
-            })
+            WritePropertyRollback::new(LogLifecycleSnapshot::capture(
+                &self.log_buffer,
+                self.log_enable,
+                self.stop_when_full,
+            ))
         })
     }
 
@@ -213,8 +242,11 @@ impl BACnetObject for EventLogObject {
         &mut self,
         rollback: WritePropertyRollback,
     ) -> Result<(), Error> {
-        self.log_buffer
-            .restore_records(rollback.downcast::<EventLogWriteRollback>()?.records);
+        rollback.downcast::<LogLifecycleSnapshot>()?.restore(
+            &mut self.log_buffer,
+            &mut self.log_enable,
+            &mut self.stop_when_full,
+        );
         Ok(())
     }
 

--- a/crates/bacnet-objects/src/event_log/tests.rs
+++ b/crates/bacnet-objects/src/event_log/tests.rs
@@ -1,6 +1,25 @@
 use super::*;
+use crate::clock::{ClockFrame, ClockReader};
 use bacnet_types::constructed::LogDatum;
 use bacnet_types::primitives::{Date, Time};
+use std::sync::Arc;
+
+struct FixedClock;
+
+impl ClockReader for FixedClock {
+    fn read_clock(&self) -> Option<ClockFrame> {
+        Some(ClockFrame {
+            local_date: make_date(),
+            local_time: make_time(9),
+            utc_offset: 0,
+            daylight_savings_status: false,
+        })
+    }
+}
+
+fn bind_clock(object: &mut EventLogObject) {
+    object.bind_clock_internal(Some(Arc::new(FixedClock)));
+}
 
 fn make_date() -> Date {
     Date {
@@ -123,6 +142,7 @@ fn ring_buffer_wraps() {
 #[test]
 fn stop_when_full() {
     let mut el = EventLogObject::new(1, "EL-1", 2).unwrap();
+    bind_clock(&mut el);
     el.write_property(
         PropertyIdentifier::STOP_WHEN_FULL,
         None,
@@ -144,6 +164,7 @@ fn stop_when_full() {
 #[test]
 fn disable_logging() {
     let mut el = EventLogObject::new(1, "EL-1", 100).unwrap();
+    bind_clock(&mut el);
     el.write_property(
         PropertyIdentifier::LOG_ENABLE,
         None,
@@ -152,12 +173,14 @@ fn disable_logging() {
     )
     .unwrap();
     el.add_record(make_record(10, 72.5));
-    assert_eq!(el.records().len(), 0);
+    assert_eq!(el.records().len(), 1);
+    assert_eq!(el.records()[0].log_datum, LogDatum::LogStatus(0b001));
 }
 
 #[test]
 fn clear_buffer_via_record_count() {
     let mut el = EventLogObject::new(1, "EL-1", 100).unwrap();
+    bind_clock(&mut el);
     el.add_record(make_record(10, 72.5));
     assert_eq!(el.records().len(), 1);
     el.write_property(
@@ -167,7 +190,8 @@ fn clear_buffer_via_record_count() {
         None,
     )
     .unwrap();
-    assert_eq!(el.records().len(), 0);
+    assert_eq!(el.records().len(), 1);
+    assert_eq!(el.records()[0].log_datum, LogDatum::LogStatus(0b010));
 }
 
 #[test]
@@ -341,8 +365,9 @@ fn event_log_clear_preserves_total_and_next_identity() {
 }
 
 #[test]
-fn event_log_rejections_do_not_consume_identity() {
+fn event_log_disabled_ordinary_rejection_does_not_consume_identity() {
     let mut el = EventLogObject::new(1, "EL-1", 1).unwrap();
+    bind_clock(&mut el);
     el.write_property(
         PropertyIdentifier::LOG_ENABLE,
         None,
@@ -350,28 +375,10 @@ fn event_log_rejections_do_not_consume_identity() {
         None,
     )
     .unwrap();
+    let before = el.log_record_identities_internal().unwrap();
     el.add_record(make_record(1, 1.0));
-    el.write_property(
-        PropertyIdentifier::LOG_ENABLE,
-        None,
-        PropertyValue::Boolean(true),
-        None,
-    )
-    .unwrap();
-    el.write_property(
-        PropertyIdentifier::STOP_WHEN_FULL,
-        None,
-        PropertyValue::Boolean(true),
-        None,
-    )
-    .unwrap();
-    el.add_record(make_record(2, 2.0));
-    el.add_record(make_record(3, 3.0));
 
-    assert_eq!(
-        el.log_record_identities_internal().unwrap()[0].sequence_number(),
-        1
-    );
+    assert_eq!(el.log_record_identities_internal().unwrap(), before);
     assert_eq!(
         el.read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
             .unwrap(),

--- a/crates/bacnet-objects/src/lib.rs
+++ b/crates/bacnet-objects/src/lib.rs
@@ -22,6 +22,7 @@ pub mod life_safety;
 pub mod lighting;
 pub mod load_control;
 pub mod log_buffer;
+pub(crate) mod log_lifecycle;
 pub mod loop_obj;
 pub mod multistate;
 pub mod network_port;
@@ -37,6 +38,9 @@ pub mod timer;
 pub mod traits;
 pub mod trend;
 pub mod value_types;
+
+#[cfg(test)]
+mod log_status_tests;
 
 #[cfg(test)]
 mod property_metadata_tests;

--- a/crates/bacnet-objects/src/log_buffer.rs
+++ b/crates/bacnet-objects/src/log_buffer.rs
@@ -51,12 +51,25 @@ pub(crate) enum LogRecordProfile {
     TrendMultiple,
 }
 
-pub(crate) struct LogRecordBufferRecords(VecDeque<BACnetLogRecord>);
-
+#[derive(Clone)]
 pub(crate) struct LogRecordBuffer {
     capacity: u32,
     records: VecDeque<BACnetLogRecord>,
     total_record_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OrdinaryAdmission {
+    IgnoredDisabled,
+    Inserted,
+    CountOnly,
+    StopBeforeFull,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ForcedAdmission {
+    Inserted,
+    CountOnly,
 }
 
 impl LogRecordBuffer {
@@ -68,24 +81,35 @@ impl LogRecordBuffer {
         }
     }
 
-    pub(crate) fn append(
+    pub(crate) fn admit_ordinary(
         &mut self,
         record: BACnetLogRecord,
         enabled: bool,
         stop_when_full: bool,
-    ) -> bool {
-        let full = self.records.len() >= self.capacity as usize;
-        if !enabled || (full && stop_when_full) {
-            return false;
+    ) -> OrdinaryAdmission {
+        if !enabled {
+            return OrdinaryAdmission::IgnoredDisabled;
+        }
+        if stop_when_full && self.next_record_would_fill() {
+            return OrdinaryAdmission::StopBeforeFull;
         }
 
-        let sequence_number = next_sequence(self.total_record_count);
-        self.total_record_count = sequence_number;
-        if full {
-            self.records.pop_front();
+        match self.insert_counted(record) {
+            ForcedAdmission::Inserted => OrdinaryAdmission::Inserted,
+            ForcedAdmission::CountOnly => OrdinaryAdmission::CountOnly,
         }
-        self.records.push_back(record);
-        true
+    }
+
+    pub(crate) fn insert_forced(&mut self, record: BACnetLogRecord) -> ForcedAdmission {
+        self.insert_counted(record)
+    }
+
+    pub(crate) fn is_full(&self) -> bool {
+        self.records.len() >= self.capacity as usize
+    }
+
+    pub(crate) fn next_record_would_fill_positive_capacity(&self) -> bool {
+        self.capacity > 0 && self.next_record_would_fill()
     }
 
     pub(crate) fn records(&self) -> &VecDeque<BACnetLogRecord> {
@@ -94,6 +118,10 @@ impl LogRecordBuffer {
 
     pub(crate) fn total_record_count(&self) -> u32 {
         self.total_record_count
+    }
+
+    pub(crate) fn capacity(&self) -> u32 {
+        self.capacity
     }
 
     pub(crate) fn clear(&mut self) {
@@ -134,13 +162,20 @@ impl LogRecordBuffer {
         )
     }
 
-    pub(crate) fn take_records(&mut self) -> LogRecordBufferRecords {
-        LogRecordBufferRecords(std::mem::take(&mut self.records))
+    fn next_record_would_fill(&self) -> bool {
+        self.capacity == 0 || self.records.len().saturating_add(1) >= self.capacity as usize
     }
 
-    pub(crate) fn restore_records(&mut self, records: LogRecordBufferRecords) {
-        debug_assert!(self.records.is_empty());
-        self.records = records.0;
+    fn insert_counted(&mut self, record: BACnetLogRecord) -> ForcedAdmission {
+        self.total_record_count = next_sequence(self.total_record_count);
+        if self.capacity == 0 {
+            return ForcedAdmission::CountOnly;
+        }
+        if self.is_full() {
+            self.records.pop_front();
+        }
+        self.records.push_back(record);
+        ForcedAdmission::Inserted
     }
 
     #[cfg(test)]
@@ -183,7 +218,10 @@ fn project_record(record: &BACnetLogRecord, profile: LogRecordProfile) -> Proper
 
 fn project_datum(datum: &LogDatum) -> PropertyValue {
     match datum {
-        LogDatum::LogStatus(value) => PropertyValue::Unsigned(*value as u64),
+        LogDatum::LogStatus(value) => PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![(value & 0b111) << 5],
+        },
         LogDatum::BooleanValue(value) => PropertyValue::Boolean(*value),
         LogDatum::RealValue(value) => PropertyValue::Real(*value),
         LogDatum::EnumValue(value) => PropertyValue::Enumerated(*value),
@@ -237,12 +275,18 @@ mod tests {
         assert_eq!(buffer.total_record_count(), 0);
         assert!(LogRecordIdentity::new(0, record(0).date, record(0).time).is_none());
 
-        assert!(buffer.append(record(1), true, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(1), true, false),
+            OrdinaryAdmission::Inserted
+        );
         assert_eq!(buffer.identities()[0].sequence_number(), 1);
 
         buffer.clear();
         buffer.set_total_record_count_for_test(u32::MAX);
-        assert!(buffer.append(record(2), true, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(2), true, false),
+            OrdinaryAdmission::Inserted
+        );
         assert_eq!(buffer.total_record_count(), 1);
         assert_eq!(buffer.identities()[0].sequence_number(), 1);
     }
@@ -250,26 +294,39 @@ mod tests {
     #[test]
     fn log_buffer_rejections_do_not_consume_sequence() {
         let mut buffer = LogRecordBuffer::new(1);
-        assert!(!buffer.append(record(1), false, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(1), false, false),
+            OrdinaryAdmission::IgnoredDisabled
+        );
         assert_eq!(buffer.total_record_count(), 0);
 
-        assert!(buffer.append(record(2), true, true));
-        assert!(!buffer.append(record(3), true, true));
-        assert_eq!(buffer.total_record_count(), 1);
-        assert_eq!(buffer.identities()[0].sequence_number(), 1);
+        assert_eq!(
+            buffer.admit_ordinary(record(2), true, true),
+            OrdinaryAdmission::StopBeforeFull
+        );
+        assert_eq!(buffer.total_record_count(), 0);
+        assert!(buffer.identities().is_empty());
     }
 
     #[test]
-    fn log_buffer_preserves_zero_capacity_runtime_behavior() {
+    fn log_buffer_zero_capacity_counts_without_retaining() {
         let mut ring = LogRecordBuffer::new(0);
-        assert!(ring.append(record(1), true, false));
-        assert!(ring.append(record(2), true, false));
-        assert_eq!(ring.records().len(), 1);
-        assert_eq!(ring.records()[0].time.hour, 2);
+        assert_eq!(
+            ring.admit_ordinary(record(1), true, false),
+            OrdinaryAdmission::CountOnly
+        );
+        assert_eq!(
+            ring.admit_ordinary(record(2), true, false),
+            OrdinaryAdmission::CountOnly
+        );
+        assert!(ring.records().is_empty());
         assert_eq!(ring.total_record_count(), 2);
 
         let mut stop_when_full = LogRecordBuffer::new(0);
-        assert!(!stop_when_full.append(record(1), true, true));
+        assert_eq!(
+            stop_when_full.admit_ordinary(record(1), true, true),
+            OrdinaryAdmission::StopBeforeFull
+        );
         assert!(stop_when_full.records().is_empty());
         assert_eq!(stop_when_full.total_record_count(), 0);
     }
@@ -277,10 +334,19 @@ mod tests {
     #[test]
     fn log_buffer_fifo_eviction_keeps_survivor_identity_and_alignment() {
         let mut buffer = LogRecordBuffer::new(2);
-        assert!(buffer.append(record(1), true, false));
-        assert!(buffer.append(record(2), true, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(1), true, false),
+            OrdinaryAdmission::Inserted
+        );
+        assert_eq!(
+            buffer.admit_ordinary(record(2), true, false),
+            OrdinaryAdmission::Inserted
+        );
         let survivor = buffer.identities()[1];
-        assert!(buffer.append(record(3), true, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(3), true, false),
+            OrdinaryAdmission::Inserted
+        );
 
         let identities = buffer.identities();
         assert_eq!(
@@ -302,9 +368,18 @@ mod tests {
     fn log_buffer_wrap_and_eviction_keep_modular_fifo_alignment() {
         let mut buffer = LogRecordBuffer::new(3);
         buffer.set_total_record_count_for_test(u32::MAX - 1);
-        assert!(buffer.append(record(1), true, false));
-        assert!(buffer.append(record(2), true, false));
-        assert!(buffer.append(record(3), true, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(1), true, false),
+            OrdinaryAdmission::Inserted
+        );
+        assert_eq!(
+            buffer.admit_ordinary(record(2), true, false),
+            OrdinaryAdmission::Inserted
+        );
+        assert_eq!(
+            buffer.admit_ordinary(record(3), true, false),
+            OrdinaryAdmission::Inserted
+        );
         assert_eq!(
             buffer
                 .identities()
@@ -314,7 +389,10 @@ mod tests {
             vec![u32::MAX, 1, 2]
         );
 
-        assert!(buffer.append(record(4), true, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(4), true, false),
+            OrdinaryAdmission::Inserted
+        );
         assert_eq!(
             buffer
                 .identities()
@@ -336,14 +414,23 @@ mod tests {
     #[test]
     fn log_buffer_clear_preserves_counter_and_constructor_resets_it() {
         let mut buffer = LogRecordBuffer::new(2);
-        assert!(buffer.append(record(1), true, false));
-        assert!(buffer.append(record(2), true, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(1), true, false),
+            OrdinaryAdmission::Inserted
+        );
+        assert_eq!(
+            buffer.admit_ordinary(record(2), true, false),
+            OrdinaryAdmission::Inserted
+        );
         buffer.clear();
 
         assert!(buffer.records().is_empty());
         assert!(buffer.identities().is_empty());
         assert_eq!(buffer.total_record_count(), 2);
-        assert!(buffer.append(record(3), true, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(3), true, false),
+            OrdinaryAdmission::Inserted
+        );
         assert_eq!(buffer.identities()[0].sequence_number(), 3);
         assert_eq!(LogRecordBuffer::new(2).total_record_count(), 0);
     }
@@ -352,8 +439,14 @@ mod tests {
     fn log_buffer_duplicate_timestamps_keep_distinct_sequences() {
         let mut buffer = LogRecordBuffer::new(2);
         let duplicate = record(4);
-        assert!(buffer.append(duplicate.clone(), true, false));
-        assert!(buffer.append(duplicate, true, false));
+        assert_eq!(
+            buffer.admit_ordinary(duplicate.clone(), true, false),
+            OrdinaryAdmission::Inserted
+        );
+        assert_eq!(
+            buffer.admit_ordinary(duplicate, true, false),
+            OrdinaryAdmission::Inserted
+        );
 
         let identities = buffer.identities();
         assert_eq!(identities[0].date(), identities[1].date());
@@ -363,18 +456,23 @@ mod tests {
     }
 
     #[test]
-    fn log_buffer_move_restore_preserves_payloads_and_derived_identities() {
+    fn log_buffer_clone_restore_preserves_payloads_and_derived_identities() {
         let mut buffer = LogRecordBuffer::new(2);
-        assert!(buffer.append(record(1), true, false));
-        assert!(buffer.append(record(2), true, false));
+        assert_eq!(
+            buffer.admit_ordinary(record(1), true, false),
+            OrdinaryAdmission::Inserted
+        );
+        assert_eq!(
+            buffer.admit_ordinary(record(2), true, false),
+            OrdinaryAdmission::Inserted
+        );
         let records = buffer.records().clone();
         let identities = buffer.identities();
         let total = buffer.total_record_count();
 
-        let moved = buffer.take_records();
-        assert!(buffer.records().is_empty());
-        assert_eq!(buffer.total_record_count(), total);
-        buffer.restore_records(moved);
+        let snapshot = buffer.clone();
+        buffer.clear();
+        buffer = snapshot;
 
         assert_eq!(buffer.records(), &records);
         assert_eq!(buffer.identities(), identities);

--- a/crates/bacnet-objects/src/log_lifecycle.rs
+++ b/crates/bacnet-objects/src/log_lifecycle.rs
@@ -1,0 +1,159 @@
+//! Shared non-recursive state transitions for BACnet log objects.
+
+use std::sync::Arc;
+
+use bacnet_types::constructed::{BACnetLogRecord, LogDatum};
+use bacnet_types::enums::{ErrorClass, ErrorCode};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{Date, Time};
+
+use crate::clock::ClockReader;
+use crate::common::protocol_error;
+use crate::log_buffer::{LogRecordBuffer, OrdinaryAdmission};
+
+pub(crate) const LOG_DISABLED: u8 = 0b001;
+pub(crate) const BUFFER_PURGED: u8 = 0b010;
+
+pub(crate) struct LogLifecycle<'a> {
+    buffer: &'a mut LogRecordBuffer,
+    enabled: &'a mut bool,
+    stop_when_full: &'a mut bool,
+    clock: Option<&'a Arc<dyn ClockReader>>,
+}
+
+#[derive(Clone)]
+pub(crate) struct LogLifecycleSnapshot {
+    buffer: LogRecordBuffer,
+    enabled: bool,
+    stop_when_full: bool,
+}
+
+impl<'a> LogLifecycle<'a> {
+    pub(crate) fn new(
+        buffer: &'a mut LogRecordBuffer,
+        enabled: &'a mut bool,
+        stop_when_full: &'a mut bool,
+        clock: Option<&'a Arc<dyn ClockReader>>,
+    ) -> Self {
+        Self {
+            buffer,
+            enabled,
+            stop_when_full,
+            clock,
+        }
+    }
+
+    pub(crate) fn try_add_ordinary(
+        &mut self,
+        record: BACnetLogRecord,
+    ) -> Result<OrdinaryAdmission, Error> {
+        let admission = self
+            .buffer
+            .admit_ordinary(record, *self.enabled, *self.stop_when_full);
+        if admission != OrdinaryAdmission::StopBeforeFull {
+            return Ok(admission);
+        }
+
+        let timestamp = valid_timestamp(self.clock)?;
+        *self.enabled = false;
+        self.insert_status(timestamp, LOG_DISABLED);
+        Ok(admission)
+    }
+
+    pub(crate) fn write_enable(&mut self, requested: bool) -> Result<(), Error> {
+        if requested == *self.enabled {
+            return Ok(());
+        }
+        if requested && *self.stop_when_full && self.buffer.is_full() {
+            return Err(protocol_error(
+                ErrorClass::OBJECT,
+                ErrorCode::LOG_BUFFER_FULL,
+            ));
+        }
+
+        let timestamp = valid_timestamp(self.clock)?;
+        if !requested {
+            *self.enabled = false;
+            self.insert_status(timestamp, LOG_DISABLED);
+            return Ok(());
+        }
+
+        let status_fills =
+            *self.stop_when_full && self.buffer.next_record_would_fill_positive_capacity();
+        *self.enabled = !status_fills;
+        self.insert_status(timestamp, u8::from(status_fills) * LOG_DISABLED);
+        Ok(())
+    }
+
+    pub(crate) fn write_stop_when_full(&mut self, requested: bool) -> Result<(), Error> {
+        if requested == *self.stop_when_full {
+            return Ok(());
+        }
+        if !requested {
+            *self.stop_when_full = false;
+            return Ok(());
+        }
+        if !self.buffer.is_full() {
+            *self.stop_when_full = true;
+            return Ok(());
+        }
+
+        let timestamp = valid_timestamp(self.clock)?;
+        *self.stop_when_full = true;
+        *self.enabled = false;
+        self.insert_status(timestamp, LOG_DISABLED);
+        Ok(())
+    }
+
+    pub(crate) fn purge(&mut self) -> Result<(), Error> {
+        let timestamp = valid_timestamp(self.clock)?;
+        let status_fills = *self.stop_when_full && self.buffer.capacity() == 1;
+        let disabled = !*self.enabled || status_fills;
+
+        self.buffer.clear();
+        if status_fills {
+            *self.enabled = false;
+        }
+        let bits = BUFFER_PURGED | u8::from(disabled) * LOG_DISABLED;
+        self.insert_status(timestamp, bits);
+        Ok(())
+    }
+
+    fn insert_status(&mut self, timestamp: (Date, Time), bits: u8) {
+        self.buffer.insert_forced(BACnetLogRecord {
+            date: timestamp.0,
+            time: timestamp.1,
+            log_datum: LogDatum::LogStatus(bits),
+            status_flags: None,
+        });
+    }
+}
+
+impl LogLifecycleSnapshot {
+    pub(crate) fn capture(buffer: &LogRecordBuffer, enabled: bool, stop_when_full: bool) -> Self {
+        Self {
+            buffer: buffer.clone(),
+            enabled,
+            stop_when_full,
+        }
+    }
+
+    pub(crate) fn restore(
+        self,
+        buffer: &mut LogRecordBuffer,
+        enabled: &mut bool,
+        stop_when_full: &mut bool,
+    ) {
+        *buffer = self.buffer;
+        *enabled = self.enabled;
+        *stop_when_full = self.stop_when_full;
+    }
+}
+
+fn valid_timestamp(clock: Option<&Arc<dyn ClockReader>>) -> Result<(Date, Time), Error> {
+    let frame = clock
+        .and_then(|clock| clock.read_clock())
+        .filter(|frame| frame.is_valid_actual_datetime())
+        .ok_or_else(|| protocol_error(ErrorClass::DEVICE, ErrorCode::OPERATIONAL_PROBLEM))?;
+    Ok((frame.local_date, frame.local_time))
+}

--- a/crates/bacnet-objects/src/log_status_tests.rs
+++ b/crates/bacnet-objects/src/log_status_tests.rs
@@ -1,0 +1,605 @@
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use bacnet_types::constructed::{BACnetLogRecord, LogDatum};
+use bacnet_types::enums::{ErrorClass, ErrorCode, PropertyIdentifier};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{Date, PropertyValue, Time};
+
+use crate::clock::{ClockFrame, ClockReader};
+use crate::event_log::EventLogObject;
+use crate::traits::BACnetObject;
+use crate::trend::{TrendLogMultipleObject, TrendLogObject};
+
+const LOG_DISABLED: u8 = 0b001;
+const BUFFER_PURGED: u8 = 0b010;
+
+#[derive(Clone, Copy, Debug)]
+enum FamilyKind {
+    Event,
+    Trend,
+    TrendMultiple,
+}
+
+impl FamilyKind {
+    const ALL: [Self; 3] = [Self::Event, Self::Trend, Self::TrendMultiple];
+
+    fn object(self, capacity: u32) -> Family {
+        match self {
+            Self::Event => Family::Event(EventLogObject::new(1, "EL-1", capacity).unwrap()),
+            Self::Trend => Family::Trend(TrendLogObject::new(1, "TL-1", capacity).unwrap()),
+            Self::TrendMultiple => {
+                Family::TrendMultiple(TrendLogMultipleObject::new(1, "TLM-1", capacity).unwrap())
+            }
+        }
+    }
+}
+
+enum Family {
+    Event(EventLogObject),
+    Trend(TrendLogObject),
+    TrendMultiple(TrendLogMultipleObject),
+}
+
+impl Family {
+    fn object(&self) -> &dyn BACnetObject {
+        match self {
+            Self::Event(object) => object,
+            Self::Trend(object) => object,
+            Self::TrendMultiple(object) => object,
+        }
+    }
+
+    fn object_mut(&mut self) -> &mut dyn BACnetObject {
+        match self {
+            Self::Event(object) => object,
+            Self::Trend(object) => object,
+            Self::TrendMultiple(object) => object,
+        }
+    }
+
+    fn records(&self) -> &VecDeque<BACnetLogRecord> {
+        match self {
+            Self::Event(object) => object.records(),
+            Self::Trend(object) => object.records(),
+            Self::TrendMultiple(object) => object.records(),
+        }
+    }
+
+    fn add_record(&mut self, record: BACnetLogRecord) {
+        match self {
+            Self::Event(object) => object.add_record(record),
+            Self::Trend(object) => object.add_record(record),
+            Self::TrendMultiple(object) => object.add_record(record),
+        }
+    }
+
+    fn clear(&mut self) {
+        match self {
+            Self::Event(object) => object.clear(),
+            Self::Trend(object) => object.clear(),
+            Self::TrendMultiple(object) => object.clear(),
+        }
+    }
+
+    fn write(&mut self, property: PropertyIdentifier, value: PropertyValue) -> Result<(), Error> {
+        self.object_mut()
+            .write_property(property, None, value, None)
+    }
+
+    fn read(&self, property: PropertyIdentifier) -> PropertyValue {
+        self.object().read_property(property, None).unwrap()
+    }
+
+    fn bind_clock(&mut self, clock: Arc<dyn ClockReader>) {
+        self.object_mut().bind_clock_internal(Some(clock));
+    }
+
+    fn total(&self) -> u64 {
+        let PropertyValue::Unsigned(total) = self.read(PropertyIdentifier::TOTAL_RECORD_COUNT)
+        else {
+            panic!("expected Total_Record_Count Unsigned");
+        };
+        total
+    }
+
+    fn enabled(&self) -> bool {
+        self.read(PropertyIdentifier::LOG_ENABLE) == PropertyValue::Boolean(true)
+    }
+
+    fn stop_when_full(&self) -> bool {
+        self.read(PropertyIdentifier::STOP_WHEN_FULL) == PropertyValue::Boolean(true)
+    }
+
+    fn identities(&self) -> Vec<u32> {
+        self.object()
+            .log_record_identities_internal()
+            .unwrap()
+            .iter()
+            .map(|identity| identity.sequence_number())
+            .collect()
+    }
+}
+
+struct TestClock {
+    frame: Option<ClockFrame>,
+    reads: AtomicUsize,
+}
+
+impl TestClock {
+    fn valid() -> Arc<Self> {
+        Arc::new(Self {
+            frame: Some(valid_frame()),
+            reads: AtomicUsize::new(0),
+        })
+    }
+
+    fn invalid() -> Arc<Self> {
+        Arc::new(Self {
+            frame: Some(ClockFrame {
+                local_time: Time {
+                    hour: Time::UNSPECIFIED,
+                    ..valid_frame().local_time
+                },
+                ..valid_frame()
+            }),
+            reads: AtomicUsize::new(0),
+        })
+    }
+
+    fn reads(&self) -> usize {
+        self.reads.load(Ordering::SeqCst)
+    }
+}
+
+impl ClockReader for TestClock {
+    fn read_clock(&self) -> Option<ClockFrame> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        self.frame
+    }
+}
+
+fn valid_frame() -> ClockFrame {
+    ClockFrame {
+        local_date: Date {
+            year: 126,
+            month: 8,
+            day: 31,
+            day_of_week: 1,
+        },
+        local_time: Time {
+            hour: 14,
+            minute: 25,
+            second: 36,
+            hundredths: 47,
+        },
+        utc_offset: 0,
+        daylight_savings_status: false,
+    }
+}
+
+fn ordinary(hour: u8, value: u64) -> BACnetLogRecord {
+    BACnetLogRecord {
+        date: valid_frame().local_date,
+        time: Time {
+            hour,
+            ..valid_frame().local_time
+        },
+        log_datum: LogDatum::UnsignedValue(value),
+        status_flags: None,
+    }
+}
+
+fn assert_status(object: &Family, bits: u8) {
+    let record = object.records().back().expect("status record");
+    assert_eq!(record.date, valid_frame().local_date);
+    assert_eq!(record.time, valid_frame().local_time);
+    assert_eq!(record.log_datum, LogDatum::LogStatus(bits));
+    assert_eq!(record.status_flags, None);
+
+    let PropertyValue::List(records) = object.read(PropertyIdentifier::LOG_BUFFER) else {
+        panic!("expected projected records");
+    };
+    let PropertyValue::List(fields) = records.last().expect("projected status record") else {
+        panic!("expected projected record fields");
+    };
+    assert_eq!(
+        fields[2],
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![(bits & 0b111) << 5],
+        }
+    );
+}
+
+fn assert_protocol(error: Error, class: ErrorClass, code: ErrorCode) {
+    match error {
+        Error::Protocol {
+            class: actual_class,
+            code: actual_code,
+        } => {
+            assert_eq!(actual_class, class.to_raw() as u32);
+            assert_eq!(actual_code, code.to_raw() as u32);
+        }
+        other => panic!("expected protocol error, got {other:?}"),
+    }
+}
+
+#[test]
+fn purge_is_unconditional_initial_status_and_repeats_for_every_log_family() {
+    for kind in FamilyKind::ALL {
+        let mut empty = kind.object(3);
+        empty.bind_clock(TestClock::valid());
+        empty
+            .write(PropertyIdentifier::RECORD_COUNT, PropertyValue::Unsigned(0))
+            .unwrap();
+        assert_eq!(empty.records().len(), 1, "{kind:?}");
+        assert_eq!(empty.total(), 1, "{kind:?}");
+        assert_eq!(empty.identities(), vec![1], "{kind:?}");
+        assert_status(&empty, BUFFER_PURGED);
+
+        empty
+            .write(PropertyIdentifier::RECORD_COUNT, PropertyValue::Unsigned(0))
+            .unwrap();
+        assert_eq!(empty.records().len(), 1, "{kind:?}");
+        assert_eq!(empty.total(), 2, "{kind:?}");
+        assert_eq!(empty.identities(), vec![2], "{kind:?}");
+        assert_status(&empty, BUFFER_PURGED);
+
+        let mut disabled = kind.object(3);
+        disabled.bind_clock(TestClock::valid());
+        disabled
+            .write(
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyValue::Boolean(false),
+            )
+            .unwrap();
+        disabled
+            .write(PropertyIdentifier::RECORD_COUNT, PropertyValue::Unsigned(0))
+            .unwrap();
+        assert_eq!(disabled.records().len(), 1, "{kind:?}");
+        assert_eq!(disabled.total(), 2, "{kind:?}");
+        assert_status(&disabled, LOG_DISABLED | BUFFER_PURGED);
+
+        let mut capacity_one = kind.object(1);
+        capacity_one.bind_clock(TestClock::valid());
+        capacity_one
+            .write(
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyValue::Boolean(true),
+            )
+            .unwrap();
+        capacity_one
+            .write(PropertyIdentifier::RECORD_COUNT, PropertyValue::Unsigned(0))
+            .unwrap();
+        assert!(!capacity_one.enabled(), "{kind:?}");
+        assert_eq!(capacity_one.records().len(), 1, "{kind:?}");
+        assert_status(&capacity_one, LOG_DISABLED | BUFFER_PURGED);
+    }
+}
+
+#[test]
+fn stop_before_full_omits_triggering_ordinary_and_clock_failure_is_atomic() {
+    for kind in FamilyKind::ALL {
+        let mut one = kind.object(1);
+        one.bind_clock(TestClock::valid());
+        one.write(
+            PropertyIdentifier::STOP_WHEN_FULL,
+            PropertyValue::Boolean(true),
+        )
+        .unwrap();
+        one.add_record(ordinary(1, 10));
+        assert!(!one.enabled(), "{kind:?}");
+        assert_eq!(one.total(), 1, "{kind:?}");
+        assert_eq!(one.records().len(), 1, "{kind:?}");
+        assert_status(&one, LOG_DISABLED);
+        one.add_record(ordinary(2, 20));
+        assert_eq!(one.total(), 1, "{kind:?}");
+
+        let mut many = kind.object(3);
+        many.bind_clock(TestClock::valid());
+        many.write(
+            PropertyIdentifier::STOP_WHEN_FULL,
+            PropertyValue::Boolean(true),
+        )
+        .unwrap();
+        many.add_record(ordinary(1, 10));
+        many.add_record(ordinary(2, 20));
+        many.add_record(ordinary(3, 30));
+        assert_eq!(many.total(), 3, "{kind:?}");
+        assert_eq!(many.records().len(), 3, "{kind:?}");
+        assert_eq!(many.records()[0].log_datum, LogDatum::UnsignedValue(10));
+        assert_eq!(many.records()[1].log_datum, LogDatum::UnsignedValue(20));
+        assert_status(&many, LOG_DISABLED);
+
+        for clock in [None, Some(TestClock::invalid())] {
+            let mut atomic = kind.object(2);
+            if let Some(clock) = clock {
+                atomic.bind_clock(clock);
+            }
+            atomic
+                .write(
+                    PropertyIdentifier::STOP_WHEN_FULL,
+                    PropertyValue::Boolean(true),
+                )
+                .unwrap();
+            atomic.add_record(ordinary(1, 10));
+            let before_records = atomic.records().clone();
+            let before_total = atomic.total();
+            let before_identities = atomic.identities();
+            atomic.add_record(ordinary(2, 20));
+            assert_eq!(atomic.records(), &before_records, "{kind:?}");
+            assert_eq!(atomic.total(), before_total, "{kind:?}");
+            assert_eq!(atomic.identities(), before_identities, "{kind:?}");
+            assert!(atomic.enabled(), "{kind:?}");
+        }
+    }
+}
+
+#[test]
+fn enable_and_stop_when_full_transitions_emit_exactly_one_status() {
+    for kind in FamilyKind::ALL {
+        let mut flag_only = kind.object(3);
+        flag_only.bind_clock(TestClock::valid());
+        flag_only
+            .write(
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyValue::Boolean(true),
+            )
+            .unwrap();
+        assert_eq!(flag_only.total(), 0, "{kind:?}");
+        flag_only
+            .write(
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyValue::Boolean(true),
+            )
+            .unwrap();
+        flag_only
+            .write(
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyValue::Boolean(false),
+            )
+            .unwrap();
+        assert_eq!(flag_only.total(), 0, "{kind:?}");
+
+        let mut transitions = kind.object(3);
+        transitions.bind_clock(TestClock::valid());
+        transitions
+            .write(
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyValue::Boolean(false),
+            )
+            .unwrap();
+        assert_eq!(transitions.total(), 1, "{kind:?}");
+        assert_status(&transitions, LOG_DISABLED);
+        transitions
+            .write(
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyValue::Boolean(false),
+            )
+            .unwrap();
+        assert_eq!(transitions.total(), 1, "{kind:?}");
+        transitions
+            .write(PropertyIdentifier::LOG_ENABLE, PropertyValue::Boolean(true))
+            .unwrap();
+        assert!(transitions.enabled(), "{kind:?}");
+        assert_eq!(transitions.total(), 2, "{kind:?}");
+        assert_status(&transitions, 0);
+
+        transitions
+            .write(
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyValue::Boolean(false),
+            )
+            .unwrap();
+        transitions.clear();
+        transitions.add_record(ordinary(1, 10));
+        assert!(transitions.records().is_empty(), "{kind:?}");
+
+        let mut fills = kind.object(3);
+        fills.bind_clock(TestClock::valid());
+        fills.add_record(ordinary(1, 10));
+        fills
+            .write(
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyValue::Boolean(false),
+            )
+            .unwrap();
+        fills
+            .write(
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyValue::Boolean(true),
+            )
+            .unwrap();
+        fills
+            .write(PropertyIdentifier::LOG_ENABLE, PropertyValue::Boolean(true))
+            .unwrap();
+        assert!(!fills.enabled(), "{kind:?}");
+        assert_eq!(fills.total(), 3, "{kind:?}");
+        assert_status(&fills, LOG_DISABLED);
+
+        let mut full = kind.object(2);
+        let clock = TestClock::valid();
+        full.bind_clock(clock.clone());
+        full.add_record(ordinary(1, 10));
+        full.add_record(ordinary(2, 20));
+        full.write(
+            PropertyIdentifier::STOP_WHEN_FULL,
+            PropertyValue::Boolean(true),
+        )
+        .unwrap();
+        assert!(!full.enabled(), "{kind:?}");
+        assert!(full.stop_when_full(), "{kind:?}");
+        assert_eq!(full.records().len(), 2, "{kind:?}");
+        assert_eq!(full.total(), 3, "{kind:?}");
+        assert_eq!(full.identities(), vec![2, 3], "{kind:?}");
+        assert_status(&full, LOG_DISABLED);
+        let reads = clock.reads();
+        let error = full
+            .write(PropertyIdentifier::LOG_ENABLE, PropertyValue::Boolean(true))
+            .unwrap_err();
+        assert_protocol(error, ErrorClass::OBJECT, ErrorCode::LOG_BUFFER_FULL);
+        assert_eq!(clock.reads(), reads, "{kind:?}");
+        assert_eq!(full.total(), 3, "{kind:?}");
+    }
+}
+
+#[test]
+fn zero_capacity_counts_without_residents_and_enforces_full_enable_gate() {
+    for kind in FamilyKind::ALL {
+        let mut object = kind.object(0);
+        let clock = TestClock::valid();
+        object.bind_clock(clock.clone());
+        object.add_record(ordinary(1, 10));
+        object.add_record(ordinary(2, 20));
+        assert!(object.records().is_empty(), "{kind:?}");
+        assert_eq!(object.total(), 2, "{kind:?}");
+        assert!(object.identities().is_empty(), "{kind:?}");
+
+        object
+            .write(PropertyIdentifier::RECORD_COUNT, PropertyValue::Unsigned(0))
+            .unwrap();
+        assert!(object.records().is_empty(), "{kind:?}");
+        assert_eq!(object.total(), 3, "{kind:?}");
+
+        object
+            .write(
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyValue::Boolean(true),
+            )
+            .unwrap();
+        assert!(!object.enabled(), "{kind:?}");
+        assert!(object.records().is_empty(), "{kind:?}");
+        assert_eq!(object.total(), 4, "{kind:?}");
+        let reads = clock.reads();
+        let error = object
+            .write(PropertyIdentifier::LOG_ENABLE, PropertyValue::Boolean(true))
+            .unwrap_err();
+        assert_protocol(error, ErrorClass::OBJECT, ErrorCode::LOG_BUFFER_FULL);
+        assert_eq!(clock.reads(), reads, "{kind:?}");
+        assert_eq!(object.total(), 4, "{kind:?}");
+    }
+}
+
+#[test]
+fn status_writes_require_a_valid_clock_before_mutation() {
+    for kind in FamilyKind::ALL {
+        for clock in [None, Some(TestClock::invalid())] {
+            let mut object = kind.object(2);
+            object.add_record(ordinary(1, 10));
+            if let Some(clock) = clock.clone() {
+                object.bind_clock(clock);
+            }
+            let before = object.records().clone();
+            let before_total = object.total();
+            let before_enable = object.enabled();
+            let before_stop = object.stop_when_full();
+            let error = object
+                .write(PropertyIdentifier::RECORD_COUNT, PropertyValue::Unsigned(0))
+                .unwrap_err();
+            assert_protocol(error, ErrorClass::DEVICE, ErrorCode::OPERATIONAL_PROBLEM);
+            assert_eq!(object.records(), &before, "{kind:?}");
+            assert_eq!(object.total(), before_total, "{kind:?}");
+            assert_eq!(object.enabled(), before_enable, "{kind:?}");
+            assert_eq!(object.stop_when_full(), before_stop, "{kind:?}");
+
+            let mut enable = kind.object(2);
+            if let Some(clock) = clock.clone() {
+                enable.bind_clock(clock);
+            }
+            let error = enable
+                .write(
+                    PropertyIdentifier::LOG_ENABLE,
+                    PropertyValue::Boolean(false),
+                )
+                .unwrap_err();
+            assert_protocol(error, ErrorClass::DEVICE, ErrorCode::OPERATIONAL_PROBLEM);
+            assert!(enable.enabled(), "{kind:?}");
+            assert_eq!(enable.total(), 0, "{kind:?}");
+
+            let mut stop = kind.object(2);
+            if let Some(clock) = clock.clone() {
+                stop.bind_clock(clock);
+            }
+            stop.add_record(ordinary(1, 10));
+            stop.add_record(ordinary(2, 20));
+            let before = stop.records().clone();
+            let error = stop
+                .write(
+                    PropertyIdentifier::STOP_WHEN_FULL,
+                    PropertyValue::Boolean(true),
+                )
+                .unwrap_err();
+            assert_protocol(error, ErrorClass::DEVICE, ErrorCode::OPERATIONAL_PROBLEM);
+            assert_eq!(stop.records(), &before, "{kind:?}");
+            assert_eq!(stop.total(), 2, "{kind:?}");
+            assert!(stop.enabled(), "{kind:?}");
+            assert!(!stop.stop_when_full(), "{kind:?}");
+        }
+    }
+}
+
+#[test]
+fn log_family_writability_matches_runtime_routes() {
+    let cases = [
+        (
+            FamilyKind::Event,
+            vec![
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyIdentifier::LOG_INTERVAL,
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyIdentifier::RECORD_COUNT,
+                PropertyIdentifier::OUT_OF_SERVICE,
+                PropertyIdentifier::DESCRIPTION,
+            ],
+        ),
+        (
+            FamilyKind::Trend,
+            vec![
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyIdentifier::LOG_INTERVAL,
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyIdentifier::RECORD_COUNT,
+                PropertyIdentifier::OUT_OF_SERVICE,
+                PropertyIdentifier::DESCRIPTION,
+            ],
+        ),
+        (
+            FamilyKind::TrendMultiple,
+            vec![
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyIdentifier::LOG_INTERVAL,
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyIdentifier::RECORD_COUNT,
+                PropertyIdentifier::DESCRIPTION,
+            ],
+        ),
+    ];
+    for (kind, writable) in cases {
+        let object = kind.object(3);
+        for property in writable {
+            assert!(
+                object.object().is_writable_property(property),
+                "{kind:?} {property:?}"
+            );
+        }
+        for property in [
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::BUFFER_SIZE,
+            PropertyIdentifier::LOG_BUFFER,
+            PropertyIdentifier::TOTAL_RECORD_COUNT,
+            PropertyIdentifier::RELIABILITY,
+        ] {
+            assert!(
+                !object.object().is_writable_property(property),
+                "{kind:?} {property:?}"
+            );
+        }
+        if matches!(kind, FamilyKind::TrendMultiple) {
+            assert!(!object
+                .object()
+                .is_writable_property(PropertyIdentifier::OUT_OF_SERVICE));
+        }
+    }
+}

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -649,4 +649,15 @@ pub trait BACnetObject: Send + Sync {
     ///
     /// Default is a no-op. TrendLog objects override to append to their buffer.
     fn add_trend_record(&mut self, _record: BACnetLogRecord) {}
+
+    /// Fallible internal trend-record insertion used by the server poller.
+    ///
+    /// The default preserves source compatibility with existing implementors by
+    /// invoking the legacy void hook and reporting success. Built-in log objects
+    /// override this to surface mandatory status-timestamp failures atomically.
+    #[doc(hidden)]
+    fn try_add_trend_record_internal(&mut self, record: BACnetLogRecord) -> Result<(), Error> {
+        self.add_trend_record(record);
+        Ok(())
+    }
 }

--- a/crates/bacnet-objects/src/trend/log_record_tests.rs
+++ b/crates/bacnet-objects/src/trend/log_record_tests.rs
@@ -65,6 +65,34 @@ fn trend_log_projects_only_present_status_flags_as_fourth_field() {
 }
 
 #[test]
+fn trend_log_keeps_log_status_and_record_status_flags_as_distinct_bitstrings() {
+    let mut trend = TrendLogObject::new(1, "TL-1", 1).unwrap();
+    let mut status = record(1, 0.0, Some(0b0100));
+    status.log_datum = LogDatum::LogStatus(0b101);
+    trend.add_record(status);
+
+    let projected = projected_records(&trend);
+    let PropertyValue::List(fields) = &projected[0] else {
+        panic!("expected projected record fields");
+    };
+    assert_eq!(fields.len(), 4);
+    assert_eq!(
+        fields[2],
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0b1010_0000],
+        }
+    );
+    assert_eq!(
+        fields[3],
+        PropertyValue::BitString {
+            unused_bits: 4,
+            data: vec![0b0100_0000],
+        }
+    );
+}
+
+#[test]
 fn trend_multiple_retains_raw_flags_but_projects_three_fields() {
     let mut trend = TrendLogMultipleObject::new(1, "TLM-1", 1).unwrap();
     trend.add_record(record(1, 10.0, Some(0b0100)));

--- a/crates/bacnet-objects/src/trend/mod.rs
+++ b/crates/bacnet-objects/src/trend/mod.rs
@@ -2,25 +2,18 @@
 
 use std::borrow::Cow;
 use std::collections::VecDeque;
+use std::sync::Arc;
 
 use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetLogRecord};
 use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
 
+use crate::clock::ClockReader;
 use crate::common::{self, read_property_list_property};
-use crate::log_buffer::{
-    LogRecordBuffer, LogRecordBufferRecords, LogRecordIdentity, LogRecordProfile,
-};
+use crate::log_buffer::{LogRecordBuffer, LogRecordIdentity, LogRecordProfile};
+use crate::log_lifecycle::{LogLifecycle, LogLifecycleSnapshot};
 use crate::traits::{BACnetObject, WritePropertyRollback};
-
-struct TrendLogWriteRollback {
-    records: LogRecordBufferRecords,
-}
-
-struct TrendLogMultipleWriteRollback {
-    records: LogRecordBufferRecords,
-}
 
 /// BACnet TrendLog object.
 ///
@@ -40,6 +33,7 @@ pub struct TrendLogObject {
     status_flags: StatusFlags,
     log_device_object_property: Option<BACnetDeviceObjectPropertyReference>,
     logging_type: u32, // 0=polled, 1=cov, 2=triggered
+    clock: Option<Arc<dyn ClockReader>>,
 }
 
 impl TrendLogObject {
@@ -59,13 +53,13 @@ impl TrendLogObject {
             status_flags: StatusFlags::empty(),
             log_device_object_property: None,
             logging_type: 0,
+            clock: None,
         })
     }
 
     /// Add a BACnetLogRecord to the trend log buffer.
     pub fn add_record(&mut self, record: BACnetLogRecord) {
-        self.log_buffer
-            .append(record, self.log_enable, self.stop_when_full);
+        let _ = self.try_add_record_internal(record);
     }
 
     /// Get the current buffer contents.
@@ -94,6 +88,19 @@ impl TrendLogObject {
     /// Set the logging type (0=polled, 1=cov, 2=triggered).
     pub fn set_logging_type(&mut self, logging_type: u32) {
         self.logging_type = logging_type;
+    }
+
+    fn try_add_record_internal(&mut self, record: BACnetLogRecord) -> Result<(), Error> {
+        self.lifecycle().try_add_ordinary(record).map(|_| ())
+    }
+
+    fn lifecycle(&mut self) -> LogLifecycle<'_> {
+        LogLifecycle::new(
+            &mut self.log_buffer,
+            &mut self.log_enable,
+            &mut self.stop_when_full,
+            self.clock.as_ref(),
+        )
     }
 }
 
@@ -193,8 +200,7 @@ impl BACnetObject for TrendLogObject {
     ) -> Result<(), Error> {
         if property == PropertyIdentifier::LOG_ENABLE {
             if let PropertyValue::Boolean(v) = value {
-                self.log_enable = v;
-                return Ok(());
+                return self.lifecycle().write_enable(v);
             }
             return Err(Error::Protocol {
                 class: ErrorClass::PROPERTY.to_raw() as u32,
@@ -213,8 +219,7 @@ impl BACnetObject for TrendLogObject {
         }
         if property == PropertyIdentifier::STOP_WHEN_FULL {
             if let PropertyValue::Boolean(v) = value {
-                self.stop_when_full = v;
-                return Ok(());
+                return self.lifecycle().write_stop_when_full(v);
             }
             return Err(Error::Protocol {
                 class: ErrorClass::PROPERTY.to_raw() as u32,
@@ -222,10 +227,8 @@ impl BACnetObject for TrendLogObject {
             });
         }
         if property == PropertyIdentifier::RECORD_COUNT {
-            // Writing 0 clears the buffer
             if let PropertyValue::Unsigned(0) = value {
-                self.clear();
-                return Ok(());
+                return self.lifecycle().purge();
             }
             return Err(Error::Protocol {
                 class: ErrorClass::PROPERTY.to_raw() as u32,
@@ -295,17 +298,39 @@ impl BACnetObject for TrendLogObject {
         Cow::Borrowed(PROPS)
     }
 
+    fn bind_clock_internal(&mut self, clock: Option<Arc<dyn ClockReader>>) {
+        self.clock = clock;
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        matches!(
+            property,
+            PropertyIdentifier::LOG_ENABLE
+                | PropertyIdentifier::LOG_INTERVAL
+                | PropertyIdentifier::STOP_WHEN_FULL
+                | PropertyIdentifier::RECORD_COUNT
+                | PropertyIdentifier::OUT_OF_SERVICE
+                | PropertyIdentifier::DESCRIPTION
+        )
+    }
+
     fn capture_write_property_rollback(
         &mut self,
         property: PropertyIdentifier,
         value: &PropertyValue,
     ) -> Option<WritePropertyRollback> {
-        (property == PropertyIdentifier::RECORD_COUNT
+        ((property == PropertyIdentifier::RECORD_COUNT
             && matches!(value, PropertyValue::Unsigned(0)))
+            || (matches!(
+                property,
+                PropertyIdentifier::LOG_ENABLE | PropertyIdentifier::STOP_WHEN_FULL
+            ) && matches!(value, PropertyValue::Boolean(_))))
         .then(|| {
-            WritePropertyRollback::new(TrendLogWriteRollback {
-                records: self.log_buffer.take_records(),
-            })
+            WritePropertyRollback::new(LogLifecycleSnapshot::capture(
+                &self.log_buffer,
+                self.log_enable,
+                self.stop_when_full,
+            ))
         })
     }
 
@@ -313,8 +338,11 @@ impl BACnetObject for TrendLogObject {
         &mut self,
         rollback: WritePropertyRollback,
     ) -> Result<(), Error> {
-        self.log_buffer
-            .restore_records(rollback.downcast::<TrendLogWriteRollback>()?.records);
+        rollback.downcast::<LogLifecycleSnapshot>()?.restore(
+            &mut self.log_buffer,
+            &mut self.log_enable,
+            &mut self.stop_when_full,
+        );
         Ok(())
     }
 
@@ -324,6 +352,10 @@ impl BACnetObject for TrendLogObject {
 
     fn add_trend_record(&mut self, record: BACnetLogRecord) {
         self.add_record(record);
+    }
+
+    fn try_add_trend_record_internal(&mut self, record: BACnetLogRecord) -> Result<(), Error> {
+        self.try_add_record_internal(record)
     }
 }
 
@@ -350,6 +382,7 @@ pub struct TrendLogMultipleObject {
     logging_type: u32, // 0=polled, 1=cov, 2=triggered
     out_of_service: bool,
     reliability: u32,
+    clock: Option<Arc<dyn ClockReader>>,
 }
 
 impl TrendLogMultipleObject {
@@ -369,13 +402,13 @@ impl TrendLogMultipleObject {
             logging_type: 0,
             out_of_service: false,
             reliability: 0,
+            clock: None,
         })
     }
 
     /// Add a BACnetLogRecord to the trend log buffer.
     pub fn add_record(&mut self, record: BACnetLogRecord) {
-        self.log_buffer
-            .append(record, self.log_enable, self.stop_when_full);
+        let _ = self.try_add_record_internal(record);
     }
 
     /// Add a property reference to the monitored list.
@@ -401,6 +434,19 @@ impl TrendLogMultipleObject {
     /// Set the logging type (0=polled, 1=cov, 2=triggered).
     pub fn set_logging_type(&mut self, logging_type: u32) {
         self.logging_type = logging_type;
+    }
+
+    fn try_add_record_internal(&mut self, record: BACnetLogRecord) -> Result<(), Error> {
+        self.lifecycle().try_add_ordinary(record).map(|_| ())
+    }
+
+    fn lifecycle(&mut self) -> LogLifecycle<'_> {
+        LogLifecycle::new(
+            &mut self.log_buffer,
+            &mut self.log_enable,
+            &mut self.stop_when_full,
+            self.clock.as_ref(),
+        )
     }
 }
 
@@ -504,8 +550,7 @@ impl BACnetObject for TrendLogMultipleObject {
     ) -> Result<(), Error> {
         if property == PropertyIdentifier::LOG_ENABLE {
             if let PropertyValue::Boolean(v) = value {
-                self.log_enable = v;
-                return Ok(());
+                return self.lifecycle().write_enable(v);
             }
             return Err(Error::Protocol {
                 class: ErrorClass::PROPERTY.to_raw() as u32,
@@ -524,8 +569,7 @@ impl BACnetObject for TrendLogMultipleObject {
         }
         if property == PropertyIdentifier::STOP_WHEN_FULL {
             if let PropertyValue::Boolean(v) = value {
-                self.stop_when_full = v;
-                return Ok(());
+                return self.lifecycle().write_stop_when_full(v);
             }
             return Err(Error::Protocol {
                 class: ErrorClass::PROPERTY.to_raw() as u32,
@@ -533,10 +577,8 @@ impl BACnetObject for TrendLogMultipleObject {
             });
         }
         if property == PropertyIdentifier::RECORD_COUNT {
-            // Writing 0 clears the buffer
             if let PropertyValue::Unsigned(0) = value {
-                self.clear();
-                return Ok(());
+                return self.lifecycle().purge();
             }
             return Err(Error::Protocol {
                 class: ErrorClass::PROPERTY.to_raw() as u32,
@@ -582,17 +624,38 @@ impl BACnetObject for TrendLogMultipleObject {
         Cow::Borrowed(PROPS)
     }
 
+    fn bind_clock_internal(&mut self, clock: Option<Arc<dyn ClockReader>>) {
+        self.clock = clock;
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        matches!(
+            property,
+            PropertyIdentifier::LOG_ENABLE
+                | PropertyIdentifier::LOG_INTERVAL
+                | PropertyIdentifier::STOP_WHEN_FULL
+                | PropertyIdentifier::RECORD_COUNT
+                | PropertyIdentifier::DESCRIPTION
+        )
+    }
+
     fn capture_write_property_rollback(
         &mut self,
         property: PropertyIdentifier,
         value: &PropertyValue,
     ) -> Option<WritePropertyRollback> {
-        (property == PropertyIdentifier::RECORD_COUNT
+        ((property == PropertyIdentifier::RECORD_COUNT
             && matches!(value, PropertyValue::Unsigned(0)))
+            || (matches!(
+                property,
+                PropertyIdentifier::LOG_ENABLE | PropertyIdentifier::STOP_WHEN_FULL
+            ) && matches!(value, PropertyValue::Boolean(_))))
         .then(|| {
-            WritePropertyRollback::new(TrendLogMultipleWriteRollback {
-                records: self.log_buffer.take_records(),
-            })
+            WritePropertyRollback::new(LogLifecycleSnapshot::capture(
+                &self.log_buffer,
+                self.log_enable,
+                self.stop_when_full,
+            ))
         })
     }
 
@@ -600,10 +663,10 @@ impl BACnetObject for TrendLogMultipleObject {
         &mut self,
         rollback: WritePropertyRollback,
     ) -> Result<(), Error> {
-        self.log_buffer.restore_records(
-            rollback
-                .downcast::<TrendLogMultipleWriteRollback>()?
-                .records,
+        rollback.downcast::<LogLifecycleSnapshot>()?.restore(
+            &mut self.log_buffer,
+            &mut self.log_enable,
+            &mut self.stop_when_full,
         );
         Ok(())
     }
@@ -614,6 +677,10 @@ impl BACnetObject for TrendLogMultipleObject {
 
     fn add_trend_record(&mut self, record: BACnetLogRecord) {
         self.add_record(record);
+    }
+
+    fn try_add_trend_record_internal(&mut self, record: BACnetLogRecord) -> Result<(), Error> {
+        self.try_add_record_internal(record)
     }
 }
 

--- a/crates/bacnet-objects/src/trend/tests.rs
+++ b/crates/bacnet-objects/src/trend/tests.rs
@@ -1,6 +1,25 @@
 use super::*;
+use crate::clock::{ClockFrame, ClockReader};
 use bacnet_types::constructed::LogDatum;
 use bacnet_types::primitives::{Date, Time};
+use std::sync::Arc;
+
+struct FixedClock;
+
+impl ClockReader for FixedClock {
+    fn read_clock(&self) -> Option<ClockFrame> {
+        Some(ClockFrame {
+            local_date: make_record(9, 0.0).date,
+            local_time: make_record(9, 0.0).time,
+            utc_offset: 0,
+            daylight_savings_status: false,
+        })
+    }
+}
+
+fn bind_clock(object: &mut dyn BACnetObject) {
+    object.bind_clock_internal(Some(Arc::new(FixedClock)));
+}
 
 fn make_record(hour: u8, value: f32) -> BACnetLogRecord {
     BACnetLogRecord {
@@ -70,6 +89,7 @@ fn trendlog_ring_buffer_wraps() {
 #[test]
 fn trendlog_stop_when_full() {
     let mut tl = TrendLogObject::new(1, "TL-1", 2).unwrap();
+    bind_clock(&mut tl);
     tl.write_property(
         PropertyIdentifier::STOP_WHEN_FULL,
         None,
@@ -91,6 +111,7 @@ fn trendlog_stop_when_full() {
 #[test]
 fn trendlog_disable_logging() {
     let mut tl = TrendLogObject::new(1, "TL-1", 100).unwrap();
+    bind_clock(&mut tl);
     tl.write_property(
         PropertyIdentifier::LOG_ENABLE,
         None,
@@ -99,12 +120,14 @@ fn trendlog_disable_logging() {
     )
     .unwrap();
     tl.add_record(make_record(10, 72.5));
-    assert_eq!(tl.records().len(), 0);
+    assert_eq!(tl.records().len(), 1);
+    assert_eq!(tl.records()[0].log_datum, LogDatum::LogStatus(0b001));
 }
 
 #[test]
 fn trendlog_clear_buffer() {
     let mut tl = TrendLogObject::new(1, "TL-1", 100).unwrap();
+    bind_clock(&mut tl);
     tl.add_record(make_record(10, 72.5));
     assert_eq!(tl.records().len(), 1);
     tl.write_property(
@@ -114,7 +137,8 @@ fn trendlog_clear_buffer() {
         None,
     )
     .unwrap();
-    assert_eq!(tl.records().len(), 0);
+    assert_eq!(tl.records().len(), 1);
+    assert_eq!(tl.records()[0].log_datum, LogDatum::LogStatus(0b010));
 }
 
 #[test]
@@ -213,6 +237,7 @@ fn trendlog_log_buffer_empty() {
 #[test]
 fn trendlog_log_buffer_overflow_stop_when_full() {
     let mut tl = TrendLogObject::new(1, "TL-1", 3).unwrap();
+    bind_clock(&mut tl);
     tl.write_property(
         PropertyIdentifier::STOP_WHEN_FULL,
         None,
@@ -235,7 +260,13 @@ fn trendlog_log_buffer_overflow_stop_when_full() {
             panic!("Expected List");
         }
         if let PropertyValue::List(fields) = &records[2] {
-            assert_eq!(fields[2], PropertyValue::Real(20.0));
+            assert_eq!(
+                fields[2],
+                PropertyValue::BitString {
+                    unused_bits: 5,
+                    data: vec![0b0010_0000],
+                }
+            );
         } else {
             panic!("Expected List");
         }
@@ -507,6 +538,7 @@ fn trendlog_multiple_empty_property_references() {
 #[test]
 fn trendlog_multiple_write_log_enable() {
     let mut tlm = TrendLogMultipleObject::new(1, "TLM-1", 100).unwrap();
+    bind_clock(&mut tlm);
     tlm.write_property(
         PropertyIdentifier::LOG_ENABLE,
         None,
@@ -521,7 +553,8 @@ fn trendlog_multiple_write_log_enable() {
     );
     // Records should not be added when disabled
     tlm.add_record(make_record(10, 72.5));
-    assert_eq!(tlm.records().len(), 0);
+    assert_eq!(tlm.records().len(), 1);
+    assert_eq!(tlm.records()[0].log_datum, LogDatum::LogStatus(0b001));
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -58,6 +58,7 @@ mod reference_writes;
 mod wpm_create_alarm;
 mod wpm_event_rollback;
 mod wpm_fault_rollback;
+mod wpm_log_lifecycle;
 mod wpm_multistate_reliability_rollback;
 mod wpm_parameter_rollback;
 mod wpm_rollback_contract;

--- a/crates/bacnet-server/src/handlers/tests/wpm_log_lifecycle.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_log_lifecycle.rs
@@ -1,0 +1,194 @@
+use super::*;
+use bacnet_objects::clock::{ClockFrame, ClockReader};
+use bacnet_objects::event_log::EventLogObject;
+use bacnet_objects::trend::{TrendLogMultipleObject, TrendLogObject};
+use bacnet_services::common::BACnetPropertyValue;
+use bacnet_services::wpm::{WriteAccessSpecification, WritePropertyMultipleRequest};
+use bacnet_types::constructed::{BACnetLogRecord, LogDatum};
+use bacnet_types::primitives::{Date, Time};
+use std::sync::Arc;
+
+struct FixedClock;
+
+impl ClockReader for FixedClock {
+    fn read_clock(&self) -> Option<ClockFrame> {
+        Some(ClockFrame {
+            local_date: Date {
+                year: 124,
+                month: 2,
+                day: 29,
+                day_of_week: 4,
+            },
+            local_time: Time {
+                hour: 12,
+                minute: 0,
+                second: 0,
+                hundredths: 0,
+            },
+            utc_offset: 0,
+            daylight_savings_status: false,
+        })
+    }
+}
+
+fn record() -> BACnetLogRecord {
+    BACnetLogRecord {
+        date: Date {
+            year: 126,
+            month: 8,
+            day: 31,
+            day_of_week: 1,
+        },
+        time: Time {
+            hour: 1,
+            minute: 2,
+            second: 3,
+            hundredths: 4,
+        },
+        log_datum: LogDatum::RealValue(42.0),
+        status_flags: None,
+    }
+}
+
+fn failed_wpm(
+    db: &mut ObjectDatabase,
+    oid: ObjectIdentifier,
+    property: PropertyIdentifier,
+    value: Vec<u8>,
+) -> (Result<Vec<ObjectIdentifier>, Error>, Vec<ObjectIdentifier>) {
+    let mut read_only = BytesMut::new();
+    bacnet_encoding::primitives::encode_app_enumerated(&mut read_only, 0);
+    let request = WritePropertyMultipleRequest {
+        list_of_write_access_specs: vec![WriteAccessSpecification {
+            object_identifier: oid,
+            list_of_properties: vec![
+                BACnetPropertyValue {
+                    property_identifier: property,
+                    property_array_index: None,
+                    value,
+                    priority: None,
+                },
+                BACnetPropertyValue {
+                    property_identifier: PropertyIdentifier::OBJECT_TYPE,
+                    property_array_index: None,
+                    value: read_only.to_vec(),
+                    priority: None,
+                },
+            ],
+        }],
+    };
+    let mut request_bytes = BytesMut::new();
+    request.encode(&mut request_bytes);
+    handle_write_property_multiple_with_residuals(db, &request_bytes)
+}
+
+#[derive(Clone, Copy)]
+enum LogKind {
+    Event,
+    Trend,
+    TrendMultiple,
+}
+
+fn add_full_log(db: &mut ObjectDatabase, kind: LogKind) -> ObjectIdentifier {
+    match kind {
+        LogKind::Event => {
+            let mut object = EventLogObject::new(1, "EL-1", 3).unwrap();
+            for _ in 0..3 {
+                object.add_record(record());
+            }
+            let oid = object.object_identifier();
+            db.add(Box::new(object)).unwrap();
+            oid
+        }
+        LogKind::Trend => {
+            let mut object = TrendLogObject::new(1, "TL-1", 3).unwrap();
+            for _ in 0..3 {
+                object.add_record(record());
+            }
+            let oid = object.object_identifier();
+            db.add(Box::new(object)).unwrap();
+            oid
+        }
+        LogKind::TrendMultiple => {
+            let mut object = TrendLogMultipleObject::new(1, "TLM-1", 3).unwrap();
+            for _ in 0..3 {
+                object.add_record(record());
+            }
+            let oid = object.object_identifier();
+            db.add(Box::new(object)).unwrap();
+            oid
+        }
+    }
+}
+
+#[test]
+fn log_enable_and_stop_rollback_restore_exact_lifecycle() {
+    for kind in [LogKind::Event, LogKind::Trend, LogKind::TrendMultiple] {
+        for property in [
+            PropertyIdentifier::LOG_ENABLE,
+            PropertyIdentifier::STOP_WHEN_FULL,
+        ] {
+            let mut db = ObjectDatabase::new();
+            db.set_clock_reader(Some(Arc::new(FixedClock)));
+            let oid = add_full_log(&mut db, kind);
+            let object = db.get(&oid).unwrap();
+            let before_buffer = object
+                .read_property(PropertyIdentifier::LOG_BUFFER, None)
+                .unwrap();
+            let before_total = object
+                .read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+                .unwrap();
+            let before_enable = object
+                .read_property(PropertyIdentifier::LOG_ENABLE, None)
+                .unwrap();
+            let before_stop = object
+                .read_property(PropertyIdentifier::STOP_WHEN_FULL, None)
+                .unwrap();
+            let before_identities = object.log_record_identities_internal().unwrap();
+
+            let mut value = BytesMut::new();
+            bacnet_encoding::primitives::encode_app_boolean(
+                &mut value,
+                property == PropertyIdentifier::STOP_WHEN_FULL,
+            );
+            let (result, residual_oids) = failed_wpm(&mut db, oid, property, value.to_vec());
+
+            assert!(result.is_err(), "{property:?} {oid:?}");
+            assert!(residual_oids.is_empty(), "{property:?} {oid:?}");
+            let object = db.get(&oid).unwrap();
+            assert_eq!(
+                object
+                    .read_property(PropertyIdentifier::LOG_BUFFER, None)
+                    .unwrap(),
+                before_buffer,
+                "{property:?} {oid:?}"
+            );
+            assert_eq!(
+                object
+                    .read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+                    .unwrap(),
+                before_total,
+                "{property:?} {oid:?}"
+            );
+            assert_eq!(
+                object
+                    .read_property(PropertyIdentifier::LOG_ENABLE, None)
+                    .unwrap(),
+                before_enable,
+                "{property:?} {oid:?}"
+            );
+            assert_eq!(
+                object
+                    .read_property(PropertyIdentifier::STOP_WHEN_FULL, None)
+                    .unwrap(),
+                before_stop,
+                "{property:?} {oid:?}"
+            );
+            assert_eq!(
+                object.log_record_identities_internal().unwrap(),
+                before_identities,
+                "{property:?} {oid:?}"
+            );
+        }
+    }
+}

--- a/crates/bacnet-server/src/handlers/tests/wpm_rollback_contract.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_rollback_contract.rs
@@ -409,6 +409,7 @@ fn access_door_rollback_restores_priority_array() {
 #[test]
 fn log_record_count_rollback_restores_cleared_buffers() {
     let mut db = ObjectDatabase::new();
+    db.set_clock_reader(Some(Arc::new(FixedAuditClock)));
     let mut trend = TrendLogObject::new(1, "TL-1", 10).unwrap();
     trend.add_record(log_record());
     trend.add_record(log_record());
@@ -530,7 +531,34 @@ fn log_record_count_rollback_restores_cleared_buffers() {
                 .unwrap()
                 .read_property(PropertyIdentifier::RECORD_COUNT, None)
                 .unwrap(),
-            PropertyValue::Unsigned(0),
+            PropertyValue::Unsigned(1),
+            "{oid:?}"
+        );
+        assert_eq!(
+            db.get(&oid)
+                .unwrap()
+                .read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+                .unwrap(),
+            PropertyValue::Unsigned(3),
+            "{oid:?}"
+        );
+        let PropertyValue::List(records) = db
+            .get(&oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::LOG_BUFFER, None)
+            .unwrap()
+        else {
+            panic!("expected log records for {oid:?}");
+        };
+        let PropertyValue::List(fields) = &records[0] else {
+            panic!("expected log record fields for {oid:?}");
+        };
+        assert_eq!(
+            fields[2],
+            PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0b0100_0000],
+            },
             "{oid:?}"
         );
     }

--- a/crates/bacnet-server/src/pics/truth_source_tests.rs
+++ b/crates/bacnet-server/src/pics/truth_source_tests.rs
@@ -16,8 +16,11 @@ use bacnet_objects::multistate::{
     MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject,
 };
 use bacnet_objects::traits::BACnetObject;
-use bacnet_types::enums::PropertyIdentifier;
+use bacnet_types::enums::{ObjectType, PropertyIdentifier};
 use bacnet_types::primitives::PropertyValue;
+
+use super::{PicsConfig, PicsGenerator};
+use crate::server::ServerConfig;
 
 /// Cross-check the central truth-source invariant: for every core I/O/V type,
 /// `is_writable_property` and `write_property` must agree. If the override
@@ -529,4 +532,76 @@ fn is_writable_property_matches_write_property_on_pulse_converter_and_averaging(
             ),
         ],
     );
+}
+
+#[test]
+fn pics_log_family_writability_comes_from_runtime_routes() {
+    use bacnet_objects::database::ObjectDatabase;
+    use bacnet_objects::event_log::EventLogObject;
+    use bacnet_objects::trend::{TrendLogMultipleObject, TrendLogObject};
+
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(EventLogObject::new(1, "EL-1", 3).unwrap()))
+        .unwrap();
+    db.add(Box::new(TrendLogObject::new(1, "TL-1", 3).unwrap()))
+        .unwrap();
+    db.add(Box::new(
+        TrendLogMultipleObject::new(1, "TLM-1", 3).unwrap(),
+    ))
+    .unwrap();
+    let server_config = ServerConfig::default();
+    let pics_config = PicsConfig::default();
+    let pics = PicsGenerator::new(&db, &server_config, &pics_config).generate();
+
+    let cases = [
+        (
+            ObjectType::EVENT_LOG,
+            &[
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyIdentifier::LOG_INTERVAL,
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyIdentifier::RECORD_COUNT,
+                PropertyIdentifier::OUT_OF_SERVICE,
+                PropertyIdentifier::DESCRIPTION,
+            ][..],
+        ),
+        (
+            ObjectType::TREND_LOG,
+            &[
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyIdentifier::LOG_INTERVAL,
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyIdentifier::RECORD_COUNT,
+                PropertyIdentifier::OUT_OF_SERVICE,
+                PropertyIdentifier::DESCRIPTION,
+            ][..],
+        ),
+        (
+            ObjectType::TREND_LOG_MULTIPLE,
+            &[
+                PropertyIdentifier::LOG_ENABLE,
+                PropertyIdentifier::LOG_INTERVAL,
+                PropertyIdentifier::STOP_WHEN_FULL,
+                PropertyIdentifier::RECORD_COUNT,
+                PropertyIdentifier::DESCRIPTION,
+            ][..],
+        ),
+    ];
+    for (object_type, expected) in cases {
+        let support = pics
+            .supported_object_types
+            .iter()
+            .find(|support| support.object_type == object_type)
+            .unwrap();
+        let writable = support
+            .supported_properties
+            .iter()
+            .filter(|property| property.access.writable)
+            .map(|property| property.property_id)
+            .collect::<Vec<_>>();
+        assert_eq!(writable.len(), expected.len(), "{object_type:?}");
+        for property in expected {
+            assert!(writable.contains(property), "{object_type:?} {property:?}");
+        }
+    }
 }

--- a/crates/bacnet-server/src/trend_log.rs
+++ b/crates/bacnet-server/src/trend_log.rs
@@ -169,7 +169,10 @@ pub async fn poll_trend_logs(db: &Arc<RwLock<ObjectDatabase>>, state: &TrendLogS
         let record = make_record(datum);
 
         if let Some(trend_obj) = db_write.get_mut(&trend_oid) {
-            trend_obj.add_trend_record(record);
+            if let Err(error) = trend_obj.try_add_trend_record_internal(record) {
+                warn!(object = %trend_oid, %error, "trend-log record insertion failed");
+                continue;
+            }
         }
 
         last_log.insert(trend_oid, now);
@@ -179,6 +182,10 @@ pub async fn poll_trend_logs(db: &Arc<RwLock<ObjectDatabase>>, state: &TrendLogS
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bacnet_objects::analog::AnalogValueObject;
+    use bacnet_objects::traits::BACnetObject;
+    use bacnet_objects::trend::TrendLogObject;
+    use bacnet_types::constructed::BACnetDeviceObjectPropertyReference;
 
     #[test]
     fn property_value_to_datum_real() {
@@ -214,5 +221,66 @@ mod tests {
         assert!(record.time.hour < 24);
         assert!(record.time.minute < 60);
         assert!(record.time.second < 60);
+    }
+
+    #[tokio::test]
+    async fn poller_retries_when_mandatory_stop_status_has_no_clock() {
+        let mut db = ObjectDatabase::new();
+        let target = AnalogValueObject::new(1, "AV-1", 95).unwrap();
+        let target_oid = target.object_identifier();
+        db.add(Box::new(target)).unwrap();
+
+        let mut trend = TrendLogObject::new(1, "TL-1", 1).unwrap();
+        trend.set_log_device_object_property(Some(BACnetDeviceObjectPropertyReference {
+            object_identifier: target_oid,
+            property_identifier: PropertyIdentifier::PRESENT_VALUE.to_raw(),
+            property_array_index: None,
+            device_identifier: None,
+        }));
+        trend
+            .write_property(
+                PropertyIdentifier::LOG_INTERVAL,
+                None,
+                PropertyValue::Unsigned(1),
+                None,
+            )
+            .unwrap();
+        trend
+            .write_property(
+                PropertyIdentifier::STOP_WHEN_FULL,
+                None,
+                PropertyValue::Boolean(true),
+                None,
+            )
+            .unwrap();
+        let trend_oid = trend.object_identifier();
+        db.add(Box::new(trend)).unwrap();
+
+        let db = Arc::new(RwLock::new(db));
+        let state = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        poll_trend_logs(&db, &state).await;
+
+        let db = db.read().await;
+        let trend = db.get(&trend_oid).unwrap();
+        assert_eq!(
+            trend
+                .read_property(PropertyIdentifier::RECORD_COUNT, None)
+                .unwrap(),
+            PropertyValue::Unsigned(0)
+        );
+        assert_eq!(
+            trend
+                .read_property(PropertyIdentifier::TOTAL_RECORD_COUNT, None)
+                .unwrap(),
+            PropertyValue::Unsigned(0)
+        );
+        assert_eq!(
+            trend
+                .read_property(PropertyIdentifier::LOG_ENABLE, None)
+                .unwrap(),
+            PropertyValue::Boolean(true)
+        );
+        drop(db);
+        assert!(!state.lock().await.contains_key(&trend_oid));
     }
 }

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -402,7 +402,40 @@
    ],
    "benchmarks": [],
    "public_claims": [],
-   "notes": "In-memory storage/model foundation only; this row makes no public support claim. Sequence identity is object metadata and is never serialized in LOG_BUFFER. Trend Log alone projects a present legacy BACnetLogRecord.status_flags value as its formal optional fourth StatusFlags bitstring; Event Log and Trend Log Multiple retain that raw shared-Rust field for source compatibility but always project only Date, Time, and datum. ReadRange By-Sequence/By-Time behavior, First Sequence Number, restart durability/persistence, formal EventLog notification-record modeling, and mandatory purge/status records remain deferred."
+    "notes": "In-memory storage/model foundation only; this row makes no public support claim. Sequence identity is object metadata and is never serialized in LOG_BUFFER. Trend Log alone projects a present legacy BACnetLogRecord.status_flags value as its formal optional fourth StatusFlags bitstring; Event Log and Trend Log Multiple retain that raw shared-Rust field for source compatibility but always project only Date, Time, and datum. Mandatory purge/status lifecycle behavior is tracked separately by BACNET-12-LOG-STATUS-LIFECYCLE. ReadRange By-Sequence/By-Time behavior, First Sequence Number, restart durability/persistence, and formal EventLog notification-record modeling remain deferred."
+  },
+  {
+   "id": "BACNET-12-LOG-STATUS-LIFECYCLE",
+   "standard_anchor": "Clause 12.25 Trend Log (pp. 319-336); Clause 12.27 Event Log (pp. 337-346); Clause 12.30 Trend Log Multiple (pp. 361-378); Clause 21.6 BACnetLogStatus (p. 914)",
+   "priority": "P1",
+   "requirement_summary": "Event Log, Trend Log, and Trend Log Multiple append mandatory BUFFER_PURGED and LOG_DISABLED lifecycle records with object-local Date/Time, deterministic Stop_When_Full ordering, non-recursive forced insertion, stable total-record identity, zero-capacity count-only behavior, and atomic clock/error handling.",
+   "status": "in-progress",
+   "code_anchors": [
+    "crates/bacnet-objects/src/log_lifecycle.rs::LogLifecycle",
+    "crates/bacnet-objects/src/log_buffer.rs::OrdinaryAdmission",
+    "crates/bacnet-objects/src/event_log.rs::EventLogObject",
+    "crates/bacnet-objects/src/trend/mod.rs::TrendLogObject",
+    "crates/bacnet-objects/src/trend/mod.rs::TrendLogMultipleObject",
+    "crates/bacnet-objects/src/traits.rs::BACnetObject::try_add_trend_record_internal",
+    "crates/bacnet-server/src/trend_log.rs::poll_trend_logs"
+   ],
+   "positive_tests": [
+    "crates/bacnet-objects/src/log_status_tests.rs::purge_is_unconditional_initial_status_and_repeats_for_every_log_family",
+    "crates/bacnet-objects/src/log_status_tests.rs::stop_before_full_omits_triggering_ordinary_and_clock_failure_is_atomic",
+    "crates/bacnet-objects/src/log_status_tests.rs::enable_and_stop_when_full_transitions_emit_exactly_one_status",
+    "crates/bacnet-objects/src/log_status_tests.rs::zero_capacity_counts_without_residents_and_enforces_full_enable_gate",
+    "crates/bacnet-objects/src/trend/log_record_tests.rs::trend_log_keeps_log_status_and_record_status_flags_as_distinct_bitstrings",
+    "crates/bacnet-server/src/handlers/tests/wpm_rollback_contract.rs::log_record_count_rollback_restores_cleared_buffers",
+    "crates/bacnet-server/src/handlers/tests/wpm_log_lifecycle.rs::log_enable_and_stop_rollback_restore_exact_lifecycle",
+    "crates/bacnet-server/src/pics/truth_source_tests.rs::pics_log_family_writability_comes_from_runtime_routes"
+   ],
+   "negative_tests": [
+    "crates/bacnet-objects/src/log_status_tests.rs::status_writes_require_a_valid_clock_before_mutation",
+    "crates/bacnet-server/src/trend_log.rs::tests::poller_retries_when_mandatory_stop_status_has_no_clock"
+   ],
+   "benchmarks": [],
+   "public_claims": [],
+   "notes": "Qualified PR-0702 evidence only; no full log-family support claim is made. The shared lifecycle covers explicit effective Enable transitions, Record_Count zero purges, Stop_When_Full activation/full behavior, and ordinary stop-before-full insertion. Public constructors, records(), add_record(), and raw clear() remain compatible. Time-window Start_Time/Stop_Time transitions, LOG_INTERRUPTED, writable Log_DeviceObjectProperty purge paths, formal EventLog notification records, Trend Log Multiple polling, ReadRange, First Sequence Number, persistence/restart, and complete log conformance remain deferred."
   },
   {
    "id": "BACNET-12-PROPERTY-METADATA-CORE",

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -13,7 +13,7 @@
 | Dimension | Value | Count |
 |---|---|---|
 | Priority | P0 | 16 |
-| Priority | P1 | 37 |
+| Priority | P1 | 38 |
 | Priority | P2 | 5 |
 | Priority | P3 | 4 |
 | Status | deferred-pending-owner-decision | 2 |
@@ -25,7 +25,7 @@
 | Status | implementation-present-needs-state-machine-audit | 4 |
 | Status | implementation-present-needs-timeout-tests | 1 |
 | Status | implementation-present-needs-window-tests | 1 |
-| Status | in-progress | 6 |
+| Status | in-progress | 7 |
 | Status | supported-with-clause-evidence | 15 |
 | Status | unknown-pending-source-review | 4 |
 | Status | unsupported-by-design | 3 |
@@ -48,6 +48,7 @@
 | `BACNET-11-LONTALK` | Clause 11 | P3 | unknown-pending-source-review | 0 |
 | `BACNET-12-OBJECT-MODEL` | Clauses 12-19 | P1 | implementation-present-needs-conformance-tests | 3 |
 | `BACNET-12-LOG-RECORD-IDENTITY` | Clause 12.25 (p. 319), Clause 12.27 (p. 337), Clause 12.30 (p. 361); Clause 15.8 (pp. 745-750); Clause 21.6 (pp. 902-914) | P1 | in-progress | 0 |
+| `BACNET-12-LOG-STATUS-LIFECYCLE` | Clause 12.25 Trend Log (pp. 319-336); Clause 12.27 Event Log (pp. 337-346); Clause 12.30 Trend Log Multiple (pp. 361-378); Clause 21.6 BACnetLogStatus (p. 914) | P1 | in-progress | 0 |
 | `BACNET-12-PROPERTY-METADATA-CORE` | Clause 12.6, Table 12-6 (pp. 189-190); Clause 12.42, Table 12-49 (pp. 444-445); Clause 15.7.3.1 (p. 743); Annex A (pp. 964-965) | P1 | in-progress | 1 |
 | `BACNET-12-ESCALATOR-STATUS-WRITABILITY` | Clause 12 general property conformance rules; Clause 12.60 Table 12-78 and Out_Of_Service; Clause 15.9.1.3; Clause 21 BACnetEscalatorMode, BACnetEscalatorOperationDirection, and BACnetEscalatorFault; Clause 23.1 | P1 | supported-with-clause-evidence | 0 |
 | `BACNET-12-DEVICE-MAX-SEGMENTS` | Clause 12.11, Table 12-13 | P1 | implementation-present-needs-conformance-tests | 0 |


### PR DESCRIPTION
## Summary
- add one shared, non-recursive lifecycle for mandatory `BACnetLogStatus` records across Event Log, Trend Log, and Trend Log Multiple
- emit `BUFFER_PURGED` for every protocol `Record_Count=0` purge and `LOG_DISABLED` for effective enable/disable and `Stop_When_Full` transitions
- validate the object-bound local clock before mutation and preserve exact WritePropertyMultiple rollback of records, identities, and flags
- keep public infallible `add_record()` and raw `clear()` source-compatible while giving the server poller a defaulted fallible internal hook
- project log status as the canonical three-bit `BACnetLogStatus` bitstring and retain zero-capacity events as count/identity-only

## Standard traceability
| ANSI/ASHRAE 135-2020 source | Implemented behavior |
|---|---|
| §12.25 Trend Log | Mandatory purge, effective enable-state, and stop-before-full status lifecycle for Trend Log |
| §12.27 Event Log | The same lifecycle for Event Log; corrects the stale §12.28 source comment |
| §12.30 Trend Log Multiple | The same lifecycle for Trend Log Multiple |
| §21.6 BACnetLogStatus | Canonical three-bit projection: `LOG_DISABLED`, `BUFFER_PURGED`, and reserved deferred `LOG_INTERRUPTED` |

Status-triggering writes fail atomically with `DEVICE / OPERATIONAL_PROBLEM` when no valid bound object clock is available. A status record that fills a `Stop_When_Full` buffer carries `LOG_DISABLED` in that same record; purge-plus-fill carries `BUFFER_PURGED | LOG_DISABLED`.

## Validation
- focused shared lifecycle, family, projection, zero-capacity, poller, WPM rollback, and PICS tests
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-server --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- repository CI-native workspace tests
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

## Compatibility and deferrals
- public `add_record()`, `records()`, and raw `clear()` remain compatible
- raw `clear()` intentionally does not synthesize a status record; protocol `Record_Count=0` does
- time-window transitions, `LOG_INTERRUPTED`, writable `Log_DeviceObjectProperty` purge routes, formal Event Log notification payloads, Trend Log Multiple polling, ReadRange, First Sequence Number, persistence/restart, and full log-family conformance remain deferred
- conformance evidence remains qualified `in-progress` and makes no public support claim

Closes #189