### PR TITLE
feat(client): expose lossless acknowledgment timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking CLI invocation:** one-shot and interactive `ack-alarm` (including
+  the `ack` alias) now require exact caller-supplied `--timestamp` and
+  `--ack-time` BACnetTimeStamp values. Neither value is inferred from a clock.
+  The five-argument Python `BACnetClient.acknowledge_alarm` signature remains
+  available for compatibility but is deprecated and emits
+  `DeprecationWarning` before retaining its historical sequence-zero behavior.
+
 - **Breaking Rust source migration:** GetEnrollmentSummary's public
   `RecipientProcess::device: Option<ObjectIdentifier>` field is replaced by
   `recipient: BACnetRecipient`, adding the standard Device-or-Address CHOICE.
@@ -19,13 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Correlated AcknowledgeAlarm core validation and a lossless Rust request API
-  (`Refs #132`). The bundled server now requires the latest committed original
+  (#132). The bundled server now requires the latest committed original
   To State and exact timestamp before setting one supported Analog or Event
   Enrollment acknowledgment bit; valid repeated transactions remain
-  idempotent. The legacy timestamp-fabricating helper is deprecated. Python,
-  CLI timestamp design, additional object families, and ACK_NOTIFICATION
-  distribution (#175) remain deferred, so this is not full Clause 13.5
-  conformance and does not close #132.
+  idempotent. Python now exposes the protocol-backed `BACnetTimeStamp` CHOICE
+  and a lossless `BACnetClient.acknowledge_alarm_request` method, while the CLI
+  uses that canonical Rust request with both mandatory timestamps. Additional
+  object families (#170) and ACK_NOTIFICATION distribution (#175) remain
+  deferred, so this does not broaden conformance claims.
 
 - Exact-delta Life Safety COV reporting for the bundled server (`Refs #177`).
   Whole-object Point/Zone subscriptions now trigger only for actual

--- a/crates/bacnet-cli/src/args.rs
+++ b/crates/bacnet-cli/src/args.rs
@@ -6,6 +6,7 @@
 
 use std::{net::Ipv4Addr, path::PathBuf};
 
+use bacnet_types::primitives::BACnetTimeStamp;
 use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -14,7 +15,7 @@ pub(crate) enum FileReadAccess {
     Record,
 }
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(name = "bacnet", about = "BACnet command-line tool", version)]
 pub(crate) struct Cli {
     /// Network interface IP address to bind (omit to select interactively in shell mode).
@@ -85,7 +86,7 @@ pub(crate) struct Cli {
     pub(crate) command: Option<Command>,
 }
 
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 pub(crate) enum Command {
     /// Launch interactive shell.
     Shell,
@@ -285,6 +286,12 @@ pub(crate) enum Command {
         /// Acknowledgment source string.
         #[arg(long, default_value = "bacnet-cli")]
         source: String,
+        /// Exact timestamp from the original event notification.
+        #[arg(long, value_parser = crate::timestamp::parse_bacnet_timestamp)]
+        timestamp: BACnetTimeStamp,
+        /// Caller-selected time of acknowledgment.
+        #[arg(long, value_parser = crate::timestamp::parse_bacnet_timestamp)]
+        ack_time: BACnetTimeStamp,
     },
 
     /// Read a range of items from a list or log buffer.
@@ -352,4 +359,112 @@ pub(crate) enum Command {
         #[arg(long, default_value_t = 65535)]
         snaplen: u32,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bacnet_types::primitives::{Date, Time};
+    use clap::error::ErrorKind;
+
+    #[test]
+    fn ack_alarm_and_alias_require_both_timestamp_flags() {
+        for command in ["ack-alarm", "ack"] {
+            let missing_both =
+                Cli::try_parse_from(["bacnet", command, "127.0.0.1", "ai:1", "--state", "1"])
+                    .unwrap_err();
+            assert_eq!(missing_both.kind(), ErrorKind::MissingRequiredArgument);
+
+            let missing_ack_time = Cli::try_parse_from([
+                "bacnet",
+                command,
+                "127.0.0.1",
+                "ai:1",
+                "--state",
+                "1",
+                "--timestamp",
+                "sequence:9",
+            ])
+            .unwrap_err();
+            assert_eq!(missing_ack_time.kind(), ErrorKind::MissingRequiredArgument);
+        }
+    }
+
+    #[test]
+    fn ack_alarm_clap_uses_lossless_shared_timestamp_parser() {
+        let cli = Cli::try_parse_from([
+            "bacnet",
+            "ack",
+            "127.0.0.1",
+            "ai:1",
+            "--state",
+            "3",
+            "--source",
+            "operator",
+            "--timestamp",
+            "time:1,2,3,4",
+            "--ack-time",
+            "datetime:2026,9,2,3;5,6,7,8",
+        ])
+        .unwrap();
+        let Some(Command::AckAlarm {
+            state,
+            source,
+            timestamp,
+            ack_time,
+            ..
+        }) = cli.command
+        else {
+            panic!("expected AckAlarm");
+        };
+        assert_eq!(state, 3);
+        assert_eq!(source, "operator");
+        assert_eq!(
+            timestamp,
+            BACnetTimeStamp::Time(Time {
+                hour: 1,
+                minute: 2,
+                second: 3,
+                hundredths: 4,
+            })
+        );
+        assert_eq!(
+            ack_time,
+            BACnetTimeStamp::DateTime {
+                date: Date {
+                    year: 126,
+                    month: 9,
+                    day: 2,
+                    day_of_week: 3,
+                },
+                time: Time {
+                    hour: 5,
+                    minute: 6,
+                    second: 7,
+                    hundredths: 8,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn ack_alarm_clap_reports_shared_parser_error_before_execution() {
+        let error = Cli::try_parse_from([
+            "bacnet",
+            "ack-alarm",
+            "127.0.0.1",
+            "ai:1",
+            "--state",
+            "1",
+            "--timestamp",
+            "time:24,0,0,0",
+            "--ack-time",
+            "sequence:1",
+        ])
+        .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::ValueValidation);
+        assert!(error
+            .to_string()
+            .contains("BACnetTimeStamp hour must be 0..=23 or 255 (unspecified), got 24"));
+    }
 }

--- a/crates/bacnet-cli/src/commands/device.rs
+++ b/crates/bacnet-cli/src/commands/device.rs
@@ -2,9 +2,10 @@
 //! AcknowledgeAlarm, CreateObject, DeleteObject, TimeSync.
 
 use bacnet_client::client::BACnetClient;
+use bacnet_services::alarm_event::AcknowledgeAlarmRequest;
 use bacnet_transport::port::TransportPort;
 use bacnet_types::enums::{EnableDisable, ObjectType, ReinitializedState};
-use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier};
 
 use crate::output::{self, OutputFormat};
 
@@ -165,8 +166,27 @@ pub async fn alarms_cmd<T: TransportPort + 'static>(
     Ok(())
 }
 
-/// Acknowledge an alarm on a remote device.
-#[allow(deprecated)]
+fn build_acknowledge_alarm_request(
+    process_id: u32,
+    object_type: ObjectType,
+    instance: u32,
+    event_state: u32,
+    source: &str,
+    timestamp: BACnetTimeStamp,
+    time_of_acknowledgment: BACnetTimeStamp,
+) -> Result<AcknowledgeAlarmRequest, bacnet_types::error::Error> {
+    Ok(AcknowledgeAlarmRequest {
+        acknowledging_process_identifier: process_id,
+        event_object_identifier: ObjectIdentifier::new(object_type, instance)?,
+        event_state_acknowledged: event_state,
+        timestamp,
+        acknowledgment_source: source.to_string(),
+        time_of_acknowledgment,
+    })
+}
+
+/// Acknowledge an alarm on a remote device with exact caller-supplied timestamps.
+#[allow(clippy::too_many_arguments)]
 pub async fn acknowledge_alarm_cmd<T: TransportPort + 'static>(
     client: &BACnetClient<T>,
     mac: &[u8],
@@ -174,15 +194,23 @@ pub async fn acknowledge_alarm_cmd<T: TransportPort + 'static>(
     instance: u32,
     event_state: u32,
     source: &str,
+    timestamp: BACnetTimeStamp,
+    time_of_acknowledgment: BACnetTimeStamp,
     format: OutputFormat,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let oid = ObjectIdentifier::new(object_type, instance)?;
     // Use PID as process identifier
     let process_id = std::process::id();
+    let request = build_acknowledge_alarm_request(
+        process_id,
+        object_type,
+        instance,
+        event_state,
+        source,
+        timestamp,
+        time_of_acknowledgment,
+    )?;
 
-    client
-        .acknowledge_alarm(mac, process_id, oid, event_state, source)
-        .await?;
+    client.acknowledge_alarm_request(mac, &request).await?;
 
     output::print_success("Alarm acknowledged", format);
     Ok(())
@@ -221,4 +249,50 @@ pub async fn create_object_cmd<T: TransportPort + 'static>(
         .join(" ");
     output::print_success(&format!("Created object (response: {hex})"), format);
     Ok(())
+}
+
+#[cfg(test)]
+mod acknowledgment_tests {
+    use super::*;
+    use bacnet_types::primitives::{Date, Time};
+
+    #[test]
+    fn request_builder_preserves_both_timestamps_and_all_metadata() {
+        let event_timestamp = BACnetTimeStamp::SequenceNumber(65_535);
+        let acknowledgment_timestamp = BACnetTimeStamp::DateTime {
+            date: Date {
+                year: 126,
+                month: 14,
+                day: 34,
+                day_of_week: 255,
+            },
+            time: Time {
+                hour: 23,
+                minute: 59,
+                second: 58,
+                hundredths: 99,
+            },
+        };
+        let request = build_acknowledge_alarm_request(
+            0x1234_5678,
+            ObjectType::ANALOG_INPUT,
+            77,
+            3,
+            "operator-console",
+            event_timestamp.clone(),
+            acknowledgment_timestamp.clone(),
+        )
+        .unwrap();
+
+        assert_eq!(request.acknowledging_process_identifier, 0x1234_5678);
+        assert_eq!(
+            request.event_object_identifier.object_type(),
+            ObjectType::ANALOG_INPUT
+        );
+        assert_eq!(request.event_object_identifier.instance_number(), 77);
+        assert_eq!(request.event_state_acknowledged, 3);
+        assert_eq!(request.timestamp, event_timestamp);
+        assert_eq!(request.acknowledgment_source, "operator-console");
+        assert_eq!(request.time_of_acknowledgment, acknowledgment_timestamp);
+    }
 }

--- a/crates/bacnet-cli/src/main.rs
+++ b/crates/bacnet-cli/src/main.rs
@@ -18,6 +18,7 @@ mod parse;
 mod resolve;
 mod session;
 mod shell;
+mod timestamp;
 mod transport;
 
 use args::{Cli, Command};
@@ -270,9 +271,11 @@ async fn execute_command<T: TransportPort + 'static>(
             object,
             state,
             source,
+            timestamp,
+            ack_time,
         } => {
-            let mac = resolve_target_mac(client, target).await?;
             let (object_type, instance) = parse::parse_object_specifier(object)?;
+            let mac = resolve_target_mac(client, target).await?;
             commands::device::acknowledge_alarm_cmd(
                 client,
                 &mac,
@@ -280,6 +283,8 @@ async fn execute_command<T: TransportPort + 'static>(
                 instance,
                 *state,
                 source,
+                timestamp.clone(),
+                ack_time.clone(),
                 format,
             )
             .await?;

--- a/crates/bacnet-cli/src/shell/admin.rs
+++ b/crates/bacnet-cli/src/shell/admin.rs
@@ -1,24 +1,93 @@
 use super::*;
 
+use bacnet_types::primitives::BACnetTimeStamp;
+
+const ACK_ALARM_USAGE: &str = "Usage: ack-alarm <target> <object> --state N \
+--timestamp <SPEC> --ack-time <SPEC> [--source S]";
+
+#[derive(Debug)]
+pub(super) struct AckAlarmArguments<'a> {
+    pub(super) target: &'a str,
+    pub(super) object: &'a str,
+    pub(super) state: u32,
+    pub(super) source: String,
+    pub(super) timestamp: BACnetTimeStamp,
+    pub(super) time_of_acknowledgment: BACnetTimeStamp,
+}
+
+pub(super) fn parse_ack_alarm_arguments(args: &[String]) -> Result<AckAlarmArguments<'_>, String> {
+    if args.len() < 2 {
+        return Err(ACK_ALARM_USAGE.into());
+    }
+
+    let mut state = None;
+    let mut source = "bacnet-cli".to_string();
+    let mut timestamp = None;
+    let mut time_of_acknowledgment = None;
+    let mut i = 2;
+    while i < args.len() {
+        let flag = args[i].as_str();
+        let value = args
+            .get(i + 1)
+            .ok_or_else(|| format!("{flag} requires a value"))?;
+        match flag {
+            "--state" => {
+                if state.is_some() {
+                    return Err("--state may only be specified once".into());
+                }
+                state = Some(
+                    value
+                        .parse::<u32>()
+                        .map_err(|_| "--state requires a numeric value".to_string())?,
+                );
+            }
+            "--source" => source = value.clone(),
+            "--timestamp" => {
+                if timestamp.is_some() {
+                    return Err("--timestamp may only be specified once".into());
+                }
+                timestamp = Some(timestamp::parse_bacnet_timestamp(value)?);
+            }
+            "--ack-time" => {
+                if time_of_acknowledgment.is_some() {
+                    return Err("--ack-time may only be specified once".into());
+                }
+                time_of_acknowledgment = Some(timestamp::parse_bacnet_timestamp(value)?);
+            }
+            _ => {
+                return Err(format!(
+                    "unknown ack-alarm option '{flag}'; {ACK_ALARM_USAGE}"
+                ))
+            }
+        }
+        i += 2;
+    }
+
+    Ok(AckAlarmArguments {
+        target: &args[0],
+        object: &args[1],
+        state: state.ok_or_else(|| "--state is required".to_string())?,
+        source,
+        timestamp: timestamp.ok_or_else(|| "--timestamp is required".to_string())?,
+        time_of_acknowledgment: time_of_acknowledgment
+            .ok_or_else(|| "--ack-time is required".to_string())?,
+    })
+}
+
 pub(super) async fn handle_ack_alarm<T: TransportPort + 'static>(
     client: &BACnetClient<T>,
     args: &[String],
     format: OutputFormat,
 ) {
-    if args.len() < 2 {
-        output::print_error("Usage: ack-alarm <target> <object> --state N [--source S]");
-        return;
-    }
-
-    let mac = match resolve_target_mac(client, &args[0]).await {
-        Ok(m) => m,
+    let arguments = match parse_ack_alarm_arguments(args) {
+        Ok(arguments) => arguments,
         Err(e) => {
             output::print_error(&e);
             return;
         }
     };
 
-    let (object_type, instance) = match parse::parse_object_specifier(&args[1]) {
+    let (object_type, instance) = match parse::parse_object_specifier(arguments.object) {
         Ok(v) => v,
         Err(e) => {
             output::print_error(&e);
@@ -26,47 +95,10 @@ pub(super) async fn handle_ack_alarm<T: TransportPort + 'static>(
         }
     };
 
-    let mut state: Option<u32> = None;
-    let mut source = "bacnet-cli".to_string();
-
-    let mut i = 2;
-    while i < args.len() {
-        match args[i].as_str() {
-            "--state" => {
-                if i + 1 < args.len() {
-                    match args[i + 1].parse::<u32>() {
-                        Ok(s) => state = Some(s),
-                        Err(_) => {
-                            output::print_error("--state requires a numeric value");
-                            return;
-                        }
-                    }
-                    i += 2;
-                    continue;
-                } else {
-                    output::print_error("--state requires a value");
-                    return;
-                }
-            }
-            "--source" => {
-                if i + 1 < args.len() {
-                    source = args[i + 1].clone();
-                    i += 2;
-                    continue;
-                } else {
-                    output::print_error("--source requires a value");
-                    return;
-                }
-            }
-            _ => {}
-        }
-        i += 1;
-    }
-
-    let state = match state {
-        Some(s) => s,
-        None => {
-            output::print_error("--state is required");
+    let mac = match resolve_target_mac(client, arguments.target).await {
+        Ok(m) => m,
+        Err(e) => {
+            output::print_error(&e);
             return;
         }
     };
@@ -76,8 +108,10 @@ pub(super) async fn handle_ack_alarm<T: TransportPort + 'static>(
         &mac,
         object_type,
         instance,
-        state,
-        &source,
+        arguments.state,
+        &arguments.source,
+        arguments.timestamp,
+        arguments.time_of_acknowledgment,
         format,
     )
     .await

--- a/crates/bacnet-cli/src/shell/mod.rs
+++ b/crates/bacnet-cli/src/shell/mod.rs
@@ -17,7 +17,7 @@ use owo_colors::OwoColorize;
 
 use crate::output::OutputFormat;
 use crate::session::Session;
-use crate::{commands, output, parse, resolve};
+use crate::{commands, output, parse, resolve, timestamp};
 
 use self::admin::{
     handle_ack_alarm, handle_create_object, handle_delete_object, handle_read_range,
@@ -409,7 +409,10 @@ Commands:
   control <target> <action>          Device communication control (enable/disable)
   reinit <target> <state>            Reinitialize device (coldstart/warmstart)
   alarms <target>                    Get event/alarm summary
-  ack-alarm <target> <obj> --state N Acknowledge an alarm
+  ack-alarm <target> <obj> --state N --timestamp <SPEC> --ack-time <SPEC>
+                                       Acknowledge with exact caller-supplied timestamps
+    SPEC: sequence:N | time:H,M,S,HS | datetime:Y,M,D,DOW;H,M,S,HS
+    --timestamp echoes the notification; --ack-time is caller-selected
   time-sync <target> [--utc]         Synchronize time with a device
   create-object <target> <object>    Create an object on a remote device
   delete-object <target> <object>    Delete an object on a remote device

--- a/crates/bacnet-cli/src/shell/tests.rs
+++ b/crates/bacnet-cli/src/shell/tests.rs
@@ -34,3 +34,65 @@ fn shell_helper_completions() {
     assert!(!helper.object_types.is_empty());
     assert!(!helper.properties.is_empty());
 }
+
+fn ack_args(options: &[&str]) -> Vec<String> {
+    ["127.0.0.1", "ai:1"]
+        .into_iter()
+        .chain(options.iter().copied())
+        .map(str::to_string)
+        .collect()
+}
+
+#[test]
+fn shell_ack_alarm_requires_both_timestamps_before_dispatch() {
+    let missing_timestamp = ack_args(&["--state", "1", "--ack-time", "sequence:2"]);
+    assert_eq!(
+        admin::parse_ack_alarm_arguments(&missing_timestamp).unwrap_err(),
+        "--timestamp is required"
+    );
+
+    let missing_ack_time = ack_args(&["--state", "1", "--timestamp", "sequence:2"]);
+    assert_eq!(
+        admin::parse_ack_alarm_arguments(&missing_ack_time).unwrap_err(),
+        "--ack-time is required"
+    );
+}
+
+#[test]
+fn shell_ack_alarm_uses_shared_parser_and_preserves_options() {
+    let args = ack_args(&[
+        "--state",
+        "3",
+        "--source",
+        "operator",
+        "--timestamp",
+        "time:1,2,3,4",
+        "--ack-time",
+        "datetime:2026,9,2,3;5,6,7,8",
+    ]);
+    let parsed = admin::parse_ack_alarm_arguments(&args).unwrap();
+    assert_eq!(parsed.state, 3);
+    assert_eq!(parsed.source, "operator");
+    assert_eq!(
+        parsed.timestamp,
+        bacnet_types::primitives::BACnetTimeStamp::Time(bacnet_types::primitives::Time {
+            hour: 1,
+            minute: 2,
+            second: 3,
+            hundredths: 4,
+        })
+    );
+
+    let invalid = ack_args(&[
+        "--state",
+        "1",
+        "--timestamp",
+        "time:24,0,0,0",
+        "--ack-time",
+        "sequence:2",
+    ]);
+    assert_eq!(
+        admin::parse_ack_alarm_arguments(&invalid).unwrap_err(),
+        timestamp::parse_bacnet_timestamp("time:24,0,0,0").unwrap_err()
+    );
+}

--- a/crates/bacnet-cli/src/shell/tests.rs
+++ b/crates/bacnet-cli/src/shell/tests.rs
@@ -96,3 +96,57 @@ fn shell_ack_alarm_uses_shared_parser_and_preserves_options() {
         timestamp::parse_bacnet_timestamp("time:24,0,0,0").unwrap_err()
     );
 }
+
+#[test]
+fn tokenized_documented_ack_alarm_preserves_quoted_datetime() {
+    let tokens = tokenize(
+        "ack-alarm 192.168.1.100 ai:1 --state 1 --timestamp sequence:417 \
+         --ack-time \"datetime:2026,9,2,3;14,30,00,00\"",
+    );
+    assert_eq!(tokens[0], "ack-alarm");
+    let parsed = admin::parse_ack_alarm_arguments(&tokens[1..]).unwrap();
+    assert_eq!(
+        parsed.timestamp,
+        bacnet_types::primitives::BACnetTimeStamp::SequenceNumber(417)
+    );
+    assert_eq!(
+        parsed.time_of_acknowledgment,
+        bacnet_types::primitives::BACnetTimeStamp::DateTime {
+            date: bacnet_types::primitives::Date {
+                year: 126,
+                month: 9,
+                day: 2,
+                day_of_week: 3,
+            },
+            time: bacnet_types::primitives::Time {
+                hour: 14,
+                minute: 30,
+                second: 0,
+                hundredths: 0,
+            },
+        }
+    );
+}
+
+#[test]
+fn tokenized_ack_alarm_accepts_one_quoted_event_timestamp_pair() {
+    let tokens = tokenize(
+        "ack 192.168.1.100 ai:1 --state 3 --timestamp \"time:1,2,3,4\" \
+         --ack-time sequence:9",
+    );
+    assert_eq!(tokens[0], "ack");
+    let parsed = admin::parse_ack_alarm_arguments(&tokens[1..]).unwrap();
+    assert_eq!(
+        parsed.timestamp,
+        bacnet_types::primitives::BACnetTimeStamp::Time(bacnet_types::primitives::Time {
+            hour: 1,
+            minute: 2,
+            second: 3,
+            hundredths: 4,
+        })
+    );
+    assert_eq!(
+        parsed.time_of_acknowledgment,
+        bacnet_types::primitives::BACnetTimeStamp::SequenceNumber(9)
+    );
+}

--- a/crates/bacnet-cli/src/timestamp.rs
+++ b/crates/bacnet-cli/src/timestamp.rs
@@ -68,8 +68,40 @@ fn parse_date(value: &str) -> Result<Date, String> {
     })
 }
 
-/// Parse an exact BACnetTimeStamp CLI value without normalization.
+fn normalize_outer_double_quotes(spec: &str) -> Result<&str, String> {
+    let starts_with_quote = spec.starts_with('"');
+    let ends_with_quote = spec.ends_with('"');
+    let spec = match (starts_with_quote, ends_with_quote, spec.len()) {
+        (true, true, length) if length >= 2 => &spec[1..length - 1],
+        (false, false, _) => spec,
+        _ => {
+            return Err(format!(
+                "invalid BACnetTimeStamp quoting in '{spec}'; use no quotes or exactly one matching outer double-quote pair"
+            ));
+        }
+    };
+
+    if spec.contains('"') {
+        return Err(format!(
+            "invalid BACnetTimeStamp quoting in '{spec}'; embedded or multiple double quotes are not accepted"
+        ));
+    }
+    if spec.contains('\'') {
+        return Err(format!(
+            "invalid BACnetTimeStamp quoting in '{spec}'; single quotes are not accepted"
+        ));
+    }
+    if spec.trim() != spec {
+        return Err(format!(
+            "invalid BACnetTimeStamp whitespace in '{spec}'; leading and trailing whitespace are not accepted"
+        ));
+    }
+    Ok(spec)
+}
+
+/// Parse an exact BACnetTimeStamp CLI value without component normalization.
 pub(crate) fn parse_bacnet_timestamp(spec: &str) -> Result<BACnetTimeStamp, String> {
+    let spec = normalize_outer_double_quotes(spec)?;
     let (kind, value) = spec
         .split_once(':')
         .ok_or_else(|| format!("invalid BACnetTimeStamp '{spec}'; expected {TIMESTAMP_GRAMMAR}"))?;
@@ -154,6 +186,62 @@ mod tests {
                 },
             }
         );
+    }
+
+    #[test]
+    fn accepts_exactly_one_outer_double_quote_pair_for_time_and_datetime() {
+        assert_eq!(
+            parse_bacnet_timestamp("\"time:1,2,3,4\"").unwrap(),
+            BACnetTimeStamp::Time(Time {
+                hour: 1,
+                minute: 2,
+                second: 3,
+                hundredths: 4,
+            })
+        );
+        assert_eq!(
+            parse_bacnet_timestamp("\"datetime:2026,9,2,3;5,6,7,8\"").unwrap(),
+            BACnetTimeStamp::DateTime {
+                date: Date {
+                    year: 126,
+                    month: 9,
+                    day: 2,
+                    day_of_week: 3,
+                },
+                time: Time {
+                    hour: 5,
+                    minute: 6,
+                    second: 7,
+                    hundredths: 8,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_unmatched_embedded_multiple_single_quotes_and_outer_whitespace() {
+        assert_eq!(
+            parse_bacnet_timestamp("\"time:1,2,3,4").unwrap_err(),
+            "invalid BACnetTimeStamp quoting in '\"time:1,2,3,4'; use no quotes or exactly one matching outer double-quote pair"
+        );
+        assert_eq!(
+            parse_bacnet_timestamp("time:1,2,3,4\"").unwrap_err(),
+            "invalid BACnetTimeStamp quoting in 'time:1,2,3,4\"'; use no quotes or exactly one matching outer double-quote pair"
+        );
+        for invalid in [
+            "\"time:1,\"2\",3,4\"",
+            "\"\"time:1,2,3,4\"\"",
+            "'time:1,2,3,4'",
+            " time:1,2,3,4",
+            "time:1,2,3,4 ",
+            "\" time:1,2,3,4\"",
+            "\"time:1,2,3,4 \"",
+        ] {
+            assert!(
+                parse_bacnet_timestamp(invalid).is_err(),
+                "accepted invalid timestamp quoting {invalid}"
+            );
+        }
     }
 
     #[test]

--- a/crates/bacnet-cli/src/timestamp.rs
+++ b/crates/bacnet-cli/src/timestamp.rs
@@ -1,0 +1,204 @@
+//! Strict command-line parsing for the three BACnetTimeStamp choices.
+
+use bacnet_types::primitives::{BACnetTimeStamp, Date, Time};
+
+pub(crate) const TIMESTAMP_GRAMMAR: &str = "sequence:<0..65535>, \
+time:<hour>,<minute>,<second>,<hundredths>, or \
+datetime:<full-year>,<month>,<day>,<day-of-week>;<hour>,<minute>,<second>,<hundredths>";
+
+fn decimal(component: &str, value: &str) -> Result<u32, String> {
+    value.parse::<u32>().map_err(|_| {
+        format!("invalid BACnetTimeStamp {component} '{value}': expected a decimal integer")
+    })
+}
+
+fn ranged_or_unspecified(
+    component: &str,
+    value: &str,
+    minimum: u8,
+    maximum: u8,
+) -> Result<u8, String> {
+    let value = decimal(component, value)?;
+    if value == u32::from(Time::UNSPECIFIED)
+        || (u32::from(minimum)..=u32::from(maximum)).contains(&value)
+    {
+        return Ok(value as u8);
+    }
+    Err(format!(
+        "BACnetTimeStamp {component} must be {minimum}..={maximum} or 255 (unspecified), got {value}"
+    ))
+}
+
+fn fields4<'a>(kind: &str, value: &'a str) -> Result<[&'a str; 4], String> {
+    let fields: Vec<_> = value.split(',').collect();
+    fields.try_into().map_err(|_| {
+        format!(
+            "invalid BACnetTimeStamp {kind} component count; expected exactly 4 comma-separated values ({TIMESTAMP_GRAMMAR})"
+        )
+    })
+}
+
+fn parse_time(value: &str) -> Result<Time, String> {
+    let [hour, minute, second, hundredths] = fields4("time", value)?;
+    Ok(Time {
+        hour: ranged_or_unspecified("hour", hour, 0, 23)?,
+        minute: ranged_or_unspecified("minute", minute, 0, 59)?,
+        second: ranged_or_unspecified("second", second, 0, 59)?,
+        hundredths: ranged_or_unspecified("hundredths", hundredths, 0, 99)?,
+    })
+}
+
+fn parse_date(value: &str) -> Result<Date, String> {
+    let [year, month, day, day_of_week] = fields4("date", value)?;
+    let full_year = decimal("full-year", year)?;
+    let year = match full_year {
+        255 => Date::UNSPECIFIED,
+        1900..=2154 => (full_year - 1900) as u8,
+        _ => {
+            return Err(format!(
+                "BACnetTimeStamp full-year must be 1900..=2154 or 255 (unspecified), got {full_year}"
+            ));
+        }
+    };
+    Ok(Date {
+        year,
+        month: ranged_or_unspecified("month", month, 1, 14)?,
+        day: ranged_or_unspecified("day", day, 1, 34)?,
+        day_of_week: ranged_or_unspecified("day-of-week", day_of_week, 1, 7)?,
+    })
+}
+
+/// Parse an exact BACnetTimeStamp CLI value without normalization.
+pub(crate) fn parse_bacnet_timestamp(spec: &str) -> Result<BACnetTimeStamp, String> {
+    let (kind, value) = spec
+        .split_once(':')
+        .ok_or_else(|| format!("invalid BACnetTimeStamp '{spec}'; expected {TIMESTAMP_GRAMMAR}"))?;
+    match kind {
+        "sequence" => {
+            let sequence = decimal("sequence number", value)?;
+            let sequence = u16::try_from(sequence).map_err(|_| {
+                format!("BACnetTimeStamp sequence number must be 0..=65535, got {sequence}")
+            })?;
+            Ok(BACnetTimeStamp::SequenceNumber(sequence))
+        }
+        "time" => Ok(BACnetTimeStamp::Time(parse_time(value)?)),
+        "datetime" => {
+            let (date, time) = value.split_once(';').ok_or_else(|| {
+                format!("invalid BACnetTimeStamp datetime '{value}'; expected {TIMESTAMP_GRAMMAR}")
+            })?;
+            Ok(BACnetTimeStamp::DateTime {
+                date: parse_date(date)?,
+                time: parse_time(time)?,
+            })
+        }
+        _ => Err(format!(
+            "unknown BACnetTimeStamp kind '{kind}'; expected sequence, time, or datetime ({TIMESTAMP_GRAMMAR})"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_all_choices_boundaries_patterns_and_unspecified_fields() {
+        assert_eq!(
+            parse_bacnet_timestamp("sequence:0").unwrap(),
+            BACnetTimeStamp::SequenceNumber(0)
+        );
+        assert_eq!(
+            parse_bacnet_timestamp("sequence:65535").unwrap(),
+            BACnetTimeStamp::SequenceNumber(65_535)
+        );
+        assert_eq!(
+            parse_bacnet_timestamp("time:23,59,59,99").unwrap(),
+            BACnetTimeStamp::Time(Time {
+                hour: 23,
+                minute: 59,
+                second: 59,
+                hundredths: 99,
+            })
+        );
+        assert_eq!(
+            parse_bacnet_timestamp("datetime:2154,14,34,255;255,0,59,255").unwrap(),
+            BACnetTimeStamp::DateTime {
+                date: Date {
+                    year: 254,
+                    month: 14,
+                    day: 34,
+                    day_of_week: 255,
+                },
+                time: Time {
+                    hour: 255,
+                    minute: 0,
+                    second: 59,
+                    hundredths: 255,
+                },
+            }
+        );
+        assert_eq!(
+            parse_bacnet_timestamp("datetime:255,255,255,255;255,255,255,255").unwrap(),
+            BACnetTimeStamp::DateTime {
+                date: Date {
+                    year: 255,
+                    month: 255,
+                    day: 255,
+                    day_of_week: 255,
+                },
+                time: Time {
+                    hour: 255,
+                    minute: 255,
+                    second: 255,
+                    hundredths: 255,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_unknown_trailing_range_and_lossy_values() {
+        for invalid in [
+            "sequence",
+            "Sequence:1",
+            "unknown:1",
+            "sequence:-1",
+            "sequence:true",
+            "sequence:65536",
+            "sequence:1,2",
+            "time:1,2,3",
+            "time:24,0,0,0",
+            "time:0,60,0,0",
+            "time:0,0,60,0",
+            "time:0,0,0,100",
+            "time:0,0,0,0,trailing",
+            "datetime:2026,1,1,1,0,0,0,0",
+            "datetime:1899,1,1,1;0,0,0,0",
+            "datetime:2155,1,1,1;0,0,0,0",
+            "datetime:2026,0,1,1;0,0,0,0",
+            "datetime:2026,15,1,1;0,0,0,0",
+            "datetime:2026,1,0,1;0,0,0,0",
+            "datetime:2026,1,35,1;0,0,0,0",
+            "datetime:2026,1,1,0;0,0,0,0",
+            "datetime:2026,1,1,8;0,0,0,0",
+            "datetime:2026,1,1,1;0,0,0,0;trailing",
+        ] {
+            assert!(
+                parse_bacnet_timestamp(invalid).is_err(),
+                "accepted invalid timestamp {invalid}"
+            );
+        }
+    }
+
+    #[test]
+    fn errors_are_stable_and_actionable() {
+        assert_eq!(
+            parse_bacnet_timestamp("time:24,0,0,0").unwrap_err(),
+            "BACnetTimeStamp hour must be 0..=23 or 255 (unspecified), got 24"
+        );
+        assert_eq!(
+            parse_bacnet_timestamp("datetime:2155,1,1,1;0,0,0,0").unwrap_err(),
+            "BACnetTimeStamp full-year must be 1900..=2154 or 255 (unspecified), got 2155"
+        );
+    }
+}

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -607,6 +607,51 @@ class ObjectIdentifier:
     def __hash__(self) -> int: ...
 
 
+class BACnetTimeStamp:
+    """Lossless BACnetTimeStamp CHOICE.
+
+    Time components accept their normal BACnet ranges or 255 for unspecified.
+    Date accepts full years 1900..2154 or 255 for unspecified, months 1..14,
+    days 1..34, and days-of-week 1..7; each non-year date field also accepts
+    255 for unspecified. Supplied values are never normalized.
+    """
+
+    @staticmethod
+    def sequence_number(value: int) -> BACnetTimeStamp:
+        """Construct the Sequence Number CHOICE with a value in 0..65535."""
+        ...
+    @staticmethod
+    def time(
+        hour: int, minute: int, second: int, hundredths: int
+    ) -> BACnetTimeStamp:
+        """Construct the Time CHOICE."""
+        ...
+    @staticmethod
+    def date_time(
+        date: tuple[int, int, int, int],
+        time: tuple[int, int, int, int],
+    ) -> BACnetTimeStamp:
+        """Construct DateTime from ``(full_year, month, day, day_of_week)`` and Time tuples."""
+        ...
+
+    @property
+    def kind(self) -> str:
+        """Selected CHOICE: ``sequence_number``, ``time``, or ``date_time``."""
+        ...
+
+    @property
+    def value(
+        self,
+    ) -> int | tuple[int, int, int, int] | tuple[
+        tuple[int, int, int, int], tuple[int, int, int, int]
+    ]:
+        """Exact selected value, using a full year for the Date tuple."""
+        ...
+
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+
+
 class PropertyValue:
     """A decoded BACnet property value with tag and Python-native value.
 
@@ -1182,6 +1227,23 @@ class BACnetClient:
 
     # --- Alarms and events ---
 
+    async def acknowledge_alarm_request(
+        self,
+        address: str,
+        acknowledging_process_identifier: int,
+        event_object_identifier: ObjectIdentifier,
+        event_state_acknowledged: int,
+        timestamp: BACnetTimeStamp,
+        acknowledgment_source: str,
+        time_of_acknowledgment: BACnetTimeStamp,
+    ) -> None:
+        """Acknowledge an alarm with exact caller-supplied BACnetTimeStamp values.
+
+        ``timestamp`` must echo the original event notification timestamp;
+        ``time_of_acknowledgment`` is selected by the caller.
+        """
+        ...
+
     async def acknowledge_alarm(
         self,
         address: str,
@@ -1190,7 +1252,11 @@ class BACnetClient:
         event_state_acknowledged: int,
         acknowledgment_source: str,
     ) -> None:
-        """Acknowledge an alarm on a remote device."""
+        """Deprecated compatibility method.
+
+        This method fabricates sequence-number zero for both timestamps. Use
+        ``acknowledge_alarm_request`` for a lossless request.
+        """
         ...
 
     async def get_event_information(

--- a/crates/rusty-bacnet/src/client/client_methods/object_device_alarm.rs
+++ b/crates/rusty-bacnet/src/client/client_methods/object_device_alarm.rs
@@ -1,5 +1,24 @@
 use super::super::*;
 
+#[allow(clippy::too_many_arguments)]
+fn build_acknowledge_alarm_request(
+    acknowledging_process_identifier: u32,
+    event_object_identifier: bacnet_types::primitives::ObjectIdentifier,
+    event_state_acknowledged: u32,
+    timestamp: BACnetTimeStamp,
+    acknowledgment_source: String,
+    time_of_acknowledgment: BACnetTimeStamp,
+) -> AcknowledgeAlarmRequest {
+    AcknowledgeAlarmRequest {
+        acknowledging_process_identifier,
+        event_object_identifier,
+        event_state_acknowledged,
+        timestamp,
+        acknowledgment_source,
+        time_of_acknowledgment,
+    }
+}
+
 #[pymethods]
 impl BACnetClient {
     // -----------------------------------------------------------------------
@@ -158,7 +177,52 @@ impl BACnetClient {
     // Alarms / Events
     // -----------------------------------------------------------------------
 
-    /// Acknowledge an alarm on a remote device.
+    /// Acknowledge an alarm on a remote device with both caller-supplied timestamps.
+    ///
+    /// `timestamp` must exactly echo the original event-notification timestamp;
+    /// `time_of_acknowledgment` is the caller-selected acknowledgment time.
+    #[pyo3(signature = (address, acknowledging_process_identifier, event_object_identifier, event_state_acknowledged, timestamp, acknowledgment_source, time_of_acknowledgment))]
+    #[allow(clippy::too_many_arguments)]
+    fn acknowledge_alarm_request<'py>(
+        &self,
+        py: Python<'py>,
+        address: String,
+        acknowledging_process_identifier: u32,
+        event_object_identifier: PyObjectIdentifier,
+        event_state_acknowledged: u32,
+        timestamp: PyBACnetTimeStamp,
+        acknowledgment_source: String,
+        time_of_acknowledgment: PyBACnetTimeStamp,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let inner = self.inner.clone();
+        let mac = parse_address(&address)?;
+        let request = build_acknowledge_alarm_request(
+            acknowledging_process_identifier,
+            event_object_identifier.to_rust(),
+            event_state_acknowledged,
+            timestamp.to_rust().clone(),
+            acknowledgment_source,
+            time_of_acknowledgment.to_rust().clone(),
+        );
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let c = {
+                let guard = inner.lock().await;
+                Arc::clone(guard.as_ref().ok_or_else(|| {
+                    PyRuntimeError::new_err("client not started — use 'async with'")
+                })?)
+            };
+            c.acknowledge_alarm_request(&mac, &request)
+                .await
+                .map_err(to_py_err)?;
+            Ok(())
+        })
+    }
+
+    /// Deprecated compatibility helper for acknowledging an alarm.
+    ///
+    /// This method fabricates SequenceNumber(0) for both timestamps. Use
+    /// `acknowledge_alarm_request` with exact caller-supplied timestamps.
     #[pyo3(signature = (address, acknowledging_process_identifier, event_object_identifier, event_state_acknowledged, acknowledgment_source))]
     #[allow(clippy::too_many_arguments, deprecated)]
     fn acknowledge_alarm<'py>(
@@ -170,6 +234,12 @@ impl BACnetClient {
         event_state_acknowledged: u32,
         acknowledgment_source: String,
     ) -> PyResult<Bound<'py, PyAny>> {
+        PyErr::warn(
+            py,
+            &py.get_type::<PyDeprecationWarning>(),
+            c"BACnetClient.acknowledge_alarm() is deprecated; use acknowledge_alarm_request() with exact event and acknowledgment timestamps",
+            2,
+        )?;
         let inner = self.inner.clone();
         let oid = event_object_identifier.to_rust();
 
@@ -295,5 +365,56 @@ impl BACnetClient {
                 Ok(dict.into_any().unbind())
             })
         })
+    }
+}
+
+#[cfg(test)]
+mod acknowledgment_request_tests {
+    use super::*;
+    use bacnet_types::enums::{EventState, ObjectType};
+    use bacnet_types::primitives::{Date, ObjectIdentifier, Time};
+
+    #[test]
+    fn python_request_builder_preserves_mixed_timestamp_choices_and_metadata() {
+        let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 91).unwrap();
+        let event_timestamp = BACnetTimeStamp::Time(Time {
+            hour: 7,
+            minute: 8,
+            second: 9,
+            hundredths: 10,
+        });
+        let acknowledgment_timestamp = BACnetTimeStamp::DateTime {
+            date: Date {
+                year: 126,
+                month: 14,
+                day: 34,
+                day_of_week: Date::UNSPECIFIED,
+            },
+            time: Time {
+                hour: 11,
+                minute: 12,
+                second: 13,
+                hundredths: 14,
+            },
+        };
+
+        let request = build_acknowledge_alarm_request(
+            0x1020_3040,
+            oid,
+            EventState::HIGH_LIMIT.to_raw(),
+            event_timestamp.clone(),
+            "operator-console".into(),
+            acknowledgment_timestamp.clone(),
+        );
+
+        assert_eq!(request.acknowledging_process_identifier, 0x1020_3040);
+        assert_eq!(request.event_object_identifier, oid);
+        assert_eq!(
+            request.event_state_acknowledged,
+            EventState::HIGH_LIMIT.to_raw()
+        );
+        assert_eq!(request.timestamp, event_timestamp);
+        assert_eq!(request.acknowledgment_source, "operator-console");
+        assert_eq!(request.time_of_acknowledgment, acknowledgment_timestamp);
     }
 }

--- a/crates/rusty-bacnet/src/client/mod.rs
+++ b/crates/rusty-bacnet/src/client/mod.rs
@@ -4,13 +4,14 @@ use std::net::Ipv4Addr;
 use std::sync::Arc;
 
 use bytes::BytesMut;
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::exceptions::{PyDeprecationWarning, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
 use tokio::sync::Mutex;
 
 use bacnet_client::client;
 use bacnet_encoding::primitives::{decode_application_value, encode_property_value};
+use bacnet_services::alarm_event::AcknowledgeAlarmRequest;
 use bacnet_services::alarm_summary::GetAlarmSummaryAck;
 type ClientInner =
     Arc<Mutex<Option<Arc<client::BACnetClient<AnyTransport<crate::mstp_py::PySerial>>>>>>;
@@ -37,13 +38,15 @@ use bacnet_transport::any::AnyTransport;
 use bacnet_transport::bip::BipTransport;
 use bacnet_transport::bip6::Bip6Transport;
 use bacnet_types::enums::{ConfirmedServiceChoice, UnconfirmedServiceChoice};
+use bacnet_types::primitives::BACnetTimeStamp;
 
 use crate::errors::to_py_err;
 use crate::types::{
-    parse_address, py_to_rpm_specs, py_to_wpm_specs, rpm_ack_to_py, PyCovNotificationIterator,
-    PyDiscoveredDevice, PyEnableDisable, PyEnrollmentSummaryEventStateFilter, PyEventState,
-    PyEventType, PyLifeSafetyOperation, PyMessagePriority, PyObjectIdentifier, PyObjectType,
-    PyPropertyIdentifier, PyPropertyValue, PyReinitializedState,
+    parse_address, py_to_rpm_specs, py_to_wpm_specs, rpm_ack_to_py, PyBACnetTimeStamp,
+    PyCovNotificationIterator, PyDiscoveredDevice, PyEnableDisable,
+    PyEnrollmentSummaryEventStateFilter, PyEventState, PyEventType, PyLifeSafetyOperation,
+    PyMessagePriority, PyObjectIdentifier, PyObjectType, PyPropertyIdentifier, PyPropertyValue,
+    PyReinitializedState,
 };
 
 /// Async BACnet client for reading/writing properties on remote devices.

--- a/crates/rusty-bacnet/src/types/mod.rs
+++ b/crates/rusty-bacnet/src/types/mod.rs
@@ -29,6 +29,7 @@ mod enums;
 mod object_identifier;
 mod property_value;
 mod rpm_wpm;
+mod timestamp;
 
 pub use address::parse_address;
 pub use cov::{PyCovNotification, PyCovNotificationIterator};
@@ -37,6 +38,7 @@ pub use enums::*;
 pub use object_identifier::PyObjectIdentifier;
 pub use property_value::PyPropertyValue;
 pub(crate) use rpm_wpm::{py_to_rpm_specs, py_to_wpm_specs, rpm_ack_to_py};
+pub use timestamp::PyBACnetTimeStamp;
 
 // Module registration
 // ---------------------------------------------------------------------------
@@ -85,6 +87,7 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Composite types
     m.add_class::<PyObjectIdentifier>()?;
     m.add_class::<PyPropertyValue>()?;
+    m.add_class::<PyBACnetTimeStamp>()?;
     m.add_class::<PyDiscoveredDevice>()?;
     m.add_class::<PyCovNotification>()?;
     m.add_class::<PyCovNotificationIterator>()?;

--- a/crates/rusty-bacnet/src/types/timestamp.rs
+++ b/crates/rusty-bacnet/src/types/timestamp.rs
@@ -1,0 +1,207 @@
+use super::*;
+
+use pyo3::types::{PyBool, PyInt, PyTuple};
+
+/// Python wrapper for the protocol's lossless `BACnetTimeStamp` CHOICE.
+///
+/// Construct one explicitly with `sequence_number`, `time`, or `date_time`.
+/// Date fields accept the complete BACnet pattern domains: month 1..=14,
+/// day 1..=34, day-of-week 1..=7, and 255 for an unspecified field. Time
+/// fields accept their normal ranges or 255 for unspecified. A full year is
+/// 1900..=2154, or 255 for unspecified.
+#[pyclass(name = "BACnetTimeStamp", frozen, from_py_object)]
+#[derive(Clone)]
+pub struct PyBACnetTimeStamp {
+    inner: primitives::BACnetTimeStamp,
+}
+
+impl PyBACnetTimeStamp {
+    pub fn to_rust(&self) -> &primitives::BACnetTimeStamp {
+        &self.inner
+    }
+}
+
+fn integer(value: &Bound<'_, PyAny>, name: &str) -> PyResult<i128> {
+    if value.is_instance_of::<PyBool>() || value.cast::<PyInt>().is_err() {
+        return Err(PyValueError::new_err(format!("{name} must be an integer")));
+    }
+    value
+        .extract::<i128>()
+        .map_err(|_| PyValueError::new_err(format!("{name} must be an integer")))
+}
+
+fn ranged_or_unspecified(
+    value: &Bound<'_, PyAny>,
+    name: &str,
+    minimum: u8,
+    maximum: u8,
+) -> PyResult<u8> {
+    let value = integer(value, name)?;
+    if value == i128::from(primitives::Time::UNSPECIFIED)
+        || (i128::from(minimum)..=i128::from(maximum)).contains(&value)
+    {
+        return Ok(value as u8);
+    }
+    Err(PyValueError::new_err(format!(
+        "{name} must be {minimum}..={maximum} or 255 (unspecified), got {value}"
+    )))
+}
+
+fn full_year(value: &Bound<'_, PyAny>) -> PyResult<u8> {
+    let value = integer(value, "full_year")?;
+    match value {
+        255 => Ok(primitives::Date::UNSPECIFIED),
+        1900..=2154 => Ok((value - 1900) as u8),
+        _ => Err(PyValueError::new_err(format!(
+            "full_year must be 1900..=2154 or 255 (unspecified), got {value}"
+        ))),
+    }
+}
+
+fn time_parts(
+    hour: &Bound<'_, PyAny>,
+    minute: &Bound<'_, PyAny>,
+    second: &Bound<'_, PyAny>,
+    hundredths: &Bound<'_, PyAny>,
+) -> PyResult<primitives::Time> {
+    Ok(primitives::Time {
+        hour: ranged_or_unspecified(hour, "hour", 0, 23)?,
+        minute: ranged_or_unspecified(minute, "minute", 0, 59)?,
+        second: ranged_or_unspecified(second, "second", 0, 59)?,
+        hundredths: ranged_or_unspecified(hundredths, "hundredths", 0, 99)?,
+    })
+}
+
+fn tuple4<'py>(
+    value: &'py Bound<'py, PyAny>,
+    name: &str,
+    shape: &str,
+) -> PyResult<&'py Bound<'py, PyTuple>> {
+    let tuple = value.cast::<PyTuple>().map_err(|_| {
+        PyValueError::new_err(format!(
+            "{name} must be a tuple of exactly 4 integers: {shape}"
+        ))
+    })?;
+    if tuple.len() != 4 {
+        return Err(PyValueError::new_err(format!(
+            "{name} must be a tuple of exactly 4 integers: {shape}"
+        )));
+    }
+    Ok(tuple)
+}
+
+fn actual_year(date: &primitives::Date) -> u16 {
+    date.actual_year()
+        .unwrap_or(u16::from(primitives::Date::UNSPECIFIED))
+}
+
+fn date_value(date: &primitives::Date) -> (u16, u8, u8, u8) {
+    (actual_year(date), date.month, date.day, date.day_of_week)
+}
+
+fn time_value(time: &primitives::Time) -> (u8, u8, u8, u8) {
+    (time.hour, time.minute, time.second, time.hundredths)
+}
+
+#[pymethods]
+impl PyBACnetTimeStamp {
+    /// Construct the Sequence Number CHOICE (0..=65535).
+    #[staticmethod]
+    fn sequence_number(value: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let value = integer(value, "sequence number")?;
+        let value = u16::try_from(value).map_err(|_| {
+            PyValueError::new_err(format!("sequence number must be 0..=65535, got {value}"))
+        })?;
+        Ok(Self {
+            inner: primitives::BACnetTimeStamp::SequenceNumber(value),
+        })
+    }
+
+    /// Construct the Time CHOICE without normalizing any component.
+    #[staticmethod]
+    fn time(
+        hour: &Bound<'_, PyAny>,
+        minute: &Bound<'_, PyAny>,
+        second: &Bound<'_, PyAny>,
+        hundredths: &Bound<'_, PyAny>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: primitives::BACnetTimeStamp::Time(time_parts(hour, minute, second, hundredths)?),
+        })
+    }
+
+    /// Construct the DateTime CHOICE from `(full_year, month, day, day_of_week)`
+    /// and `(hour, minute, second, hundredths)` tuples.
+    #[staticmethod]
+    fn date_time(date: &Bound<'_, PyAny>, time: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let date = tuple4(date, "date", "(full_year, month, day, day_of_week)")?;
+        let time = tuple4(time, "time", "(hour, minute, second, hundredths)")?;
+        let date = primitives::Date {
+            year: full_year(&date.get_item(0)?)?,
+            month: ranged_or_unspecified(&date.get_item(1)?, "month", 1, 14)?,
+            day: ranged_or_unspecified(&date.get_item(2)?, "day", 1, 34)?,
+            day_of_week: ranged_or_unspecified(&date.get_item(3)?, "day_of_week", 1, 7)?,
+        };
+        let time = time_parts(
+            &time.get_item(0)?,
+            &time.get_item(1)?,
+            &time.get_item(2)?,
+            &time.get_item(3)?,
+        )?;
+        Ok(Self {
+            inner: primitives::BACnetTimeStamp::DateTime { date, time },
+        })
+    }
+
+    /// Selected CHOICE: `sequence_number`, `time`, or `date_time`.
+    #[getter]
+    fn kind(&self) -> &'static str {
+        match &self.inner {
+            primitives::BACnetTimeStamp::Time(_) => "time",
+            primitives::BACnetTimeStamp::SequenceNumber(_) => "sequence_number",
+            primitives::BACnetTimeStamp::DateTime { .. } => "date_time",
+        }
+    }
+
+    /// Exact selected value: an integer, a Time tuple, or `(Date, Time)` tuples.
+    #[getter]
+    fn value(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        Ok(match &self.inner {
+            primitives::BACnetTimeStamp::SequenceNumber(value) => {
+                value.into_pyobject(py)?.into_any().unbind()
+            }
+            primitives::BACnetTimeStamp::Time(time) => {
+                time_value(time).into_pyobject(py)?.into_any().unbind()
+            }
+            primitives::BACnetTimeStamp::DateTime { date, time } => {
+                (date_value(date), time_value(time))
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind()
+            }
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        match &self.inner {
+            primitives::BACnetTimeStamp::SequenceNumber(value) => {
+                format!("BACnetTimeStamp.sequence_number({value})")
+            }
+            primitives::BACnetTimeStamp::Time(time) => {
+                let (hour, minute, second, hundredths) = time_value(time);
+                format!("BACnetTimeStamp.time({hour}, {minute}, {second}, {hundredths})")
+            }
+            primitives::BACnetTimeStamp::DateTime { date, time } => {
+                format!(
+                    "BACnetTimeStamp.date_time({:?}, {:?})",
+                    date_value(date),
+                    time_value(time)
+                )
+            }
+        }
+    }
+
+    fn __eq__(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}

--- a/crates/rusty-bacnet/tests/test_acknowledgment_timestamps.py
+++ b/crates/rusty-bacnet/tests/test_acknowledgment_timestamps.py
@@ -1,0 +1,189 @@
+"""Built-artifact tests for lossless AcknowledgeAlarm timestamps."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import unittest
+import warnings
+from pathlib import Path
+from typing import Any
+
+import rusty_bacnet
+from rusty_bacnet import BACnetClient, BACnetTimeStamp, ObjectIdentifier, ObjectType
+
+
+def stub_classes() -> dict[str, ast.ClassDef]:
+    stub_path = Path(rusty_bacnet.__file__).with_suffix(".pyi")
+    tree = ast.parse(stub_path.read_text(encoding="utf-8"), filename=str(stub_path))
+    return {
+        node.name: node for node in tree.body if isinstance(node, ast.ClassDef)
+    }
+
+
+def method(class_node: ast.ClassDef, name: str) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    return next(
+        node
+        for node in class_node.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == name
+    )
+
+
+class BACnetTimeStampArtifactTests(unittest.TestCase):
+    def test_all_choices_preserve_exact_components_and_are_read_only(self) -> None:
+        sequence = BACnetTimeStamp.sequence_number(65_535)
+        time = BACnetTimeStamp.time(23, 59, 59, 99)
+        unspecified = BACnetTimeStamp.time(255, 255, 255, 255)
+        date_time = BACnetTimeStamp.date_time(
+            (2154, 14, 34, 255), (0, 1, 2, 3)
+        )
+        unspecified_date = BACnetTimeStamp.date_time(
+            (255, 255, 255, 255), (255, 255, 255, 255)
+        )
+
+        self.assertEqual((sequence.kind, sequence.value), ("sequence_number", 65_535))
+        self.assertEqual((time.kind, time.value), ("time", (23, 59, 59, 99)))
+        self.assertEqual(unspecified.value, (255, 255, 255, 255))
+        self.assertEqual(
+            date_time.value, ((2154, 14, 34, 255), (0, 1, 2, 3))
+        )
+        self.assertEqual(
+            unspecified_date.value,
+            ((255, 255, 255, 255), (255, 255, 255, 255)),
+        )
+        self.assertEqual(
+            BACnetTimeStamp.date_time((1900, 1, 1, 1), (0, 0, 0, 0)).value,
+            ((1900, 1, 1, 1), (0, 0, 0, 0)),
+        )
+        self.assertEqual(time, BACnetTimeStamp.time(23, 59, 59, 99))
+        self.assertIn("BACnetTimeStamp.date_time", repr(date_time))
+        with self.assertRaises(AttributeError):
+            time.value = (1, 2, 3, 4)  # type: ignore[misc]
+
+    def test_factories_reject_types_booleans_ranges_and_lossy_years(self) -> None:
+        for invalid in (-1, 65_536, True, "1"):
+            with self.subTest(sequence=invalid), self.assertRaises(ValueError):
+                BACnetTimeStamp.sequence_number(invalid)  # type: ignore[arg-type]
+
+        invalid_times = (
+            (24, 0, 0, 0),
+            (0, 60, 0, 0),
+            (0, 0, 60, 0),
+            (0, 0, 0, 100),
+            (True, 0, 0, 0),
+        )
+        for parts in invalid_times:
+            with self.subTest(time=parts), self.assertRaises(ValueError):
+                BACnetTimeStamp.time(*parts)
+
+        invalid_dates: tuple[Any, ...] = (
+            [2026, 1, 1, 1],
+            (2026, 1, 1),
+            (1899, 1, 1, 1),
+            (2155, 1, 1, 1),
+            (2026, 0, 1, 1),
+            (2026, 15, 1, 1),
+            (2026, 1, 0, 1),
+            (2026, 1, 35, 1),
+            (2026, 1, 1, 0),
+            (2026, 1, 1, 8),
+            (True, 1, 1, 1),
+        )
+        for date in invalid_dates:
+            with self.subTest(date=date), self.assertRaises(ValueError):
+                BACnetTimeStamp.date_time(date, (0, 0, 0, 0))
+        with self.assertRaisesRegex(
+            ValueError, "^time must be a tuple of exactly 4 integers"
+        ):
+            invalid_time: Any = (0, 0, 0)
+            BACnetTimeStamp.date_time((2026, 1, 1, 1), invalid_time)
+
+    def test_runtime_stub_and_packaging_are_in_parity(self) -> None:
+        self.assertIs(getattr(rusty_bacnet, "BACnetTimeStamp"), BACnetTimeStamp)
+        module_path = Path(rusty_bacnet.__file__)
+        stub_path = module_path.with_suffix(".pyi")
+        self.assertTrue(stub_path.is_file())
+        self.assertTrue(module_path.with_name("py.typed").is_file())
+        classes = stub_classes()
+        self.assertIn("BACnetTimeStamp", classes)
+
+        runtime_parameters = list(
+            inspect.signature(BACnetClient.acknowledge_alarm_request).parameters.values()
+        )
+        expected = [
+            "self",
+            "address",
+            "acknowledging_process_identifier",
+            "event_object_identifier",
+            "event_state_acknowledged",
+            "timestamp",
+            "acknowledgment_source",
+            "time_of_acknowledgment",
+        ]
+        self.assertEqual([parameter.name for parameter in runtime_parameters], expected)
+        self.assertTrue(
+            all(parameter.default is inspect.Parameter.empty for parameter in runtime_parameters)
+        )
+
+        client_method = method(classes["BACnetClient"], "acknowledge_alarm_request")
+        stub_args = [*client_method.args.posonlyargs, *client_method.args.args]
+        self.assertEqual([arg.arg for arg in stub_args], expected)
+        timestamp_annotation = stub_args[5].annotation
+        acknowledgment_annotation = stub_args[7].annotation
+        self.assertIsNotNone(timestamp_annotation)
+        self.assertIsNotNone(acknowledgment_annotation)
+        assert timestamp_annotation is not None
+        assert acknowledgment_annotation is not None
+        self.assertEqual(ast.unparse(timestamp_annotation), "BACnetTimeStamp")
+        self.assertEqual(ast.unparse(acknowledgment_annotation), "BACnetTimeStamp")
+
+    def test_both_canonical_timestamps_are_mandatory(self) -> None:
+        client = BACnetClient()
+        oid = ObjectIdentifier(ObjectType.ANALOG_INPUT, 1)
+        timestamp = BACnetTimeStamp.sequence_number(1)
+        call: Any = client.acknowledge_alarm_request
+        with self.assertRaises(TypeError):
+            call("127.0.0.1:47808", 7, oid, 1, timestamp, "operator")
+        with self.assertRaises(TypeError):
+            call(
+                "127.0.0.1:47808",
+                7,
+                oid,
+                1,
+                0,
+                "operator",
+                timestamp,
+            )
+
+    def test_legacy_signature_and_warning_precede_lifecycle_failure(self) -> None:
+        expected = [
+            "self",
+            "address",
+            "acknowledging_process_identifier",
+            "event_object_identifier",
+            "event_state_acknowledged",
+            "acknowledgment_source",
+        ]
+        parameters = list(inspect.signature(BACnetClient.acknowledge_alarm).parameters.values())
+        self.assertEqual([parameter.name for parameter in parameters], expected)
+
+        async def invoke() -> None:
+            client = BACnetClient()
+            oid = ObjectIdentifier(ObjectType.ANALOG_INPUT, 1)
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with self.assertRaisesRegex(RuntimeError, "client not started"):
+                    await client.acknowledge_alarm(
+                        "127.0.0.1:47808", 7, oid, 1, "legacy-operator"
+                    )
+                self.assertEqual(len(caught), 1)
+                self.assertIs(caught[0].category, DeprecationWarning)
+                self.assertIn("acknowledge_alarm_request", str(caught[0].message))
+
+        asyncio.run(invoke())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -203,8 +203,11 @@ Subscribes and then watches for COV notifications in real time. Press Ctrl+C to 
 ```bash
 bacnet alarms 192.168.1.100                              # get event/alarm summary
 
-bacnet ack-alarm 192.168.1.100 ai:1 --state 1            # acknowledge an alarm
-bacnet ack-alarm 192.168.1.100 ai:1 --state 1 --source "operator"  # custom source
+bacnet ack-alarm 192.168.1.100 ai:1 --state 1 \
+  --timestamp sequence:417 --ack-time time:14,30,00,00
+bacnet ack-alarm 192.168.1.100 ai:1 --state 1 --source "operator" \
+  --timestamp time:14,29,58,25 \
+  --ack-time "datetime:2026,9,2,3;14,30,00,00"
 ```
 
 **ack-alarm flags:**
@@ -212,7 +215,25 @@ bacnet ack-alarm 192.168.1.100 ai:1 --state 1 --source "operator"  # custom sour
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--state <N>` | (required) | Event state to acknowledge (0=normal, 1=fault, etc.) |
+| `--timestamp <SPEC>` | (required) | Exact timestamp from the original event notification |
+| `--ack-time <SPEC>` | (required) | Caller-selected time of acknowledgment |
 | `--source <S>` | `bacnet-cli` | Acknowledgment source string |
+
+Both timestamp flags use the same strict grammar:
+
+- `sequence:<0..65535>`
+- `time:<hour>,<minute>,<second>,<hundredths>`
+- `datetime:<full-year>,<month>,<day>,<day-of-week>;<hour>,<minute>,<second>,<hundredths>`
+
+Date years are `1900..2154`; months are `1..14`, days are `1..34`,
+days-of-week are `1..7`, and Time uses hours `0..23`, minutes/seconds
+`0..59`, and hundredths `0..99`. Any Date/Time component may be `255`
+when BACnet's unspecified value is intended (use full-year `255` for an
+unspecified year). Values are preserved exactly and neither timestamp is
+inferred from a clock. Quote `datetime:` values in command shells because the
+grammar contains a semicolon. `--timestamp` must come from the original event
+notification; `--ack-time` is explicitly chosen by the caller. The current
+raw `alarms` response is not a guided source for these values.
 
 **Alias:** `ack` = ack-alarm
 


### PR DESCRIPTION
## Summary
- expose a protocol-backed Python `BACnetTimeStamp` with Time, Sequence Number, and DateTime factories
- add canonical Python `BACnetClient.acknowledge_alarm_request` with both mandatory timestamps
- retain the existing five-argument Python helper as a warning-emitting deprecated compatibility path
- require exact `--timestamp` and `--ack-time` values for one-shot and interactive CLI acknowledgment
- route both public canonical paths through the existing lossless Rust request API

## Source-to-behavior traceability
| ANSI/ASHRAE 135-2020 source | Implemented behavior |
|---|---|
| §13.5 / Table 13-9 | Python and CLI preserve all six mandatory AcknowledgeAlarm fields; the event timestamp is caller-supplied and neither timestamp is fabricated. |
| Clause 21 | Both public paths carry `BACnetTimeStamp` values into the canonical Rust service request. |
| BACnetTimeStamp production | Python and CLI represent Time, Sequence Number `0..=65535`, and DateTime choices without normalization. |

Server state/timestamp correlation remains owned by merged PR #493. Typed GetEventInformation output, additional object families (#170), and ACK_NOTIFICATION distribution (#175) remain separate work.

## Compatibility
- **Python:** additive canonical API; the existing positional `acknowledge_alarm` signature remains available and emits `DeprecationWarning` before retaining its historical sequence-zero behavior.
- **CLI:** intentionally breaking invocation; `ack-alarm` and alias `ack` now require both `--timestamp` and `--ack-time`.
- CLI grammar:
  - `sequence:N`, where N is `0..65535`
  - `time:H,M,S,HS`
  - `datetime:Y,M,D,DOW;H,M,S,HS`

## Validation
- focused Python timestamp/request, CLI parser/Clap/shell/request-builder, client codec, and service round-trip tests
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-client --locked`
- `cargo test -p bacnet-services --locked`
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-cli --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- ephemeral CPython 3.14 wheel build/install/import: 22 artifact tests passed; `.pyi` and `py.typed` verified
- conformance-doc, file-size, no-secret, and `git diff --check`

Closes #132