### PR TITLE
feat(objects): add Audit Reporter property core

### DIFF
--- a/crates/bacnet-objects/src/audit.rs
+++ b/crates/bacnet-objects/src/audit.rs
@@ -4,11 +4,14 @@ use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::Arc;
 
+use bacnet_types::bitstring::{AuditOperationFlags, BACnetPriorityFilter};
 use bacnet_types::constructed::{
     BACnetAuditLogDatum, BACnetAuditLogQueryParameters, BACnetAuditLogRecord,
     BACnetAuditLogRecordResult, BACnetAuditNotification, BACnetRecipient,
 };
-use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
+use bacnet_types::enums::{
+    AuditLevel, ErrorClass, ErrorCode, EventState, ObjectType, PropertyIdentifier, Reliability,
+};
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
 
@@ -576,6 +579,10 @@ pub struct AuditReporterObject {
     name: String,
     description: String,
     status_flags: StatusFlags,
+    audit_level: AuditLevel,
+    auditable_operations: AuditOperationFlags,
+    audit_priority_filter: BACnetPriorityFilter,
+    issue_confirmed_notifications: bool,
 }
 
 impl AuditReporterObject {
@@ -586,12 +593,42 @@ impl AuditReporterObject {
             name: name.into(),
             description: String::new(),
             status_flags: StatusFlags::empty(),
+            audit_level: AuditLevel::NONE,
+            auditable_operations: AuditOperationFlags::empty(),
+            audit_priority_filter: BACnetPriorityFilter::all(),
+            issue_confirmed_notifications: false,
         })
     }
 
     /// Set the description string.
     pub fn set_description(&mut self, desc: impl Into<String>) {
         self.description = desc.into();
+    }
+
+    /// Set the locally managed audit level.
+    pub fn set_audit_level(&mut self, level: AuditLevel) -> Result<(), Error> {
+        if level == AuditLevel::DEFAULT {
+            return Err(Error::OutOfRange(
+                "Audit Reporter audit level must not be DEFAULT".into(),
+            ));
+        }
+        self.audit_level = level;
+        Ok(())
+    }
+
+    /// Set the locally managed operation filter.
+    pub fn set_auditable_operations(&mut self, operations: AuditOperationFlags) {
+        self.auditable_operations = operations;
+    }
+
+    /// Set the locally managed command-priority filter.
+    pub fn set_audit_priority_filter(&mut self, filter: BACnetPriorityFilter) {
+        self.audit_priority_filter = filter;
+    }
+
+    /// Select confirmed or unconfirmed audit notifications for future producers.
+    pub fn set_issue_confirmed_notifications(&mut self, confirmed: bool) {
+        self.issue_confirmed_notifications = confirmed;
     }
 }
 
@@ -626,7 +663,29 @@ impl BACnetObject for AuditReporterObject {
                 unused_bits: 4,
                 data: vec![self.status_flags.bits() << 4],
             }),
-            p if p == PropertyIdentifier::EVENT_STATE => Ok(PropertyValue::Enumerated(0)),
+            p if p == PropertyIdentifier::RELIABILITY => Ok(PropertyValue::Enumerated(
+                Reliability::NO_FAULT_DETECTED.to_raw(),
+            )),
+            p if p == PropertyIdentifier::EVENT_STATE => {
+                Ok(PropertyValue::Enumerated(EventState::NORMAL.to_raw()))
+            }
+            p if p == PropertyIdentifier::AUDIT_LEVEL => {
+                Ok(PropertyValue::Enumerated(self.audit_level.to_raw()))
+            }
+            p if p == PropertyIdentifier::AUDIT_SOURCE_REPORTER => {
+                Ok(PropertyValue::Boolean(false))
+            }
+            p if p == PropertyIdentifier::AUDITABLE_OPERATIONS => {
+                let (unused_bits, data) = self.auditable_operations.to_bacnet();
+                Ok(PropertyValue::BitString { unused_bits, data })
+            }
+            p if p == PropertyIdentifier::AUDIT_PRIORITY_FILTER => {
+                let (unused_bits, data) = self.audit_priority_filter.to_bacnet();
+                Ok(PropertyValue::BitString { unused_bits, data })
+            }
+            p if p == PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS => {
+                Ok(PropertyValue::Boolean(self.issue_confirmed_notifications))
+            }
             p if p == PropertyIdentifier::PROPERTY_LIST => {
                 read_property_list_property(&self.property_list(), array_index)
             }
