### PR TITLE
feat(server): support ReadRange by time for log buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Exact ReadRange By Position and By Sequence selection for sequence-numbered
-  Event Log, Trend Log, and Trend Log Multiple buffers (#134, #339). Signed
-  ranges now select around an exact one-based position or stable resident
-  sequence identity without sorting or sequence arithmetic, preserve FIFO,
-  purge-status, and Unsigned32 wrap order, return exact endpoint flags and
-  First Sequence Number metadata, and stage the complete ACK before emission.
-  The client now rejects missing or zero sequence metadata on nonempty By
-  Sequence/By Time ACKs and rejects unexpected metadata elsewhere. By Time,
-  indexed Log_Buffer reads, response-size pagination/segmentation, persistence,
-  and complete log-family conformance remain deferred.
+- Exact ReadRange By Position, By Sequence, and By Time selection for resident
+  Event Log, Trend Log, and Trend Log Multiple buffers (#134, #339). By Time
+  validates aligned specific record timestamps, anchors strictly after/before
+  the reference without sorting clock-rollback records, and returns resident
+  order with exact endpoint flags. Nonempty By Sequence and By Time ACKs carry
+  the oldest returned record's nonzero First Sequence Number. ReadRange rejects
+  every array index on these BACnetLIST properties. Trend preserves its formal
+  optional record StatusFlags bytes; Event and Trend Log Multiple keep the
+  shared raw field but serialize only Date, Time, and datum. Complete ACKs
+  remain staged before emission; response-size pagination/segmentation,
+  persistence, and full ReadRange/log-family conformance remain deferred.
 
 - Mandatory `BACnetLogStatus` lifecycle records for Event Log, Trend Log, and
   Trend Log Multiple (#189). `Record_Count=0`, effective Enable transitions,
@@ -30,8 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   defaulted fallible hook so mandatory timestamp failures remain retryable.
   Time-window transitions, `LOG_INTERRUPTED`, writable
   `Log_DeviceObjectProperty` purge routes, formal Event Log notification
-  payloads, ReadRange By Time, persistence, and full log conformance remain
-  deferred.
+  payloads, persistence, and full log conformance remain deferred.
 
 - Stable in-memory record identity for Event Log, Trend Log, and Trend Log
   Multiple (#134, #339). Each accepted append now owns a nonzero Unsigned32
@@ -42,8 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing public `records()` and `add_record()` signatures. Trend Log projects
   a present optional record StatusFlags bitstring; Event Log and Trend Log
   Multiple retain the legacy raw Rust field but do not put it on the wire.
-  ReadRange By Time selection, persistence, and formal Event Log notification
-  records remain deferred.
+  Persistence and formal Event Log notification records remain deferred.
 
 - Object-owned multi-state configuration Reliability and recovery for
   Multi-state Input, Output, and Value (#226). The Standard requires

--- a/crates/bacnet-server/src/handlers/read_range.rs
+++ b/crates/bacnet-server/src/handlers/read_range.rs
@@ -1,7 +1,9 @@
 use std::ops::Range;
 
 use super::*;
+use bacnet_objects::log_buffer::LogRecordIdentity;
 use bacnet_services::read_range::{RangeSpec, ReadRangeAck, ReadRangeRequest};
+use bacnet_types::primitives::{Date, Time};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct SignedRangeSelection {
@@ -62,6 +64,76 @@ fn list_item_not_numbered() -> Error {
     }
 }
 
+fn list_item_not_timestamped() -> Error {
+    Error::Protocol {
+        class: ErrorClass::PROPERTY.to_raw() as u32,
+        code: ErrorCode::LIST_ITEM_NOT_TIMESTAMPED.to_raw() as u32,
+    }
+}
+
+type CivilDateTime = (u16, u8, u8, u8, u8, u8, u8);
+
+fn civil_datetime(date: Date, time: Time) -> Option<CivilDateTime> {
+    let year = date.actual_year()?;
+    if !(1..=12).contains(&date.month)
+        || !(1..=31).contains(&date.day)
+        || !(1..=7).contains(&date.day_of_week)
+        || !(0..=23).contains(&time.hour)
+        || !(0..=59).contains(&time.minute)
+        || !(0..=59).contains(&time.second)
+        || !(0..=99).contains(&time.hundredths)
+    {
+        return None;
+    }
+    Some((
+        year,
+        date.month,
+        date.day,
+        time.hour,
+        time.minute,
+        time.second,
+        time.hundredths,
+    ))
+}
+
+/// Select a signed ReadRange window around the resident timestamp anchor.
+///
+/// Identity validation is all-or-nothing. The endpoint scan follows resident
+/// order, while timestamp comparison ignores day-of-week after validating it.
+pub(super) fn select_time_range(
+    item_count: usize,
+    identities: Option<&[LogRecordIdentity]>,
+    reference_time: (Date, Time),
+    count: i32,
+) -> Result<(SignedRangeSelection, Option<u32>), Error> {
+    let identities = identities.ok_or_else(list_item_not_timestamped)?;
+    if identities.len() != item_count {
+        return Err(list_item_not_timestamped());
+    }
+    let reference =
+        civil_datetime(reference_time.0, reference_time.1).ok_or_else(list_item_not_timestamped)?;
+    let timestamps = identities
+        .iter()
+        .map(|identity| civil_datetime(identity.date(), identity.time()))
+        .collect::<Option<Vec<_>>>()
+        .ok_or_else(list_item_not_timestamped)?;
+    let anchor = if count > 0 {
+        timestamps
+            .iter()
+            .position(|timestamp| *timestamp > reference)
+    } else {
+        timestamps
+            .iter()
+            .rposition(|timestamp| *timestamp < reference)
+    };
+    let selection = select_signed_range(item_count, anchor, count);
+    let first_sequence_number = identities
+        .get(selection.range.start)
+        .filter(|_| !selection.range.is_empty())
+        .map(LogRecordIdentity::sequence_number);
+    Ok((selection, first_sequence_number))
+}
+
 pub(super) fn append_read_range_ack_with<F>(
     request: &ReadRangeRequest,
     items: &[PropertyValue],
@@ -96,9 +168,8 @@ where
 
 /// Handle a ReadRange request.
 ///
-/// By Position uses the list's exact one-based order. By Sequence is available
-/// only for `LOG_BUFFER` when the object supplies aligned resident identities.
-/// By Time remains explicitly unsupported by this handler.
+/// By Position uses the list's exact one-based order. By Sequence and By Time
+/// use aligned resident identities supplied for `LOG_BUFFER` by the object.
 pub fn handle_read_range(
     db: &ObjectDatabase,
     service_data: &[u8],
@@ -109,6 +180,14 @@ pub fn handle_read_range(
         class: ErrorClass::OBJECT.to_raw() as u32,
         code: ErrorCode::UNKNOWN_OBJECT.to_raw() as u32,
     })?;
+    if request.property_array_index.is_some()
+        && !object.is_array_property(request.property_identifier)
+    {
+        return Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::PROPERTY_IS_NOT_AN_ARRAY.to_raw() as u32,
+        });
+    }
     let value = object.read_property(request.property_identifier, request.property_array_index)?;
     let items = match value {
         PropertyValue::List(items) => items,
@@ -155,11 +234,15 @@ pub fn handle_read_range(
                 .then(|| identities[selection.range.start].sequence_number());
             (selection, first_sequence_number)
         }
-        Some(RangeSpec::ByTime { .. }) => {
-            return Err(Error::Protocol {
-                class: ErrorClass::SERVICES.to_raw() as u32,
-                code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
-            });
+        Some(RangeSpec::ByTime {
+            reference_time,
+            count,
+        }) => {
+            if request.property_identifier != PropertyIdentifier::LOG_BUFFER {
+                return Err(list_item_not_timestamped());
+            }
+            let identities = object.log_record_identities_internal();
+            select_time_range(items.len(), identities.as_deref(), *reference_time, *count)?
         }
     };
 

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -54,6 +54,7 @@ mod passwords;
 mod property_metadata;
 mod read_event_arrays;
 mod read_range;
+mod read_range_time;
 mod read_rpm;
 mod reference_writes;
 mod wpm_create_alarm;

--- a/crates/bacnet-server/src/handlers/tests/read_range.rs
+++ b/crates/bacnet-server/src/handlers/tests/read_range.rs
@@ -2,29 +2,22 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use super::*;
-use bacnet_client::client::BACnetClient;
-use bacnet_encoding::apdu::{decode_apdu, encode_apdu, Apdu, ComplexAck};
-use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
 use bacnet_objects::clock::{ClockFrame, ClockReader};
 use bacnet_objects::event_log::EventLogObject;
 use bacnet_objects::log_buffer::LogRecordIdentity;
 use bacnet_objects::trend::{TrendLogMultipleObject, TrendLogObject};
 use bacnet_services::read_range::{RangeSpec, ReadRangeAck, ReadRangeRequest};
-use bacnet_transport::loopback::LoopbackTransport;
-use bacnet_transport::port::TransportPort;
 use bacnet_types::constructed::{BACnetLogRecord, LogDatum};
-use bacnet_types::enums::ConfirmedServiceChoice;
 use bacnet_types::primitives::{Date, Time};
-use tokio::time::{timeout, Duration};
 
-const DATE: Date = Date {
+pub(super) const DATE: Date = Date {
     year: 126,
     month: 8,
     day: 31,
     day_of_week: 1,
 };
 
-fn time(hour: u8) -> Time {
+pub(super) fn time(hour: u8) -> Time {
     Time {
         hour,
         minute: 2,
@@ -33,7 +26,7 @@ fn time(hour: u8) -> Time {
     }
 }
 
-fn identity(sequence_number: u32, hour: u8) -> LogRecordIdentity {
+pub(super) fn identity(sequence_number: u32, hour: u8) -> LogRecordIdentity {
     LogRecordIdentity::new(sequence_number, DATE, time(hour)).unwrap()
 }
 
@@ -90,7 +83,7 @@ impl BACnetObject for ListObject {
     }
 }
 
-fn list_db(
+pub(super) fn list_db(
     property: PropertyIdentifier,
     items: Vec<PropertyValue>,
     identities: Option<Vec<LogRecordIdentity>>,
@@ -107,16 +100,26 @@ fn list_db(
     (db, oid)
 }
 
-fn call(
+pub(super) fn call(
     db: &ObjectDatabase,
     oid: ObjectIdentifier,
     property: PropertyIdentifier,
     range: Option<RangeSpec>,
 ) -> Result<ReadRangeAck, Error> {
+    call_with_index(db, oid, property, None, range)
+}
+
+pub(super) fn call_with_index(
+    db: &ObjectDatabase,
+    oid: ObjectIdentifier,
+    property: PropertyIdentifier,
+    property_array_index: Option<u32>,
+    range: Option<RangeSpec>,
+) -> Result<ReadRangeAck, Error> {
     let request = ReadRangeRequest {
         object_identifier: oid,
         property_identifier: property,
-        property_array_index: None,
+        property_array_index,
         range,
     };
     let mut request_bytes = BytesMut::new();
@@ -134,7 +137,7 @@ fn encoded_items(items: &[PropertyValue]) -> Vec<u8> {
     encoded.to_vec()
 }
 
-fn unsigned_items(values: &[u64]) -> Vec<PropertyValue> {
+pub(super) fn unsigned_items(values: &[u64]) -> Vec<PropertyValue> {
     values
         .iter()
         .copied()
@@ -142,7 +145,7 @@ fn unsigned_items(values: &[u64]) -> Vec<PropertyValue> {
         .collect()
 }
 
-fn assert_ack(
+pub(super) fn assert_ack(
     ack: &ReadRangeAck,
     expected: &[PropertyValue],
     flags: (bool, bool, bool),
@@ -334,7 +337,7 @@ fn record(value: u64) -> BACnetLogRecord {
     }
 }
 
-fn projected_record(value: u64) -> PropertyValue {
+pub(super) fn projected_record(value: u64) -> PropertyValue {
     PropertyValue::List(vec![
         PropertyValue::Date(DATE),
         PropertyValue::Time(time(value as u8)),
@@ -343,13 +346,13 @@ fn projected_record(value: u64) -> PropertyValue {
 }
 
 #[derive(Clone, Copy)]
-enum LogFamily {
+pub(super) enum LogFamily {
     Event,
     Trend,
     TrendMultiple,
 }
 
-fn fifo_log(family: LogFamily) -> Box<dyn BACnetObject> {
+pub(super) fn fifo_log(family: LogFamily) -> Box<dyn BACnetObject> {
     match family {
         LogFamily::Event => {
             let mut object = EventLogObject::new(1, "EL-1", 3).unwrap();
@@ -480,27 +483,20 @@ fn purge_status_record_replaces_old_sequence_continuation() {
     assert_eq!(status.item_count, 1);
     assert_eq!(status.result_flags, (true, true, false));
     assert_eq!(status.first_sequence_number, Some(status_sequence));
-}
 
-#[test]
-fn by_time_keeps_explicit_typed_denial() {
-    let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, unsigned_items(&[1]), None);
-    let error = call(
+    let status_by_time = call(
         &db,
         oid,
         PropertyIdentifier::LOG_BUFFER,
         Some(RangeSpec::ByTime {
-            reference_time: (DATE, time(1)),
+            reference_time: (DATE, time(11)),
             count: 1,
         }),
     )
-    .unwrap_err();
-    assert!(matches!(
-        error,
-        Error::Protocol { class, code }
-            if class == ErrorClass::SERVICES.to_raw() as u32
-                && code == ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32
-    ));
+    .unwrap();
+    assert_eq!(status_by_time.item_count, 1);
+    assert_eq!(status_by_time.result_flags, (true, true, false));
+    assert_eq!(status_by_time.first_sequence_number, Some(status_sequence));
 }
 
 #[test]
@@ -541,115 +537,4 @@ fn item_encoding_error_keeps_response_byte_for_byte_unchanged() {
         Error::Encoding(message) if message == "synthetic item encoding failure"
     ));
     assert_eq!(response, before);
-}
-
-#[tokio::test]
-async fn client_decodes_server_ack_and_continues_by_returned_sequence() {
-    let client_mac = vec![0x31];
-    let server_mac = vec![0x32];
-    let (client_transport, mut server_transport) =
-        LoopbackTransport::pair(client_mac.clone(), server_mac.clone());
-    let mut server_rx = server_transport.start().await.unwrap();
-
-    let object = fifo_log(LogFamily::Trend);
-    let oid = object.object_identifier();
-    let mut db = ObjectDatabase::new();
-    db.add(object).unwrap();
-
-    let server_task = tokio::spawn(async move {
-        for _ in 0..2 {
-            let received = timeout(Duration::from_secs(2), server_rx.recv())
-                .await
-                .expect("server timed out waiting for ReadRange")
-                .expect("server transport closed");
-            assert_eq!(&received.source_mac[..], &client_mac);
-            let npdu = decode_npdu(received.npdu).unwrap();
-            let Apdu::ConfirmedRequest(request) = decode_apdu(npdu.payload).unwrap() else {
-                panic!("expected confirmed ReadRange request");
-            };
-            assert_eq!(request.service_choice, ConfirmedServiceChoice::READ_RANGE);
-
-            let mut service_ack = BytesMut::new();
-            handle_read_range(&db, &request.service_request, &mut service_ack).unwrap();
-            let response = Apdu::ComplexAck(ComplexAck {
-                segmented: false,
-                more_follows: false,
-                invoke_id: request.invoke_id,
-                sequence_number: None,
-                proposed_window_size: None,
-                service_choice: request.service_choice,
-                service_ack: service_ack.freeze(),
-            });
-            let mut encoded_apdu = BytesMut::new();
-            encode_apdu(&mut encoded_apdu, &response).unwrap();
-            let mut encoded_npdu = BytesMut::new();
-            encode_npdu(
-                &mut encoded_npdu,
-                &Npdu {
-                    payload: encoded_apdu.freeze(),
-                    ..Npdu::default()
-                },
-            )
-            .unwrap();
-            server_transport
-                .send_unicast(&encoded_npdu, &client_mac)
-                .await
-                .unwrap();
-        }
-        server_transport.stop().await.unwrap();
-    });
-
-    let mut client = BACnetClient::generic_builder()
-        .transport(client_transport)
-        .apdu_timeout_ms(2_000)
-        .build()
-        .await
-        .unwrap();
-    let first = client
-        .read_range(
-            &server_mac,
-            oid,
-            PropertyIdentifier::LOG_BUFFER,
-            None,
-            Some(RangeSpec::BySequenceNumber {
-                reference_seq: 4,
-                count: -3,
-            }),
-        )
-        .await
-        .unwrap();
-    assert_ack(
-        &first,
-        &[
-            projected_record(2),
-            projected_record(3),
-            projected_record(4),
-        ],
-        (true, true, false),
-        Some(2),
-    );
-
-    let returned_sequence = first.first_sequence_number.unwrap();
-    let continuation = client
-        .read_range(
-            &server_mac,
-            oid,
-            PropertyIdentifier::LOG_BUFFER,
-            None,
-            Some(RangeSpec::BySequenceNumber {
-                reference_seq: returned_sequence,
-                count: 2,
-            }),
-        )
-        .await
-        .unwrap();
-    assert_ack(
-        &continuation,
-        &[projected_record(2), projected_record(3)],
-        (true, false, false),
-        Some(returned_sequence),
-    );
-
-    client.stop().await.unwrap();
-    server_task.await.unwrap();
 }

--- a/crates/bacnet-server/src/handlers/tests/read_range_time.rs
+++ b/crates/bacnet-server/src/handlers/tests/read_range_time.rs
@@ -1,0 +1,480 @@
+use super::read_range::*;
+use super::*;
+use bacnet_client::client::BACnetClient;
+use bacnet_encoding::apdu::{decode_apdu, encode_apdu, Apdu, ComplexAck};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_objects::event_log::EventLogObject;
+use bacnet_objects::log_buffer::LogRecordIdentity;
+use bacnet_objects::trend::{TrendLogMultipleObject, TrendLogObject};
+use bacnet_services::read_range::{RangeSpec, ReadRangeRequest};
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_transport::port::TransportPort;
+use bacnet_types::constructed::{BACnetLogRecord, LogDatum};
+use bacnet_types::enums::ConfirmedServiceChoice;
+use bacnet_types::primitives::{Date, Time};
+use tokio::time::{timeout, Duration};
+
+fn assert_property_error(error: Error, expected: ErrorCode) {
+    assert!(matches!(
+        error,
+        Error::Protocol { class, code }
+            if class == ErrorClass::PROPERTY.to_raw() as u32
+                && code == expected.to_raw() as u32
+    ));
+}
+
+#[test]
+fn by_time_excludes_equal_duplicates_and_reports_exact_endpoints() {
+    let other_weekday = Date {
+        day_of_week: 2,
+        ..DATE
+    };
+    let identities = vec![
+        identity(1, 1),
+        identity(2, 2),
+        LogRecordIdentity::new(3, other_weekday, time(2)).unwrap(),
+        identity(4, 3),
+        identity(5, 4),
+    ];
+    let (db, oid) = list_db(
+        PropertyIdentifier::LOG_BUFFER,
+        unsigned_items(&[10, 20, 30, 40, 50]),
+        Some(identities),
+    );
+    let reference = (
+        Date {
+            day_of_week: 7,
+            ..DATE
+        },
+        time(2),
+    );
+
+    let positive = call(
+        &db,
+        oid,
+        PropertyIdentifier::LOG_BUFFER,
+        Some(RangeSpec::ByTime {
+            reference_time: reference,
+            count: 2,
+        }),
+    )
+    .unwrap();
+    assert_ack(
+        &positive,
+        &unsigned_items(&[40, 50]),
+        (false, true, false),
+        Some(4),
+    );
+
+    let negative = call(
+        &db,
+        oid,
+        PropertyIdentifier::LOG_BUFFER,
+        Some(RangeSpec::ByTime {
+            reference_time: reference,
+            count: -2,
+        }),
+    )
+    .unwrap();
+    assert_ack(
+        &negative,
+        &unsigned_items(&[10]),
+        (true, false, false),
+        Some(1),
+    );
+}
+
+#[test]
+fn by_time_scans_resident_endpoints_without_sorting_clock_rollback() {
+    let identities = vec![
+        identity(1, 5),
+        identity(2, 1),
+        identity(3, 4),
+        identity(4, 2),
+    ];
+    let (db, oid) = list_db(
+        PropertyIdentifier::LOG_BUFFER,
+        unsigned_items(&[10, 20, 30, 40]),
+        Some(identities),
+    );
+    for (count, expected, flags, sequence) in [
+        (2, vec![10, 20], (true, false, false), 1),
+        (-2, vec![30, 40], (false, true, false), 3),
+    ] {
+        let ack = call(
+            &db,
+            oid,
+            PropertyIdentifier::LOG_BUFFER,
+            Some(RangeSpec::ByTime {
+                reference_time: (DATE, time(3)),
+                count,
+            }),
+        )
+        .unwrap();
+        assert_ack(&ack, &unsigned_items(&expected), flags, Some(sequence));
+    }
+}
+
+#[test]
+fn by_time_empty_and_no_match_are_success_without_metadata() {
+    let (empty_db, empty_oid) =
+        list_db(PropertyIdentifier::LOG_BUFFER, Vec::new(), Some(Vec::new()));
+    let empty = call(
+        &empty_db,
+        empty_oid,
+        PropertyIdentifier::LOG_BUFFER,
+        Some(RangeSpec::ByTime {
+            reference_time: (DATE, time(1)),
+            count: 1,
+        }),
+    )
+    .unwrap();
+    assert_ack(&empty, &[], (false, false, false), None);
+
+    let (db, oid) = list_db(
+        PropertyIdentifier::LOG_BUFFER,
+        unsigned_items(&[10, 20]),
+        Some(vec![identity(1, 1), identity(2, 2)]),
+    );
+    for (reference_time, count) in [(time(2), 1), (time(1), -1)] {
+        let miss = call(
+            &db,
+            oid,
+            PropertyIdentifier::LOG_BUFFER,
+            Some(RangeSpec::ByTime {
+                reference_time: (DATE, reference_time),
+                count,
+            }),
+        )
+        .unwrap();
+        assert_ack(&miss, &[], (false, false, false), None);
+    }
+}
+
+#[test]
+fn by_time_rejects_invalid_absent_or_misaligned_timestamp_identities() {
+    let invalid = [
+        (
+            Date {
+                year: Date::UNSPECIFIED,
+                ..DATE
+            },
+            time(1),
+        ),
+        (Date { month: 0, ..DATE }, time(1)),
+        (Date { month: 13, ..DATE }, time(1)),
+        (Date { day: 0, ..DATE }, time(1)),
+        (Date { day: 32, ..DATE }, time(1)),
+        (
+            Date {
+                day_of_week: 0,
+                ..DATE
+            },
+            time(1),
+        ),
+        (
+            DATE,
+            Time {
+                hour: 24,
+                ..time(1)
+            },
+        ),
+        (
+            DATE,
+            Time {
+                minute: 60,
+                ..time(1)
+            },
+        ),
+        (
+            DATE,
+            Time {
+                second: 60,
+                ..time(1)
+            },
+        ),
+        (
+            DATE,
+            Time {
+                hundredths: 100,
+                ..time(1)
+            },
+        ),
+    ];
+    for (date, invalid_time) in invalid {
+        let identities = Some(vec![LogRecordIdentity::new(1, date, invalid_time).unwrap()]);
+        let (db, oid) = list_db(
+            PropertyIdentifier::LOG_BUFFER,
+            unsigned_items(&[1]),
+            identities,
+        );
+        let error = call(
+            &db,
+            oid,
+            PropertyIdentifier::LOG_BUFFER,
+            Some(RangeSpec::ByTime {
+                reference_time: (DATE, time(0)),
+                count: 1,
+            }),
+        )
+        .unwrap_err();
+        assert_property_error(error, ErrorCode::LIST_ITEM_NOT_TIMESTAMPED);
+    }
+
+    for (property, identities) in [
+        (PropertyIdentifier::LOG_BUFFER, None),
+        (PropertyIdentifier::LOG_BUFFER, Some(vec![identity(1, 1)])),
+        (
+            PropertyIdentifier::PROPERTY_LIST,
+            Some(vec![identity(1, 1), identity(2, 2)]),
+        ),
+    ] {
+        let (db, oid) = list_db(property, unsigned_items(&[1, 2]), identities);
+        let error = call(
+            &db,
+            oid,
+            property,
+            Some(RangeSpec::ByTime {
+                reference_time: (DATE, time(0)),
+                count: 1,
+            }),
+        )
+        .unwrap_err();
+        assert_property_error(error, ErrorCode::LIST_ITEM_NOT_TIMESTAMPED);
+    }
+}
+
+#[test]
+fn every_log_family_reads_by_time_after_fifo_eviction() {
+    for family in [LogFamily::Event, LogFamily::Trend, LogFamily::TrendMultiple] {
+        let object = fifo_log(family);
+        let oid = object.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(object).unwrap();
+        for (reference, count, expected, flags, sequence) in [
+            (2, 2, vec![3, 4], (false, true, false), 3),
+            (4, -2, vec![2, 3], (true, false, false), 2),
+        ] {
+            let ack = call(
+                &db,
+                oid,
+                PropertyIdentifier::LOG_BUFFER,
+                Some(RangeSpec::ByTime {
+                    reference_time: (DATE, time(reference)),
+                    count,
+                }),
+            )
+            .unwrap();
+            let expected = expected
+                .into_iter()
+                .map(projected_record)
+                .collect::<Vec<_>>();
+            assert_ack(&ack, &expected, flags, Some(sequence));
+        }
+    }
+}
+
+fn record_with_status(value: u64) -> BACnetLogRecord {
+    BACnetLogRecord {
+        date: DATE,
+        time: time(value as u8),
+        log_datum: LogDatum::UnsignedValue(value),
+        status_flags: Some(0b0100),
+    }
+}
+
+fn log_with_record(family: LogFamily, record: BACnetLogRecord) -> Box<dyn BACnetObject> {
+    match family {
+        LogFamily::Event => {
+            let mut object = EventLogObject::new(1, "EL-1", 1).unwrap();
+            object.add_record(record);
+            Box::new(object)
+        }
+        LogFamily::Trend => {
+            let mut object = TrendLogObject::new(1, "TL-1", 1).unwrap();
+            object.add_record(record);
+            Box::new(object)
+        }
+        LogFamily::TrendMultiple => {
+            let mut object = TrendLogMultipleObject::new(1, "TLM-1", 1).unwrap();
+            object.add_record(record);
+            Box::new(object)
+        }
+    }
+}
+
+#[test]
+fn read_range_preserves_family_specific_status_projection_bytes() {
+    for family in [LogFamily::Event, LogFamily::Trend, LogFamily::TrendMultiple] {
+        let object = log_with_record(family, record_with_status(1));
+        let oid = object.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(object).unwrap();
+        let ack = call(
+            &db,
+            oid,
+            PropertyIdentifier::LOG_BUFFER,
+            Some(RangeSpec::ByTime {
+                reference_time: (DATE, time(0)),
+                count: 1,
+            }),
+        )
+        .unwrap();
+        let mut fields = vec![
+            PropertyValue::Date(DATE),
+            PropertyValue::Time(time(1)),
+            PropertyValue::Unsigned(1),
+        ];
+        if matches!(family, LogFamily::Trend) {
+            fields.push(PropertyValue::BitString {
+                unused_bits: 4,
+                data: vec![0b0100_0000],
+            });
+        }
+        assert_ack(
+            &ack,
+            &[PropertyValue::List(fields)],
+            (true, true, false),
+            Some(1),
+        );
+    }
+}
+
+#[test]
+fn indexed_log_buffer_is_rejected_for_every_log_family() {
+    for family in [LogFamily::Event, LogFamily::Trend, LogFamily::TrendMultiple] {
+        let object = fifo_log(family);
+        let oid = object.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(object).unwrap();
+        let error =
+            call_with_index(&db, oid, PropertyIdentifier::LOG_BUFFER, Some(1), None).unwrap_err();
+        assert_property_error(error, ErrorCode::PROPERTY_IS_NOT_AN_ARRAY);
+    }
+}
+
+#[test]
+fn zero_array_index_is_rejected_by_request_decoder() {
+    let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, Vec::new(), Some(Vec::new()));
+    let request = ReadRangeRequest {
+        object_identifier: oid,
+        property_identifier: PropertyIdentifier::LOG_BUFFER,
+        property_array_index: Some(0),
+        range: None,
+    };
+    let mut service_data = BytesMut::new();
+    request.encode(&mut service_data);
+    let error = handle_read_range(&db, &service_data, &mut BytesMut::new()).unwrap_err();
+    assert!(matches!(error, Error::Decoding { .. }));
+}
+
+#[tokio::test]
+async fn client_accepts_by_time_ack_and_continues_by_returned_sequence() {
+    let client_mac = vec![0x31];
+    let server_mac = vec![0x32];
+    let (client_transport, mut server_transport) =
+        LoopbackTransport::pair(client_mac.clone(), server_mac.clone());
+    let mut server_rx = server_transport.start().await.unwrap();
+
+    let object = fifo_log(LogFamily::Trend);
+    let oid = object.object_identifier();
+    let mut db = ObjectDatabase::new();
+    db.add(object).unwrap();
+
+    let server_task = tokio::spawn(async move {
+        for _ in 0..2 {
+            let received = timeout(Duration::from_secs(2), server_rx.recv())
+                .await
+                .expect("server timed out waiting for ReadRange")
+                .expect("server transport closed");
+            assert_eq!(&received.source_mac[..], &client_mac);
+            let npdu = decode_npdu(received.npdu).unwrap();
+            let Apdu::ConfirmedRequest(request) = decode_apdu(npdu.payload).unwrap() else {
+                panic!("expected confirmed ReadRange request");
+            };
+            assert_eq!(request.service_choice, ConfirmedServiceChoice::READ_RANGE);
+
+            let mut service_ack = BytesMut::new();
+            handle_read_range(&db, &request.service_request, &mut service_ack).unwrap();
+            let response = Apdu::ComplexAck(ComplexAck {
+                segmented: false,
+                more_follows: false,
+                invoke_id: request.invoke_id,
+                sequence_number: None,
+                proposed_window_size: None,
+                service_choice: request.service_choice,
+                service_ack: service_ack.freeze(),
+            });
+            let mut encoded_apdu = BytesMut::new();
+            encode_apdu(&mut encoded_apdu, &response).unwrap();
+            let mut encoded_npdu = BytesMut::new();
+            encode_npdu(
+                &mut encoded_npdu,
+                &Npdu {
+                    payload: encoded_apdu.freeze(),
+                    ..Npdu::default()
+                },
+            )
+            .unwrap();
+            server_transport
+                .send_unicast(&encoded_npdu, &client_mac)
+                .await
+                .unwrap();
+        }
+        server_transport.stop().await.unwrap();
+    });
+
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .apdu_timeout_ms(2_000)
+        .build()
+        .await
+        .unwrap();
+    let first = client
+        .read_range(
+            &server_mac,
+            oid,
+            PropertyIdentifier::LOG_BUFFER,
+            None,
+            Some(RangeSpec::ByTime {
+                reference_time: (DATE, time(1)),
+                count: 3,
+            }),
+        )
+        .await
+        .unwrap();
+    assert_ack(
+        &first,
+        &[
+            projected_record(2),
+            projected_record(3),
+            projected_record(4),
+        ],
+        (true, true, false),
+        Some(2),
+    );
+
+    let returned_sequence = first.first_sequence_number.unwrap();
+    let continuation = client
+        .read_range(
+            &server_mac,
+            oid,
+            PropertyIdentifier::LOG_BUFFER,
+            None,
+            Some(RangeSpec::BySequenceNumber {
+                reference_seq: returned_sequence,
+                count: 2,
+            }),
+        )
+        .await
+        .unwrap();
+    assert_ack(
+        &continuation,
+        &[projected_record(2), projected_record(3)],
+        (true, false, false),
+        Some(returned_sequence),
+    );
+
+    client.stop().await.unwrap();
+    server_task.await.unwrap();
+}

--- a/docs/conformance/bacnet-135-2020.json
+++ b/docs/conformance/bacnet-135-2020.json
@@ -402,7 +402,7 @@
    ],
    "benchmarks": [],
    "public_claims": [],
-   "notes": "In-memory storage/model foundation only; this row makes no public support claim. Sequence identity is object metadata and is never serialized in LOG_BUFFER. Trend Log alone projects a present legacy BACnetLogRecord.status_flags value as its formal optional fourth StatusFlags bitstring; Event Log and Trend Log Multiple retain that raw shared-Rust field for source compatibility but always project only Date, Time, and datum. Mandatory purge/status lifecycle behavior is tracked separately by BACNET-12-LOG-STATUS-LIFECYCLE, and the server's qualified By Sequence consumer is tracked by BACNET-15-READ-RANGE-LOG-BUFFER. ReadRange By Time, restart durability/persistence, and formal EventLog notification-record modeling remain deferred."
+    "notes": "In-memory storage/model foundation only; this row makes no public support claim. Sequence identity is object metadata and is never serialized in LOG_BUFFER. Trend Log alone projects a present legacy BACnetLogRecord.status_flags value as its formal optional fourth StatusFlags bitstring; Event Log and Trend Log Multiple retain that raw shared-Rust field for source compatibility but always project only Date, Time, and datum. Mandatory purge/status lifecycle behavior is tracked separately by BACNET-12-LOG-STATUS-LIFECYCLE, and the server's qualified By Sequence and By Time consumers are tracked by BACNET-15-READ-RANGE-LOG-BUFFER. Restart durability/persistence and formal EventLog notification-record modeling remain deferred."
   },
   {
    "id": "BACNET-12-LOG-STATUS-LIFECYCLE",
@@ -435,36 +435,45 @@
    ],
    "benchmarks": [],
    "public_claims": [],
-   "notes": "Qualified PR-0702 evidence only; no full log-family support claim is made. The shared lifecycle covers explicit effective Enable transitions, Record_Count zero purges, Stop_When_Full activation/full behavior, and ordinary stop-before-full insertion. Public constructors, records(), add_record(), and raw clear() remain compatible. ReadRange By Sequence can continue through the resident purge status identity under BACNET-15-READ-RANGE-LOG-BUFFER. Time-window Start_Time/Stop_Time transitions, LOG_INTERRUPTED, writable Log_DeviceObjectProperty purge paths, formal EventLog notification records, Trend Log Multiple polling, ReadRange By Time, persistence/restart, and complete log conformance remain deferred."
+    "notes": "Qualified PR-0702 evidence only; no full log-family support claim is made. The shared lifecycle covers explicit effective Enable transitions, Record_Count zero purges, Stop_When_Full activation/full behavior, and ordinary stop-before-full insertion. Public constructors, records(), add_record(), and raw clear() remain compatible. ReadRange By Sequence and By Time can select the resident purge status identity under BACNET-15-READ-RANGE-LOG-BUFFER. Time-window Start_Time/Stop_Time transitions, LOG_INTERRUPTED, writable Log_DeviceObjectProperty purge paths, formal EventLog notification records, Trend Log Multiple polling, persistence/restart, and complete log conformance remain deferred."
   },
   {
    "id": "BACNET-15-READ-RANGE-LOG-BUFFER",
-   "standard_anchor": "Clause 12.1.5.2 (PDF p. 164 / printed p. 162); Clause 15.8 and Clause 15.8.1.1.4-15.8.1.3 (PDF pp. 747-753 / printed pp. 745-751)",
+    "standard_anchor": "Clause 12.1.5.2 (PDF p. 164 / printed p. 162); Clause 12.27 (PDF pp. 337-340 / printed pp. 335-338); Clause 15.8 and Clause 15.8.1.1.4-15.8.1.3 (PDF pp. 747-753 / printed pp. 745-751); Clause 21.6 BACnetEventLogRecord, BACnetLogRecord, and BACnetLogMultipleRecord (PDF pp. 906, 916)",
    "priority": "P1",
-   "requirement_summary": "The bundled server selects ReadRange By Position around an exact one-based list position and By Sequence around an exact aligned resident identity for Event Log, Trend Log, and Trend Log Multiple LOG_BUFFER properties. Positive and negative counts return records oldest-to-newest with boundary short reads, empty misses carry no endpoint flags or First Sequence Number, nonempty results report included resident endpoints, and nonempty By Sequence results identify the oldest returned record. The client requires a nonzero First Sequence Number on every nonempty By Sequence or By Time ACK and rejects it on By Position, no-range, and empty ACKs.",
+    "requirement_summary": "The bundled server rejects a ReadRange array index when the object classifies the property as a BACnetLIST or scalar, then selects By Position around an exact one-based list position and By Sequence or By Time through aligned resident identities for Event Log, Trend Log, and Trend Log Multiple LOG_BUFFER properties. By Time anchors positive Count at the first resident timestamp strictly newer than the specific reference and negative Count at the last resident timestamp strictly older, preserves oldest-to-newest resident order across duplicate or nonmonotonic clock-rollback timestamps, and never sorts by time. Empty misses carry no endpoint flags or First Sequence Number; nonempty identity-based results report included resident endpoints and the oldest returned record's nonzero sequence. Trend alone projects its optional top-level StatusFlags; Event and Trend Log Multiple project Date, Time, and datum only. The client validates the required nonzero First Sequence Number on every nonempty By Sequence or By Time ACK.",
    "status": "in-progress",
-   "code_anchors": [
-    "crates/bacnet-server/src/handlers/read_range.rs::select_signed_range",
-    "crates/bacnet-server/src/handlers/read_range.rs::handle_read_range",
-    "crates/bacnet-objects/src/traits.rs::BACnetObject::log_record_identities_internal",
-    "crates/bacnet-client/src/client/file_list.rs::validate_read_range_ack"
+    "code_anchors": [
+     "crates/bacnet-server/src/handlers/read_range.rs::select_signed_range",
+     "crates/bacnet-server/src/handlers/read_range.rs::select_time_range",
+     "crates/bacnet-server/src/handlers/read_range.rs::handle_read_range",
+     "crates/bacnet-objects/src/traits.rs::BACnetObject::is_array_property",
+     "crates/bacnet-objects/src/traits.rs::BACnetObject::log_record_identities_internal",
+     "crates/bacnet-client/src/client/file_list.rs::validate_read_range_ack"
    ],
    "positive_tests": [
     "crates/bacnet-server/src/handlers/tests/read_range.rs::by_position_is_one_based_signed_and_reports_exact_endpoints",
-    "crates/bacnet-server/src/handlers/tests/read_range.rs::by_sequence_uses_exact_wrapped_identity_without_sorting",
-    "crates/bacnet-server/src/handlers/tests/read_range.rs::every_log_family_continues_by_surviving_fifo_identity",
-    "crates/bacnet-server/src/handlers/tests/read_range.rs::purge_status_record_replaces_old_sequence_continuation",
-    "crates/bacnet-server/src/handlers/tests/read_range.rs::client_decodes_server_ack_and_continues_by_returned_sequence",
-    "crates/bacnet-client/src/client/file_list.rs::tests::first_sequence_number_must_match_the_requested_range"
+     "crates/bacnet-server/src/handlers/tests/read_range.rs::by_sequence_uses_exact_wrapped_identity_without_sorting",
+     "crates/bacnet-server/src/handlers/tests/read_range.rs::every_log_family_continues_by_surviving_fifo_identity",
+     "crates/bacnet-server/src/handlers/tests/read_range.rs::purge_status_record_replaces_old_sequence_continuation",
+     "crates/bacnet-server/src/handlers/tests/read_range_time.rs::by_time_excludes_equal_duplicates_and_reports_exact_endpoints",
+     "crates/bacnet-server/src/handlers/tests/read_range_time.rs::by_time_scans_resident_endpoints_without_sorting_clock_rollback",
+     "crates/bacnet-server/src/handlers/tests/read_range_time.rs::by_time_empty_and_no_match_are_success_without_metadata",
+     "crates/bacnet-server/src/handlers/tests/read_range_time.rs::every_log_family_reads_by_time_after_fifo_eviction",
+     "crates/bacnet-server/src/handlers/tests/read_range_time.rs::read_range_preserves_family_specific_status_projection_bytes",
+     "crates/bacnet-server/src/handlers/tests/read_range_time.rs::client_accepts_by_time_ack_and_continues_by_returned_sequence",
+     "crates/bacnet-client/src/client/file_list.rs::tests::first_sequence_number_must_match_the_requested_range"
    ],
    "negative_tests": [
-    "crates/bacnet-server/src/handlers/tests/read_range.rs::by_sequence_rejects_unnumbered_properties_and_misalignment",
-    "crates/bacnet-server/src/handlers/tests/read_range.rs::item_encoding_error_keeps_response_byte_for_byte_unchanged",
-    "crates/bacnet-server/src/handlers/tests/read_range.rs::by_time_keeps_explicit_typed_denial"
+     "crates/bacnet-server/src/handlers/tests/read_range.rs::by_sequence_rejects_unnumbered_properties_and_misalignment",
+     "crates/bacnet-server/src/handlers/tests/read_range.rs::item_encoding_error_keeps_response_byte_for_byte_unchanged",
+     "crates/bacnet-server/src/handlers/tests/read_range_time.rs::by_time_rejects_invalid_absent_or_misaligned_timestamp_identities",
+     "crates/bacnet-server/src/handlers/tests/read_range_time.rs::indexed_log_buffer_is_rejected_for_every_log_family",
+     "crates/bacnet-server/src/handlers/tests/read_range_time.rs::zero_array_index_is_rejected_by_request_decoder"
    ],
    "benchmarks": [],
    "public_claims": [],
-   "notes": "Qualified PR-0703 evidence only; no full ReadRange or log-family support claim is made. Sequence selection is limited to LOG_BUFFER properties whose object supplies an exactly aligned resident identity view; another list property and an unnumbered or misaligned LOG_BUFFER fail PROPERTY / LIST_ITEM_NOT_NUMBERED. This implementation returns every matched requested item without a separate response/PDU cap, so a smaller requested Count is not truncation and MORE_ITEMS remains FALSE. By Time remains explicitly denied SERVICES / SERVICE_REQUEST_DENIED. Indexed Log_Buffer reads, response-size pagination/segmentation, persistence/restart, formal Event Log notification records, and complete ReadRange/log conformance remain deferred. No runtime PICS/service bit is changed."
+    "notes": "Qualified PR-0704 evidence only; no full ReadRange or log-family support claim is made. By Sequence and By Time are limited to LOG_BUFFER properties whose object supplies an exactly aligned resident identity view. Another list property or an absent, malformed, or misaligned timestamp identity view fails PROPERTY / LIST_ITEM_NOT_TIMESTAMPED for By Time; an unnumbered or misaligned sequence identity view fails PROPERTY / LIST_ITEM_NOT_NUMBERED for By Sequence. ReadRange applies the object-owned BACnetARRAY classification before reading the property, so every index on these BACnetLIST LOG_BUFFER properties fails PROPERTY / PROPERTY_IS_NOT_AN_ARRAY. The shared raw Rust record retains status flags for source compatibility, but Clause 21.6 serializes top-level optional StatusFlags only for Trend Log, not Event Log or Trend Log Multiple. This implementation fully encodes every selected item without a separate response/PDU cap, so MORE_ITEMS remains FALSE. Response-size pagination/segmentation, persistence/restart, formal Event Log notification records, and complete ReadRange/log conformance remain deferred. No runtime PICS/service bit is changed."
   },
   {
    "id": "BACNET-12-PROPERTY-METADATA-CORE",

--- a/docs/conformance/support-summary.md
+++ b/docs/conformance/support-summary.md
@@ -49,7 +49,7 @@
 | `BACNET-12-OBJECT-MODEL` | Clauses 12-19 | P1 | implementation-present-needs-conformance-tests | 3 |
 | `BACNET-12-LOG-RECORD-IDENTITY` | Clause 12.25 (p. 319), Clause 12.27 (p. 337), Clause 12.30 (p. 361); Clause 15.8 (pp. 745-750); Clause 21.6 (pp. 902-914) | P1 | in-progress | 0 |
 | `BACNET-12-LOG-STATUS-LIFECYCLE` | Clause 12.25 Trend Log (pp. 319-336); Clause 12.27 Event Log (pp. 337-346); Clause 12.30 Trend Log Multiple (pp. 361-378); Clause 21.6 BACnetLogStatus (p. 914) | P1 | in-progress | 0 |
-| `BACNET-15-READ-RANGE-LOG-BUFFER` | Clause 12.1.5.2 (PDF p. 164 / printed p. 162); Clause 15.8 and Clause 15.8.1.1.4-15.8.1.3 (PDF pp. 747-753 / printed pp. 745-751) | P1 | in-progress | 0 |
+| `BACNET-15-READ-RANGE-LOG-BUFFER` | Clause 12.1.5.2 (PDF p. 164 / printed p. 162); Clause 12.27 (PDF pp. 337-340 / printed pp. 335-338); Clause 15.8 and Clause 15.8.1.1.4-15.8.1.3 (PDF pp. 747-753 / printed pp. 745-751); Clause 21.6 BACnetEventLogRecord, BACnetLogRecord, and BACnetLogMultipleRecord (PDF pp. 906, 916) | P1 | in-progress | 0 |
 | `BACNET-12-PROPERTY-METADATA-CORE` | Clause 12.6, Table 12-6 (pp. 189-190); Clause 12.42, Table 12-49 (pp. 444-445); Clause 15.7.3.1 (p. 743); Annex A (pp. 964-965) | P1 | in-progress | 1 |
 | `BACNET-12-ESCALATOR-STATUS-WRITABILITY` | Clause 12 general property conformance rules; Clause 12.60 Table 12-78 and Out_Of_Service; Clause 15.9.1.3; Clause 21 BACnetEscalatorMode, BACnetEscalatorOperationDirection, and BACnetEscalatorFault; Clause 23.1 | P1 | supported-with-clause-evidence | 0 |
 | `BACNET-12-DEVICE-MAX-SEGMENTS` | Clause 12.11, Table 12-13 | P1 | implementation-present-needs-conformance-tests | 0 |


### PR DESCRIPTION
## Summary
- implement strict ReadRange By Time selection for Event Log, Trend Log, and Trend Log Multiple resident buffers
- return aligned First Sequence Number and endpoint flags without sorting clock-rollback records
- reject array indexes on `LOG_BUFFER` BACnetLIST properties before object projection
- preserve the formal record profiles: optional top-level StatusFlags only for Trend Log
- update qualified changelog and conformance evidence without making a full ReadRange/log support claim

## Source-to-behavior traceability
| Standard 135-2020 source | Implemented behavior |
|---|---|
| §12.27, Event Log `Log_Buffer` | Uses the object-owned aligned timestamp/sequence identity of each resident record. |
| §15.8 By Time | Positive Count anchors at the first resident timestamp strictly newer than the reference; negative Count anchors at the last resident timestamp strictly older. Selected records remain in resident order. |
| §15.8 result metadata | Empty matches return no flags or First Sequence Number; nonempty results identify the first returned resident sequence and exact resident endpoints. |
| §15.8 array/list errors | Any array index on `LOG_BUFFER` is rejected as `PROPERTY / PROPERTY_IS_NOT_AN_ARRAY`; malformed or absent timestamp identity returns `LIST_ITEM_NOT_TIMESTAMPED`. |
| §21.6 record productions | Trend Log retains its optional top-level StatusFlags bytes. Event Log and Trend Log Multiple retain source-compatible raw storage but serialize only their formal Date, Time, and datum fields. |

Issue #134 was filed against v0.10.1 and treated the shared raw Event record field as permission for a top-level wire field. The §21.6 productions distinguish those profiles, so this closes the issue by preserving every field authorized for each wire type rather than widening Event or Trend Log Multiple.

## Validation
- `cargo fmt --all -- --check`
- focused ReadRange tests (17 passed)
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-services --locked`
- `cargo test -p bacnet-client --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

## Deferred
- PDU/APDU response budgeting, truncation, pagination/segmentation, and `MORE_ITEMS=true`
- arbitrary timestamped non-log list APIs
- persistence/restart and formal Event Log notification records
- complete ReadRange/log-family conformance and public support claims

Closes #134