### PR TITLE
fix(sc): validate reconnect configuration before startup

### DIFF
--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -698,6 +698,9 @@ impl ScClientBuilder {
         self,
         ws: W,
     ) -> Result<BACnetClient<bacnet_transport::sc::ScTransport<W>>, Error> {
+        if let Some(config) = &self.reconnect {
+            config.validate()?;
+        }
         self.validate_identity()?;
         self.options.validate()?;
         validate_max_segments(self.config.max_segments)?;
@@ -706,12 +709,19 @@ impl ScClientBuilder {
     }
 
     /// Connect to the hub and start the client.
+    ///
+    /// Reconnect configuration is validated before TLS lookup or dialing, and
+    /// again when the transport starts. An error still consumes this builder
+    /// and drops its inputs; this does not promise generic endpoint rollback.
     pub async fn build(
         self,
     ) -> Result<
         BACnetClient<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>>,
         Error,
     > {
+        if let Some(config) = &self.reconnect {
+            config.validate()?;
+        }
         self.validate_identity()?;
         self.options.validate()?;
         validate_max_segments(self.config.max_segments)?;

--- a/crates/bacnet-client/src/client/sc_builder_tests.rs
+++ b/crates/bacnet-client/src/client/sc_builder_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use bacnet_transport::sc::{LoopbackWebSocket, WebSocketPort};
+use bacnet_transport::sc::{LoopbackWebSocket, ScReconnectConfig, WebSocketPort};
 use bacnet_transport::sc_frame::{decode_sc_message, encode_sc_message, ScFunction, ScMessage};
 use bytes::{Bytes, BytesMut};
 use tokio::time::{timeout, Duration};
@@ -116,4 +116,109 @@ fn sc_client_builder_rejects_broadcast_vmac_and_zero_device_uuid() {
         zero_uuid,
         Err(Error::Encoding(message)) if message.contains("device_uuid")
     ));
+}
+
+#[tokio::test]
+async fn sc_client_builder_rejects_invalid_reconnect_before_tls_lookup() {
+    for max_retries in [0, 10] {
+        for (initial_delay_ms, max_delay_ms) in [(0, 1), (1, 0), (0, 0), (2, 1)] {
+            let error = BACnetClient::sc_builder()
+                .vmac([0x22; 6])
+                .device_uuid([0xAB; 16])
+                .reconnect(ScReconnectConfig {
+                    initial_delay_ms,
+                    max_delay_ms,
+                    max_retries,
+                })
+                .build()
+                .await
+                .err()
+                .expect("invalid reconnect must fail");
+            assert!(
+                matches!(&error, Error::OutOfRange(message) if message.contains("reconnect")),
+                "expected reconnect error before TLS lookup, got {error:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn sc_client_builder_valid_reconnect_preserves_missing_tls_error() {
+    for reconnect in [
+        None,
+        Some(ScReconnectConfig::default()),
+        Some(ScReconnectConfig {
+            initial_delay_ms: 1,
+            max_delay_ms: 1,
+            max_retries: 0,
+        }),
+        Some(ScReconnectConfig {
+            initial_delay_ms: 1,
+            max_delay_ms: 2,
+            max_retries: u32::MAX,
+        }),
+    ] {
+        let mut builder = BACnetClient::sc_builder()
+            .vmac([0x22; 6])
+            .device_uuid([0xAB; 16]);
+        if let Some(config) = reconnect {
+            builder = builder.reconnect(config);
+        }
+        assert!(matches!(
+            builder.build().await,
+            Err(Error::Encoding(message)) if message == "SC client builder: tls_config is required"
+        ));
+    }
+}
+
+struct RejectIoWebSocket {
+    calls: Arc<std::sync::atomic::AtomicUsize>,
+    drops: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+impl WebSocketPort for RejectIoWebSocket {
+    async fn send(&self, _: &[u8]) -> Result<(), Error> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Err(Error::Encoding("unexpected WebSocket send".into()))
+    }
+
+    async fn recv(&self) -> Result<Vec<u8>, Error> {
+        self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Err(Error::Encoding("unexpected WebSocket receive".into()))
+    }
+}
+
+impl Drop for RejectIoWebSocket {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[tokio::test]
+async fn sc_client_test_builder_reconnect_preflight_drops_input_without_io() {
+    for (initial_delay_ms, max_delay_ms) in [(0, 1), (1, 0), (0, 0), (2, 1)] {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let drops = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let error = BACnetClient::sc_builder()
+            .vmac([0x22; 6])
+            .device_uuid([0xAB; 16])
+            .reconnect(ScReconnectConfig {
+                initial_delay_ms,
+                max_delay_ms,
+                max_retries: 0,
+            })
+            .build_with_websocket_for_test(RejectIoWebSocket {
+                calls: calls.clone(),
+                drops: drops.clone(),
+            })
+            .await
+            .err()
+            .expect("invalid reconnect must fail");
+        assert!(
+            matches!(&error, Error::OutOfRange(message) if message.contains("reconnect")),
+            "expected reconnect preflight error, got {error:?}"
+        );
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(drops.load(std::sync::atomic::Ordering::SeqCst), 1);
+    }
 }

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -157,12 +157,20 @@ impl ScServerBuilder {
     }
 
     /// Connect to the hub and start the server.
+    ///
+    /// Reconnect configuration is validated before binding-table construction,
+    /// TLS lookup, or dialing, and again when the transport starts. An error
+    /// still consumes this builder and drops its inputs; this does not promise
+    /// generic endpoint rollback.
     pub async fn build(
         self,
     ) -> Result<
         BACnetServer<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>>,
         Error,
     > {
+        if let Some(config) = &self.reconnect {
+            config.validate()?;
+        }
         DeviceBindingTable::from_configured(self.configured_device_bindings.clone(), |mac| {
             mac == bacnet_transport::sc_frame::BROADCAST_VMAC
         })?;
@@ -203,5 +211,71 @@ impl ScServerBuilder {
             self.configured_device_bindings,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bacnet_transport::sc::ScReconnectConfig;
+
+    #[tokio::test]
+    async fn sc_server_builder_rejects_invalid_reconnect_before_tls_and_bindings() {
+        for broadcast_binding in [false, true] {
+            for max_retries in [0, 10] {
+                for (initial_delay_ms, max_delay_ms) in [(0, 1), (1, 0), (0, 0), (2, 1)] {
+                    let mut builder = BACnetServer::sc_builder().reconnect(ScReconnectConfig {
+                        initial_delay_ms,
+                        max_delay_ms,
+                        max_retries,
+                    });
+                    if broadcast_binding {
+                        let device = ObjectIdentifier::new(ObjectType::DEVICE, 46).unwrap();
+                        let binding = DeviceBinding::local(
+                            device,
+                            bacnet_transport::sc_frame::BROADCAST_VMAC,
+                        )
+                        .unwrap();
+                        builder = builder.device_binding(binding).unwrap();
+                    }
+                    let error = builder
+                        .build()
+                        .await
+                        .err()
+                        .expect("invalid reconnect must fail");
+                    assert!(
+                        matches!(&error, Error::OutOfRange(message) if message.contains("reconnect")),
+                        "expected reconnect error before TLS/bindings, got {error:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn sc_server_builder_valid_reconnect_preserves_missing_tls_error() {
+        for reconnect in [
+            None,
+            Some(ScReconnectConfig::default()),
+            Some(ScReconnectConfig {
+                initial_delay_ms: 1,
+                max_delay_ms: 1,
+                max_retries: 0,
+            }),
+            Some(ScReconnectConfig {
+                initial_delay_ms: 1,
+                max_delay_ms: 2,
+                max_retries: u32::MAX,
+            }),
+        ] {
+            let mut builder = BACnetServer::sc_builder();
+            if let Some(config) = reconnect {
+                builder = builder.reconnect(config);
+            }
+            assert!(matches!(
+                builder.build().await,
+                Err(Error::Encoding(message)) if message == "SC server builder: tls_config is required"
+            ));
+        }
     }
 }

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -172,6 +172,12 @@ impl<W: WebSocketPort> ScTransport<W> {
     /// for true transport-level recovery from a dead WebSocket/TCP/TLS connection;
     /// otherwise reconnect attempts can only reuse the current WebSocket object.
     /// The local VMAC is preserved across reconnections.
+    ///
+    /// [`TransportPort::start`] validates this configuration before any transport
+    /// startup state changes or I/O, retaining the socket on validation failure.
+    /// It cannot undo a caller-owned dial: call [`ScReconnectConfig::validate`]
+    /// before dialing if needed. Generic endpoint startup may change its own
+    /// state before calling the transport; this is not transactional rollback.
     pub fn with_reconnect(mut self, config: ScReconnectConfig) -> Self {
         self.reconnect_config = Some(config);
         self
@@ -267,6 +273,10 @@ async fn publish_connected_ws<W: WebSocketPort>(
 
 impl<W: WebSocketPort> TransportPort for ScTransport<W> {
     async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        if let Some(config) = &self.reconnect_config {
+            config.validate()?;
+        }
+
         /// NPDU receive channel capacity — smaller than BIP/Ethernet since SC is hub-relayed.
         const NPDU_CHANNEL_CAPACITY: usize = 64;
 
@@ -811,6 +821,9 @@ mod primary_restore_tests;
 
 #[cfg(test)]
 mod redial_tests;
+
+#[cfg(test)]
+mod reconnect_validation_tests;
 
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-transport/src/sc/reconnect.rs
+++ b/crates/bacnet-transport/src/sc/reconnect.rs
@@ -1,3 +1,5 @@
+use bacnet_types::error::Error;
+
 /// Configuration for SC transport reconnection with exponential backoff.
 #[derive(Debug, Clone)]
 pub struct ScReconnectConfig {
@@ -5,7 +7,9 @@ pub struct ScReconnectConfig {
     pub initial_delay_ms: u64,
     /// Maximum delay between reconnect attempts (ms).
     pub max_delay_ms: u64,
-    /// Maximum number of reconnect attempts before giving up.
+    /// Maximum reconnect attempts on the active hub after a disconnect.
+    /// Zero skips these retries, not the initial connection, eligible failover,
+    /// or primary restoration while connected to failover.
     pub max_retries: u32,
 }
 
@@ -19,8 +23,96 @@ impl Default for ScReconnectConfig {
     }
 }
 
+impl ScReconnectConfig {
+    /// Check that delays are nonzero and the initial delay does not exceed the maximum.
+    ///
+    /// This defensive guard applies even when `max_retries` is zero. It does not
+    /// impose a production minimum delay, timeout cap, or retry-count policy;
+    /// acceptance does not establish deployment safety or Annex AB.6.1 conformance.
+    /// Call this before dialing if supplying a socket to a raw SC transport.
+    pub fn validate(&self) -> Result<(), Error> {
+        if self.initial_delay_ms == 0 {
+            return Err(Error::OutOfRange(
+                "BACnet/SC reconnect initial_delay_ms must be greater than zero".into(),
+            ));
+        }
+        if self.max_delay_ms == 0 {
+            return Err(Error::OutOfRange(
+                "BACnet/SC reconnect max_delay_ms must be greater than zero".into(),
+            ));
+        }
+        if self.initial_delay_ms > self.max_delay_ms {
+            return Err(Error::OutOfRange(format!(
+                "BACnet/SC reconnect initial_delay_ms must not exceed max_delay_ms, \
+                 got initial_delay_ms={} max_delay_ms={}",
+                self.initial_delay_ms, self.max_delay_ms
+            )));
+        }
+        Ok(())
+    }
+}
+
 impl super::ScConnection {
     pub(super) fn reset_for_connect_retry(&mut self) {
         *self = Self::new(self.local_vmac, self.device_uuid);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconnect_validation_rejects_zero_and_inverted_delays_for_all_retry_counts() {
+        for max_retries in [0, 1, 10, u32::MAX] {
+            for (initial_delay_ms, max_delay_ms, field) in [
+                (0, 1, "initial_delay_ms"),
+                (1, 0, "max_delay_ms"),
+                (0, 0, "initial_delay_ms"),
+                (2, 1, "initial_delay_ms"),
+                (u64::MAX, u64::MAX - 1, "initial_delay_ms"),
+            ] {
+                let config = ScReconnectConfig {
+                    initial_delay_ms,
+                    max_delay_ms,
+                    max_retries,
+                };
+                assert!(
+                    matches!(config.validate(), Err(Error::OutOfRange(message))
+                        if message.contains("reconnect") && message.contains(field)),
+                    "{config:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn reconnect_validation_accepts_positive_ordered_delays_without_timer_or_retry_caps() {
+        let default = ScReconnectConfig::default();
+        assert_eq!(default.initial_delay_ms, 10_000);
+        assert_eq!(default.max_delay_ms, 600_000);
+        assert_eq!(default.max_retries, 10);
+        default.validate().unwrap();
+
+        // Validate only: accepted extreme values are not safe timer/deployment promises.
+        for max_retries in [0, 1, 10, u32::MAX] {
+            for (initial_delay_ms, max_delay_ms) in [
+                (1, 1),
+                (1, 2),
+                (10_000, 600_000),
+                (600_001, 600_001),
+                (1, u64::MAX),
+                (u64::MAX - 1, u64::MAX),
+                (u64::MAX, u64::MAX),
+            ] {
+                ScReconnectConfig {
+                    initial_delay_ms,
+                    max_delay_ms,
+                    max_retries,
+                }
+                .validate()
+                .unwrap();
+            }
+        }
     }
 }

--- a/crates/bacnet-transport/src/sc/reconnect_validation_tests.rs
+++ b/crates/bacnet-transport/src/sc/reconnect_validation_tests.rs
@@ -1,0 +1,252 @@
+use super::*;
+use std::sync::atomic::AtomicUsize;
+
+#[derive(Default)]
+struct SocketCounts {
+    sends: AtomicUsize,
+    receives: AtomicUsize,
+    drops: AtomicUsize,
+}
+
+struct CountingWebSocket {
+    inner: LoopbackWebSocket,
+    counts: Arc<SocketCounts>,
+}
+
+impl WebSocketPort for CountingWebSocket {
+    async fn send(&self, data: &[u8]) -> Result<(), Error> {
+        self.counts.sends.fetch_add(1, Ordering::SeqCst);
+        self.inner.send(data).await
+    }
+
+    async fn recv(&self) -> Result<Vec<u8>, Error> {
+        self.counts.receives.fetch_add(1, Ordering::SeqCst);
+        self.inner.recv().await
+    }
+}
+
+impl Drop for CountingWebSocket {
+    fn drop(&mut self) {
+        self.counts.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test]
+async fn invalid_reconnect_start_preserves_transport_and_socket_for_repair() {
+    for heartbeat_mode in ["default", "invalid", "test bypass"] {
+        check_invalid_start_and_repair(heartbeat_mode).await;
+    }
+}
+
+async fn check_invalid_start_and_repair(heartbeat_mode: &str) {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let (failover, _failover_hub) = LoopbackWebSocket::pair();
+    let counts = Arc::new(SocketCounts::default());
+    let dials = Arc::new(AtomicUsize::new(0));
+    let ws = CountingWebSocket {
+        inner: client,
+        counts: counts.clone(),
+    };
+    let vmac = [0x22; 6];
+    let uuid = [0xAB; 16];
+    let mut transport = ScTransport::new(ws, vmac)
+        .with_device_uuid(uuid)
+        .with_connect_timeout_ms(10)
+        .with_failover(CountingWebSocket {
+            inner: failover,
+            counts: counts.clone(),
+        })
+        .with_connector({
+            let dials = dials.clone();
+            move || {
+                dials.fetch_add(1, Ordering::SeqCst);
+                async { Err(Error::Encoding("unexpected primary dial".into())) }
+            }
+        })
+        .with_failover_connector({
+            let dials = dials.clone();
+            move || {
+                dials.fetch_add(1, Ordering::SeqCst);
+                async { Err(Error::Encoding("unexpected failover dial".into())) }
+            }
+        });
+    transport = match heartbeat_mode {
+        "invalid" => transport.with_heartbeat_interval_ms(0),
+        "test bypass" => transport.with_test_heartbeat_timing_ms(1, 2),
+        _ => transport,
+    };
+    let state = transport.connection_state_changes();
+
+    for max_retries in [0, 10, u32::MAX] {
+        for (initial_delay_ms, max_delay_ms) in [(0, 1), (1, 0), (0, 0), (2, 1)] {
+            transport = transport.with_reconnect(ScReconnectConfig {
+                initial_delay_ms,
+                max_delay_ms,
+                max_retries,
+            });
+            for _ in 0..2 {
+                let error = transport.start().await.unwrap_err();
+                assert!(
+                    matches!(&error, Error::OutOfRange(message) if message.contains("reconnect")),
+                    "expected reconnect configuration error, got {error:?}"
+                );
+                tokio::task::yield_now().await;
+                assert_eq!(counts.sends.load(Ordering::SeqCst), 0);
+                assert_eq!(counts.receives.load(Ordering::SeqCst), 0);
+                assert_eq!(counts.drops.load(Ordering::SeqCst), 0);
+                assert_eq!(dials.load(Ordering::SeqCst), 0);
+                assert!(!state.has_changed().unwrap());
+                assert_eq!(*state.borrow(), ScConnectionState::Disconnected);
+                assert!(transport.connection().is_none());
+                assert!(transport.ws.is_some());
+                assert!(transport.failover_ws.is_some());
+                assert!(transport.ws_shared.is_none());
+                assert!(transport.recv_task.is_none());
+                assert!(transport.restore_disconnect_task.lock().unwrap().is_none());
+                assert_eq!(transport.local_mac(), vmac);
+                assert_eq!(transport.device_uuid, uuid);
+                assert_eq!(transport.max_apdu_length(), DEFAULT_MAX_APDU_LENGTH);
+            }
+        }
+    }
+
+    transport = transport
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 1,
+            max_delay_ms: 1,
+            max_retries: 0,
+        })
+        .with_heartbeat_interval_ms(30_000)
+        .with_heartbeat_timeout_ms(60_000);
+    let (started, ()) = tokio::join!(transport.start(), hub_accept(&hub, [0x10; 6]));
+    let _rx = started.unwrap();
+    assert_eq!(*state.borrow(), ScConnectionState::Connected);
+    assert_eq!(counts.sends.load(Ordering::SeqCst), 1);
+    assert_eq!(dials.load(Ordering::SeqCst), 0);
+    assert_eq!(transport.local_mac(), vmac);
+    assert_eq!(
+        transport.connection().unwrap().lock().await.device_uuid,
+        uuid
+    );
+    transport.stop().await.unwrap();
+    assert_eq!(counts.drops.load(Ordering::SeqCst), 2);
+    assert!(transport.recv_task.is_none());
+    assert!(transport.restore_disconnect_task.lock().unwrap().is_none());
+}
+
+async fn hub_accept(hub: &LoopbackWebSocket, vmac: Vmac) {
+    let request = tokio::time::timeout(Duration::from_secs(1), hub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let request = decode_sc_message(&request).unwrap();
+    assert_eq!(request.function, ScFunction::ConnectRequest);
+    let mut payload = Vec::from(vmac);
+    payload.extend_from_slice(&[0; 16]);
+    payload.extend_from_slice(&1476u16.to_be_bytes());
+    payload.extend_from_slice(&1476u16.to_be_bytes());
+    let accept = ScMessage {
+        function: ScFunction::ConnectAccept,
+        message_id: request.message_id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &accept);
+    hub.send(&buf).await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn zero_retries_skips_active_hub_retry_but_allows_initial_failover_and_restoration() {
+    let (primary, primary_hub) = LoopbackWebSocket::pair();
+    let (failover, failover_hub) = LoopbackWebSocket::pair();
+    let dials = Arc::new(AtomicUsize::new(0));
+    let (hub_tx, mut hub_rx) = mpsc::unbounded_channel();
+    let mut transport = ScTransport::new(primary, [0x22; 6])
+        .with_failover(failover)
+        .with_connect_timeout_ms(500)
+        .with_reconnect(ScReconnectConfig {
+            initial_delay_ms: 1_000,
+            max_delay_ms: 1_000,
+            max_retries: 0,
+        })
+        .with_connector({
+            let dials = dials.clone();
+            move || {
+                dials.fetch_add(1, Ordering::SeqCst);
+                let (client, hub) = LoopbackWebSocket::pair();
+                hub_tx.send(hub).unwrap();
+                async { Ok(client) }
+            }
+        });
+
+    let (started, ()) = tokio::join!(transport.start(), hub_accept(&primary_hub, [0x10; 6]));
+    let _rx = started.unwrap();
+    wait_for_hub(&transport, [0x10; 6]).await;
+    assert_eq!(dials.load(Ordering::SeqCst), 0);
+    tokio::task::yield_now().await;
+
+    // Losing the active hub skips its retry loop, but still permits failover.
+    drop(primary_hub);
+    hub_accept(&failover_hub, [0x20; 6]).await;
+    wait_for_hub(&transport, [0x20; 6]).await;
+    assert_eq!(dials.load(Ordering::SeqCst), 0);
+    assert!(hub_rx.try_recv().is_err());
+
+    // Primary restoration uses the reconnect timeout even with zero retries.
+    tokio::time::advance(Duration::from_millis(999)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(dials.load(Ordering::SeqCst), 0);
+    tokio::time::advance(Duration::from_millis(1)).await;
+    let restored_hub = tokio::time::timeout(Duration::from_secs(1), hub_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    hub_accept(&restored_hub, [0x10; 6]).await;
+    wait_for_hub(&transport, [0x10; 6]).await;
+    assert_eq!(dials.load(Ordering::SeqCst), 1);
+
+    let disconnect = tokio::time::timeout(Duration::from_secs(1), failover_hub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        decode_sc_message(&disconnect).unwrap().function,
+        ScFunction::DisconnectRequest
+    );
+    transport
+        .send_unicast(&[1, 2, 3], &[0x33; 6])
+        .await
+        .unwrap();
+    let data = tokio::time::timeout(Duration::from_secs(1), restored_hub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let message = decode_sc_message(&data).unwrap();
+    assert_eq!(message.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(message.destination_vmac, Some([0x33; 6]));
+    assert_eq!(message.payload.as_ref(), [1, 2, 3]);
+    transport.stop().await.unwrap();
+    assert!(transport.recv_task.is_none());
+    assert!(transport.restore_disconnect_task.lock().unwrap().is_none());
+}
+
+async fn wait_for_hub<W: WebSocketPort>(transport: &ScTransport<W>, vmac: Vmac) {
+    let mut state = transport.connection_state_changes();
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            state.borrow_and_update();
+            let conn = transport.connection().unwrap().lock().await;
+            if conn.state == ScConnectionState::Connected && conn.hub_vmac == Some(vmac) {
+                return;
+            }
+            drop(conn);
+            state.changed().await.unwrap();
+        }
+    })
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
## Summary
- Add a shared reconnect validator rejecting zero initial/max delays and inverted ranges.
- Validate raw SC transport startup before transport state changes, I/O, or tasks; retain supplied sockets on rejection.
- Preflight Rust SC client/server builders before TLS lookup and dialing, with production-boundary regressions.

## Scope and compatibility
Refs #526 — validation-only partial delivery; keep the issue open.
Public builder signatures, fields, defaults, positive ordered delays, and existing retry/failover behavior are preserved. Raw validation cannot undo caller-owned dialing; consuming builders still drop their inputs. Generic endpoint rollback is not promised.

Timeout range/cap enforcement, jitter, deployment-safe lower bounds, retry-budget policy, and diagnostic throttling remain under #526. #514 is a separate next candidate. No dependency, CI, Python exposure, or public support expansion.

## Source grounding
Local Standard 135-2020, Annex AB.6.1, printed p. 1401 / PDF p. 1403, distinguishes configurable minimum support, fixed minimum ranges, and the 600-second ceiling. This defensive guard does not establish Annex AB.6.1 conformance or deployment safety. AB.5.2 restoration context was also checked. Licensed text is not reproduced.

## Validation
- Red-before-green raw-start regression: unchanged production reached Timeout(10ms) instead of returning a configuration error.
- Red-before-green actual client/server build regressions: unchanged production reached TLS lookup; test helper performed WebSocket I/O.
- 113 SC tests passed both without default features and with sc-tls; focused client/server sc-tls builder suites passed.
- Workspace fmt, Clippy, tests (excluding Python crate), Python-crate test compilation, conformance generation check, file-size, no-secret, and diff checks passed.
- Existing hosted Linux full-feature CI is required before merge; immutable review pending.

## Acceptance boundaries
Tests cover independent/both zero fields, inversion, retry-count boundaries, retained defaults and positive equality, repeated rejection without I/O/state/task effects, repair using retained sockets, and zero-retry failover/restoration behavior.