### PR TITLE
fix(server): enforce GetAlarmSummary alarm predicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The deprecated GetAlarmSummary server now selects only advertised
+  Event_State/Notify_Type/Acked_Transitions candidates whose Event_State is
+  non-NORMAL and whose Notify_Type is ALARM, while excluding an explicitly
+  disabled Event_Detection_Enable and preserving the exact state and canonical
+  acknowledgment bits (#172). Under the repository's local strict-projection
+  policy, unreadable, wrongly typed, or noncanonical required fields reached by
+  that predicate now return DEVICE / OPERATIONAL_PROBLEM instead of fabricated
+  defaults; this is a behavior correction, not a broader conformance claim.
+
 - GetEventInformation now projects each advertised event-initiating object as
   one strict typed snapshot, applies the NORMAL-or-unacknowledged selection
   rule independently of Event_Enable, preserves all three BACnetTimeStamp

--- a/crates/bacnet-server/src/handlers/alarm_event/get_alarm_summary.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/get_alarm_summary.rs
@@ -4,52 +4,159 @@
 //! on a single module.
 
 use super::super::*;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::enums::NotifyType;
+
+const ALARM_SUMMARY_SIGNATURE: [PropertyIdentifier; 3] = [
+    PropertyIdentifier::EVENT_STATE,
+    PropertyIdentifier::NOTIFY_TYPE,
+    PropertyIdentifier::ACKED_TRANSITIONS,
+];
+
+struct AlarmSummaryProjection {
+    object_identifier: ObjectIdentifier,
+    event_state: u32,
+    acknowledged_transitions: (u8, Vec<u8>),
+}
+
+enum AlarmSummaryProjectionResult {
+    NotEventInitiating,
+    Excluded,
+    Projected(AlarmSummaryProjection),
+}
+
+impl AlarmSummaryProjection {
+    fn read(object: &dyn BACnetObject) -> Result<AlarmSummaryProjectionResult, Error> {
+        let advertised = object.property_list();
+        if !ALARM_SUMMARY_SIGNATURE
+            .iter()
+            .all(|property| advertised.contains(property))
+        {
+            return Ok(AlarmSummaryProjectionResult::NotEventInitiating);
+        }
+
+        let object_identifier = object.object_identifier();
+        if advertised.contains(&PropertyIdentifier::EVENT_DETECTION_ENABLE) {
+            match read_required(
+                object,
+                object_identifier,
+                PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            )? {
+                PropertyValue::Boolean(false) => return Ok(AlarmSummaryProjectionResult::Excluded),
+                PropertyValue::Boolean(true) => {}
+                _ => {
+                    return Err(operational_problem(
+                        object_identifier,
+                        "Event_Detection_Enable is not Boolean",
+                    ))
+                }
+            }
+        }
+
+        let event_state =
+            read_enumerated(object, object_identifier, PropertyIdentifier::EVENT_STATE)?;
+        if event_state == EventState::NORMAL.to_raw() {
+            return Ok(AlarmSummaryProjectionResult::Excluded);
+        }
+
+        let notify_type =
+            read_enumerated(object, object_identifier, PropertyIdentifier::NOTIFY_TYPE)?;
+        if notify_type != NotifyType::ALARM.to_raw() {
+            return Ok(AlarmSummaryProjectionResult::Excluded);
+        }
+
+        let acknowledged_transitions = read_acknowledged_transitions(object, object_identifier)?;
+        Ok(AlarmSummaryProjectionResult::Projected(Self {
+            object_identifier,
+            event_state,
+            acknowledged_transitions,
+        }))
+    }
+}
 
 /// Handle a GetAlarmSummary request.
 ///
-/// Returns objects with event_state != NORMAL.
+/// Clause 13.10 selects event-initiating objects whose Event_State is not
+/// NORMAL and whose Notify_Type is ALARM. As a local strict-projection policy,
+/// malformed advertised candidate fields fail the service instead of being
+/// replaced with fabricated values.
 pub fn handle_get_alarm_summary(db: &ObjectDatabase, buf: &mut BytesMut) -> Result<(), Error> {
     use bacnet_services::alarm_summary::{AlarmSummaryEntry, GetAlarmSummaryAck};
 
     let mut entries = Vec::new();
     for (_oid, object) in db.iter_objects() {
-        // Clause 12.12: Event_Detection_Enable controls whether the object is
-        // considered by the event-summarization services.
-        if !super::event_detection_enabled(object) {
-            continue;
-        }
-
-        let oid = object.object_identifier();
-        let event_state = object
-            .read_property(PropertyIdentifier::EVENT_STATE, None)
-            .ok()
-            .and_then(|v| match v {
-                PropertyValue::Enumerated(e) => Some(e),
-                _ => None,
-            })
-            .unwrap_or(0);
-
-        if event_state != 0 {
-            let acked = object
-                .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
-                .ok()
-                .and_then(|v| match v {
-                    PropertyValue::BitString {
-                        unused_bits, data, ..
-                    } => Some((unused_bits, data)),
-                    _ => None,
-                })
-                .unwrap_or((5, vec![0xE0])); // all acknowledged by default
-
-            entries.push(AlarmSummaryEntry {
-                object_identifier: oid,
-                alarm_state: bacnet_types::enums::EventState::from_raw(event_state),
-                acknowledged_transitions: acked,
-            });
-        }
+        let projection = match AlarmSummaryProjection::read(object)? {
+            AlarmSummaryProjectionResult::NotEventInitiating
+            | AlarmSummaryProjectionResult::Excluded => continue,
+            AlarmSummaryProjectionResult::Projected(projection) => projection,
+        };
+        entries.push(AlarmSummaryEntry {
+            object_identifier: projection.object_identifier,
+            alarm_state: EventState::from_raw(projection.event_state),
+            acknowledged_transitions: projection.acknowledged_transitions,
+        });
     }
 
     let ack = GetAlarmSummaryAck { entries };
     ack.encode(buf);
     Ok(())
+}
+
+fn read_required(
+    object: &dyn BACnetObject,
+    object_identifier: ObjectIdentifier,
+    property: PropertyIdentifier,
+) -> Result<PropertyValue, Error> {
+    object.read_property(property, None).map_err(|error| {
+        operational_problem(
+            object_identifier,
+            format!("required property {property:?} is unreadable: {error}"),
+        )
+    })
+}
+
+fn read_enumerated(
+    object: &dyn BACnetObject,
+    object_identifier: ObjectIdentifier,
+    property: PropertyIdentifier,
+) -> Result<u32, Error> {
+    match read_required(object, object_identifier, property)? {
+        PropertyValue::Enumerated(value) => Ok(value),
+        _ => Err(operational_problem(
+            object_identifier,
+            format!("required property {property:?} is not Enumerated"),
+        )),
+    }
+}
+
+fn read_acknowledged_transitions(
+    object: &dyn BACnetObject,
+    object_identifier: ObjectIdentifier,
+) -> Result<(u8, Vec<u8>), Error> {
+    match read_required(
+        object,
+        object_identifier,
+        PropertyIdentifier::ACKED_TRANSITIONS,
+    )? {
+        PropertyValue::BitString { unused_bits, data }
+            if unused_bits == 5 && data.len() == 1 && data[0] & 0x1f == 0 =>
+        {
+            Ok((unused_bits, data))
+        }
+        _ => Err(operational_problem(
+            object_identifier,
+            "Acked_Transitions is not a canonical three-bit BitString",
+        )),
+    }
+}
+
+fn operational_problem(
+    object_identifier: ObjectIdentifier,
+    detail: impl std::fmt::Display,
+) -> Error {
+    tracing::warn!(?object_identifier, reason = %detail, "GetAlarmSummary projection failed");
+    Error::Protocol {
+        class: ErrorClass::DEVICE.to_raw() as u32,
+        code: ErrorCode::OPERATIONAL_PROBLEM.to_raw() as u32,
+    }
 }

--- a/crates/bacnet-server/src/handlers/tests/alarm_summary_projection.rs
+++ b/crates/bacnet-server/src/handlers/tests/alarm_summary_projection.rs
@@ -1,0 +1,305 @@
+use std::borrow::Cow;
+
+use bacnet_services::alarm_summary::GetAlarmSummaryAck;
+use bacnet_types::enums::NotifyType;
+
+use super::*;
+
+struct AlarmSummaryFixture {
+    oid: ObjectIdentifier,
+    name: String,
+    advertised: Vec<PropertyIdentifier>,
+    values: Vec<(PropertyIdentifier, PropertyValue)>,
+}
+
+impl AlarmSummaryFixture {
+    fn alarm(instance: u32) -> Self {
+        Self {
+            oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap(),
+            name: format!("ALARM-SUMMARY-{instance}"),
+            advertised: vec![
+                PropertyIdentifier::EVENT_STATE,
+                PropertyIdentifier::NOTIFY_TYPE,
+                PropertyIdentifier::ACKED_TRANSITIONS,
+            ],
+            values: vec![
+                (
+                    PropertyIdentifier::EVENT_STATE,
+                    PropertyValue::Enumerated(EventState::OFFNORMAL.to_raw()),
+                ),
+                (
+                    PropertyIdentifier::NOTIFY_TYPE,
+                    PropertyValue::Enumerated(NotifyType::ALARM.to_raw()),
+                ),
+                (
+                    PropertyIdentifier::ACKED_TRANSITIONS,
+                    transition_bits(0b111),
+                ),
+            ],
+        }
+    }
+
+    fn advertise(&mut self, property: PropertyIdentifier) {
+        if !self.advertised.contains(&property) {
+            self.advertised.push(property);
+        }
+    }
+
+    fn set(&mut self, property: PropertyIdentifier, value: PropertyValue) {
+        self.values.retain(|(candidate, _)| *candidate != property);
+        self.values.push((property, value));
+    }
+
+    fn remove(&mut self, property: PropertyIdentifier) {
+        self.values.retain(|(candidate, _)| *candidate != property);
+    }
+}
+
+impl BACnetObject for AlarmSummaryFixture {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        &self.name
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        self.values
+            .iter()
+            .find(|(candidate, _)| *candidate == property)
+            .map(|(_, value)| value.clone())
+            .ok_or(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            })
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Owned(self.advertised.clone())
+    }
+}
+
+fn transition_bits(bits: u8) -> PropertyValue {
+    PropertyValue::BitString {
+        unused_bits: 5,
+        data: vec![bacnet_types::bitstring::pack_octet(bits)],
+    }
+}
+
+fn response(db: &ObjectDatabase) -> Result<GetAlarmSummaryAck, Error> {
+    let mut encoded = BytesMut::new();
+    handle_get_alarm_summary(db, &mut encoded)?;
+    GetAlarmSummaryAck::decode(&encoded)
+}
+
+fn assert_operational_problem(error: Error) {
+    assert!(matches!(
+        error,
+        Error::Protocol { class, code }
+            if class == ErrorClass::DEVICE.to_raw() as u32
+                && code == ErrorCode::OPERATIONAL_PROBLEM.to_raw() as u32
+    ));
+}
+
+fn add(db: &mut ObjectDatabase, object: AlarmSummaryFixture) {
+    db.add(Box::new(object)).unwrap();
+}
+
+#[test]
+fn selects_only_active_alarm_notify_type_and_preserves_output_fields() {
+    let mut db = ObjectDatabase::new();
+    let mut selected = AlarmSummaryFixture::alarm(1);
+    selected.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Enumerated(EventState::FAULT.to_raw()),
+    );
+    selected.set(
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        transition_bits(0b010),
+    );
+    add(&mut db, selected);
+
+    let mut informational = AlarmSummaryFixture::alarm(2);
+    informational.set(
+        PropertyIdentifier::NOTIFY_TYPE,
+        PropertyValue::Enumerated(NotifyType::EVENT.to_raw()),
+    );
+    add(&mut db, informational);
+
+    let mut normal_alarm = AlarmSummaryFixture::alarm(3);
+    normal_alarm.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Enumerated(EventState::NORMAL.to_raw()),
+    );
+    add(&mut db, normal_alarm);
+
+    let ack = response(&db).unwrap();
+    assert_eq!(ack.entries.len(), 1);
+    assert_eq!(ack.entries[0].object_identifier.instance_number(), 1);
+    assert_eq!(ack.entries[0].alarm_state, EventState::FAULT);
+    assert_eq!(
+        ack.entries[0].acknowledged_transitions,
+        (5, vec![0b0100_0000])
+    );
+}
+
+#[test]
+fn detection_false_is_excluded_absence_is_eligible_and_missing_signature_is_skipped() {
+    let mut db = ObjectDatabase::new();
+    let mut disabled = AlarmSummaryFixture::alarm(1);
+    disabled.advertise(PropertyIdentifier::EVENT_DETECTION_ENABLE);
+    disabled.set(
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+        PropertyValue::Boolean(false),
+    );
+    disabled.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Boolean(false),
+    );
+    disabled.set(
+        PropertyIdentifier::NOTIFY_TYPE,
+        PropertyValue::Boolean(false),
+    );
+    disabled.set(
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        PropertyValue::Boolean(false),
+    );
+    add(&mut db, disabled);
+
+    add(&mut db, AlarmSummaryFixture::alarm(2));
+
+    let mut not_event_initiating = AlarmSummaryFixture::alarm(3);
+    not_event_initiating
+        .advertised
+        .retain(|property| *property != PropertyIdentifier::NOTIFY_TYPE);
+    not_event_initiating.values.clear();
+    add(&mut db, not_event_initiating);
+
+    let ack = response(&db).unwrap();
+    assert_eq!(ack.entries.len(), 1);
+    assert_eq!(ack.entries[0].object_identifier.instance_number(), 2);
+}
+
+#[test]
+fn excluded_state_and_notify_types_short_circuit_malformed_later_fields() {
+    let mut db = ObjectDatabase::new();
+    let mut normal = AlarmSummaryFixture::alarm(1);
+    normal.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Enumerated(EventState::NORMAL.to_raw()),
+    );
+    normal.set(
+        PropertyIdentifier::NOTIFY_TYPE,
+        PropertyValue::Boolean(false),
+    );
+    normal.set(
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        PropertyValue::Boolean(false),
+    );
+    add(&mut db, normal);
+
+    for (instance, notify_type) in [
+        (2, NotifyType::EVENT.to_raw()),
+        (3, NotifyType::ACK_NOTIFICATION.to_raw()),
+        (4, 99),
+    ] {
+        let mut non_alarm = AlarmSummaryFixture::alarm(instance);
+        non_alarm.set(
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyValue::Enumerated(notify_type),
+        );
+        non_alarm.set(
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            PropertyValue::Boolean(false),
+        );
+        add(&mut db, non_alarm);
+    }
+
+    let mut encoded = BytesMut::new();
+    handle_get_alarm_summary(&db, &mut encoded).unwrap();
+    assert!(encoded.is_empty());
+    assert!(GetAlarmSummaryAck::decode(&encoded)
+        .unwrap()
+        .entries
+        .is_empty());
+}
+
+#[test]
+fn unreadable_and_wrongly_typed_advertised_fields_are_operational_problems() {
+    for (property, value) in [
+        (
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            Some(PropertyValue::Unsigned(1)),
+        ),
+        (PropertyIdentifier::EVENT_DETECTION_ENABLE, None),
+        (
+            PropertyIdentifier::EVENT_STATE,
+            Some(PropertyValue::Boolean(true)),
+        ),
+        (PropertyIdentifier::EVENT_STATE, None),
+        (
+            PropertyIdentifier::NOTIFY_TYPE,
+            Some(PropertyValue::Boolean(true)),
+        ),
+        (PropertyIdentifier::NOTIFY_TYPE, None),
+        (
+            PropertyIdentifier::ACKED_TRANSITIONS,
+            Some(PropertyValue::Boolean(true)),
+        ),
+        (PropertyIdentifier::ACKED_TRANSITIONS, None),
+    ] {
+        let mut object = AlarmSummaryFixture::alarm(1);
+        if property == PropertyIdentifier::EVENT_DETECTION_ENABLE {
+            object.advertise(property);
+        }
+        object.remove(property);
+        if let Some(value) = value {
+            object.set(property, value);
+        }
+        let mut db = ObjectDatabase::new();
+        add(&mut db, object);
+        assert_operational_problem(response(&db).unwrap_err());
+    }
+}
+
+#[test]
+fn acknowledged_transitions_requires_one_canonical_three_bit_octet() {
+    for malformed in [
+        PropertyValue::BitString {
+            unused_bits: 4,
+            data: vec![0b1110_0000],
+        },
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0b1110_0000, 0],
+        },
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0b1110_0001],
+        },
+    ] {
+        let mut object = AlarmSummaryFixture::alarm(1);
+        object.set(PropertyIdentifier::ACKED_TRANSITIONS, malformed);
+        let mut db = ObjectDatabase::new();
+        add(&mut db, object);
+        assert_operational_problem(response(&db).unwrap_err());
+    }
+}

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -36,6 +36,7 @@ fn make_db_with_device_and_ai() -> ObjectDatabase {
 
 mod acknowledge_alarm;
 mod acknowledge_alarm_ee;
+mod alarm_summary_projection;
 mod alert_enrollment;
 mod array_index_gating;
 mod async_dcc;

--- a/crates/bacnet-server/src/server/alarm_summary_tests.rs
+++ b/crates/bacnet-server/src/server/alarm_summary_tests.rs
@@ -1,0 +1,135 @@
+use std::borrow::Cow;
+
+use bacnet_encoding::apdu::decode_apdu;
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_objects::traits::BACnetObject;
+
+use super::*;
+
+struct MalformedAlarmObject {
+    oid: ObjectIdentifier,
+}
+
+impl BACnetObject for MalformedAlarmObject {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.oid
+    }
+
+    fn object_name(&self) -> &str {
+        "MALFORMED-ALARM"
+    }
+
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _array_index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        match property {
+            PropertyIdentifier::EVENT_STATE => Ok(PropertyValue::Boolean(true)),
+            PropertyIdentifier::NOTIFY_TYPE => {
+                Ok(PropertyValue::Enumerated(NotifyType::ALARM.to_raw()))
+            }
+            PropertyIdentifier::ACKED_TRANSITIONS => Ok(PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0xe0],
+            }),
+            _ => Err(Error::Protocol {
+                class: ErrorClass::PROPERTY.to_raw() as u32,
+                code: ErrorCode::UNKNOWN_PROPERTY.to_raw() as u32,
+            }),
+        }
+    }
+
+    fn write_property(
+        &mut self,
+        _property: PropertyIdentifier,
+        _array_index: Option<u32>,
+        _value: PropertyValue,
+        _priority: Option<u8>,
+    ) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::PROPERTY.to_raw() as u32,
+            code: ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32,
+        })
+    }
+
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::NOTIFY_TYPE,
+            PropertyIdentifier::ACKED_TRANSITIONS,
+        ])
+    }
+}
+
+#[tokio::test]
+async fn projection_operational_problem_dispatches_error_apdu() {
+    let mut database = ObjectDatabase::new();
+    database
+        .add(Box::new(MalformedAlarmObject {
+            oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+        }))
+        .unwrap();
+    let db = Arc::new(RwLock::new(database));
+    let network = Arc::new(NetworkLayer::new(BipTransport::new(
+        Ipv4Addr::LOCALHOST,
+        0,
+        Ipv4Addr::BROADCAST,
+    )));
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
+    let seg_ack_senders = Arc::new(Mutex::new(HashMap::new()));
+    let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
+    let cov_in_flight = Arc::new(Semaphore::new(1));
+    let server_tsm = Arc::new(Mutex::new(ServerTsm::new()));
+    let notification_transactions = NotificationTransactions::new();
+    let confirmed_request_tracker = Arc::new(ConfirmedRequestTracker::default());
+    let device_bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
+    let comm_state = Arc::new(AtomicU8::new(0));
+    let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
+    let confirmed = ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 480,
+        invoke_id: 0x50,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::GET_ALARM_SUMMARY,
+        service_request: Bytes::new(),
+    };
+    let (tx, rx) = oneshot::channel();
+
+    BACnetServer::<BipTransport>::handle_confirmed_request(
+        &db,
+        &network,
+        &cov_table,
+        &seg_ack_senders,
+        &seg_send_permits,
+        &cov_in_flight,
+        &server_tsm,
+        &notification_transactions,
+        &confirmed_request_tracker,
+        &device_bindings,
+        &comm_state,
+        &dcc_timer,
+        &ServerConfig::default(),
+        &MacAddr::from_slice(&[1]),
+        None,
+        confirmed,
+        Some(tx),
+    )
+    .await;
+
+    let response = decode_apdu(decode_npdu(rx.await.unwrap()).unwrap().payload).unwrap();
+    let Apdu::Error(error) = response else {
+        panic!("expected GetAlarmSummary Error APDU");
+    };
+    assert_eq!(error.invoke_id, 0x50);
+    assert_eq!(
+        error.service_choice,
+        ConfirmedServiceChoice::GET_ALARM_SUMMARY
+    );
+    assert_eq!(error.error_class, ErrorClass::DEVICE);
+    assert_eq!(error.error_code, ErrorCode::OPERATIONAL_PROBLEM);
+}

