### PR TITLE
feat(python): add typed Audit client API

### DIFF
--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -6,7 +6,7 @@ as class attributes; vendor-proprietary values are available via ``from_raw()``.
 
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+from typing import Any, Literal, NotRequired, Optional, TypedDict, Union
 
 
 # ---------------------------------------------------------------------------
@@ -433,6 +433,39 @@ class ErrorCode:
     def __hash__(self) -> int: ...
 
 
+class AuditOperation:
+    """BACnet audit operation.
+
+    Typed Audit request mappings accept standard values 0..15 and proprietary
+    values 32..63. ``from_raw()`` remains a lossless enum-wrapper constructor;
+    reserved or wider values are rejected when used in a request mapping.
+    """
+
+    READ: AuditOperation
+    WRITE: AuditOperation
+    CREATE: AuditOperation
+    DELETE: AuditOperation
+    LIFE_SAFETY: AuditOperation
+    ACKNOWLEDGE_ALARM: AuditOperation
+    DEVICE_DISABLE_COMM: AuditOperation
+    DEVICE_ENABLE_COMM: AuditOperation
+    DEVICE_RESET: AuditOperation
+    DEVICE_BACKUP: AuditOperation
+    DEVICE_RESTORE: AuditOperation
+    SUBSCRIPTION: AuditOperation
+    NOTIFICATION: AuditOperation
+    AUDITING_FAILURE: AuditOperation
+    NETWORK_CHANGES: AuditOperation
+    GENERAL: AuditOperation
+
+    @staticmethod
+    def from_raw(value: int) -> AuditOperation: ...
+    def to_raw(self) -> int: ...
+    def __repr__(self) -> str: ...
+    def __eq__(self, other: object) -> bool: ...
+    def __hash__(self) -> int: ...
+
+
 class EnableDisable:
     """BACnet DeviceCommunicationControl enable/disable options (Clause 16.4)."""
 
@@ -650,6 +683,151 @@ class BACnetTimeStamp:
 
     def __repr__(self) -> str: ...
     def __eq__(self, other: object) -> bool: ...
+
+
+class AuditRecipientDevice(TypedDict):
+    """Audit recipient selected by Device object identifier."""
+
+    kind: Literal["device"]
+    object_identifier: ObjectIdentifier
+
+
+class AuditRecipientAddress(TypedDict):
+    """Audit recipient selected by BACnet network and MAC address."""
+
+    kind: Literal["address"]
+    network_number: int
+    mac_address: bytes
+
+
+AuditRecipientInput = AuditRecipientDevice | AuditRecipientAddress
+
+
+class AuditPropertyReference(TypedDict):
+    property_identifier: PropertyIdentifier
+    property_array_index: NotRequired[int | None]
+
+
+class AuditNotificationInput(TypedDict):
+    source_device: AuditRecipientInput
+    operation: AuditOperation
+    target_device: AuditRecipientInput
+    source_timestamp: NotRequired[BACnetTimeStamp | None]
+    target_timestamp: NotRequired[BACnetTimeStamp | None]
+    source_object: NotRequired[ObjectIdentifier | None]
+    source_comment: NotRequired[str | None]
+    target_comment: NotRequired[str | None]
+    invoke_id: NotRequired[int | None]
+    source_user_id: NotRequired[int | None]
+    source_user_role: NotRequired[int | None]
+    target_object: NotRequired[ObjectIdentifier | None]
+    target_property: NotRequired[AuditPropertyReference | None]
+    target_priority: NotRequired[int | None]
+    target_value: NotRequired[bytes | None]
+    current_value: NotRequired[bytes | None]
+    result: NotRequired[tuple[ErrorClass, ErrorCode] | None]
+
+
+class AuditNotificationRequestInput(TypedDict):
+    notifications: list[AuditNotificationInput]
+
+
+class AuditLogQueryByTargetInput(TypedDict):
+    kind: Literal["by_target"]
+    target_device_identifier: ObjectIdentifier
+    successful_actions_only: bool
+    target_device_address: NotRequired[AuditRecipientAddress | None]
+    target_object_identifier: NotRequired[ObjectIdentifier | None]
+    target_property_identifier: NotRequired[PropertyIdentifier | None]
+    target_array_index: NotRequired[int | None]
+    target_priority: NotRequired[int | None]
+    operations: NotRequired[int | None]
+
+
+class AuditLogQueryBySourceInput(TypedDict):
+    kind: Literal["by_source"]
+    source_device_identifier: ObjectIdentifier
+    successful_actions_only: bool
+    source_device_address: NotRequired[AuditRecipientAddress | None]
+    source_object_identifier: NotRequired[ObjectIdentifier | None]
+    operations: NotRequired[int | None]
+
+
+AuditLogQueryParametersInput = AuditLogQueryByTargetInput | AuditLogQueryBySourceInput
+
+
+class AuditLogQueryRequestInput(TypedDict):
+    audit_log: ObjectIdentifier
+    query_parameters: AuditLogQueryParametersInput
+    requested_count: int
+    start_at_sequence_number: NotRequired[int | None]
+
+
+BACnetDateTime = tuple[
+    tuple[int, int, int, int],
+    tuple[int, int, int, int],
+]
+
+
+class AuditPropertyReferenceResult(TypedDict):
+    property_identifier: PropertyIdentifier
+    property_array_index: int | None
+
+
+class AuditNotification(TypedDict):
+    """Canonical return mapping for a decoded Audit notification."""
+
+    source_timestamp: BACnetTimeStamp | None
+    target_timestamp: BACnetTimeStamp | None
+    source_device: AuditRecipientInput
+    source_object: ObjectIdentifier | None
+    operation: AuditOperation
+    source_comment: str | None
+    target_comment: str | None
+    invoke_id: int | None
+    source_user_id: int | None
+    source_user_role: int | None
+    target_device: AuditRecipientInput
+    target_object: ObjectIdentifier | None
+    target_property: AuditPropertyReferenceResult | None
+    target_priority: int | None
+    target_value: bytes | None
+    current_value: bytes | None
+    result: tuple[ErrorClass, ErrorCode] | None
+
+
+class AuditLogStatusDatum(TypedDict):
+    kind: Literal["log_status"]
+    log_status: int
+
+
+class AuditNotificationDatum(TypedDict):
+    kind: Literal["audit_notification"]
+    audit_notification: AuditNotification
+
+
+class AuditTimeChangeDatum(TypedDict):
+    kind: Literal["time_change"]
+    time_change: float
+
+
+AuditLogDatum = AuditLogStatusDatum | AuditNotificationDatum | AuditTimeChangeDatum
+
+
+class AuditLogRecord(TypedDict):
+    timestamp: BACnetDateTime
+    datum: AuditLogDatum
+
+
+class AuditLogRecordResult(TypedDict):
+    sequence_number: int
+    record: AuditLogRecord
+
+
+class AuditLogQueryAck(TypedDict):
+    audit_log: ObjectIdentifier
+    records: list[AuditLogRecordResult]
+    no_more_items: bool
 
 
 class PropertyValue:
@@ -1478,6 +1656,30 @@ class BACnetClient:
         ...
 
     # --- Audit ---
+
+    async def confirmed_audit_notification_typed(
+        self,
+        address: str,
+        request: AuditNotificationRequestInput,
+    ) -> None:
+        """Send a validated mapping through the native confirmed Audit helper."""
+        ...
+
+    async def unconfirmed_audit_notification_typed(
+        self,
+        address: str,
+        request: AuditNotificationRequestInput,
+    ) -> None:
+        """Send a validated mapping through the native unconfirmed Audit helper."""
+        ...
+
+    async def audit_log_query_typed(
+        self,
+        address: str,
+        request: AuditLogQueryRequestInput,
+    ) -> AuditLogQueryAck:
+        """Send a typed Audit Log query and return a canonical decoded mapping."""
+        ...
 
     async def confirmed_audit_notification(
         self, address: str, service_data: bytes

--- a/crates/rusty-bacnet/src/client/client_methods/vt_audit_time_directed.rs
+++ b/crates/rusty-bacnet/src/client/client_methods/vt_audit_time_directed.rs
@@ -142,6 +142,31 @@ impl BACnetClient {
         })
     }
 
+    /// Send a ConfirmedAuditNotification from a validated Python mapping.
+    #[pyo3(signature = (address, request))]
+    fn confirmed_audit_notification_typed<'py>(
+        &self,
+        py: Python<'py>,
+        address: String,
+        request: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let request = audit_notification_request_from_py(request)?;
+        let inner = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mac = parse_address(&address)?;
+            let c = {
+                let guard = inner.lock().await;
+                Arc::clone(guard.as_ref().ok_or_else(|| {
+                    PyRuntimeError::new_err("client not started — use 'async with'")
+                })?)
+            };
+            c.confirmed_audit_notification(&mac, &request)
+                .await
+                .map_err(to_py_err)?;
+            Ok(Python::attach(|py| py.None()))
+        })
+    }
+
     /// Send an UnconfirmedAuditNotification request (raw service data).
     ///
     /// `service_data` must be a complete, pre-encoded Clause 21
@@ -174,6 +199,31 @@ impl BACnetClient {
         })
     }
 
+    /// Send an UnconfirmedAuditNotification from a validated Python mapping.
+    #[pyo3(signature = (address, request))]
+    fn unconfirmed_audit_notification_typed<'py>(
+        &self,
+        py: Python<'py>,
+        address: String,
+        request: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let request = audit_notification_request_from_py(request)?;
+        let inner = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mac = parse_address(&address)?;
+            let c = {
+                let guard = inner.lock().await;
+                Arc::clone(guard.as_ref().ok_or_else(|| {
+                    PyRuntimeError::new_err("client not started — use 'async with'")
+                })?)
+            };
+            c.unconfirmed_audit_notification(&mac, &request)
+                .await
+                .map_err(to_py_err)?;
+            Ok(Python::attach(|py| py.None()))
+        })
+    }
+
     /// Send an AuditLogQuery request (raw service data). Returns raw response bytes.
     ///
     /// `service_data` must be a complete, pre-encoded Clause 21
@@ -200,6 +250,29 @@ impl BACnetClient {
                 .await
                 .map_err(to_py_err)?;
             Python::attach(|py| Ok(PyBytes::new(py, &resp).into_any().unbind()))
+        })
+    }
+
+    /// Send an AuditLogQuery from a validated mapping and return a typed mapping ACK.
+    #[pyo3(signature = (address, request))]
+    fn audit_log_query_typed<'py>(
+        &self,
+        py: Python<'py>,
+        address: String,
+        request: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let request = audit_log_query_request_from_py(request)?;
+        let inner = self.inner.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mac = parse_address(&address)?;
+            let c = {
+                let guard = inner.lock().await;
+                Arc::clone(guard.as_ref().ok_or_else(|| {
+                    PyRuntimeError::new_err("client not started — use 'async with'")
+                })?)
+            };
+            let ack = c.audit_log_query(&mac, &request).await.map_err(to_py_err)?;
+            Python::attach(|py| audit_log_query_ack_to_py(py, &ack))
         })
     }
 

