### PR TITLE
feat(server): execute opt-in Life Safety resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Opt-in, application-owned synchronous execution for `RESET`, `RESET_ALARM`,
+  and `RESET_FAULT` on built-in Life Safety Point and Zone objects (`Refs
+  #177`). Separate typed contexts expose only modeled immutable local state,
+  and typed atomic commits may update only Point Present/Tracking/Silenced or
+  Zone Present/Silenced before the object clears `Operation_Expected`.
+  Missing executors, unsupported variants, invalid state, operational failure,
+  panic, invalid commits, and authorization denial retain exact Result(-)
+  handling; targetless reset keeps successful object commits while suppressing
+  per-object failures. No built-in or physical reset behavior is inferred,
+  Zone Tracking_Value and PICS/BIBB claims remain deferred, and bounded
+  duplicate tracking does not replace application-owned actuation idempotency.
+
 - Synchronous pre-start Python management for pending built-in File objects
   (#420). Servers can select stream or record access, copy payloads in and out,
   and set effective clamped octet/record growth caps on the exact object later

--- a/crates/bacnet-objects/src/life_safety.rs
+++ b/crates/bacnet-objects/src/life_safety.rs
@@ -11,6 +11,14 @@ use std::borrow::Cow;
 use crate::common::{self, read_common_properties};
 use crate::traits::{BACnetObject, LifeSafetyOperationEffect};
 
+mod reset;
+
+pub use reset::{
+    LifeSafetyPointResetCommit, LifeSafetyPointResetContext, LifeSafetyPointResetExecutor,
+    LifeSafetyResetError, LifeSafetyZoneResetCommit, LifeSafetyZoneResetContext,
+    LifeSafetyZoneResetExecutor,
+};
+
 fn life_safety_error(code: ErrorCode) -> Error {
     Error::Protocol {
         class: ErrorClass::OBJECT.to_raw() as u32,
@@ -92,6 +100,8 @@ pub struct LifeSafetyPointObject {
     out_of_service: bool,
     /// Reliability (0 = NO_FAULT_DETECTED).
     reliability: u32,
+    /// Application-owned physical reset integration, configured before insertion.
+    reset_executor: Option<LifeSafetyPointResetExecutor>,
 }
 
 impl LifeSafetyPointObject {
@@ -117,6 +127,7 @@ impl LifeSafetyPointObject {
             status_flags: StatusFlags::empty(),
             out_of_service: false,
             reliability: 0,
+            reset_executor: None,
         })
     }
 
@@ -143,6 +154,20 @@ impl LifeSafetyPointObject {
     /// Set the next LifeSafetyOperation expected by local device logic.
     pub fn set_operation_expected(&mut self, operation: LifeSafetyOperation) {
         self.operation_expected = operation.to_raw();
+    }
+
+    /// Configure the application-owned reset executor before database insertion.
+    ///
+    /// The executor is used only for `RESET`, `RESET_ALARM`, and `RESET_FAULT`.
+    /// See [`LifeSafetyPointResetExecutor`] for its synchronous execution contract.
+    pub fn set_reset_executor(&mut self, executor: LifeSafetyPointResetExecutor) {
+        self.reset_executor = Some(executor);
+    }
+
+    /// Configure and return this point for insertion into an object database.
+    pub fn with_reset_executor(mut self, executor: LifeSafetyPointResetExecutor) -> Self {
+        self.set_reset_executor(executor);
+        self
     }
 
     /// Set the direct reading (raw sensor value).
@@ -302,7 +327,11 @@ impl BACnetObject for LifeSafetyPointObject {
         &mut self,
         operation: LifeSafetyOperation,
     ) -> Result<LifeSafetyOperationEffect, Error> {
-        apply_silenced_operation(&mut self.silenced, &mut self.operation_expected, operation)
+        if reset::is_reset_operation(operation) {
+            self.apply_reset_operation(operation)
+        } else {
+            apply_silenced_operation(&mut self.silenced, &mut self.operation_expected, operation)
+        }
     }
 
     fn set_life_safety_operation_expected_internal(
@@ -343,6 +372,8 @@ pub struct LifeSafetyZoneObject {
     out_of_service: bool,
     /// Reliability (0 = NO_FAULT_DETECTED).
     reliability: u32,
+    /// Application-owned physical reset integration, configured before insertion.
+    reset_executor: Option<LifeSafetyZoneResetExecutor>,
 }
 
 impl LifeSafetyZoneObject {
@@ -365,6 +396,7 @@ impl LifeSafetyZoneObject {
             status_flags: StatusFlags::empty(),
             out_of_service: false,
             reliability: 0,
+            reset_executor: None,
         })
     }
 
@@ -386,6 +418,20 @@ impl LifeSafetyZoneObject {
     /// Set the next LifeSafetyOperation expected by local device logic.
     pub fn set_operation_expected(&mut self, operation: LifeSafetyOperation) {
         self.operation_expected = operation.to_raw();
+    }
+
+    /// Configure the application-owned reset executor before database insertion.
+    ///
+    /// The executor is used only for `RESET`, `RESET_ALARM`, and `RESET_FAULT`.
+    /// See [`LifeSafetyZoneResetExecutor`] for its synchronous execution contract.
+    pub fn set_reset_executor(&mut self, executor: LifeSafetyZoneResetExecutor) {
+        self.reset_executor = Some(executor);
+    }
+
+    /// Configure and return this zone for insertion into an object database.
+    pub fn with_reset_executor(mut self, executor: LifeSafetyZoneResetExecutor) -> Self {
+        self.set_reset_executor(executor);
+        self
     }
 
     /// Set the description.
@@ -511,7 +557,11 @@ impl BACnetObject for LifeSafetyZoneObject {
         &mut self,
         operation: LifeSafetyOperation,
     ) -> Result<LifeSafetyOperationEffect, Error> {
-        apply_silenced_operation(&mut self.silenced, &mut self.operation_expected, operation)
+        if reset::is_reset_operation(operation) {
+            self.apply_reset_operation(operation)
+        } else {
+            apply_silenced_operation(&mut self.silenced, &mut self.operation_expected, operation)
+        }
     }
 
     fn set_life_safety_operation_expected_internal(
@@ -529,3 +579,6 @@ impl BACnetObject for LifeSafetyZoneObject {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod reset_tests;

--- a/crates/bacnet-objects/src/life_safety/reset.rs
+++ b/crates/bacnet-objects/src/life_safety/reset.rs
@@ -1,0 +1,266 @@
+//! Application-owned reset execution for built-in Life Safety objects.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::sync::Arc;
+
+use bacnet_types::enums::{
+    ErrorClass, ErrorCode, LifeSafetyOperation, LifeSafetyState, SilencedState,
+};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::ObjectIdentifier;
+
+use crate::traits::LifeSafetyOperationEffect;
+
+use super::{life_safety_error, LifeSafetyPointObject, LifeSafetyZoneObject};
+
+/// Immutable Life Safety Point state supplied to a reset executor.
+///
+/// Network provenance is deliberately absent. The server-owned authorizer is
+/// the authority boundary; this context describes only truthful local state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LifeSafetyPointResetContext {
+    /// Object receiving the operation.
+    pub object_identifier: ObjectIdentifier,
+    /// Exact reset variant requested by the peer.
+    pub operation: LifeSafetyOperation,
+    /// Current `Present_Value`.
+    pub present_value: LifeSafetyState,
+    /// Current `Tracking_Value`.
+    pub tracking_value: LifeSafetyState,
+    /// Current `Silenced` value.
+    pub silenced: SilencedState,
+    /// Current `Operation_Expected`, equal to `operation` when invoked.
+    pub operation_expected: LifeSafetyOperation,
+}
+
+/// Atomic local-state proposal returned by a Life Safety Point reset executor.
+///
+/// Omitted properties remain unchanged. No value is inferred from another
+/// property, and successful application always clears `Operation_Expected`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LifeSafetyPointResetCommit {
+    /// Replacement `Present_Value`, when application truth changed.
+    pub present_value: Option<LifeSafetyState>,
+    /// Replacement `Tracking_Value`, when application truth changed.
+    pub tracking_value: Option<LifeSafetyState>,
+    /// Replacement `Silenced`, when application truth changed.
+    pub silenced: Option<SilencedState>,
+}
+
+/// Immutable Life Safety Zone state supplied to a reset executor.
+///
+/// Zone `Tracking_Value` is intentionally absent because the built-in Zone
+/// object does not model that required property yet. Network provenance is
+/// retained only by the server-owned authorization boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LifeSafetyZoneResetContext {
+    /// Object receiving the operation.
+    pub object_identifier: ObjectIdentifier,
+    /// Exact reset variant requested by the peer.
+    pub operation: LifeSafetyOperation,
+    /// Current `Present_Value`.
+    pub present_value: LifeSafetyState,
+    /// Current `Silenced` value.
+    pub silenced: SilencedState,
+    /// Current `Operation_Expected`, equal to `operation` when invoked.
+    pub operation_expected: LifeSafetyOperation,
+}
+
+/// Atomic local-state proposal returned by a Life Safety Zone reset executor.
+///
+/// Omitted properties remain unchanged. No quiet state or unsilencing is
+/// implicit, and successful application always clears `Operation_Expected`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LifeSafetyZoneResetCommit {
+    /// Replacement `Present_Value`, when application truth changed.
+    pub present_value: Option<LifeSafetyState>,
+    /// Replacement `Silenced`, when application truth changed.
+    pub silenced: Option<SilencedState>,
+}
+
+/// Protocol-classified failure reported by an application reset executor.
+///
+/// The closed set prevents callbacks from escaping arbitrary protocol errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LifeSafetyResetError {
+    /// The application does not implement the exact recognized reset variant.
+    UnsupportedVariant,
+    /// Local physical or application state cannot accept this reset now.
+    InvalidOperationInThisState,
+    /// Authorization-like denial or an operational executor failure.
+    ServiceRequestDenied,
+}
+
+/// Synchronous application-owned Life Safety Point reset executor.
+///
+/// The server invokes this callback while holding the object-database write
+/// lock. It must be fast, nonblocking, non-reentrant, and panic-free. Panics are
+/// caught where unwinding is supported and fail closed. Because duplicate
+/// tracking is bounded and process-local, physical actuation must also be
+/// application-idempotent. The callback receives no mutable object reference.
+pub type LifeSafetyPointResetExecutor = Arc<
+    dyn Fn(&LifeSafetyPointResetContext) -> Result<LifeSafetyPointResetCommit, LifeSafetyResetError>
+        + Send
+        + Sync,
+>;
+
+/// Synchronous application-owned Life Safety Zone reset executor.
+///
+/// The server invokes this callback while holding the object-database write
+/// lock. It must be fast, nonblocking, non-reentrant, and panic-free. Panics are
+/// caught where unwinding is supported and fail closed. Because duplicate
+/// tracking is bounded and process-local, physical actuation must also be
+/// application-idempotent. The callback receives no mutable object reference.
+pub type LifeSafetyZoneResetExecutor = Arc<
+    dyn Fn(&LifeSafetyZoneResetContext) -> Result<LifeSafetyZoneResetCommit, LifeSafetyResetError>
+        + Send
+        + Sync,
+>;
+
+pub(super) fn is_reset_operation(operation: LifeSafetyOperation) -> bool {
+    matches!(
+        operation,
+        LifeSafetyOperation::RESET
+            | LifeSafetyOperation::RESET_ALARM
+            | LifeSafetyOperation::RESET_FAULT
+    )
+}
+
+fn reset_error(error: LifeSafetyResetError) -> Error {
+    match error {
+        LifeSafetyResetError::UnsupportedVariant => {
+            life_safety_error(ErrorCode::VALUE_OUT_OF_RANGE)
+        }
+        LifeSafetyResetError::InvalidOperationInThisState => {
+            life_safety_error(ErrorCode::INVALID_OPERATION_IN_THIS_STATE)
+        }
+        LifeSafetyResetError::ServiceRequestDenied => Error::Protocol {
+            class: ErrorClass::SERVICES.to_raw() as u32,
+            code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+        },
+    }
+}
+
+fn optional_functionality_error() -> Error {
+    life_safety_error(ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED)
+}
+
+fn invalid_operation_error() -> Error {
+    life_safety_error(ErrorCode::INVALID_OPERATION_IN_THIS_STATE)
+}
+
+fn commit_value_error() -> Error {
+    life_safety_error(ErrorCode::VALUE_OUT_OF_RANGE)
+}
+
+fn valid_life_safety_state(state: LifeSafetyState) -> bool {
+    LifeSafetyState::ALL_NAMED
+        .iter()
+        .any(|&(_, named)| named == state)
+        || (256..=65_535).contains(&state.to_raw())
+}
+
+fn valid_silenced_state(state: SilencedState) -> bool {
+    SilencedState::ALL_NAMED
+        .iter()
+        .any(|&(_, named)| named == state)
+}
+
+impl LifeSafetyPointObject {
+    pub(super) fn apply_reset_operation(
+        &mut self,
+        operation: LifeSafetyOperation,
+    ) -> Result<LifeSafetyOperationEffect, Error> {
+        if !is_reset_operation(operation) || self.operation_expected != operation.to_raw() {
+            return Err(invalid_operation_error());
+        }
+        let executor = self
+            .reset_executor
+            .clone()
+            .ok_or_else(optional_functionality_error)?;
+        let context = LifeSafetyPointResetContext {
+            object_identifier: self.oid,
+            operation,
+            present_value: LifeSafetyState::from_raw(self.present_value),
+            tracking_value: LifeSafetyState::from_raw(self.tracking_value),
+            silenced: SilencedState::from_raw(self.silenced),
+            operation_expected: LifeSafetyOperation::from_raw(self.operation_expected),
+        };
+        let result = match catch_unwind(AssertUnwindSafe(|| executor(&context))) {
+            Ok(result) => result,
+            Err(_) => return Err(reset_error(LifeSafetyResetError::ServiceRequestDenied)),
+        };
+        let commit = result.map_err(reset_error)?;
+
+        if commit
+            .present_value
+            .is_some_and(|value| !valid_life_safety_state(value))
+            || commit
+                .tracking_value
+                .is_some_and(|value| !valid_life_safety_state(value))
+            || commit
+                .silenced
+                .is_some_and(|value| !valid_silenced_state(value))
+        {
+            return Err(commit_value_error());
+        }
+
+        if let Some(value) = commit.present_value {
+            self.present_value = value.to_raw();
+        }
+        if let Some(value) = commit.tracking_value {
+            self.tracking_value = value.to_raw();
+        }
+        if let Some(value) = commit.silenced {
+            self.silenced = value.to_raw();
+        }
+        self.operation_expected = LifeSafetyOperation::NONE.to_raw();
+        Ok(LifeSafetyOperationEffect::Applied)
+    }
+}
+
+impl LifeSafetyZoneObject {
+    pub(super) fn apply_reset_operation(
+        &mut self,
+        operation: LifeSafetyOperation,
+    ) -> Result<LifeSafetyOperationEffect, Error> {
+        if !is_reset_operation(operation) || self.operation_expected != operation.to_raw() {
+            return Err(invalid_operation_error());
+        }
+        let executor = self
+            .reset_executor
+            .clone()
+            .ok_or_else(optional_functionality_error)?;
+        let context = LifeSafetyZoneResetContext {
+            object_identifier: self.oid,
+            operation,
+            present_value: LifeSafetyState::from_raw(self.present_value),
+            silenced: SilencedState::from_raw(self.silenced),
+            operation_expected: LifeSafetyOperation::from_raw(self.operation_expected),
+        };
+        let result = match catch_unwind(AssertUnwindSafe(|| executor(&context))) {
+            Ok(result) => result,
+            Err(_) => return Err(reset_error(LifeSafetyResetError::ServiceRequestDenied)),
+        };
+        let commit = result.map_err(reset_error)?;
+
+        if commit
+            .present_value
+            .is_some_and(|value| !valid_life_safety_state(value))
+            || commit
+                .silenced
+                .is_some_and(|value| !valid_silenced_state(value))
+        {
+            return Err(commit_value_error());
+        }
+
+        if let Some(value) = commit.present_value {
+            self.present_value = value.to_raw();
+        }
+        if let Some(value) = commit.silenced {
+            self.silenced = value.to_raw();
+        }
+        self.operation_expected = LifeSafetyOperation::NONE.to_raw();
+        Ok(LifeSafetyOperationEffect::Applied)
+    }
+}

--- a/crates/bacnet-objects/src/life_safety/reset_tests.rs
+++ b/crates/bacnet-objects/src/life_safety/reset_tests.rs
@@ -1,0 +1,337 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use bacnet_types::enums::{
+    ErrorClass, ErrorCode, LifeSafetyOperation, LifeSafetyState, PropertyIdentifier, SilencedState,
+};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::PropertyValue;
+
+use crate::traits::{BACnetObject, LifeSafetyOperationEffect};
+
+use super::*;
+
+fn read(object: &dyn BACnetObject, property: PropertyIdentifier) -> u32 {
+    match object.read_property(property, None).unwrap() {
+        PropertyValue::Enumerated(value) => value,
+        other => panic!("expected enumerated value, got {other:?}"),
+    }
+}
+
+fn point_state(point: &LifeSafetyPointObject) -> (u32, u32, u32, u32) {
+    (
+        read(point, PropertyIdentifier::PRESENT_VALUE),
+        read(point, PropertyIdentifier::TRACKING_VALUE),
+        read(point, PropertyIdentifier::SILENCED),
+        read(point, PropertyIdentifier::OPERATION_EXPECTED),
+    )
+}
+
+fn zone_state(zone: &LifeSafetyZoneObject) -> (u32, u32, u32) {
+    (
+        read(zone, PropertyIdentifier::PRESENT_VALUE),
+        read(zone, PropertyIdentifier::SILENCED),
+        read(zone, PropertyIdentifier::OPERATION_EXPECTED),
+    )
+}
+
+fn assert_error(error: Error, class: ErrorClass, code: ErrorCode) {
+    assert!(matches!(
+        error,
+        Error::Protocol {
+            class: actual_class,
+            code: actual_code,
+        } if actual_class == class.to_raw() as u32 && actual_code == code.to_raw() as u32
+    ));
+}
+
+#[test]
+fn point_reset_variants_receive_exact_context_and_commit_atomically() {
+    for operation in [
+        LifeSafetyOperation::RESET,
+        LifeSafetyOperation::RESET_ALARM,
+        LifeSafetyOperation::RESET_FAULT,
+    ] {
+        let mut point = LifeSafetyPointObject::new(operation.to_raw(), "point").unwrap();
+        let oid = point.object_identifier();
+        point.set_present_value(LifeSafetyState::ALARM.to_raw());
+        point.set_tracking_value(LifeSafetyState::FAULT.to_raw());
+        point.set_silenced(SilencedState::ALL_SILENCED);
+        point.set_operation_expected(operation);
+        point.set_reset_executor(Arc::new(move |context| {
+            assert_eq!(
+                *context,
+                LifeSafetyPointResetContext {
+                    object_identifier: oid,
+                    operation,
+                    present_value: LifeSafetyState::ALARM,
+                    tracking_value: LifeSafetyState::FAULT,
+                    silenced: SilencedState::ALL_SILENCED,
+                    operation_expected: operation,
+                }
+            );
+            Ok(LifeSafetyPointResetCommit {
+                present_value: Some(LifeSafetyState::ACTIVE),
+                tracking_value: Some(LifeSafetyState::PRE_ALARM),
+                silenced: Some(SilencedState::AUDIBLE_SILENCED),
+            })
+        }));
+
+        assert_eq!(
+            point.apply_life_safety_operation(operation).unwrap(),
+            LifeSafetyOperationEffect::Applied
+        );
+        assert_eq!(
+            point_state(&point),
+            (
+                LifeSafetyState::ACTIVE.to_raw(),
+                LifeSafetyState::PRE_ALARM.to_raw(),
+                SilencedState::AUDIBLE_SILENCED.to_raw(),
+                LifeSafetyOperation::NONE.to_raw(),
+            )
+        );
+    }
+}
+
+#[test]
+fn zone_reset_variants_receive_exact_context_and_commit_atomically() {
+    for operation in [
+        LifeSafetyOperation::RESET,
+        LifeSafetyOperation::RESET_ALARM,
+        LifeSafetyOperation::RESET_FAULT,
+    ] {
+        let mut zone = LifeSafetyZoneObject::new(operation.to_raw(), "zone").unwrap();
+        let oid = zone.object_identifier();
+        zone.set_present_value(LifeSafetyState::FAULT_ALARM.to_raw());
+        zone.set_silenced(SilencedState::VISIBLE_SILENCED);
+        zone.set_operation_expected(operation);
+        zone.set_reset_executor(Arc::new(move |context| {
+            assert_eq!(
+                *context,
+                LifeSafetyZoneResetContext {
+                    object_identifier: oid,
+                    operation,
+                    present_value: LifeSafetyState::FAULT_ALARM,
+                    silenced: SilencedState::VISIBLE_SILENCED,
+                    operation_expected: operation,
+                }
+            );
+            Ok(LifeSafetyZoneResetCommit {
+                present_value: Some(LifeSafetyState::SUPERVISORY),
+                silenced: Some(SilencedState::UNSILENCED),
+            })
+        }));
+
+        assert_eq!(
+            zone.apply_life_safety_operation(operation).unwrap(),
+            LifeSafetyOperationEffect::Applied
+        );
+        assert_eq!(
+            zone_state(&zone),
+            (
+                LifeSafetyState::SUPERVISORY.to_raw(),
+                SilencedState::UNSILENCED.to_raw(),
+                LifeSafetyOperation::NONE.to_raw(),
+            )
+        );
+    }
+}
+
+#[test]
+fn no_delta_reset_success_preserves_values_and_clears_expected_operation() {
+    let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
+    point.set_present_value(LifeSafetyState::ALARM.to_raw());
+    point.set_tracking_value(LifeSafetyState::FAULT.to_raw());
+    point.set_silenced(SilencedState::ALL_SILENCED);
+    point.set_operation_expected(LifeSafetyOperation::RESET);
+    point.set_reset_executor(Arc::new(|_| Ok(LifeSafetyPointResetCommit::default())));
+    let before = point_state(&point);
+
+    point
+        .apply_life_safety_operation(LifeSafetyOperation::RESET)
+        .unwrap();
+
+    let after = point_state(&point);
+    assert_eq!((after.0, after.1, after.2), (before.0, before.1, before.2));
+    assert_eq!(
+        read(&point, PropertyIdentifier::OPERATION_EXPECTED),
+        LifeSafetyOperation::NONE.to_raw()
+    );
+}
+
+#[test]
+fn wrong_expected_reset_never_calls_executor_or_changes_state() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&calls);
+    let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
+    point.set_present_value(LifeSafetyState::ALARM.to_raw());
+    point.set_tracking_value(LifeSafetyState::FAULT.to_raw());
+    point.set_silenced(SilencedState::ALL_SILENCED);
+    point.set_operation_expected(LifeSafetyOperation::RESET_FAULT);
+    point.set_reset_executor(Arc::new(move |_| {
+        observed.fetch_add(1, Ordering::AcqRel);
+        Ok(LifeSafetyPointResetCommit::default())
+    }));
+    let before = point_state(&point);
+
+    let error = point
+        .apply_life_safety_operation(LifeSafetyOperation::RESET_ALARM)
+        .unwrap_err();
+
+    assert_error(
+        error,
+        ErrorClass::OBJECT,
+        ErrorCode::INVALID_OPERATION_IN_THIS_STATE,
+    );
+    assert_eq!(calls.load(Ordering::Acquire), 0);
+    assert_eq!(point_state(&point), before);
+}
+
+#[test]
+fn missing_point_and_zone_executors_fail_without_mutation() {
+    let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
+    point.set_present_value(LifeSafetyState::ALARM.to_raw());
+    point.set_operation_expected(LifeSafetyOperation::RESET);
+    let point_before = point_state(&point);
+    assert_error(
+        point
+            .apply_life_safety_operation(LifeSafetyOperation::RESET)
+            .unwrap_err(),
+        ErrorClass::OBJECT,
+        ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+    );
+    assert_eq!(point_state(&point), point_before);
+
+    let mut zone = LifeSafetyZoneObject::new(1, "zone").unwrap();
+    zone.set_present_value(LifeSafetyState::FAULT.to_raw());
+    zone.set_operation_expected(LifeSafetyOperation::RESET_FAULT);
+    let zone_before = zone_state(&zone);
+    assert_error(
+        zone.apply_life_safety_operation(LifeSafetyOperation::RESET_FAULT)
+            .unwrap_err(),
+        ErrorClass::OBJECT,
+        ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+    );
+    assert_eq!(zone_state(&zone), zone_before);
+}
+
+#[test]
+fn executor_failures_and_panics_map_exactly_without_mutation() {
+    let cases = [
+        (
+            LifeSafetyResetError::UnsupportedVariant,
+            ErrorClass::OBJECT,
+            ErrorCode::VALUE_OUT_OF_RANGE,
+        ),
+        (
+            LifeSafetyResetError::InvalidOperationInThisState,
+            ErrorClass::OBJECT,
+            ErrorCode::INVALID_OPERATION_IN_THIS_STATE,
+        ),
+        (
+            LifeSafetyResetError::ServiceRequestDenied,
+            ErrorClass::SERVICES,
+            ErrorCode::SERVICE_REQUEST_DENIED,
+        ),
+    ];
+    for (executor_error, class, code) in cases {
+        let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
+        point.set_present_value(LifeSafetyState::ALARM.to_raw());
+        point.set_tracking_value(LifeSafetyState::FAULT.to_raw());
+        point.set_silenced(SilencedState::ALL_SILENCED);
+        point.set_operation_expected(LifeSafetyOperation::RESET);
+        point.set_reset_executor(Arc::new(move |_| Err(executor_error)));
+        let before = point_state(&point);
+
+        assert_error(
+            point
+                .apply_life_safety_operation(LifeSafetyOperation::RESET)
+                .unwrap_err(),
+            class,
+            code,
+        );
+        assert_eq!(point_state(&point), before);
+    }
+
+    let mut zone = LifeSafetyZoneObject::new(1, "zone").unwrap();
+    zone.set_present_value(LifeSafetyState::ALARM.to_raw());
+    zone.set_operation_expected(LifeSafetyOperation::RESET);
+    zone.set_reset_executor(Arc::new(|_| panic!("executor bug")));
+    let before = zone_state(&zone);
+    assert_error(
+        zone.apply_life_safety_operation(LifeSafetyOperation::RESET)
+            .unwrap_err(),
+        ErrorClass::SERVICES,
+        ErrorCode::SERVICE_REQUEST_DENIED,
+    );
+    assert_eq!(zone_state(&zone), before);
+}
+
+#[test]
+fn invalid_commits_cannot_partially_mutate_point_or_zone() {
+    let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
+    point.set_present_value(LifeSafetyState::ALARM.to_raw());
+    point.set_tracking_value(LifeSafetyState::FAULT.to_raw());
+    point.set_silenced(SilencedState::ALL_SILENCED);
+    point.set_operation_expected(LifeSafetyOperation::RESET);
+    point.set_reset_executor(Arc::new(|_| {
+        Ok(LifeSafetyPointResetCommit {
+            present_value: Some(LifeSafetyState::QUIET),
+            tracking_value: Some(LifeSafetyState::from_raw(35)),
+            silenced: Some(SilencedState::UNSILENCED),
+        })
+    }));
+    let before = point_state(&point);
+    assert_error(
+        point
+            .apply_life_safety_operation(LifeSafetyOperation::RESET)
+            .unwrap_err(),
+        ErrorClass::OBJECT,
+        ErrorCode::VALUE_OUT_OF_RANGE,
+    );
+    assert_eq!(point_state(&point), before);
+
+    let mut zone = LifeSafetyZoneObject::new(1, "zone").unwrap();
+    zone.set_present_value(LifeSafetyState::FAULT.to_raw());
+    zone.set_silenced(SilencedState::ALL_SILENCED);
+    zone.set_operation_expected(LifeSafetyOperation::RESET);
+    zone.set_reset_executor(Arc::new(|_| {
+        Ok(LifeSafetyZoneResetCommit {
+            present_value: Some(LifeSafetyState::QUIET),
+            silenced: Some(SilencedState::from_raw(4)),
+        })
+    }));
+    let before = zone_state(&zone);
+    assert_error(
+        zone.apply_life_safety_operation(LifeSafetyOperation::RESET)
+            .unwrap_err(),
+        ErrorClass::OBJECT,
+        ErrorCode::VALUE_OUT_OF_RANGE,
+    );
+    assert_eq!(zone_state(&zone), before);
+}
+
+#[test]
+fn trusted_local_rearm_executes_two_reset_cycles() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&calls);
+    let mut point = LifeSafetyPointObject::new(1, "point")
+        .unwrap()
+        .with_reset_executor(Arc::new(move |_| {
+            observed.fetch_add(1, Ordering::AcqRel);
+            Ok(LifeSafetyPointResetCommit::default())
+        }));
+
+    for _ in 0..2 {
+        point.set_operation_expected(LifeSafetyOperation::RESET);
+        point
+            .apply_life_safety_operation(LifeSafetyOperation::RESET)
+            .unwrap();
+    }
+
+    assert_eq!(calls.load(Ordering::Acquire), 2);
+    assert_eq!(
+        read(&point, PropertyIdentifier::OPERATION_EXPECTED),
+        LifeSafetyOperation::NONE.to_raw()
+    );
+}