@@ -667,9 +726,19 @@ impl BACnetObject for AuditReporterObject {
             PropertyIdentifier::DESCRIPTION,
             PropertyIdentifier::OBJECT_TYPE,
             PropertyIdentifier::STATUS_FLAGS,
+            PropertyIdentifier::RELIABILITY,
             PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::AUDIT_LEVEL,
+            PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+            PropertyIdentifier::AUDITABLE_OPERATIONS,
+            PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+            PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
         ];
         Cow::Borrowed(PROPS)
+    }
+
+    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
+        property == PropertyIdentifier::DESCRIPTION
     }
 }
 

--- a/crates/bacnet-objects/src/audit.rs
+++ b/crates/bacnet-objects/src/audit.rs
@@ -17,11 +17,13 @@ use bacnet_types::primitives::{ObjectIdentifier, PropertyValue, StatusFlags};
 
 use crate::clock::ClockReader;
 use crate::common::read_property_list_property;
+use crate::property_metadata::PropertyMetadata;
 use crate::traits::{BACnetObject, WritePropertyRollback};
 
 mod notification;
 mod persistence;
 mod receipt;
+mod reporter_metadata;
 pub use notification::AuditLogNotificationSink;
 use persistence::{validate_record, validate_snapshot};
 pub use persistence::{
@@ -641,6 +643,10 @@ impl BACnetObject for AuditReporterObject {
         &self.name
     }
 
+    fn property_metadata(&self) -> Cow<'_, [PropertyMetadata]> {
+        Cow::Borrowed(reporter_metadata::AUDIT_REPORTER_PROPERTIES)
+    }
+
     fn read_property(
         &self,
         property: PropertyIdentifier,
@@ -720,25 +726,9 @@ impl BACnetObject for AuditReporterObject {
     }
 
     fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
-        static PROPS: &[PropertyIdentifier] = &[
-            PropertyIdentifier::OBJECT_IDENTIFIER,
-            PropertyIdentifier::OBJECT_NAME,
-            PropertyIdentifier::DESCRIPTION,
-            PropertyIdentifier::OBJECT_TYPE,
-            PropertyIdentifier::STATUS_FLAGS,
-            PropertyIdentifier::RELIABILITY,
-            PropertyIdentifier::EVENT_STATE,
-            PropertyIdentifier::AUDIT_LEVEL,
-            PropertyIdentifier::AUDIT_SOURCE_REPORTER,
-            PropertyIdentifier::AUDITABLE_OPERATIONS,
-            PropertyIdentifier::AUDIT_PRIORITY_FILTER,
-            PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
-        ];
-        Cow::Borrowed(PROPS)
-    }
-
-    fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
-        property == PropertyIdentifier::DESCRIPTION
+        crate::property_metadata::property_list_from_metadata(
+            reporter_metadata::AUDIT_REPORTER_PROPERTIES,
+        )
     }
 }
 