--- a/crates/rusty-bacnet/src/client/mod.rs
+++ b/crates/rusty-bacnet/src/client/mod.rs
@@ -42,6 +42,7 @@ use bacnet_types::primitives::BACnetTimeStamp;
 
 use crate::errors::to_py_err;
 use crate::types::{
+    audit_log_query_ack_to_py, audit_log_query_request_from_py, audit_notification_request_from_py,
     parse_address, py_to_rpm_specs, py_to_wpm_specs, rpm_ack_to_py, PyBACnetTimeStamp,
     PyCovNotificationIterator, PyDiscoveredDevice, PyEnableDisable,
     PyEnrollmentSummaryEventStateFilter, PyEventState, PyEventType, PyLifeSafetyOperation,

--- a/crates/rusty-bacnet/src/types/audit.rs
+++ b/crates/rusty-bacnet/src/types/audit.rs
@@ -1,0 +1,541 @@
+//! Python mapping boundary for typed Audit client services.
+
+use bacnet_services::audit::{
+    AuditLogQueryRequest, AuditNotificationRequest, AuditPropertyReference,
+    BACnetAuditLogQueryParameters, BACnetAuditNotification,
+};
+use bacnet_services::common::MAX_DECODED_ITEMS;
+use bacnet_types::bitstring::AuditOperationFlags;
+use bacnet_types::constructed::{BACnetAddress, BACnetRecipient};
+use bacnet_types::enums::AuditOperation;
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyBool, PyBytes, PyInt, PyList, PyMapping, PyString, PyTuple};
+
+use super::{
+    PyAuditOperation, PyBACnetTimeStamp, PyErrorClass, PyErrorCode, PyObjectIdentifier,
+    PyPropertyIdentifier,
+};
+
+const NOTIFICATION_REQUIRED: &[&str] = &["source_device", "operation", "target_device"];
+const NOTIFICATION_OPTIONAL: &[&str] = &[
+    "source_timestamp",
+    "target_timestamp",
+    "source_object",
+    "source_comment",
+    "target_comment",
+    "invoke_id",
+    "source_user_id",
+    "source_user_role",
+    "target_object",
+    "target_property",
+    "target_priority",
+    "target_value",
+    "current_value",
+    "result",
+];
+
+fn mapping<'a, 'py>(
+    value: &'a Bound<'py, PyAny>,
+    name: &str,
+) -> PyResult<&'a Bound<'py, PyMapping>> {
+    value
+        .cast::<PyMapping>()
+        .map_err(|_| PyTypeError::new_err(format!("{name} must be a mapping")))
+}
+
+fn validate_keys(
+    value: &Bound<'_, PyMapping>,
+    name: &str,
+    required: &[&str],
+    optional: &[&str],
+) -> PyResult<()> {
+    for key in value.keys()?.iter() {
+        if key.cast::<PyString>().is_err() {
+            return Err(PyTypeError::new_err(format!(
+                "{name} mapping keys must be strings"
+            )));
+        }
+        let key = key.extract::<String>()?;
+        if !required.contains(&key.as_str()) && !optional.contains(&key.as_str()) {
+            return Err(PyValueError::new_err(format!(
+                "{name} contains unknown key '{key}'"
+            )));
+        }
+    }
+    for &key in required {
+        if !value.contains(key)? {
+            return Err(PyValueError::new_err(format!(
+                "{name} is missing required key '{key}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn required_item<'py>(
+    value: &Bound<'py, PyMapping>,
+    name: &str,
+    key: &str,
+) -> PyResult<Bound<'py, PyAny>> {
+    if !value.contains(key)? {
+        return Err(PyValueError::new_err(format!(
+            "{name} is missing required key '{key}'"
+        )));
+    }
+    value.get_item(key)
+}
+
+fn optional_item<'py>(
+    value: &Bound<'py, PyMapping>,
+    key: &str,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    if !value.contains(key)? {
+        return Ok(None);
+    }
+    let item = value.get_item(key)?;
+    Ok((!item.is_none()).then_some(item))
+}
+
+fn discriminator(value: &Bound<'_, PyMapping>, name: &str) -> PyResult<String> {
+    required_item(value, name, "kind")?
+        .extract::<String>()
+        .map_err(|_| PyValueError::new_err(format!("{name}.kind must be a valid discriminator")))
+}
+
+fn integer(value: &Bound<'_, PyAny>, name: &str) -> PyResult<i128> {
+    if value.is_instance_of::<PyBool>() || value.cast::<PyInt>().is_err() {
+        return Err(PyTypeError::new_err(format!("{name} must be an integer")));
+    }
+    value.extract::<i128>().map_err(|_| {
+        PyValueError::new_err(format!("{name} is outside the supported integer range"))
+    })
+}
+
+fn ranged_integer(
+    value: &Bound<'_, PyAny>,
+    name: &str,
+    minimum: u64,
+    maximum: u64,
+) -> PyResult<u64> {
+    let value = integer(value, name)?;
+    if value < i128::from(minimum) || value > i128::from(maximum) {
+        return Err(PyValueError::new_err(format!(
+            "{name} must be {minimum}..={maximum}, got {value}"
+        )));
+    }
+    Ok(value as u64)
+}
+
+fn boolean(value: &Bound<'_, PyAny>, name: &str) -> PyResult<bool> {
+    if !value.is_instance_of::<PyBool>() {
+        return Err(PyTypeError::new_err(format!("{name} must be a bool")));
+    }
+    value.extract::<bool>()
+}
+
+fn string(value: &Bound<'_, PyAny>, name: &str) -> PyResult<String> {
+    if value.cast::<PyString>().is_err() {
+        return Err(PyTypeError::new_err(format!("{name} must be a str")));
+    }
+    value.extract::<String>()
+}
+
+fn bytes(value: &Bound<'_, PyAny>, name: &str) -> PyResult<Vec<u8>> {
+    value
+        .cast::<PyBytes>()
+        .map(|value| value.as_bytes().to_vec())
+        .map_err(|_| PyTypeError::new_err(format!("{name} must be bytes")))
+}
+
+fn object_identifier(value: &Bound<'_, PyAny>, name: &str) -> PyResult<ObjectIdentifier> {
+    value
+        .extract::<PyObjectIdentifier>()
+        .map(|value| value.to_rust())
+        .map_err(|_| PyTypeError::new_err(format!("{name} must be an ObjectIdentifier")))
+}
+
+fn recipient(value: &Bound<'_, PyAny>, name: &str) -> PyResult<BACnetRecipient> {
+    let value = mapping(value, name)?;
+    match discriminator(value, name)?.as_str() {
+        "device" => {
+            validate_keys(value, name, &["kind", "object_identifier"], &[])?;
+            Ok(BACnetRecipient::Device(object_identifier(
+                &required_item(value, name, "object_identifier")?,
+                &format!("{name}.object_identifier"),
+            )?))
+        }
+        "address" => Ok(BACnetRecipient::Address(address_mapping(value, name)?)),
+        kind => Err(PyValueError::new_err(format!(
+            "{name}.kind must be 'device' or 'address', got '{kind}'"
+        ))),
+    }
+}
+
+fn address_mapping(value: &Bound<'_, PyMapping>, name: &str) -> PyResult<BACnetAddress> {
+    validate_keys(value, name, &["kind", "network_number", "mac_address"], &[])?;
+    let kind = discriminator(value, name)?;
+    if kind != "address" {
+        return Err(PyValueError::new_err(format!(
+            "{name}.kind must be 'address', got '{kind}'"
+        )));
+    }
+    let network_number = ranged_integer(
+        &required_item(value, name, "network_number")?,
+        &format!("{name}.network_number"),
+        0,
+        u16::MAX.into(),
+    )? as u16;
+    let mac_address = bytes(
+        &required_item(value, name, "mac_address")?,
+        &format!("{name}.mac_address"),
+    )?;
+    Ok(BACnetAddress {
+        network_number,
+        mac_address: MacAddr::from_slice(&mac_address),
+    })
+}
+
+fn optional_address(
+    value: Option<Bound<'_, PyAny>>,
+    name: &str,
+) -> PyResult<Option<BACnetAddress>> {
+    value
+        .map(|value| {
+            let value = mapping(&value, name)?;
+            address_mapping(value, name)
+        })
+        .transpose()
+}
+
+fn property_reference(value: &Bound<'_, PyAny>, name: &str) -> PyResult<AuditPropertyReference> {
+    let value = mapping(value, name)?;
+    validate_keys(
+        value,
+        name,
+        &["property_identifier"],
+        &["property_array_index"],
+    )?;
+    let property_identifier = required_item(value, name, "property_identifier")?
+        .extract::<PyPropertyIdentifier>()
+        .map(|value| value.to_rust())
+        .map_err(|_| {
+            PyTypeError::new_err(format!(
+                "{name}.property_identifier must be a PropertyIdentifier"
+            ))
+        })?;
+    let property_array_index = optional_item(value, "property_array_index")?
+        .map(|value| ranged_integer(&value, &format!("{name}.property_array_index"), 0, u64::MAX))
+        .transpose()?;
+    Ok(AuditPropertyReference {
+        property_identifier,
+        property_array_index,
+    })
+}
+
+fn operation(value: &Bound<'_, PyAny>, name: &str) -> PyResult<AuditOperation> {
+    let operation = value
+        .extract::<PyAuditOperation>()
+        .map(|value| value.to_rust())
+        .map_err(|_| PyTypeError::new_err(format!("{name} must be an AuditOperation")))?;
+    let raw = operation.to_raw();
+    if raw <= 15 || (32..=63).contains(&raw) {
+        Ok(operation)
+    } else {
+        Err(PyValueError::new_err(format!(
+            "{name} must select a standard operation 0..=15 or proprietary operation 32..=63, got {raw}"
+        )))
+    }
+}
+
+fn result(
+    value: &Bound<'_, PyAny>,
+    name: &str,
+) -> PyResult<(
+    bacnet_types::enums::ErrorClass,
+    bacnet_types::enums::ErrorCode,
+)> {
+    let value = value.cast::<PyTuple>().map_err(|_| {
+        PyTypeError::new_err(format!("{name} must be an (ErrorClass, ErrorCode) tuple"))
+    })?;
+    if value.len() != 2 {
+        return Err(PyTypeError::new_err(format!(
+            "{name} must be an (ErrorClass, ErrorCode) tuple"
+        )));
+    }
+    let error_class = value
+        .get_item(0)?
+        .extract::<PyErrorClass>()
+        .map(|value| value.to_rust())
+        .map_err(|_| PyTypeError::new_err(format!("{name}[0] must be an ErrorClass")))?;
+    let error_code = value
+        .get_item(1)?
+        .extract::<PyErrorCode>()
+        .map(|value| value.to_rust())
+        .map_err(|_| PyTypeError::new_err(format!("{name}[1] must be an ErrorCode")))?;
+    Ok((error_class, error_code))
+}
+
+fn notification(value: &Bound<'_, PyAny>, name: &str) -> PyResult<BACnetAuditNotification> {
+    let value = mapping(value, name)?;
+    validate_keys(value, name, NOTIFICATION_REQUIRED, NOTIFICATION_OPTIONAL)?;
+
+    let timestamp = |key: &str| -> PyResult<Option<bacnet_types::primitives::BACnetTimeStamp>> {
+        optional_item(value, key)?
+            .map(|item| {
+                item.extract::<PyBACnetTimeStamp>()
+                    .map(|value| value.to_rust().clone())
+                    .map_err(|_| {
+                        PyTypeError::new_err(format!("{name}.{key} must be a BACnetTimeStamp"))
+                    })
+            })
+            .transpose()
+    };
+    let optional_oid = |key: &str| -> PyResult<Option<ObjectIdentifier>> {
+        optional_item(value, key)?
+            .map(|item| object_identifier(&item, &format!("{name}.{key}")))
+            .transpose()
+    };
+    let optional_string = |key: &str| -> PyResult<Option<String>> {
+        optional_item(value, key)?
+            .map(|item| string(&item, &format!("{name}.{key}")))
+            .transpose()
+    };
+    let optional_unsigned = |key: &str, maximum: u64| -> PyResult<Option<u64>> {
+        optional_item(value, key)?
+            .map(|item| ranged_integer(&item, &format!("{name}.{key}"), 0, maximum))
+            .transpose()
+    };
+
+    let target_priority = optional_item(value, "target_priority")?
+        .map(|item| ranged_integer(&item, &format!("{name}.target_priority"), 1, 16))
+        .transpose()?
+        .map(|value| value as u8);
+
+    Ok(BACnetAuditNotification {
+        source_timestamp: timestamp("source_timestamp")?,
+        target_timestamp: timestamp("target_timestamp")?,
+        source_device: recipient(
+            &required_item(value, name, "source_device")?,
+            &format!("{name}.source_device"),
+        )?,
+        source_object: optional_oid("source_object")?,
+        operation: operation(
+            &required_item(value, name, "operation")?,
+            &format!("{name}.operation"),
+        )?,
+        source_comment: optional_string("source_comment")?,
+        target_comment: optional_string("target_comment")?,
+        invoke_id: optional_unsigned("invoke_id", u8::MAX.into())?.map(|value| value as u8),
+        source_user_id: optional_unsigned("source_user_id", u16::MAX.into())?
+            .map(|value| value as u16),
+        source_user_role: optional_unsigned("source_user_role", u8::MAX.into())?
+            .map(|value| value as u8),
+        target_device: recipient(
+            &required_item(value, name, "target_device")?,
+            &format!("{name}.target_device"),
+        )?,
+        target_object: optional_oid("target_object")?,
+        target_property: optional_item(value, "target_property")?
+            .map(|item| property_reference(&item, &format!("{name}.target_property")))
+            .transpose()?,
+        target_priority,
+        target_value: optional_item(value, "target_value")?
+            .map(|item| bytes(&item, &format!("{name}.target_value")))
+            .transpose()?,
+        current_value: optional_item(value, "current_value")?
+            .map(|item| bytes(&item, &format!("{name}.current_value")))
+            .transpose()?,
+        result: optional_item(value, "result")?
+            .map(|item| result(&item, &format!("{name}.result")))
+            .transpose()?,
+    })
+}
+
+/// Convert the public Audit notification mapping without retaining Python objects.
+pub(crate) fn audit_notification_request_from_py(
+    value: &Bound<'_, PyAny>,
+) -> PyResult<AuditNotificationRequest> {
+    let value = mapping(value, "request")?;
+    validate_keys(value, "request", &["notifications"], &[])?;
+    let notifications = required_item(value, "request", "notifications")?;
+    let notifications = notifications
+        .cast::<PyList>()
+        .map_err(|_| PyTypeError::new_err("request.notifications must be a list"))?;
+    if notifications.is_empty() || notifications.len() > MAX_DECODED_ITEMS {
+        return Err(PyValueError::new_err(format!(
+            "request.notifications count must be 1..={MAX_DECODED_ITEMS}, got {}",
+            notifications.len()
+        )));
+    }
+    let notifications = notifications
+        .iter()
+        .enumerate()
+        .map(|(index, value)| notification(&value, &format!("request.notifications[{index}]")))
+        .collect::<PyResult<Vec<_>>>()?;
+    Ok(AuditNotificationRequest { notifications })
+}
+
+fn operation_flags(value: &Bound<'_, PyAny>, name: &str) -> PyResult<AuditOperationFlags> {
+    let bits = ranged_integer(value, name, 0, u64::MAX)?;
+    AuditOperationFlags::from_bits(bits)
+        .map_err(|error| PyValueError::new_err(format!("{name}: {error}")))
+}
+
+fn query_parameters(
+    value: &Bound<'_, PyAny>,
+    name: &str,
+) -> PyResult<BACnetAuditLogQueryParameters> {
+    let value = mapping(value, name)?;
+    match discriminator(value, name)?.as_str() {
+        "by_target" => {
+            validate_keys(
+                value,
+                name,
+                &[
+                    "kind",
+                    "target_device_identifier",
+                    "successful_actions_only",
+                ],
+                &[
+                    "target_device_address",
+                    "target_object_identifier",
+                    "target_property_identifier",
+                    "target_array_index",
+                    "target_priority",
+                    "operations",
+                ],
+            )?;
+            let target_property_identifier = optional_item(value, "target_property_identifier")?
+                .map(|item| {
+                    item.extract::<PyPropertyIdentifier>()
+                        .map(|value| value.to_rust())
+                        .map_err(|_| {
+                            PyTypeError::new_err(format!(
+                                "{name}.target_property_identifier must be a PropertyIdentifier"
+                            ))
+                        })
+                })
+                .transpose()?;
+            Ok(BACnetAuditLogQueryParameters::ByTarget {
+                target_device_identifier: object_identifier(
+                    &required_item(value, name, "target_device_identifier")?,
+                    &format!("{name}.target_device_identifier"),
+                )?,
+                target_device_address: optional_address(
+                    optional_item(value, "target_device_address")?,
+                    &format!("{name}.target_device_address"),
+                )?,
+                target_object_identifier: optional_item(value, "target_object_identifier")?
+                    .map(|item| {
+                        object_identifier(&item, &format!("{name}.target_object_identifier"))
+                    })
+                    .transpose()?,
+                target_property_identifier,
+                target_array_index: optional_item(value, "target_array_index")?
+                    .map(|item| {
+                        ranged_integer(&item, &format!("{name}.target_array_index"), 0, u64::MAX)
+                    })
+                    .transpose()?,
+                target_priority: optional_item(value, "target_priority")?
+                    .map(|item| ranged_integer(&item, &format!("{name}.target_priority"), 1, 16))
+                    .transpose()?
+                    .map(|value| value as u8),
+                operations: optional_item(value, "operations")?
+                    .map(|item| operation_flags(&item, &format!("{name}.operations")))
+                    .transpose()?,
+                successful_actions_only: boolean(
+                    &required_item(value, name, "successful_actions_only")?,
+                    &format!("{name}.successful_actions_only"),
+                )?,
+            })
+        }
+        "by_source" => {
+            validate_keys(
+                value,
+                name,
+                &[
+                    "kind",
+                    "source_device_identifier",
+                    "successful_actions_only",
+                ],
+                &[
+                    "source_device_address",
+                    "source_object_identifier",
+                    "operations",
+                ],
+            )?;
+            Ok(BACnetAuditLogQueryParameters::BySource {
+                source_device_identifier: object_identifier(
+                    &required_item(value, name, "source_device_identifier")?,
+                    &format!("{name}.source_device_identifier"),
+                )?,
+                source_device_address: optional_address(
+                    optional_item(value, "source_device_address")?,
+                    &format!("{name}.source_device_address"),
+                )?,
+                source_object_identifier: optional_item(value, "source_object_identifier")?
+                    .map(|item| {
+                        object_identifier(&item, &format!("{name}.source_object_identifier"))
+                    })
+                    .transpose()?,
+                operations: optional_item(value, "operations")?
+                    .map(|item| operation_flags(&item, &format!("{name}.operations")))
+                    .transpose()?,
+                successful_actions_only: boolean(
+                    &required_item(value, name, "successful_actions_only")?,
+                    &format!("{name}.successful_actions_only"),
+                )?,
+            })
+        }
+        kind => Err(PyValueError::new_err(format!(
+            "{name}.kind must be 'by_target' or 'by_source', got '{kind}'"
+        ))),
+    }
+}
+
+/// Convert the public Audit Log query mapping without retaining Python objects.
+pub(crate) fn audit_log_query_request_from_py(
+    value: &Bound<'_, PyAny>,
+) -> PyResult<AuditLogQueryRequest> {
+    let value = mapping(value, "request")?;
+    validate_keys(
+        value,
+        "request",
+        &["audit_log", "query_parameters", "requested_count"],
+        &["start_at_sequence_number"],
+    )?;
+    Ok(AuditLogQueryRequest {
+        audit_log: object_identifier(
+            &required_item(value, "request", "audit_log")?,
+            "request.audit_log",
+        )?,
+        query_parameters: query_parameters(
+            &required_item(value, "request", "query_parameters")?,
+            "request.query_parameters",
+        )?,
+        start_at_sequence_number: optional_item(value, "start_at_sequence_number")?
+            .map(|item| {
+                ranged_integer(
+                    &item,
+                    "request.start_at_sequence_number",
+                    0,
+                    u32::MAX.into(),
+                )
+            })
+            .transpose()?
+            .map(|value| value as u32),
+        requested_count: ranged_integer(
+            &required_item(value, "request", "requested_count")?,
+            "request.requested_count",
+            0,
+            u16::MAX.into(),
+        )? as u16,
+    })
+}
+
+#[cfg(test)]
+#[path = "audit/tests.rs"]
+mod tests;

--- a/crates/rusty-bacnet/src/types/audit/tests.rs
+++ b/crates/rusty-bacnet/src/types/audit/tests.rs
@@ -1,0 +1,531 @@
+use super::*;
+
+use bacnet_services::audit::{
+    AuditLogQueryAck, BACnetAuditLogDatum, BACnetAuditLogRecord, BACnetAuditLogRecordResult,
+};
+use bacnet_types::constructed::BACnetRecipient;
+use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
+use bacnet_types::primitives::{BACnetTimeStamp, Date, Time};
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::types::{PyDict, PyList};
+use pyo3::PyTypeInfo;
+
+use crate::types::audit_projection::audit_log_query_ack_to_py;
+
+fn oid(object_type: ObjectType, instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(object_type, instance).unwrap()
+}
+
+fn py_oid(object_type: ObjectType, instance: u32) -> PyObjectIdentifier {
+    PyObjectIdentifier::from_rust(oid(object_type, instance))
+}
+
+fn device_recipient(py: Python<'_>, instance: u32) -> Bound<'_, PyDict> {
+    let value = PyDict::new(py);
+    value.set_item("kind", "device").unwrap();
+    value
+        .set_item("object_identifier", py_oid(ObjectType::DEVICE, instance))
+        .unwrap();
+    value
+}
+
+fn address_recipient(py: Python<'_>) -> Bound<'_, PyDict> {
+    let value = PyDict::new(py);
+    value.set_item("kind", "address").unwrap();
+    value.set_item("network_number", u16::MAX).unwrap();
+    value
+        .set_item("mac_address", PyBytes::new(py, b"\x01\x02"))
+        .unwrap();
+    value
+}
+
+fn minimal_notification(py: Python<'_>, raw_operation: u32) -> Bound<'_, PyDict> {
+    let value = PyDict::new(py);
+    value
+        .set_item("source_device", device_recipient(py, 1))
+        .unwrap();
+    value
+        .set_item(
+            "operation",
+            PyAuditOperation {
+                inner: AuditOperation::from_raw(raw_operation),
+            },
+        )
+        .unwrap();
+    value
+        .set_item("target_device", device_recipient(py, 2))
+        .unwrap();
+    value
+}
+
+fn notification_request<'py>(
+    py: Python<'py>,
+    notification: &Bound<'py, PyDict>,
+) -> Bound<'py, PyDict> {
+    let request = PyDict::new(py);
+    let notifications = PyList::new(py, [notification]).unwrap();
+    request.set_item("notifications", notifications).unwrap();
+    request
+}
+
+fn assert_error_type<T: PyTypeInfo>(py: Python<'_>, error: PyErr) {
+    assert!(error.is_instance_of::<T>(py), "unexpected error: {error}");
+}
+
+#[test]
+fn notification_mapping_preserves_every_field_and_native_unsigned_bounds() {
+    Python::initialize();
+    Python::attach(|py| {
+        let notification = minimal_notification(py, 63);
+        notification
+            .set_item(
+                "source_timestamp",
+                PyBACnetTimeStamp::from_rust(BACnetTimeStamp::SequenceNumber(u16::MAX)),
+            )
+            .unwrap();
+        notification
+            .set_item(
+                "target_timestamp",
+                PyBACnetTimeStamp::from_rust(BACnetTimeStamp::Time(Time {
+                    hour: 1,
+                    minute: 2,
+                    second: 3,
+                    hundredths: 4,
+                })),
+            )
+            .unwrap();
+        notification
+            .set_item("source_object", py_oid(ObjectType::ANALOG_INPUT, 3))
+            .unwrap();
+        notification.set_item("source_comment", "source").unwrap();
+        notification.set_item("target_comment", "target").unwrap();
+        notification.set_item("invoke_id", u8::MAX).unwrap();
+        notification.set_item("source_user_id", u16::MAX).unwrap();
+        notification.set_item("source_user_role", u8::MAX).unwrap();
+        notification
+            .set_item("target_device", address_recipient(py))
+            .unwrap();
+        notification
+            .set_item("target_object", py_oid(ObjectType::ANALOG_OUTPUT, 4))
+            .unwrap();
+        let property = PyDict::new(py);
+        property
+            .set_item(
+                "property_identifier",
+                PyPropertyIdentifier {
+                    inner: PropertyIdentifier::PRESENT_VALUE,
+                },
+            )
+            .unwrap();
+        property.set_item("property_array_index", u64::MAX).unwrap();
+        notification.set_item("target_property", property).unwrap();
+        notification.set_item("target_priority", 16).unwrap();
+        notification
+            .set_item("target_value", PyBytes::new(py, &[0x00]))
+            .unwrap();
+        notification
+            .set_item("current_value", PyBytes::new(py, &[0x11]))
+            .unwrap();
+        notification
+            .set_item(
+                "result",
+                (
+                    PyErrorClass {
+                        inner: ErrorClass::PROPERTY,
+                    },
+                    PyErrorCode {
+                        inner: ErrorCode::WRITE_ACCESS_DENIED,
+                    },
+                ),
+            )
+            .unwrap();
+
+        let parsed =
+            audit_notification_request_from_py(notification_request(py, &notification).as_any())
+                .unwrap();
+        let parsed = &parsed.notifications[0];
+        assert_eq!(parsed.operation, AuditOperation::from_raw(63));
+        assert_eq!(parsed.invoke_id, Some(u8::MAX));
+        assert_eq!(parsed.source_user_id, Some(u16::MAX));
+        assert_eq!(parsed.source_user_role, Some(u8::MAX));
+        assert_eq!(parsed.target_priority, Some(16));
+        assert_eq!(parsed.target_value.as_deref(), Some([0x00].as_slice()));
+        assert_eq!(parsed.current_value.as_deref(), Some([0x11].as_slice()));
+        assert_eq!(
+            parsed.result,
+            Some((ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED))
+        );
+        assert_eq!(
+            parsed
+                .target_property
+                .as_ref()
+                .unwrap()
+                .property_array_index,
+            Some(u64::MAX)
+        );
+        let BACnetRecipient::Address(address) = &parsed.target_device else {
+            panic!("expected address recipient");
+        };
+        assert_eq!(address.network_number, u16::MAX);
+        assert_eq!(address.mac_address.as_slice(), b"\x01\x02");
+    });
+}
+
+#[test]
+fn notification_mapping_rejects_schema_type_range_and_operation_errors() {
+    Python::initialize();
+    Python::attach(|py| {
+        assert_error_type::<PyTypeError>(
+            py,
+            audit_notification_request_from_py(PyList::empty(py).as_any()).unwrap_err(),
+        );
+
+        let empty = PyDict::new(py);
+        empty.set_item("notifications", PyList::empty(py)).unwrap();
+        assert_error_type::<PyValueError>(
+            py,
+            audit_notification_request_from_py(empty.as_any()).unwrap_err(),
+        );
+
+        for raw in [16, 31, 64] {
+            let item = minimal_notification(py, raw);
+            assert_error_type::<PyValueError>(
+                py,
+                audit_notification_request_from_py(notification_request(py, &item).as_any())
+                    .unwrap_err(),
+            );
+        }
+
+        let wrong_type = minimal_notification(py, 0);
+        wrong_type.set_item("invoke_id", true).unwrap();
+        assert_error_type::<PyTypeError>(
+            py,
+            audit_notification_request_from_py(notification_request(py, &wrong_type).as_any())
+                .unwrap_err(),
+        );
+
+        let out_of_range = minimal_notification(py, 0);
+        out_of_range.set_item("target_priority", 0).unwrap();
+        assert_error_type::<PyValueError>(
+            py,
+            audit_notification_request_from_py(notification_request(py, &out_of_range).as_any())
+                .unwrap_err(),
+        );
+
+        let unknown = minimal_notification(py, 0);
+        unknown.set_item("unknown", 1).unwrap();
+        assert_error_type::<PyValueError>(
+            py,
+            audit_notification_request_from_py(notification_request(py, &unknown).as_any())
+                .unwrap_err(),
+        );
+
+        let bad_discriminator = minimal_notification(py, 0);
+        let source = PyDict::new(py);
+        source.set_item("kind", "DEVICE").unwrap();
+        source
+            .set_item("object_identifier", py_oid(ObjectType::DEVICE, 1))
+            .unwrap();
+        bad_discriminator.set_item("source_device", source).unwrap();
+        assert_error_type::<PyValueError>(
+            py,
+            audit_notification_request_from_py(
+                notification_request(py, &bad_discriminator).as_any(),
+            )
+            .unwrap_err(),
+        );
+    });
+}
+
+fn base_query<'py>(py: Python<'py>, parameters: &Bound<'py, PyDict>) -> Bound<'py, PyDict> {
+    let query = PyDict::new(py);
+    query
+        .set_item("audit_log", py_oid(ObjectType::AUDIT_LOG, 10))
+        .unwrap();
+    query.set_item("query_parameters", parameters).unwrap();
+    query.set_item("requested_count", u16::MAX).unwrap();
+    query
+        .set_item("start_at_sequence_number", u32::MAX)
+        .unwrap();
+    query
+}
+
+#[test]
+fn query_mapping_preserves_both_choices_and_rejects_invalid_flags() {
+    Python::initialize();
+    Python::attach(|py| {
+        let by_target = PyDict::new(py);
+        by_target.set_item("kind", "by_target").unwrap();
+        by_target
+            .set_item("target_device_identifier", py_oid(ObjectType::DEVICE, 11))
+            .unwrap();
+        by_target
+            .set_item("target_device_address", address_recipient(py))
+            .unwrap();
+        by_target
+            .set_item(
+                "target_object_identifier",
+                py_oid(ObjectType::ANALOG_VALUE, 12),
+            )
+            .unwrap();
+        by_target
+            .set_item(
+                "target_property_identifier",
+                PyPropertyIdentifier {
+                    inner: PropertyIdentifier::PRESENT_VALUE,
+                },
+            )
+            .unwrap();
+        by_target.set_item("target_array_index", u64::MAX).unwrap();
+        by_target.set_item("target_priority", 16).unwrap();
+        by_target
+            .set_item("operations", (1u64 << 15) | (1u64 << 63))
+            .unwrap();
+        by_target.set_item("successful_actions_only", true).unwrap();
+        let parsed = audit_log_query_request_from_py(base_query(py, &by_target).as_any()).unwrap();
+        assert_eq!(parsed.start_at_sequence_number, Some(u32::MAX));
+        assert_eq!(parsed.requested_count, u16::MAX);
+        let BACnetAuditLogQueryParameters::ByTarget {
+            target_array_index,
+            target_priority,
+            operations,
+            ..
+        } = parsed.query_parameters
+        else {
+            panic!("expected by-target query");
+        };
+        assert_eq!(target_array_index, Some(u64::MAX));
+        assert_eq!(target_priority, Some(16));
+        assert_eq!(operations.unwrap().bits(), (1u64 << 15) | (1u64 << 63));
+
+        let by_source = PyDict::new(py);
+        by_source.set_item("kind", "by_source").unwrap();
+        by_source
+            .set_item("source_device_identifier", py_oid(ObjectType::DEVICE, 13))
+            .unwrap();
+        by_source
+            .set_item("successful_actions_only", false)
+            .unwrap();
+        let parsed = audit_log_query_request_from_py(base_query(py, &by_source).as_any()).unwrap();
+        assert!(matches!(
+            parsed.query_parameters,
+            BACnetAuditLogQueryParameters::BySource { .. }
+        ));
+
+        for invalid in [1u64 << 16, 1u64 << 31] {
+            by_source.set_item("operations", invalid).unwrap();
+            assert_error_type::<PyValueError>(
+                py,
+                audit_log_query_request_from_py(base_query(py, &by_source).as_any()).unwrap_err(),
+            );
+        }
+        by_source.set_item("operations", -1).unwrap();
+        assert_error_type::<PyValueError>(
+            py,
+            audit_log_query_request_from_py(base_query(py, &by_source).as_any()).unwrap_err(),
+        );
+        by_source.set_item("operations", true).unwrap();
+        assert_error_type::<PyTypeError>(
+            py,
+            audit_log_query_request_from_py(base_query(py, &by_source).as_any()).unwrap_err(),
+        );
+    });
+}
+
+fn audit_notification(all_optional: bool) -> BACnetAuditNotification {
+    BACnetAuditNotification {
+        source_timestamp: all_optional.then_some(BACnetTimeStamp::SequenceNumber(1)),
+        target_timestamp: all_optional.then_some(BACnetTimeStamp::Time(Time {
+            hour: 1,
+            minute: 2,
+            second: 3,
+            hundredths: 4,
+        })),
+        source_device: BACnetRecipient::Device(oid(ObjectType::DEVICE, 1)),
+        source_object: all_optional.then_some(oid(ObjectType::ANALOG_INPUT, 2)),
+        operation: AuditOperation::WRITE,
+        source_comment: all_optional.then(|| "source".into()),
+        target_comment: all_optional.then(|| "target".into()),
+        invoke_id: all_optional.then_some(3),
+        source_user_id: all_optional.then_some(4),
+        source_user_role: all_optional.then_some(5),
+        target_device: BACnetRecipient::Address(BACnetAddress {
+            network_number: 6,
+            mac_address: MacAddr::from_slice(b"\x07"),
+        }),
+        target_object: all_optional.then_some(oid(ObjectType::ANALOG_OUTPUT, 8)),
+        target_property: all_optional.then_some(AuditPropertyReference {
+            property_identifier: PropertyIdentifier::PRESENT_VALUE,
+            property_array_index: Some(u64::MAX),
+        }),
+        target_priority: all_optional.then_some(16),
+        target_value: all_optional.then(|| vec![0x00]),
+        current_value: all_optional.then(|| vec![0x11]),
+        result: all_optional.then_some((ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED)),
+    }
+}
+
+#[test]
+fn ack_projection_covers_every_datum_and_nested_optional_field() {
+    let timestamp = || {
+        (
+            Date {
+                year: 126,
+                month: 9,
+                day: 4,
+                day_of_week: 5,
+            },
+            Time {
+                hour: 12,
+                minute: 34,
+                second: 56,
+                hundredths: 78,
+            },
+        )
+    };
+    let datums = [
+        BACnetAuditLogDatum::LogStatus(0b010),
+        BACnetAuditLogDatum::AuditNotification(audit_notification(true)),
+        BACnetAuditLogDatum::AuditNotification(audit_notification(false)),
+        BACnetAuditLogDatum::TimeChange(-1.5),
+    ];
+    let ack = AuditLogQueryAck {
+        audit_log: oid(ObjectType::AUDIT_LOG, 9),
+        records: datums
+            .into_iter()
+            .enumerate()
+            .map(|(index, datum)| BACnetAuditLogRecordResult {
+                sequence_number: index as u64 + 1,
+                record: BACnetAuditLogRecord {
+                    timestamp: timestamp(),
+                    datum,
+                },
+            })
+            .collect(),
+        no_more_items: true,
+    };
+
+    Python::initialize();
+    Python::attach(|py| {
+        let projected = audit_log_query_ack_to_py(py, &ack).unwrap();
+        let projected = projected.bind(py).cast::<PyDict>().unwrap();
+        assert_eq!(projected.len(), 3);
+        assert_eq!(
+            projected
+                .get_item("audit_log")
+                .unwrap()
+                .unwrap()
+                .extract::<PyObjectIdentifier>()
+                .unwrap()
+                .to_rust(),
+            oid(ObjectType::AUDIT_LOG, 9)
+        );
+        assert!(projected
+            .get_item("no_more_items")
+            .unwrap()
+            .unwrap()
+            .is_truthy()
+            .unwrap());
+        let records = projected
+            .get_item("records")
+            .unwrap()
+            .unwrap()
+            .cast_into::<PyList>()
+            .unwrap();
+        assert_eq!(records.len(), 4);
+
+        let mut kinds = Vec::new();
+        for (index, item) in records.iter().enumerate() {
+            let item = item.cast_into::<PyDict>().unwrap();
+            assert_eq!(item.len(), 2);
+            assert_eq!(
+                item.get_item("sequence_number")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<u64>()
+                    .unwrap(),
+                index as u64 + 1
+            );
+            let record = item
+                .get_item("record")
+                .unwrap()
+                .unwrap()
+                .cast_into::<PyDict>()
+                .unwrap();
+            assert_eq!(
+                record
+                    .get_item("timestamp")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<((u16, u8, u8, u8), (u8, u8, u8, u8))>()
+                    .unwrap(),
+                ((2026, 9, 4, 5), (12, 34, 56, 78))
+            );
+            let datum = record
+                .get_item("datum")
+                .unwrap()
+                .unwrap()
+                .cast_into::<PyDict>()
+                .unwrap();
+            kinds.push(
+                datum
+                    .get_item("kind")
+                    .unwrap()
+                    .unwrap()
+                    .extract::<String>()
+                    .unwrap(),
+            );
+            match index {
+                0 => assert_eq!(
+                    datum
+                        .get_item("log_status")
+                        .unwrap()
+                        .unwrap()
+                        .extract::<u8>()
+                        .unwrap(),
+                    0b010
+                ),
+                3 => assert_eq!(
+                    datum
+                        .get_item("time_change")
+                        .unwrap()
+                        .unwrap()
+                        .extract::<f32>()
+                        .unwrap(),
+                    -1.5
+                ),
+                _ => {}
+            }
+            if index == 1 || index == 2 {
+                let notification = datum
+                    .get_item("audit_notification")
+                    .unwrap()
+                    .unwrap()
+                    .cast_into::<PyDict>()
+                    .unwrap();
+                assert_eq!(notification.len(), 17);
+                for key in NOTIFICATION_OPTIONAL {
+                    assert!(notification.contains(*key).unwrap());
+                }
+                if index == 1 {
+                    for key in NOTIFICATION_OPTIONAL {
+                        assert!(!notification.get_item(*key).unwrap().unwrap().is_none());
+                    }
+                } else {
+                    for key in NOTIFICATION_OPTIONAL {
+                        assert!(notification.get_item(*key).unwrap().unwrap().is_none());
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            kinds,
+            [
+                "log_status",
+                "audit_notification",
+                "audit_notification",
+                "time_change"
+            ]
+        );
+    });
+}

--- a/crates/rusty-bacnet/src/types/audit_projection.rs
+++ b/crates/rusty-bacnet/src/types/audit_projection.rs
@@ -1,0 +1,180 @@
+//! Projection of decoded Audit Log query ACKs into Python-owned mappings.
+
+use bacnet_services::audit::{
+    AuditLogQueryAck, AuditPropertyReference, BACnetAuditLogDatum, BACnetAuditNotification,
+};
+use bacnet_types::constructed::BACnetRecipient;
+use bacnet_types::primitives::Date;
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyBytes, PyDict, PyList};
+
+use super::{
+    PyAuditOperation, PyBACnetTimeStamp, PyErrorClass, PyErrorCode, PyObjectIdentifier,
+    PyPropertyIdentifier,
+};
+
+fn recipient_to_py<'py>(
+    py: Python<'py>,
+    recipient: &BACnetRecipient,
+) -> PyResult<Bound<'py, PyDict>> {
+    let result = PyDict::new(py);
+    match recipient {
+        BACnetRecipient::Device(object_identifier) => {
+            result.set_item("kind", "device")?;
+            result.set_item(
+                "object_identifier",
+                PyObjectIdentifier::from_rust(*object_identifier),
+            )?;
+        }
+        BACnetRecipient::Address(address) => {
+            result.set_item("kind", "address")?;
+            result.set_item("network_number", address.network_number)?;
+            result.set_item("mac_address", PyBytes::new(py, &address.mac_address))?;
+        }
+    }
+    Ok(result)
+}
+
+fn property_reference_to_py<'py>(
+    py: Python<'py>,
+    reference: &AuditPropertyReference,
+) -> PyResult<Bound<'py, PyDict>> {
+    let result = PyDict::new(py);
+    result.set_item(
+        "property_identifier",
+        PyPropertyIdentifier {
+            inner: reference.property_identifier,
+        },
+    )?;
+    result.set_item("property_array_index", reference.property_array_index)?;
+    Ok(result)
+}
+
+fn notification_to_py<'py>(
+    py: Python<'py>,
+    notification: &BACnetAuditNotification,
+) -> PyResult<Bound<'py, PyDict>> {
+    let result = PyDict::new(py);
+    result.set_item(
+        "source_timestamp",
+        notification
+            .source_timestamp
+            .clone()
+            .map(PyBACnetTimeStamp::from_rust),
+    )?;
+    result.set_item(
+        "target_timestamp",
+        notification
+            .target_timestamp
+            .clone()
+            .map(PyBACnetTimeStamp::from_rust),
+    )?;
+    result.set_item(
+        "source_device",
+        recipient_to_py(py, &notification.source_device)?,
+    )?;
+    result.set_item(
+        "source_object",
+        notification
+            .source_object
+            .map(PyObjectIdentifier::from_rust),
+    )?;
+    result.set_item(
+        "operation",
+        PyAuditOperation {
+            inner: notification.operation,
+        },
+    )?;
+    result.set_item("source_comment", notification.source_comment.as_deref())?;
+    result.set_item("target_comment", notification.target_comment.as_deref())?;
+    result.set_item("invoke_id", notification.invoke_id)?;
+    result.set_item("source_user_id", notification.source_user_id)?;
+    result.set_item("source_user_role", notification.source_user_role)?;
+    result.set_item(
+        "target_device",
+        recipient_to_py(py, &notification.target_device)?,
+    )?;
+    result.set_item(
+        "target_object",
+        notification
+            .target_object
+            .map(PyObjectIdentifier::from_rust),
+    )?;
+    match &notification.target_property {
+        Some(reference) => {
+            result.set_item("target_property", property_reference_to_py(py, reference)?)?
+        }
+        None => result.set_item("target_property", py.None())?,
+    }
+    result.set_item("target_priority", notification.target_priority)?;
+    match &notification.target_value {
+        Some(value) => result.set_item("target_value", PyBytes::new(py, value))?,
+        None => result.set_item("target_value", py.None())?,
+    }
+    match &notification.current_value {
+        Some(value) => result.set_item("current_value", PyBytes::new(py, value))?,
+        None => result.set_item("current_value", py.None())?,
+    }
+    result.set_item(
+        "result",
+        notification.result.map(|(error_class, error_code)| {
+            (
+                PyErrorClass { inner: error_class },
+                PyErrorCode { inner: error_code },
+            )
+        }),
+    )?;
+    Ok(result)
+}
+
+fn actual_year(date: &Date) -> u16 {
+    date.actual_year().unwrap_or(u16::from(Date::UNSPECIFIED))
+}
+
+fn datum_to_py<'py>(py: Python<'py>, datum: &BACnetAuditLogDatum) -> PyResult<Bound<'py, PyDict>> {
+    let result = PyDict::new(py);
+    match datum {
+        BACnetAuditLogDatum::LogStatus(status) => {
+            result.set_item("kind", "log_status")?;
+            result.set_item("log_status", status)?;
+        }
+        BACnetAuditLogDatum::AuditNotification(notification) => {
+            result.set_item("kind", "audit_notification")?;
+            result.set_item("audit_notification", notification_to_py(py, notification)?)?;
+        }
+        BACnetAuditLogDatum::TimeChange(change) => {
+            result.set_item("kind", "time_change")?;
+            result.set_item("time_change", change)?;
+        }
+    }
+    Ok(result)
+}
+
+/// Project a completely decoded ACK into canonical Python-owned mappings.
+pub(crate) fn audit_log_query_ack_to_py(
+    py: Python<'_>,
+    ack: &AuditLogQueryAck,
+) -> PyResult<Py<PyAny>> {
+    let result = PyDict::new(py);
+    result.set_item("audit_log", PyObjectIdentifier::from_rust(ack.audit_log))?;
+    let records = PyList::empty(py);
+    for item in &ack.records {
+        let record_result = PyDict::new(py);
+        record_result.set_item("sequence_number", item.sequence_number)?;
+        let record = PyDict::new(py);
+        let (date, time) = &item.record.timestamp;
+        record.set_item(
+            "timestamp",
+            (
+                (actual_year(date), date.month, date.day, date.day_of_week),
+                (time.hour, time.minute, time.second, time.hundredths),
+            ),
+        )?;
+        record.set_item("datum", datum_to_py(py, &item.record.datum)?)?;
+        record_result.set_item("record", record)?;
+        records.append(record_result)?;
+    }
+    result.set_item("records", records)?;
+    result.set_item("no_more_items", ack.no_more_items)?;
+    Ok(result.into_any().unbind())
+}

