### PR TITLE
fix(client): retain device route on I-Am collision

### DIFF
--- a/crates/bacnet-client/src/client/device_events.rs
+++ b/crates/bacnet-client/src/client/device_events.rs
@@ -9,4 +9,15 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
     pub fn device_events(&self) -> broadcast::Receiver<DeviceEvent> {
         self.device_tx.subscribe()
     }
+
+    /// Get a receiver for Device-instance collision notifications. Each call
+    /// returns a new independent receiver.
+    ///
+    /// Delivery is notification-only and best-effort: receivers can lag and
+    /// missed notifications do not affect collision handling. The `retained`
+    /// snapshot identifies the discovery-table row that remains authoritative;
+    /// the conflicting `incoming` snapshot is not installed in the table.
+    pub fn device_collision_events(&self) -> broadcast::Receiver<DeviceCollisionEvent> {
+        self.device_collision_tx.subscribe()
+    }
 }

--- a/crates/bacnet-client/src/client/device_events_tests.rs
+++ b/crates/bacnet-client/src/client/device_events_tests.rs
@@ -8,11 +8,20 @@ use bacnet_types::enums::{ObjectType, Segmentation};
 use bacnet_types::primitives::ObjectIdentifier;
 
 fn i_am_npdu(instance: u32, vendor_id: u16) -> BytesMut {
+    i_am_npdu_with_capabilities(instance, vendor_id, 1476, Segmentation::NONE)
+}
+
+fn i_am_npdu_with_capabilities(
+    instance: u32,
+    vendor_id: u16,
+    max_apdu_length: u32,
+    segmentation_supported: Segmentation,
+) -> BytesMut {
     let mut service_request = BytesMut::new();
     IAmRequest {
         object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, instance).unwrap(),
-        max_apdu_length: 1476,
-        segmentation_supported: Segmentation::NONE,
+        max_apdu_length,
+        segmentation_supported,
         vendor_id,
     }
     .encode(&mut service_request);