--- a/crates/bacnet-objects/src/life_safety/tests.rs
+++ b/crates/bacnet-objects/src/life_safety/tests.rs
@@ -261,7 +261,7 @@ fn point_life_safety_operation_covers_silence_and_unsilence_matrix() {
 }
 
 #[test]
-fn point_rejects_wrong_expected_operation_and_reset_without_mutation() {
+fn point_rejects_wrong_expected_silence_and_reset_without_mutation() {
     let mut point = LifeSafetyPointObject::new(1, "LSP-1").unwrap();
     point.set_operation_expected(LifeSafetyOperation::SILENCE_AUDIBLE);
 
@@ -281,7 +281,11 @@ fn point_rejects_wrong_expected_operation_and_reset_without_mutation() {
     let error = point
         .apply_life_safety_operation(LifeSafetyOperation::RESET)
         .unwrap_err();
-    assert_protocol_error(error, ErrorClass::OBJECT, ErrorCode::VALUE_OUT_OF_RANGE);
+    assert_protocol_error(
+        error,
+        ErrorClass::OBJECT,
+        ErrorCode::INVALID_OPERATION_IN_THIS_STATE,
+    );
     assert_eq!(
         read_enumerated(&point, PropertyIdentifier::OPERATION_EXPECTED),
         LifeSafetyOperation::SILENCE_AUDIBLE.to_raw()

--- a/crates/bacnet-server/src/handlers/alarm_event/life_safety_operation.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/life_safety_operation.rs
@@ -7,9 +7,11 @@ use bacnet_types::enums::{ErrorClass, ErrorCode, LifeSafetyOperation};
 
 /// Handle a LifeSafetyOperation request.
 ///
-/// Targeted requests return the exact Clause 13.13 object error. Requests
-/// without an Object Identifier attempt every object and retain successful
-/// per-object mutations. Returned identifiers are objects whose state changed.
+/// Targeted requests return the exact Clause 13.13 object error. Targetless
+/// reset requests attempt only Life Safety Point and Zone objects; targetless
+/// silence/unsilence retains its generic legacy traversal. Successful
+/// per-object mutations are retained. Returned identifiers are objects whose
+/// state changed.
 pub fn handle_life_safety_operation(
     db: &mut ObjectDatabase,
     request: &LifeSafetyOperationRequest,
@@ -20,6 +22,12 @@ pub fn handle_life_safety_operation(
         let object = db
             .get_mut(&oid)
             .ok_or_else(|| life_safety_error(ErrorClass::OBJECT, ErrorCode::UNKNOWN_OBJECT))?;
+        if is_reset_operation(request.request) && !is_life_safety_object(oid) {
+            return Err(life_safety_error(
+                ErrorClass::OBJECT,
+                ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+            ));
+        }
         return match object.apply_life_safety_operation(request.request)? {
             LifeSafetyOperationEffect::Applied => Ok(vec![oid]),
             LifeSafetyOperationEffect::AlreadyApplied => Ok(Vec::new()),
@@ -27,6 +35,9 @@ pub fn handle_life_safety_operation(
     }
 
     let mut object_ids = db.list_objects();
+    if is_reset_operation(request.request) {
+        object_ids.retain(|oid| is_life_safety_object(*oid));
+    }
     object_ids.sort_by_key(|oid| (oid.object_type().to_raw(), oid.instance_number()));
     let attempted = object_ids.len();
     let mut changed = Vec::new();
@@ -55,11 +66,8 @@ pub fn handle_life_safety_operation(
 
 /// Validate the standard operations accepted by the service.
 ///
-/// Built-in reset execution remains unavailable until application-executor and
-/// duplicate-response semantics are defined. A targeted built-in object returns
-/// the specified unsupported-operation error from its object hook. A request
-/// without an Object Identifier still performs the Clause 13.13 all-applicable
-/// attempt and returns Result(+), even when every built-in object rejects reset.
+/// `NONE` and reserved/unknown values are rejected. All three reset variants
+/// are delegated distinctly to configured built-in Point/Zone executors.
 pub fn validate_life_safety_operation(operation: LifeSafetyOperation) -> Result<(), Error> {
     if (LifeSafetyOperation::SILENCE.to_raw()..=LifeSafetyOperation::UNSILENCE_VISUAL.to_raw())
         .contains(&operation.to_raw())
@@ -71,6 +79,22 @@ pub fn validate_life_safety_operation(operation: LifeSafetyOperation) -> Result<
             ErrorCode::VALUE_OUT_OF_RANGE,
         ))
     }
+}
+
+fn is_reset_operation(operation: LifeSafetyOperation) -> bool {
+    matches!(
+        operation,
+        LifeSafetyOperation::RESET
+            | LifeSafetyOperation::RESET_ALARM
+            | LifeSafetyOperation::RESET_FAULT
+    )
+}
+
+fn is_life_safety_object(oid: ObjectIdentifier) -> bool {
+    matches!(
+        oid.object_type(),
+        ObjectType::LIFE_SAFETY_POINT | ObjectType::LIFE_SAFETY_ZONE
+    )
 }
 
 pub(crate) fn life_safety_error(class: ErrorClass, code: ErrorCode) -> Error {

--- a/crates/bacnet-server/src/handlers/tests/life_safety_operation.rs
+++ b/crates/bacnet-server/src/handlers/tests/life_safety_operation.rs
@@ -107,11 +107,12 @@ fn life_safety_operation_reports_target_errors() {
 }
 
 #[test]
-fn life_safety_operation_rejects_reserved_and_builtin_reset() {
+fn life_safety_operation_rejects_none_and_reserved_and_reports_missing_reset_executor() {
     let oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 1).unwrap();
+    let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
+    point.set_operation_expected(LifeSafetyOperation::RESET);
     let mut db = ObjectDatabase::new();
-    db.add(Box::new(LifeSafetyPointObject::new(1, "point").unwrap()))
-        .unwrap();
+    db.add(Box::new(point)).unwrap();
 
     for operation in [LifeSafetyOperation::NONE, LifeSafetyOperation::from_raw(10)] {
         let error =
@@ -122,11 +123,15 @@ fn life_safety_operation_rejects_reserved_and_builtin_reset() {
     let error =
         handle_life_safety_operation(&mut db, &request(LifeSafetyOperation::RESET, Some(oid)))
             .unwrap_err();
-    assert_protocol_error(error, ErrorClass::OBJECT, ErrorCode::VALUE_OUT_OF_RANGE);
+    assert_protocol_error(
+        error,
+        ErrorClass::OBJECT,
+        ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+    );
 }
 
 #[test]
-fn life_safety_operation_without_target_attempts_reset_without_mutation() {
+fn life_safety_operation_without_target_suppresses_missing_reset_executor() {
     let oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 1).unwrap();
     let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
     point.set_operation_expected(LifeSafetyOperation::RESET);

--- a/crates/bacnet-server/src/handlers/tests/life_safety_reset.rs
+++ b/crates/bacnet-server/src/handlers/tests/life_safety_reset.rs
@@ -1,0 +1,350 @@
+use std::borrow::Cow;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use bacnet_objects::life_safety::{
+    LifeSafetyPointObject, LifeSafetyPointResetCommit, LifeSafetyPointResetContext,
+    LifeSafetyPointResetExecutor, LifeSafetyResetError, LifeSafetyZoneObject,
+    LifeSafetyZoneResetCommit, LifeSafetyZoneResetContext, LifeSafetyZoneResetExecutor,
+};
+use bacnet_objects::traits::LifeSafetyOperationEffect;
+use bacnet_services::life_safety::LifeSafetyOperationRequest;
+use bacnet_types::enums::{
+    ErrorClass, ErrorCode, LifeSafetyOperation, LifeSafetyState, ObjectType, PropertyIdentifier,
+    SilencedState,
+};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+
+use super::*;
+
+fn request(
+    operation: LifeSafetyOperation,
+    object_identifier: Option<ObjectIdentifier>,
+) -> LifeSafetyOperationRequest {
+    LifeSafetyOperationRequest {
+        requesting_process_identifier: 7,
+        requesting_source: "operator".into(),
+        request: operation,
+        object_identifier,
+    }
+}
+
+fn read(db: &ObjectDatabase, oid: ObjectIdentifier, property: PropertyIdentifier) -> u32 {
+    match db.get(&oid).unwrap().read_property(property, None).unwrap() {
+        PropertyValue::Enumerated(value) => value,
+        other => panic!("expected enumerated value, got {other:?}"),
+    }
+}
+
+fn assert_protocol_error(error: Error, class: ErrorClass, code: ErrorCode) {
+    assert!(matches!(
+        error,
+        Error::Protocol {
+            class: actual_class,
+            code: actual_code,
+        } if actual_class == class.to_raw() as u32 && actual_code == code.to_raw() as u32
+    ));
+}
+
+#[test]
+fn targeted_reset_variants_apply_to_point_and_zone() {
+    for operation in [
+        LifeSafetyOperation::RESET,
+        LifeSafetyOperation::RESET_ALARM,
+        LifeSafetyOperation::RESET_FAULT,
+    ] {
+        let point_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 1).unwrap();
+        let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
+        point.set_present_value(LifeSafetyState::ALARM.to_raw());
+        point.set_tracking_value(LifeSafetyState::FAULT.to_raw());
+        point.set_silenced(SilencedState::ALL_SILENCED);
+        point.set_operation_expected(operation);
+        point.set_reset_executor(Arc::new(move |context| {
+            assert_eq!(
+                *context,
+                LifeSafetyPointResetContext {
+                    object_identifier: point_oid,
+                    operation,
+                    present_value: LifeSafetyState::ALARM,
+                    tracking_value: LifeSafetyState::FAULT,
+                    silenced: SilencedState::ALL_SILENCED,
+                    operation_expected: operation,
+                }
+            );
+            Ok(LifeSafetyPointResetCommit {
+                present_value: Some(LifeSafetyState::QUIET),
+                tracking_value: None,
+                silenced: Some(SilencedState::UNSILENCED),
+            })
+        }));
+
+        let zone_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_ZONE, 1).unwrap();
+        let mut zone = LifeSafetyZoneObject::new(1, "zone").unwrap();
+        zone.set_present_value(LifeSafetyState::FAULT_ALARM.to_raw());
+        zone.set_silenced(SilencedState::VISIBLE_SILENCED);
+        zone.set_operation_expected(operation);
+        zone.set_reset_executor(Arc::new(move |context| {
+            assert_eq!(
+                *context,
+                LifeSafetyZoneResetContext {
+                    object_identifier: zone_oid,
+                    operation,
+                    present_value: LifeSafetyState::FAULT_ALARM,
+                    silenced: SilencedState::VISIBLE_SILENCED,
+                    operation_expected: operation,
+                }
+            );
+            Ok(LifeSafetyZoneResetCommit {
+                present_value: Some(LifeSafetyState::SUPERVISORY),
+                silenced: None,
+            })
+        }));
+
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(point)).unwrap();
+        db.add(Box::new(zone)).unwrap();
+        assert_eq!(
+            handle_life_safety_operation(&mut db, &request(operation, Some(point_oid))).unwrap(),
+            vec![point_oid]
+        );
+        assert_eq!(
+            handle_life_safety_operation(&mut db, &request(operation, Some(zone_oid))).unwrap(),
+            vec![zone_oid]
+        );
+        assert_eq!(
+            read(&db, point_oid, PropertyIdentifier::PRESENT_VALUE),
+            LifeSafetyState::QUIET.to_raw()
+        );
+        assert_eq!(
+            read(&db, point_oid, PropertyIdentifier::TRACKING_VALUE),
+            LifeSafetyState::FAULT.to_raw(),
+            "an omitted update remains unchanged"
+        );
+        assert_eq!(
+            read(&db, zone_oid, PropertyIdentifier::SILENCED),
+            SilencedState::VISIBLE_SILENCED.to_raw(),
+            "reset never implicitly unsilences"
+        );
+        for oid in [point_oid, zone_oid] {
+            assert_eq!(
+                read(&db, oid, PropertyIdentifier::OPERATION_EXPECTED),
+                LifeSafetyOperation::NONE.to_raw()
+            );
+        }
+    }
+}
+
+struct ResetHookSpy {
+    oid: ObjectIdentifier,
+    calls: Arc<AtomicUsize>,
+}
+
+impl BACnetObject for ResetHookSpy {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "reset-spy"
+    }
+
+    fn read_property(
+        &self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        Err(Error::Encoding("unused reset-spy read".into()))
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Encoding("unused reset-spy write".into()))
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[])
+    }
+
+    fn apply_life_safety_operation(
+        &mut self,
+        _operation: LifeSafetyOperation,
+    ) -> Result<LifeSafetyOperationEffect, Error> {
+        self.calls.fetch_add(1, Ordering::AcqRel);
+        Ok(LifeSafetyOperationEffect::Applied)
+    }
+}
+
+#[test]
+fn targeted_reset_never_calls_non_life_safety_hook() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 9).unwrap();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(ResetHookSpy {
+        oid,
+        calls: Arc::clone(&calls),
+    }))
+    .unwrap();
+
+    let error =
+        handle_life_safety_operation(&mut db, &request(LifeSafetyOperation::RESET, Some(oid)))
+            .unwrap_err();
+
+    assert_protocol_error(
+        error,
+        ErrorClass::OBJECT,
+        ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+    );
+    assert_eq!(calls.load(Ordering::Acquire), 0);
+}
+
+#[test]
+fn targetless_reset_attempts_only_ordered_point_and_zone_candidates() {
+    let order = Arc::new(Mutex::new(Vec::new()));
+    let make_point_executor = |oid: ObjectIdentifier,
+                               result: Result<LifeSafetyPointResetCommit, LifeSafetyResetError>|
+     -> LifeSafetyPointResetExecutor {
+        let order = Arc::clone(&order);
+        Arc::new(move |_: &LifeSafetyPointResetContext| {
+            order.lock().unwrap().push(oid);
+            result
+        })
+    };
+    let make_zone_executor = |oid: ObjectIdentifier,
+                              result: Result<LifeSafetyZoneResetCommit, LifeSafetyResetError>|
+     -> LifeSafetyZoneResetExecutor {
+        let order = Arc::clone(&order);
+        Arc::new(move |_: &LifeSafetyZoneResetContext| {
+            order.lock().unwrap().push(oid);
+            result
+        })
+    };
+
+    let point_success_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 1).unwrap();
+    let mut point_success = LifeSafetyPointObject::new(1, "point-success").unwrap();
+    point_success.set_present_value(LifeSafetyState::ALARM.to_raw());
+    point_success.set_operation_expected(LifeSafetyOperation::RESET);
+    point_success.set_reset_executor(make_point_executor(
+        point_success_oid,
+        Ok(LifeSafetyPointResetCommit {
+            present_value: Some(LifeSafetyState::QUIET),
+            ..Default::default()
+        }),
+    ));
+
+    let point_no_executor_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 2).unwrap();
+    let mut point_no_executor = LifeSafetyPointObject::new(2, "point-no-executor").unwrap();
+    point_no_executor.set_operation_expected(LifeSafetyOperation::RESET);
+
+    let point_rejected_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 3).unwrap();
+    let mut point_rejected = LifeSafetyPointObject::new(3, "point-rejected").unwrap();
+    point_rejected.set_operation_expected(LifeSafetyOperation::RESET);
+    point_rejected.set_reset_executor(make_point_executor(
+        point_rejected_oid,
+        Err(LifeSafetyResetError::InvalidOperationInThisState),
+    ));
+
+    let point_panics_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 4).unwrap();
+    let panic_order = Arc::clone(&order);
+    let mut point_panics = LifeSafetyPointObject::new(4, "point-panics").unwrap();
+    point_panics.set_operation_expected(LifeSafetyOperation::RESET);
+    point_panics.set_reset_executor(Arc::new(move |_| {
+        panic_order.lock().unwrap().push(point_panics_oid);
+        panic!("executor bug")
+    }));
+
+    let zone_success_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_ZONE, 1).unwrap();
+    let mut zone_success = LifeSafetyZoneObject::new(1, "zone-success").unwrap();
+    zone_success.set_present_value(LifeSafetyState::FAULT.to_raw());
+    zone_success.set_operation_expected(LifeSafetyOperation::RESET);
+    zone_success.set_reset_executor(make_zone_executor(
+        zone_success_oid,
+        Ok(LifeSafetyZoneResetCommit {
+            present_value: Some(LifeSafetyState::ACTIVE),
+            ..Default::default()
+        }),
+    ));
+
+    let zone_wrong_expected_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_ZONE, 2).unwrap();
+    let mut zone_wrong_expected = LifeSafetyZoneObject::new(2, "zone-wrong-expected").unwrap();
+    zone_wrong_expected.set_operation_expected(LifeSafetyOperation::RESET_ALARM);
+    zone_wrong_expected.set_reset_executor(make_zone_executor(
+        zone_wrong_expected_oid,
+        Ok(LifeSafetyZoneResetCommit::default()),
+    ));
+
+    let zone_denied_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_ZONE, 3).unwrap();
+    let mut zone_denied = LifeSafetyZoneObject::new(3, "zone-denied").unwrap();
+    zone_denied.set_operation_expected(LifeSafetyOperation::RESET);
+    zone_denied.set_reset_executor(make_zone_executor(
+        zone_denied_oid,
+        Err(LifeSafetyResetError::ServiceRequestDenied),
+    ));
+
+    let non_life_calls = Arc::new(AtomicUsize::new(0));
+    let non_life_oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let mut db = ObjectDatabase::new();
+    for object in [
+        Box::new(point_success) as Box<dyn BACnetObject>,
+        Box::new(point_no_executor),
+        Box::new(point_rejected),
+        Box::new(point_panics),
+        Box::new(zone_success),
+        Box::new(zone_wrong_expected),
+        Box::new(zone_denied),
+        Box::new(ResetHookSpy {
+            oid: non_life_oid,
+            calls: Arc::clone(&non_life_calls),
+        }),
+    ] {
+        db.add(object).unwrap();
+    }
+
+    let changed =
+        handle_life_safety_operation(&mut db, &request(LifeSafetyOperation::RESET, None)).unwrap();
+
+    assert_eq!(changed, vec![point_success_oid, zone_success_oid]);
+    assert_eq!(
+        *order.lock().unwrap(),
+        vec![
+            point_success_oid,
+            point_rejected_oid,
+            point_panics_oid,
+            zone_success_oid,
+            zone_denied_oid,
+        ]
+    );
+    assert_eq!(non_life_calls.load(Ordering::Acquire), 0);
+    assert_eq!(
+        read(&db, point_success_oid, PropertyIdentifier::PRESENT_VALUE),
+        LifeSafetyState::QUIET.to_raw()
+    );
+    assert_eq!(
+        read(&db, zone_success_oid, PropertyIdentifier::PRESENT_VALUE),
+        LifeSafetyState::ACTIVE.to_raw()
+    );
+    for oid in [
+        point_no_executor_oid,
+        point_rejected_oid,
+        point_panics_oid,
+        zone_denied_oid,
+    ] {
+        assert_eq!(
+            read(&db, oid, PropertyIdentifier::OPERATION_EXPECTED),
+            LifeSafetyOperation::RESET.to_raw()
+        );
+    }
+    assert_eq!(
+        read(
+            &db,
+            zone_wrong_expected_oid,
+            PropertyIdentifier::OPERATION_EXPECTED,
+        ),
+        LifeSafetyOperation::RESET_ALARM.to_raw()
+    );
+}

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -49,6 +49,7 @@ mod file_persistence;
 mod file_storage_hook;
 mod framed_properties;
 mod life_safety_operation;
