### PR TITLE
feat(objects): acknowledge binary and multistate alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Correlated AcknowledgeAlarm core validation and a lossless Rust request API
   (#132). The bundled server now requires the latest committed original
-  To State and exact timestamp before setting one supported Analog or Event
-  Enrollment acknowledgment bit; valid repeated transactions remain
-  idempotent. Python now exposes the protocol-backed `BACnetTimeStamp` CHOICE
-  and a lossless `BACnetClient.acknowledge_alarm_request` method, while the CLI
-  uses that canonical Rust request with both mandatory timestamps. Additional
-  object families (#170) and ACK_NOTIFICATION distribution (#175) remain
-  deferred, so this does not broaden conformance claims.
+  To State and exact timestamp before setting one supported Analog, Binary,
+  Multi-state, or Event Enrollment acknowledgment bit; valid repeated
+  transactions remain idempotent. Python now exposes the protocol-backed
+  `BACnetTimeStamp` CHOICE and a lossless
+  `BACnetClient.acknowledge_alarm_request` method, while the CLI uses that
+  canonical Rust request with both mandatory timestamps. Binary
+  Input/Output/Value and Multi-state Input/Output/Value now share the same
+  correlated behavior (#170). Alert Enrollment remains excluded, and
+  ACK_NOTIFICATION distribution (#175) remains deferred, so this does not
+  claim full Clause 13.5 compliance or broaden conformance claims.
 
 - Exact-delta Life Safety COV reporting for the bundled server (`Refs #177`).
   Whole-object Point/Zone subscriptions now trigger only for actual

--- a/crates/bacnet-objects/src/acknowledge_alarm_object_family_tests.rs
+++ b/crates/bacnet-objects/src/acknowledge_alarm_object_family_tests.rs
@@ -1,0 +1,150 @@
+use crate::binary::{BinaryInputObject, BinaryOutputObject, BinaryValueObject};
+use crate::event::{EventStateChange, EventTransition, EventTransitionCommit};
+use crate::multistate::{MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject};
+use crate::traits::BACnetObject;
+use bacnet_types::enums::{ErrorClass, ErrorCode, EventState, PropertyIdentifier};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{BACnetTimeStamp, PropertyValue};
+
+#[derive(Debug, PartialEq)]
+struct EventSnapshot {
+    event_state: PropertyValue,
+    acked_transitions: PropertyValue,
+    time_stamps: PropertyValue,
+    message_texts: PropertyValue,
+}
+
+fn target_objects() -> Vec<Box<dyn BACnetObject>> {
+    vec![
+        Box::new(BinaryInputObject::new(1, "BI-ack").unwrap()),
+        Box::new(BinaryOutputObject::new(1, "BO-ack").unwrap()),
+        Box::new(BinaryValueObject::new(1, "BV-ack").unwrap()),
+        Box::new(MultiStateInputObject::new(1, "MSI-ack", 3).unwrap()),
+        Box::new(MultiStateOutputObject::new(1, "MSO-ack", 3).unwrap()),
+        Box::new(MultiStateValueObject::new(1, "MSV-ack", 3).unwrap()),
+    ]
+}
+
+fn snapshot(object: &dyn BACnetObject) -> EventSnapshot {
+    EventSnapshot {
+        event_state: object
+            .read_property(PropertyIdentifier::EVENT_STATE, None)
+            .unwrap(),
+        acked_transitions: object
+            .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+            .unwrap(),
+        time_stamps: object
+            .read_property(PropertyIdentifier::EVENT_TIME_STAMPS, None)
+            .unwrap(),
+        message_texts: object
+            .read_property(PropertyIdentifier::EVENT_MESSAGE_TEXTS, None)
+            .unwrap(),
+    }
+}
+
+fn acked_transitions(object: &dyn BACnetObject) -> u8 {
+    let PropertyValue::BitString { data, .. } = object
+        .read_property(PropertyIdentifier::ACKED_TRANSITIONS, None)
+        .unwrap()
+    else {
+        panic!("Acked_Transitions must be a bit string");
+    };
+    bacnet_types::bitstring::unpack_octet(&data, 3)
+}
+
+fn assert_protocol(error: Error, class: ErrorClass, code: ErrorCode) {
+    assert!(matches!(
+        error,
+        Error::Protocol {
+            class: actual_class,
+            code: actual_code,
+        } if actual_class == class.to_raw() as u32 && actual_code == code.to_raw() as u32
+    ));
+}
+
+#[test]
+fn binary_and_multistate_families_require_exact_idempotent_correlation() {
+    let stamp = BACnetTimeStamp::SequenceNumber(42);
+
+    for mut object in target_objects() {
+        let object_name = object.object_name().to_owned();
+        object
+            .write_property(
+                PropertyIdentifier::EVENT_DETECTION_ENABLE,
+                None,
+                PropertyValue::Boolean(true),
+                None,
+            )
+            .unwrap();
+        object
+            .commit_event_transition_internal(EventTransitionCommit {
+                change: EventStateChange {
+                    from: EventState::NORMAL,
+                    to: EventState::OFFNORMAL,
+                },
+                coordinate: EventTransition::ToOffnormal,
+                ack_required: true,
+                timestamp: stamp.clone(),
+                message_text: Some(format!("{object_name} committed")),
+            })
+            .unwrap();
+
+        assert_eq!(acked_transitions(&*object), 0b110, "{object_name}");
+        let before = snapshot(&*object);
+
+        let state_error = object
+            .acknowledge_alarm_correlated_internal(
+                EventState::HIGH_LIMIT,
+                &BACnetTimeStamp::SequenceNumber(99),
+            )
+            .unwrap_err();
+        assert_protocol(
+            state_error,
+            ErrorClass::SERVICES,
+            ErrorCode::INVALID_EVENT_STATE,
+        );
+        assert_eq!(snapshot(&*object), before, "{object_name}");
+
+        let timestamp_error = object
+            .acknowledge_alarm_correlated_internal(
+                EventState::OFFNORMAL,
+                &BACnetTimeStamp::SequenceNumber(41),
+            )
+            .unwrap_err();
+        assert_protocol(
+            timestamp_error,
+            ErrorClass::SERVICES,
+            ErrorCode::INVALID_TIME_STAMP,
+        );
+        assert_eq!(snapshot(&*object), before, "{object_name}");
+
+        object
+            .acknowledge_alarm_correlated_internal(EventState::OFFNORMAL, &stamp)
+            .unwrap();
+        assert_eq!(acked_transitions(&*object), 0b111, "{object_name}");
+        let after = snapshot(&*object);
+        assert_eq!(after.event_state, before.event_state, "{object_name}");
+        assert_eq!(after.time_stamps, before.time_stamps, "{object_name}");
+        assert_eq!(after.message_texts, before.message_texts, "{object_name}");
+
+        object
+            .acknowledge_alarm_correlated_internal(EventState::OFFNORMAL, &stamp)
+            .unwrap();
+        assert_eq!(snapshot(&*object), after, "{object_name}");
+
+        object
+            .write_property(
+                PropertyIdentifier::EVENT_DETECTION_ENABLE,
+                None,
+                PropertyValue::Boolean(false),
+                None,
+            )
+            .unwrap();
+        let disabled = snapshot(&*object);
+        let error = object
+            .acknowledge_alarm_correlated_internal(EventState::OFFNORMAL, &stamp)
+            .unwrap_err();
+        assert_protocol(error, ErrorClass::OBJECT, ErrorCode::NO_ALARM_CONFIGURED);
+        assert_eq!(snapshot(&*object), disabled, "{object_name}");
+    }
+}

--- a/crates/bacnet-objects/src/binary/input.rs
+++ b/crates/bacnet-objects/src/binary/input.rs
@@ -273,6 +273,24 @@ impl BACnetObject for BinaryInputObject {
         reliability_before_out_of_service
     );
 
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.event_detector.acked_transitions,
+            event_state,
+            timestamp,
+        )
+    }
+
     fn read_property(
         &self,
         property: PropertyIdentifier,

--- a/crates/bacnet-objects/src/binary/mod.rs
+++ b/crates/bacnet-objects/src/binary/mod.rs
@@ -1,7 +1,7 @@
 //! Binary Input (type 3), Binary Output (type 4), and Binary Value (type 5)
 //! objects per ASHRAE 135-2020 Clauses 12.6, 12.7, and 12.8.
 
-use bacnet_types::enums::{ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{ErrorClass, ErrorCode, EventState, ObjectType, PropertyIdentifier};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;

--- a/crates/bacnet-objects/src/binary/output.rs
+++ b/crates/bacnet-objects/src/binary/output.rs
@@ -116,6 +116,24 @@ impl BACnetObject for BinaryOutputObject {
         reliability_before_out_of_service
     );
 
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.event_detector.acked_transitions,
+            event_state,
+            timestamp,
+        )
+    }
+
     fn read_property(
         &self,
         property: PropertyIdentifier,

--- a/crates/bacnet-objects/src/binary/value.rs
+++ b/crates/bacnet-objects/src/binary/value.rs
@@ -117,6 +117,24 @@ impl BACnetObject for BinaryValueObject {
         reliability_before_out_of_service
     );
 
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.event_detector.acked_transitions,
+            event_state,
+            timestamp,
+        )
+    }
+
     fn read_property(
         &self,
         property: PropertyIdentifier,

--- a/crates/bacnet-objects/src/lib.rs
+++ b/crates/bacnet-objects/src/lib.rs
@@ -53,3 +53,6 @@ mod reliability_inhibit_tests;
 
 #[cfg(test)]
 mod enrollment_summary_capability_tests;
+
+#[cfg(test)]
+mod acknowledge_alarm_object_family_tests;

--- a/crates/bacnet-objects/src/multistate/input.rs
+++ b/crates/bacnet-objects/src/multistate/input.rs
@@ -157,6 +157,24 @@ impl BACnetObject for MultiStateInputObject {
         reliability_evaluator
     );
 
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.event_detector.acked_transitions,
+            event_state,
+            timestamp,
+        )
+    }
+
     fn read_property(
         &self,
         property: PropertyIdentifier,

--- a/crates/bacnet-objects/src/multistate/mod.rs
+++ b/crates/bacnet-objects/src/multistate/mod.rs
@@ -2,7 +2,9 @@
 //! Multi-State Value (type 19) objects per ASHRAE 135-2020 Clauses 12.18,
 //! 12.19, and 12.20.
 
-use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier, Reliability};
+use bacnet_types::enums::{
+    ErrorClass, ErrorCode, EventState, ObjectType, PropertyIdentifier, Reliability,
+};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier, PropertyValue, StatusFlags};
 use std::borrow::Cow;