@@ -45,6 +54,7 @@ async fn device_events_emit_discovered_and_updated_for_i_am() {
         .await
         .unwrap();
     let mut events = client.device_events();
+    let mut collisions = client.device_collision_events();
 
     sender_transport
         .send_unicast(&i_am_npdu(1001, 42), client.local_mac())
@@ -58,9 +68,16 @@ async fn device_events_emit_discovered_and_updated_for_i_am() {
     assert_eq!(event.device.object_identifier.instance_number(), 1001);
     assert_eq!(event.device.mac_address.as_slice(), sender_mac.as_slice());
     assert_eq!(event.device.vendor_id, 42);
+    assert!(matches!(
+        collisions.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
 
     sender_transport
-        .send_unicast(&i_am_npdu(1001, 84), client.local_mac())
+        .send_unicast(
+            &i_am_npdu_with_capabilities(1001, 84, 480, Segmentation::BOTH),
+            client.local_mac(),
+        )
         .await
         .unwrap();
     let event = timeout(Duration::from_secs(1), events.recv())
@@ -70,7 +87,99 @@ async fn device_events_emit_discovered_and_updated_for_i_am() {
     assert_eq!(event.kind, DeviceEventKind::Updated);
     assert_eq!(event.device.object_identifier.instance_number(), 1001);
     assert_eq!(event.device.vendor_id, 84);
-    assert_eq!(client.get_device(1001).await.unwrap().vendor_id, 84);
+    assert_eq!(event.device.max_apdu_length, 480);
+    assert_eq!(event.device.segmentation_supported, Segmentation::BOTH);
+    let row = client.get_device(1001).await.unwrap();
+    assert_eq!(row.vendor_id, 84);
+    assert_eq!(row.max_apdu_length, 480);
+    assert_eq!(row.segmentation_supported, Segmentation::BOTH);
+    assert!(matches!(
+        collisions.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
+
+    client.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn collision_event_retains_authoritative_route_without_device_update() {
+    let client_mac = vec![0x01];
+    let incoming_mac = vec![0x02];
+    let retained_mac = vec![0x03];
+    let (client_transport, sender_transport) =
+        LoopbackTransport::pair(client_mac, incoming_mac.clone());
+    let mut client = BACnetClient::generic_builder()
+        .transport(client_transport)
+        .build()
+        .await
+        .unwrap();
+    let mut device_events = client.device_events();
+    let mut collision_events = client.device_collision_events();
+    let retained_seen = Instant::now();
+    let retained = DiscoveredDevice {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 1001).unwrap(),
+        mac_address: MacAddr::from_slice(&retained_mac),
+        max_apdu_length: 1024,
+        segmentation_supported: Segmentation::RECEIVE,
+        max_segments_accepted: Some(8),
+        vendor_id: 42,
+        last_seen: retained_seen,
+        source_network: None,
+        source_address: None,
+    };
+    client.device_table.lock().await.upsert(retained);
+
+    let before_send = Instant::now();
+    sender_transport
+        .send_unicast(
+            &i_am_npdu_with_capabilities(1001, 84, 480, Segmentation::BOTH),
+            client.local_mac(),
+        )
+        .await
+        .unwrap();
+    let event = timeout(Duration::from_secs(1), collision_events.recv())
+        .await
+        .expect("timed out waiting for collision event")
+        .expect("device collision event channel closed");
+    let after_receive = Instant::now();
+
+    assert_eq!(event.retained.object_identifier.instance_number(), 1001);
+    assert_eq!(
+        event.retained.mac_address.as_slice(),
+        retained_mac.as_slice()
+    );
+    assert_eq!(event.retained.max_apdu_length, 1024);
+    assert_eq!(event.retained.segmentation_supported, Segmentation::RECEIVE);
+    assert_eq!(event.retained.max_segments_accepted, Some(8));
+    assert_eq!(event.retained.vendor_id, 42);
+    assert_eq!(event.retained.last_seen, retained_seen);
+    assert!(event.retained.is_local());
+    assert_eq!(event.incoming.object_identifier.instance_number(), 1001);
+    assert_eq!(
+        event.incoming.mac_address.as_slice(),
+        incoming_mac.as_slice()
+    );
+    assert_eq!(event.incoming.max_apdu_length, 480);
+    assert_eq!(event.incoming.segmentation_supported, Segmentation::BOTH);
+    assert_eq!(event.incoming.max_segments_accepted, None);
+    assert_eq!(event.incoming.vendor_id, 84);
+    assert!(event.incoming.last_seen >= before_send);
+    assert!(event.incoming.last_seen <= after_receive);
+    assert!(event.incoming.is_local());
+    assert!(matches!(
+        device_events.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
+
+    let row = client.get_device(1001).await.unwrap();
+    assert_eq!(row.mac_address.as_slice(), retained_mac.as_slice());
+    assert_eq!(row.max_apdu_length, 1024);
+    assert_eq!(row.segmentation_supported, Segmentation::RECEIVE);
+    assert_eq!(row.max_segments_accepted, Some(8));
+    assert_eq!(row.vendor_id, 42);
+    assert_eq!(row.last_seen, retained_seen);
+    let resolved = client.resolve_device(1001).await.unwrap();
+    assert_eq!(resolved, (retained_mac, None));
 
     client.stop().await.unwrap();
 }

--- a/crates/bacnet-client/src/client/dispatch.rs
+++ b/crates/bacnet-client/src/client/dispatch.rs
@@ -15,6 +15,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         cov_tx: &broadcast::Sender<ReceivedCOVNotification>,
         confirmed_cov_ack_policy: &ConfirmedCOVNotificationAckPolicy,
         device_tx: &broadcast::Sender<DeviceEvent>,
+        device_collision_tx: &broadcast::Sender<DeviceCollisionEvent>,
         seg_state: &mut HashMap<SegKey, SegmentedReceiveState>,
         seg_ack_senders: &Arc<Mutex<HashMap<SegKey, SegmentAckRoute>>>,
         source_mac: &[u8],
@@ -450,15 +451,30 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                 source_network: src_net,
                                 source_address: src_addr,
                             };
-                            let status =
-                                device_table.lock().await.upsert_with_result(device.clone());
-                            let kind = match status {
-                                DeviceUpsertResult::Inserted => Some(DeviceEventKind::Discovered),
-                                DeviceUpsertResult::Updated => Some(DeviceEventKind::Updated),
-                                DeviceUpsertResult::Dropped => None,
+                            let status = {
+                                let mut table = device_table.lock().await;
+                                table.upsert_with_result(device.clone())
                             };
-                            if let Some(kind) = kind {
-                                let _ = device_tx.send(DeviceEvent { kind, device });
+                            match status {
+                                DeviceUpsertResult::Inserted => {
+                                    let _ = device_tx.send(DeviceEvent {
+                                        kind: DeviceEventKind::Discovered,
+                                        device,
+                                    });
+                                }
+                                DeviceUpsertResult::Updated => {
+                                    let _ = device_tx.send(DeviceEvent {
+                                        kind: DeviceEventKind::Updated,
+                                        device,
+                                    });
+                                }
+                                DeviceUpsertResult::Collision { retained } => {
+                                    let _ = device_collision_tx.send(DeviceCollisionEvent {
+                                        retained,
+                                        incoming: device,
+                                    });
+                                }
+                                DeviceUpsertResult::Dropped => {}
                             }
                         }
                         Err(e) => {

--- a/crates/bacnet-client/src/client/lifecycle.rs
+++ b/crates/bacnet-client/src/client/lifecycle.rs
@@ -64,6 +64,9 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
         let confirmed_cov_ack_policy = options.confirmed_cov_notification_ack_policy.clone();
         let (device_tx, _) = broadcast::channel::<DeviceEvent>(DEVICE_EVENT_CHANNEL_CAPACITY);
         let device_tx_dispatch = device_tx.clone();
+        let (device_collision_tx, _) =
+            broadcast::channel::<DeviceCollisionEvent>(DEVICE_EVENT_CHANNEL_CAPACITY);
+        let device_collision_tx_dispatch = device_collision_tx.clone();
         let seg_ack_senders: Arc<Mutex<HashMap<SegKey, SegmentAckRoute>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let seg_ack_senders_dispatch = Arc::clone(&seg_ack_senders);
@@ -156,6 +159,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
                                     &cov_tx_dispatch,
                                     &confirmed_cov_ack_policy,
                                     &device_tx_dispatch,
+                                    &device_collision_tx_dispatch,
                                     &mut seg_state,
                                     &seg_ack_senders_dispatch,
                                     &received.source_mac,
@@ -183,6 +187,7 @@ impl<T: TransportPort + 'static> BACnetClient<T> {
             device_table,
             cov_tx,
             device_tx,
+            device_collision_tx,
             dispatch_task: Some(dispatch_task),
             seg_ack_senders,
             cleanup_tx,

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -80,6 +80,15 @@ pub struct DeviceEvent {
     pub device: DiscoveredDevice,
 }
 
+/// Notification emitted when two endpoints claim the same Device instance.
+#[derive(Debug, Clone)]
+pub struct DeviceCollisionEvent {
+    /// Snapshot of the authoritative discovery-table row that was retained.
+    pub retained: DiscoveredDevice,
+    /// Snapshot constructed from the conflicting incoming I-Am.
+    pub incoming: DiscoveredDevice,
+}
+
 /// Client configuration.
 #[derive(Debug, Clone)]
 pub struct ClientConfig {
@@ -416,6 +425,7 @@ pub struct BACnetClient<T: TransportPort> {
     device_table: Arc<Mutex<DeviceTable>>,
     cov_tx: broadcast::Sender<ReceivedCOVNotification>,
     device_tx: broadcast::Sender<DeviceEvent>,
+    device_collision_tx: broadcast::Sender<DeviceCollisionEvent>,
     dispatch_task: Option<JoinHandle<()>>,
     /// Owner-qualified channels feeding SegmentACKs to in-flight segmented sends.
     ///

--- a/crates/bacnet-client/src/discovery.rs
+++ b/crates/bacnet-client/src/discovery.rs
@@ -84,7 +84,8 @@ struct TableEntry {
 /// Thread-safe device discovery table.
 ///
 /// Keyed by device instance number (the instance part of the DEVICE object
-/// identifier). Updated whenever an IAm is received.
+/// identifier). Ordinary I-Am refreshes update a row, while a conflicting
+/// complete endpoint claim leaves the first authoritative row unchanged.
 ///
 /// # Address-space invariant
 ///
@@ -109,11 +110,18 @@ pub struct DeviceTable {
     devices: HashMap<u32, TableEntry>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(crate) enum DeviceUpsertResult {
     Inserted,
     Updated,
+    Collision { retained: DiscoveredDevice },
     Dropped,
+}
+
+enum DeviceEndpoint<'a> {
+    Local(&'a [u8]),
+    Routed(u16, &'a [u8]),
+    Incomplete,
 }
 
 impl DeviceTable {
@@ -127,16 +135,52 @@ impl DeviceTable {
     ///
     /// The row's `segmentation_supported` is treated as authoritative
     /// capability (explicit configuration); see [`PeerSegmentation`].
+    /// This explicit administrative path replaces any row with the same
+    /// instance regardless of endpoint identity.
     ///
     /// The table is capped at 4096 entries. If the table is full and the
     /// device is not already present, the new entry is silently dropped.
     pub fn upsert(&mut self, device: DiscoveredDevice) {
-        let _ = self.upsert_with_result(device);
+        let segmentation = PeerSegmentation::Authoritative(device.segmentation_supported);
+        let _ = self.insert_entry(device, segmentation);
     }
 
     pub(crate) fn upsert_with_result(&mut self, device: DiscoveredDevice) -> DeviceUpsertResult {
+        let key = device.object_identifier.instance_number();
+        if let Some(existing) = self.devices.get(&key) {
+            let replace = existing.segmentation == PeerSegmentation::Placeholder
+                || match (Self::endpoint(&existing.device), Self::endpoint(&device)) {
+                    // A malformed retained row has no stable endpoint identity;
+                    // accepting the next I-Am keeps it repairable.
+                    (DeviceEndpoint::Incomplete, _) => true,
+                    // A malformed incoming row cannot displace stable routing.
+                    (_, DeviceEndpoint::Incomplete) => false,
+                    (DeviceEndpoint::Local(current), DeviceEndpoint::Local(incoming)) => {
+                        current == incoming
+                    }
+                    (
+                        DeviceEndpoint::Routed(current_network, current_address),
+                        DeviceEndpoint::Routed(incoming_network, incoming_address),
+                    ) => current_network == incoming_network && current_address == incoming_address,
+                    _ => false,
+                };
+            if !replace {
+                return DeviceUpsertResult::Collision {
+                    retained: existing.device.clone(),
+                };
+            }
+        }
+
         let segmentation = PeerSegmentation::Authoritative(device.segmentation_supported);
         self.insert_entry(device, segmentation)
+    }
+
+    fn endpoint(device: &DiscoveredDevice) -> DeviceEndpoint<'_> {
+        match (&device.source_network, &device.source_address) {
+            (None, None) => DeviceEndpoint::Local(device.mac_address.as_slice()),
+            (Some(network), Some(address)) => DeviceEndpoint::Routed(*network, address.as_slice()),
+            _ => DeviceEndpoint::Incomplete,
+        }
     }
 
     /// Insert or update a device whose capability fields are manual
@@ -297,6 +341,10 @@ impl DeviceTable {
 }
 
 #[cfg(test)]
+#[path = "discovery_collision_tests.rs"]
+mod discovery_collision_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use bacnet_types::enums::ObjectType;
@@ -338,14 +386,14 @@ mod tests {
     #[test]
     fn upsert_with_result_reports_insert_and_update() {
         let mut table = DeviceTable::new();
-        assert_eq!(
+        assert!(matches!(
             table.upsert_with_result(make_device(1234)),
             DeviceUpsertResult::Inserted
-        );
-        assert_eq!(
+        ));
+        assert!(matches!(
             table.upsert_with_result(make_device(1234)),
             DeviceUpsertResult::Updated
-        );
+        ));
     }
 
     #[test]

--- a/crates/bacnet-client/src/discovery_collision_tests.rs
+++ b/crates/bacnet-client/src/discovery_collision_tests.rs
@@ -1,0 +1,220 @@
+use super::*;
+use bacnet_types::enums::ObjectType;
+
+fn local_device(instance: u32, mac: &[u8], last_seen: Instant) -> DiscoveredDevice {
+    DiscoveredDevice {
+        object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, instance).unwrap(),
+        mac_address: MacAddr::from_slice(mac),
+        max_apdu_length: 1476,
+        segmentation_supported: Segmentation::NONE,
+        max_segments_accepted: None,
+        vendor_id: 42,
+        last_seen,
+        source_network: None,
+        source_address: None,
+    }
+}
+
+fn routed_device(
+    instance: u32,
+    router_mac: &[u8],
+    network: u16,
+    address: &[u8],
+    last_seen: Instant,
+) -> DiscoveredDevice {
+    let mut device = local_device(instance, router_mac, last_seen);
+    device.source_network = Some(network);
+    device.source_address = Some(MacAddr::from_slice(address));
+    device
+}
+
+fn assert_same_device(actual: &DiscoveredDevice, expected: &DiscoveredDevice) {
+    assert_eq!(actual.object_identifier, expected.object_identifier);
+    assert_eq!(actual.mac_address, expected.mac_address);
+    assert_eq!(actual.max_apdu_length, expected.max_apdu_length);
+    assert_eq!(
+        actual.segmentation_supported,
+        expected.segmentation_supported
+    );
+    assert_eq!(actual.max_segments_accepted, expected.max_segments_accepted);
+    assert_eq!(actual.vendor_id, expected.vendor_id);
+    assert_eq!(actual.last_seen, expected.last_seen);
+    assert_eq!(actual.source_network, expected.source_network);
+    assert_eq!(actual.source_address, expected.source_address);
+}
+
+fn retained_from_collision(result: DeviceUpsertResult) -> DiscoveredDevice {
+    match result {
+        DeviceUpsertResult::Collision { retained } => retained,
+        other => panic!("expected collision, got {other:?}"),
+    }
+}
+
+#[test]
+fn first_i_am_inserts_and_same_local_endpoint_refreshes_metadata() {
+    let now = Instant::now();
+    let mut table = DeviceTable::new();
+    let original = local_device(1001, &[0x01], now);
+
+    assert!(matches!(
+        table.upsert_with_result(original.clone()),
+        DeviceUpsertResult::Inserted
+    ));
+
+    let mut refreshed = original;
+    refreshed.max_apdu_length = 480;
+    refreshed.segmentation_supported = Segmentation::BOTH;
+    refreshed.max_segments_accepted = Some(8);
+    refreshed.vendor_id = 84;
+    refreshed.last_seen = now + Duration::from_secs(10);
+    assert!(matches!(
+        table.upsert_with_result(refreshed.clone()),
+        DeviceUpsertResult::Updated
+    ));
+    assert_same_device(table.get(1001).unwrap(), &refreshed);
+}
+
+#[test]
+fn different_local_endpoint_collides_and_retains_exact_row() {
+    let now = Instant::now();
+    let mut table = DeviceTable::new();
+    let retained = local_device(1001, &[0x01], now);
+    table.upsert_with_result(retained.clone());
+
+    let mut incoming = local_device(1001, &[0x02], now + Duration::from_secs(10));
+    incoming.vendor_id = 84;
+    let collision = retained_from_collision(table.upsert_with_result(incoming));
+
+    assert_same_device(&collision, &retained);
+    assert_same_device(table.get(1001).unwrap(), &retained);
+}
+
+#[test]
+fn same_routed_endpoint_refreshes_router_and_metadata() {
+    let now = Instant::now();
+    let mut table = DeviceTable::new();
+    let original = routed_device(1001, &[0x10], 100, &[0x03], now);
+    table.upsert_with_result(original.clone());
+
+    let mut refreshed = routed_device(1001, &[0x20], 100, &[0x03], now + Duration::from_secs(10));
+    refreshed.max_apdu_length = 480;
+    refreshed.segmentation_supported = Segmentation::BOTH;
+    refreshed.vendor_id = 84;
+    assert!(matches!(
+        table.upsert_with_result(refreshed.clone()),
+        DeviceUpsertResult::Updated
+    ));
+    assert_same_device(table.get(1001).unwrap(), &refreshed);
+}
+
+#[test]
+fn differing_complete_endpoint_identities_collide() {
+    let now = Instant::now();
+    let routed = routed_device(1001, &[0x10], 100, &[0x03], now);
+    let mut table = DeviceTable::new();
+    table.upsert_with_result(routed.clone());
+
+    for incoming in [
+        routed_device(1001, &[0x20], 200, &[0x03], now),
+        routed_device(1001, &[0x20], 100, &[0x04], now),
+    ] {
+        let collision = retained_from_collision(table.upsert_with_result(incoming));
+        assert_same_device(&collision, &routed);
+        assert_same_device(table.get(1001).unwrap(), &routed);
+    }
+
+    let local = local_device(2002, &[0x01], now);
+    let mut local_table = DeviceTable::new();
+    local_table.upsert_with_result(local.clone());
+    let collision = retained_from_collision(local_table.upsert_with_result(routed_device(
+        2002,
+        &[0x10],
+        100,
+        &[0x03],
+        now,
+    )));
+    assert_same_device(&collision, &local);
+
+    let routed = routed_device(3003, &[0x10], 100, &[0x03], now);
+    let mut routed_table = DeviceTable::new();
+    routed_table.upsert_with_result(routed.clone());
+    let collision =
+        retained_from_collision(routed_table.upsert_with_result(local_device(3003, &[0x01], now)));
+    assert_same_device(&collision, &routed);
+}
+
+#[test]
+fn placeholder_and_partial_rows_remain_repairable_by_complete_i_am() {
+    let now = Instant::now();
+    let mut placeholder_table = DeviceTable::new();
+    placeholder_table.upsert_placeholder(local_device(1001, &[0x01], now));
+    let replacement = local_device(1001, &[0x02], now + Duration::from_secs(10));
+    assert!(matches!(
+        placeholder_table.upsert_with_result(replacement.clone()),
+        DeviceUpsertResult::Updated
+    ));
+    assert_same_device(placeholder_table.get(1001).unwrap(), &replacement);
+
+    let mut partial = local_device(2002, &[0x01], now);
+    partial.source_network = Some(100);
+    let mut partial_table = DeviceTable::new();
+    partial_table.upsert(partial);
+    let replacement = routed_device(2002, &[0x10], 200, &[0x03], now);
+    assert!(matches!(
+        partial_table.upsert_with_result(replacement.clone()),
+        DeviceUpsertResult::Updated
+    ));
+    assert_same_device(partial_table.get(2002).unwrap(), &replacement);
+}
+
+#[test]
+fn partial_incoming_row_cannot_displace_stable_authority() {
+    let now = Instant::now();
+    let retained = local_device(1001, &[0x01], now);
+    let mut table = DeviceTable::new();
+    table.upsert_with_result(retained.clone());
+
+    let mut partial = local_device(1001, &[0x01], now + Duration::from_secs(10));
+    partial.source_address = Some(MacAddr::from_slice(&[0x03]));
+    let collision = retained_from_collision(table.upsert_with_result(partial));
+
+    assert_same_device(&collision, &retained);
+    assert_same_device(table.get(1001).unwrap(), &retained);
+}
+
+#[test]
+fn explicit_manual_upsert_overwrites_different_endpoint() {
+    let now = Instant::now();
+    let mut table = DeviceTable::new();
+    table.upsert_with_result(local_device(1001, &[0x01], now));
+    let manual = routed_device(1001, &[0x10], 100, &[0x03], now);
+
+    table.upsert(manual.clone());
+
+    assert_same_device(table.get(1001).unwrap(), &manual);
+}
+
+#[test]
+fn repeated_collisions_do_not_refresh_and_claimant_can_insert_after_purge() {
+    let now = Instant::now();
+    let retained = local_device(1001, &[0x01], now);
+    let mut table = DeviceTable::new();
+    table.upsert_with_result(retained.clone());
+
+    let mut claimant = local_device(1001, &[0x02], now + Duration::from_secs(10));
+    for vendor_id in [84, 85] {
+        claimant.vendor_id = vendor_id;
+        claimant.last_seen += Duration::from_secs(10);
+        let collision = retained_from_collision(table.upsert_with_result(claimant.clone()));
+        assert_same_device(&collision, &retained);
+        assert_same_device(table.get(1001).unwrap(), &retained);
+    }
+
+    let removed = table.purge_stale_at(now + Duration::from_secs(61), Duration::from_secs(60));
+    assert_eq!(removed.len(), 1);
+    assert!(matches!(
+        table.upsert_with_result(claimant.clone()),
+        DeviceUpsertResult::Inserted
+    ));
+    assert_same_device(table.get(1001).unwrap(), &claimant);
+}


### PR DESCRIPTION
## Summary
- classify I-Am refreshes by BACnet peer endpoint: local source MAC or routed `(SNET, SADR)`
- retain the first authoritative row when a different endpoint claims the same Device instance, preventing a later conflicting I-Am from redirecting requests
- expose exact retained/incoming snapshots through a new additive `device_collision_events()` stream while leaving the existing `DeviceEvent` API unchanged

## Contract
- same-endpoint Vendor ID, Max APDU, segmentation, and routed next-hop changes remain ordinary `Updated` refreshes
- real I-Am data can still replace legacy placeholders or repair partial routing metadata
- explicit manual registrations remain administrative overwrites
- collisions do not mutate or refresh the retained row; normal stale purge/clear behavior remains the recovery boundary
- no claimant history, quarantine state, raw packet retention, or Python API change

## Standards grounding
- ANSI/ASHRAE 135-2020 §12.11 requires Device Object Identifiers to be unique throughout the BACnet internetwork
- §6.2 defines SNET/SADR as original source identity, while the local source MAC is the routed next hop
- §16.10 defines I-Am identity/capability fields; those fields do not provide the complete Model/Vendor/Serial tuple needed to prove physical-device identity
- the Standard does not prescribe a client-side collision winner, so retain-first is the documented local safety policy

## Validation
- `cargo test -p bacnet-client --locked`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `.github/scripts/check-file-size.sh`
- `.github/scripts/check-no-secrets.sh`
- `git diff --check`

Closes #456