### PR TITLE
feat(objects,server): supply Present_Value from the application

### DIFF
--- a/crates/bacnet-objects/src/analog/input.rs
+++ b/crates/bacnet-objects/src/analog/input.rs
@@ -71,6 +71,21 @@ impl AnalogInputObject {
         self.present_value = value;
     }
 
+    /// Validate and store a `Present_Value` write, without any access check.
+    ///
+    /// Shared by the network and internal routes, which differ only in the
+    /// `Out_Of_Service` condition each requires.
+    fn apply_present_value(&mut self, value: PropertyValue) -> Result<(), Error> {
+        let PropertyValue::Real(v) = value else {
+            return Err(common::invalid_data_type_error());
+        };
+        if !v.is_finite() {
+            return Err(common::value_out_of_range_error());
+        }
+        self.present_value = v;
+        Ok(())
+    }
+
     /// Set the description string.
     pub fn set_description(&mut self, desc: impl Into<String>) {
         self.description = desc.into();
@@ -175,14 +190,7 @@ impl BACnetObject for AnalogInputObject {
             if !self.out_of_service {
                 return Err(common::write_access_denied_error());
             }
-            if let PropertyValue::Real(v) = value {
-                if !v.is_finite() {
-                    return Err(common::value_out_of_range_error());
-                }
-                self.present_value = v;
-                return Ok(());
-            }
-            return Err(common::invalid_data_type_error());
+            return self.apply_present_value(value);
         }
         if let Some(result) = self.reliability_inhibit.write_inhibit(
             &mut self.reliability,
@@ -314,6 +322,18 @@ impl BACnetObject for AnalogInputObject {
         self.reliability = reliability;
         self.fault_out_of_range.clear_ownership();
         Ok(())
+    }
+
+    fn set_present_value_internal(
+        &mut self,
+        _array_index: Option<u32>,
+        value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        self.apply_present_value(value)
     }
 
     fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {

--- a/crates/bacnet-objects/src/binary/input.rs
+++ b/crates/bacnet-objects/src/binary/input.rs
@@ -211,6 +211,21 @@ impl BinaryInputObject {
         self.present_value = value;
     }
 
+    /// Validate and store a `Present_Value` write, without any access check.
+    ///
+    /// Shared by the network and internal routes, which differ only in the
+    /// `Out_Of_Service` condition each requires.
+    fn apply_present_value(&mut self, value: PropertyValue) -> Result<(), Error> {
+        let PropertyValue::Enumerated(v) = value else {
+            return Err(common::invalid_data_type_error());
+        };
+        if v > 1 {
+            return Err(common::value_out_of_range_error());
+        }
+        self.present_value = v;
+        Ok(())
+    }
+
     /// Set the description string.
     pub fn set_description(&mut self, desc: impl Into<String>) {
         self.description = desc.into();
@@ -319,14 +334,7 @@ impl BACnetObject for BinaryInputObject {
             if !self.out_of_service {
                 return Err(common::write_access_denied_error());
             }
-            if let PropertyValue::Enumerated(v) = value {
-                if v > 1 {
-                    return Err(common::value_out_of_range_error());
-                }
-                self.present_value = v;
-                return Ok(());
-            }
-            return Err(common::invalid_data_type_error());
+            return self.apply_present_value(value);
         }
         if property == PropertyIdentifier::ACTIVE_TEXT {
             if let PropertyValue::CharacterString(s) = value {
@@ -421,6 +429,18 @@ impl BACnetObject for BinaryInputObject {
         }
         self.reliability = reliability;
         Ok(())
+    }
+
+    fn set_present_value_internal(
+        &mut self,
+        _array_index: Option<u32>,
+        value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        self.apply_present_value(value)
     }
 
     fn reliability_evaluation_inhibited_internal(&self) -> bool {

--- a/crates/bacnet-objects/src/multistate/input.rs
+++ b/crates/bacnet-objects/src/multistate/input.rs
@@ -70,6 +70,22 @@ impl MultiStateInputObject {
         let _ = self.recompute_reliability();
     }
 
+    /// Validate and store a `Present_Value` write, without any access check.
+    ///
+    /// Shared by the network and internal routes, which differ only in the
+    /// `Out_Of_Service` condition each requires.
+    fn apply_present_value(&mut self, value: PropertyValue) -> Result<(), Error> {
+        let PropertyValue::Unsigned(v) = value else {
+            return Err(common::invalid_data_type_error());
+        };
+        if v < 1 || v > self.number_of_states as u64 {
+            return Err(common::value_out_of_range_error());
+        }
+        self.present_value = v as u32;
+        let _ = self.recompute_reliability();
+        Ok(())
+    }
+
     /// Change the locally configured number of states.
     ///
     /// The BACnet `Number_Of_States` property remains read-only. A successful
@@ -208,15 +224,7 @@ impl BACnetObject for MultiStateInputObject {
             if !self.out_of_service {
                 return Err(common::write_access_denied_error());
             }
-            if let PropertyValue::Unsigned(v) = value {
-                if v < 1 || v > self.number_of_states as u64 {
-                    return Err(common::value_out_of_range_error());
-                }
-                self.present_value = v as u32;
-                let _ = self.recompute_reliability();
-                return Ok(());
-            }
-            return Err(common::invalid_data_type_error());
+            return self.apply_present_value(value);
         }
         if property == PropertyIdentifier::STATE_TEXT {
             match array_index {
@@ -337,6 +345,18 @@ impl BACnetObject for MultiStateInputObject {
         self.reliability = reliability;
         self.reliability_evaluator.clear_ownership();
         Ok(())
+    }
+
+    fn set_present_value_internal(
+        &mut self,
+        _array_index: Option<u32>,
+        value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        self.apply_present_value(value)
     }
 
     fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {

--- a/crates/bacnet-objects/src/reliability_writability_tests.rs
+++ b/crates/bacnet-objects/src/reliability_writability_tests.rs
@@ -356,3 +356,104 @@ reliability_gate_test!(
     schedule_reliability_requires_out_of_service,
     ScheduleObject::new(1, "SCHED-1", PropertyValue::Real(0.0)).unwrap()
 );
+
+/// `Present_Value` ownership on an Input mirrors Reliability's, inverted: the
+/// network writes only while `Out_Of_Service` is TRUE, the application only
+/// while it is FALSE. A gateway supplying a proxied reading must not override a
+/// value an engineer has put out of service to simulate.
+fn assert_present_value_ownership(object: &mut dyn BACnetObject, value: PropertyValue) {
+    object
+        .write_property(PropertyIdentifier::PRESENT_VALUE, None, value.clone(), None)
+        .expect_err("in-service Present_Value write must be refused over the network");
+
+    object
+        .set_present_value_internal(None, value.clone(), None)
+        .expect("the application must supply Present_Value while in service");
+
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::PRESENT_VALUE, None)
+            .expect("Present_Value must be readable"),
+        value
+    );
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::OUT_OF_SERVICE, None)
+            .expect("Out_Of_Service must be readable"),
+        PropertyValue::Boolean(false),
+        "supplying a value must not put the object out of service"
+    );
+
+    object
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .expect("Out_Of_Service must be writable");
+
+    let denied = object
+        .set_present_value_internal(None, value, None)
+        .expect_err("the application must not override an out-of-service value");
+    match denied {
+        Error::Protocol { class, code } => {
+            assert_eq!(class, ErrorClass::PROPERTY.to_raw() as u32);
+            assert_eq!(code, ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32);
+        }
+        other => panic!("expected PROPERTY / WRITE_ACCESS_DENIED, got {other:?}"),
+    }
+}
+
+#[test]
+fn analog_input_present_value_is_application_supplied() {
+    let mut object = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+    assert_present_value_ownership(&mut object, PropertyValue::Real(21.5));
+}
+
+#[test]
+fn binary_input_present_value_is_application_supplied() {
+    let mut object = BinaryInputObject::new(1, "BI-1").unwrap();
+    assert_present_value_ownership(&mut object, PropertyValue::Enumerated(1));
+}
+
+#[test]
+fn multistate_input_present_value_is_application_supplied() {
+    let mut object = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
+    assert_present_value_ownership(&mut object, PropertyValue::Unsigned(2));
+}
+
+/// The commandable types carry no `Out_Of_Service` condition on
+/// `Present_Value`, so the trait default is already correct for them.
+#[test]
+fn commandable_present_value_accepts_application_writes_by_default() {
+    let mut object = AnalogValueObject::new(1, "AV-1", 62).unwrap();
+
+    object
+        .set_present_value_internal(None, PropertyValue::Real(21.5), None)
+        .expect("a commandable Present_Value takes an application write");
+
+    assert_eq!(
+        object
+            .read_property(PropertyIdentifier::PRESENT_VALUE, None)
+            .expect("Present_Value must be readable"),
+        PropertyValue::Real(21.5)
+    );
+}
+
+/// The application route skips the access check, not the validation.
+#[test]
+fn application_present_value_writes_are_still_validated() {
+    let mut analog = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+    analog
+        .set_present_value_internal(None, PropertyValue::Real(f32::NAN), None)
+        .expect_err("non-finite Present_Value must be refused");
+    analog
+        .set_present_value_internal(None, PropertyValue::Enumerated(1), None)
+        .expect_err("a mistyped Present_Value must be refused");
+
+    let mut multistate = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
+    multistate
+        .set_present_value_internal(None, PropertyValue::Unsigned(4), None)
+        .expect_err("a state above Number_Of_States must be refused");
+}

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -688,6 +688,35 @@ pub trait BACnetObject: Send + Sync {
         })
     }
 
+    /// Apply a `Present_Value` supplied by the process the object represents.
+    ///
+    /// The **internal** counterpart to the network
+    /// [`write_property`](Self::write_property) route, with the same symmetric
+    /// ownership as
+    /// [`set_reliability_internal`](Self::set_reliability_internal): an Input's
+    /// `Present_Value` is writable by clients only while `Out_Of_Service` is
+    /// TRUE, and by the application only while it is FALSE.
+    ///
+    /// Only the access check differs between the two routes; data-type and
+    /// range validation are identical.
+    ///
+    /// The default routes to `write_property`, which is already correct for the
+    /// commandable types, whose `Present_Value` carries no `Out_Of_Service`
+    /// condition.
+    fn set_present_value_internal(
+        &mut self,
+        array_index: Option<u32>,
+        value: PropertyValue,
+        priority: Option<u8>,
+    ) -> Result<(), Error> {
+        self.write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            array_index,
+            value,
+            priority,
+        )
+    }
+
     /// Borrow this object's Audit Log query storage, if it has any.
     ///
     /// This read-only, type-erased channel lets the bundled server execute an

--- a/crates/bacnet-server/src/server/local_writes.rs
+++ b/crates/bacnet-server/src/server/local_writes.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+/// What a local mutation is, and on whose behalf.
+///
+/// An Input gates `Present_Value` on `Out_Of_Service` in opposite directions
+/// for the two, so this decides which check applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalWrite {
+    /// A client on the network, writing any property.
+    Network {
+        property: PropertyIdentifier,
+        array_index: Option<u32>,
+    },
+    /// The process the object represents, supplying its own `Present_Value`.
+    Application { array_index: Option<u32> },
+}
+
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Arm or rearm a Life Safety object from trusted local application logic.
     ///
@@ -59,6 +74,55 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         value: PropertyValue,
         priority: Option<u8>,
     ) -> Result<(), Error> {
+        self.write_local_as(
+            oid,
+            LocalWrite::Network {
+                property,
+                array_index,
+            },
+            value,
+            priority,
+        )
+        .await
+    }
+
+    /// Supply `Present_Value` for the process a local object represents, firing
+    /// the notifications [`BACnetServer::write_local`] fires.
+    ///
+    /// Routes through [`BACnetObject::set_present_value_internal`], so an Input
+    /// accepts the write while in service and refuses it while a client owns
+    /// the value.
+    ///
+    /// [`BACnetObject::set_present_value_internal`]: bacnet_objects::traits::BACnetObject::set_present_value_internal
+    pub async fn set_present_value_local(
+        &self,
+        oid: &ObjectIdentifier,
+        array_index: Option<u32>,
+        value: PropertyValue,
+        priority: Option<u8>,
+    ) -> Result<(), Error> {
+        self.write_local_as(
+            oid,
+            LocalWrite::Application { array_index },
+            value,
+            priority,
+        )
+        .await
+    }
+
+    async fn write_local_as(
+        &self,
+        oid: &ObjectIdentifier,
+        write: LocalWrite,
+        value: PropertyValue,
+        priority: Option<u8>,
+    ) -> Result<(), Error> {
+        // Only a network write can carry OBJECT_NAME, so only it needs the name
+        // index kept in step.
+        let renaming = matches!(
+            write,
+            LocalWrite::Network { property, .. } if property == PropertyIdentifier::OBJECT_NAME
+        );
         let life_safety = crate::life_safety_cov::is_life_safety_object(*oid);
         let exact_changes = {
             let mut db = self.db.write().await;
@@ -69,14 +133,22 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     code: ErrorCode::UNKNOWN_OBJECT.to_raw() as u32,
                 });
             }
-            if property == PropertyIdentifier::OBJECT_NAME {
+            if renaming {
                 if let PropertyValue::CharacterString(ref new_name) = value {
                     db.check_name_available(oid, new_name)?;
                 }
             }
             let object = db.get_mut(oid).expect("existence checked above");
-            object.write_property(property, array_index, value, priority)?;
-            if property == PropertyIdentifier::OBJECT_NAME {
+            match write {
+                LocalWrite::Network {
+                    property,
+                    array_index,
+                } => object.write_property(property, array_index, value, priority)?,
+                LocalWrite::Application { array_index } => {
+                    object.set_present_value_internal(array_index, value, priority)?
+                }
+            }
+            if renaming {
                 db.update_name_index(oid);
             }
             snapshots.changes(&db, std::slice::from_ref(oid))


### PR DESCRIPTION
Adds `BACnetObject::set_present_value_internal` and `BACnetServer::set_present_value_local`, so the application hosting the database can set an Input's `Present_Value`. Mirrors the existing `set_reliability_internal`.

Without something like this, it's not possible for the device process to update the values in the object database, as `write_property` is only the network route and there's no process side equivalent.