### PR TITLE
fix(alarm): correlate AcknowledgeAlarm requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Correlated AcknowledgeAlarm core validation and a lossless Rust request API
+  (`Refs #132`). The bundled server now requires the latest committed original
+  To State and exact timestamp before setting one supported Analog or Event
+  Enrollment acknowledgment bit; valid repeated transactions remain
+  idempotent. The legacy timestamp-fabricating helper is deprecated. Python,
+  CLI timestamp design, additional object families, and ACK_NOTIFICATION
+  distribution (#175) remain deferred, so this is not full Clause 13.5
+  conformance and does not close #132.
+
 - Exact-delta Life Safety COV reporting for the bundled server (`Refs #177`).
   Whole-object Point/Zone subscriptions now trigger only for actual
   `Present_Value` or `Status_Flags` changes and report exactly those two

--- a/crates/bacnet-cli/src/commands/device.rs
+++ b/crates/bacnet-cli/src/commands/device.rs
@@ -166,6 +166,7 @@ pub async fn alarms_cmd<T: TransportPort + 'static>(
 }
 
 /// Acknowledge an alarm on a remote device.
+#[allow(deprecated)]
 pub async fn acknowledge_alarm_cmd<T: TransportPort + 'static>(
     client: &BACnetClient<T>,
     mac: &[u8],

--- a/crates/bacnet-client/src/client/acknowledge_alarm_tests.rs
+++ b/crates/bacnet-client/src/client/acknowledge_alarm_tests.rs
@@ -1,0 +1,122 @@
+use super::*;
+
+use bacnet_encoding::apdu::{decode_apdu, SimpleAck};
+use bacnet_services::alarm_event::AcknowledgeAlarmRequest;
+use bacnet_transport::loopback::LoopbackTransport;
+use bacnet_types::enums::{EventState, ObjectType};
+use bacnet_types::primitives::{BACnetTimeStamp, Date, ObjectIdentifier, Time};
+
+fn time(hour: u8) -> BACnetTimeStamp {
+    BACnetTimeStamp::Time(Time {
+        hour,
+        minute: 2,
+        second: 3,
+        hundredths: 4,
+    })
+}
+
+fn date_time(day: u8) -> BACnetTimeStamp {
+    BACnetTimeStamp::DateTime {
+        date: Date {
+            year: 126,
+            month: 9,
+            day,
+            day_of_week: 3,
+        },
+        time: Time {
+            hour: 5,
+            minute: 6,
+            second: 7,
+            hundredths: 8,
+        },
+    }
+}
+
+#[tokio::test]
+async fn canonical_acknowledge_alarm_preserves_every_caller_supplied_field() {
+    let client_mac = vec![0x01];
+    let remote_mac = vec![0x02];
+    let (client_transport, remote_transport) =
+        LoopbackTransport::pair(client_mac, remote_mac.clone());
+    let mut remote_network = NetworkLayer::new(remote_transport);
+    let mut remote_rx = remote_network.start().await.unwrap();
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+
+    let requests = vec![
+        AcknowledgeAlarmRequest {
+            acknowledging_process_identifier: 11,
+            event_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+            event_state_acknowledged: EventState::HIGH_LIMIT.to_raw(),
+            timestamp: BACnetTimeStamp::SequenceNumber(101),
+            acknowledgment_source: "sequence-to-time".into(),
+            time_of_acknowledgment: time(9),
+        },
+        AcknowledgeAlarmRequest {
+            acknowledging_process_identifier: 22,
+            event_object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_OUTPUT, 2).unwrap(),
+            event_state_acknowledged: EventState::FAULT.to_raw(),
+            timestamp: time(10),
+            acknowledgment_source: "time-to-date-time".into(),
+            time_of_acknowledgment: date_time(2),
+        },
+        AcknowledgeAlarmRequest {
+            acknowledging_process_identifier: 33,
+            event_object_identifier: ObjectIdentifier::new(ObjectType::EVENT_ENROLLMENT, 3)
+                .unwrap(),
+            event_state_acknowledged: EventState::NORMAL.to_raw(),
+            timestamp: date_time(3),
+            acknowledgment_source: "date-time-to-sequence".into(),
+            time_of_acknowledgment: BACnetTimeStamp::SequenceNumber(303),
+        },
+    ];
+    let expected = requests.clone();
+
+    let responder = tokio::spawn(async move {
+        for expected_request in expected {
+            let received = timeout(Duration::from_secs(1), remote_rx.recv())
+                .await
+                .expect("remote timed out")
+                .expect("remote channel closed");
+            let Apdu::ConfirmedRequest(request) = decode_apdu(received.apdu).unwrap() else {
+                panic!("expected ConfirmedRequest");
+            };
+            assert_eq!(
+                request.service_choice,
+                ConfirmedServiceChoice::ACKNOWLEDGE_ALARM
+            );
+            assert_eq!(
+                AcknowledgeAlarmRequest::decode(&request.service_request).unwrap(),
+                expected_request
+            );
+
+            let mut ack = BytesMut::new();
+            encode_apdu(
+                &mut ack,
+                &Apdu::SimpleAck(SimpleAck {
+                    invoke_id: request.invoke_id,
+                    service_choice: request.service_choice,
+                }),
+            )
+            .unwrap();
+            remote_network
+                .send_apdu(&ack, &received.source_mac, false, NetworkPriority::NORMAL)
+                .await
+                .unwrap();
+        }
+        remote_network.stop().await.unwrap();
+    });
+
+    for request in &requests {
+        client
+            .acknowledge_alarm_request(&remote_mac, request)
+            .await
+            .unwrap();
+    }
+
+    responder.await.unwrap();
+    client.stop().await.unwrap();
+}

--- a/crates/bacnet-client/src/client/file_list.rs
+++ b/crates/bacnet-client/src/client/file_list.rs
@@ -114,7 +114,35 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         .await
     }
 
+    /// Send a caller-supplied AcknowledgeAlarm request without fabricating fields.
+    pub async fn acknowledge_alarm_request(
+        &self,
+        destination_mac: &[u8],
+        request: &bacnet_services::alarm_event::AcknowledgeAlarmRequest,
+    ) -> Result<(), Error> {
+        let mut buf = BytesMut::new();
+        request.encode(&mut buf)?;
+
+        let _ = self
+            .confirmed_request(
+                destination_mac,
+                ConfirmedServiceChoice::ACKNOWLEDGE_ALARM,
+                &buf,
+            )
+            .await?;
+
+        Ok(())
+    }
+
     /// Acknowledge an alarm on a remote device.
+    ///
+    /// This compatibility helper fabricates sequence-zero timestamps, which
+    /// are not a valid general correlation mechanism. Use
+    /// [`Self::acknowledge_alarm_request`] with the original notification's
+    /// exact timestamp and a caller-selected acknowledgment time.
+    #[deprecated(
+        note = "use acknowledge_alarm_request with caller-supplied correlation timestamps"
+    )]
     pub async fn acknowledge_alarm(
         &self,
         destination_mac: &[u8],
@@ -133,18 +161,8 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             acknowledgment_source: acknowledgment_source.to_string(),
             time_of_acknowledgment: bacnet_types::primitives::BACnetTimeStamp::SequenceNumber(0),
         };
-        let mut buf = BytesMut::new();
-        request.encode(&mut buf)?;
-
-        let _ = self
-            .confirmed_request(
-                destination_mac,
-                ConfirmedServiceChoice::ACKNOWLEDGE_ALARM,
-                &buf,
-            )
-            .await?;
-
-        Ok(())
+        self.acknowledge_alarm_request(destination_mac, &request)
+            .await
     }
 
     /// Read a range of items from a list or log-buffer property.

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -808,6 +808,8 @@ pub use cov_renewal::{
 };
 
 #[cfg(test)]
+mod acknowledge_alarm_tests;
+#[cfg(test)]
 mod builder_options_tests;
 #[cfg(test)]
 mod confirmed_request_dispatch_tests;

--- a/crates/bacnet-integration-tests/tests/server/routing_alarm.rs
+++ b/crates/bacnet-integration-tests/tests/server/routing_alarm.rs
@@ -293,6 +293,36 @@ async fn subscribe_cov_routed_ack_and_initial_notification_return_to_remote_subs
 // AcknowledgeAlarm integration test
 // ---------------------------------------------------------------------------
 
+async fn make_acknowledge_alarm_server() -> BACnetServer<BipTransport> {
+    use bacnet_objects::event::{EventStateChange, EventTransition, EventTransitionCommit};
+    use bacnet_types::enums::EventState;
+    use bacnet_types::primitives::BACnetTimeStamp;
+
+    let mut db = ObjectDatabase::new();
+    let mut ai = AnalogInputObject::new(1, "Zone Temp", 62).unwrap();
+    ai.commit_event_transition_internal(EventTransitionCommit {
+        change: EventStateChange {
+            from: EventState::NORMAL,
+            to: EventState::HIGH_LIMIT,
+        },
+        coordinate: EventTransition::ToOffnormal,
+        ack_required: true,
+        timestamp: BACnetTimeStamp::SequenceNumber(42),
+        message_text: None,
+    })
+    .unwrap();
+    db.add(Box::new(ai)).unwrap();
+
+    BACnetServer::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .broadcast_address(Ipv4Addr::LOCALHOST)
+        .database(db)
+        .build()
+        .await
+        .unwrap()
+}
+
 /// Send an AcknowledgeAlarm confirmed request to the server and verify
 /// we receive a SimpleACK back (service choice 0 = ACKNOWLEDGE_ALARM).
 #[tokio::test]