--- a/crates/bacnet-server/src/server/requests/confirmed_response.rs
+++ b/crates/bacnet-server/src/server/requests/confirmed_response.rs
@@ -61,3 +61,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         error_apdu_from_error(invoke_id, service_choice, error)
     }
 }
+
+#[cfg(test)]
+#[path = "../alarm_summary_tests.rs"]
+mod alarm_summary_tests;

--- a/crates/bacnet-services/src/alarm_summary.rs
+++ b/crates/bacnet-services/src/alarm_summary.rs
@@ -1,4 +1,4 @@
-//! GetAlarmSummary service per ASHRAE 135-2020 Clause 13.7 (deprecated).
+//! GetAlarmSummary service per ASHRAE 135-2020 Clause 13.10 (deprecated).
 
 use bacnet_encoding::primitives;
 use bacnet_encoding::tags;


### PR DESCRIPTION
## Summary
- select GetAlarmSummary entries only when Event_State is non-NORMAL and Notify_Type is ALARM
- exclude candidates with Event_Detection_Enable FALSE while retaining objects that do not advertise that property
- preserve actual Alarm State and canonical three-bit Acked_Transitions values
- replace fabricated malformed-field defaults with the repository's local `DEVICE / OPERATIONAL_PROBLEM` projection policy
- correct the service module citation from Clause 13.7 to Clause 13.10

