### PR TITLE
feat(python): add pre-start File management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Synchronous pre-start Python management for pending built-in File objects
+  (#420). Servers can select stream or record access, copy payloads in and out,
+  and set effective clamped octet/record growth caps on the exact object later
+  moved into the runtime database. Mode mismatches use the existing typed
+  `SERVICES / INVALID_FILE_ACCESS_METHOD` error; payload setters retain
+  File_Size/Record_Count and Modification_Date/Archive behavior. Caps do not
+  truncate trusted preloads, and AtomicWriteFile still enforces Read_Only,
+  access mode, caps, and atomic failure. This local API is pre-start-only,
+  returns copies, adds no live replacement or persistence, and broadens no
+  Clause 14 conformance claim.
+
 - Conditional built-in `FileObject` resize properties (#417). Mutable exact
   stream-access representatives accept bounded `File_Size` writes, while
   mutable exact record-access representatives accept bounded `Record_Count`

--- a/crates/bacnet-objects/src/file.rs
+++ b/crates/bacnet-objects/src/file.rs
@@ -47,6 +47,37 @@ pub const DEFAULT_MAX_RECORD_COUNT: u64 = 10_000;
 /// [`DEFAULT_MAX_RECORD_COUNT`] for why it is the decoder's limit.
 const MAX_RECORD_CAP: u64 = DEFAULT_MAX_RECORD_COUNT;
 
+/// Trusted local configuration for the built-in in-memory File payload.
+///
+/// This narrow capability is separate from [`FileStorage`]: configuration may
+/// preload data regardless of `Read_Only` or the later network-write growth
+/// caps, while AtomicWriteFile continues to use `FileStorage` and enforce both.
+/// Payload operations reject a shape that does not match the active
+/// `File_Access_Method` before mutating the object.
+#[doc(hidden)]
+pub trait FileConfiguration: Send + Sync {
+    /// Select the active File access method without converting either payload.
+    fn set_access_method(&mut self, method: FileAccessMethod);
+
+    /// Replace the stream payload through the File object's accounting path.
+    fn set_stream_data(&mut self, data: Vec<u8>) -> Result<(), Error>;
+
+    /// Borrow the stream payload when stream access is active.
+    fn stream_data(&self) -> Result<&[u8], Error>;
+
+    /// Replace the record payload through the File object's accounting path.
+    fn set_record_data(&mut self, records: Vec<Vec<u8>>) -> Result<(), Error>;
+
+    /// Borrow the record payload when record access is active.
+    fn record_data(&self) -> Result<&[Vec<u8>], Error>;
+
+    /// Set and return the effective octet growth cap.
+    fn set_max_file_size(&mut self, max_octets: u64) -> u64;
+
+    /// Set and return the effective record-count growth cap.
+    fn set_max_record_count(&mut self, max_records: u64) -> u64;
+}
+
 /// One stream-access read window, as AtomicReadFile returns it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileStreamRead {
@@ -514,6 +545,44 @@ impl FileStorage for FileObject {
     }
 }
 
+impl FileConfiguration for FileObject {
+    fn set_access_method(&mut self, method: FileAccessMethod) {
+        FileObject::set_file_access_method(self, method.to_raw());
+    }
+
+    fn set_stream_data(&mut self, data: Vec<u8>) -> Result<(), Error> {
+        self.require_access(FileAccessMethod::STREAM_ACCESS)?;
+        FileObject::set_data(self, data);
+        Ok(())
+    }
+
+    fn stream_data(&self) -> Result<&[u8], Error> {
+        self.require_access(FileAccessMethod::STREAM_ACCESS)?;
+        Ok(FileObject::data(self))
+    }
+
+    fn set_record_data(&mut self, records: Vec<Vec<u8>>) -> Result<(), Error> {
+        self.require_access(FileAccessMethod::RECORD_ACCESS)?;
+        FileObject::set_records(self, records);
+        Ok(())
+    }
+
+    fn record_data(&self) -> Result<&[Vec<u8>], Error> {
+        self.require_access(FileAccessMethod::RECORD_ACCESS)?;
+        Ok(FileObject::records(self))
+    }
+
+    fn set_max_file_size(&mut self, max_octets: u64) -> u64 {
+        FileObject::set_max_file_size(self, max_octets);
+        FileObject::max_file_size(self)
+    }
+
+    fn set_max_record_count(&mut self, max_records: u64) -> u64 {
+        FileObject::set_max_record_count(self, max_records);
+        FileObject::max_record_count(self)
+    }
+}
+
 impl BACnetObject for FileObject {
     fn object_identifier(&self) -> ObjectIdentifier {
         self.oid
@@ -650,6 +719,14 @@ impl BACnetObject for FileObject {
 
     fn bind_clock_internal(&mut self, clock: Option<Arc<dyn ClockReader>>) {
         self.clock = clock;
+    }
+
+    fn file_configuration_internal(&self) -> Option<&dyn FileConfiguration> {
+        Some(self)
+    }
+
+    fn file_configuration_internal_mut(&mut self) -> Option<&mut dyn FileConfiguration> {
+        Some(self)
     }
 
     fn file_storage_internal(&self) -> Option<&dyn FileStorage> {

--- a/crates/bacnet-objects/src/file/storage_tests.rs
+++ b/crates/bacnet-objects/src/file/storage_tests.rs
@@ -70,6 +70,23 @@ fn retained_datetime() -> (Date, Time) {
     )
 }
 
+fn unspecified_datetime() -> (Date, Time) {
+    (
+        Date {
+            year: Date::UNSPECIFIED,
+            month: Date::UNSPECIFIED,
+            day: Date::UNSPECIFIED,
+            day_of_week: Date::UNSPECIFIED,
+        },
+        Time {
+            hour: Time::UNSPECIFIED,
+            minute: Time::UNSPECIFIED,
+            second: Time::UNSPECIFIED,
+            hundredths: Time::UNSPECIFIED,
+        },
+    )
+}
+
 #[derive(Debug, PartialEq)]
 struct StreamState {
     data: Vec<u8>,
@@ -510,9 +527,13 @@ impl BACnetObject for NoStorageFile {
 #[test]
 fn storage_hooks_default_to_none_and_file_object_opts_in() {
     let mut none = NoStorageFile;
+    assert!(none.file_configuration_internal().is_none());
+    assert!(none.file_configuration_internal_mut().is_none());
     assert!(none.file_storage_internal().is_none());
     assert!(none.file_storage_internal_mut().is_none());
     let mut file = stream_file();
+    assert!(file.file_configuration_internal().is_some());
+    assert!(file.file_configuration_internal_mut().is_some());
     assert!(file.file_storage_internal().is_some());
     assert!(file.file_storage_internal_mut().is_some());
     // 65 was the fabricated "File Data" property the old handler read (it
@@ -521,4 +542,109 @@ fn storage_hooks_default_to_none_and_file_object_opts_in() {
         .property_list()
         .iter()
         .any(|p| *p == PropertyIdentifier::from_raw(65)));
+}
+
+#[test]
+fn configuration_capability_enforces_shape_and_routes_payload_metadata() {
+    let retained = retained_datetime();
+    let mut file = FileObject::new(1, "FILE-1", "text/plain").unwrap();
+    file.set_read_only(true);
+    file.set_modification_date(retained.0, retained.1);
+    file.set_archive(true);
+
+    {
+        let configuration = file.file_configuration_internal_mut().unwrap();
+        configuration.set_stream_data(vec![1, 2, 3]).unwrap();
+        assert_eq!(configuration.stream_data().unwrap(), &[1, 2, 3]);
+    }
+    assert_eq!(file.file_size(), 3);
+    assert!(file.read_only(), "trusted preload does not clear Read_Only");
+    assert_eq!(file.modification_date, unspecified_datetime());
+    assert!(!file.archive());
+
+    file.set_modification_date(retained.0, retained.1);
+    file.set_archive(true);
+    let expected = stream_state(&file);
+    let err = file
+        .file_configuration_internal_mut()
+        .unwrap()
+        .set_record_data(vec![vec![9]])
+        .unwrap_err();
+    assert_eq!(protocol_pair(err), invalid_method_pair());
+    assert_eq!(stream_state(&file), expected);
+
+    file.file_configuration_internal_mut()
+        .unwrap()
+        .set_access_method(FileAccessMethod::RECORD_ACCESS);
+    file.set_modification_date(retained.0, retained.1);
+    file.set_archive(true);
+    {
+        let configuration = file.file_configuration_internal_mut().unwrap();
+        configuration
+            .set_record_data(vec![vec![0xAA], vec![0xBB, 0xCC]])
+            .unwrap();
+        assert_eq!(
+            configuration.record_data().unwrap(),
+            &[vec![0xAA], vec![0xBB, 0xCC]]
+        );
+    }
+    assert_eq!(file.file_size(), 3);
+    assert_eq!(
+        file.read_property(PropertyIdentifier::RECORD_COUNT, None)
+            .unwrap(),
+        PropertyValue::Unsigned(2)
+    );
+    assert_eq!(file.modification_date, unspecified_datetime());
+    assert!(!file.archive());
+
+    file.set_modification_date(retained.0, retained.1);
+    file.set_archive(true);
+    let expected = record_state(&file);
+    let err = file
+        .file_configuration_internal_mut()
+        .unwrap()
+        .set_stream_data(vec![7, 8])
+        .unwrap_err();
+    assert_eq!(protocol_pair(err), invalid_method_pair());
+    assert_eq!(record_state(&file), expected);
+}
+
+#[test]
+fn configuration_capability_caps_are_effective_growth_limits_not_preload_limits() {
+    let mut stream = stream_file();
+    {
+        let configuration = stream.file_configuration_internal_mut().unwrap();
+        assert_eq!(configuration.set_max_file_size(u64::MAX), i32::MAX as u64);
+        assert_eq!(configuration.set_max_file_size(4), 4);
+    }
+    let expected = stream_state(&stream);
+    assert_eq!(
+        protocol_pair(
+            stream
+                .write_stream(FileWriteStart::Append, &[0x99])
+                .unwrap_err()
+        ),
+        file_full_pair()
+    );
+    assert_eq!(stream_state(&stream), expected);
+
+    let mut record = record_file();
+    {
+        let configuration = record.file_configuration_internal_mut().unwrap();
+        assert_eq!(
+            configuration.set_max_record_count(u64::MAX),
+            DEFAULT_MAX_RECORD_COUNT
+        );
+        assert_eq!(configuration.set_max_record_count(2), 2);
+    }
+    let expected = record_state(&record);
+    assert_eq!(
+        protocol_pair(
+            record
+                .write_records(FileWriteStart::Append, &[vec![0x99]])
+                .unwrap_err()
+        ),
+        file_full_pair()
+    );
+    assert_eq!(record_state(&record), expected);
 }

--- a/crates/bacnet-objects/src/file/tests.rs
+++ b/crates/bacnet-objects/src/file/tests.rs
@@ -301,6 +301,37 @@ fn file_metadata_equal_and_empty_mutations_sample_the_next_frame() {
 }
 
 #[test]
+fn configuration_getters_do_not_mutate_or_sample_the_clock() {
+    let retained = clock_frame(1);
+    let next = clock_frame(12);
+    let mut file = FileObject::new(1, "FILE", "text/plain").unwrap();
+    file.set_data(vec![1, 2]);
+    file.set_modification_date(retained.local_date, retained.local_time);
+    file.set_archive(true);
+    file.bind_clock_internal(Some(Arc::new(SequenceClock::new([next]))));
+
+    assert_eq!(
+        file.file_configuration_internal()
+            .unwrap()
+            .stream_data()
+            .unwrap(),
+        &[1, 2]
+    );
+    assert_eq!(
+        file.modification_date,
+        (retained.local_date, retained.local_time)
+    );
+    assert!(file.archive());
+
+    file.file_configuration_internal_mut()
+        .unwrap()
+        .set_stream_data(vec![3, 4])
+        .unwrap();
+    assert_eq!(file.modification_date, (next.local_date, next.local_time));
+    assert!(!file.archive());
+}
+
+#[test]
 fn file_metadata_manual_assignment_clears_archive_only_when_changed() {
     let first = clock_frame(4);
     let second = clock_frame(5);

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -17,7 +17,7 @@ use crate::event::{EventTransitionCommit, EventTransitionCommitError, Transition
 use crate::event_enrollment::{
     EventEnrollmentEvalState, EventEnrollmentMonitoredSource, EventEnrollmentReliabilityCommit,
 };
-use crate::file::FileStorage;
+use crate::file::{FileConfiguration, FileStorage};
 use crate::log_buffer::LogRecordIdentity;
 
 mod defaults;
@@ -602,6 +602,27 @@ pub trait BACnetObject: Send + Sync {
     fn audit_log_notification_sink_internal(
         &mut self,
     ) -> Option<&mut dyn AuditLogNotificationSink> {
+        None
+    }
+
+    /// Borrow this object's trusted local File configuration capability.
+    ///
+    /// The default returns `None`. The built-in [`crate::file::FileObject`]
+    /// opts in so bindings can configure its pending payload, access method,
+    /// and growth limits without general object downcasting or a parallel
+    /// state cache.
+    #[doc(hidden)]
+    fn file_configuration_internal(&self) -> Option<&dyn FileConfiguration> {
+        None
+    }
+
+    /// Mutably borrow this object's trusted local File configuration capability.
+    ///
+    /// The default returns `None`; payload mutations remain object-owned and
+    /// must preserve the same accounting and metadata behavior as the built-in
+    /// File setters.
+    #[doc(hidden)]
+    fn file_configuration_internal_mut(&mut self) -> Option<&mut dyn FileConfiguration> {
         None
     }
 

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1579,6 +1579,40 @@ class BACnetServer:
 
     # --- Files/network ---
     def add_file(self, instance: int, name: str, file_type: str = "application/octet-stream") -> None: ...
+    def set_file_access_method(self, /, instance: int, access_method: str) -> None:
+        """Select ``"stream"`` or ``"record"`` on a pending built-in File.
+
+        This synchronous operation is valid only before ``start()``. Select the
+        access method before loading the corresponding payload; changing modes
+        does not convert stream data to records or vice versa.
+        """
+        ...
+    def set_file_data(self, /, instance: int, data: bytes) -> None:
+        """Copy bytes into a pending stream-access built-in File before ``start()``."""
+        ...
+    def get_file_data(self, /, instance: int) -> bytes:
+        """Return a fresh bytes copy from a pending stream File before ``start()``."""
+        ...
+    def set_file_records(self, /, instance: int, records: list[bytes]) -> None:
+        """Copy records into a pending record-access built-in File before ``start()``."""
+        ...
+    def get_file_records(self, /, instance: int) -> list[bytes]:
+        """Return a fresh list and fresh bytes from a pending record File before ``start()``."""
+        ...
+    def set_max_file_size(self, /, instance: int, max_octets: int) -> int:
+        """Set and return the effective octet growth cap before ``start()``.
+
+        The built-in File clamp is authoritative. This does not truncate
+        preloaded content.
+        """
+        ...
+    def set_max_record_count(self, /, instance: int, max_records: int) -> int:
+        """Set and return the effective record growth cap before ``start()``.
+
+        The built-in File clamp is authoritative. This does not truncate
+        preloaded records.
+        """
+        ...
     def add_network_port(self, instance: int, name: str, network_type: int = 0) -> None: ...
 
     # --- Server lifecycle ---

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -131,6 +131,7 @@ impl BACnetServer {
 }
 
 mod server_methods {
+    mod file_configuration;
     mod lifecycle;
     mod registration;
 }

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -1,0 +1,425 @@
+use super::super::*;
+
+use bacnet_objects::file::FileConfiguration;
+use bacnet_types::enums::{FileAccessMethod, ObjectType};
+use bacnet_types::primitives::ObjectIdentifier;
+use pyo3::exceptions::{PyRuntimeError, PyTypeError, PyValueError};
+use pyo3::types::{PyBytes, PyList};
+
+const INVALID_ACCESS_METHOD: &str = "access_method must be 'stream' or 'record'";
+const STARTED_CONFIGURATION: &str =
+    "cannot configure files after start() — server is already running";
+
+fn parse_access_method(access_method: &str) -> PyResult<FileAccessMethod> {
+    match access_method {
+        "stream" => Ok(FileAccessMethod::STREAM_ACCESS),
+        "record" => Ok(FileAccessMethod::RECORD_ACCESS),
+        _ => Err(PyValueError::new_err(INVALID_ACCESS_METHOD)),
+    }
+}
+
+fn file_oid(instance: u32) -> PyResult<ObjectIdentifier> {
+    ObjectIdentifier::new(ObjectType::FILE, instance).map_err(to_py_err)
+}
+
+fn missing_file(instance: u32) -> PyErr {
+    PyValueError::new_err(format!("no pending File object with instance {instance}"))
+}
+
+fn missing_configuration(instance: u32) -> PyErr {
+    PyTypeError::new_err(format!(
+        "pending File object with instance {instance} does not support built-in File configuration"
+    ))
+}
+
+impl BACnetServer {
+    fn with_pending_file_configuration<R>(
+        &self,
+        instance: u32,
+        operation: impl FnOnce(&dyn FileConfiguration) -> PyResult<R>,
+    ) -> PyResult<R> {
+        let oid = file_oid(instance)?;
+        let guard = self.lock_pending()?;
+        if self.started.load(Ordering::Acquire) {
+            return Err(PyRuntimeError::new_err(STARTED_CONFIGURATION));
+        }
+        let object = guard
+            .iter()
+            .rev()
+            .find(|object| object.object_identifier() == oid)
+            .ok_or_else(|| missing_file(instance))?;
+        let configuration = object
+            .file_configuration_internal()
+            .ok_or_else(|| missing_configuration(instance))?;
+        operation(configuration)
+    }
+
+    fn with_pending_file_configuration_mut<R>(
+        &self,
+        instance: u32,
+        operation: impl FnOnce(&mut dyn FileConfiguration) -> PyResult<R>,
+    ) -> PyResult<R> {
+        let oid = file_oid(instance)?;
+        let mut guard = self.lock_pending()?;
+        if self.started.load(Ordering::Acquire) {
+            return Err(PyRuntimeError::new_err(STARTED_CONFIGURATION));
+        }
+        let object = guard
+            .iter_mut()
+            .rev()
+            .find(|object| object.object_identifier() == oid)
+            .ok_or_else(|| missing_file(instance))?;
+        let configuration = object
+            .file_configuration_internal_mut()
+            .ok_or_else(|| missing_configuration(instance))?;
+        operation(configuration)
+    }
+}
+
+#[pymethods]
+impl BACnetServer {
+    /// Select a pending built-in File's access method before start().
+    ///
+    /// Choose the access method before loading the corresponding payload;
+    /// changing it does not convert stream data to records or vice versa.
+    #[pyo3(signature = (instance, access_method))]
+    fn set_file_access_method(&self, instance: u32, access_method: &str) -> PyResult<()> {
+        let access_method = parse_access_method(access_method)?;
+        self.with_pending_file_configuration_mut(instance, |configuration| {
+            configuration.set_access_method(access_method);
+            Ok(())
+        })
+    }
+
+    /// Copy bytes into a pending stream-access built-in File before start().
+    #[pyo3(signature = (instance, data))]
+    fn set_file_data(&self, instance: u32, data: &Bound<'_, PyBytes>) -> PyResult<()> {
+        let data = data.as_bytes().to_vec();
+        self.with_pending_file_configuration_mut(instance, |configuration| {
+            configuration.set_stream_data(data).map_err(to_py_err)
+        })
+    }
+
+    /// Return a fresh bytes copy from a pending stream-access File before start().
+    #[pyo3(signature = (instance))]
+    fn get_file_data<'py>(&self, py: Python<'py>, instance: u32) -> PyResult<Bound<'py, PyBytes>> {
+        let data = self.with_pending_file_configuration(instance, |configuration| {
+            configuration
+                .stream_data()
+                .map(|data| data.to_vec())
+                .map_err(to_py_err)
+        })?;
+        Ok(PyBytes::new(py, &data))
+    }
+
+    /// Copy a list of bytes records into a pending record-access File before start().
+    #[pyo3(signature = (instance, records))]
+    fn set_file_records(&self, instance: u32, records: &Bound<'_, PyList>) -> PyResult<()> {
+        let records = records
+            .iter()
+            .map(|record| {
+                record
+                    .cast::<PyBytes>()
+                    .map(|record| record.as_bytes().to_vec())
+                    .map_err(Into::into)
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+        self.with_pending_file_configuration_mut(instance, |configuration| {
+            configuration.set_record_data(records).map_err(to_py_err)
+        })
+    }
+
+    /// Return a fresh list with fresh bytes values from a pending record File before start().
+    #[pyo3(signature = (instance))]
+    fn get_file_records<'py>(
+        &self,
+        py: Python<'py>,
+        instance: u32,
+    ) -> PyResult<Bound<'py, PyList>> {
+        let records = self.with_pending_file_configuration(instance, |configuration| {
+            configuration
+                .record_data()
+                .map(|records| records.to_vec())
+                .map_err(to_py_err)
+        })?;
+        let result = PyList::empty(py);
+        for record in records {
+            result.append(PyBytes::new(py, &record))?;
+        }
+        Ok(result)
+    }
+
+    /// Set and return a pending File's effective octet growth cap before start().
+    ///
+    /// The cap is clamped by FileObject and does not truncate preloaded content.
+    #[pyo3(signature = (instance, max_octets))]
+    fn set_max_file_size(&self, instance: u32, max_octets: u64) -> PyResult<u64> {
+        self.with_pending_file_configuration_mut(instance, |configuration| {
+            Ok(configuration.set_max_file_size(max_octets))
+        })
+    }
+
+    /// Set and return a pending File's effective record growth cap before start().
+    ///
+    /// The cap is clamped by FileObject and does not truncate preloaded records.
+    #[pyo3(signature = (instance, max_records))]
+    fn set_max_record_count(&self, instance: u32, max_records: u64) -> PyResult<u64> {
+        self.with_pending_file_configuration_mut(instance, |configuration| {
+            Ok(configuration.set_max_record_count(max_records))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bacnet_objects::binary::BinaryValueObject;
+    use bacnet_types::enums::{ErrorClass, ErrorCode, PropertyIdentifier};
+    use bacnet_types::error::Error;
+    use std::borrow::Cow;
+
+    fn test_server() -> BACnetServer {
+        BACnetServer {
+            inner: Arc::new(Mutex::new(None)),
+            device_instance: 1,
+            device_name: "Test Device".into(),
+            transport_type: "bip".into(),
+            interface: "0.0.0.0".into(),
+            port: 0,
+            broadcast_address: "255.255.255.255".into(),
+            sc_hub: None,
+            sc_vmac: None,
+            sc_ca_cert: None,
+            sc_client_cert: None,
+            sc_client_key: None,
+            sc_heartbeat_interval_ms: None,
+            sc_heartbeat_timeout_ms: None,
+            ipv6_interface: None,
+            serial_port: None,
+            mstp_baud: 38_400,
+            mstp_mac: 1,
+            mstp_max_master: 127,
+            mstp_max_info_frames: 1,
+            dcc_password: None,
+            reinit_password: None,
+            started: Arc::new(AtomicBool::new(false)),
+            pending_objects: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    fn file(instance: u32, name: &str, data: &[u8]) -> FileObject {
+        let mut file = FileObject::new(instance, name, "application/octet-stream").unwrap();
+        file.set_data(data.to_vec());
+        file
+    }
+
+    fn py_message(py: Python<'_>, error: &PyErr) -> String {
+        error
+            .value(py)
+            .str()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    struct NoConfigurationFile;
+
+    impl BACnetObject for NoConfigurationFile {
+        fn object_identifier(&self) -> ObjectIdentifier {
+            ObjectIdentifier::new(ObjectType::FILE, 7).unwrap()
+        }
+
+        fn object_name(&self) -> &str {
+            "NO-CONFIGURATION"
+        }
+
+        fn read_property(
+            &self,
+            _property: PropertyIdentifier,
+            _array_index: Option<u32>,
+        ) -> Result<PropertyValue, Error> {
+            Err(Error::Encoding("not used by this test".into()))
+        }
+
+        fn write_property(
+            &mut self,
+            _property: PropertyIdentifier,
+            _array_index: Option<u32>,
+            _value: PropertyValue,
+            _priority: Option<u8>,
+        ) -> Result<(), Error> {
+            Err(Error::Encoding("not used by this test".into()))
+        }
+
+        fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+            Cow::Borrowed(&[])
+        }
+    }
+
+    #[test]
+    fn pending_lookup_uses_file_identity_and_reverse_replacement_order() {
+        let server = test_server();
+        server
+            .push_pending(Box::new(file(4, "FIRST", b"first")))
+            .unwrap();
+        server
+            .push_pending(Box::new(BinaryValueObject::new(4, "NON-FILE").unwrap()))
+            .unwrap();
+        server
+            .push_pending(Box::new(file(4, "SECOND", b"second")))
+            .unwrap();
+
+        Python::attach(|py| {
+            server
+                .set_file_data(4, &PyBytes::new(py, b"effective"))
+                .unwrap();
+        });
+
+        let guard = server.lock_pending().unwrap();
+        assert_eq!(
+            guard[0]
+                .file_configuration_internal()
+                .unwrap()
+                .stream_data()
+                .unwrap(),
+            b"first"
+        );
+        assert_eq!(
+            guard[2]
+                .file_configuration_internal()
+                .unwrap()
+                .stream_data()
+                .unwrap(),
+            b"effective"
+        );
+    }
+
+    #[test]
+    fn missing_wrong_capability_invalid_method_and_mode_errors_are_atomic() {
+        let server = test_server();
+        server
+            .push_pending(Box::new(BinaryValueObject::new(5, "NON-FILE").unwrap()))
+            .unwrap();
+        server
+            .push_pending(Box::new(file(6, "FILE", b"kept")))
+            .unwrap();
+        server.push_pending(Box::new(NoConfigurationFile)).unwrap();
+
+        Python::attach(|py| {
+            let missing = server.get_file_data(py, 5).unwrap_err();
+            assert!(missing.is_instance_of::<PyValueError>(py));
+            assert_eq!(
+                py_message(py, &missing),
+                "no pending File object with instance 5"
+            );
+
+            let wrong_capability = server.get_file_data(py, 7).unwrap_err();
+            assert!(wrong_capability.is_instance_of::<PyTypeError>(py));
+
+            let invalid = server.set_file_access_method(6, "STREAM").unwrap_err();
+            assert!(invalid.is_instance_of::<PyValueError>(py));
+            assert_eq!(py_message(py, &invalid), INVALID_ACCESS_METHOD);
+            assert_eq!(server.get_file_data(py, 6).unwrap().as_bytes(), b"kept");
+
+            server.set_file_access_method(6, "record").unwrap();
+            let records = PyList::new(py, [PyBytes::new(py, b"one")]).unwrap();
+            server.set_file_records(6, &records).unwrap();
+            let mismatch = server
+                .set_file_data(6, &PyBytes::new(py, b"changed"))
+                .unwrap_err();
+            assert!(mismatch.is_instance_of::<crate::errors::BacnetProtocolError>(py));
+            assert_eq!(
+                mismatch
+                    .value(py)
+                    .getattr("error_class")
+                    .unwrap()
+                    .extract::<u32>()
+                    .unwrap(),
+                ErrorClass::SERVICES.to_raw() as u32
+            );
+            assert_eq!(
+                mismatch
+                    .value(py)
+                    .getattr("error_code")
+                    .unwrap()
+                    .extract::<u32>()
+                    .unwrap(),
+                ErrorCode::INVALID_FILE_ACCESS_METHOD.to_raw() as u32
+            );
+            assert_eq!(
+                server
+                    .get_file_records(py, 6)
+                    .unwrap()
+                    .get_item(0)
+                    .unwrap()
+                    .cast::<PyBytes>()
+                    .unwrap()
+                    .as_bytes(),
+                b"one"
+            );
+        });
+    }
+
+    #[test]
+    fn started_and_drained_states_reject_without_mutation() {
+        let started = test_server();
+        started
+            .push_pending(Box::new(file(8, "STARTED", b"kept")))
+            .unwrap();
+        started.started.store(true, Ordering::Release);
+        Python::attach(|py| {
+            let error = started
+                .set_file_data(8, &PyBytes::new(py, b"changed"))
+                .unwrap_err();
+            assert!(error.is_instance_of::<PyRuntimeError>(py));
+            assert_eq!(py_message(py, &error), STARTED_CONFIGURATION);
+        });
+        assert_eq!(
+            started.lock_pending().unwrap()[0]
+                .file_configuration_internal()
+                .unwrap()
+                .stream_data()
+                .unwrap(),
+            b"kept"
+        );
+
+        let drained = test_server();
+        drained
+            .push_pending(Box::new(file(9, "DRAINED", b"gone")))
+            .unwrap();
+        drained.lock_pending().unwrap().drain(..);
+        Python::attach(|py| {
+            let error = drained.get_file_data(py, 9).unwrap_err();
+            assert!(error.is_instance_of::<PyValueError>(py));
+            assert_eq!(
+                py_message(py, &error),
+                "no pending File object with instance 9"
+            );
+        });
+    }
+
+    #[test]
+    fn cap_methods_return_the_file_objects_effective_values() {
+        let server = test_server();
+        server
+            .push_pending(Box::new(file(10, "CAPPED", b"preloaded")))
+            .unwrap();
+        assert_eq!(
+            server.set_max_file_size(10, u64::MAX).unwrap(),
+            i32::MAX as u64
+        );
+        assert_eq!(
+            server.set_max_record_count(10, u64::MAX).unwrap(),
+            bacnet_objects::file::DEFAULT_MAX_RECORD_COUNT
+        );
+        assert_eq!(server.set_max_file_size(10, 2).unwrap(), 2);
+        assert_eq!(
+            server
+                .with_pending_file_configuration(10, |configuration| {
+                    Ok(configuration.stream_data().unwrap().to_vec())
+                })
+                .unwrap(),
+            b"preloaded"
+        );
+    }
+}

--- a/crates/rusty-bacnet/tests/test_file_management.py
+++ b/crates/rusty-bacnet/tests/test_file_management.py
@@ -1,0 +1,216 @@
+"""Artifact tests for synchronous pre-start built-in File management."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import re
+import unittest
+from pathlib import Path
+from typing import Any
+
+import rusty_bacnet
+from rusty_bacnet import (
+    BACnetServer,
+    BacnetProtocolError,
+    ErrorClass,
+    ErrorCode,
+)
+
+
+METHOD_PARAMETERS = {
+    "set_file_access_method": ["self", "instance", "access_method"],
+    "set_file_data": ["self", "instance", "data"],
+    "get_file_data": ["self", "instance"],
+    "set_file_records": ["self", "instance", "records"],
+    "get_file_records": ["self", "instance"],
+    "set_max_file_size": ["self", "instance", "max_octets"],
+    "set_max_record_count": ["self", "instance", "max_records"],
+}
+METHOD_ANNOTATIONS = {
+    "set_file_access_method": (["int", "str"], "None"),
+    "set_file_data": (["int", "bytes"], "None"),
+    "get_file_data": (["int"], "bytes"),
+    "set_file_records": (["int", "list[bytes]"], "None"),
+    "get_file_records": (["int"], "list[bytes]"),
+    "set_max_file_size": (["int", "int"], "int"),
+    "set_max_record_count": (["int", "int"], "int"),
+}
+INVALID_ACCESS_METHOD = "access_method must be 'stream' or 'record'"
+
+
+def stub_methods() -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    stub_path = Path(rusty_bacnet.__file__).with_suffix(".pyi")
+    tree = ast.parse(stub_path.read_text(encoding="utf-8"), filename=str(stub_path))
+    server = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "BACnetServer"
+    )
+    return {
+        node.name: node
+        for node in server.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def annotation_text(annotation: ast.expr | None) -> str:
+    assert annotation is not None
+    return ast.unparse(annotation)
+
+
+def make_server(**overrides: Any) -> BACnetServer:
+    config: dict[str, Any] = {
+        "device_instance": 420_708,
+        "device_name": "File Management Artifact Test",
+        "port": 0,
+    }
+    config.update(overrides)
+    return BACnetServer(**config)
+
+
+class FileManagementSignatureTests(unittest.TestCase):
+    def test_runtime_and_stub_signatures_are_exact_and_synchronous(self) -> None:
+        methods = stub_methods()
+        for name, expected in METHOD_PARAMETERS.items():
+            with self.subTest(method=name):
+                runtime = getattr(BACnetServer, name)
+                parameters = list(inspect.signature(runtime).parameters.values())
+                self.assertEqual([parameter.name for parameter in parameters], expected)
+                self.assertIs(parameters[0].kind, inspect.Parameter.POSITIONAL_ONLY)
+                self.assertTrue(
+                    all(
+                        parameter.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+                        for parameter in parameters[1:]
+                    )
+                )
+                self.assertFalse(inspect.iscoroutinefunction(runtime))
+
+                stub = methods[name]
+                self.assertIs(type(stub), ast.FunctionDef)
+                self.assertEqual([arg.arg for arg in stub.args.posonlyargs], ["self"])
+                self.assertEqual([arg.arg for arg in stub.args.args], expected[1:])
+                annotations, returns = METHOD_ANNOTATIONS[name]
+                self.assertEqual(
+                    [annotation_text(arg.annotation) for arg in stub.args.args],
+                    annotations,
+                )
+                self.assertEqual(annotation_text(stub.returns), returns)
+
+
+class FileManagementRuntimeTests(unittest.TestCase):
+    def test_stream_and_record_payloads_are_copied(self) -> None:
+        server = make_server()
+        server.add_file(1, "Stream")
+        source = b"stream payload"
+        server.set_file_data(1, source)
+        first = server.get_file_data(1)
+        second = server.get_file_data(1)
+        self.assertIsInstance(first, bytes)
+        self.assertEqual(first, source)
+        self.assertIsNot(first, second)
+        mutable_copy = bytearray(first)
+        mutable_copy[0] = ord("S")
+        self.assertEqual(server.get_file_data(1), source)
+
+        server.add_file(2, "Records")
+        server.set_file_access_method(2, "record")
+        source_records = [b"one", b"two"]
+        server.set_file_records(2, source_records)
+        source_records[0] = b"changed"
+        source_records.append(b"three")
+
+        records = server.get_file_records(2)
+        second_records = server.get_file_records(2)
+        self.assertEqual(records, [b"one", b"two"])
+        self.assertIsNot(records, second_records)
+        self.assertIsNot(records[0], second_records[0])
+        records[0] = b"changed"
+        records.pop()
+        self.assertEqual(server.get_file_records(2), [b"one", b"two"])
+
+    def test_errors_caps_and_mode_mismatches_are_atomic(self) -> None:
+        server = make_server()
+        server.add_file(3, "Stream")
+        server.set_file_data(3, b"preloaded")
+
+        with self.assertRaisesRegex(
+            ValueError, f"^{re.escape(INVALID_ACCESS_METHOD)}$"
+        ):
+            server.set_file_access_method(3, "STREAM")
+        self.assertEqual(server.get_file_data(3), b"preloaded")
+
+        with self.assertRaises(BacnetProtocolError) as mismatch:
+            server.get_file_records(3)
+        self.assertEqual(mismatch.exception.error_class, ErrorClass.SERVICES.to_raw())
+        self.assertEqual(
+            mismatch.exception.error_code,
+            ErrorCode.INVALID_FILE_ACCESS_METHOD.to_raw(),
+        )
+        self.assertEqual(server.get_file_data(3), b"preloaded")
+
+        self.assertEqual(server.set_max_file_size(3, (1 << 64) - 1), (1 << 31) - 1)
+        self.assertEqual(server.set_max_file_size(3, 2), 2)
+        self.assertEqual(server.get_file_data(3), b"preloaded")
+        with self.assertRaises(OverflowError):
+            server.set_max_file_size(3, -1)
+        with self.assertRaises(OverflowError):
+            server.set_max_file_size(3, 1 << 64)
+        self.assertEqual(server.get_file_data(3), b"preloaded")
+
+        server.add_file(4, "Records")
+        server.set_file_access_method(4, "record")
+        server.set_file_records(4, [b"one", b"two"])
+        invalid_records: Any = [b"valid", bytearray(b"not bytes")]
+        with self.assertRaises(TypeError):
+            server.set_file_records(4, invalid_records)
+        self.assertEqual(server.get_file_records(4), [b"one", b"two"])
+        self.assertEqual(server.set_max_record_count(4, (1 << 64) - 1), 10_000)
+        self.assertEqual(server.set_max_record_count(4, 1), 1)
+        self.assertEqual(server.get_file_records(4), [b"one", b"two"])
+        with self.assertRaises(BacnetProtocolError):
+            server.set_file_data(4, b"wrong shape")
+        self.assertEqual(server.get_file_records(4), [b"one", b"two"])
+
+    def test_lookup_type_inputs_and_drained_lifecycle_fail_stably(self) -> None:
+        server = make_server()
+        server.add_analog_input(5, "Not a File")
+        with self.assertRaisesRegex(
+            ValueError, "^no pending File object with instance 5$"
+        ):
+            server.get_file_data(5)
+        with self.assertRaisesRegex(
+            ValueError, "^no pending File object with instance 99$"
+        ):
+            server.get_file_data(99)
+
+        server.add_file(8, "First duplicate")
+        server.set_file_data(8, b"first")
+        server.add_file(8, "Effective duplicate")
+        self.assertEqual(server.get_file_data(8), b"")
+        server.set_file_data(8, b"effective")
+        self.assertEqual(server.get_file_data(8), b"effective")
+
+        server.add_file(6, "Strict bytes")
+        invalid_data: Any = bytearray(b"not bytes")
+        with self.assertRaises(TypeError):
+            server.set_file_data(6, invalid_data)
+        self.assertEqual(server.get_file_data(6), b"")
+
+        drained = make_server(transport="invalid-for-artifact-test")
+        drained.add_file(7, "Drained")
+
+        async def start_and_fail() -> None:
+            await drained.start()
+
+        with self.assertRaisesRegex(RuntimeError, "^unknown transport"):
+            asyncio.run(start_and_fail())
+        with self.assertRaisesRegex(
+            ValueError, "^no pending File object with instance 7$"
+        ):
+            drained.get_file_data(7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1170,8 +1170,33 @@ server.add_date_time_pattern_value(instance=1, name="Schedule Pattern")
 server.add_accumulator(instance=1, name="kWh Meter", units=70)      # 70 = kilowatt-hours
 server.add_pulse_converter(instance=1, name="Pulse Count", units=95) # 95 = counts
 server.add_file(instance=1, name="Config File", file_type="text/plain")
+server.set_file_data(instance=1, data=b"mode=occupied\n")
+
+server.add_file(instance=2, name="Record File")
+server.set_file_access_method(instance=2, access_method="record")
+server.set_file_records(instance=2, records=[b"first", b"second"])
 server.add_network_port(instance=1, name="BIP Port", network_type=0)
 ```
+
+The seven File configuration methods are synchronous and operate only on a
+pending built-in File before `start()`:
+
+- `set_file_access_method(instance, access_method)` accepts only `"stream"` or
+  `"record"`. Select the mode before loading its corresponding payload; a mode
+  change preserves both stored channels and does not convert between them.
+- `set_file_data` / `get_file_data` require stream mode.
+- `set_file_records` / `get_file_records` require record mode.
+- `set_max_file_size` and `set_max_record_count` return the effective value
+  after the built-in File clamp. These are growth limits for later
+  AtomicWriteFile requests; lowering a cap does not truncate preloaded content.
+
+Inputs are copied. Getters return a fresh `bytes`, or a fresh `list` containing
+fresh `bytes`, so later Python-side mutation cannot alter Rust storage.
+Preloading is trusted local configuration and is independent of `Read_Only`;
+network clients read and write runtime content through AtomicReadFile and
+AtomicWriteFile, where `Read_Only`, access method, caps, and all-or-failure
+behavior remain enforced. These methods do not mutate a live database and do
+not persist File content across stop/restart.
 
 ### Lifecycle
 
@@ -1234,7 +1259,7 @@ All BACnet errors are raised as Python exceptions:
 | Exception | Meaning |
 |-----------|---------|
 | `BacnetError` | Base exception for all BACnet errors |
-| `BacnetProtocolError` | Remote device returned a BACnet error (class + code) |
+| `BacnetProtocolError` | A remote or local BACnet protocol check returned an error (class + code) |
 | `BacnetTimeoutError` | Request timed out (APDU retries exhausted) |
 | `BacnetRejectError` | Remote device rejected the request |
 | `BacnetAbortError` | Remote device aborted the request |

--- a/examples/python/bip_client_server.py
+++ b/examples/python/bip_client_server.py
@@ -2,6 +2,7 @@
 
 Demonstrates:
 - Starting a BACnet/IP server with multiple object types
+- Preloading stream- and record-access File objects before start
 - Reading and writing properties from a client
 - ReadPropertyMultiple for efficient bulk reads
 - Device discovery via WhoIs/IAm
@@ -35,6 +36,11 @@ async def main():
     server.add_binary_output(instance=1, name="Fan Enable")
     server.add_binary_value(instance=1, name="Override Mode")
     server.add_multistate_value(instance=1, name="Operating Mode", number_of_states=4)
+    server.add_file(instance=1, name="Controller Config", file_type="text/plain")
+    server.set_file_data(instance=1, data=b"mode=occupied\n")
+    server.add_file(instance=2, name="Startup Records")
+    server.set_file_access_method(instance=2, access_method="record")
+    server.set_file_records(instance=2, records=[b"boot", b"ready"])
 
     await server.start()
     addr = await server.local_address()


### PR DESCRIPTION
## Summary
- add seven synchronous pre-start methods for pending built-in File objects: select access method, copy stream/record payloads in and out, and set effective growth caps
- mutate the exact `FileObject` later drained into the runtime database through a narrow default-off configuration capability
- preserve File accounting, metadata, read-only, access-method, cap, and AtomicReadFile/AtomicWriteFile behavior
- keep runtime/stub signatures aligned and document copy, lifecycle, and cap semantics
- add installed-wheel artifact coverage without introducing CI or broader protocol claims

## Public lifecycle decision
These methods operate only before `BACnetServer.start()`. Runtime file access remains AtomicReadFile/AtomicWriteFile; this PR does not introduce live database replacement, stop/restart persistence, or a parallel File state cache.

## Source-to-behavior traceability
| Standard 135-2020 source | Implemented behavior |
|---|---|
| §12.13 / Table 12-16 | Python configuration preserves the active stream/record shape, File_Size/Record_Count accounting, Modification_Date/Archive behavior, Read_Only semantics, and local capacity policy owned by the built-in File object. |
| §§14.1–14.2 | Preloaded stream bytes and record byte lists are the same payloads later exposed through AtomicReadFile and governed by AtomicWriteFile access-method, read-only, cap, and atomic-failure checks. |

The Standard does not define this local Python API; this is binding parity for already-supported File storage, not an expanded Clause 14 conformance claim.

## Validation
- `cargo fmt --all -- --check`
- focused File configuration capability and Python binding tests
- `cargo test -p bacnet-objects --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- repository CI-native workspace tests excluding the PyO3 root crate
- `uvx maturin build --release --locked --manifest-path crates/rusty-bacnet/Cargo.toml` into a temporary directory
- isolated matching CPython 3.14t wheel install/import and 15 artifact tests
- Python `py_compile` plus stub AST/runtime-signature parity
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

The raw macOS `cargo test -p rusty-bacnet` path retains the repository's known PyO3 cdylib undefined-Python-symbol linker incompatibility; the CI-native `cargo check` and installed-wheel executable gate passed.

## Boundaries
- `add_file` and ObjectDatabase are unchanged
- no runtime mutation API, custom FileStorage management, service-handler changes, raw property escape hatch, CLI, restore orchestration, combined endpoint work, stub-wide checker, CI, README/PICS/BIBB, or conformance-status expansion
- payloads and returned values are copies; cap setters return effective clamped values and do not truncate trusted preloads

Closes #420