--- a/crates/rusty-bacnet/src/types/enums.rs
+++ b/crates/rusty-bacnet/src/types/enums.rs
@@ -73,6 +73,12 @@ py_bacnet_enum!(
 py_bacnet_enum!("ErrorClass", PyErrorClass, bacnet_enums::ErrorClass, u16);
 py_bacnet_enum!("ErrorCode", PyErrorCode, bacnet_enums::ErrorCode, u16);
 py_bacnet_enum!(
+    "AuditOperation",
+    PyAuditOperation,
+    bacnet_enums::AuditOperation,
+    u32
+);
+py_bacnet_enum!(
     "EnableDisable",
     PyEnableDisable,
     bacnet_enums::EnableDisable,

--- a/crates/rusty-bacnet/src/types/mod.rs
+++ b/crates/rusty-bacnet/src/types/mod.rs
@@ -23,6 +23,8 @@ use bacnet_types::enums as bacnet_enums;
 use bacnet_types::primitives;
 
 mod address;
+mod audit;
+mod audit_projection;
 mod cov;
 mod device;
 mod enums;
@@ -32,6 +34,8 @@ mod rpm_wpm;
 mod timestamp;
 
 pub use address::parse_address;
+pub(crate) use audit::{audit_log_query_request_from_py, audit_notification_request_from_py};
+pub(crate) use audit_projection::audit_log_query_ack_to_py;
 pub use cov::{PyCovNotification, PyCovNotificationIterator};
 pub use device::PyDiscoveredDevice;
 pub use enums::*;
@@ -57,6 +61,9 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_class::<PyErrorCode>()?;
     PyErrorCode::register_constants(&m.getattr("ErrorCode")?)?;
+
+    m.add_class::<PyAuditOperation>()?;
+    PyAuditOperation::register_constants(&m.getattr("AuditOperation")?)?;
 
     m.add_class::<PyEnableDisable>()?;
     PyEnableDisable::register_constants(&m.getattr("EnableDisable")?)?;

--- a/crates/rusty-bacnet/src/types/timestamp.rs
+++ b/crates/rusty-bacnet/src/types/timestamp.rs
@@ -19,6 +19,10 @@ impl PyBACnetTimeStamp {
     pub fn to_rust(&self) -> &primitives::BACnetTimeStamp {
         &self.inner
     }
+
+    pub(crate) fn from_rust(timestamp: primitives::BACnetTimeStamp) -> Self {
+        Self { inner: timestamp }
+    }
 }
 
 fn integer(value: &Bound<'_, PyAny>, name: &str) -> PyResult<i128> {

--- a/crates/rusty-bacnet/tests/test_audit_api.py
+++ b/crates/rusty-bacnet/tests/test_audit_api.py
@@ -1,0 +1,610 @@
+"""Installed-artifact tests for the typed Python Audit client boundary."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import tempfile
+import unittest
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Callable, cast
+
+import rusty_bacnet
+from rusty_bacnet import (
+    AuditOperation,
+    BACnetClient,
+    BACnetServer,
+    BACnetTimeStamp,
+    BacnetProtocolError,
+    ErrorClass,
+    ErrorCode,
+    ObjectIdentifier,
+    ObjectType,
+    PropertyIdentifier,
+)
+
+
+ADDRESS = "127.0.0.1:47808"
+STANDARD_OPERATIONS = (
+    "READ",
+    "WRITE",
+    "CREATE",
+    "DELETE",
+    "LIFE_SAFETY",
+    "ACKNOWLEDGE_ALARM",
+    "DEVICE_DISABLE_COMM",
+    "DEVICE_ENABLE_COMM",
+    "DEVICE_RESET",
+    "DEVICE_BACKUP",
+    "DEVICE_RESTORE",
+    "SUBSCRIPTION",
+    "NOTIFICATION",
+    "AUDITING_FAILURE",
+    "NETWORK_CHANGES",
+    "GENERAL",
+)
+
+
+def installed_stub() -> ast.Module:
+    stub_path = Path(rusty_bacnet.__file__).with_suffix(".pyi")
+    return ast.parse(stub_path.read_text(encoding="utf-8"), filename=str(stub_path))
+
+
+def stub_classes(tree: ast.Module) -> dict[str, ast.ClassDef]:
+    return {
+        node.name: node for node in tree.body if isinstance(node, ast.ClassDef)
+    }
+
+
+def stub_method(class_node: ast.ClassDef, name: str) -> ast.AsyncFunctionDef:
+    return next(
+        node
+        for node in class_node.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name
+    )
+
+
+def annotation_text(annotation: ast.expr | None) -> str:
+    assert annotation is not None
+    return ast.unparse(annotation)
+
+
+def typed_dict_keys(class_node: ast.ClassDef) -> set[str]:
+    return {
+        node.target.id
+        for node in class_node.body
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+    }
+
+
+def device_recipient(instance: int) -> dict[str, Any]:
+    return {
+        "kind": "device",
+        "object_identifier": ObjectIdentifier(ObjectType.DEVICE, instance),
+    }
+
+
+def address_recipient() -> dict[str, Any]:
+    return {"kind": "address", "network_number": 65_535, "mac_address": b"\x01"}
+
+
+def minimal_notification(operation: AuditOperation | None = None) -> dict[str, Any]:
+    return {
+        "source_device": device_recipient(1),
+        "operation": operation or AuditOperation.READ,
+        "target_device": device_recipient(2),
+    }
+
+
+def notification_request(notification: Any | None = None) -> dict[str, Any]:
+    return {
+        "notifications": [
+            minimal_notification() if notification is None else notification
+        ]
+    }
+
+
+def target_query() -> dict[str, Any]:
+    return {
+        "audit_log": ObjectIdentifier(ObjectType.AUDIT_LOG, 1),
+        "query_parameters": {
+            "kind": "by_target",
+            "target_device_identifier": ObjectIdentifier(ObjectType.DEVICE, 2),
+            "successful_actions_only": True,
+        },
+        "requested_count": 10,
+    }
+
+
+class AuditContractArtifactTests(unittest.TestCase):
+    def test_enum_wrapper_constants_and_proprietary_boundaries(self) -> None:
+        self.assertIs(rusty_bacnet.AuditOperation, AuditOperation)
+        for raw, name in enumerate(STANDARD_OPERATIONS):
+            with self.subTest(operation=name):
+                value = getattr(AuditOperation, name)
+                self.assertEqual(value.to_raw(), raw)
+                self.assertEqual(value, AuditOperation.from_raw(raw))
+                self.assertEqual(hash(value), raw)
+        for raw in (32, 63):
+            self.assertEqual(AuditOperation.from_raw(raw).to_raw(), raw)
+        self.assertEqual(AuditOperation.from_raw(16).to_raw(), 16)
+        self.assertEqual(AuditOperation.from_raw(64).to_raw(), 64)
+
+    def test_runtime_stub_and_packaging_expose_exact_additive_contracts(self) -> None:
+        module_path = Path(rusty_bacnet.__file__)
+        self.assertTrue(module_path.with_suffix(".pyi").is_file())
+        self.assertTrue(module_path.with_name("py.typed").is_file())
+
+        tree = installed_stub()
+        classes = stub_classes(tree)
+        expected_typed_dicts = {
+            "AuditRecipientDevice": {"kind", "object_identifier"},
+            "AuditRecipientAddress": {"kind", "network_number", "mac_address"},
+            "AuditPropertyReference": {
+                "property_identifier",
+                "property_array_index",
+            },
+            "AuditNotificationInput": {
+                "source_timestamp",
+                "target_timestamp",
+                "source_device",
+                "source_object",
+                "operation",
+                "source_comment",
+                "target_comment",
+                "invoke_id",
+                "source_user_id",
+                "source_user_role",
+                "target_device",
+                "target_object",
+                "target_property",
+                "target_priority",
+                "target_value",
+                "current_value",
+                "result",
+            },
+            "AuditNotificationRequestInput": {"notifications"},
+            "AuditLogQueryByTargetInput": {
+                "kind",
+                "target_device_identifier",
+                "target_device_address",
+                "target_object_identifier",
+                "target_property_identifier",
+                "target_array_index",
+                "target_priority",
+                "operations",
+                "successful_actions_only",
+            },
+            "AuditLogQueryBySourceInput": {
+                "kind",
+                "source_device_identifier",
+                "source_device_address",
+                "source_object_identifier",
+                "operations",
+                "successful_actions_only",
+            },
+            "AuditLogQueryRequestInput": {
+                "audit_log",
+                "query_parameters",
+                "start_at_sequence_number",
+                "requested_count",
+            },
+            "AuditPropertyReferenceResult": {
+                "property_identifier",
+                "property_array_index",
+            },
+            "AuditNotification": {
+                "source_timestamp",
+                "target_timestamp",
+                "source_device",
+                "source_object",
+                "operation",
+                "source_comment",
+                "target_comment",
+                "invoke_id",
+                "source_user_id",
+                "source_user_role",
+                "target_device",
+                "target_object",
+                "target_property",
+                "target_priority",
+                "target_value",
+                "current_value",
+                "result",
+            },
+            "AuditLogStatusDatum": {"kind", "log_status"},
+            "AuditNotificationDatum": {"kind", "audit_notification"},
+            "AuditTimeChangeDatum": {"kind", "time_change"},
+            "AuditLogRecord": {"timestamp", "datum"},
+            "AuditLogRecordResult": {"sequence_number", "record"},
+            "AuditLogQueryAck": {"audit_log", "records", "no_more_items"},
+        }
+        for name, keys in expected_typed_dicts.items():
+            with self.subTest(typed_dict=name):
+                self.assertIn(name, classes)
+                self.assertEqual(typed_dict_keys(classes[name]), keys)
+                self.assertFalse(
+                    hasattr(rusty_bacnet, name),
+                    "TypedDict contracts must not create nominal runtime classes",
+                )
+
+        client = classes["BACnetClient"]
+        typed_methods = {
+            "confirmed_audit_notification_typed": (
+                "AuditNotificationRequestInput",
+                "None",
+            ),
+            "unconfirmed_audit_notification_typed": (
+                "AuditNotificationRequestInput",
+                "None",
+            ),
+            "audit_log_query_typed": ("AuditLogQueryRequestInput", "AuditLogQueryAck"),
+        }
+        for name, (request_type, return_type) in typed_methods.items():
+            with self.subTest(method=name):
+                runtime_parameters = list(
+                    inspect.signature(getattr(BACnetClient, name)).parameters.values()
+                )
+                self.assertEqual(
+                    [parameter.name for parameter in runtime_parameters],
+                    ["self", "address", "request"],
+                )
+                self.assertTrue(
+                    all(
+                        parameter.default is inspect.Parameter.empty
+                        for parameter in runtime_parameters
+                    )
+                )
+                method = stub_method(client, name)
+                arguments = [*method.args.posonlyargs, *method.args.args]
+                self.assertEqual(
+                    [argument.arg for argument in arguments],
+                    ["self", "address", "request"],
+                )
+                self.assertEqual(annotation_text(arguments[1].annotation), "str")
+                self.assertEqual(annotation_text(arguments[2].annotation), request_type)
+                self.assertEqual(annotation_text(method.returns), return_type)
+
+        raw_methods = {
+            "confirmed_audit_notification": "None",
+            "unconfirmed_audit_notification": "None",
+            "audit_log_query": "bytes",
+        }
+        for name, return_type in raw_methods.items():
+            with self.subTest(raw=name):
+                self.assertEqual(
+                    list(inspect.signature(getattr(BACnetClient, name)).parameters),
+                    ["self", "address", "service_data"],
+                )
+                method = stub_method(client, name)
+                arguments = [*method.args.posonlyargs, *method.args.args]
+                self.assertEqual(
+                    [argument.arg for argument in arguments],
+                    ["self", "address", "service_data"],
+                )
+                self.assertEqual(annotation_text(arguments[2].annotation), "bytes")
+                self.assertEqual(annotation_text(method.returns), return_type)
+
+    def test_notification_validation_uses_documented_exception_classes(self) -> None:
+        client = BACnetClient()
+        method: Callable[[str, Any], Any] = client.confirmed_audit_notification_typed
+
+        type_errors: list[Any] = [
+            [],
+            {"notifications": ()},
+            {"notifications": [1]},
+            notification_request(
+                {
+                    **minimal_notification(),
+                    "operation": 0,
+                }
+            ),
+            notification_request(
+                {
+                    **minimal_notification(),
+                    "invoke_id": True,
+                }
+            ),
+            notification_request(
+                {
+                    **minimal_notification(),
+                    "target_value": bytearray(b"\x00"),
+                }
+            ),
+            notification_request(
+                {
+                    **minimal_notification(),
+                    "result": [ErrorClass.PROPERTY, ErrorCode.OTHER],
+                }
+            ),
+        ]
+        for request in type_errors:
+            with self.subTest(type_error=request), self.assertRaises(TypeError):
+                _unused = method(ADDRESS, request)
+
+        value_errors: list[Any] = [
+            {},
+            {"notifications": []},
+            {"notifications": [minimal_notification()], "extra": 1},
+            notification_request({"operation": AuditOperation.READ}),
+            notification_request(
+                {
+                    **minimal_notification(),
+                    "source_device": {
+                        "kind": "DEVICE",
+                        "object_identifier": ObjectIdentifier(ObjectType.DEVICE, 1),
+                    },
+                }
+            ),
+        ]
+        for raw in (16, 31, 64, 2**32 - 1):
+            value_errors.append(notification_request(minimal_notification(AuditOperation.from_raw(raw))))
+        for key, invalid in (
+            ("invoke_id", -1),
+            ("invoke_id", 256),
+            ("source_user_id", 65_536),
+            ("source_user_role", 256),
+            ("target_priority", 0),
+            ("target_priority", 17),
+        ):
+            value_errors.append(
+                notification_request({**minimal_notification(), key: invalid})
+            )
+        value_errors.append(
+            notification_request(
+                {
+                    **minimal_notification(),
+                    "source_device": {
+                        "kind": "address",
+                        "network_number": 65_536,
+                        "mac_address": b"",
+                    },
+                }
+            )
+        )
+        value_errors.append(
+            notification_request(
+                {
+                    **minimal_notification(),
+                    "target_property": {
+                        "property_identifier": PropertyIdentifier.PRESENT_VALUE,
+                        "property_array_index": 2**64,
+                    },
+                }
+            )
+        )
+        value_errors.append({"notifications": [minimal_notification()] * 10_001})
+        for request in value_errors:
+            with self.subTest(value_error=request), self.assertRaises(ValueError):
+                _unused = method(ADDRESS, request)
+
+    def test_query_validation_accepts_both_choices_and_rejects_invalid_values(self) -> None:
+        client = BACnetClient()
+        method: Callable[[str, Any], Any] = client.audit_log_query_typed
+
+        type_errors = [
+            [],
+            {**target_query(), "requested_count": True},
+            {
+                **target_query(),
+                "query_parameters": {
+                    **target_query()["query_parameters"],
+                    "successful_actions_only": 1,
+                },
+            },
+            {
+                **target_query(),
+                "query_parameters": {
+                    **target_query()["query_parameters"],
+                    "operations": True,
+                },
+            },
+        ]
+        for request in type_errors:
+            with self.subTest(type_error=request), self.assertRaises(TypeError):
+                _unused = method(ADDRESS, request)
+
+        value_errors = [
+            {},
+            {**target_query(), "extra": 1},
+            {**target_query(), "requested_count": -1},
+            {**target_query(), "requested_count": 65_536},
+            {**target_query(), "start_at_sequence_number": -1},
+            {**target_query(), "start_at_sequence_number": 2**32},
+            {**target_query(), "query_parameters": {"kind": "by_target"}},
+            {
+                **target_query(),
+                "query_parameters": {
+                    **target_query()["query_parameters"],
+                    "kind": "target",
+                },
+            },
+        ]
+        for operations in (-1, 2**64, 1 << 16, 1 << 31):
+            value_errors.append(
+                {
+                    **target_query(),
+                    "query_parameters": {
+                        **target_query()["query_parameters"],
+                        "operations": operations,
+                    },
+                }
+            )
+        for request in value_errors:
+            with self.subTest(value_error=request), self.assertRaises(ValueError):
+                _unused = method(ADDRESS, request)
+
+        async def accepted_before_lifecycle_check() -> None:
+            by_source = {
+                "audit_log": ObjectIdentifier(ObjectType.AUDIT_LOG, 1),
+                "query_parameters": {
+                    "kind": "by_source",
+                    "source_device_identifier": ObjectIdentifier(ObjectType.DEVICE, 1),
+                    "source_device_address": MappingProxyType(address_recipient()),
+                    "source_object_identifier": None,
+                    "operations": (1 << 0) | (1 << 15) | (1 << 32) | (1 << 63),
+                    "successful_actions_only": False,
+                },
+                "start_at_sequence_number": None,
+                "requested_count": 65_535,
+            }
+            typed_query = cast(Callable[[str, Any], Any], client.audit_log_query_typed)
+            with self.assertRaisesRegex(RuntimeError, "client not started"):
+                await typed_query(ADDRESS, MappingProxyType(by_source))
+
+        asyncio.run(accepted_before_lifecycle_check())
+
+    def test_live_server_typed_and_raw_paths_preserve_fail_closed_behavior(self) -> None:
+        asyncio.run(self._exercise_live_server())
+
+    async def _exercise_live_server(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            server = BACnetServer(
+                device_instance=503_511,
+                device_name="Typed Audit Artifact Test",
+                interface="127.0.0.1",
+                port=0,
+                broadcast_address="127.0.0.1",
+            )
+            server.add_audit_log(
+                1,
+                "Audit Log",
+                str(Path(directory) / "audit-log"),
+                buffer_size=10,
+            )
+            await server.start()
+            try:
+                address = await server.local_address()
+                async with BACnetClient(
+                    interface="127.0.0.1",
+                    port=0,
+                    broadcast_address="127.0.0.1",
+                    apdu_timeout_ms=2_000,
+                ) as client:
+                    typed_query = cast(
+                        Callable[[str, Any], Any], client.audit_log_query_typed
+                    )
+                    typed_confirmed = cast(
+                        Callable[[str, Any], Any],
+                        client.confirmed_audit_notification_typed,
+                    )
+                    typed_unconfirmed = cast(
+                        Callable[[str, Any], Any],
+                        client.unconfirmed_audit_notification_typed,
+                    )
+                    request = target_query()
+                    parameters = request["query_parameters"]
+                    before = (
+                        tuple(request),
+                        request["audit_log"],
+                        request["requested_count"],
+                        dict(parameters),
+                    )
+                    ack = await typed_query(address, MappingProxyType(request))
+                    self.assertEqual(set(ack), {"audit_log", "records", "no_more_items"})
+                    self.assertEqual(ack["audit_log"], request["audit_log"])
+                    self.assertEqual(ack["records"], [])
+                    self.assertIs(ack["no_more_items"], True)
+                    self.assertEqual(
+                        before,
+                        (
+                            tuple(request),
+                            request["audit_log"],
+                            request["requested_count"],
+                            dict(parameters),
+                        ),
+                    )
+
+                    invalid = notification_request(
+                        minimal_notification(AuditOperation.from_raw(16))
+                    )
+                    with self.assertRaises(ValueError):
+                        _unused = typed_unconfirmed(address, invalid)
+
+                    notification = notification_request(
+                        {
+                            **minimal_notification(AuditOperation.WRITE),
+                            "source_timestamp": BACnetTimeStamp.sequence_number(1),
+                            "target_device": address_recipient(),
+                            "target_property": {
+                                "property_identifier": PropertyIdentifier.PRESENT_VALUE,
+                                "property_array_index": None,
+                            },
+                            "target_value": None,
+                            "result": None,
+                        }
+                    )
+                    with self.assertRaises(BacnetProtocolError) as raised:
+                        await typed_confirmed(address, notification)
+                    self.assertEqual(
+                        raised.exception.error_class, ErrorClass.SERVICES.to_raw()
+                    )
+                    self.assertEqual(
+                        raised.exception.error_code,
+                        ErrorCode.SERVICE_REQUEST_DENIED.to_raw(),
+                    )
+                    self.assertIsNone(
+                        await typed_unconfirmed(address, notification)
+                    )
+                    self.assertEqual(
+                        (await typed_query(address, request))["records"],
+                        [],
+                    )
+
+                    raw_query = bytes(
+                        [
+                            0x0C,
+                            0x0F,
+                            0x40,
+                            0x00,
+                            0x01,
+                            0x1E,
+                            0x0E,
+                            0x0C,
+                            0x02,
+                            0x00,
+                            0x00,
+                            0x02,
+                            0x79,
+                            0x01,
+                            0x0F,
+                            0x1F,
+                            0x39,
+                            0x05,
+                        ]
+                    )
+                    self.assertEqual(
+                        await client.audit_log_query(address, raw_query),
+                        bytes([0x0C, 0x0F, 0x40, 0x00, 0x01, 0x1E, 0x1F, 0x29, 0x01]),
+                    )
+                    raw_notification = bytes(
+                        [
+                            0x0E,
+                            0x2E,
+                            0x0C,
+                            0x02,
+                            0x00,
+                            0x00,
+                            0x01,
+                            0x2F,
+                            0x49,
+                            0x00,
+                            0xAE,
+                            0x0C,
+                            0x02,
+                            0x00,
+                            0x00,
+                            0x02,
+                            0xAF,
+                            0x0F,
+                        ]
+                    )
+                    await client.unconfirmed_audit_notification(address, raw_notification)
+            finally:
+                await server.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -952,6 +952,122 @@ raw = await client.vt_data(
 
 ### Audit Services
 
+The additive `_typed` methods accept dictionaries (or other Python mappings)
+described by the installed `TypedDict` stubs. They convert into the native Rust
+Audit request models before transport; the native client helpers remain the
+only service encoder, transaction coordinator, and strict query-ACK decoder.
+The mapping objects, wrapper values, and address string are not modified.
+
+`AuditOperation` is the one Audit runtime wrapper. Its named constants are the
+standard operations 0 through 15. `AuditOperation.from_raw()` remains lossless,
+but request mappings accept only standard operations 0..15 or proprietary
+operations 32..63; reserved 16..31 and values above 63 are rejected.
+
+Recipients are discriminated mappings:
+
+```python
+device = {"kind": "device", "object_identifier": device_oid}
+address = {
+    "kind": "address",
+    "network_number": 5,  # Unsigned16
+    "mac_address": b"\x01\x02",
+}
+```
+
+An `AuditNotificationInput` requires `source_device`, `operation`, and
+`target_device`. Its optional keys are `source_timestamp`, `target_timestamp`,
+`source_object`, `source_comment`, `target_comment`, `invoke_id`,
+`source_user_id`, `source_user_role`, `target_object`, `target_property`,
+`target_priority`, `target_value`, `current_value`, and `result`.
+`target_property` uses `property_identifier` and optional
+`property_array_index`; `result` is an `(ErrorClass, ErrorCode)` tuple.
+`target_value` and `current_value` are `bytes | None` containing structurally
+valid raw `ABSTRACT-SYNTAX.&Type` values, not `PropertyValue` objects.
+
+#### `confirmed_audit_notification_typed(address, request) -> None`
+
+Send one or more structured notifications and wait for the confirmed response.
+The `notifications` list must contain 1..10,000 items.
+
+```python
+from rusty_bacnet import AuditOperation
+
+await client.confirmed_audit_notification_typed(
+    "192.168.1.100:47808",
+    {
+        "notifications": [
+            {
+                "source_device": device,
+                "operation": AuditOperation.WRITE,
+                "target_device": device,
+                "target_property": {
+                    "property_identifier": PropertyIdentifier.PRESENT_VALUE,
+                },
+                "target_priority": 8,
+            }
+        ]
+    },
+)
+```
+
+#### `unconfirmed_audit_notification_typed(address, request) -> None`
+
+Send the same mapping contract without waiting for a response.
+
+#### `audit_log_query_typed(address, request) -> AuditLogQueryAck`
+
+The request requires `audit_log`, discriminated `query_parameters`, and an
+Unsigned16 `requested_count`; `start_at_sequence_number` is an optional
+Unsigned32. Query parameters use `kind: "by_target"` with required
+`target_device_identifier`, or `kind: "by_source"` with required
+`source_device_identifier`. Both require `successful_actions_only`. Optional
+fields follow the installed `AuditLogQueryByTargetInput` and
+`AuditLogQueryBySourceInput` definitions. `operations` is an integer bit mask:
+bits 0..15 and 32..63 are permitted, while reserved bits 16..31, negative
+values, and masks wider than 64 bits are rejected.
+
+```python
+ack = await client.audit_log_query_typed(
+    "192.168.1.100:47808",
+    {
+        "audit_log": ObjectIdentifier(ObjectType.AUDIT_LOG, 1),
+        "query_parameters": {
+            "kind": "by_target",
+            "target_device_identifier": ObjectIdentifier(ObjectType.DEVICE, 100),
+            "operations": 1 << AuditOperation.WRITE.to_raw(),
+            "successful_actions_only": True,
+        },
+        "requested_count": 100,
+    },
+)
+```
+
+The ACK always has exactly `audit_log`, `records`, and `no_more_items`. Each
+record result has `sequence_number` and `record`; each record has `timestamp`
+and `datum`. `timestamp` is `(date, time)`, where date is
+`(full_year, month, day, day_of_week)` and time is
+`(hour, minute, second, hundredths)`, matching the established
+`BACnetTimeStamp.date_time(...).value` convention. Datum mappings use `kind`
+values `"log_status"`, `"audit_notification"`, or `"time_change"`, with a
+same-named payload key. Nested notifications use the canonical field names
+listed above and include every optional key with either its decoded value or
+`None`. ACK projection is all-or-error and never returns a partial mapping.
+
+All mappings reject unknown keys. A non-mapping container, wrong field
+container, or wrong wrapper/value type raises `TypeError`; missing required
+keys, bad discriminators, reserved values, and out-of-range integers raise
+`ValueError`. Native validation, transport, and protocol failures use the
+existing `BacnetError` hierarchy. Validation and native encoding complete
+before an APDU can be sent.
+
+This boundary follows the Standard 135-2020 Audit query, notification, actor,
+and formal type productions. It preserves the qualified Clause 21 model's
+Unsigned32 start sequence and mandatory Boolean success filter despite the
+known conflicting service-clause description; it does not add notification
+generation policy, authorization, persistence, or conformance claims.
+
+#### Raw Audit escape hatches
+
 #### `confirmed_audit_notification(address, service_data)`
 
 Send a confirmed audit notification. `service_data` is a raw escape hatch: the
@@ -992,15 +1108,15 @@ raw = await client.audit_log_query(
 )
 ```
 
-These three methods are generic outbound byte paths. They do not validate the
-payload or provide structured Python audit models. A bundled server with an
+These three methods remain signature- and byte-compatible generic outbound
+paths. They do not validate the caller-provided payload. A bundled server with an
 explicitly persisted Audit Log object can execute the raw AuditLogQuery payload
 against its retained in-memory records and return a raw typed ACK payload. The
 Rust server API can also receive ConfirmedAuditNotification when an application
-explicitly configures one sink and a fail-closed authorizer; this release adds
-no Python builder for that receiver. Unconfirmed receipt, query authorization,
-durable idempotency, and a high-level structured Python Audit API remain
-unsupported.
+explicitly configures one sink and a fail-closed authorizer. The Python server
+does not expose that receiver configuration. The typed client boundary does not
+weaken that authorization or add query authorization, producer behavior,
+forwarding, or durable idempotency.
 
 ---
 


### PR DESCRIPTION
## Summary

- add explicit mapping-based Python APIs for typed ConfirmedAuditNotification, UnconfirmedAuditNotification, and AuditLogQuery client calls
- add strict mapping validation, `AuditOperation`, typed stubs, and all-or-error AuditLogQuery ACK projection
- preserve the existing raw `service_data: bytes` methods as compatibility escape hatches

## Scope

This is the Python boundary over the native Rust Audit client helpers merged in #511. It does not add Audit record production/forwarding policy, durable idempotency/provenance, rate limiting, server behavior, wire-model changes, or broader conformance/support claims.

The permanent API-shape decision for this slice is additive `*_typed` methods with `TypedDict`/mapping contracts; raw methods remain unchanged.

## Standard traceability

Re-read against the repository's licensed Standard 135-2020 copy:

- service behavior: §§13.19–13.21, printed pp. 719–724
- Clause 21 Audit service request/ACK wire models, printed pp. 862, 865, and 868
- Audit query/notification supporting types, printed pp. 886–887
- Audit Logging actor/record context: §19.6, printed pp. 817–822

The existing qualified Clause 21 model remains authoritative for this implementation. This PR does not resolve the known §13.19 versus Clause 21 query-field width/optionality conflict or promote support claims.

## Validation

- `cargo fmt --all -- --check`
- focused Rust Audit conversion/projection tests
- `cargo test -p bacnet-client audit --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- release wheel build with `maturin==1.9.6`
- isolated-venv installed-wheel Audit API tests
- workspace Clippy and tests excluding the top-level extension crate
- conformance generation, file-size, secret scan, and diff checks

Refs #345