@@ -301,7 +331,7 @@ async fn acknowledge_alarm_returns_simple_ack() {
     use bacnet_types::enums::ConfirmedServiceChoice;
     use bacnet_types::primitives::BACnetTimeStamp;
 
-    let mut server = make_server().await;
+    let mut server = make_acknowledge_alarm_server().await;
     let mut client = make_client().await;
     let server_mac = server.local_mac().to_vec();
 

--- a/crates/bacnet-objects/src/analog/input.rs
+++ b/crates/bacnet-objects/src/analog/input.rs
@@ -304,6 +304,24 @@ impl BACnetObject for AnalogInputObject {
         Ok(())
     }
 
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.event_detector.acked_transitions,
+            event_state,
+            timestamp,
+        )
+    }
+
     fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
         if self.out_of_service || self.reliability_inhibit.enabled() {
             return Err(common::write_access_denied_error());
@@ -537,6 +555,7 @@ mod detection_enable_reset_tests {
         });
         ai.event_detector.fault_reliability = Some(1);
         ai.event_history.time_stamps[0] = BACnetTimeStamp::SequenceNumber(7);
+        ai.event_history.original_to_states[0] = Some(EventState::HIGH_LIMIT);
         ai.event_history.message_texts[0] = "offnormal".into();
         let rollback = ai
             .capture_write_property_rollback(
@@ -566,9 +585,16 @@ mod detection_enable_reset_tests {
             ai.event_history.time_stamps[0],
             BACnetTimeStamp::SequenceNumber(7)
         );
+        assert_eq!(
+            ai.event_history.original_to_states[0],
+            Some(EventState::HIGH_LIMIT)
+        );
         assert_eq!(ai.event_history.message_texts[0], "offnormal");
     }
 }
+
+#[cfg(test)]
+mod acknowledge_alarm_correlation_tests;
 
 #[cfg(test)]
 mod fault_out_of_range_non_finite_tests {

--- a/crates/bacnet-objects/src/analog/input/acknowledge_alarm_correlation_tests.rs
+++ b/crates/bacnet-objects/src/analog/input/acknowledge_alarm_correlation_tests.rs
@@ -1,0 +1,96 @@
+use super::*;
+
+use crate::event::{EventStateChange, EventTransition, EventTransitionCommit, PendingTransition};
+
+fn committed_input() -> AnalogInputObject {
+    let mut object = AnalogInputObject::new(1, "AI-correlated", 62).unwrap();
+    object
+        .commit_event_transition_internal(EventTransitionCommit {
+            change: EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            coordinate: EventTransition::ToOffnormal,
+            ack_required: true,
+            timestamp: BACnetTimeStamp::SequenceNumber(42),
+            message_text: Some("high".into()),
+        })
+        .unwrap();
+    object.event_detector.pending = Some(PendingTransition {
+        state: EventState::NORMAL,
+        remaining: 3,
+    });
+    object.event_detector.fault_reliability = Some(Reliability::OVER_RANGE.to_raw());
+    object
+}
+
+fn assert_invalid_event_state(error: Error) {
+    assert!(matches!(
+        error,
+        Error::Protocol { class, code }
+            if class == ErrorClass::SERVICES.to_raw() as u32
+                && code == ErrorCode::INVALID_EVENT_STATE.to_raw() as u32
+    ));
+}
+
+#[test]
+fn rejected_correlation_preserves_detector_pending_and_all_event_history() {
+    let mut object = committed_input();
+    let before = (
+        object.event_detector.event_state,
+        object.event_detector.acked_transitions,
+        object.event_detector.pending.clone(),
+        object.event_detector.fault_reliability,
+        object.event_history.clone(),
+    );
+
+    let error = object
+        .acknowledge_alarm_correlated_internal(
+            EventState::LOW_LIMIT,
+            &BACnetTimeStamp::SequenceNumber(99),
+        )
+        .unwrap_err();
+
+    assert_invalid_event_state(error);
+    assert_eq!(
+        (
+            object.event_detector.event_state,
+            object.event_detector.acked_transitions,
+            object.event_detector.pending,
+            object.event_detector.fault_reliability,
+            object.event_history,
+        ),
+        before
+    );
+}
+
+#[test]
+fn idempotent_valid_correlation_changes_no_detector_or_history_state() {
+    let mut object = committed_input();
+    object.event_detector.acked_transitions |= EventTransition::ToOffnormal.bit_mask();
+    let before = (
+        object.event_detector.event_state,
+        object.event_detector.acked_transitions,
+        object.event_detector.pending.clone(),
+        object.event_detector.fault_reliability,
+        object.event_history.clone(),
+    );
+
+    object
+        .acknowledge_alarm_correlated_internal(
+            EventState::HIGH_LIMIT,
+            &BACnetTimeStamp::SequenceNumber(42),
+        )
+        .unwrap();
+
+    assert_eq!(
+        (
+            object.event_detector.event_state,
+            object.event_detector.acked_transitions,
+            object.event_detector.pending,
+            object.event_detector.fault_reliability,
+            object.event_history,
+        ),
+        before
+    );
+}

--- a/crates/bacnet-objects/src/analog/mod.rs
+++ b/crates/bacnet-objects/src/analog/mod.rs
@@ -2,7 +2,9 @@
 //!
 //! Per ASHRAE 135-2020 Clauses 12.2 (AI), 12.3 (AO), and 12.4 (AV).
 
-use bacnet_types::enums::{ObjectType, PropertyIdentifier, Reliability};
+use bacnet_types::enums::{
+    ErrorClass, ErrorCode, EventState, ObjectType, PropertyIdentifier, Reliability,
+};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;

--- a/crates/bacnet-objects/src/analog/output.rs
+++ b/crates/bacnet-objects/src/analog/output.rs
@@ -341,6 +341,24 @@ impl BACnetObject for AnalogOutputObject {
         Ok(())
     }
 
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.event_detector.acked_transitions,
+            event_state,
+            timestamp,
+        )
+    }
+
     fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
         if self.out_of_service || self.reliability_inhibit.enabled() {
             return Err(common::write_access_denied_error());

--- a/crates/bacnet-objects/src/analog/value.rs
+++ b/crates/bacnet-objects/src/analog/value.rs
@@ -368,6 +368,24 @@ impl BACnetObject for AnalogValueObject {
         Ok(())
     }
 
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.event_detector.acked_transitions,
+            event_state,
+            timestamp,
+        )
+    }
+
     fn set_reliability_internal(&mut self, reliability: u32) -> Result<(), Error> {
         if self.out_of_service || self.reliability_inhibit.enabled() {
             return Err(common::write_access_denied_error());

--- a/crates/bacnet-objects/src/event/history.rs
+++ b/crates/bacnet-objects/src/event/history.rs
@@ -1,7 +1,7 @@
 //! Shared storage for intrinsic-reporting event history properties.
 
 use bacnet_encoding::primitives::encode_timestamp_choice;
-use bacnet_types::enums::{EventState, PropertyIdentifier};
+use bacnet_types::enums::{ErrorClass, ErrorCode, EventState, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, PropertyValue};
 use bytes::BytesMut;
@@ -12,6 +12,8 @@ use super::{EventTransition, EventTransitionCommit, EventTransitionCommitError};
 pub(crate) struct EventHistory {
     /// Transition slots ordered `[TO_OFFNORMAL, TO_FAULT, TO_NORMAL]`.
     pub(crate) time_stamps: [BACnetTimeStamp; 3],
+    /// Exact committed To State for each transition slot.
+    pub(crate) original_to_states: [Option<EventState>; 3],
     /// Transition slots ordered `[TO_OFFNORMAL, TO_FAULT, TO_NORMAL]`.
     pub(crate) message_texts: [String; 3],
 }
@@ -71,6 +73,7 @@ impl<'a> EventTransitionState<'a> {
             *self.acked_transitions &= !bit;
         }
         self.history.time_stamps[index] = commit.timestamp;
+        self.history.original_to_states[index] = Some(commit.change.to);
         if let Some(message_text) = commit.message_text {
             self.history.message_texts[index] = message_text;
         }
@@ -216,6 +219,7 @@ impl Default for EventHistory {
                 BACnetTimeStamp::SequenceNumber(0),
                 BACnetTimeStamp::SequenceNumber(0),
             ],
+            original_to_states: [None, None, None],
             message_texts: [String::new(), String::new(), String::new()],
         }
     }
