### PR TITLE
fix(server): enforce GetEventInformation projection and paging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GetEventInformation now projects each advertised event-initiating object as
+  one strict typed snapshot, applies the NORMAL-or-unacknowledged selection
+  rule independently of Event_Enable, preserves all three BACnetTimeStamp
+  choices, and resolves all three priorities from exactly one associated
+  Notification Class (#128, #206). Missing or malformed projection/class data
+  returns DEVICE / OPERATIONAL_PROBLEM instead of fabricated zero values.
+  Responses use encoded Object Identifier order and byte-accurate APDU
+  continuation when segmentation is unavailable; segmentation-capable peers
+  retain the complete response for the existing segmented ComplexACK path.
+
 - Binary Lighting Output `Relinquish_Default` now accepts only OFF or ON and
   atomically refuses all other values with `PROPERTY / VALUE_OUT_OF_RANGE`
   (#283). `Present_Value` now interprets WARN, WARN_OFF,

--- a/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
@@ -1,33 +1,151 @@
 //! GetEventInformation service handler.
-//!
-//! One file per service so the Batch 4 handler PRs do not serialize
-//! on a single module.
 
 use super::super::*;
 use bacnet_encoding::primitives::decode_timestamp_choice;
+use bacnet_objects::traits::BACnetObject;
 
-/// Handle a GetEventInformation request.
+const EVENT_SUMMARY_SIGNATURE: [PropertyIdentifier; 6] = [
+    PropertyIdentifier::EVENT_STATE,
+    PropertyIdentifier::ACKED_TRANSITIONS,
+    PropertyIdentifier::EVENT_TIME_STAMPS,
+    PropertyIdentifier::NOTIFY_TYPE,
+    PropertyIdentifier::EVENT_ENABLE,
+    PropertyIdentifier::NOTIFICATION_CLASS,
+];
+
+/// A complete, strictly validated snapshot of one event-initiating object.
+struct EventSummaryProjection {
+    object_identifier: ObjectIdentifier,
+    event_state: u32,
+    acknowledged_transitions: u8,
+    event_timestamps: [BACnetTimeStamp; 3],
+    notify_type: u32,
+    event_enable: u8,
+    event_priorities: [u32; 3],
+    notification_class: u32,
+}
+
+enum EventSummaryProjectionResult {
+    NotEventInitiating,
+    Excluded,
+    Projected(EventSummaryProjection),
+}
+
+impl EventSummaryProjection {
+    fn read(
+        object: &dyn BACnetObject,
+        db: &ObjectDatabase,
+    ) -> Result<EventSummaryProjectionResult, Error> {
+        let advertised = object.property_list();
+        if !EVENT_SUMMARY_SIGNATURE
+            .iter()
+            .all(|property| advertised.contains(property))
+        {
+            return Ok(EventSummaryProjectionResult::NotEventInitiating);
+        }
+
+        let object_identifier = object.object_identifier();
+        if advertised.contains(&PropertyIdentifier::EVENT_DETECTION_ENABLE) {
+            match read_required(
+                object,
+                object_identifier,
+                PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            )? {
+                PropertyValue::Boolean(false) => return Ok(EventSummaryProjectionResult::Excluded),
+                PropertyValue::Boolean(true) => {}
+                _ => {
+                    return Err(operational_problem(
+                        object_identifier,
+                        "Event_Detection_Enable is not Boolean",
+                    ))
+                }
+            }
+        }
+
+        let event_state =
+            read_enumerated(object, object_identifier, PropertyIdentifier::EVENT_STATE)?;
+        let acknowledged_transitions = read_transition_bits(
+            object,
+            object_identifier,
+            PropertyIdentifier::ACKED_TRANSITIONS,
+        )?;
+        let event_timestamps = read_event_timestamps(object, object_identifier)?;
+        let notify_type =
+            read_enumerated(object, object_identifier, PropertyIdentifier::NOTIFY_TYPE)?;
+        let event_enable =
+            read_transition_bits(object, object_identifier, PropertyIdentifier::EVENT_ENABLE)?;
+        let notification_class = read_unsigned_u32(
+            object,
+            object_identifier,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+        )?;
+        let event_priorities =
+            read_notification_class_priorities(db, object_identifier, notification_class)?;
+
+        Ok(EventSummaryProjectionResult::Projected(Self {
+            object_identifier,
+            event_state,
+            acknowledged_transitions,
+            event_timestamps,
+            notify_type,
+            event_enable,
+            event_priorities,
+            notification_class,
+        }))
+    }
+
+    fn is_selected(&self) -> bool {
+        self.event_state != EventState::NORMAL.to_raw() || self.acknowledged_transitions != 0b111
+    }
+}
+
+impl From<EventSummaryProjection> for EventSummary {
+    fn from(value: EventSummaryProjection) -> Self {
+        Self {
+            object_identifier: value.object_identifier,
+            event_state: value.event_state,
+            acknowledged_transitions: value.acknowledged_transitions,
+            event_timestamps: value.event_timestamps,
+            notify_type: value.notify_type,
+            event_enable: value.event_enable,
+            event_priorities: value.event_priorities,
+            notification_class: value.notification_class,
+        }
+    }
+}
+
+/// Handle a GetEventInformation request without service-level byte pagination.
 ///
-/// Returns event summaries for objects whose event_state is not NORMAL.
-/// Supports pagination via `last_received_object_identifier`.
+/// Server dispatch uses the budget-aware variant when segmented transmission is
+/// unavailable. This wrapper remains unbounded for existing direct callers.
 pub fn handle_get_event_information(
     db: &ObjectDatabase,
     service_data: &[u8],
     buf: &mut BytesMut,
 ) -> Result<(), Error> {
-    const MAX_SUMMARIES: usize = 25;
+    handle_get_event_information_with_budget(db, service_data, buf, None)
+}
 
+/// Build a GetEventInformation ACK within an optional service-ACK byte budget.
+///
+/// The budget excludes the unsegmented ComplexACK envelope. If even the first
+/// complete summary does not fit, it is retained so dispatch's generic
+/// segmentation/Abort path remains authoritative and cannot emit an empty page
+/// with `More_Events` set.
+pub(crate) fn handle_get_event_information_with_budget(
+    db: &ObjectDatabase,
+    service_data: &[u8],
+    buf: &mut BytesMut,
+    max_service_ack_bytes: Option<usize>,
+) -> Result<(), Error> {
     let request = GetEventInformationRequest::decode(service_data)?;
-
-    let mut summaries = Vec::new();
-    let mut more_events = false;
     let cursor = request
         .last_received_object_identifier
         .map(|identifier| identifier.encode());
     let mut object_identifiers = db.list_objects();
     object_identifiers.sort_unstable_by_key(ObjectIdentifier::encode);
-    let notification_class_identifiers = db.find_by_type(ObjectType::NOTIFICATION_CLASS);
 
+    let mut summaries = Vec::new();
     for oid in object_identifiers {
         if cursor.is_some_and(|cursor| oid.encode() <= cursor) {
             continue;
@@ -35,142 +153,263 @@ pub fn handle_get_event_information(
         let Some(object) = db.get(&oid) else {
             continue;
         };
-
-        // Clause 12.12: Event_Detection_Enable controls whether the object is
-        // considered by the event-summarization services. Checked after the
-        // pagination skip so a disabled object cannot break resumption.
-        if !super::event_detection_enabled(object) {
-            continue;
-        }
-
-        if let Ok(PropertyValue::Enumerated(state)) =
-            object.read_property(PropertyIdentifier::EVENT_STATE, None)
-        {
-            if state != bacnet_types::enums::EventState::NORMAL.to_raw() {
-                if summaries.len() >= MAX_SUMMARIES {
-                    more_events = true;
-                    break;
-                }
-
-                let notification_class = object
-                    .read_property(PropertyIdentifier::NOTIFICATION_CLASS, None)
-                    .ok()
-                    .and_then(|v| match v {
-                        PropertyValue::Unsigned(n) => u32::try_from(n).ok(),
-                        _ => None,
-                    })
-                    .unwrap_or(0);
-
-                let event_enable = object
-                    .read_property(PropertyIdentifier::EVENT_ENABLE, None)
-                    .ok()
-                    .and_then(|v| match v {
-                        PropertyValue::BitString { data, .. } => {
-                            Some(bacnet_types::bitstring::unpack_octet(&data, 3))
-                        }
-                        _ => None,
-                    })
-                    .unwrap_or(0x07);
-
-                let notify_type = object
-                    .read_property(PropertyIdentifier::NOTIFY_TYPE, None)
-                    .ok()
-                    .and_then(|v| match v {
-                        PropertyValue::Enumerated(n) => Some(n),
-                        _ => None,
-                    })
-                    .unwrap_or(0);
-
-                let matching_notification_class =
-                    notification_class_identifiers.iter().find_map(|nc_oid| {
-                        let nc_obj = db.get(nc_oid)?;
-                        matches!(
-                            nc_obj.read_property(PropertyIdentifier::NOTIFICATION_CLASS, None),
-                            Ok(PropertyValue::Unsigned(class_number))
-                                if class_number == u64::from(notification_class)
-                        )
-                        .then_some(nc_obj)
-                    });
-                let event_priorities = matching_notification_class
-                    .and_then(|nc_obj| {
-                        nc_obj
-                            .read_property(PropertyIdentifier::PRIORITY, None)
-                            .ok()
-                    })
-                    .and_then(|v| match v {
-                        PropertyValue::List(items) => {
-                            let [
-                                PropertyValue::Unsigned(offnormal),
-                                PropertyValue::Unsigned(fault),
-                                PropertyValue::Unsigned(normal),
-                            ] = items.as_slice()
-                            else {
-                                return None;
-                            };
-                            Some([
-                                u32::try_from(*offnormal).ok()?,
-                                u32::try_from(*fault).ok()?,
-                                u32::try_from(*normal).ok()?,
-                            ])
-                        }
-                        _ => None,
-                    })
-                    .unwrap_or([0, 0, 0]);
-
-                let acked = object
-                    .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
-                    .ok()
-                    .and_then(|v| match v {
-                        PropertyValue::BitString { data, .. } => {
-                            Some(bacnet_types::bitstring::unpack_octet(&data, 3))
-                        }
-                        _ => None,
-                    })
-                    .unwrap_or(0x07);
-
-                let event_timestamps = object
-                    .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
-                    .ok()
-                    .and_then(|v| match v {
-                        PropertyValue::List(items) => {
-                            let [offnormal, fault, normal] = items.as_slice() else {
-                                return None;
-                            };
-                            Some([
-                                decode_event_timestamp(offnormal)?,
-                                decode_event_timestamp(fault)?,
-                                decode_event_timestamp(normal)?,
-                            ])
-                        }
-                        _ => None,
-                    })
-                    .unwrap_or([
-                        BACnetTimeStamp::SequenceNumber(0),
-                        BACnetTimeStamp::SequenceNumber(0),
-                        BACnetTimeStamp::SequenceNumber(0),
-                    ]);
-
-                summaries.push(EventSummary {
-                    object_identifier: oid,
-                    event_state: state,
-                    acknowledged_transitions: acked,
-                    event_timestamps,
-                    notify_type,
-                    event_enable,
-                    event_priorities,
-                    notification_class,
-                });
-            }
+        let projection = match EventSummaryProjection::read(object, db)? {
+            EventSummaryProjectionResult::NotEventInitiating
+            | EventSummaryProjectionResult::Excluded => continue,
+            EventSummaryProjectionResult::Projected(projection) => projection,
+        };
+        if projection.is_selected() {
+            summaries.push(projection.into());
         }
     }
 
-    let ack = GetEventInformationAck {
-        list_of_event_summaries: summaries,
-        more_events,
+    let ack = paginate_ack(summaries, max_service_ack_bytes)?;
+    let mut encoded = BytesMut::new();
+    ack.encode(&mut encoded)?;
+    buf.extend_from_slice(&encoded);
+    Ok(())
+}
+
+fn paginate_ack(
+    summaries: Vec<EventSummary>,
+    max_service_ack_bytes: Option<usize>,
+) -> Result<GetEventInformationAck, Error> {
+    let Some(max_service_ack_bytes) = max_service_ack_bytes else {
+        return Ok(GetEventInformationAck {
+            list_of_event_summaries: summaries,
+            more_events: false,
+        });
     };
 
-    ack.encode(buf)?;
-    Ok(())
+    let full = GetEventInformationAck {
+        list_of_event_summaries: summaries.clone(),
+        more_events: false,
+    };
+    if summaries.is_empty() || encoded_ack_len(&full)? <= max_service_ack_bytes {
+        return Ok(full);
+    }
+
+    // Candidate length grows monotonically with each complete summary. Trial
+    // encode whole ACK candidates (including wrappers and More_Events) while a
+    // binary search locates the maximal fitting prefix without quadratic work.
+    let mut low = 0usize;
+    let mut high = summaries.len() - 1;
+    while low < high {
+        let count = low + (high - low).div_ceil(2);
+        let candidate = GetEventInformationAck {
+            list_of_event_summaries: summaries[..count].to_vec(),
+            more_events: true,
+        };
+        if encoded_ack_len(&candidate)? <= max_service_ack_bytes {
+            low = count;
+        } else {
+            high = count - 1;
+        }
+    }
+
+    let count = low.max(1);
+    Ok(GetEventInformationAck {
+        list_of_event_summaries: summaries[..count].to_vec(),
+        more_events: count < summaries.len(),
+    })
+}
+
+fn encoded_ack_len(ack: &GetEventInformationAck) -> Result<usize, Error> {
+    let mut encoded = BytesMut::new();
+    ack.encode(&mut encoded)?;
+    Ok(encoded.len())
+}
+
+fn read_required(
+    object: &dyn BACnetObject,
+    object_identifier: ObjectIdentifier,
+    property: PropertyIdentifier,
+) -> Result<PropertyValue, Error> {
+    object.read_property(property, None).map_err(|error| {
+        operational_problem(
+            object_identifier,
+            format!("required property {property:?} is unreadable: {error}"),
+        )
+    })
+}
+
+fn read_enumerated(
+    object: &dyn BACnetObject,
+    object_identifier: ObjectIdentifier,
+    property: PropertyIdentifier,
+) -> Result<u32, Error> {
+    match read_required(object, object_identifier, property)? {
+        PropertyValue::Enumerated(value) => Ok(value),
+        _ => Err(operational_problem(
+            object_identifier,
+            format!("required property {property:?} is not Enumerated"),
+        )),
+    }
+}
+
+fn read_unsigned_u32(
+    object: &dyn BACnetObject,
+    object_identifier: ObjectIdentifier,
+    property: PropertyIdentifier,
+) -> Result<u32, Error> {
+    match read_required(object, object_identifier, property)? {
+        PropertyValue::Unsigned(value) => u32::try_from(value).map_err(|_| {
+            operational_problem(
+                object_identifier,
+                format!("required property {property:?} exceeds Unsigned32"),
+            )
+        }),
+        _ => Err(operational_problem(
+            object_identifier,
+            format!("required property {property:?} is not Unsigned"),
+        )),
+    }
+}
+
+fn read_transition_bits(
+    object: &dyn BACnetObject,
+    object_identifier: ObjectIdentifier,
+    property: PropertyIdentifier,
+) -> Result<u8, Error> {
+    match read_required(object, object_identifier, property)? {
+        PropertyValue::BitString { unused_bits, data }
+            if unused_bits == 5 && data.len() == 1 && data[0] & 0x1f == 0 =>
+        {
+            Ok(bacnet_types::bitstring::unpack_octet(&data, 3))
+        }
+        _ => Err(operational_problem(
+            object_identifier,
+            format!("required property {property:?} is not a canonical three-bit BitString"),
+        )),
+    }
+}
+
+fn read_event_timestamps(
+    object: &dyn BACnetObject,
+    object_identifier: ObjectIdentifier,
+) -> Result<[BACnetTimeStamp; 3], Error> {
+    let PropertyValue::List(items) = read_required(
+        object,
+        object_identifier,
+        PropertyIdentifier::EVENT_TIME_STAMPS,
+    )?
+    else {
+        return Err(operational_problem(
+            object_identifier,
+            "Event_Time_Stamps is not a three-item List",
+        ));
+    };
+    let [offnormal, fault, normal] = items.as_slice() else {
+        return Err(operational_problem(
+            object_identifier,
+            "Event_Time_Stamps does not contain exactly three items",
+        ));
+    };
+
+    Ok([
+        decode_event_timestamp(offnormal).ok_or_else(|| {
+            operational_problem(object_identifier, "invalid TO_OFFNORMAL event timestamp")
+        })?,
+        decode_event_timestamp(fault).ok_or_else(|| {
+            operational_problem(object_identifier, "invalid TO_FAULT event timestamp")
+        })?,
+        decode_event_timestamp(normal).ok_or_else(|| {
+            operational_problem(object_identifier, "invalid TO_NORMAL event timestamp")
+        })?,
+    ])
+}
+
+fn read_notification_class_priorities(
+    db: &ObjectDatabase,
+    event_object_identifier: ObjectIdentifier,
+    notification_class: u32,
+) -> Result<[u32; 3], Error> {
+    let mut matching = None;
+    for class_oid in db.find_by_type(ObjectType::NOTIFICATION_CLASS) {
+        let Some(class_object) = db.get(&class_oid) else {
+            continue;
+        };
+        let Some(class_number) = read_notification_class_number(class_object) else {
+            continue;
+        };
+        if class_number == notification_class {
+            if matching.replace(class_object).is_some() {
+                return Err(operational_problem(
+                    event_object_identifier,
+                    format!("multiple Notification Class objects match {notification_class}"),
+                ));
+            }
+        }
+    }
+    let class_object = matching.ok_or_else(|| {
+        operational_problem(
+            event_object_identifier,
+            format!("no Notification Class object matches {notification_class}"),
+        )
+    })?;
+
+    let PropertyValue::List(priorities) = read_required(
+        class_object,
+        event_object_identifier,
+        PropertyIdentifier::PRIORITY,
+    )?
+    else {
+        return Err(operational_problem(
+            event_object_identifier,
+            "Notification Class Priority is not a three-item List",
+        ));
+    };
+    let [offnormal, fault, normal] = priorities.as_slice() else {
+        return Err(operational_problem(
+            event_object_identifier,
+            "Notification Class Priority does not contain exactly three items",
+        ));
+    };
+
+    Ok([
+        read_priority_coordinate(event_object_identifier, offnormal, "TO_OFFNORMAL")?,
+        read_priority_coordinate(event_object_identifier, fault, "TO_FAULT")?,
+        read_priority_coordinate(event_object_identifier, normal, "TO_NORMAL")?,
+    ])
+}
+
+fn read_notification_class_number(object: &dyn BACnetObject) -> Option<u32> {
+    match object
+        .read_property(PropertyIdentifier::NOTIFICATION_CLASS, None)
+        .ok()?
+    {
+        PropertyValue::Unsigned(value) => u32::try_from(value).ok(),
+        _ => None,
+    }
+}
+
+fn read_priority_coordinate(
+    object_identifier: ObjectIdentifier,
+    value: &PropertyValue,
+    coordinate: &str,
+) -> Result<u32, Error> {
+    match value {
+        PropertyValue::Unsigned(priority) if *priority <= 255 => Ok(*priority as u32),
+        PropertyValue::Unsigned(_) => Err(operational_problem(
+            object_identifier,
+            format!("Notification Class {coordinate} Priority exceeds 255"),
+        )),
+        _ => Err(operational_problem(
+            object_identifier,
+            format!("Notification Class {coordinate} Priority is not Unsigned"),
+        )),
+    }
+}
+
+fn operational_problem(
+    object_identifier: ObjectIdentifier,
+    detail: impl std::fmt::Display,
+) -> Error {
+    tracing::warn!(?object_identifier, reason = %detail, "GetEventInformation projection failed");
+    Error::Protocol {
+        class: ErrorClass::DEVICE.to_raw() as u32,
+        code: ErrorCode::OPERATIONAL_PROBLEM.to_raw() as u32,
+    }
 }
 
 fn decode_event_timestamp(value: &PropertyValue) -> Option<BACnetTimeStamp> {

--- a/crates/bacnet-server/src/handlers/tests/acknowledge_alarm_ee.rs
+++ b/crates/bacnet-server/src/handlers/tests/acknowledge_alarm_ee.rs
@@ -44,6 +44,8 @@ fn make_db_with_ack_required_ee() -> (ObjectDatabase, ObjectIdentifier) {
     let mut nc = NotificationClass::new(7, "NC-7").unwrap();
     nc.ack_required = [true, false, false]; // TO_OFFNORMAL requires ack
     db.add(Box::new(nc)).unwrap();
+    db.add(Box::new(NotificationClass::new(0, "NC-0").unwrap()))
+        .unwrap();
 
     (db, ee_oid)
 }

--- a/crates/bacnet-server/src/handlers/tests/detection_enable_summary.rs
+++ b/crates/bacnet-server/src/handlers/tests/detection_enable_summary.rs
@@ -62,6 +62,20 @@ impl BACnetObject for DisabledAlarmingObject {
                 bacnet_types::enums::EventType::OUT_OF_RANGE.to_raw(),
             )),
             p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(0)),
+            p if p == PropertyIdentifier::EVENT_ENABLE => Ok(PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0xe0],
+            }),
+            p if p == PropertyIdentifier::ACKED_TRANSITIONS => Ok(PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0xe0],
+            }),
+            p if p == PropertyIdentifier::NOTIFY_TYPE => Ok(PropertyValue::Enumerated(0)),
+            p if p == PropertyIdentifier::EVENT_TIME_STAMPS => Ok(PropertyValue::List(vec![
+                PropertyValue::Unsigned(0),
+                PropertyValue::Unsigned(0),
+                PropertyValue::Unsigned(0),
+            ])),
             _ => Err(Error::Protocol {
                 class: bacnet_types::enums::ErrorClass::PROPERTY.to_raw() as u32,
                 code: bacnet_types::enums::ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
@@ -81,13 +95,19 @@ impl BACnetObject for DisabledAlarmingObject {
         })
     }
     fn property_list(&self) -> std::borrow::Cow<'static, [PropertyIdentifier]> {
-        static PROPS: &[PropertyIdentifier] = &[
+        let mut properties = vec![
             PropertyIdentifier::EVENT_STATE,
-            PropertyIdentifier::EVENT_DETECTION_ENABLE,
             PropertyIdentifier::EVENT_TYPE,
             PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
         ];
-        std::borrow::Cow::Borrowed(PROPS)
+        if self.detection_enable.is_some() {
+            properties.push(PropertyIdentifier::EVENT_DETECTION_ENABLE);
+        }
+        std::borrow::Cow::Owned(properties)
     }
 }
 