--- a/crates/bacnet-objects/src/audit/reporter.rs
+++ b/crates/bacnet-objects/src/audit/reporter.rs
@@ -1,0 +1,308 @@
+use bacnet_types::bitstring::{AuditOperationFlags, BACnetPriorityFilter};
+use bacnet_types::enums::{
+    AuditLevel, AuditOperation, ErrorClass, ErrorCode, EventState, ObjectType, PropertyIdentifier,
+    Reliability,
+};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
+
+use crate::traits::BACnetObject;
+
+use super::super::AuditReporterObject;
+
+fn read(reporter: &AuditReporterObject, property: PropertyIdentifier) -> PropertyValue {
+    reporter.read_property(property, None).unwrap()
+}
+
+fn assert_write_access_denied(error: Error) {
+    assert!(matches!(
+        error,
+        Error::Protocol { class, code }
+            if class == ErrorClass::PROPERTY.to_raw() as u32
+                && code == ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32
+    ));
+}
+
+#[test]
+fn audit_reporter_constructor_has_exact_inert_required_property_defaults() {
+    let reporter = AuditReporterObject::new(42, "AR-42").unwrap();
+    let identifier = ObjectIdentifier::new(ObjectType::AUDIT_REPORTER, 42).unwrap();
+    let expected = [
+        (
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyValue::ObjectIdentifier(identifier),
+        ),
+        (
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyValue::CharacterString("AR-42".into()),
+        ),
+        (
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyValue::Enumerated(ObjectType::AUDIT_REPORTER.to_raw()),
+        ),
+        (
+            PropertyIdentifier::DESCRIPTION,
+            PropertyValue::CharacterString(String::new()),
+        ),
+        (
+            PropertyIdentifier::STATUS_FLAGS,
+            PropertyValue::BitString {
+                unused_bits: 4,
+                data: vec![0],
+            },
+        ),
+        (
+            PropertyIdentifier::RELIABILITY,
+            PropertyValue::Enumerated(Reliability::NO_FAULT_DETECTED.to_raw()),
+        ),
+        (
+            PropertyIdentifier::EVENT_STATE,
+            PropertyValue::Enumerated(EventState::NORMAL.to_raw()),
+        ),
+        (
+            PropertyIdentifier::AUDIT_LEVEL,
+            PropertyValue::Enumerated(AuditLevel::NONE.to_raw()),
+        ),
+        (
+            PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+            PropertyValue::Boolean(false),
+        ),
+        (
+            PropertyIdentifier::AUDITABLE_OPERATIONS,
+            PropertyValue::BitString {
+                unused_bits: 0,
+                data: Vec::new(),
+            },
+        ),
+        (
+            PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+            PropertyValue::BitString {
+                unused_bits: 0,
+                data: vec![0xff, 0xff],
+            },
+        ),
+        (
+            PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
+            PropertyValue::Boolean(false),
+        ),
+    ];
+
+    for (property, value) in expected {
+        assert_eq!(read(&reporter, property), value, "property {property}");
+    }
+}
+
+#[test]
+fn audit_reporter_property_list_preserves_bacnet_array_projection() {
+    let reporter = AuditReporterObject::new(1, "AR-1").unwrap();
+    let supported = [
+        PropertyIdentifier::OBJECT_IDENTIFIER,
+        PropertyIdentifier::OBJECT_NAME,
+        PropertyIdentifier::DESCRIPTION,
+        PropertyIdentifier::OBJECT_TYPE,
+        PropertyIdentifier::STATUS_FLAGS,
+        PropertyIdentifier::RELIABILITY,
+        PropertyIdentifier::EVENT_STATE,
+        PropertyIdentifier::AUDIT_LEVEL,
+        PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+        PropertyIdentifier::AUDITABLE_OPERATIONS,
+        PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+        PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
+    ];
+    assert_eq!(reporter.property_list().as_ref(), supported);
+
+    let projected = supported
+        .into_iter()
+        .filter(|property| {
+            ![
+                PropertyIdentifier::OBJECT_IDENTIFIER,
+                PropertyIdentifier::OBJECT_NAME,
+                PropertyIdentifier::OBJECT_TYPE,
+            ]
+            .contains(property)
+        })
+        .map(|property| PropertyValue::Enumerated(property.to_raw()))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        reporter
+            .read_property(PropertyIdentifier::PROPERTY_LIST, None)
+            .unwrap(),
+        PropertyValue::List(projected.clone())
+    );
+    assert_eq!(
+        reporter
+            .read_property(PropertyIdentifier::PROPERTY_LIST, Some(0))
+            .unwrap(),
+        PropertyValue::Unsigned(projected.len() as u64)
+    );
+    for (index, value) in projected.into_iter().enumerate() {
+        assert_eq!(
+            reporter
+                .read_property(PropertyIdentifier::PROPERTY_LIST, Some(index as u32 + 1),)
+                .unwrap(),
+            value
+        );
+    }
+
+    let error = reporter
+        .read_property(PropertyIdentifier::PROPERTY_LIST, Some(10))
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::Protocol { class, code }
+            if class == ErrorClass::PROPERTY.to_raw() as u32
+                && code == ErrorCode::INVALID_ARRAY_INDEX.to_raw() as u32
+    ));
+}
+
+#[test]
+fn audit_reporter_local_setters_round_trip_extensible_values() {
+    let mut reporter = AuditReporterObject::new(1, "AR-1").unwrap();
+    let proprietary_level = AuditLevel::from_raw(128);
+    reporter.set_audit_level(proprietary_level).unwrap();
+
+    let mut operations = AuditOperationFlags::empty();
+    assert!(operations.insert(AuditOperation::WRITE));
+    assert!(operations.insert(AuditOperation::GENERAL));
+    reporter.set_auditable_operations(operations);
+
+    let mut priorities = BACnetPriorityFilter::empty();
+    priorities.set(1, true).unwrap();
+    priorities.set(16, true).unwrap();
+    reporter.set_audit_priority_filter(priorities);
+    reporter.set_issue_confirmed_notifications(true);
+
+    assert_eq!(
+        read(&reporter, PropertyIdentifier::AUDIT_LEVEL),
+        PropertyValue::Enumerated(proprietary_level.to_raw())
+    );
+    let (unused_bits, data) = operations.to_bacnet();
+    assert_eq!(
+        read(&reporter, PropertyIdentifier::AUDITABLE_OPERATIONS),
+        PropertyValue::BitString { unused_bits, data }
+    );
+    let (unused_bits, data) = priorities.to_bacnet();
+    assert_eq!(
+        read(&reporter, PropertyIdentifier::AUDIT_PRIORITY_FILTER),
+        PropertyValue::BitString { unused_bits, data }
+    );
+    assert_eq!(
+        read(&reporter, PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,),
+        PropertyValue::Boolean(true)
+    );
+}
+
+#[test]
+fn audit_reporter_rejects_default_level_before_mutation() {
+    let mut reporter = AuditReporterObject::new(1, "AR-1").unwrap();
+    reporter.set_audit_level(AuditLevel::AUDIT_CONFIG).unwrap();
+    assert!(matches!(
+        reporter.set_audit_level(AuditLevel::DEFAULT),
+        Err(Error::OutOfRange(_))
+    ));
+    assert_eq!(
+        read(&reporter, PropertyIdentifier::AUDIT_LEVEL),
+        PropertyValue::Enumerated(AuditLevel::AUDIT_CONFIG.to_raw())
+    );
+}
+
+#[test]
+fn audit_reporter_network_writes_to_new_properties_are_denied_without_mutation() {
+    let mut reporter = AuditReporterObject::new(1, "AR-1").unwrap();
+    reporter.set_audit_level(AuditLevel::AUDIT_ALL).unwrap();
+    reporter.set_issue_confirmed_notifications(true);
+
+    let writes = [
+        (
+            PropertyIdentifier::RELIABILITY,
+            PropertyValue::Enumerated(Reliability::CONFIGURATION_ERROR.to_raw()),
+        ),
+        (
+            PropertyIdentifier::AUDIT_LEVEL,
+            PropertyValue::Enumerated(AuditLevel::NONE.to_raw()),
+        ),
+        (
+            PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+            PropertyValue::Boolean(true),
+        ),
+        (
+            PropertyIdentifier::AUDITABLE_OPERATIONS,
+            PropertyValue::BitString {
+                unused_bits: 7,
+                data: vec![0x80],
+            },
+        ),
+        (
+            PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+            PropertyValue::BitString {
+                unused_bits: 0,
+                data: vec![0, 0],
+            },
+        ),
+        (
+            PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
+            PropertyValue::Boolean(false),
+        ),
+    ];
+
+    for (property, value) in writes {
+        let before = read(&reporter, property);
+        let error = reporter
+            .write_property(property, None, value, None)
+            .unwrap_err();
+        assert_write_access_denied(error);
+        assert_eq!(read(&reporter, property), before);
+        assert!(!reporter.is_writable_property(property));
+    }
+}
+
+#[test]
+fn audit_reporter_description_write_and_metadata_remain_compatible() {
+    let mut reporter = AuditReporterObject::new(1, "AR-1").unwrap();
+    assert!(reporter.is_writable_property(PropertyIdentifier::DESCRIPTION));
+    for property in reporter.property_list().iter().copied() {
+        assert_eq!(
+            reporter.is_writable_property(property),
+            property == PropertyIdentifier::DESCRIPTION
+        );
+    }
+    assert!(!reporter.is_writable_property(PropertyIdentifier::PROPERTY_LIST));
+
+    reporter
+        .write_property(
+            PropertyIdentifier::DESCRIPTION,
+            None,
+            PropertyValue::CharacterString("network description".into()),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        read(&reporter, PropertyIdentifier::DESCRIPTION),
+        PropertyValue::CharacterString("network description".into())
+    );
+
+    let error = reporter
+        .write_property(
+            PropertyIdentifier::DESCRIPTION,
+            None,
+            PropertyValue::Boolean(false),
+            None,
+        )
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        Error::Protocol { class, code }
+            if class == ErrorClass::PROPERTY.to_raw() as u32
+                && code == ErrorCode::INVALID_DATA_TYPE.to_raw() as u32
+    ));
+    assert_eq!(
+        read(&reporter, PropertyIdentifier::DESCRIPTION),
+        PropertyValue::CharacterString("network description".into())
+    );
+
+    reporter.set_description("local description");
+    assert_eq!(
+        read(&reporter, PropertyIdentifier::DESCRIPTION),
+        PropertyValue::CharacterString("local description".into())
+    );
+}