@@ -224,6 +228,34 @@ impl Default for EventHistory {
 impl EventHistory {
     pub(crate) fn reset(&mut self) {
         *self = Self::default();
+    }
+
+    /// Validate an acknowledgment against the latest committed transition slot.
+    pub(crate) fn acknowledge_correlated(
+        &self,
+        acked_transitions: &mut u8,
+        requested_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        let coordinate = EventTransition::for_target_state(requested_state);
+        let index = coordinate.index();
+        let Some(original_state) = self.original_to_states[index] else {
+            return Err(service_error(ErrorCode::INVALID_TIME_STAMP));
+        };
+
+        let state_matches = original_state == requested_state
+            || (requested_state == EventState::OFFNORMAL
+                && EventTransition::for_target_state(original_state)
+                    == EventTransition::ToOffnormal);
+        if !state_matches {
+            return Err(service_error(ErrorCode::INVALID_EVENT_STATE));
+        }
+        if self.time_stamps[index] != *timestamp {
+            return Err(service_error(ErrorCode::INVALID_TIME_STAMP));
+        }
+
+        *acked_transitions |= coordinate.bit_mask();
+        Ok(())
     }
 
     /// Reads the fixed-size event arrays with their BACnet array semantics.
@@ -259,6 +291,16 @@ impl EventHistory {
         }
     }
 }