## Source-to-behavior traceability
| ANSI/ASHRAE 135-2020 source | Implemented behavior |
|---|---|
| §13.10 definition of active alarm | Require `Event_State != NORMAL && Notify_Type == ALARM`. |
| §13.10 Service Procedure | Ignore explicit Event_Detection_Enable FALSE and return a zero-entry positive response when nothing qualifies. |
| §13.10 Result(+) | Emit actual Object Identifier, Alarm State, and Acknowledged Transitions for each selected object. |

The Standard excerpt does not prescribe a malformed object-property fallback. This PR applies the repository's local strict-projection policy: an advertised required field that is unreadable, wrongly typed, or noncanonical when reached returns `DEVICE / OPERATIONAL_PROBLEM`. Disabled, NORMAL, and non-ALARM candidates short-circuit before unrelated fields are read.

GetAlarmSummary remains deprecated. This correction does not add sorting, paging, or a broader support/conformance claim.

## Validation
- focused GetAlarmSummary predicate, malformed-field, empty-result, and dispatch Error-APDU tests
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-services --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- file-size, no-secret, and `git diff --check`

## Scope boundaries
- no public Rust, wire, client, or Python API changes
- no GetEventInformation/GetEnrollmentSummary changes
- no object-model, paging, segmentation, conformance-ledger, README, PICS, BIBB, or CI changes

Closes #172