--- a/crates/bacnet-objects/src/audit/reporter.rs
+++ b/crates/bacnet-objects/src/audit/reporter.rs
@@ -6,6 +6,7 @@ use bacnet_types::enums::{
 use bacnet_types::error::Error;
 use bacnet_types::primitives::{ObjectIdentifier, PropertyValue};
 
+use crate::property_metadata::{PropertyConformance, PropertyWriteCapability};
 use crate::traits::BACnetObject;
 
 use super::super::AuditReporterObject;
@@ -93,13 +94,90 @@ fn audit_reporter_constructor_has_exact_inert_required_property_defaults() {
 }
 
 #[test]
+fn audit_reporter_canonical_metadata_and_required_projection_are_complete() {
+    use PropertyConformance::{Optional, RequiredRead};
+    use PropertyWriteCapability::{Always, ReadOnly};
+
+    let reporter = AuditReporterObject::new(1, "AR-1").unwrap();
+    let metadata = reporter.property_metadata();
+    assert_eq!(
+        metadata
+            .iter()
+            .map(|row| {
+                (
+                    row.property_identifier,
+                    row.conformance,
+                    row.write_capability,
+                )
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            (
+                PropertyIdentifier::OBJECT_IDENTIFIER,
+                RequiredRead,
+                ReadOnly
+            ),
+            (PropertyIdentifier::OBJECT_NAME, RequiredRead, ReadOnly),
+            (PropertyIdentifier::OBJECT_TYPE, RequiredRead, ReadOnly),
+            (PropertyIdentifier::DESCRIPTION, Optional, Always),
+            (PropertyIdentifier::STATUS_FLAGS, RequiredRead, ReadOnly),
+            (PropertyIdentifier::RELIABILITY, RequiredRead, ReadOnly),
+            (PropertyIdentifier::EVENT_STATE, RequiredRead, ReadOnly),
+            (PropertyIdentifier::AUDIT_LEVEL, RequiredRead, ReadOnly),
+            (
+                PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+                RequiredRead,
+                ReadOnly,
+            ),
+            (
+                PropertyIdentifier::AUDITABLE_OPERATIONS,
+                RequiredRead,
+                ReadOnly,
+            ),
+            (
+                PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+                RequiredRead,
+                ReadOnly,
+            ),
+            (
+                PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
+                RequiredRead,
+                ReadOnly,
+            ),
+            (PropertyIdentifier::PROPERTY_LIST, RequiredRead, ReadOnly),
+        ]
+    );
+    assert!(metadata.iter().all(|row| row.presence_condition.is_none()));
+
+    let required = reporter.required_properties();
+    assert_eq!(
+        required.as_ref(),
+        [
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::STATUS_FLAGS,
+            PropertyIdentifier::RELIABILITY,
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::AUDIT_LEVEL,
+            PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+            PropertyIdentifier::AUDITABLE_OPERATIONS,
+            PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+            PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
+            PropertyIdentifier::PROPERTY_LIST,
+        ]
+    );
+    assert!(!required.contains(&PropertyIdentifier::DESCRIPTION));
+}
+
+#[test]
 fn audit_reporter_property_list_preserves_bacnet_array_projection() {
     let reporter = AuditReporterObject::new(1, "AR-1").unwrap();
     let supported = [
         PropertyIdentifier::OBJECT_IDENTIFIER,
         PropertyIdentifier::OBJECT_NAME,
-        PropertyIdentifier::DESCRIPTION,
         PropertyIdentifier::OBJECT_TYPE,
+        PropertyIdentifier::DESCRIPTION,
         PropertyIdentifier::STATUS_FLAGS,
         PropertyIdentifier::RELIABILITY,
         PropertyIdentifier::EVENT_STATE,

--- a/crates/bacnet-objects/src/audit/reporter_metadata.rs
+++ b/crates/bacnet-objects/src/audit/reporter_metadata.rs
@@ -1,0 +1,83 @@
+use bacnet_types::enums::PropertyIdentifier;
+
+use crate::property_metadata::{
+    PropertyConformance::{Optional, RequiredRead},
+    PropertyMetadata,
+    PropertyWriteCapability::{Always, ReadOnly},
+};
+
+pub(super) static AUDIT_REPORTER_PROPERTIES: &[PropertyMetadata] = &[
+    PropertyMetadata::new(
+        PropertyIdentifier::OBJECT_IDENTIFIER,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::OBJECT_NAME,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::OBJECT_TYPE,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(PropertyIdentifier::DESCRIPTION, Optional, None, Always),
+    PropertyMetadata::new(
+        PropertyIdentifier::STATUS_FLAGS,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::RELIABILITY,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::EVENT_STATE,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::AUDIT_LEVEL,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::AUDITABLE_OPERATIONS,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+    PropertyMetadata::new(
+        PropertyIdentifier::PROPERTY_LIST,
+        RequiredRead,
+        None,
+        ReadOnly,
+    ),
+];

--- a/crates/bacnet-objects/src/audit/tests.rs
+++ b/crates/bacnet-objects/src/audit/tests.rs
@@ -18,6 +18,8 @@ use super::{
     FileAuditLogPersistence, MAX_AUDIT_RECORDS,
 };
 
+mod reporter;
+
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn temp_base(label: &str) -> PathBuf {

--- a/crates/bacnet-server/src/handlers/tests/property_metadata.rs
+++ b/crates/bacnet-server/src/handlers/tests/property_metadata.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+use bacnet_objects::audit::AuditReporterObject;
 use bacnet_objects::binary::BinaryInputObject;
 use bacnet_objects::event_enrollment::{AlertEnrollmentObject, EventEnrollmentObject};
 use bacnet_objects::value_types::TimeValueObject;
@@ -19,6 +20,8 @@ fn make_metadata_db() -> ObjectDatabase {
         AlertEnrollmentObject::new(1, "AE-1", alert_source).unwrap(),
     ))
     .unwrap();
+    db.add(Box::new(AuditReporterObject::new(1, "AR-1").unwrap()))
+        .unwrap();
     db
 }
 
@@ -270,6 +273,50 @@ fn rpm_metadata_selectors_are_exact_for_alert_enrollment() {
             PropertyIdentifier::ACKED_TRANSITIONS,
             PropertyIdentifier::NOTIFY_TYPE,
             PropertyIdentifier::EVENT_TIME_STAMPS,
+        ]
+    );
+    assert_eq!(
+        rpm_property_ids(&db, oid, PropertyIdentifier::OPTIONAL),
+        vec![PropertyIdentifier::DESCRIPTION]
+    );
+}
+
+#[test]
+fn rpm_metadata_selectors_are_exact_for_audit_reporter() {
+    let db = make_metadata_db();
+    let oid = ObjectIdentifier::new(ObjectType::AUDIT_REPORTER, 1).unwrap();
+
+    assert_eq!(
+        rpm_property_ids(&db, oid, PropertyIdentifier::ALL),
+        vec![
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::DESCRIPTION,
+            PropertyIdentifier::STATUS_FLAGS,
+            PropertyIdentifier::RELIABILITY,
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::AUDIT_LEVEL,
+            PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+            PropertyIdentifier::AUDITABLE_OPERATIONS,
+            PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+            PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
+        ]
+    );
+    assert_eq!(
+        rpm_property_ids(&db, oid, PropertyIdentifier::REQUIRED),
+        vec![
+            PropertyIdentifier::OBJECT_IDENTIFIER,
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::OBJECT_TYPE,
+            PropertyIdentifier::STATUS_FLAGS,
+            PropertyIdentifier::RELIABILITY,
+            PropertyIdentifier::EVENT_STATE,
+            PropertyIdentifier::AUDIT_LEVEL,
+            PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+            PropertyIdentifier::AUDITABLE_OPERATIONS,
+            PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+            PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
         ]
     );
     assert_eq!(

--- a/crates/bacnet-server/src/pics/property_metadata_tests.rs
+++ b/crates/bacnet-server/src/pics/property_metadata_tests.rs
@@ -1,4 +1,5 @@
 use bacnet_objects::{
+    audit::AuditReporterObject,
     binary::BinaryInputObject,
     event_enrollment::{AlertEnrollmentObject, EventEnrollmentObject},
     staging::{StagingConfig, StagingObject},
@@ -231,6 +232,65 @@ fn pics_projects_migrated_property_metadata() {
             (PropertyIdentifier::NOTIFY_TYPE, false, true),
             (PropertyIdentifier::EVENT_TIME_STAMPS, false, false),
             (PropertyIdentifier::PROPERTY_LIST, false, false),
+        ]
+    );
+}
+
+#[test]
+fn pics_audit_reporter_metadata_is_complete_and_exact() {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(AuditReporterObject::new(1, "ar-1").unwrap()))
+        .unwrap();
+    let pics = generate_pics(&db, &ServerConfig::default(), &PicsConfig::default());
+    let reporter = pics
+        .supported_object_types
+        .iter()
+        .find(|support| support.object_type == ObjectType::AUDIT_REPORTER)
+        .expect("Audit Reporter support");
+    let rows = reporter
+        .supported_properties
+        .iter()
+        .map(|property| {
+            (
+                property.property_id,
+                property.access.readable,
+                property.access.optional,
+                property.access.writable,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        rows,
+        vec![
+            (PropertyIdentifier::OBJECT_IDENTIFIER, true, false, false),
+            (PropertyIdentifier::OBJECT_NAME, true, false, false),
+            (PropertyIdentifier::OBJECT_TYPE, true, false, false),
+            (PropertyIdentifier::DESCRIPTION, true, true, true),
+            (PropertyIdentifier::STATUS_FLAGS, true, false, false),
+            (PropertyIdentifier::RELIABILITY, true, false, false),
+            (PropertyIdentifier::EVENT_STATE, true, false, false),
+            (PropertyIdentifier::AUDIT_LEVEL, true, false, false),
+            (
+                PropertyIdentifier::AUDIT_SOURCE_REPORTER,
+                true,
+                false,
+                false,
+            ),
+            (PropertyIdentifier::AUDITABLE_OPERATIONS, true, false, false,),
+            (
+                PropertyIdentifier::AUDIT_PRIORITY_FILTER,
+                true,
+                false,
+                false,
+            ),
+            (
+                PropertyIdentifier::ISSUE_CONFIRMED_NOTIFICATIONS,
+                true,
+                false,
+                false,
+            ),
+            (PropertyIdentifier::PROPERTY_LIST, true, false, false),
         ]
     );
 }

--- a/crates/bacnet-types/src/bitstring.rs
+++ b/crates/bacnet-types/src/bitstring.rs
@@ -25,6 +25,9 @@ use crate::enums::{AuditOperation, ObjectType, ServiceSupported};
 use crate::error::{Error, Result};
 
 pub use crate::primitives::StatusFlags;
+pub use priority_filter::BACnetPriorityFilter;
+
+mod priority_filter;
 
 /// Read bit `n` of a BACnet bit string (MSB-first) from its content bytes.
 ///

--- a/crates/bacnet-types/src/bitstring/priority_filter.rs
+++ b/crates/bacnet-types/src/bitstring/priority_filter.rs
@@ -1,0 +1,183 @@
+//! Fixed-width command-priority filter used by Audit Reporter objects.
+
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+
+use crate::error::{Error, Result};
+
+/// `BACnetPriorityFilter` — one bit for each command priority from 1 through 16.
+///
+/// The bit-position-preserving `u16` representation uses bit 0 for priority 1
+/// and bit 15 for priority 16. BACnet encoding places those positions
+/// most-significant-bit first in exactly two content octets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct BACnetPriorityFilter {
+    bits: u16,
+}
+
+impl BACnetPriorityFilter {
+    /// A filter that selects no command priorities.
+    #[inline]
+    pub const fn empty() -> Self {
+        Self { bits: 0 }
+    }
+
+    /// A filter that selects every command priority.
+    #[inline]
+    pub const fn all() -> Self {
+        Self { bits: u16::MAX }
+    }
+
+    /// Construct from the bit-position-preserving representation.
+    #[inline]
+    pub const fn from_bits(bits: u16) -> Self {
+        Self { bits }
+    }
+
+    /// Return the bit-position-preserving representation.
+    #[inline]
+    pub const fn bits(self) -> u16 {
+        self.bits
+    }
+
+    /// Whether command `priority` is selected.
+    ///
+    /// Priorities outside 1 through 16 are never selected.
+    #[inline]
+    pub const fn contains(self, priority: u8) -> bool {
+        match Self::priority_mask(priority) {
+            Some(mask) => self.bits & mask != 0,
+            None => false,
+        }
+    }
+
+    /// Select or clear command `priority`.
+    ///
+    /// An out-of-range priority is rejected before the filter is mutated.
+    pub fn set(&mut self, priority: u8, selected: bool) -> Result<()> {
+        let Some(mask) = Self::priority_mask(priority) else {
+            return Err(Error::OutOfRange(
+                "BACnetPriorityFilter: priority must be in 1..=16".into(),
+            ));
+        };
+        if selected {
+            self.bits |= mask;
+        } else {
+            self.bits &= !mask;
+        }
+        Ok(())
+    }
+
+    const fn priority_mask(priority: u8) -> Option<u16> {
+        if priority >= 1 && priority <= 16 {
+            Some(1u16 << (priority - 1))
+        } else {
+            None
+        }
+    }
+
+    /// Decode one fixed-width BACnet BIT STRING payload.
+    ///
+    /// The payload must contain exactly 16 meaningful bits: two content
+    /// octets, zero unused bits, and no alternate-width representation.
+    pub fn from_bacnet(unused_bits: u8, data: &[u8]) -> Result<Self> {
+        if unused_bits != 0 {
+            return Err(Error::decoding(
+                0,
+                "BACnetPriorityFilter: a 16-bit value must have zero unused bits",
+            ));
+        }
+        if data.len() != 2 {
+            return Err(Error::decoding(
+                0,
+                "BACnetPriorityFilter: payload must contain exactly two octets",
+            ));
+        }
+
+        Ok(Self {
+            bits: u16::from(data[0].reverse_bits()) | (u16::from(data[1].reverse_bits()) << 8),
+        })
+    }
+
+    /// Encode as the canonical two-octet BACnet BIT STRING payload.
+    pub fn to_bacnet(self) -> (u8, Vec<u8>) {
+        (
+            0,
+            vec![
+                (self.bits as u8).reverse_bits(),
+                ((self.bits >> 8) as u8).reverse_bits(),
+            ],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audit_priority_filter_construction_and_raw_round_trip() {
+        assert_eq!(BACnetPriorityFilter::empty().bits(), 0);
+        assert_eq!(BACnetPriorityFilter::all().bits(), u16::MAX);
+
+        let raw = 0x8181;
+        assert_eq!(BACnetPriorityFilter::from_bits(raw).bits(), raw);
+    }
+
+    #[test]
+    fn audit_priority_filter_uses_msb_first_priority_positions() {
+        for (priority, expected) in [
+            (1, vec![0x80, 0x00]),
+            (8, vec![0x01, 0x00]),
+            (9, vec![0x00, 0x80]),
+            (16, vec![0x00, 0x01]),
+        ] {
+            let mut filter = BACnetPriorityFilter::empty();
+            filter.set(priority, true).unwrap();
+            assert!(filter.contains(priority));
+            assert_eq!(filter.to_bacnet(), (0, expected.clone()));
+            assert_eq!(
+                BACnetPriorityFilter::from_bacnet(0, &expected).unwrap(),
+                filter
+            );
+        }
+
+        assert_eq!(BACnetPriorityFilter::empty().to_bacnet(), (0, vec![0, 0]));
+        assert_eq!(
+            BACnetPriorityFilter::all().to_bacnet(),
+            (0, vec![0xff, 0xff])
+        );
+    }
+
+    #[test]
+    fn audit_priority_filter_mutation_is_bounded_and_transactional() {
+        let mut filter = BACnetPriorityFilter::from_bits(0x8001);
+        filter.set(1, false).unwrap();
+        filter.set(8, true).unwrap();
+        assert!(!filter.contains(1));
+        assert!(filter.contains(8));
+        assert!(filter.contains(16));
+
+        let before = filter;
+        assert!(filter.set(0, true).is_err());
+        assert_eq!(filter, before);
+        assert!(filter.set(17, false).is_err());
+        assert_eq!(filter, before);
+        assert!(!filter.contains(0));
+        assert!(!filter.contains(17));
+    }
+
+    #[test]
+    fn audit_priority_filter_rejects_noncanonical_width_and_padding() {
+        for (unused_bits, data) in [
+            (1, &[0x80, 0x00][..]),
+            (7, &[0x80, 0x00][..]),
+            (8, &[0x80, 0x00][..]),
+            (0, &[][..]),
+            (0, &[0x80][..]),
+            (0, &[0x80, 0x00, 0x00][..]),
+        ] {
+            assert!(BACnetPriorityFilter::from_bacnet(unused_bits, data).is_err());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a fixed-width, MSB-first `BACnetPriorityFilter` for command priorities 1–16
- expose the required Audit Reporter properties with inert defaults and validated local-only configuration
- preserve `AuditReporterObject::new(instance, name)` and keep all new properties network read-only

## Standards basis
Paraphrased from the repository's licensed ASHRAE Standard 135-2020 source:
- §12.63 / Table 12-82, printed pp. 619–621: required Audit Reporter properties and Reporter-level constraints
- Clause 21, printed p. 885: `BACnetAuditLevel` values and extensibility
- Clause 21, printed pp. 923–924: the 16-position `BACnetPriorityFilter`

## Scope
This is a prerequisite property/configuration slice only. It does **not** add notification generation, routing, forwarding, source-reporter ownership, remote audit configuration, delayed sends, monitored-object selection, Python APIs, or public conformance claims.

## Validation
- `cargo fmt --check`
- `cargo test -p bacnet-types audit_priority_filter`
- `cargo test -p bacnet-objects audit::tests`
- `cargo test -p bacnet-objects audit::query_tests`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

All listed gates pass. Repository-wide `cargo clippy --workspace --all-targets -- -D warnings` remains blocked by pre-existing missing-documentation and unrelated lint debt; a changed-package diagnostic with missing-docs allowed passes.

Partial progress toward #345.