+
+fn service_error(code: ErrorCode) -> Error {
+    Error::Protocol {
+        class: ErrorClass::SERVICES.to_raw() as u32,
+        code: code.to_raw() as u32,
+    }
+}
+
+#[cfg(test)]
+mod correlation_tests;
 
 fn timestamp_value(stamp: &BACnetTimeStamp) -> PropertyValue {
     let mut encoded = BytesMut::new();
@@ -329,6 +371,7 @@ mod tests {
     fn reset_restores_mutated_history_to_default() {
         let mut history = EventHistory::default();
         history.time_stamps[1] = BACnetTimeStamp::SequenceNumber(42);
+        history.original_to_states[1] = Some(EventState::FAULT);
         history.message_texts[2] = "transition".into();
 
         history.reset();
@@ -346,6 +389,7 @@ mod tests {
                 BACnetTimeStamp::SequenceNumber(20),
                 BACnetTimeStamp::SequenceNumber(30),
             ],
+            original_to_states: [None, None, None],
             message_texts: [
                 "old-offnormal".into(),
                 "old-fault".into(),
@@ -370,6 +414,7 @@ mod tests {
         assert_eq!(state, EventState::HIGH_LIMIT);
         assert_eq!(acked, 0b100, "only TO_OFFNORMAL is cleared");
         assert_eq!(history.time_stamps[0], time(1));
+        assert_eq!(history.original_to_states[0], Some(EventState::HIGH_LIMIT));
         assert_eq!(history.time_stamps[1], BACnetTimeStamp::SequenceNumber(20));
         assert_eq!(history.time_stamps[2], BACnetTimeStamp::SequenceNumber(30));
         assert_eq!(
@@ -395,6 +440,7 @@ mod tests {
         assert_eq!(acked, 0b110, "TO_FAULT is set and other bits are untouched");
         assert_eq!(history.time_stamps[0], time(1));
         assert_eq!(history.time_stamps[1], BACnetTimeStamp::SequenceNumber(0));
+        assert_eq!(history.original_to_states[1], Some(EventState::FAULT));
         assert_eq!(history.time_stamps[2], BACnetTimeStamp::SequenceNumber(30));
         assert_eq!(history.message_texts, ["high-limit", "fault", "old-normal"]);
 
@@ -418,6 +464,14 @@ mod tests {
             history.time_stamps,
             [time(1), BACnetTimeStamp::SequenceNumber(0), date_time(27)]
         );
+        assert_eq!(
+            history.original_to_states,
+            [
+                Some(EventState::HIGH_LIMIT),
+                Some(EventState::FAULT),
+                Some(EventState::NORMAL),
+            ]
+        );
         assert_eq!(history.message_texts, ["high-limit", "fault", "normal"]);
     }
 
@@ -431,6 +485,7 @@ mod tests {
                 BACnetTimeStamp::SequenceNumber(2),
                 BACnetTimeStamp::SequenceNumber(3),
             ],
+            original_to_states: [None, None, None],
             message_texts: ["offnormal".into(), "fault".into(), "normal".into()],
         };
         let messages_before = history.message_texts.clone();
@@ -472,6 +527,11 @@ mod tests {
         let mut acked = 0b101;
         let mut history = EventHistory {
             time_stamps: [time(9), BACnetTimeStamp::SequenceNumber(44), date_time(26)],
+            original_to_states: [
+                Some(EventState::HIGH_LIMIT),
+                Some(EventState::FAULT),
+                Some(EventState::NORMAL),
+            ],
             message_texts: ["offnormal".into(), "fault".into(), "normal".into()],
         };
         let expected_state = state;

--- a/crates/bacnet-objects/src/event/history/correlation_tests.rs
+++ b/crates/bacnet-objects/src/event/history/correlation_tests.rs
@@ -1,0 +1,235 @@
+use super::*;
+
+use bacnet_types::primitives::{Date, Time};
+
+use crate::event::{EventStateChange, EventTransitionCommit};
+
+fn sequence(value: u16) -> BACnetTimeStamp {
+    BACnetTimeStamp::SequenceNumber(value)
+}
+
+fn time(hour: u8) -> BACnetTimeStamp {
+    BACnetTimeStamp::Time(Time {
+        hour,
+        minute: 2,
+        second: 3,
+        hundredths: 4,
+    })
+}
+
+fn date_time(day: u8) -> BACnetTimeStamp {
+    BACnetTimeStamp::DateTime {
+        date: Date {
+            year: 126,
+            month: 9,
+            day,
+            day_of_week: 3,
+        },
+        time: Time {
+            hour: 5,
+            minute: 6,
+            second: 7,
+            hundredths: 8,
+        },
+    }
+}
+
+fn commit(
+    state: &mut EventState,
+    acked: &mut u8,
+    history: &mut EventHistory,
+    to: EventState,
+    timestamp: BACnetTimeStamp,
+) {
+    let from = *state;
+    EventTransitionState::new(state, acked, history)
+        .commit(EventTransitionCommit {
+            change: EventStateChange { from, to },
+            coordinate: EventTransition::for_target_state(to),
+            ack_required: true,
+            timestamp,
+            message_text: None,
+        })
+        .unwrap();
+}
+
+fn assert_service_error(result: Result<(), Error>, expected: ErrorCode) {
+    assert!(matches!(
+        result,
+        Err(Error::Protocol { class, code })
+            if class == ErrorClass::SERVICES.to_raw() as u32
+                && code == expected.to_raw() as u32
+    ));
+}
+
+#[test]
+fn exact_timestamp_choices_acknowledge_prior_coordinates_one_bit_at_a_time() {
+    let mut state = EventState::NORMAL;
+    let mut acked = 0b111;
+    let mut history = EventHistory::default();
+    let stamps = [time(1), sequence(22), date_time(2)];
+
+    commit(
+        &mut state,
+        &mut acked,
+        &mut history,
+        EventState::HIGH_LIMIT,
+        stamps[0].clone(),
+    );
+    commit(
+        &mut state,
+        &mut acked,
+        &mut history,
+        EventState::FAULT,
+        stamps[1].clone(),
+    );
+    commit(
+        &mut state,
+        &mut acked,
+        &mut history,
+        EventState::NORMAL,
+        stamps[2].clone(),
+    );
+    assert_eq!(state, EventState::NORMAL);
+    assert_eq!(acked, 0);
+
+    let history_before = history.clone();
+    for (requested_state, stamp, expected) in [
+        (EventState::HIGH_LIMIT, &stamps[0], 0b001),
+        (EventState::FAULT, &stamps[1], 0b011),
+        (EventState::NORMAL, &stamps[2], 0b111),
+    ] {
+        history
+            .acknowledge_correlated(&mut acked, requested_state, stamp)
+            .unwrap();
+        assert_eq!(acked, expected);
+        assert_eq!(history, history_before);
+    }
+}
+
+#[test]
+fn latest_same_coordinate_timestamp_replaces_the_older_timestamp() {
+    let mut state = EventState::NORMAL;
+    let mut acked = 0b111;
+    let mut history = EventHistory::default();
+    commit(
+        &mut state,
+        &mut acked,
+        &mut history,
+        EventState::HIGH_LIMIT,
+        sequence(1),
+    );
+    commit(
+        &mut state,
+        &mut acked,
+        &mut history,
+        EventState::LOW_LIMIT,
+        sequence(2),
+    );
+    let before = (acked, history.clone());
+
+    assert_service_error(
+        history.acknowledge_correlated(&mut acked, EventState::LOW_LIMIT, &sequence(1)),
+        ErrorCode::INVALID_TIME_STAMP,
+    );
+    assert_eq!((acked, history.clone()), before);
+    assert_service_error(
+        history.acknowledge_correlated(&mut acked, EventState::HIGH_LIMIT, &sequence(1)),
+        ErrorCode::INVALID_EVENT_STATE,
+    );
+    assert_eq!((acked, history.clone()), before);
+    history
+        .acknowledge_correlated(&mut acked, EventState::LOW_LIMIT, &sequence(2))
+        .unwrap();
+    assert_eq!(acked, before.0 | 0b001);
+}
+
+#[test]
+fn request_side_offnormal_wildcard_matches_every_residual_offnormal_state() {
+    for stored in [
+        EventState::HIGH_LIMIT,
+        EventState::LOW_LIMIT,
+        EventState::LIFE_SAFETY_ALARM,
+        EventState::from_raw(65_535),
+    ] {
+        let mut state = EventState::NORMAL;
+        let mut acked = 0b110;
+        let mut history = EventHistory::default();
+        commit(&mut state, &mut acked, &mut history, stored, sequence(9));
+
+        history
+            .acknowledge_correlated(&mut acked, EventState::OFFNORMAL, &sequence(9))
+            .unwrap();
+        assert_eq!(acked, 0b111, "stored state {stored:?}");
+    }
+}
+
+#[test]
+fn concrete_state_matching_is_exact_and_precedes_timestamp_validation() {
+    for (stored, requested) in [
+        (EventState::LOW_LIMIT, EventState::HIGH_LIMIT),
+        (EventState::OFFNORMAL, EventState::HIGH_LIMIT),
+        (EventState::from_raw(60_001), EventState::from_raw(60_002)),
+    ] {
+        let mut state = EventState::NORMAL;
+        let mut acked = 0b101;
+        let mut history = EventHistory::default();
+        commit(&mut state, &mut acked, &mut history, stored, sequence(12));
+        let before = (acked, history.clone());
+
+        assert_service_error(
+            history.acknowledge_correlated(&mut acked, requested, &sequence(99)),
+            ErrorCode::INVALID_EVENT_STATE,
+        );
+        assert_eq!((acked, history.clone()), before);
+    }
+}
+
+#[test]
+fn exact_generic_and_proprietary_states_match_their_committed_identity() {
+    for stored in [EventState::OFFNORMAL, EventState::from_raw(60_001)] {
+        let mut state = EventState::NORMAL;
+        let mut acked = 0b110;
+        let mut history = EventHistory::default();
+        commit(&mut state, &mut acked, &mut history, stored, sequence(14));
+
+        history
+            .acknowledge_correlated(&mut acked, stored, &sequence(14))
+            .unwrap();
+        assert_eq!(acked, 0b111);
+    }
+}
+
+#[test]
+fn uninitialized_sequence_zero_slot_is_not_a_committed_transition() {
+    let history = EventHistory::default();
+    let mut acked = 0b010;
+    let before = (acked, history.clone());
+
+    assert_service_error(
+        history.acknowledge_correlated(&mut acked, EventState::HIGH_LIMIT, &sequence(0)),
+        ErrorCode::INVALID_TIME_STAMP,
+    );
+    assert_eq!((acked, history), before);
+}
+
+#[test]
+fn already_set_bit_is_idempotent_and_preserves_all_history() {
+    let mut state = EventState::NORMAL;
+    let mut acked = 0b111;
+    let mut history = EventHistory::default();
+    commit(
+        &mut state,
+        &mut acked,
+        &mut history,
+        EventState::HIGH_LIMIT,
+        sequence(7),
+    );
+    acked |= 0b001;
+    let before = (state, acked, history.clone());
+
+    history
+        .acknowledge_correlated(&mut acked, EventState::HIGH_LIMIT, &sequence(7))
+        .unwrap();
+    assert_eq!((state, acked, history), before);
+}

--- a/crates/bacnet-objects/src/event_enrollment/mod.rs
+++ b/crates/bacnet-objects/src/event_enrollment/mod.rs
@@ -3,9 +3,9 @@
 use bacnet_types::constructed::{
     BACnetDeviceObjectPropertyReference, BACnetEventParameter, FaultParameters,
 };
-use bacnet_types::enums::{EventState, ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{ErrorClass, ErrorCode, EventState, ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
-use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
+use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;
 
 use crate::common::{self, read_common_properties};
@@ -113,6 +113,25 @@ impl EventEnrollmentObject {
     /// meaning no event of that type has ever occurred (ASHRAE 135-2020
     /// Clause 12.12).
     const RESET_ACKED_TRANSITIONS: u8 = 0b111;
+
+    fn has_configured_event_generation(&self) -> bool {
+        let event_algorithm_supported = matches!(
+            &self.event_parameters,
+            BACnetEventParameter::OutOfRange { .. }
+                | BACnetEventParameter::FloatingLimit { .. }
+                | BACnetEventParameter::ChangeOfState { .. }
+                | BACnetEventParameter::ChangeOfBitstring { .. }
+                | BACnetEventParameter::ChangeOfValue { .. }
+                | BACnetEventParameter::Opaque { tag: 0xFF, .. }
+        );
+        let fault_algorithm_supported = matches!(
+            self.effective_fault_parameters(),
+            FaultParameters::FaultStatusFlags { .. } | FaultParameters::FaultOutOfRange { .. }
+        );
+        self.event_detection_enable
+            && self.object_property_reference.is_some()
+            && (event_algorithm_supported || fault_algorithm_supported)
+    }
 
     /// Apply the reset ASHRAE 135-2020 Clause 13.2.2.1 requires while
     /// `Event_Detection_Enable` is FALSE: "no transitions shall occur,
@@ -510,6 +529,24 @@ impl BACnetObject for EventEnrollmentObject {
         }
         self.acked_transitions |= transition_bit & 0x07;
         Ok(())
+    }
+
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.has_configured_event_generation() {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.acked_transitions,
+            event_state,
+            timestamp,
+        )
     }
 
     /// Clause 13.2.3's transition-received maintenance of `Acked_Transitions`:

--- a/crates/bacnet-objects/src/event_enrollment/tests/atomic_commit.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/atomic_commit.rs
@@ -68,6 +68,10 @@ fn stock_enrollment_atomically_commits_state_ack_and_exact_history_coordinate() 
     );
     assert_eq!(timestamp_at(&object, 2), BACnetTimeStamp::SequenceNumber(0));
     assert_eq!(timestamp_at(&object, 3), BACnetTimeStamp::SequenceNumber(0));
+    assert_eq!(
+        object.event_history.original_to_states,
+        [Some(EventState::HIGH_LIMIT), None, None]
+    );
 
     object
         .commit_event_transition_internal(EventTransitionCommit {
@@ -84,6 +88,10 @@ fn stock_enrollment_atomically_commits_state_ack_and_exact_history_coordinate() 
     assert_eq!(
         timestamp_at(&object, 1),
         BACnetTimeStamp::SequenceNumber(42)
+    );
+    assert_eq!(
+        object.event_history.original_to_states,
+        [Some(EventState::HIGH_LIMIT), None, None]
     );
     assert_eq!(
         object

--- a/crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs
+++ b/crates/bacnet-objects/src/event_enrollment/tests/timestamps.rs
@@ -174,6 +174,11 @@ fn event_enrollment_detection_disable_resets_history_and_rollback_restores_it() 
     let expected = seeded_timestamps();
     let mut object = EventEnrollmentObject::new(1, "EE-1", 0).unwrap();
     object.event_history.time_stamps = expected.clone();
+    object.event_history.original_to_states = [
+        Some(EventState::HIGH_LIMIT),
+        Some(EventState::FAULT),
+        Some(EventState::NORMAL),
+    ];
     let rollback = object
         .capture_write_property_rollback(
             PropertyIdentifier::EVENT_DETECTION_ENABLE,
@@ -193,6 +198,14 @@ fn event_enrollment_detection_disable_resets_history_and_rollback_restores_it() 
 
     object.restore_write_property_rollback(rollback).unwrap();
     assert_seeded_timestamp_reads(&object, &expected, "restored Event Enrollment");
+    assert_eq!(
+        object.event_history.original_to_states,
+        [
+            Some(EventState::HIGH_LIMIT),
+            Some(EventState::FAULT),
+            Some(EventState::NORMAL),
+        ]
+    );
 }
 
 #[test]

--- a/crates/bacnet-objects/src/rollback.rs
+++ b/crates/bacnet-objects/src/rollback.rs
@@ -16,6 +16,7 @@ pub(crate) enum IntrinsicWriteRollback {
         pending: Option<PendingTransition>,
         fault_reliability: Option<u32>,
         time_stamps: [BACnetTimeStamp; 3],
+        original_to_states: [Option<EventState>; 3],
         message_texts: [String; 3],
     },
     TimeDelayNormal(Option<u32>),
@@ -137,6 +138,7 @@ macro_rules! impl_intrinsic_write_rollback {
                             pending: self.$detector_field.pending.clone(),
                             fault_reliability: self.$detector_field.fault_reliability,
                             time_stamps: self.$history_field.time_stamps.clone(),
+                            original_to_states: self.$history_field.original_to_states,
                             message_texts: self.$history_field.message_texts.clone(),
                         },
                     ))
@@ -196,6 +198,7 @@ macro_rules! impl_intrinsic_write_rollback {
                     pending,
                     fault_reliability,
                     time_stamps,
+                    original_to_states,
                     message_texts,
                 } => {
                     self.$detection_enable_field = enabled;
@@ -204,6 +207,7 @@ macro_rules! impl_intrinsic_write_rollback {
                     self.$detector_field.pending = pending;
                     self.$detector_field.fault_reliability = fault_reliability;
                     self.$history_field.time_stamps = time_stamps;
+                    self.$history_field.original_to_states = original_to_states;
                     self.$history_field.message_texts = message_texts;
                     Ok(())
                 }

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -10,7 +10,7 @@ use bacnet_types::enums::{
     ErrorClass, ErrorCode, EventState, LifeSafetyOperation, PropertyIdentifier,
 };
 use bacnet_types::error::Error;
-use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier, PropertyValue};
 
 use crate::audit::{AuditLogNotificationSink, AuditLogStorage};
 use crate::clock::ClockReader;
@@ -465,6 +465,19 @@ pub trait BACnetObject: Send + Sync {
             class: bacnet_types::enums::ErrorClass::OBJECT.to_raw() as u32,
             code: bacnet_types::enums::ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw()
                 as u32,
+        })
+    }
+
+    /// Correlate an acknowledgment with the latest committed transition.
+    #[doc(hidden)]
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        _event_state: EventState,
+        _timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::OBJECT.to_raw() as u32,
+            code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
         })
     }
 

--- a/crates/bacnet-server/src/handlers/alarm_event/acknowledge_alarm.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/acknowledge_alarm.rs
@@ -7,15 +7,10 @@ use super::super::*;
 
 /// Handle an AcknowledgeAlarm request.
 ///
-/// Updates the acknowledged_transitions bitfield on the referenced object.
+/// Correlates the request with one committed transition before acknowledging it.
 pub fn handle_acknowledge_alarm(db: &mut ObjectDatabase, service_data: &[u8]) -> Result<(), Error> {
     let request = AcknowledgeAlarmRequest::decode(service_data)?;
-
-    let transition_bit: u8 = match EventState::from_raw(request.event_state_acknowledged) {
-        s if s == EventState::NORMAL => 0x04, // TO_NORMAL
-        s if s == EventState::FAULT => 0x02,  // TO_FAULT
-        _ => 0x01,                            // TO_OFFNORMAL
-    };
+    let event_state = EventState::from_raw(request.event_state_acknowledged);
 
     let object = db
         .get_mut(&request.event_object_identifier)
@@ -24,7 +19,16 @@ pub fn handle_acknowledge_alarm(db: &mut ObjectDatabase, service_data: &[u8]) ->
             code: ErrorCode::UNKNOWN_OBJECT.to_raw() as u32,
         })?;
 
-    object.acknowledge_alarm(transition_bit)?;
+    object.acknowledge_alarm_correlated_internal(event_state, &request.timestamp)?;
+
+    // ACK_NOTIFICATION distribution and acknowledgment metadata retention are
+    // deferred to #175. This core slice validates every required request field
+    // but intentionally retains none of this metadata after successful use.
+    let _ = (
+        request.acknowledging_process_identifier,
+        request.acknowledgment_source,
+        request.time_of_acknowledgment,
+    );
 
     Ok(())
 }