--- a/crates/bacnet-objects/src/multistate/output.rs
+++ b/crates/bacnet-objects/src/multistate/output.rs
@@ -176,6 +176,24 @@ impl BACnetObject for MultiStateOutputObject {
         present_value
     );
 
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.event_detector.acked_transitions,
+            event_state,
+            timestamp,
+        )
+    }
+
     fn read_property(
         &self,
         property: PropertyIdentifier,

--- a/crates/bacnet-objects/src/multistate/value.rs
+++ b/crates/bacnet-objects/src/multistate/value.rs
@@ -185,6 +185,24 @@ impl BACnetObject for MultiStateValueObject {
         present_value
     );
 
+    fn acknowledge_alarm_correlated_internal(
+        &mut self,
+        event_state: EventState,
+        timestamp: &BACnetTimeStamp,
+    ) -> Result<(), Error> {
+        if !self.event_detection_enable {
+            return Err(Error::Protocol {
+                class: ErrorClass::OBJECT.to_raw() as u32,
+                code: ErrorCode::NO_ALARM_CONFIGURED.to_raw() as u32,
+            });
+        }
+        self.event_history.acknowledge_correlated(
+            &mut self.event_detector.acked_transitions,
+            event_state,
+            timestamp,
+        )
+    }
+
     fn read_property(
         &self,
         property: PropertyIdentifier,

--- a/crates/bacnet-server/src/handlers/tests/acknowledge_alarm.rs
+++ b/crates/bacnet-server/src/handlers/tests/acknowledge_alarm.rs
@@ -3,10 +3,12 @@ use super::*;
 use bacnet_encoding::primitives;
 use bacnet_encoding::tags::{encode_tag, TagClass};
 use bacnet_objects::analog::{AnalogOutputObject, AnalogValueObject};
-use bacnet_objects::binary::BinaryInputObject;
+use bacnet_objects::binary::{BinaryInputObject, BinaryOutputObject, BinaryValueObject};
 use bacnet_objects::event::{EventStateChange, EventTransitionCommit};
 use bacnet_objects::event_enrollment::{AlertEnrollmentObject, EventEnrollmentObject};
-use bacnet_objects::multistate::MultiStateInputObject;
+use bacnet_objects::multistate::{
+    MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject,
+};
 use bacnet_services::alarm_event::AcknowledgeAlarmRequest;
 use bacnet_types::constructed::{BACnetDeviceObjectPropertyReference, BACnetEventParameter};
 use bacnet_types::enums::EventType;
@@ -32,6 +34,18 @@ fn add_committed<O: BACnetObject + 'static>(
         .unwrap();
     db.add(Box::new(object)).unwrap();
     oid
+}
+
+fn with_event_detection<O: BACnetObject>(mut object: O) -> O {
+    object
+        .write_property(
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    object
 }
 
 fn encode_request(
@@ -117,40 +131,102 @@ fn configured_event_enrollment() -> EventEnrollmentObject {
 fn supported_families_acknowledge_only_the_correlated_transition() {
     let mut db = ObjectDatabase::new();
     let stamp = BACnetTimeStamp::SequenceNumber(42);
-    let oids = [
-        add_committed(
-            &mut db,
-            AnalogInputObject::new(1, "AI-ack", 62).unwrap(),
+    let cases = [
+        (
+            add_committed(
+                &mut db,
+                AnalogInputObject::new(1, "AI-ack", 62).unwrap(),
+                EventState::HIGH_LIMIT,
+                stamp.clone(),
+            ),
             EventState::HIGH_LIMIT,
-            stamp.clone(),
         ),
-        add_committed(
-            &mut db,
-            AnalogOutputObject::new(1, "AO-ack", 62).unwrap(),
+        (
+            add_committed(
+                &mut db,
+                AnalogOutputObject::new(1, "AO-ack", 62).unwrap(),
+                EventState::HIGH_LIMIT,
+                stamp.clone(),
+            ),
             EventState::HIGH_LIMIT,
-            stamp.clone(),
         ),
-        add_committed(
-            &mut db,
-            AnalogValueObject::new(1, "AV-ack", 62).unwrap(),
+        (
+            add_committed(
+                &mut db,
+                AnalogValueObject::new(1, "AV-ack", 62).unwrap(),
+                EventState::HIGH_LIMIT,
+                stamp.clone(),
+            ),
             EventState::HIGH_LIMIT,
-            stamp.clone(),
         ),
-        add_committed(
-            &mut db,
-            configured_event_enrollment(),
+        (
+            add_committed(
+                &mut db,
+                BinaryInputObject::new(1, "BI-ack").unwrap(),
+                EventState::OFFNORMAL,
+                stamp.clone(),
+            ),
+            EventState::OFFNORMAL,
+        ),
+        (
+            add_committed(
+                &mut db,
+                with_event_detection(BinaryOutputObject::new(1, "BO-ack").unwrap()),
+                EventState::OFFNORMAL,
+                stamp.clone(),
+            ),
+            EventState::OFFNORMAL,
+        ),
+        (
+            add_committed(
+                &mut db,
+                BinaryValueObject::new(1, "BV-ack").unwrap(),
+                EventState::OFFNORMAL,
+                stamp.clone(),
+            ),
+            EventState::OFFNORMAL,
+        ),
+        (
+            add_committed(
+                &mut db,
+                MultiStateInputObject::new(1, "MSI-ack", 3).unwrap(),
+                EventState::OFFNORMAL,
+                stamp.clone(),
+            ),
+            EventState::OFFNORMAL,
+        ),
+        (
+            add_committed(
+                &mut db,
+                with_event_detection(MultiStateOutputObject::new(1, "MSO-ack", 3).unwrap()),
+                EventState::OFFNORMAL,
+                stamp.clone(),
+            ),
+            EventState::OFFNORMAL,
+        ),
+        (
+            add_committed(
+                &mut db,
+                MultiStateValueObject::new(1, "MSV-ack", 3).unwrap(),
+                EventState::OFFNORMAL,
+                stamp.clone(),
+            ),
+            EventState::OFFNORMAL,
+        ),
+        (
+            add_committed(
+                &mut db,
+                configured_event_enrollment(),
+                EventState::HIGH_LIMIT,
+                stamp.clone(),
+            ),
             EventState::HIGH_LIMIT,
-            stamp.clone(),
         ),
     ];
 
-    for oid in oids {
+    for (oid, state) in cases {
         assert_eq!(acked(&db, oid), 0b110);
-        handle_acknowledge_alarm(
-            &mut db,
-            &encode_request(oid, EventState::HIGH_LIMIT, stamp.clone()),
-        )
-        .unwrap();
+        handle_acknowledge_alarm(&mut db, &encode_request(oid, state, stamp.clone())).unwrap();
         assert_eq!(acked(&db, oid), 0b111);
     }
 }
@@ -215,18 +291,14 @@ fn unknown_uninitialized_and_unsupported_objects_fail_closed() {
     assert_protocol(error, ErrorClass::OBJECT, ErrorCode::UNKNOWN_OBJECT);
 
     let mut db = ObjectDatabase::new();
-    let objects: Vec<Box<dyn BACnetObject>> = vec![
-        Box::new(BinaryInputObject::new(1, "BI-unsupported").unwrap()),
-        Box::new(MultiStateInputObject::new(1, "MSI-unsupported", 3).unwrap()),
-        Box::new(
-            AlertEnrollmentObject::new(
-                1,
-                "AE-unsupported",
-                ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 7).unwrap(),
-            )
-            .unwrap(),
-        ),
-    ];
+    let objects: Vec<Box<dyn BACnetObject>> = vec![Box::new(
+        AlertEnrollmentObject::new(
+            1,
+            "AE-unsupported",
+            ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 7).unwrap(),
+        )
+        .unwrap(),
+    )];
     for object in objects {
         let oid = object.object_identifier();
         db.add(object).unwrap();

--- a/crates/bacnet-server/src/server/acknowledge_alarm_tests.rs
+++ b/crates/bacnet-server/src/server/acknowledge_alarm_tests.rs
@@ -3,17 +3,21 @@ use super::*;
 use bacnet_encoding::apdu::decode_apdu;
 use bacnet_encoding::npdu::decode_npdu;
 use bacnet_objects::analog::AnalogInputObject;
+use bacnet_objects::binary::{BinaryInputObject, BinaryOutputObject, BinaryValueObject};
 use bacnet_objects::event::{EventStateChange, EventTransition, EventTransitionCommit};
+use bacnet_objects::multistate::{
+    MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject,
+};
 use bacnet_objects::traits::BACnetObject;
 use bacnet_services::alarm_event::AcknowledgeAlarmRequest;
 use bacnet_types::enums::EventState;
 use bacnet_types::primitives::BACnetTimeStamp;
 
-fn request(oid: ObjectIdentifier) -> AcknowledgeAlarmRequest {
+fn request(oid: ObjectIdentifier, state: EventState) -> AcknowledgeAlarmRequest {
     AcknowledgeAlarmRequest {
         acknowledging_process_identifier: 71,
         event_object_identifier: oid,
-        event_state_acknowledged: EventState::HIGH_LIMIT.to_raw(),
+        event_state_acknowledged: state.to_raw(),
         timestamp: BACnetTimeStamp::SequenceNumber(42),
         acknowledgment_source: "operator".into(),
         time_of_acknowledgment: BACnetTimeStamp::SequenceNumber(77),
@@ -108,6 +112,70 @@ fn assert_simple_ack(apdu: Apdu, invoke_id: u8) {
     );
 }
 
+fn target_objects() -> Vec<Box<dyn BACnetObject>> {
+    vec![
+        Box::new(BinaryInputObject::new(1, "BI-ack").unwrap()),
+        Box::new(BinaryOutputObject::new(1, "BO-ack").unwrap()),
+        Box::new(BinaryValueObject::new(1, "BV-ack").unwrap()),
+        Box::new(MultiStateInputObject::new(1, "MSI-ack", 3).unwrap()),
+        Box::new(MultiStateOutputObject::new(1, "MSO-ack", 3).unwrap()),
+        Box::new(MultiStateValueObject::new(1, "MSV-ack", 3).unwrap()),
+    ]
+}
+
+#[tokio::test]
+async fn binary_and_multistate_families_return_simple_ack() {
+    let mut objects = ObjectDatabase::new();
+    let mut oids = Vec::new();
+    for mut object in target_objects() {
+        object
+            .write_property(
+                PropertyIdentifier::EVENT_DETECTION_ENABLE,
+                None,
+                PropertyValue::Boolean(true),
+                None,
+            )
+            .unwrap();
+        let oid = object.object_identifier();
+        object
+            .commit_event_transition_internal(EventTransitionCommit {
+                change: EventStateChange {
+                    from: EventState::NORMAL,
+                    to: EventState::OFFNORMAL,
+                },
+                coordinate: EventTransition::ToOffnormal,
+                ack_required: true,
+                timestamp: BACnetTimeStamp::SequenceNumber(42),
+                message_text: Some("offnormal".into()),
+            })
+            .unwrap();
+        objects.add(object).unwrap();
+        oids.push(oid);
+    }
+
+    let db = Arc::new(RwLock::new(objects));
+    let tracker = Arc::new(ConfirmedRequestTracker::default());
+    let notification_transactions = NotificationTransactions::new();
+    let source = MacAddr::from_slice(&[1, 2, 3]);
+
+    for (index, oid) in oids.into_iter().enumerate() {
+        let invoke_id = 0x60 + index as u8;
+        let response = dispatch(
+            &db,
+            &tracker,
+            &notification_transactions,
+            &source,
+            invoke_id,
+            &request(oid, EventState::OFFNORMAL),
+        )
+        .await
+        .unwrap();
+        assert_simple_ack(response, invoke_id);
+        assert_eq!(acked(&*db.read().await, oid), 0b111);
+    }
+    assert_eq!(notification_transactions.active_count(), 0);
+}
+
 #[tokio::test]
 async fn exact_duplicate_is_silent_and_new_invoke_id_is_idempotent_success() {
     let mut ai = AnalogInputObject::new(1, "AI-ack", 62).unwrap();
@@ -129,7 +197,7 @@ async fn exact_duplicate_is_silent_and_new_invoke_id_is_idempotent_success() {
     let tracker = Arc::new(ConfirmedRequestTracker::default());
     let notification_transactions = NotificationTransactions::new();
     let source = MacAddr::from_slice(&[1, 2, 3]);
-    let request = request(oid);
+    let request = request(oid, EventState::HIGH_LIMIT);
 
     let first = dispatch(
         &db,


### PR DESCRIPTION
## Summary
- extend correlated AcknowledgeAlarm handling to Binary Input/Output/Value and Multi-state Input/Output/Value
- preserve exact state/timestamp validation, mutation-free failures, and idempotent exact-bit updates through the existing object-owned EventHistory path
- add exhaustive object, handler, and server SimpleACK coverage for all six families

## Source-to-behavior traceability
| Requirement | ANSI/ASHRAE 135-2020 source | Implemented behavior |
|---|---|---|
| Correlate acknowledgments to the event | §§13.2.3, 13.5 | Each new family delegates to EventHistory::acknowledge_correlated and rejects mismatched state/timestamp before mutation. |
| Reject objects not configured for event generation | §13.5.1.3 | Disabled family objects return OBJECT / NO_ALARM_CONFIGURED. |
| Set the matching acknowledgment coordinate | §13.5 service procedure | Success sets exactly the correlated Acked_Transitions bit and remains idempotent. |

Alert Enrollment remains excluded because its normal alert transition is non-ack-required under §12.52.8. ACK_NOTIFICATION delivery remains separately tracked by #175, so this PR does not claim full Clause 13.5 compliance or broaden PICS/BIBB support.

## Validation
- cargo test -p bacnet-objects --locked
- cargo test -p bacnet-server --locked
- cargo fmt --all -- --check
- cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked
- cargo test --workspace --exclude rusty-bacnet --locked
- cargo check -p rusty-bacnet --tests --locked
- python3 scripts/generate-conformance-docs.py --check
- bash .github/scripts/check-file-size.sh
- bash .github/scripts/check-no-secrets.sh
- git diff --check

Closes #170
Refs #175