@@ -201,7 +221,11 @@ fn get_event_information_excludes_detection_disabled_object() {
     use bacnet_services::alarm_event::GetEventInformationRequest;
 
     let responses = [true, false].map(|enabled| {
-        let db = db_with_enrollment(enabled);
+        let mut db = db_with_enrollment(enabled);
+        db.add(Box::new(
+            bacnet_objects::notification_class::NotificationClass::new(0, "NC-0").unwrap(),
+        ))
+        .unwrap();
         let request = GetEventInformationRequest {
             last_received_object_identifier: None,
         };

--- a/crates/bacnet-server/src/handlers/tests/device_event.rs
+++ b/crates/bacnet-server/src/handlers/tests/device_event.rs
@@ -1,5 +1,6 @@
 use super::*;
 use bacnet_encoding::primitives::encode_timestamp_choice;
+use bacnet_objects::notification_class::NotificationClass;
 use bacnet_types::primitives::{Date, Time};
 
 struct EventSummaryFixture {
@@ -95,6 +96,27 @@ fn timestamp_value(timestamp: &BACnetTimeStamp) -> PropertyValue {
     let mut encoded = BytesMut::new();
     encode_timestamp_choice(&mut encoded, timestamp).unwrap();
     PropertyValue::ApplicationData(encoded.to_vec())
+}
+
+fn add_notification_class(
+    db: &mut ObjectDatabase,
+    instance: u32,
+    class_number: u32,
+    priority: [u8; 3],
+) {
+    let mut class = NotificationClass::new(instance, format!("NC-{instance}")).unwrap();
+    class.notification_class = class_number;
+    class.priority = priority;
+    db.add(Box::new(class)).unwrap();
+}
+
+fn assert_operational_problem(error: Error) {
+    assert!(matches!(
+        error,
+        Error::Protocol { class, code }
+            if class == ErrorClass::DEVICE.to_raw() as u32
+                && code == ErrorCode::OPERATIONAL_PROBLEM.to_raw() as u32
+    ));
 }
 
 fn commit_test_proposal(
@@ -194,7 +216,8 @@ fn reinitialize_device_handler() {
 
 #[test]
 fn get_event_information_empty() {
-    let db = make_db_with_ai();
+    let mut db = make_db_with_ai();
+    add_notification_class(&mut db, 10, 0, [255; 3]);
     let request = bacnet_services::alarm_event::GetEventInformationRequest {
         last_received_object_identifier: None,
     };
@@ -259,6 +282,7 @@ fn get_event_information_reports_non_normal_objects() {
         .expect("out-of-range value must propose HIGH_LIMIT");
     commit_test_proposal(&mut ai, proposal);
     db.add(Box::new(ai)).unwrap();
+    add_notification_class(&mut db, 10, 5, [255; 3]);
 
     let request = bacnet_services::alarm_event::GetEventInformationRequest {
         last_received_object_identifier: None,
@@ -276,8 +300,6 @@ fn get_event_information_reports_non_normal_objects() {
 #[test]
 fn get_event_information_reads_event_enable_notify_type_and_priorities() {
     use bacnet_objects::event::LimitEnable;
-    use bacnet_objects::notification_class::NotificationClass;
-
     let mut db = ObjectDatabase::new();
     let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
     ai.write_property(
@@ -346,10 +368,7 @@ fn get_event_information_reads_event_enable_notify_type_and_priorities() {
     db.add(Box::new(ai)).unwrap();
 
     // Add NotificationClass object with custom priorities
-    let mut nc = NotificationClass::new(5, "NC-5").unwrap();
-    nc.notification_class = 7;
-    nc.priority = [100, 150, 200];
-    db.add(Box::new(nc)).unwrap();
+    add_notification_class(&mut db, 5, 7, [100, 150, 200]);
 
     let request = bacnet_services::alarm_event::GetEventInformationRequest {
         last_received_object_identifier: None,
@@ -367,26 +386,11 @@ fn get_event_information_reads_event_enable_notify_type_and_priorities() {
 }
 
 #[test]
-fn get_event_information_forwards_valid_sequence_timestamps_and_defaults_invalid_array() {
+fn get_event_information_forwards_valid_sequence_timestamps_and_rejects_invalid_array() {
     let mut db = ObjectDatabase::new();
     db.add(Box::new(event_summary_fixture(1, [11, 65535, 33])))
         .unwrap();
-    db.add(Box::new(event_summary_fixture(2, [65536, 44, 55])))
-        .unwrap();
-    let mut trailing_data = timestamp_value(&BACnetTimeStamp::SequenceNumber(66));
-    let PropertyValue::ApplicationData(encoded) = &mut trailing_data else {
-        unreachable!("timestamp helper must return ApplicationData")
-    };
-    encoded.push(0);
-    db.add(Box::new(event_summary_fixture_with_values(
-        3,
-        [
-            trailing_data,
-            timestamp_value(&BACnetTimeStamp::SequenceNumber(77)),
-            timestamp_value(&BACnetTimeStamp::SequenceNumber(88)),
-        ],
-    )))
-    .unwrap();
+    add_notification_class(&mut db, 10, 0, [255; 3]);
 
     let ack = get_event_information_ack(&db, None);
     assert_eq!(
@@ -397,21 +401,41 @@ fn get_event_information_forwards_valid_sequence_timestamps_and_defaults_invalid
             BACnetTimeStamp::SequenceNumber(33),
         ]
     );
-    assert_eq!(
-        ack.list_of_event_summaries[1].event_timestamps,
-        [
-            BACnetTimeStamp::SequenceNumber(0),
-            BACnetTimeStamp::SequenceNumber(0),
-            BACnetTimeStamp::SequenceNumber(0),
-        ]
+
+    let mut invalid_sequence = ObjectDatabase::new();
+    invalid_sequence
+        .add(Box::new(event_summary_fixture(2, [65536, 44, 55])))
+        .unwrap();
+    add_notification_class(&mut invalid_sequence, 10, 0, [255; 3]);
+    let mut request = BytesMut::new();
+    GetEventInformationRequest {
+        last_received_object_identifier: None,
+    }
+    .encode(&mut request);
+    assert_operational_problem(
+        handle_get_event_information(&invalid_sequence, &request, &mut BytesMut::new())
+            .unwrap_err(),
     );
-    assert_eq!(
-        ack.list_of_event_summaries[2].event_timestamps,
-        [
-            BACnetTimeStamp::SequenceNumber(0),
-            BACnetTimeStamp::SequenceNumber(0),
-            BACnetTimeStamp::SequenceNumber(0),
-        ]
+
+    let mut trailing_data = timestamp_value(&BACnetTimeStamp::SequenceNumber(66));
+    let PropertyValue::ApplicationData(encoded) = &mut trailing_data else {
+        unreachable!("timestamp helper must return ApplicationData")
+    };
+    encoded.push(0);
+    let mut trailing = ObjectDatabase::new();
+    trailing
+        .add(Box::new(event_summary_fixture_with_values(
+            3,
+            [
+                trailing_data,
+                timestamp_value(&BACnetTimeStamp::SequenceNumber(77)),
+                timestamp_value(&BACnetTimeStamp::SequenceNumber(88)),
+            ],
+        )))
+        .unwrap();
+    add_notification_class(&mut trailing, 10, 0, [255; 3]);
+    assert_operational_problem(
+        handle_get_event_information(&trailing, &request, &mut BytesMut::new()).unwrap_err(),
     );
 }
 
@@ -448,6 +472,7 @@ fn get_event_information_preserves_timestamp_choices() {
             .map(|timestamp| timestamp_value(&timestamp)),
     )))
     .unwrap();
+    add_notification_class(&mut db, 10, 0, [255; 3]);
 
     let ack = get_event_information_ack(&db, None);
     assert_eq!(ack.list_of_event_summaries[0].event_timestamps, expected);
@@ -460,6 +485,7 @@ fn get_event_information_paginates_by_object_identifier_after_cursor_removal() {
         db.add(Box::new(event_summary_fixture(instance, [0; 3])))
             .unwrap();
     }
+    add_notification_class(&mut db, 50, 0, [255; 3]);
 
     let first_page = get_event_information_ack(&db, None);
     let first_instances: Vec<_> = first_page
@@ -467,10 +493,10 @@ fn get_event_information_paginates_by_object_identifier_after_cursor_removal() {
         .iter()
         .map(|summary| summary.object_identifier.instance_number())
         .collect();
-    assert_eq!(first_instances, (1..=25).collect::<Vec<_>>());
-    assert!(first_page.more_events);
+    assert_eq!(first_instances, (1..=27).collect::<Vec<_>>());
+    assert!(!first_page.more_events);
 
-    let cursor = first_page.list_of_event_summaries[24].object_identifier;
+    let cursor = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 25).unwrap();
     db.remove(&cursor).unwrap();
     let second_page = get_event_information_ack(&db, Some(cursor));
     let second_instances: Vec<_> = second_page

--- a/crates/bacnet-server/src/handlers/tests/get_event_information_projection.rs
+++ b/crates/bacnet-server/src/handlers/tests/get_event_information_projection.rs
@@ -1,0 +1,609 @@
+use std::borrow::Cow;
+
+use bacnet_encoding::primitives::encode_timestamp_choice;
+use bacnet_objects::notification_class::NotificationClass;
+use bacnet_services::alarm_event::{GetEventInformationAck, GetEventInformationRequest};
+use bacnet_types::primitives::{Date, Time};
+
+use super::*;
+
+struct ProjectionFixture {
+    oid: ObjectIdentifier,
+    name: String,
+    advertised: Vec<PropertyIdentifier>,
+    values: Vec<(PropertyIdentifier, PropertyValue)>,
+}
+
+impl ProjectionFixture {
+    fn summary(instance: u32) -> Self {
+        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap();
+        Self {
+            oid,
+            name: format!("SUMMARY-{instance}"),
+            advertised: vec![
+                PropertyIdentifier::EVENT_STATE,
+                PropertyIdentifier::ACKED_TRANSITIONS,
+                PropertyIdentifier::EVENT_TIME_STAMPS,
+                PropertyIdentifier::NOTIFY_TYPE,
+                PropertyIdentifier::EVENT_ENABLE,
+                PropertyIdentifier::NOTIFICATION_CLASS,
+            ],
+            values: vec![
+                (
+                    PropertyIdentifier::EVENT_STATE,
+                    PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw()),
+                ),
+                (
+                    PropertyIdentifier::ACKED_TRANSITIONS,
+                    transition_bits(0b111),
+                ),
+                (
+                    PropertyIdentifier::EVENT_TIME_STAMPS,
+                    PropertyValue::List(vec![
+                        PropertyValue::Unsigned(1),
+                        PropertyValue::Unsigned(2),
+                        PropertyValue::Unsigned(3),
+                    ]),
+                ),
+                (
+                    PropertyIdentifier::NOTIFY_TYPE,
+                    PropertyValue::Enumerated(0),
+                ),
+                (PropertyIdentifier::EVENT_ENABLE, transition_bits(0b111)),
+                (
+                    PropertyIdentifier::NOTIFICATION_CLASS,
+                    PropertyValue::Unsigned(42),
+                ),
+            ],
+        }
+    }
+
+    fn notification_class(
+        instance: u32,
+        class_number: Option<PropertyValue>,
+        priority: Option<PropertyValue>,
+    ) -> Self {
+        let mut values = Vec::new();
+        if let Some(class_number) = class_number {
+            values.push((PropertyIdentifier::NOTIFICATION_CLASS, class_number));
+        }
+        if let Some(priority) = priority {
+            values.push((PropertyIdentifier::PRIORITY, priority));
+        }
+        Self {
+            oid: ObjectIdentifier::new(ObjectType::NOTIFICATION_CLASS, instance).unwrap(),
+            name: format!("CLASS-{instance}"),
+            advertised: vec![
+                PropertyIdentifier::NOTIFICATION_CLASS,
+                PropertyIdentifier::PRIORITY,
+            ],
+            values,
+        }
+    }
+
+    fn set(&mut self, property: PropertyIdentifier, value: PropertyValue) {
+        self.values.retain(|(candidate, _)| *candidate != property);
+        self.values.push((property, value));
+    }
+
+    fn remove(&mut self, property: PropertyIdentifier) {
+        self.values.retain(|(candidate, _)| *candidate != property);
+    }
+
+    fn advertise(&mut self, property: PropertyIdentifier) {
+        if !self.advertised.contains(&property) {
+            self.advertised.push(property);
+        }
+    }
+}
+
+impl BACnetObject for ProjectionFixture {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        &self.name
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        self.values
+            .iter()
+            .find(|(candidate, _)| *candidate == property)
+            .map(|(_, value)| value.clone())
+            .ok_or(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            })
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Owned(self.advertised.clone())
+    }
+}
+
+fn transition_bits(bits: u8) -> PropertyValue {
+    PropertyValue::BitString {
+        unused_bits: 5,
+        data: vec![bacnet_types::bitstring::pack_octet(bits)],
+    }
+}
+
+fn timestamp_value(timestamp: &BACnetTimeStamp) -> PropertyValue {
+    let mut encoded = BytesMut::new();
+    encode_timestamp_choice(&mut encoded, timestamp).unwrap();
+    PropertyValue::ApplicationData(encoded.to_vec())
+}
+
+fn add_class(db: &mut ObjectDatabase, instance: u32, priorities: [u8; 3]) {
+    let mut class = NotificationClass::new(instance, format!("NC-{instance}")).unwrap();
+    class.notification_class = 42;
+    class.priority = priorities;
+    db.add(Box::new(class)).unwrap();
+}
+
+fn request(cursor: Option<ObjectIdentifier>) -> BytesMut {
+    let mut encoded = BytesMut::new();
+    GetEventInformationRequest {
+        last_received_object_identifier: cursor,
+    }
+    .encode(&mut encoded);
+    encoded
+}
+
+fn response(
+    db: &ObjectDatabase,
+    cursor: Option<ObjectIdentifier>,
+    budget: Option<usize>,
+) -> Result<(GetEventInformationAck, usize), Error> {
+    let mut encoded = BytesMut::new();
+    handle_get_event_information_with_budget(db, &request(cursor), &mut encoded, budget)?;
+    Ok((GetEventInformationAck::decode(&encoded)?, encoded.len()))
+}
+
+fn encoded_ack_len(summaries: &[bacnet_services::alarm_event::EventSummary], more: bool) -> usize {
+    let mut encoded = BytesMut::new();
+    GetEventInformationAck {
+        list_of_event_summaries: summaries.to_vec(),
+        more_events: more,
+    }
+    .encode(&mut encoded)
+    .unwrap();
+    encoded.len()
+}
+
+fn assert_operational_problem(error: Error) {
+    assert!(matches!(
+        error,
+        Error::Protocol { class, code }
+            if class == ErrorClass::DEVICE.to_raw() as u32
+                && code == ErrorCode::OPERATIONAL_PROBLEM.to_raw() as u32
+    ));
+}
+
+#[test]
+fn selection_uses_state_acknowledgments_and_detection_not_event_enable() {
+    let mut db = ObjectDatabase::new();
+    let mut normal_unacked = ProjectionFixture::summary(1);
+    normal_unacked.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Enumerated(EventState::NORMAL.to_raw()),
+    );
+    normal_unacked.set(
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        transition_bits(0b110),
+    );
+    normal_unacked.set(PropertyIdentifier::EVENT_ENABLE, transition_bits(0));
+    db.add(Box::new(normal_unacked)).unwrap();
+
+    let mut normal_acked = ProjectionFixture::summary(2);
+    normal_acked.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Enumerated(EventState::NORMAL.to_raw()),
+    );
+    db.add(Box::new(normal_acked)).unwrap();
+    db.add(Box::new(ProjectionFixture::summary(3))).unwrap();
+    add_class(&mut db, 99, [4, 80, 255]);
+
+    let (ack, _) = response(&db, None, None).unwrap();
+    let instances: Vec<_> = ack
+        .list_of_event_summaries
+        .iter()
+        .map(|summary| summary.object_identifier.instance_number())
+        .collect();
+    assert_eq!(instances, vec![1, 3]);
+    assert_eq!(ack.list_of_event_summaries[0].event_enable, 0);
+    assert_eq!(
+        ack.list_of_event_summaries[0].event_priorities,
+        [4, 80, 255]
+    );
+}
+
+#[test]
+fn detection_false_excludes_but_absent_is_eligible_and_malformed_errors() {
+    let mut db = ObjectDatabase::new();
+    let mut disabled = ProjectionFixture::summary(1);
+    disabled.advertise(PropertyIdentifier::EVENT_DETECTION_ENABLE);
+    disabled.set(
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+        PropertyValue::Boolean(false),
+    );
+    disabled.set(PropertyIdentifier::EVENT_STATE, PropertyValue::Unsigned(1));
+    disabled.remove(PropertyIdentifier::EVENT_TIME_STAMPS);
+    disabled.set(
+        PropertyIdentifier::NOTIFICATION_CLASS,
+        PropertyValue::Unsigned(999),
+    );
+    db.add(Box::new(disabled)).unwrap();
+    db.add(Box::new(ProjectionFixture::summary(2))).unwrap();
+    add_class(&mut db, 99, [1, 2, 3]);
+    let (ack, _) = response(&db, None, None).unwrap();
+    assert_eq!(ack.list_of_event_summaries.len(), 1);
+    assert_eq!(
+        ack.list_of_event_summaries[0]
+            .object_identifier
+            .instance_number(),
+        2
+    );
+
+    let mut malformed_db = ObjectDatabase::new();
+    let mut malformed = ProjectionFixture::summary(3);
+    malformed.advertise(PropertyIdentifier::EVENT_DETECTION_ENABLE);
+    malformed.set(
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+        PropertyValue::Unsigned(1),
+    );
+    malformed_db.add(Box::new(malformed)).unwrap();
+    add_class(&mut malformed_db, 99, [1, 2, 3]);
+    assert_operational_problem(response(&malformed_db, None, None).unwrap_err());
+
+    let mut unreadable_db = ObjectDatabase::new();
+    let mut unreadable = ProjectionFixture::summary(4);
+    unreadable.advertise(PropertyIdentifier::EVENT_DETECTION_ENABLE);
+    unreadable.remove(PropertyIdentifier::EVENT_DETECTION_ENABLE);
+    unreadable_db.add(Box::new(unreadable)).unwrap();
+    add_class(&mut unreadable_db, 99, [1, 2, 3]);
+    assert_operational_problem(response(&unreadable_db, None, None).unwrap_err());
+}
+
+#[test]
+fn malformed_required_projection_fields_error_and_non_event_objects_are_skipped() {
+    let malformed = [
+        (PropertyIdentifier::EVENT_STATE, PropertyValue::Unsigned(1)),
+        (
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            PropertyValue::BitString {
+                unused_bits: 4,
+                data: vec![0xe0],
+            },
+        ),
+        (PropertyIdentifier::NOTIFY_TYPE, PropertyValue::Unsigned(0)),
+        (
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0xe1],
+            },
+        ),
+        (
+            PropertyIdentifier::NOTIFICATION_CLASS,
+            PropertyValue::Enumerated(42),
+        ),
+        (
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+            PropertyValue::List(vec![PropertyValue::Unsigned(1); 2]),
+        ),
+    ];
+
+    for (property, value) in malformed {
+        let mut db = ObjectDatabase::new();
+        let mut object = ProjectionFixture::summary(1);
+        object.set(property, value);
+        db.add(Box::new(object)).unwrap();
+        add_class(&mut db, 99, [1, 2, 3]);
+        assert_operational_problem(response(&db, None, None).unwrap_err());
+    }
+
+    let mut unreadable_db = ObjectDatabase::new();
+    let mut unreadable = ProjectionFixture::summary(1);
+    unreadable.remove(PropertyIdentifier::NOTIFY_TYPE);
+    unreadable_db.add(Box::new(unreadable)).unwrap();
+    add_class(&mut unreadable_db, 99, [1, 2, 3]);
+    assert_operational_problem(response(&unreadable_db, None, None).unwrap_err());
+
+    let mut skipped_db = ObjectDatabase::new();
+    let skipped = ProjectionFixture {
+        oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+        name: "NON-EVENT".into(),
+        advertised: vec![PropertyIdentifier::EVENT_STATE],
+        values: Vec::new(),
+    };
+    skipped_db.add(Box::new(skipped)).unwrap();
+    let (ack, _) = response(&skipped_db, None, None).unwrap();
+    assert!(ack.list_of_event_summaries.is_empty());
+}
+
+#[test]
+fn notification_class_lookup_requires_one_exact_well_formed_match() {
+    let mut valid_with_unrelated_malformed = ObjectDatabase::new();
+    valid_with_unrelated_malformed
+        .add(Box::new(ProjectionFixture::summary(1)))
+        .unwrap();
+    add_class(&mut valid_with_unrelated_malformed, 99, [1, 2, 3]);
+    for malformed in [
+        ProjectionFixture::notification_class(1, Some(PropertyValue::Enumerated(42)), None),
+        ProjectionFixture::notification_class(2, None, None),
+        ProjectionFixture::notification_class(
+            3,
+            Some(PropertyValue::Unsigned(u64::from(u32::MAX) + 1)),
+            None,
+        ),
+    ] {
+        valid_with_unrelated_malformed
+            .add(Box::new(malformed))
+            .unwrap();
+    }
+    let (ack, _) = response(&valid_with_unrelated_malformed, None, None).unwrap();
+    assert_eq!(ack.list_of_event_summaries.len(), 1);
+    assert_eq!(ack.list_of_event_summaries[0].event_priorities, [1, 2, 3]);
+
+    let scenarios = [
+        "missing",
+        "duplicate",
+        "malformed-number",
+        "missing-number",
+        "out-of-u32-number",
+        "missing-priority",
+        "malformed-priority",
+        "wrong-length",
+        "over-255",
+    ];
+    for scenario in scenarios {
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(ProjectionFixture::summary(1))).unwrap();
+        match scenario {
+            "missing" => {}
+            "duplicate" => {
+                add_class(&mut db, 1, [1, 2, 3]);
+                add_class(&mut db, 2, [4, 5, 6]);
+            }
+            "malformed-number" => db
+                .add(Box::new(ProjectionFixture::notification_class(
+                    1,
+                    Some(PropertyValue::Enumerated(42)),
+                    Some(PropertyValue::List(vec![PropertyValue::Unsigned(1); 3])),
+                )))
+                .unwrap(),
+            "missing-number" => db
+                .add(Box::new(ProjectionFixture::notification_class(
+                    1,
+                    None,
+                    Some(PropertyValue::List(vec![PropertyValue::Unsigned(1); 3])),
+                )))
+                .unwrap(),
+            "out-of-u32-number" => db
+                .add(Box::new(ProjectionFixture::notification_class(
+                    1,
+                    Some(PropertyValue::Unsigned(u64::from(u32::MAX) + 1)),
+                    Some(PropertyValue::List(vec![PropertyValue::Unsigned(1); 3])),
+                )))
+                .unwrap(),
+            "missing-priority" => db
+                .add(Box::new(ProjectionFixture::notification_class(
+                    1,
+                    Some(PropertyValue::Unsigned(42)),
+                    None,
+                )))
+                .unwrap(),
+            "malformed-priority" => db
+                .add(Box::new(ProjectionFixture::notification_class(
+                    1,
+                    Some(PropertyValue::Unsigned(42)),
+                    Some(PropertyValue::Enumerated(1)),
+                )))
+                .unwrap(),
+            "wrong-length" => db
+                .add(Box::new(ProjectionFixture::notification_class(
+                    1,
+                    Some(PropertyValue::Unsigned(42)),
+                    Some(PropertyValue::List(vec![PropertyValue::Unsigned(1); 2])),
+                )))
+                .unwrap(),
+            "over-255" => db
+                .add(Box::new(ProjectionFixture::notification_class(
+                    1,
+                    Some(PropertyValue::Unsigned(42)),
+                    Some(PropertyValue::List(vec![
+                        PropertyValue::Unsigned(1),
+                        PropertyValue::Unsigned(256),
+                        PropertyValue::Unsigned(3),
+                    ])),
+                )))
+                .unwrap(),
+            _ => unreachable!(),
+        }
+        assert_operational_problem(response(&db, None, None).unwrap_err());
+    }
+}
+
+#[test]
+fn timestamp_choices_keep_coordinate_order_and_malformed_values_error() {
+    let expected = [
+        BACnetTimeStamp::Time(Time {
+            hour: 1,
+            minute: 2,
+            second: 3,
+            hundredths: 4,
+        }),
+        BACnetTimeStamp::SequenceNumber(65535),
+        BACnetTimeStamp::DateTime {
+            date: Date {
+                year: 126,
+                month: 8,
+                day: 31,
+                day_of_week: 1,
+            },
+            time: Time {
+                hour: 5,
+                minute: 6,
+                second: 7,
+                hundredths: 8,
+            },
+        },
+    ];
+    let mut db = ObjectDatabase::new();
+    let mut object = ProjectionFixture::summary(1);
+    object.set(
+        PropertyIdentifier::EVENT_TIME_STAMPS,
+        PropertyValue::List(
+            expected
+                .clone()
+                .map(|timestamp| timestamp_value(&timestamp))
+                .to_vec(),
+        ),
+    );
+    db.add(Box::new(object)).unwrap();
+    add_class(&mut db, 99, [1, 2, 3]);
+    let (ack, _) = response(&db, None, None).unwrap();
+    assert_eq!(ack.list_of_event_summaries[0].event_timestamps, expected);
+
+    let mut malformed_db = ObjectDatabase::new();
+    let mut malformed = ProjectionFixture::summary(1);
+    malformed.set(
+        PropertyIdentifier::EVENT_TIME_STAMPS,
+        PropertyValue::List(vec![PropertyValue::CharacterString("bad".into()); 3]),
+    );
+    malformed_db.add(Box::new(malformed)).unwrap();
+    add_class(&mut malformed_db, 99, [1, 2, 3]);
+    assert_operational_problem(response(&malformed_db, None, None).unwrap_err());
+}
+
+#[test]
+fn byte_budget_selects_maximal_prefix_on_both_sides_of_twenty_five() {
+    let mut db = ObjectDatabase::new();
+    for instance in (1..=30).rev() {
+        let mut object = ProjectionFixture::summary(instance);
+        if instance == 4 {
+            object.set(
+                PropertyIdentifier::EVENT_TIME_STAMPS,
+                PropertyValue::List(vec![
+                    timestamp_value(&BACnetTimeStamp::DateTime {
+                        date: Date {
+                            year: 126,
+                            month: 9,
+                            day: 1,
+                            day_of_week: 2,
+                        },
+                        time: Time {
+                            hour: 1,
+                            minute: 2,
+                            second: 3,
+                            hundredths: 4,
+                        },
+                    }),
+                    PropertyValue::Unsigned(2),
+                    PropertyValue::Unsigned(3),
+                ]),
+            );
+        }
+        db.add(Box::new(object)).unwrap();
+    }
+    add_class(&mut db, 99, [1, 2, 3]);
+
+    let (full, _) = response(&db, None, None).unwrap();
+    assert_eq!(full.list_of_event_summaries.len(), 30);
+    let three_budget = encoded_ack_len(&full.list_of_event_summaries[..3], true);
+    assert!(encoded_ack_len(&full.list_of_event_summaries[..4], true) > three_budget);
+    let (first, first_len) = response(&db, None, Some(three_budget)).unwrap();
+    assert_eq!(first.list_of_event_summaries.len(), 3);
+    assert_eq!(first_len, three_budget);
+    assert!(first.more_events);
+
+    let cursor = first
+        .list_of_event_summaries
+        .last()
+        .unwrap()
+        .object_identifier;
+    let (second, _) = response(&db, Some(cursor), Some(three_budget)).unwrap();
+    let resumed: Vec<_> = second
+        .list_of_event_summaries
+        .iter()
+        .map(|summary| summary.object_identifier.instance_number())
+        .collect();
+    assert!(!resumed.is_empty());
+    assert_eq!(resumed[0], 4);
+    let first_instances: Vec<_> = first
+        .list_of_event_summaries
+        .iter()
+        .map(|summary| summary.object_identifier.instance_number())
+        .collect();
+    assert_eq!(first_instances, vec![1, 2, 3]);
+    assert_eq!(
+        first_instances
+            .into_iter()
+            .chain(resumed.iter().copied())
+            .collect::<Vec<_>>(),
+        (1..=3 + resumed.len() as u32).collect::<Vec<_>>()
+    );
+
+    let twenty_seven_budget = encoded_ack_len(&full.list_of_event_summaries[..27], true);
+    let (large, large_len) = response(&db, None, Some(twenty_seven_budget)).unwrap();
+    assert_eq!(large.list_of_event_summaries.len(), 27);
+    assert_eq!(large_len, twenty_seven_budget);
+    assert!(large.more_events);
+
+    let (oversized_first, oversized_len) = response(&db, None, Some(1)).unwrap();
+    assert_eq!(oversized_first.list_of_event_summaries.len(), 1);
+    assert!(oversized_first.more_events);
+    assert!(oversized_len > 1);
+}
+
+#[test]
+fn ordering_cursor_successor_and_empty_result_are_deterministic() {
+    let empty = ObjectDatabase::new();
+    let (ack, _) = response(&empty, None, None).unwrap();
+    assert!(ack.list_of_event_summaries.is_empty());
+    assert!(!ack.more_events);
+
+    let mut db = ObjectDatabase::new();
+    for instance in [9, 1, 5] {
+        db.add(Box::new(ProjectionFixture::summary(instance)))
+            .unwrap();
+    }
+    add_class(&mut db, 99, [1, 2, 3]);
+    let deleted_cursor = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 4).unwrap();
+    let (ack, _) = response(&db, Some(deleted_cursor), None).unwrap();
+    let instances: Vec<_> = ack
+        .list_of_event_summaries
+        .iter()
+        .map(|summary| summary.object_identifier.instance_number())
+        .collect();
+    assert_eq!(instances, vec![5, 9]);
+
+    let present_cursor = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 5).unwrap();
+    let (ack, _) = response(&db, Some(present_cursor), None).unwrap();
+    assert_eq!(ack.list_of_event_summaries.len(), 1);
+    assert_eq!(
+        ack.list_of_event_summaries[0]
+            .object_identifier
+            .instance_number(),
+        9
+    );
+}

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -53,6 +53,7 @@ mod file_metadata;
 mod file_persistence;
 mod file_storage_hook;
 mod framed_properties;
+mod get_event_information_projection;
 mod life_safety_cov;
 mod life_safety_operation;
 mod life_safety_reset;

--- a/crates/bacnet-server/src/server/requests/event_information.rs
+++ b/crates/bacnet-server/src/server/requests/event_information.rs
@@ -1,0 +1,66 @@
+use super::*;
+
+pub(super) fn can_segment(segmentation: Segmentation) -> bool {
+    matches!(segmentation, Segmentation::BOTH | Segmentation::TRANSMIT)
+}
+
+pub(super) fn limit(peer: u16, local: u32) -> u16 {
+    peer.min(u16::try_from(local).unwrap_or(u16::MAX))
+}
+
+pub(super) async fn response(
+    db: &RwLock<ObjectDatabase>,
+    request: &ConfirmedRequestPdu,
+    effective_max_apdu: u16,
+    segmented_response_available: bool,
+) -> Apdu {
+    let service_ack_budget = (!segmented_response_available).then(|| {
+        unsegmented_complex_ack_service_budget(
+            request.invoke_id,
+            request.service_choice,
+            effective_max_apdu,
+        )
+    });
+    let mut service_ack = BytesMut::new();
+    let db = db.read().await;
+    match handlers::handle_get_event_information_with_budget(
+        &db,
+        &request.service_request,
+        &mut service_ack,
+        service_ack_budget,
+    ) {
+        Ok(()) => Apdu::ComplexAck(ComplexAck {
+            segmented: false,
+            more_follows: false,
+            invoke_id: request.invoke_id,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: request.service_choice,
+            service_ack: service_ack.freeze(),
+        }),
+        Err(error) => confirmed_response::error_apdu_from_error(
+            request.invoke_id,
+            request.service_choice,
+            &error,
+        ),
+    }
+}
+
+fn unsegmented_complex_ack_service_budget(
+    invoke_id: u8,
+    service_choice: ConfirmedServiceChoice,
+    max_apdu: u16,
+) -> usize {
+    let envelope = Apdu::ComplexAck(ComplexAck {
+        segmented: false,
+        more_follows: false,
+        invoke_id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice,
+        service_ack: Bytes::new(),
+    });
+    let mut encoded = BytesMut::new();
+    encode_apdu(&mut encoded, &envelope).expect("valid empty ComplexACK encoding");
+    usize::from(max_apdu).saturating_sub(encoded.len())
+}

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -7,6 +7,7 @@ mod endpoint_responder;
 #[cfg(test)]
 #[path = "endpoint_shared_runtime_tests.rs"]
 mod endpoint_shared_runtime_tests;
+mod event_information;
 #[cfg(test)]
 mod executed;
 mod unconfirmed;
@@ -46,6 +47,10 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let client_max_apdu = req.max_apdu_length;
         let client_accepts_segmented = req.segmented_response_accepted;
         let client_max_segments = req.max_segments;
+        let effective_max_apdu = event_information::limit(client_max_apdu, config.max_apdu_length);
+        let device_transmits_segments =
+            event_information::can_segment(config.segmentation_supported);
+        let segmented_response_available = client_accepts_segmented && device_transmits_segments;
         let mut written_oids: Vec<ObjectIdentifier> = Vec::new();
         let mut coarse_cov_oids: Vec<ObjectIdentifier> = Vec::new();
         let mut life_safety_cov_changes = Vec::new();
@@ -295,15 +300,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 }
             }
             s if s == ConfirmedServiceChoice::GET_EVENT_INFORMATION => {
-                let db = db.read().await;
-                match handlers::handle_get_event_information(
-                    &db,
-                    &req.service_request,
-                    &mut ack_buf,
-                ) {
-                    Ok(()) => complex_ack(ack_buf),
-                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
-                }
+                event_information::response(
+                    db,
+                    &req,
+                    effective_max_apdu,
+                    segmented_response_available,
+                )
+                .await
             }
             s if s == ConfirmedServiceChoice::ACKNOWLEDGE_ALARM => {
                 let mut db = db.write().await;
@@ -515,7 +518,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let mut full_buf = BytesMut::new();
             encode_apdu(&mut full_buf, &response).expect("valid APDU encoding");
 
-            if full_buf.len() > client_max_apdu as usize {
+            if full_buf.len() > effective_max_apdu as usize {
                 // Clause 5.4.5.3 CannotSendSegmentedComplexACK reads both
                 // sides of the exchange: case (a) — "this device does not
                 // support the transmission of segmented messages" — and case
@@ -523,8 +526,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 // "cannot be sent as one PDU or multiple PDUs" and draws the
                 // same Abort; SendSegmentedComplexACK is available only when
                 // the device supports transmitting segments (#381).
-                let device_transmits_segments = config.segmentation_supported == Segmentation::BOTH
-                    || config.segmentation_supported == Segmentation::TRANSMIT;
                 if !client_accepts_segmented || !device_transmits_segments {
                     let abort = Apdu::Abort(AbortPdu {
                         sent_by_server: true,
@@ -559,7 +560,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             invoke_id,
                             service_choice,
                             &service_ack_data,
-                            client_max_apdu,
+                            effective_max_apdu,
                             client_max_segments,
                         )
                         .await;

--- a/crates/bacnet-server/src/server/segmentation_tests/get_event_information.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/get_event_information.rs
@@ -1,0 +1,271 @@
+use std::borrow::Cow;
+
+use bacnet_encoding::primitives::encode_timestamp_choice;
+use bacnet_objects::notification_class::NotificationClass;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_services::alarm_event::GetEventInformationRequest;
+use bacnet_types::enums::EventState;
+use bacnet_types::primitives::{BACnetTimeStamp, Date, Time};
+
+use super::*;
+
+const INVOKE_ID: u8 = 77;
+
+struct LargeSummaryObject {
+    oid: ObjectIdentifier,
+    timestamps: Vec<PropertyValue>,
+}
+
+impl LargeSummaryObject {
+    fn new() -> Self {
+        let timestamps = (1..=3)
+            .map(|hour| {
+                let timestamp = BACnetTimeStamp::DateTime {
+                    date: Date {
+                        year: 126,
+                        month: 9,
+                        day: hour,
+                        day_of_week: hour,
+                    },
+                    time: Time {
+                        hour,
+                        minute: 2,
+                        second: 3,
+                        hundredths: 4,
+                    },
+                };
+                let mut encoded = BytesMut::new();
+                encode_timestamp_choice(&mut encoded, &timestamp).unwrap();
+                PropertyValue::ApplicationData(encoded.to_vec())
+            })
+            .collect();
+        Self {
+            oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+            timestamps,
+        }
+    }
+}
+
+impl BACnetObject for LargeSummaryObject {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "LARGE-SUMMARY"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        match property {
+            p if p == PropertyIdentifier::EVENT_STATE => {
+                Ok(PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw()))
+            }
+            p if p == PropertyIdentifier::ACKED_TRANSITIONS
+                || p == PropertyIdentifier::EVENT_ENABLE =>
+            {
+                Ok(PropertyValue::BitString {
+                    unused_bits: 5,
+                    data: vec![0xe0],
+                })
+            }
+            p if p == PropertyIdentifier::EVENT_TIME_STAMPS => {
+                Ok(PropertyValue::List(self.timestamps.clone()))
+            }
+            p if p == PropertyIdentifier::NOTIFY_TYPE => Ok(PropertyValue::Enumerated(0)),
+            p if p == PropertyIdentifier::NOTIFICATION_CLASS => Ok(PropertyValue::Unsigned(42)),
+            _ => Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            }),
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            PropertyIdentifier::EVENT_TIME_STAMPS,
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyIdentifier::NOTIFICATION_CLASS,
+        ])
+    }
+}
+
+fn database() -> ObjectDatabase {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(LargeSummaryObject::new())).unwrap();
+    let mut class = NotificationClass::new(99, "NC-99").unwrap();
+    class.notification_class = 42;
+    class.priority = [1, 100, 255];
+    db.add(Box::new(class)).unwrap();
+    db
+}
+
+fn service_request() -> Bytes {
+    let mut encoded = BytesMut::new();
+    GetEventInformationRequest {
+        last_received_object_identifier: None,
+    }
+    .encode(&mut encoded);
+    encoded.freeze()
+}
+
+fn full_service_ack() -> Bytes {
+    let mut encoded = BytesMut::new();
+    handlers::handle_get_event_information(&database(), &service_request(), &mut encoded).unwrap();
+    encoded.freeze()
+}
+
+fn unsegmented_apdu_len(service_ack: Bytes) -> usize {
+    let mut encoded = BytesMut::new();
+    encode_apdu(
+        &mut encoded,
+        &Apdu::ComplexAck(ComplexAck {
+            segmented: false,
+            more_follows: false,
+            invoke_id: INVOKE_ID,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: ConfirmedServiceChoice::GET_EVENT_INFORMATION,
+            service_ack,
+        }),
+    )
+    .unwrap();
+    encoded.len()
+}
+
+async fn dispatch(
+    segmentation: Segmentation,
+    client_accepts_segmented: bool,
+    client_max_apdu: u16,
+    local_max_apdu: u32,
+) -> (
+    SentFrames,
+    Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
+    MacAddr,
+) {
+    let sent = SentFrames::default();
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(Arc::clone(
+        &sent,
+    ))));
+    let db = Arc::new(RwLock::new(database()));
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let cov_in_flight = Arc::new(Semaphore::new(1));
+    let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+    let notification_transactions = NotificationTransactions::new();
+    let confirmed_request_tracker = Arc::new(ConfirmedRequestTracker::default());
+    let device_bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
+    let comm_state = Arc::new(AtomicU8::new(0));
+    let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
+    let config = ServerConfig {
+        max_apdu_length: local_max_apdu,
+        segmentation_supported: segmentation,
+        ..ServerConfig::default()
+    };
+    let source_mac = test_mac(41);
+
+    BACnetServer::<RecordingTransport>::handle_confirmed_request(
+        &db,
+        &network,
+        &cov_table,
+        &seg_ack_senders,
+        &seg_send_permits,
+        &cov_in_flight,
+        &server_tsm,
+        &notification_transactions,
+        &confirmed_request_tracker,
+        &device_bindings,
+        &comm_state,
+        &dcc_timer,
+        &config,
+        source_mac.as_slice(),
+        None,
+        ConfirmedRequestPdu {
+            segmented: false,
+            more_follows: false,
+            segmented_response_accepted: client_accepts_segmented,
+            max_segments: None,
+            max_apdu_length: client_max_apdu,
+            invoke_id: INVOKE_ID,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: ConfirmedServiceChoice::GET_EVENT_INFORMATION,
+            service_request: service_request(),
+        },
+        None,
+    )
+    .await;
+
+    (sent, seg_ack_senders, source_mac)
+}
+
+#[tokio::test]
+async fn first_summary_over_unsegmented_budget_uses_existing_segmentation_abort() {
+    assert!(unsegmented_apdu_len(full_service_ack()) > 50);
+    for (client_max_apdu, local_max_apdu) in [(50, 1476), (480, 50)] {
+        let (sent, _, _) =
+            dispatch(Segmentation::NONE, false, client_max_apdu, local_max_apdu).await;
+        wait_for_sent_len(&sent, 1).await;
+        assert_eq!(sent_count(&sent), 1);
+        assert_eq!(
+            abort_reason(&sent, 0),
+            AbortReason::SEGMENTATION_NOT_SUPPORTED
+        );
+    }
+}
+
+#[tokio::test]
+async fn segmentation_capable_dispatch_retains_the_complete_service_ack() {
+    let expected = full_service_ack();
+    assert!(unsegmented_apdu_len(expected.clone()) > 50);
+    let (sent, seg_ack_senders, source_mac) = dispatch(Segmentation::BOTH, true, 50, 1476).await;
+    let key = segmented_transaction_key(&source_mac, None, INVOKE_ID);
+    let mut reconstructed = BytesMut::new();
+    let mut index = 0usize;
+
+    loop {
+        wait_for_sent_len(&sent, index + 1).await;
+        let Apdu::ComplexAck(ack) = decoded_sent_apdu(&sent, index) else {
+            panic!("expected segmented ComplexAck");
+        };
+        assert!(ack.segmented);
+        assert_eq!(
+            ack.service_choice,
+            ConfirmedServiceChoice::GET_EVENT_INFORMATION
+        );
+        assert_eq!(ack.sequence_number, Some(index as u8));
+        reconstructed.extend_from_slice(&ack.service_ack);
+        if !ack.more_follows {
+            break;
+        }
+        send_segment_ack(
+            &seg_ack_senders,
+            &key,
+            segment_ack(INVOKE_ID, false, index as u8),
+        )
+        .await;
+        index += 1;
+    }
+
+    assert_eq!(reconstructed.freeze(), expected);
+}

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -419,5 +419,6 @@ fn fake_segmented_send_handle(
 mod ack_window;
 mod control_limits;
 mod duplicate_window;
+mod get_event_information;
 mod request_reassembly;
 mod routing_overlap;


### PR DESCRIPTION
## Summary
- replace permissive GetEventInformation field fallbacks with one strict private event-summary projection
- apply the Event_State-or-unacknowledged selection rule independently of Event_Enable and short-circuit Event_Detection_Enable FALSE
- preserve all three BACnetTimeStamp choices and resolve three transition priorities from exactly one associated Notification Class
- paginate by encoded Object Identifier order and exact ComplexACK byte budget when segmentation is unavailable
- retain the complete response for the existing segmented ComplexACK path

## Source-to-behavior traceability
| ANSI/ASHRAE 135-2020 source | Implemented behavior |
|---|---|
| §13.2.4 / Table 13-2 and §13.12 | Select objects whose Event_Detection_Enable is not FALSE and whose Event_State is non-NORMAL or whose Acked_Transitions has a FALSE bit; Event_Enable is projected, not used as a selection gate. |
| §13.12 | Emit exactly the seven EventSummary fields in encoded Object Identifier order; resume strictly after the cursor, including a deleted cursor's determinable successor. |
| §12.21 | Resolve Priority as three strict 0..=255 coordinates from exactly one valid associated Notification Class. |
| §21.6 | Preserve Time, SequenceNumber, and DateTime timestamp choices without fabricating zeros. |
| §5.4.5.3 | Use maximal byte-fitting continuation only when segmented transmission is unavailable; otherwise retain the full service ACK for the existing segmented response path. |

An explicitly disabled candidate is excluded before unrelated projection/class reads. Missing or malformed data on an enabled advertised candidate, a missing/duplicate associated class, or malformed matched priorities returns `DEVICE / OPERATIONAL_PROBLEM`; malformed unrelated Notification Class objects do not poison a valid exact match.

## Validation
- `cargo fmt --all -- --check`
- focused GetEventInformation projection, cursor, pagination, and segmentation tests
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-services --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

## Scope boundaries
- no public BACnetObject, EventSummary wire-model, client, Python, or object API changes
- no GetAlarmSummary/GetEnrollmentSummary redesign
- no broad event-service or conformance claim beyond the executable GetEventInformation behavior above

Closes #128
Closes #206