### PR TITLE
feat(server): add strict input Present_Value updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Rust-only, application-owned logical `Present_Value` updates for in-service
+  Analog Input, Binary Input, and Multi-state Input objects, using the existing
+  server post-write intrinsic-event and COV processing. Out-of-service client
+  simulations remain protected; Python exposure remains tracked in #503.
+
 - Correlated AcknowledgeAlarm core validation and a lossless Rust request API
   (#132). The bundled server now requires the latest committed original
   To State and exact timestamp before setting one supported Analog or Event

--- a/crates/bacnet-objects/src/analog/input.rs
+++ b/crates/bacnet-objects/src/analog/input.rs
@@ -62,13 +62,32 @@ impl AnalogInputObject {
         })
     }
 
-    /// Set the present value (used by the application to update sensor readings).
+    /// Mutate `Present_Value` on an unattached or otherwise application-owned object.
+    ///
+    /// This low-level helper bypasses running-server `Out_Of_Service` ownership,
+    /// validation, intrinsic-event processing, and COV processing. Applications
+    /// updating a live object should use `BACnetServer::set_present_value_local`.
     pub fn set_present_value(&mut self, value: f32) {
         debug_assert!(
             value.is_finite(),
             "set_present_value called with non-finite value"
         );
         self.present_value = value;
+    }
+
+    /// Validate and store a `Present_Value` write, without any access check.
+    ///
+    /// Shared by the network and internal routes, which differ only in the
+    /// `Out_Of_Service` condition each requires.
+    fn apply_present_value(&mut self, value: PropertyValue) -> Result<(), Error> {
+        let PropertyValue::Real(v) = value else {
+            return Err(common::invalid_data_type_error());
+        };
+        if !v.is_finite() {
+            return Err(common::value_out_of_range_error());
+        }
+        self.present_value = v;
+        Ok(())
     }
 
     /// Set the description string.
@@ -175,14 +194,7 @@ impl BACnetObject for AnalogInputObject {
             if !self.out_of_service {
                 return Err(common::write_access_denied_error());
             }
-            if let PropertyValue::Real(v) = value {
-                if !v.is_finite() {
-                    return Err(common::value_out_of_range_error());
-                }
-                self.present_value = v;
-                return Ok(());
-            }
-            return Err(common::invalid_data_type_error());
+            return self.apply_present_value(value);
         }
         if let Some(result) = self.reliability_inhibit.write_inhibit(
             &mut self.reliability,
@@ -333,6 +345,14 @@ impl BACnetObject for AnalogInputObject {
         self.reliability = reliability;
         self.fault_out_of_range.clear_ownership();
         Ok(())
+    }
+
+    fn set_present_value_internal(&mut self, value: PropertyValue) -> Result<(), Error> {
+        // Local safe-ownership policy: preserve the client's OOS simulation.
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        self.apply_present_value(value)
     }
 
     fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {

--- a/crates/bacnet-objects/src/binary/input.rs
+++ b/crates/bacnet-objects/src/binary/input.rs
@@ -206,9 +206,30 @@ impl BinaryInputObject {
         })
     }
 
-    /// Set the present value (used by application to update input state).
+    /// Mutate logical `Present_Value` on an unattached or application-owned object.
+    ///
+    /// The value is BACnet INACTIVE (`0`) or ACTIVE (`1`) **after Polarity**,
+    /// not a raw electrical or physical state. This low-level helper bypasses
+    /// running-server `Out_Of_Service` ownership, validation, intrinsic-event
+    /// processing, and COV processing. Applications updating a live object
+    /// should use `BACnetServer::set_present_value_local`.
     pub fn set_present_value(&mut self, value: u32) {
         self.present_value = value;
+    }
+
+    /// Validate and store a `Present_Value` write, without any access check.
+    ///
+    /// Shared by the network and internal routes, which differ only in the
+    /// `Out_Of_Service` condition each requires.
+    fn apply_present_value(&mut self, value: PropertyValue) -> Result<(), Error> {
+        let PropertyValue::Enumerated(v) = value else {
+            return Err(common::invalid_data_type_error());
+        };
+        if v > 1 {
+            return Err(common::value_out_of_range_error());
+        }
+        self.present_value = v;
+        Ok(())
     }
 
     /// Set the description string.