--- a/crates/bacnet-server/src/handlers/tests/acknowledge_alarm.rs
+++ b/crates/bacnet-server/src/handlers/tests/acknowledge_alarm.rs
@@ -1,0 +1,337 @@
+use super::*;
+
+use bacnet_encoding::primitives;
+use bacnet_encoding::tags::{encode_tag, TagClass};
+use bacnet_objects::analog::{AnalogOutputObject, AnalogValueObject};
+use bacnet_objects::binary::BinaryInputObject;
+use bacnet_objects::event::{EventStateChange, EventTransitionCommit};
+use bacnet_objects::event_enrollment::{AlertEnrollmentObject, EventEnrollmentObject};
+use bacnet_objects::multistate::MultiStateInputObject;
+use bacnet_services::alarm_event::AcknowledgeAlarmRequest;
+use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetEventParameter};
+use bacnet_types::enums::EventType;
+
+fn add_committed<O: BACnetObject + 'static>(
+    db: &mut ObjectDatabase,
+    mut object: O,
+    state: EventState,
+    timestamp: BACnetTimeStamp,
+) -> ObjectIdentifier {
+    let oid = object.object_identifier();
+    object
+        .commit_event_transition_internal(EventTransitionCommit {
+            change: EventStateChange {
+                from: EventState::NORMAL,
+                to: state,
+            },
+            coordinate: bacnet_objects::event::EventTransition::for_target_state(state),
+            ack_required: true,
+            timestamp,
+            message_text: Some("committed".into()),
+        })
+        .unwrap();
+    db.add(Box::new(object)).unwrap();
+    oid
+}
+
+fn encode_request(
+    oid: ObjectIdentifier,
+    state: EventState,
+    timestamp: BACnetTimeStamp,
+) -> BytesMut {
+    let request = AcknowledgeAlarmRequest {
+        acknowledging_process_identifier: 17,
+        event_object_identifier: oid,
+        event_state_acknowledged: state.to_raw(),
+        timestamp,
+        acknowledgment_source: "operator".into(),
+        time_of_acknowledgment: BACnetTimeStamp::SequenceNumber(88),
+    };
+    let mut encoded = BytesMut::new();
+    request.encode(&mut encoded).unwrap();
+    encoded
+}
+
+fn encode_request_with_raw_source(oid: ObjectIdentifier, source: &[u8]) -> BytesMut {
+    let mut encoded = BytesMut::new();
+    primitives::encode_ctx_unsigned(&mut encoded, 0, 17);
+    primitives::encode_ctx_object_id(&mut encoded, 1, &oid);
+    primitives::encode_ctx_enumerated(&mut encoded, 2, EventState::HIGH_LIMIT.to_raw());
+    primitives::encode_timestamp(&mut encoded, 3, &BACnetTimeStamp::SequenceNumber(42)).unwrap();
+    encode_tag(&mut encoded, 4, TagClass::Context, source.len() as u32);
+    encoded.extend_from_slice(source);
+    primitives::encode_timestamp(&mut encoded, 5, &BACnetTimeStamp::SequenceNumber(88)).unwrap();
+    encoded
+}
+
+fn acked(db: &ObjectDatabase, oid: ObjectIdentifier) -> u8 {
+    let PropertyValue::BitString { data, .. } = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+        .unwrap()
+    else {
+        panic!("Acked_Transitions must be a bit string");
+    };
+    bacnet_types::bitstring::unpack_octet(&data, 3)
+}
+
+fn snapshot(db: &ObjectDatabase, oid: ObjectIdentifier) -> (PropertyValue, PropertyValue, u8) {
+    let object = db.get(&oid).unwrap();
+    (
+        object
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        object
+            .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
+            .unwrap(),
+        acked(db, oid),
+    )
+}
+
+fn assert_protocol(error: Error, class: ErrorClass, code: ErrorCode) {
+    assert!(matches!(
+        error,
+        Error::Protocol { class: actual_class, code: actual_code }
+            if actual_class == class.to_raw() as u32 && actual_code == code.to_raw() as u32
+    ));
+}
+
+fn configured_event_enrollment() -> EventEnrollmentObject {
+    let mut object =
+        EventEnrollmentObject::new(1, "EE-ack", EventType::OUT_OF_RANGE.to_raw()).unwrap();
+    object.set_object_property_reference(Some(BACnetDeviceObjectPropertyReference::new_local(
+        ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 77).unwrap(),
+        PropertyIdentifier::PRESENT_VALUE.to_raw(),
+    )));
+    object.set_event_parameters(BACnetEventParameter::OutOfRange {
+        time_delay: 0,
+        low_limit: 0.0,
+        high_limit: 1.0,
+        deadband: 0.1,
+    });
+    object
+}
+
+#[test]
+fn supported_families_acknowledge_only_the_correlated_transition() {
+    let mut db = ObjectDatabase::new();
+    let stamp = BACnetTimeStamp::SequenceNumber(42);
+    let oids = [
+        add_committed(
+            &mut db,
+            AnalogInputObject::new(1, "AI-ack", 62).unwrap(),
+            EventState::HIGH_LIMIT,
+            stamp.clone(),
+        ),
+        add_committed(
+            &mut db,
+            AnalogOutputObject::new(1, "AO-ack", 62).unwrap(),
+            EventState::HIGH_LIMIT,
+            stamp.clone(),
+        ),
+        add_committed(
+            &mut db,
+            AnalogValueObject::new(1, "AV-ack", 62).unwrap(),
+            EventState::HIGH_LIMIT,
+            stamp.clone(),
+        ),
+        add_committed(
+            &mut db,
+            configured_event_enrollment(),
+            EventState::HIGH_LIMIT,
+            stamp.clone(),
+        ),
+    ];
+
+    for oid in oids {
+        assert_eq!(acked(&db, oid), 0b110);
+        handle_acknowledge_alarm(
+            &mut db,
+            &encode_request(oid, EventState::HIGH_LIMIT, stamp.clone()),
+        )
+        .unwrap();
+        assert_eq!(acked(&db, oid), 0b111);
+    }
+}
+
+#[test]
+fn state_and_timestamp_mismatches_return_exact_errors_without_mutation() {
+    let mut db = ObjectDatabase::new();
+    let oid = add_committed(
+        &mut db,
+        AnalogInputObject::new(1, "AI-invalid", 62).unwrap(),
+        EventState::LOW_LIMIT,
+        BACnetTimeStamp::SequenceNumber(42),
+    );
+    let before = snapshot(&db, oid);
+
+    let state_error = handle_acknowledge_alarm(
+        &mut db,
+        &encode_request(
+            oid,
+            EventState::HIGH_LIMIT,
+            BACnetTimeStamp::SequenceNumber(99),
+        ),
+    )
+    .unwrap_err();
+    assert_protocol(
+        state_error,
+        ErrorClass::SERVICES,
+        ErrorCode::INVALID_EVENT_STATE,
+    );
+    assert_eq!(snapshot(&db, oid), before);
+
+    let timestamp_error = handle_acknowledge_alarm(
+        &mut db,
+        &encode_request(
+            oid,
+            EventState::LOW_LIMIT,
+            BACnetTimeStamp::SequenceNumber(41),
+        ),
+    )
+    .unwrap_err();
+    assert_protocol(
+        timestamp_error,
+        ErrorClass::SERVICES,
+        ErrorCode::INVALID_TIME_STAMP,
+    );
+    assert_eq!(snapshot(&db, oid), before);
+}
+
+#[test]
+fn unknown_uninitialized_and_unsupported_objects_fail_closed() {
+    let missing = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 99).unwrap();
+    let mut empty = ObjectDatabase::new();
+    let error = handle_acknowledge_alarm(
+        &mut empty,
+        &encode_request(
+            missing,
+            EventState::HIGH_LIMIT,
+            BACnetTimeStamp::SequenceNumber(0),
+        ),
+    )
+    .unwrap_err();
+    assert_protocol(error, ErrorClass::OBJECT, ErrorCode::UNKNOWN_OBJECT);
+
+    let mut db = ObjectDatabase::new();
+    let objects: Vec<Box<dyn BACnetObject>> = vec![
+        Box::new(BinaryInputObject::new(1, "BI-unsupported").unwrap()),
+        Box::new(MultiStateInputObject::new(1, "MSI-unsupported", 3).unwrap()),
+        Box::new(
+            AlertEnrollmentObject::new(
+                1,
+                "AE-unsupported",
+                ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 7).unwrap(),
+            )
+            .unwrap(),
+        ),
+    ];
+    for object in objects {
+        let oid = object.object_identifier();
+        db.add(object).unwrap();
+        let before = acked(&db, oid);
+        let error = handle_acknowledge_alarm(
+            &mut db,
+            &encode_request(
+                oid,
+                EventState::HIGH_LIMIT,
+                BACnetTimeStamp::SequenceNumber(0),
+            ),
+        )
+        .unwrap_err();
+        assert_protocol(error, ErrorClass::OBJECT, ErrorCode::NO_ALARM_CONFIGURED);
+        assert_eq!(acked(&db, oid), before);
+    }
+
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 8).unwrap();
+    db.add(Box::new(AnalogInputObject::new(8, "AI-empty", 62).unwrap()))
+        .unwrap();
+    let before = snapshot(&db, oid);
+    let error = handle_acknowledge_alarm(
+        &mut db,
+        &encode_request(
+            oid,
+            EventState::HIGH_LIMIT,
+            BACnetTimeStamp::SequenceNumber(0),
+        ),
+    )
+    .unwrap_err();
+    assert_protocol(error, ErrorClass::SERVICES, ErrorCode::INVALID_TIME_STAMP);
+    assert_eq!(snapshot(&db, oid), before);
+
+    let unconfigured = EventEnrollmentObject::new(8, "EE-unconfigured", 0).unwrap();
+    let oid = unconfigured.object_identifier();
+    db.add(Box::new(unconfigured)).unwrap();
+    let before = acked(&db, oid);
+    let error = handle_acknowledge_alarm(
+        &mut db,
+        &encode_request(
+            oid,
+            EventState::OFFNORMAL,
+            BACnetTimeStamp::SequenceNumber(0),
+        ),
+    )
+    .unwrap_err();
+    assert_protocol(error, ErrorClass::OBJECT, ErrorCode::NO_ALARM_CONFIGURED);
+    assert_eq!(acked(&db, oid), before);
+}
+
+#[test]
+fn disabled_analog_input_returns_no_alarm_configured_before_correlation() {
+    let mut db = ObjectDatabase::new();
+    let oid = add_committed(
+        &mut db,
+        AnalogInputObject::new(1, "AI-disabled", 62).unwrap(),
+        EventState::HIGH_LIMIT,
+        BACnetTimeStamp::SequenceNumber(42),
+    );
+    db.get_mut(&oid)
+        .unwrap()
+        .write_property(
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .unwrap();
+    let before = snapshot(&db, oid);
+
+    let error = handle_acknowledge_alarm(
+        &mut db,
+        &encode_request(
+            oid,
+            EventState::HIGH_LIMIT,
+            BACnetTimeStamp::SequenceNumber(42),
+        ),
+    )
+    .unwrap_err();
+    assert_protocol(error, ErrorClass::OBJECT, ErrorCode::NO_ALARM_CONFIGURED);
+    assert_eq!(snapshot(&db, oid), before);
+}
+
+#[test]
+fn invalid_source_text_is_sanitized_but_malformed_source_framing_is_rejected() {
+    let mut db = ObjectDatabase::new();
+    let oid = add_committed(
+        &mut db,
+        AnalogInputObject::new(1, "AI-source", 62).unwrap(),
+        EventState::HIGH_LIMIT,
+        BACnetTimeStamp::SequenceNumber(42),
+    );
+
+    for source in [
+        &[1, 0xff][..],
+        &[0xff, 0xff][..],
+        &[0, 0xff][..],
+        &[4, 0xd8, 0x00][..],
+    ] {
+        handle_acknowledge_alarm(&mut db, &encode_request_with_raw_source(oid, source)).unwrap();
+        assert_eq!(acked(&db, oid), 0b111);
+    }
+
+    let before = snapshot(&db, oid);
+    let error = handle_acknowledge_alarm(&mut db, &encode_request_with_raw_source(oid, &[]));
+    assert!(matches!(error, Err(Error::Decoding { .. })));
+    assert_eq!(snapshot(&db, oid), before);
+}

--- a/crates/bacnet-server/src/handlers/tests/acknowledge_alarm_ee.rs
+++ b/crates/bacnet-server/src/handlers/tests/acknowledge_alarm_ee.rs
@@ -48,12 +48,16 @@ fn make_db_with_ack_required_ee() -> (ObjectDatabase, ObjectIdentifier) {
     (db, ee_oid)
 }
 
-fn ack_request(ee_oid: ObjectIdentifier, event_state: u32) -> bytes::BytesMut {
+fn ack_request(
+    ee_oid: ObjectIdentifier,
+    event_state: u32,
+    timestamp: BACnetTimeStamp,
+) -> bytes::BytesMut {
     let request = AcknowledgeAlarmRequest {
         acknowledging_process_identifier: 1,
         event_object_identifier: ee_oid,
         event_state_acknowledged: event_state,
-        timestamp: BACnetTimeStamp::SequenceNumber(1),
+        timestamp,
         acknowledgment_source: "operator".into(),
         time_of_acknowledgment: BACnetTimeStamp::SequenceNumber(2),
     };
@@ -102,7 +106,11 @@ fn ee_acknowledge_alarm_round_trip_over_services() {
     // offnormal 'To State', Table 13-9).
     handle_acknowledge_alarm(
         &mut db,
-        &ack_request(ee_oid, EventState::OFFNORMAL.to_raw()),
+        &ack_request(
+            ee_oid,
+            EventState::OFFNORMAL.to_raw(),
+            BACnetTimeStamp::SequenceNumber(0),
+        ),
     )
     .unwrap();
     assert_eq!(
@@ -115,7 +123,11 @@ fn ee_acknowledge_alarm_round_trip_over_services() {
     // success, and the other bits are untouched.
     handle_acknowledge_alarm(
         &mut db,
-        &ack_request(ee_oid, EventState::OFFNORMAL.to_raw()),
+        &ack_request(
+            ee_oid,
+            EventState::OFFNORMAL.to_raw(),
+            BACnetTimeStamp::SequenceNumber(0),
+        ),
     )
     .unwrap();
     assert_eq!(gei_summary_acked(&db, ee_oid), 0b111);
@@ -128,9 +140,39 @@ fn ee_acknowledge_to_normal_bit() {
     let (mut db, ee_oid) = make_db_with_ack_required_ee();
     db.get_mut(&ee_oid)
         .unwrap()
-        .set_acked_transitions_internal(0x04, false)
+        .commit_event_transition_internal(bacnet_objects::event::EventTransitionCommit {
+            change: bacnet_objects::event::EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            coordinate: bacnet_objects::event::EventTransition::ToOffnormal,
+            ack_required: false,
+            timestamp: BACnetTimeStamp::SequenceNumber(1),
+            message_text: None,
+        })
         .unwrap();
-    handle_acknowledge_alarm(&mut db, &ack_request(ee_oid, EventState::NORMAL.to_raw())).unwrap();
+    db.get_mut(&ee_oid)
+        .unwrap()
+        .commit_event_transition_internal(bacnet_objects::event::EventTransitionCommit {
+            change: bacnet_objects::event::EventStateChange {
+                from: EventState::HIGH_LIMIT,
+                to: EventState::NORMAL,
+            },
+            coordinate: bacnet_objects::event::EventTransition::ToNormal,
+            ack_required: true,
+            timestamp: BACnetTimeStamp::SequenceNumber(2),
+            message_text: None,
+        })
+        .unwrap();
+    handle_acknowledge_alarm(
+        &mut db,
+        &ack_request(
+            ee_oid,
+            EventState::NORMAL.to_raw(),
+            BACnetTimeStamp::SequenceNumber(2),
+        ),
+    )
+    .unwrap();
     match db
         .get(&ee_oid)
         .unwrap()
@@ -163,7 +205,11 @@ fn ee_acknowledge_alarm_detection_disabled_refused() {
 
     let err = handle_acknowledge_alarm(
         &mut db,
-        &ack_request(ee_oid, EventState::OFFNORMAL.to_raw()),
+        &ack_request(
+            ee_oid,
+            EventState::OFFNORMAL.to_raw(),
+            BACnetTimeStamp::SequenceNumber(1),
+        ),
     )
     .unwrap_err();
     match err {

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -34,6 +34,7 @@ fn make_db_with_device_and_ai() -> ObjectDatabase {
     db
 }
 
+mod acknowledge_alarm;
 mod acknowledge_alarm_ee;
 mod alert_enrollment;
 mod array_index_gating;

--- a/crates/bacnet-server/src/handlers/tests/wpm_create_alarm.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_create_alarm.rs
@@ -289,55 +289,6 @@ fn create_object_bad_initial_value_rolls_back() {
     );
 }
 
-// -----------------------------------------------------------------------
-// AcknowledgeAlarm handler tests
-// -----------------------------------------------------------------------
-
-#[test]
-fn acknowledge_alarm_success() {
-    let mut db = make_db_with_ai();
-    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
-
-    let request = AcknowledgeAlarmRequest {
-        acknowledging_process_identifier: 1,
-        event_object_identifier: oid,
-        event_state_acknowledged: 3,
-        timestamp: BACnetTimeStamp::SequenceNumber(42),
-        acknowledgment_source: "operator".into(),
-        time_of_acknowledgment: BACnetTimeStamp::SequenceNumber(0),
-    };
-    let mut buf = BytesMut::new();
-    request.encode(&mut buf).unwrap();
-
-    handle_acknowledge_alarm(&mut db, &buf).unwrap();
-}
-
-#[test]
-fn acknowledge_alarm_unknown_object_fails() {
-    let mut db = make_db_with_ai();
-    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 99).unwrap();
-
-    let request = AcknowledgeAlarmRequest {
-        acknowledging_process_identifier: 1,
-        event_object_identifier: oid,
-        event_state_acknowledged: 3,
-        timestamp: BACnetTimeStamp::SequenceNumber(42),
-        acknowledgment_source: "operator".into(),
-        time_of_acknowledgment: BACnetTimeStamp::SequenceNumber(0),
-    };
-    let mut buf = BytesMut::new();
-    request.encode(&mut buf).unwrap();
-
-    let err = handle_acknowledge_alarm(&mut db, &buf).unwrap_err();
-    match err {
-        Error::Protocol { class, code } => {
-            assert_eq!(class, ErrorClass::OBJECT.to_raw() as u32);
-            assert_eq!(code, ErrorCode::UNKNOWN_OBJECT.to_raw() as u32);
-        }
-        other => panic!("expected Protocol error, got: {other:?}"),
-    }
-}
-
 /// Build a database with one commandable AnalogOutput whose priority-8 slot
 /// holds an active command, so a `PRESENT_VALUE` write at priority 8 has a real
 /// slot to overwrite. Returns the db and the AO's object identifier.

--- a/crates/bacnet-server/src/server/acknowledge_alarm_tests.rs
+++ b/crates/bacnet-server/src/server/acknowledge_alarm_tests.rs
@@ -1,0 +1,173 @@
+use super::*;
+
+use bacnet_encoding::apdu::decode_apdu;
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_objects::analog::AnalogInputObject;
+use bacnet_objects::event::{EventStateChange, EventTransition, EventTransitionCommit};
+use bacnet_objects::traits::BACnetObject;
+use bacnet_services::alarm_event::AcknowledgeAlarmRequest;
+use bacnet_types::enums::EventState;
+use bacnet_types::primitives::BACnetTimeStamp;
+
+fn request(oid: ObjectIdentifier) -> AcknowledgeAlarmRequest {
+    AcknowledgeAlarmRequest {
+        acknowledging_process_identifier: 71,
+        event_object_identifier: oid,
+        event_state_acknowledged: EventState::HIGH_LIMIT.to_raw(),
+        timestamp: BACnetTimeStamp::SequenceNumber(42),
+        acknowledgment_source: "operator".into(),
+        time_of_acknowledgment: BACnetTimeStamp::SequenceNumber(77),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn dispatch(
+    db: &Arc<RwLock<ObjectDatabase>>,
+    tracker: &Arc<ConfirmedRequestTracker>,
+    notification_transactions: &Arc<NotificationTransactions>,
+    source_mac: &MacAddr,
+    invoke_id: u8,
+    request: &AcknowledgeAlarmRequest,
+) -> Result<Apdu, tokio::sync::oneshot::error::RecvError> {
+    let network = Arc::new(NetworkLayer::new(BipTransport::new(
+        Ipv4Addr::LOCALHOST,
+        0,
+        Ipv4Addr::BROADCAST,
+    )));
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let cov_in_flight = Arc::new(Semaphore::new(1));
+    let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+    let device_bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
+    let comm_state = Arc::new(AtomicU8::new(0));
+    let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
+    let mut service_request = BytesMut::new();
+    request.encode(&mut service_request).unwrap();
+    let confirmed = ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 480,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::ACKNOWLEDGE_ALARM,
+        service_request: service_request.freeze(),
+    };
+    let (tx, rx) = oneshot::channel();
+
+    BACnetServer::<BipTransport>::handle_confirmed_request(
+        db,
+        &network,
+        &cov_table,
+        &seg_ack_senders,
+        &seg_send_permits,
+        &cov_in_flight,
+        &server_tsm,
+        notification_transactions,
+        tracker,
+        &device_bindings,
+        &comm_state,
+        &dcc_timer,
+        &ServerConfig::default(),
+        source_mac,
+        None,
+        confirmed,
+        Some(tx),
+    )
+    .await;
+
+    rx.await.map(|bytes| {
+        let npdu = decode_npdu(bytes).unwrap();
+        decode_apdu(npdu.payload).unwrap()
+    })
+}
+
+fn acked(db: &ObjectDatabase, oid: ObjectIdentifier) -> u8 {
+    let PropertyValue::BitString { data, .. } = db
+        .get(&oid)
+        .unwrap()
+        .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+        .unwrap()
+    else {
+        panic!("Acked_Transitions must be a bit string");
+    };
+    bacnet_types::bitstring::unpack_octet(&data, 3)
+}
+
+fn assert_simple_ack(apdu: Apdu, invoke_id: u8) {
+    let Apdu::SimpleAck(ack) = apdu else {
+        panic!("expected SimpleACK");
+    };
+    assert_eq!(ack.invoke_id, invoke_id);
+    assert_eq!(
+        ack.service_choice,
+        ConfirmedServiceChoice::ACKNOWLEDGE_ALARM
+    );
+}
+
+#[tokio::test]
+async fn exact_duplicate_is_silent_and_new_invoke_id_is_idempotent_success() {
+    let mut ai = AnalogInputObject::new(1, "AI-ack", 62).unwrap();
+    let oid = ai.object_identifier();
+    ai.commit_event_transition_internal(EventTransitionCommit {
+        change: EventStateChange {
+            from: EventState::NORMAL,
+            to: EventState::HIGH_LIMIT,
+        },
+        coordinate: EventTransition::ToOffnormal,
+        ack_required: true,
+        timestamp: BACnetTimeStamp::SequenceNumber(42),
+        message_text: Some("high".into()),
+    })
+    .unwrap();
+    let mut objects = ObjectDatabase::new();
+    objects.add(Box::new(ai)).unwrap();
+    let db = Arc::new(RwLock::new(objects));
+    let tracker = Arc::new(ConfirmedRequestTracker::default());
+    let notification_transactions = NotificationTransactions::new();
+    let source = MacAddr::from_slice(&[1, 2, 3]);
+    let request = request(oid);
+
+    let first = dispatch(
+        &db,
+        &tracker,
+        &notification_transactions,
+        &source,
+        0x51,
+        &request,
+    )
+    .await
+    .unwrap();
+    assert_simple_ack(first, 0x51);
+    assert_eq!(acked(&*db.read().await, oid), 0b111);
+    assert_eq!(notification_transactions.active_count(), 0);
+
+    assert!(dispatch(
+        &db,
+        &tracker,
+        &notification_transactions,
+        &source,
+        0x51,
+        &request,
+    )
+    .await
+    .is_err());
+    assert_eq!(acked(&*db.read().await, oid), 0b111);
+
+    let new_transaction = dispatch(
+        &db,
+        &tracker,
+        &notification_transactions,
+        &source,
+        0x52,
+        &request,
+    )
+    .await
+    .unwrap();
+    assert_simple_ack(new_transaction, 0x52);
+    assert_eq!(acked(&*db.read().await, oid), 0b111);
+    assert_eq!(notification_transactions.active_count(), 0);
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -985,6 +985,8 @@ mod segmented_receive;
 mod shutdown;
 
 #[cfg(test)]
+mod acknowledge_alarm_tests;
+#[cfg(test)]
 mod audit_log_query_tests;
 #[cfg(test)]
 mod binary_lighting_task_tests;

--- a/crates/bacnet-services/src/alarm_event/acknowledge_alarm.rs
+++ b/crates/bacnet-services/src/alarm_event/acknowledge_alarm.rs
@@ -2,6 +2,13 @@ use super::*;
 
 use crate::common::{decode_context, decode_context_u32};
 
+fn decode_acknowledgment_source(content: &[u8]) -> Result<String, Error> {
+    if content.is_empty() {
+        return primitives::decode_character_string(content);
+    }
+    Ok(primitives::decode_character_string(content).unwrap_or_default())
+}
+
 // ---------------------------------------------------------------------------
 // AcknowledgeAlarm
 // ---------------------------------------------------------------------------
@@ -60,7 +67,7 @@ impl AcknowledgeAlarmRequest {
         // [4] acknowledgmentSource
         let (content, end) =
             decode_context(data, offset, 4, "AcknowledgeAlarm acknowledgment-source")?;
-        let acknowledgment_source = primitives::decode_character_string(content)?;
+        let acknowledgment_source = decode_acknowledgment_source(content)?;
         offset = end;
 
         // [5] timeOfAcknowledgment

--- a/crates/bacnet-services/src/alarm_event/tests/service_round_trip.rs
+++ b/crates/bacnet-services/src/alarm_event/tests/service_round_trip.rs
@@ -1,4 +1,5 @@
 use super::*;
+use bacnet_types::enums::EventState;
 
 fn raw_context_unsigned(buf: &mut BytesMut, tag_number: u8, value: &[u8]) {
     bacnet_encoding::tags::encode_tag(
@@ -25,6 +26,24 @@ fn raw_acknowledge_alarm(process_id: &[u8], event_state: &[u8], field_tags: [u8;
     primitives::encode_ctx_character_string(&mut buf, field_tags[4], "operator").unwrap();
     primitives::encode_timestamp(&mut buf, field_tags[5], &BACnetTimeStamp::SequenceNumber(0))
         .unwrap();
+    buf
+}
+
+fn raw_acknowledge_alarm_with_source(source: &[u8]) -> BytesMut {
+    let mut buf = BytesMut::new();
+    raw_context_unsigned(&mut buf, 0, &[1]);
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    primitives::encode_ctx_object_id(&mut buf, 1, &oid);
+    raw_context_unsigned(&mut buf, 2, &[EventState::HIGH_LIMIT.to_raw() as u8]);
+    primitives::encode_timestamp(&mut buf, 3, &BACnetTimeStamp::SequenceNumber(42)).unwrap();
+    bacnet_encoding::tags::encode_tag(
+        &mut buf,
+        4,
+        bacnet_encoding::tags::TagClass::Context,
+        source.len() as u32,
+    );
+    buf.extend_from_slice(source);
+    primitives::encode_timestamp(&mut buf, 5, &BACnetTimeStamp::SequenceNumber(7)).unwrap();
     buf
 }
 
@@ -96,6 +115,33 @@ fn acknowledge_alarm_rejects_trailing_data() {
     let mut encoded = raw_acknowledge_alarm(&[1], &[1], [0, 1, 2, 3, 4, 5]);
     primitives::encode_ctx_unsigned(&mut encoded, 6, 1);
     assert!(AcknowledgeAlarmRequest::decode(&encoded).is_err());
+}
+
+#[test]
+fn acknowledge_alarm_sanitizes_unsupported_or_invalid_source_text() {
+    for source in [
+        &[1, 0xff][..],
+        &[2, 0xff][..],
+        &[3, 0xff][..],
+        &[0xff, 0xff][..],
+        &[0, 0xff][..],
+        &[4, 0xd8, 0x00][..],
+        &[4, 0x00][..],
+    ] {
+        let decoded =
+            AcknowledgeAlarmRequest::decode(&raw_acknowledge_alarm_with_source(source)).unwrap();
+        assert_eq!(decoded.acknowledgment_source, "", "source {source:?}");
+        assert_eq!(decoded.timestamp, BACnetTimeStamp::SequenceNumber(42));
+        assert_eq!(
+            decoded.time_of_acknowledgment,
+            BACnetTimeStamp::SequenceNumber(7)
+        );
+    }
+}
+
+#[test]
+fn acknowledge_alarm_rejects_source_without_charset_framing() {
+    assert!(AcknowledgeAlarmRequest::decode(&raw_acknowledge_alarm_with_source(&[])).is_err());
 }
 
 #[test]

--- a/crates/rusty-bacnet/src/client/client_methods/object_device_alarm.rs
+++ b/crates/rusty-bacnet/src/client/client_methods/object_device_alarm.rs
@@ -160,7 +160,7 @@ impl BACnetClient {
 
     /// Acknowledge an alarm on a remote device.
     #[pyo3(signature = (address, acknowledging_process_identifier, event_object_identifier, event_state_acknowledged, acknowledgment_source))]
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments, deprecated)]
     fn acknowledge_alarm<'py>(
         &self,
         py: Python<'py>,


### PR DESCRIPTION
## Summary
- correlate AcknowledgeAlarm with the latest committed transition coordinate, original To State, and exact timestamp before mutation
- retain concrete To State identity alongside object-owned event history and preserve it through reset/rollback paths
- support the existing Analog Input/Output/Value and Event Enrollment families through a defaulted internal hook; unsupported families remain fail-closed
- add a lossless request-based Rust client API while retaining and deprecating the legacy zero-timestamp helper

## Source-to-behavior traceability
| Requirement | ANSI/ASHRAE 135-2020 source | Implemented behavior |
|---|---|---|
| R1 | §13.5 Result(-) rows | Missing objects return `OBJECT/UNKNOWN_OBJECT`; unsupported or unconfigured objects return `OBJECT/NO_ALARM_CONFIGURED`. |
| R2 | §13.5 Event State Acknowledged | The request matches the committed original To State exactly, except request-side `OFFNORMAL` matches any offnormal To State; mismatch returns `SERVICES/INVALID_EVENT_STATE`. |
| R3 | §13.5 Time Stamp | The request must exactly match the latest committed timestamp for that transition coordinate; an absent or mismatched slot returns `SERVICES/INVALID_TIME_STAMP`. Correlation does not depend on current `Event_State`. |
| R4 | §§13.2.3, 13.5 | Success sets exactly one `Acked_Transitions` bit. An already-set bit is idempotent success; exact APDU retransmissions remain silently discarded by the generic confirmed-request boundary. |
| R5 | §13.5 Acknowledgment Source | Unsupported or invalid source text is locally sanitized without rejecting an otherwise valid acknowledgment; malformed wire framing still fails decoding. |
| R6 | §13.5 request fields | `acknowledge_alarm_request` preserves every caller-supplied field and both timestamp choices; the legacy timestamp-fabricating helper remains source-compatible but deprecated. |
| R7 | §13.2.3 acknowledgment distribution | ACK_NOTIFICATION (#175), Python/CLI timestamp design, and additional object-family support (#170) remain deferred. |

This is a bounded core correction, not a full Clause 13.5 conformance claim. Issue #132 remains open for the deferred public-client migration.

## Validation
- focused AcknowledgeAlarm codec/source, event-history correlation/rollback, supported-object, server duplicate/idempotence, client capture, and routed integration tests
- `cargo test -p bacnet-services --locked`
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-client --locked`
- affected `bacnet-integration-tests` routing-alarm tests
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo fmt --all -- --check`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

## Deferred
- ACK_NOTIFICATION distribution and metadata ownership (#175)
- Python and CLI timestamp APIs
- Binary, Multi-state, and Alert Enrollment acknowledgment support (#170)
- any new authorization or persistence policy

Refs #132