### PR TITLE
fix(objects): enforce Pulse Converter Present_Value OOS policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,6 +231,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Direct in-service network writes to Pulse Converter `Present_Value` are now
+  denied under the repository's Pulse Converter safety policy. Out-of-service
+  simulation writes remain accepted as required by ASHRAE 135-2020 §12.23
+  (`Closes #280`). This does not claim full Pulse Converter conformance.
+
 - Alert Enrollment now serves the bounded ASHRAE 135-2020 Table 12-61
   property model (`Closes #291`). `Present_Value` is the read-only
   `ObjectIdentifier` of the most recent alert source, and both the Rust

--- a/crates/bacnet-objects/src/accumulator.rs
+++ b/crates/bacnet-objects/src/accumulator.rs
@@ -333,6 +333,9 @@ impl BACnetObject for PulseConverterObject {
         }
         match property {
             p if p == PropertyIdentifier::PRESENT_VALUE => {
+                if !self.out_of_service {
+                    return Err(common::write_access_denied_error());
+                }
                 if let PropertyValue::Real(v) = value {
                     common::reject_non_finite(v)?;
                     self.present_value = v;
@@ -400,12 +403,10 @@ impl BACnetObject for PulseConverterObject {
         Some(self.cov_increment)
     }
 
-    /// Mirror the `write_property` arms exactly (PICS truth invariant):
-    /// Pulse Converter accepts PRESENT_VALUE / SCALE_FACTOR / ADJUST_VALUE /
-    /// INPUT_REFERENCE plus the shared DESCRIPTION / OUT_OF_SERVICE /
-    /// COV_INCREMENT routes. OBJECT_NAME is NOT advertised: unlike the
-    /// historical default's blanket claim, no arm routes it (a network write
-    /// falls through to WRITE_ACCESS_DENIED).
+    /// Mirror the static `write_property` routes (PICS truth invariant):
+    /// PRESENT_VALUE is advertised because its route is available while OOS;
+    /// this method does not report current-state authorization. OBJECT_NAME is
+    /// not advertised because no arm routes it.
     fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
         matches!(
             property,
@@ -423,6 +424,10 @@ impl BACnetObject for PulseConverterObject {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[path = "pulse_converter_policy_tests.rs"]
+mod pulse_converter_policy_tests;
 
 #[cfg(test)]
 mod tests {
@@ -553,8 +558,15 @@ mod tests {
     }
 
     #[test]
-    fn pulse_converter_read_write_present_value() {
+    fn pulse_converter_read_write_present_value_while_out_of_service() {
         let mut pc = PulseConverterObject::new(1, "PC-1", 62).unwrap();
+        pc.write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
         pc.write_property(
             PropertyIdentifier::PRESENT_VALUE,
             None,

--- a/crates/bacnet-objects/src/pulse_converter_policy_tests.rs
+++ b/crates/bacnet-objects/src/pulse_converter_policy_tests.rs
@@ -1,0 +1,58 @@
+use super::*;
+use bacnet_types::enums::{ErrorClass, ErrorCode};
+
+fn assert_write_access_denied(result: Result<(), Error>) {
+    match result {
+        Err(Error::Protocol { class, code }) => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(code, ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32);
+        }
+        other => panic!("expected PROPERTY/WRITE_ACCESS_DENIED, got {other:?}"),
+    }
+}
+
+fn present_value(pc: &PulseConverterObject) -> PropertyValue {
+    pc.read_property(PropertyIdentifier::PRESENT_VALUE, None)
+        .unwrap()
+}
+
+#[test]
+fn present_value_is_denied_in_service_before_value_validation() {
+    let mut pc = PulseConverterObject::new(1, "PC-1", 62).unwrap();
+    assert!(pc.is_writable_property(PropertyIdentifier::PRESENT_VALUE));
+
+    for value in [
+        PropertyValue::Real(12.5),
+        PropertyValue::Unsigned(12),
+        PropertyValue::Real(f32::NAN),
+    ] {
+        assert_write_access_denied(pc.write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            value,
+            None,
+        ));
+        assert_eq!(present_value(&pc), PropertyValue::Real(0.0));
+    }
+}
+
+#[test]
+fn present_value_round_trips_while_out_of_service() {
+    let mut pc = PulseConverterObject::new(1, "PC-1", 62).unwrap();
+    pc.write_property(
+        PropertyIdentifier::OUT_OF_SERVICE,
+        None,
+        PropertyValue::Boolean(true),
+        None,
+    )
+    .unwrap();
+    pc.write_property(
+        PropertyIdentifier::PRESENT_VALUE,
+        None,
+        PropertyValue::Real(12.5),
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(present_value(&pc), PropertyValue::Real(12.5));
+}

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -55,6 +55,7 @@ mod life_safety_reset;
 mod multi_element_writes;
 mod passwords;
 mod property_metadata;
+mod pulse_converter_writes;
 mod read_event_arrays;
 mod read_range;
 mod read_range_time;

--- a/crates/bacnet-server/src/handlers/tests/pulse_converter_writes.rs
+++ b/crates/bacnet-server/src/handlers/tests/pulse_converter_writes.rs
@@ -1,0 +1,180 @@
+use super::*;
+use bacnet_objects::accumulator::PulseConverterObject;
+use bacnet_services::common::BACnetPropertyValue;
+use bacnet_services::wpm::{WriteAccessSpecification, WritePropertyMultipleRequest};
+
+fn pulse_converter_db() -> (ObjectDatabase, ObjectIdentifier) {
+    let mut db = ObjectDatabase::new();
+    let object = PulseConverterObject::new(1, "PC-1", 62).unwrap();
+    let oid = object.object_identifier();
+    db.add(Box::new(object)).unwrap();
+    (db, oid)
+}
+
+fn encode_value(value: PropertyValue) -> Vec<u8> {
+    let mut bytes = BytesMut::new();
+    encode_property_value(&mut bytes, &value).unwrap();
+    bytes.to_vec()
+}
+
+fn write_wire(
+    db: &mut ObjectDatabase,
+    oid: ObjectIdentifier,
+    property: PropertyIdentifier,
+    value: PropertyValue,
+) -> Result<ObjectIdentifier, Error> {
+    let request = WritePropertyRequest {
+        object_identifier: oid,
+        property_identifier: property,
+        property_array_index: None,
+        property_value: encode_value(value),
+        priority: None,
+    };
+    let mut bytes = BytesMut::new();
+    request.encode(&mut bytes);
+    handle_write_property(db, &bytes)
+}
+
+fn write_multiple_wire(
+    db: &mut ObjectDatabase,
+    oid: ObjectIdentifier,
+    writes: Vec<(PropertyIdentifier, PropertyValue)>,
+) -> Result<Vec<ObjectIdentifier>, Error> {
+    let request = WritePropertyMultipleRequest {
+        list_of_write_access_specs: vec![WriteAccessSpecification {
+            object_identifier: oid,
+            list_of_properties: writes
+                .into_iter()
+                .map(|(property_identifier, value)| BACnetPropertyValue {
+                    property_identifier,
+                    property_array_index: None,
+                    value: encode_value(value),
+                    priority: None,
+                })
+                .collect(),
+        }],
+    };
+    let mut bytes = BytesMut::new();
+    request.encode(&mut bytes);
+    handle_write_property_multiple(db, &bytes)
+}
+
+fn assert_write_access_denied<T>(result: Result<T, Error>) {
+    match result {
+        Err(Error::Protocol { class, code }) => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(code, ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32);
+        }
+        Err(other) => panic!("expected PROPERTY/WRITE_ACCESS_DENIED, got {other:?}"),
+        Ok(_) => panic!("expected PROPERTY/WRITE_ACCESS_DENIED, got success"),
+    }
+}
+
+fn assert_state(
+    db: &ObjectDatabase,
+    oid: ObjectIdentifier,
+    present_value: f32,
+    out_of_service: bool,
+) {
+    let object = db.get(&oid).unwrap();
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::PRESENT_VALUE, None)
+            .unwrap(),
+        PropertyValue::Real(present_value)
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::OUT_OF_SERVICE, None)
+            .unwrap(),
+        PropertyValue::Boolean(out_of_service)
+    );
+}
+
+#[test]
+fn write_property_present_value_requires_out_of_service() {
+    let (mut db, oid) = pulse_converter_db();
+
+    assert_write_access_denied(write_wire(
+        &mut db,
+        oid,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Real(12.5),
+    ));
+    assert_state(&db, oid, 0.0, false);
+
+    write_wire(
+        &mut db,
+        oid,
+        PropertyIdentifier::OUT_OF_SERVICE,
+        PropertyValue::Boolean(true),
+    )
+    .unwrap();
+    write_wire(
+        &mut db,
+        oid,
+        PropertyIdentifier::PRESENT_VALUE,
+        PropertyValue::Real(12.5),
+    )
+    .unwrap();
+    assert_state(&db, oid, 12.5, true);
+}
+
+#[test]
+fn write_property_multiple_present_value_before_oos_fails_without_mutation() {
+    let (mut db, oid) = pulse_converter_db();
+
+    assert_write_access_denied(write_multiple_wire(
+        &mut db,
+        oid,
+        vec![
+            (PropertyIdentifier::PRESENT_VALUE, PropertyValue::Real(12.5)),
+            (
+                PropertyIdentifier::OUT_OF_SERVICE,
+                PropertyValue::Boolean(true),
+            ),
+        ],
+    ));
+    assert_state(&db, oid, 0.0, false);
+}
+
+#[test]
+fn write_property_multiple_oos_before_present_value_succeeds() {
+    let (mut db, oid) = pulse_converter_db();
+
+    write_multiple_wire(
+        &mut db,
+        oid,
+        vec![
+            (
+                PropertyIdentifier::OUT_OF_SERVICE,
+                PropertyValue::Boolean(true),
+            ),
+            (PropertyIdentifier::PRESENT_VALUE, PropertyValue::Real(12.5)),
+        ],
+    )
+    .unwrap();
+    assert_state(&db, oid, 12.5, true);
+}
+
+#[test]
+fn write_property_multiple_later_failure_rolls_back_present_value_and_oos() {
+    let (mut db, oid) = pulse_converter_db();
+
+    assert_write_access_denied(write_multiple_wire(
+        &mut db,
+        oid,
+        vec![
+            (
+                PropertyIdentifier::OUT_OF_SERVICE,
+                PropertyValue::Boolean(true),
+            ),
+            (PropertyIdentifier::PRESENT_VALUE, PropertyValue::Real(12.5)),
+            (
+                PropertyIdentifier::OBJECT_TYPE,
+                PropertyValue::Enumerated(ObjectType::PULSE_CONVERTER.to_raw()),
+            ),
+        ],
+    ));
+    assert_state(&db, oid, 0.0, false);
+}

--- a/crates/bacnet-server/src/pics/truth_source_tests.rs
+++ b/crates/bacnet-server/src/pics/truth_source_tests.rs
@@ -416,6 +416,7 @@ fn is_writable_property_matches_write_property_on_all_core_types() {
 fn is_writable_property_matches_write_property_on_pulse_converter_and_averaging() {
     use bacnet_objects::accumulator::PulseConverterObject;
     use bacnet_objects::averaging::AveragingObject;
+    use bacnet_objects::database::ObjectDatabase;
     use bacnet_types::enums::ObjectType;
     use bacnet_types::primitives::ObjectIdentifier;
 
@@ -459,6 +460,10 @@ fn is_writable_property_matches_write_property_on_pulse_converter_and_averaging(
         &mut pc,
         "PC",
         &[
+            (
+                PropertyIdentifier::OUT_OF_SERVICE,
+                PropertyValue::Boolean(true),
+            ),
             (PropertyIdentifier::PRESENT_VALUE, PropertyValue::Real(10.0)),
             (PropertyIdentifier::SCALE_FACTOR, PropertyValue::Real(1.5)),
             (PropertyIdentifier::ADJUST_VALUE, PropertyValue::Real(2.0)),
@@ -467,10 +472,6 @@ fn is_writable_property_matches_write_property_on_pulse_converter_and_averaging(
             (
                 PropertyIdentifier::DESCRIPTION,
                 PropertyValue::CharacterString("d".into()),
-            ),
-            (
-                PropertyIdentifier::OUT_OF_SERVICE,
-                PropertyValue::Boolean(true),
             ),
         ],
         &[
@@ -496,6 +497,18 @@ fn is_writable_property_matches_write_property_on_pulse_converter_and_averaging(
             ),
         ],
     );
+
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(pc)).unwrap();
+    let pics = PicsGenerator::new(&db, &ServerConfig::default(), &PicsConfig::default()).generate();
+    let pulse_support = pics
+        .supported_object_types
+        .iter()
+        .find(|support| support.object_type == ObjectType::PULSE_CONVERTER)
+        .unwrap();
+    assert!(pulse_support.supported_properties.iter().any(|property| {
+        property.property_id == PropertyIdentifier::PRESENT_VALUE && property.access.writable
+    }));
 
     let mut avg = AveragingObject::new(1, "AVG-1").unwrap();
     assert_exactly(


### PR DESCRIPTION
## Summary
- deny direct Pulse Converter `Present_Value` writes while the object is in service
- preserve finite `REAL` simulation writes while `Out_Of_Service` is true
- keep static/PICS writability because the conditional write route exists
- cover confirmed WriteProperty plus WritePropertyMultiple ordering and rollback

## Source-to-behavior traceability
| Source / policy | Implemented behavior |
|---|---|
| ANSI/ASHRAE 135-2020 §12.23, Table 12-27 footnote 1 and `Present_Value`/`Out_Of_Service` text | `Present_Value` remains writable for simulation while `Out_Of_Service` is true. |
| Repository Pulse Converter safety policy (GATE-0004/D5) | Because §12.23 does not require or expressly authorize direct in-service writes, those writes fail with `PROPERTY / WRITE_ACCESS_DENIED` before value validation or mutation. |
| Existing PICS route convention | `is_writable_property(PRESENT_VALUE)` remains true: it represents an implemented conditional route, not current-state authorization. |

The Standard explicitly requires OOS writability but does not explicitly prohibit in-service direct writes; the denial is the repository's conservative policy choice rather than a broader conformance claim.

## Validation
- focused Pulse Converter object tests: in-service authorization precedence/no mutation and OOS success
- focused confirmed WriteProperty tests
- WPM tests for `[PV, OOS]` failure, `[OOS, PV]` success, and later-failure rollback of both fields
- generated PICS remains writable for the conditional route
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-server --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

## Explicit deferrals
This PR does **not** claim full Pulse Converter §12.23 conformance. Existing model gaps remain outside this issue: `Count`, `Count_Before_Change`, `Count_Change_Time`, `Update_Time`, the atomic `Adjust_Value` algorithm, input-reference evaluation, OOS-exit recoupling, full property-metadata migration, and unresolved `Scale_Factor` write policy.

Closes #280