@@ -320,14 +341,7 @@ impl BACnetObject for BinaryInputObject {
             if !self.out_of_service {
                 return Err(common::write_access_denied_error());
             }
-            if let PropertyValue::Enumerated(v) = value {
-                if v > 1 {
-                    return Err(common::value_out_of_range_error());
-                }
-                self.present_value = v;
-                return Ok(());
-            }
-            return Err(common::invalid_data_type_error());
+            return self.apply_present_value(value);
         }
         if property == PropertyIdentifier::ACTIVE_TEXT {
             if let PropertyValue::CharacterString(s) = value {
@@ -422,6 +436,14 @@ impl BACnetObject for BinaryInputObject {
         }
         self.reliability = reliability;
         Ok(())
+    }
+
+    fn set_present_value_internal(&mut self, value: PropertyValue) -> Result<(), Error> {
+        // Local safe-ownership policy: preserve the client's OOS simulation.
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        self.apply_present_value(value)
     }
 
     fn reliability_evaluation_inhibited_internal(&self) -> bool {

--- a/crates/bacnet-objects/src/multistate/input.rs
+++ b/crates/bacnet-objects/src/multistate/input.rs
@@ -64,10 +64,31 @@ impl MultiStateInputObject {
         self.event_detector.alarm_values = values;
     }
 
-    /// Set the present value (used by application to update input state).
+    /// Mutate `Present_Value` on an unattached or otherwise application-owned object.
+    ///
+    /// This low-level helper bypasses running-server `Out_Of_Service` ownership,
+    /// range validation, intrinsic-event processing, and COV processing, while
+    /// retaining this object's reliability recomputation. Applications updating
+    /// a live object should use `BACnetServer::set_present_value_local`.
     pub fn set_present_value(&mut self, value: u32) {
         self.present_value = value;
         let _ = self.recompute_reliability();
+    }
+
+    /// Validate and store a `Present_Value` write, without any access check.
+    ///
+    /// Shared by the network and internal routes, which differ only in the
+    /// `Out_Of_Service` condition each requires.
+    fn apply_present_value(&mut self, value: PropertyValue) -> Result<(), Error> {
+        let PropertyValue::Unsigned(v) = value else {
+            return Err(common::invalid_data_type_error());
+        };
+        if v < 1 || v > self.number_of_states as u64 {
+            return Err(common::value_out_of_range_error());
+        }
+        self.present_value = v as u32;
+        let _ = self.recompute_reliability();
+        Ok(())
     }
 
     /// Change the locally configured number of states.
@@ -209,15 +230,7 @@ impl BACnetObject for MultiStateInputObject {
             if !self.out_of_service {
                 return Err(common::write_access_denied_error());
             }
-            if let PropertyValue::Unsigned(v) = value {
-                if v < 1 || v > self.number_of_states as u64 {
-                    return Err(common::value_out_of_range_error());
-                }
-                self.present_value = v as u32;
-                let _ = self.recompute_reliability();
-                return Ok(());
-            }
-            return Err(common::invalid_data_type_error());
+            return self.apply_present_value(value);
         }
         if property == PropertyIdentifier::STATE_TEXT {
             match array_index {
@@ -338,6 +351,14 @@ impl BACnetObject for MultiStateInputObject {
         self.reliability = reliability;
         self.reliability_evaluator.clear_ownership();
         Ok(())
+    }
+
+    fn set_present_value_internal(&mut self, value: PropertyValue) -> Result<(), Error> {
+        // Local safe-ownership policy: preserve the client's OOS simulation.
+        if self.out_of_service {
+            return Err(common::write_access_denied_error());
+        }
+        self.apply_present_value(value)
     }
 
     fn evaluate_reliability_internal(&mut self) -> Result<ReliabilityEvaluation, Error> {

--- a/crates/bacnet-objects/src/reliability_writability_tests.rs
+++ b/crates/bacnet-objects/src/reliability_writability_tests.rs
@@ -356,3 +356,286 @@ reliability_gate_test!(
     schedule_reliability_requires_out_of_service,
     ScheduleObject::new(1, "SCHED-1", PropertyValue::Real(0.0)).unwrap()
 );
+
+fn assert_protocol_error(error: Error, class: ErrorClass, code: ErrorCode) {
+    match error {
+        Error::Protocol {
+            class: actual_class,
+            code: actual_code,
+        } => {
+            assert_eq!(actual_class, class.to_raw() as u32);
+            assert_eq!(actual_code, code.to_raw() as u32);
+        }
+        other => panic!("expected {class:?} / {code:?}, got {other:?}"),
+    }
+}
+
+fn read(object: &dyn BACnetObject, property: PropertyIdentifier) -> PropertyValue {
+    object
+        .read_property(property, None)
+        .expect("test property must be readable")
+}
+
+/// Clients own an Input's simulation while OOS; the application owns its live
+/// logical value while in service.
+fn assert_present_value_ownership(
+    object: &mut dyn BACnetObject,
+    application_value: PropertyValue,
+    simulated_value: PropertyValue,
+    rejected_application_value: PropertyValue,
+) {
+    let initial = read(object, PropertyIdentifier::PRESENT_VALUE);
+    let denied = object
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            application_value.clone(),
+            None,
+        )
+        .expect_err("in-service Present_Value write must be refused over the network");
+    assert_protocol_error(denied, ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED);
+    assert_eq!(read(object, PropertyIdentifier::PRESENT_VALUE), initial);
+
+    object
+        .set_present_value_internal(application_value.clone())
+        .expect("the application must supply Present_Value while in service");
+
+    assert_eq!(
+        read(object, PropertyIdentifier::PRESENT_VALUE),
+        application_value
+    );
+    assert_eq!(
+        read(object, PropertyIdentifier::OUT_OF_SERVICE),
+        PropertyValue::Boolean(false),
+        "supplying a value must not put the object out of service"
+    );
+
+    object
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .expect("Out_Of_Service must be writable");
+    object
+        .write_property(
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            simulated_value.clone(),
+            None,
+        )
+        .expect("the network may supply an out-of-service simulation value");
+    let simulated_reliability = read(object, PropertyIdentifier::RELIABILITY);
+
+    let denied = object
+        .set_present_value_internal(rejected_application_value)
+        .expect_err("the application must not override an out-of-service value");
+    assert_protocol_error(denied, ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED);
+    assert_eq!(
+        read(object, PropertyIdentifier::PRESENT_VALUE),
+        simulated_value
+    );
+    assert_eq!(
+        read(object, PropertyIdentifier::RELIABILITY),
+        simulated_reliability,
+        "an OOS application rejection must not recompute Reliability"
+    );
+}
+
+#[test]
+fn analog_input_present_value_is_application_supplied() {
+    let mut object = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+    assert_present_value_ownership(
+        &mut object,
+        PropertyValue::Real(21.5),
+        PropertyValue::Real(72.0),
+        PropertyValue::Real(19.0),
+    );
+}
+
+#[test]
+fn binary_input_present_value_is_application_supplied() {
+    let mut object = BinaryInputObject::new(1, "BI-1").unwrap();
+    assert_present_value_ownership(
+        &mut object,
+        PropertyValue::Enumerated(1),
+        PropertyValue::Enumerated(0),
+        PropertyValue::Enumerated(1),
+    );
+}
+
+#[test]
+fn multistate_input_present_value_is_application_supplied() {
+    let mut object = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
+    assert_present_value_ownership(
+        &mut object,
+        PropertyValue::Unsigned(2),
+        PropertyValue::Unsigned(3),
+        PropertyValue::Unsigned(1),
+    );
+}
+
+#[test]
+fn commandable_present_value_fails_closed_by_default() {
+    let mut object = AnalogValueObject::new(1, "AV-1", 62).unwrap();
+
+    let error = object
+        .set_present_value_internal(PropertyValue::Real(21.5))
+        .expect_err("commandable objects must not inherit privileged authority");
+    assert_protocol_error(
+        error,
+        ErrorClass::OBJECT,
+        ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+    );
+    assert_eq!(
+        read(&object, PropertyIdentifier::PRESENT_VALUE),
+        PropertyValue::Real(0.0)
+    );
+}
+
+fn assert_internal_rejection_is_atomic(
+    object: &mut dyn BACnetObject,
+    value: PropertyValue,
+    code: ErrorCode,
+) {
+    let present_value = read(object, PropertyIdentifier::PRESENT_VALUE);
+    let reliability = read(object, PropertyIdentifier::RELIABILITY);
+    let error = object
+        .set_present_value_internal(value)
+        .expect_err("invalid application Present_Value must be refused");
+    assert_protocol_error(error, ErrorClass::PROPERTY, code);
+    assert_eq!(
+        read(object, PropertyIdentifier::PRESENT_VALUE),
+        present_value
+    );
+    assert_eq!(read(object, PropertyIdentifier::RELIABILITY), reliability);
+}
+
+#[test]
+fn application_present_value_writes_are_still_validated() {
+    let mut analog = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+    analog
+        .set_present_value_internal(PropertyValue::Real(21.5))
+        .unwrap();
+    assert_internal_rejection_is_atomic(
+        &mut analog,
+        PropertyValue::Enumerated(1),
+        ErrorCode::INVALID_DATA_TYPE,
+    );
+    for value in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+        assert_internal_rejection_is_atomic(
+            &mut analog,
+            PropertyValue::Real(value),
+            ErrorCode::VALUE_OUT_OF_RANGE,
+        );
+    }
+
+    let mut binary = BinaryInputObject::new(1, "BI-1").unwrap();
+    binary
+        .set_present_value_internal(PropertyValue::Enumerated(1))
+        .unwrap();
+    assert_internal_rejection_is_atomic(
+        &mut binary,
+        PropertyValue::Boolean(false),
+        ErrorCode::INVALID_DATA_TYPE,
+    );
+    assert_internal_rejection_is_atomic(
+        &mut binary,
+        PropertyValue::Enumerated(2),
+        ErrorCode::VALUE_OUT_OF_RANGE,
+    );
+
+    let mut multistate = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
+    multistate
+        .set_present_value_internal(PropertyValue::Unsigned(2))
+        .unwrap();
+    assert_internal_rejection_is_atomic(
+        &mut multistate,
+        PropertyValue::Enumerated(1),
+        ErrorCode::INVALID_DATA_TYPE,
+    );
+    for value in [0, 4] {
+        assert_internal_rejection_is_atomic(
+            &mut multistate,
+            PropertyValue::Unsigned(value),
+            ErrorCode::VALUE_OUT_OF_RANGE,
+        );
+    }
+}
+
+#[test]
+fn multistate_application_updates_preserve_reliability_policy() {
+    let mut object = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
+    object
+        .set_present_value_internal(PropertyValue::Unsigned(3))
+        .unwrap();
+    object.set_number_of_states(2).unwrap();
+    assert_eq!(
+        read(&object, PropertyIdentifier::RELIABILITY),
+        PropertyValue::Enumerated(Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw())
+    );
+    object
+        .set_present_value_internal(PropertyValue::Unsigned(2))
+        .unwrap();
+    assert_eq!(
+        read(&object, PropertyIdentifier::RELIABILITY),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+        "a valid application update must synchronously recompute Reliability"
+    );
+
+    object
+        .write_property(
+            PropertyIdentifier::RELIABILITY_EVALUATION_INHIBIT,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    object.set_number_of_states(1).unwrap();
+    assert_eq!(
+        read(&object, PropertyIdentifier::RELIABILITY),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+        "inhibit must suppress the shrink-triggered recomputation"
+    );
+    object
+        .write_property(
+            PropertyIdentifier::RELIABILITY_EVALUATION_INHIBIT,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        read(&object, PropertyIdentifier::RELIABILITY),
+        PropertyValue::Enumerated(Reliability::MULTI_STATE_OUT_OF_RANGE.to_raw())
+    );
+
+    object.set_number_of_states(2).unwrap();
+    object
+        .write_property(
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    object.set_number_of_states(1).unwrap();
+    assert_eq!(
+        read(&object, PropertyIdentifier::RELIABILITY),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+        "OOS must suppress local reliability evaluation"
+    );
+    let error = object
+        .set_present_value_internal(PropertyValue::Unsigned(1))
+        .expect_err("application update must not replace the OOS simulation");
+    assert_protocol_error(error, ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED);
+    assert_eq!(
+        read(&object, PropertyIdentifier::PRESENT_VALUE),
+        PropertyValue::Unsigned(2)
+    );
+    assert_eq!(
+        read(&object, PropertyIdentifier::RELIABILITY),
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw())
+    );
+}

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -715,6 +715,24 @@ pub trait BACnetObject: Send + Sync {
         })
     }
 
+    /// Apply the logical `Present_Value` supplied by an Input's application.
+    ///
+    /// This narrow internal hook is distinct from the network
+    /// [`write_property`](Self::write_property) route. Built-in Analog Input,
+    /// Binary Input, and Multi-state Input objects opt in. Their implementations
+    /// accept application updates only while in service; rejecting them while
+    /// `Out_Of_Service` is TRUE is a local ownership policy that protects the
+    /// client's simulation value, not a requirement imposed by the Standard.
+    ///
+    /// The default fails closed so commandable and other object families do not
+    /// acquire privileged `Present_Value` write authority through this hook.
+    fn set_present_value_internal(&mut self, _value: PropertyValue) -> Result<(), Error> {
+        Err(Error::Protocol {
+            class: ErrorClass::OBJECT.to_raw() as u32,
+            code: ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw() as u32,
+        })
+    }
+
     /// Borrow this object's Audit Log query storage, if it has any.
     ///
     /// This read-only, type-erased channel lets the bundled server execute an

--- a/crates/bacnet-server/src/server/input_present_value_tests.rs
+++ b/crates/bacnet-server/src/server/input_present_value_tests.rs
@@ -1,0 +1,476 @@
+use super::super::cov_notifications_tests::RecordingTransport;
+use super::super::*;
+use bacnet_encoding::{apdu::decode_apdu, npdu::decode_npdu};
+use bacnet_objects::analog::{AnalogInputObject, AnalogValueObject};
+use bacnet_objects::binary::BinaryInputObject;
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_objects::multistate::MultiStateInputObject;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_services::cov::COVNotificationRequest;
+use bacnet_types::enums::{EventState, Reliability};
+use bytes::Bytes;
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
+
+type SentFrames = StdArc<StdMutex<Vec<(Bytes, MacAddr)>>>;
+
+struct Fixture {
+    server: BACnetServer<RecordingTransport>,
+    sent: SentFrames,
+    ai: ObjectIdentifier,
+    bi: ObjectIdentifier,
+    msi: ObjectIdentifier,
+    av: ObjectIdentifier,
+}
+
+async fn fixture() -> Fixture {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let mut ai = AnalogInputObject::new(1, "AI-1", 62).unwrap();
+    for (property, value) in [
+        (PropertyIdentifier::HIGH_LIMIT, PropertyValue::Real(80.0)),
+        (PropertyIdentifier::LOW_LIMIT, PropertyValue::Real(20.0)),
+        (PropertyIdentifier::DEADBAND, PropertyValue::Real(2.0)),
+        (
+            PropertyIdentifier::LIMIT_ENABLE,
+            PropertyValue::BitString {
+                unused_bits: 6,
+                data: vec![0xC0],
+            },
+        ),
+        (
+            PropertyIdentifier::EVENT_ENABLE,
+            PropertyValue::BitString {
+                unused_bits: 5,
+                data: vec![0x80],
+            },
+        ),
+    ] {
+        ai.write_property(property, None, value, None).unwrap();
+    }
+
+    let bi = BinaryInputObject::new(1, "BI-1").unwrap();
+    let msi = MultiStateInputObject::new(1, "MSI-1", 3).unwrap();
+    let av = AnalogValueObject::new(1, "AV-1", 62).unwrap();
+    let ids = (
+        ai.object_identifier(),
+        bi.object_identifier(),
+        msi.object_identifier(),
+        av.object_identifier(),
+    );
+    let device = DeviceObject::new(DeviceConfig {
+        instance: 100,
+        name: "Input-local-write-test-device".into(),
+        ..DeviceConfig::default()
+    })
+    .unwrap();
+
+    let mut db = clocked_test_database();
+    db.add(Box::new(device)).unwrap();
+    db.add(Box::new(ai)).unwrap();
+    db.add(Box::new(bi)).unwrap();
+    db.add(Box::new(msi)).unwrap();
+    db.add(Box::new(av)).unwrap();
+    let server = BACnetServer::generic_builder()
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .database(db)
+        .enable_event_enrollment(false)
+        .build()
+        .await
+        .unwrap();
+
+    Fixture {
+        server,
+        sent,
+        ai: ids.0,
+        bi: ids.1,
+        msi: ids.2,
+        av: ids.3,
+    }
+}
+
+async fn read(
+    server: &BACnetServer<RecordingTransport>,
+    oid: &ObjectIdentifier,
+    property: PropertyIdentifier,
+) -> PropertyValue {
+    server
+        .database()
+        .read()
+        .await
+        .get(oid)
+        .unwrap()
+        .read_property(property, None)
+        .unwrap()
+}
+
+fn assert_protocol_error(error: Error, class: ErrorClass, code: ErrorCode) {
+    match error {
+        Error::Protocol {
+            class: actual_class,
+            code: actual_code,
+        } => {
+            assert_eq!(actual_class, class.to_raw() as u32);
+            assert_eq!(actual_code, code.to_raw() as u32);
+        }
+        other => panic!("expected {class:?} / {code:?}, got {other:?}"),
+    }
+}
+
+async fn subscribe(server: &BACnetServer<RecordingTransport>, oid: ObjectIdentifier) {
+    server.cov_table.write().await.subscribe(CovSubscription {
+        subscriber_mac: MacAddr::from_slice(&[
+            127,
+            0,
+            0,
+            1,
+            0xBA,
+            oid.object_type().to_raw() as u8,
+        ]),
+        subscriber_network: None,
+        subscriber_process_identifier: oid.object_type().to_raw(),
+        monitored_object_identifier: oid,
+        issue_confirmed_notifications: false,
+        expires_at: None,
+        last_notified_value: None,
+        monitored_property: Some(PropertyIdentifier::PRESENT_VALUE),
+        monitored_property_array_index: None,
+        cov_increment: None,
+        notification_kind: CovNotificationKind::Single,
+        timestamped: false,
+    });
+}
+
+async fn object_state(
+    server: &BACnetServer<RecordingTransport>,
+    oid: &ObjectIdentifier,
+) -> (PropertyValue, PropertyValue) {
+    (
+        read(server, oid, PropertyIdentifier::PRESENT_VALUE).await,
+        read(server, oid, PropertyIdentifier::RELIABILITY).await,
+    )
+}
+
+async fn assert_rejected_without_mutation(
+    fixture: &Fixture,
+    oid: &ObjectIdentifier,
+    value: PropertyValue,
+    code: ErrorCode,
+) {
+    let before = object_state(&fixture.server, oid).await;
+    let sent_before = fixture.sent.lock().unwrap().len();
+    let error = fixture
+        .server
+        .set_present_value_local(oid, value)
+        .await
+        .expect_err("invalid input value must be rejected");
+    assert_protocol_error(error, ErrorClass::PROPERTY, code);
+    assert_eq!(object_state(&fixture.server, oid).await, before);
+    assert_eq!(fixture.sent.lock().unwrap().len(), sent_before);
+}
+
+#[tokio::test]
+async fn application_path_updates_only_supported_inputs_while_in_service() {
+    let mut fixture = fixture().await;
+    for (oid, value) in [
+        (fixture.ai, PropertyValue::Real(21.5)),
+        (fixture.bi, PropertyValue::Enumerated(1)),
+        (fixture.msi, PropertyValue::Unsigned(2)),
+    ] {
+        fixture
+            .server
+            .set_present_value_local(&oid, value.clone())
+            .await
+            .unwrap();
+        assert_eq!(
+            read(&fixture.server, &oid, PropertyIdentifier::PRESENT_VALUE).await,
+            value
+        );
+        assert_eq!(
+            read(&fixture.server, &oid, PropertyIdentifier::OUT_OF_SERVICE).await,
+            PropertyValue::Boolean(false)
+        );
+    }
+    fixture.server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn network_and_application_routes_preserve_input_simulation_ownership() {
+    let mut fixture = fixture().await;
+    subscribe(&fixture.server, fixture.ai).await;
+
+    let error = fixture
+        .server
+        .write_local(
+            &fixture.ai,
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(40.0),
+            None,
+        )
+        .await
+        .expect_err("network-equivalent in-service write must be denied");
+    assert_protocol_error(error, ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED);
+    assert_eq!(
+        read(
+            &fixture.server,
+            &fixture.ai,
+            PropertyIdentifier::PRESENT_VALUE
+        )
+        .await,
+        PropertyValue::Real(0.0)
+    );
+    assert!(fixture.sent.lock().unwrap().is_empty());
+
+    fixture
+        .server
+        .write_local(
+            &fixture.ai,
+            PropertyIdentifier::OUT_OF_SERVICE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .await
+        .unwrap();
+    fixture
+        .server
+        .write_local(
+            &fixture.ai,
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(72.0),
+            None,
+        )
+        .await
+        .unwrap();
+    let reliability = read(
+        &fixture.server,
+        &fixture.ai,
+        PropertyIdentifier::RELIABILITY,
+    )
+    .await;
+    let sent_before_rejection = fixture.sent.lock().unwrap().len();
+
+    let error = fixture
+        .server
+        .set_present_value_local(&fixture.ai, PropertyValue::Real(19.0))
+        .await
+        .expect_err("application must not replace an OOS simulation");
+    assert_protocol_error(error, ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED);
+    assert_eq!(
+        read(
+            &fixture.server,
+            &fixture.ai,
+            PropertyIdentifier::PRESENT_VALUE
+        )
+        .await,
+        PropertyValue::Real(72.0)
+    );
+    assert_eq!(
+        read(
+            &fixture.server,
+            &fixture.ai,
+            PropertyIdentifier::RELIABILITY
+        )
+        .await,
+        reliability
+    );
+    assert_eq!(
+        fixture.sent.lock().unwrap().len(),
+        sent_before_rejection,
+        "rejected application update must not enter the COV path"
+    );
+    fixture.server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn server_path_rejects_invalid_input_values_atomically() {
+    let mut fixture = fixture().await;
+    for oid in [fixture.ai, fixture.bi, fixture.msi] {
+        subscribe(&fixture.server, oid).await;
+    }
+    for (oid, value) in [
+        (fixture.ai, PropertyValue::Real(21.5)),
+        (fixture.bi, PropertyValue::Enumerated(1)),
+        (fixture.msi, PropertyValue::Unsigned(2)),
+    ] {
+        fixture
+            .server
+            .set_present_value_local(&oid, value)
+            .await
+            .unwrap();
+    }
+    fixture.sent.lock().unwrap().clear();
+
+    for (oid, value, code) in [
+        (
+            fixture.ai,
+            PropertyValue::Enumerated(1),
+            ErrorCode::INVALID_DATA_TYPE,
+        ),
+        (
+            fixture.ai,
+            PropertyValue::Real(f32::NAN),
+            ErrorCode::VALUE_OUT_OF_RANGE,
+        ),
+        (
+            fixture.bi,
+            PropertyValue::Boolean(false),
+            ErrorCode::INVALID_DATA_TYPE,
+        ),
+        (
+            fixture.bi,
+            PropertyValue::Enumerated(2),
+            ErrorCode::VALUE_OUT_OF_RANGE,
+        ),
+        (
+            fixture.msi,
+            PropertyValue::Enumerated(1),
+            ErrorCode::INVALID_DATA_TYPE,
+        ),
+        (
+            fixture.msi,
+            PropertyValue::Unsigned(0),
+            ErrorCode::VALUE_OUT_OF_RANGE,
+        ),
+        (
+            fixture.msi,
+            PropertyValue::Unsigned(4),
+            ErrorCode::VALUE_OUT_OF_RANGE,
+        ),
+    ] {
+        assert_rejected_without_mutation(&fixture, &oid, value, code).await;
+    }
+    fixture.server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn unknown_and_unsupported_objects_fail_before_side_effects() {
+    let mut fixture = fixture().await;
+    let unknown = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 999).unwrap();
+    subscribe(&fixture.server, fixture.av).await;
+    subscribe(&fixture.server, unknown).await;
+
+    let error = fixture
+        .server
+        .set_present_value_local(&unknown, PropertyValue::Real(1.0))
+        .await
+        .expect_err("unknown object must fail");
+    assert_protocol_error(error, ErrorClass::OBJECT, ErrorCode::UNKNOWN_OBJECT);
+    let error = fixture
+        .server
+        .set_present_value_local(&fixture.av, PropertyValue::Real(42.0))
+        .await
+        .expect_err("commandable object must not use the privileged input path");
+    assert_protocol_error(
+        error,
+        ErrorClass::OBJECT,
+        ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED,
+    );
+    assert_eq!(
+        read(
+            &fixture.server,
+            &fixture.av,
+            PropertyIdentifier::PRESENT_VALUE
+        )
+        .await,
+        PropertyValue::Real(0.0)
+    );
+    assert_eq!(
+        read(
+            &fixture.server,
+            &fixture.av,
+            PropertyIdentifier::RELIABILITY
+        )
+        .await,
+        PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw())
+    );
+    assert!(fixture.sent.lock().unwrap().is_empty());
+
+    fixture
+        .server
+        .write_local(
+            &fixture.av,
+            PropertyIdentifier::PRESENT_VALUE,
+            None,
+            PropertyValue::Real(42.0),
+            Some(8),
+        )
+        .await
+        .expect("generic local route must retain commandable-object behavior");
+    assert_eq!(
+        read(
+            &fixture.server,
+            &fixture.av,
+            PropertyIdentifier::PRESENT_VALUE
+        )
+        .await,
+        PropertyValue::Real(42.0)
+    );
+    assert_eq!(fixture.sent.lock().unwrap().len(), 1);
+    fixture.server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn successful_input_update_runs_existing_event_and_cov_pipeline() {
+    let mut fixture = fixture().await;
+    subscribe(&fixture.server, fixture.ai).await;
+
+    fixture
+        .server
+        .set_present_value_local(&fixture.ai, PropertyValue::Real(81.0))
+        .await
+        .unwrap();
+    assert_eq!(
+        read(
+            &fixture.server,
+            &fixture.ai,
+            PropertyIdentifier::EVENT_STATE
+        )
+        .await,
+        PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw()),
+        "the existing intrinsic-event evaluator must observe the local update"
+    );
+    let frame = fixture.sent.lock().unwrap()[0].0.clone();
+    let npdu = decode_npdu(frame).unwrap();
+    let Apdu::UnconfirmedRequest(request) = decode_apdu(npdu.payload).unwrap() else {
+        panic!("expected unconfirmed COV notification");
+    };
+    assert_eq!(
+        request.service_choice,
+        UnconfirmedServiceChoice::UNCONFIRMED_COV_NOTIFICATION
+    );
+    let notification = COVNotificationRequest::decode(&request.service_request).unwrap();
+    assert_eq!(notification.monitored_object_identifier, fixture.ai);
+    assert_eq!(fixture.sent.lock().unwrap().len(), 1);
+
+    let error = fixture
+        .server
+        .set_present_value_local(&fixture.ai, PropertyValue::Real(f32::NAN))
+        .await
+        .expect_err("rejected update must stop before post-write processing");
+    assert_protocol_error(error, ErrorClass::PROPERTY, ErrorCode::VALUE_OUT_OF_RANGE);
+    assert_eq!(
+        read(
+            &fixture.server,
+            &fixture.ai,
+            PropertyIdentifier::PRESENT_VALUE
+        )
+        .await,
+        PropertyValue::Real(81.0)
+    );
+    assert_eq!(
+        read(
+            &fixture.server,
+            &fixture.ai,
+            PropertyIdentifier::EVENT_STATE
+        )
+        .await,
+        PropertyValue::Enumerated(EventState::HIGH_LIMIT.to_raw())
+    );
+    assert_eq!(
+        fixture.sent.lock().unwrap().len(),
+        1,
+        "rejected update must not emit COV"
+    );
+    fixture.server.stop().await.unwrap();
+}

--- a/crates/bacnet-server/src/server/local_writes.rs
+++ b/crates/bacnet-server/src/server/local_writes.rs
@@ -1,5 +1,25 @@
 use super::*;
 
+#[cfg(test)]
+#[path = "input_present_value_tests.rs"]
+mod input_present_value_tests;
+
+/// What a local mutation is, and on whose behalf.
+///
+/// An Input gates `Present_Value` on `Out_Of_Service` in opposite directions
+/// for the two, so this decides which check applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LocalWrite {
+    /// A client on the network, writing any property.
+    Network {
+        property: PropertyIdentifier,
+        array_index: Option<u32>,
+        priority: Option<u8>,
+    },
+    /// The application supplying a supported Input's logical `Present_Value`.
+    ApplicationInputPresentValue,
+}
+
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Arm or rearm a Life Safety object from trusted local application logic.
     ///
@@ -59,6 +79,54 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         value: PropertyValue,
         priority: Option<u8>,
     ) -> Result<(), Error> {
+        self.write_local_as(
+            oid,
+            LocalWrite::Network {
+                property,
+                array_index,
+                priority,
+            },
+            value,
+        )
+        .await
+    }
+
+    /// Supply a supported Input's logical `Present_Value` from Rust application code.
+    ///
+    /// Analog Input, Binary Input, and Multi-state Input opt in. Binary values
+    /// are logical INACTIVE/ACTIVE states after Polarity, not raw physical
+    /// states. The update runs the existing post-write intrinsic-event and COV
+    /// processing after the database lock is released; configured delays and
+    /// distribution policy still determine when notifications are delivered.
+    ///
+    /// Applications are denied while `Out_Of_Service` is TRUE to protect a
+    /// client's simulation value. That ownership rule is local policy, not a
+    /// Standard mandate. Other object families fail closed; use
+    /// [`BACnetServer::write_local`] for ordinary network-equivalent writes and
+    /// commandable objects. Python exposure is tracked separately in #503.
+    ///
+    /// [`BACnetObject::set_present_value_internal`]: bacnet_objects::traits::BACnetObject::set_present_value_internal
+    pub async fn set_present_value_local(
+        &self,
+        oid: &ObjectIdentifier,
+        value: PropertyValue,
+    ) -> Result<(), Error> {
+        self.write_local_as(oid, LocalWrite::ApplicationInputPresentValue, value)
+            .await
+    }
+
+    async fn write_local_as(
+        &self,
+        oid: &ObjectIdentifier,
+        write: LocalWrite,
+        value: PropertyValue,
+    ) -> Result<(), Error> {
+        // Only a network write can carry OBJECT_NAME, so only it needs the name
+        // index kept in step.
+        let renaming = matches!(
+            write,
+            LocalWrite::Network { property, .. } if property == PropertyIdentifier::OBJECT_NAME
+        );
         let life_safety = crate::life_safety_cov::is_life_safety_object(*oid);
         let exact_changes = {
             let mut db = self.db.write().await;
@@ -69,14 +137,23 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     code: ErrorCode::UNKNOWN_OBJECT.to_raw() as u32,
                 });
             }
-            if property == PropertyIdentifier::OBJECT_NAME {
+            if renaming {
                 if let PropertyValue::CharacterString(ref new_name) = value {
                     db.check_name_available(oid, new_name)?;
                 }
             }
             let object = db.get_mut(oid).expect("existence checked above");
-            object.write_property(property, array_index, value, priority)?;
-            if property == PropertyIdentifier::OBJECT_NAME {
+            match write {
+                LocalWrite::Network {
+                    property,
+                    array_index,
+                    priority,
+                } => object.write_property(property, array_index, value, priority)?,
+                LocalWrite::ApplicationInputPresentValue => {
+                    object.set_present_value_internal(value)?
+                }
+            }
+            if renaming {
                 db.update_name_index(oid);
             }
             snapshots.changes(&db, std::slice::from_ref(oid))


### PR DESCRIPTION
## Summary
- add a fail-closed, object-owned hook for application-supplied Input `Present_Value`
- opt in Analog Input, Binary Input, and Multi-state Input with exact type/range and `Out_Of_Service` ownership checks
- add `BACnetServer::set_present_value_local(oid, value)` and run the existing post-write intrinsic-event/COV pipeline
- keep commandable objects on the existing generic `write_local` path

## Contributor integration
This is a current-`dev` maintainer integration of contributor PR #491 and exact source commit `12f556433d111ddecfafbcf96ff7f3cd9bc76342`. GitHub did not permit updating that fork branch, so the contributor change was imported onto current `dev`, narrowed to the owner-selected strict Input-only API, and retained with `Co-authored-by` attribution.

Supersedes #491.

## Source-to-behavior traceability
| ANSI/ASHRAE 135-2020 source | Implemented behavior |
|---|---|
| §12.2 Analog Input | Application code may supply finite REAL logical `Present_Value` while the input is in service; network simulation writes remain available while `Out_Of_Service` is true. |
| §12.6 Binary Input | Application values are BACnet logical INACTIVE/ACTIVE (`0`/`1`) after `Polarity`, not raw electrical states; OOS simulation remains network-owned. |
| §12.18 Multi-state Input | Application values remain in `1..=Number_Of_States`, with existing range-reliability/inhibit/OOS behavior preserved. |

Rejecting application updates while OOS is an explicit local safe-ownership policy protecting a client's simulation value; it is not claimed as a Standard-mandated error policy.

## API boundary
- Rust-only and additive
- only AI, BI, and MSI opt in
- no array index or priority on the new method
- default trait implementation returns `OBJECT / OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED`
- commandable and other object families gain no privileged authority

Python exposure is tracked separately in #503.

## Validation
- focused object ownership, validation, atomicity, and MSI reliability tests
- focused server local-write, COV, intrinsic-event, and error-path tests
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-objects --locked`
- `cargo test -p bacnet-server --locked`
- `cargo test -p bacnet-services --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked --features bacnet-types/serde,bacnet-transport/ipv6,bacnet-transport/sc-tls`
- conformance-doc, file-size, no-secret, and `git diff --check`

## Deferred
- Python binding/stub/wheel support (#503)
- raw physical Binary Input/Polarity conversion and `Interface_Value`
- universal privileged local Present_Value writes
- generic COV transaction/coalescing redesign
- M05 acknowledgment families (#170)