+mod life_safety_reset;
 mod multi_element_writes;
 mod passwords;
 mod property_metadata;

--- a/crates/bacnet-server/src/server/life_safety_operation_tests.rs
+++ b/crates/bacnet-server/src/server/life_safety_operation_tests.rs
@@ -6,9 +6,9 @@ use std::sync::Mutex as StdMutex;
 use bacnet_encoding::apdu::decode_apdu;
 use bacnet_encoding::npdu::decode_npdu;
 use bacnet_objects::analog::AnalogInputObject;
-use bacnet_objects::life_safety::LifeSafetyPointObject;
+use bacnet_objects::life_safety::{LifeSafetyPointObject, LifeSafetyPointResetCommit};
 use bacnet_services::life_safety::LifeSafetyOperationRequest;
-use bacnet_types::enums::{LifeSafetyOperation, SilencedState};
+use bacnet_types::enums::{LifeSafetyOperation, LifeSafetyState, SilencedState};
 
 fn point_oid(instance: u32) -> ObjectIdentifier {
     ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, instance).unwrap()
@@ -143,10 +143,16 @@ fn assert_simple_ack(apdu: Apdu) {
 #[tokio::test]
 async fn local_rearm_api_supports_two_operation_cycles() {
     let oid = point_oid(1);
+    let executions = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&executions);
+    let point = LifeSafetyPointObject::new(1, "point")
+        .unwrap()
+        .with_reset_executor(Arc::new(move |_| {
+            observed.fetch_add(1, Ordering::AcqRel);
+            Ok(LifeSafetyPointResetCommit::default())
+        }));
     let mut objects = ObjectDatabase::new();
-    objects
-        .add(Box::new(LifeSafetyPointObject::new(1, "point").unwrap()))
-        .unwrap();
+    objects.add(Box::new(point)).unwrap();
     let mut server = BACnetServer::<BipTransport>::bip_builder()
         .interface(Ipv4Addr::LOCALHOST)
         .port(0)
@@ -156,7 +162,7 @@ async fn local_rearm_api_supports_two_operation_cycles() {
         .await
         .unwrap();
 
-    for operation in [LifeSafetyOperation::SILENCE, LifeSafetyOperation::UNSILENCE] {
+    for operation in [LifeSafetyOperation::RESET, LifeSafetyOperation::RESET_FAULT] {
         server
             .set_life_safety_operation_expected_local(&oid, operation)
             .await
@@ -168,13 +174,14 @@ async fn local_rearm_api_supports_two_operation_cycles() {
         assert_eq!(changed, vec![oid]);
     }
 
+    assert_eq!(executions.load(Ordering::Acquire), 2);
     let db = server.db.read().await;
     assert_eq!(
         db.get(&oid)
             .unwrap()
-            .read_property(PropertyIdentifier::SILENCED, None)
+            .read_property(PropertyIdentifier::OPERATION_EXPECTED, None)
             .unwrap(),
-        PropertyValue::Enumerated(SilencedState::UNSILENCED.to_raw())
+        PropertyValue::Enumerated(LifeSafetyOperation::NONE.to_raw())
     );
     drop(db);
     server.stop().await.unwrap();
@@ -183,8 +190,18 @@ async fn local_rearm_api_supports_two_operation_cycles() {
 #[tokio::test]
 async fn life_safety_operation_default_policy_denies_without_mutation() {
     let oid = point_oid(1);
+    let executions = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&executions);
     let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
-    point.set_operation_expected(LifeSafetyOperation::SILENCE);
+    point.set_present_value(LifeSafetyState::ALARM.to_raw());
+    point.set_operation_expected(LifeSafetyOperation::RESET);
+    point.set_reset_executor(Arc::new(move |_| {
+        observed.fetch_add(1, Ordering::AcqRel);
+        Ok(LifeSafetyPointResetCommit {
+            present_value: Some(LifeSafetyState::QUIET),
+            ..Default::default()
+        })
+    }));
     let mut objects = ObjectDatabase::new();
     objects.add(Box::new(point)).unwrap();
     let db = Arc::new(RwLock::new(objects));
@@ -194,7 +211,7 @@ async fn life_safety_operation_default_policy_denies_without_mutation() {
         ServerConfig::default(),
         MacAddr::from_slice(&[1, 2, 3]),
         None,
-        request(LifeSafetyOperation::SILENCE, Some(oid)),
+        request(LifeSafetyOperation::RESET, Some(oid)),
     )
     .await;
 
@@ -203,15 +220,49 @@ async fn life_safety_operation_default_policy_denies_without_mutation() {
         ErrorClass::SERVICES,
         ErrorCode::SERVICE_REQUEST_DENIED,
     );
+    assert_eq!(executions.load(Ordering::Acquire), 0);
     let guard = db.read().await;
     assert_eq!(
         guard
             .get(&oid)
             .unwrap()
-            .read_property(PropertyIdentifier::SILENCED, None)
+            .read_property(PropertyIdentifier::PRESENT_VALUE, None)
             .unwrap(),
-        PropertyValue::Enumerated(SilencedState::UNSILENCED.to_raw())
+        PropertyValue::Enumerated(LifeSafetyState::ALARM.to_raw())
     );
+    assert_eq!(
+        guard
+            .get(&oid)
+            .unwrap()
+            .read_property(PropertyIdentifier::OPERATION_EXPECTED, None)
+            .unwrap(),
+        PropertyValue::Enumerated(LifeSafetyOperation::RESET.to_raw())
+    );
+}
+
+#[tokio::test]
+async fn unknown_target_is_rejected_before_authorization() {
+    let authorizations = Arc::new(AtomicUsize::new(0));
+    let observed = Arc::clone(&authorizations);
+    let config = ServerConfig {
+        life_safety_operation_authorizer: Some(Arc::new(move |_| {
+            observed.fetch_add(1, Ordering::AcqRel);
+            true
+        })),
+        ..ServerConfig::default()
+    };
+
+    let apdu = dispatch_life_safety_operation(
+        Arc::new(RwLock::new(ObjectDatabase::new())),
+        config,
+        MacAddr::from_slice(&[1]),
+        None,
+        request(LifeSafetyOperation::RESET, Some(point_oid(99))),
+    )
+    .await;
+
+    assert_error(apdu, ErrorClass::OBJECT, ErrorCode::UNKNOWN_OBJECT);
+    assert_eq!(authorizations.load(Ordering::Acquire), 0);
 }
 
 #[tokio::test]
@@ -308,7 +359,7 @@ async fn life_safety_operation_dispatch_preserves_all_targeted_error_rows() {
         allow(),
         source.clone(),
         None,
-        request(LifeSafetyOperation::SILENCE, Some(analog_oid)),
+        request(LifeSafetyOperation::RESET, Some(analog_oid)),
     )
     .await;
     assert_error(
@@ -318,10 +369,10 @@ async fn life_safety_operation_dispatch_preserves_all_targeted_error_rows() {
     );
 
     let oid = point_oid(1);
+    let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
+    point.set_operation_expected(LifeSafetyOperation::RESET);
     let mut objects = ObjectDatabase::new();
-    objects
-        .add(Box::new(LifeSafetyPointObject::new(1, "point").unwrap()))
-        .unwrap();
+    objects.add(Box::new(point)).unwrap();
     let db = Arc::new(RwLock::new(objects));
     let apdu = dispatch_life_safety_operation(
         Arc::clone(&db),
@@ -331,7 +382,11 @@ async fn life_safety_operation_dispatch_preserves_all_targeted_error_rows() {
         request(LifeSafetyOperation::RESET, Some(oid)),
     )
     .await;
-    assert_error(apdu, ErrorClass::OBJECT, ErrorCode::VALUE_OUT_OF_RANGE);
+    assert_error(
+        apdu,
+        ErrorClass::OBJECT,
+        ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+    );
 
     let apdu = dispatch_life_safety_operation(
         db,
@@ -349,7 +404,7 @@ async fn life_safety_operation_dispatch_preserves_all_targeted_error_rows() {
 }
 
 #[tokio::test]
-async fn life_safety_operation_targetless_reset_attempt_returns_simple_ack_without_mutation() {
+async fn life_safety_operation_targetless_missing_executor_returns_simple_ack_without_mutation() {
     let oid = point_oid(1);
     let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
     point.set_operation_expected(LifeSafetyOperation::RESET);
@@ -413,8 +468,23 @@ async fn life_safety_operation_panicking_authorizer_fails_closed() {
 #[tokio::test]
 async fn exact_success_duplicate_is_silent_and_changed_reuse_executes_normally() {
     let oid = point_oid(1);
+    let executions = Arc::new(AtomicUsize::new(0));
+    let observed_executions = Arc::clone(&executions);
     let mut point = LifeSafetyPointObject::new(1, "point").unwrap();
-    point.set_operation_expected(LifeSafetyOperation::SILENCE);
+    point.set_present_value(LifeSafetyState::ALARM.to_raw());
+    point.set_operation_expected(LifeSafetyOperation::RESET);
+    point.set_reset_executor(Arc::new(move |context| {
+        observed_executions.fetch_add(1, Ordering::AcqRel);
+        let present_value = if context.operation == LifeSafetyOperation::RESET {
+            LifeSafetyState::QUIET
+        } else {
+            LifeSafetyState::ACTIVE
+        };
+        Ok(LifeSafetyPointResetCommit {
+            present_value: Some(present_value),
+            ..Default::default()
+        })
+    }));
     let mut objects = ObjectDatabase::new();
     objects.add(Box::new(point)).unwrap();
     let db = Arc::new(RwLock::new(objects));
@@ -429,7 +499,7 @@ async fn exact_success_duplicate_is_silent_and_changed_reuse_executes_normally()
     };
     let tracker = Arc::new(ConfirmedRequestTracker::default());
     let source = MacAddr::from_slice(&[1, 2, 3]);
-    let silence = request(LifeSafetyOperation::SILENCE, Some(oid));
+    let reset = request(LifeSafetyOperation::RESET, Some(oid));
 
     let first = dispatch_life_safety_operation_with_tracker(
         Arc::clone(&db),
@@ -438,7 +508,7 @@ async fn exact_success_duplicate_is_silent_and_changed_reuse_executes_normally()
         source.clone(),
         None,
         0x51,
-        silence.clone(),
+        reset.clone(),
     )
     .await
     .unwrap();
@@ -450,26 +520,27 @@ async fn exact_success_duplicate_is_silent_and_changed_reuse_executes_normally()
         source.clone(),
         None,
         0x51,
-        silence,
+        reset,
     )
     .await
     .is_err());
     assert_eq!(authorizations.load(Ordering::Acquire), 1);
+    assert_eq!(executions.load(Ordering::Acquire), 1);
     assert_eq!(
         db.read()
             .await
             .get(&oid)
             .unwrap()
-            .read_property(PropertyIdentifier::SILENCED, None)
+            .read_property(PropertyIdentifier::PRESENT_VALUE, None)
             .unwrap(),
-        PropertyValue::Enumerated(SilencedState::ALL_SILENCED.to_raw())
+        PropertyValue::Enumerated(LifeSafetyState::QUIET.to_raw())
     );
 
     db.write()
         .await
         .get_mut(&oid)
         .unwrap()
-        .set_life_safety_operation_expected_internal(LifeSafetyOperation::UNSILENCE)
+        .set_life_safety_operation_expected_internal(LifeSafetyOperation::RESET_ALARM)
         .unwrap();
     let changed = dispatch_life_safety_operation_with_tracker(
         Arc::clone(&db),
@@ -478,20 +549,21 @@ async fn exact_success_duplicate_is_silent_and_changed_reuse_executes_normally()
         source,
         None,
         0x51,
-        request(LifeSafetyOperation::UNSILENCE, Some(oid)),
+        request(LifeSafetyOperation::RESET_ALARM, Some(oid)),
     )
     .await
     .unwrap();
     assert_simple_ack(changed);
     assert_eq!(authorizations.load(Ordering::Acquire), 2);
+    assert_eq!(executions.load(Ordering::Acquire), 2);
     assert_eq!(
         db.read()
             .await
             .get(&oid)
             .unwrap()
-            .read_property(PropertyIdentifier::SILENCED, None)
+            .read_property(PropertyIdentifier::PRESENT_VALUE, None)
             .unwrap(),
-        PropertyValue::Enumerated(SilencedState::UNSILENCED.to_raw())
+        PropertyValue::Enumerated(LifeSafetyState::ACTIVE.to_raw())
     );
 }
 


### PR DESCRIPTION
## Summary
- recognize `RESET`, `RESET_ALARM`, and `RESET_FAULT` as standard LifeSafetyOperation requests
- add opt-in application-owned executors for built-in Life Safety Point and Zone objects
- apply typed local-state commits atomically and clear `Operation_Expected` only after successful execution
- preserve targeted Result(-) errors and targetless attempt-all-applicable semantics
- keep detected exact duplicates silent through the merged confirmed-request admission boundary

## Ownership and safety contract
Reset behavior is deliberately object-owned rather than inferred by the server:

- no executor means `OBJECT / OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED`
- wrong expected/local state means `OBJECT / INVALID_OPERATION_IN_THIS_STATE`
- executor-declared unsupported variant means `OBJECT / VALUE_OUT_OF_RANGE`
- executor operational failure or panic fails closed as `SERVICES / SERVICE_REQUEST_DENIED`
- callbacks receive immutable modeled state and return typed optional commits; no mutable object reference or network provenance is exposed
- omitted commit values remain unchanged, and no reset implicitly copies Tracking Value, sets QUIET, or unsilences

Callbacks run synchronously under the object-database write lock and must be fast, nonblocking, non-reentrant, panic-free, and application-idempotent. The merged duplicate detector is bounded and cannot guarantee exactly-once physical actuation across fallback, expiry, or restart.

## Source-to-behavior traceability
| ANSI/ASHRAE 135-2020 source | Implemented behavior |
|---|---|
| §§12.15–12.16 | Point/Zone state derivation remains local; reset commits update only explicit modeled values supplied by the application. |
| §13.13 | All three reset variants are recognized; targeted success requires executor success; targetless reset attempts only Point/Zone objects, retains successes, suppresses per-object failures, and returns Result(+). |
| §13.13 / §18 error rows | Unknown, unsupported object/functionality, unsupported variant, denied execution, and invalid-state paths retain exact errors. |
| §5.3.5.3 | Detected exact duplicate reset requests are silent before second authorization or execution; no response replay is introduced. |

## Validation
- `cargo fmt --all -- --check`
- focused Point/Zone reset, handler, authorization, rearm, and duplicate tests
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-services --locked`
- `cargo test -p bacnet-types --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

## Deferred
- built-in or physical reset behavior
- Zone `Tracking_Value` modeling
- runtime executor rebinding or server-level executor APIs
- network provenance in executor context
- async actuation, property-aware COV, and PICS/BIBB/README/Python claims

Refs #177