### PR TITLE
fix(server): reclaim stalled segmented requests

### DIFF
--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -99,9 +99,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
             while let Some(received) = apdu_rx.recv().await {
                 let now = Instant::now();
-                seg_receivers.retain(|_key, state| {
-                    now.duration_since(state.last_activity) < SEG_RECEIVER_TIMEOUT
-                });
+                super::segmented_receive::expire_segmented_requests(&mut seg_receivers, now);
 
                 match apdu::decode_apdu(received.apdu.clone()) {
                     Ok(decoded) => {
@@ -234,6 +232,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                             .await;
                                             continue;
                                         }
+                                        state.last_progress = Instant::now();
                                         state.accepted_segments += 1;
                                         state.expected_seq = seq.wrapping_add(1);
                                         state.last_acked_seq = seq;
@@ -320,6 +319,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                         receiver,
                                         first_req: req.clone(),
                                         last_activity: Instant::now(),
+                                        last_progress: Instant::now(),
                                         expected_seq: 1,
                                         initial_sequence_number: 0,
                                         duplicate_count: 0,

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -841,6 +841,8 @@ struct SegmentedRequestState {
     receiver: SegmentReceiver,
     first_req: bacnet_encoding::apdu::ConfirmedRequest,
     last_activity: Instant,
+    /// Last successfully saved new in-order segment, independent of SegmentTimer.
+    last_progress: Instant,
     expected_seq: u8,
     /// Last sequence number in the previously completed receive window.
     initial_sequence_number: u8,

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -420,5 +420,7 @@ mod ack_window;
 mod control_limits;
 mod duplicate_window;
 mod get_event_information;
+mod request_progress;
+mod request_progress_expiry;
 mod request_reassembly;
 mod routing_overlap;

--- a/crates/bacnet-server/src/server/segmentation_tests/request_progress.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/request_progress.rs
@@ -1,0 +1,175 @@
+//! Private defensive no-progress cleanup (#527), not a SegmentTimer transition.
+
+use super::*;
+use request_reassembly::{
+    expect_positive_ack, present_value, recv_apdu, send_segment_with_window, split_into,
+    start_reassembly_server, write_property_payload,
+};
+use tokio::time::{sleep_until, timeout, Instant as TokioInstant};
+
+#[tokio::test]
+async fn request_progress_reclaims_128_stalled_slots_before_admission() {
+    timeout(Duration::from_secs(25), async {
+        let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+        let discarded = split_into(&write_property_payload("must-not-be-written"), 2);
+        let initial_value = present_value(&server).await;
+        for invoke_id in 0..128 {
+            send_segment_with_window(&client, invoke_id, 0, 1, true, &discarded[0]).await;
+            expect_positive_ack(&mut rx, invoke_id, 0).await;
+        }
+        let started = TokioInstant::now();
+        let admitted = split_into(&write_property_payload("admitted-after-cleanup"), 2);
+        send_segment_with_window(&client, 128, 0, 1, true, &admitted[0]).await;
+        match recv_apdu(&mut rx, "all 128 slots occupied").await {
+            Apdu::Abort(abort) => {
+                assert!(abort.sent_by_server);
+                assert_eq!(abort.invoke_id, 128);
+                assert_eq!(abort.abort_reason, AbortReason::BUFFER_OVERFLOW);
+            }
+            other => panic!("expected capacity Abort, got {other:?}"),
+        }
+
+        // Alternate retransmission and gap traffic every second. The window-one
+        // baseline produces a NAK for each, providing a dispatch barrier and
+        // proving that every original session remains live without new saves.
+        for second in 1..=15 {
+            sleep_until(started + Duration::from_secs(second)).await;
+            for invoke_id in 0..128 {
+                let seq = if second % 2 == 0 { 0 } else { 2 };
+                send_segment_with_window(&client, invoke_id, seq, 1, true, &[0xEE]).await;
+                match recv_apdu(&mut rx, "stalled session activity").await {
+                    Apdu::SegmentAck(ack) => {
+                        assert!(ack.negative_ack && ack.sent_by_server);
+                        assert_eq!(ack.invoke_id, invoke_id);
+                        assert_eq!(ack.sequence_number, 0);
+                    }
+                    other => panic!("session expired during activity setup: {other:?}"),
+                }
+            }
+        }
+        assert!(
+            started.elapsed() < Duration::from_secs(16),
+            "setup too slow"
+        );
+        sleep_until(started + Duration::from_secs(17)).await;
+
+        // Protocol activity is only two seconds old. Under the old activity-only
+        // policy all 128 slots are still occupied and this gets BUFFER_OVERFLOW.
+        // No manually pruned map or test clock participates in this dispatch.
+        send_segment_with_window(&client, 128, 0, 1, true, &admitted[0]).await;
+        expect_positive_ack(&mut rx, 128, 0).await;
+        assert_eq!(present_value(&server).await, initial_value);
+
+        // Cleanup itself emits nothing. A current noninitial segment still gets
+        // the existing invalid-state Abort, rather than resurrecting old data.
+        send_segment_with_window(&client, 0, 1, 1, false, &discarded[1]).await;
+        match recv_apdu(&mut rx, "noninitial after cleanup").await {
+            Apdu::Abort(abort) => {
+                assert!(abort.sent_by_server);
+                assert_eq!(abort.invoke_id, 0);
+                assert_eq!(abort.abort_reason, AbortReason::INVALID_APDU_IN_THIS_STATE);
+            }
+            other => panic!("expected invalid-state Abort, got {other:?}"),
+        }
+        assert_eq!(present_value(&server).await, initial_value);
+
+        send_segment_with_window(&client, 128, 1, 1, false, &admitted[1]).await;
+        expect_positive_ack(&mut rx, 128, 1).await;
+        assert!(matches!(recv_apdu(&mut rx, "admitted write").await,
+            Apdu::SimpleAck(ack) if ack.invoke_id == 128));
+        assert_eq!(present_value(&server).await, "admitted-after-cleanup");
+
+        // Same-key sequence zero can open a new incarnation: no tombstone or
+        // fairness claim. Only its new payload may reach the service.
+        let reopened = split_into(&write_property_payload("new-incarnation"), 2);
+        send_segment_with_window(&client, 0, 0, 1, true, &reopened[0]).await;
+        expect_positive_ack(&mut rx, 0, 0).await;
+        send_segment_with_window(&client, 0, 1, 1, false, &reopened[1]).await;
+        expect_positive_ack(&mut rx, 0, 1).await;
+        assert!(matches!(recv_apdu(&mut rx, "reopened write").await,
+            Apdu::SimpleAck(ack) if ack.invoke_id == 0));
+        assert_eq!(present_value(&server).await, "new-incarnation");
+        assert!(timeout(Duration::from_millis(100), rx.recv())
+            .await
+            .is_err());
+    })
+    .await
+    .expect("bounded hostile repetition test exceeded 25 seconds");
+}
+
+#[tokio::test]
+async fn request_progress_new_in_order_saves_sustain_transfer_beyond_16_seconds() {
+    timeout(Duration::from_secs(25), async {
+        let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+        let text = "progress-is-not-total-age";
+        let chunks = split_into(&write_property_payload(text), 3);
+        send_segment_with_window(&client, 42, 0, 1, true, &chunks[0]).await;
+        expect_positive_ack(&mut rx, 42, 0).await;
+        let started = TokioInstant::now();
+        let mut last_seq = 0;
+        for second in 1..=18 {
+            sleep_until(started + Duration::from_secs(second)).await;
+            if second == 9 || second == 18 {
+                last_seq += 1;
+                send_segment_with_window(
+                    &client,
+                    42,
+                    last_seq,
+                    1,
+                    second != 18,
+                    &chunks[last_seq as usize],
+                )
+                .await;
+                expect_positive_ack(&mut rx, 42, last_seq).await;
+            } else {
+                // Retransmissions preserve protocol activity but cannot replace
+                // the saved bytes or be the reason the progress budget resets.
+                send_segment_with_window(&client, 42, last_seq, 1, true, &[0xEE]).await;
+                assert!(matches!(recv_apdu(&mut rx, "retransmission NAK").await,
+                    Apdu::SegmentAck(ack) if ack.negative_ack && ack.sent_by_server
+                        && ack.invoke_id == 42 && ack.sequence_number == last_seq));
+            }
+        }
+        assert!(started.elapsed() >= Duration::from_secs(18));
+        assert!(
+            matches!(recv_apdu(&mut rx, "progressing write completes").await,
+            Apdu::SimpleAck(ack) if ack.invoke_id == 42)
+        );
+        assert_eq!(present_value(&server).await, text);
+    })
+    .await
+    .expect("bounded progressing transfer exceeded 25 seconds");
+}
+
+#[tokio::test]
+async fn request_progress_failed_initial_or_next_save_leaves_no_incarnation() {
+    let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+    let initial_value = present_value(&server).await;
+    let chunks = split_into(&write_property_payload("only-successful-saves"), 2);
+    for failed_seq in [0, 1] {
+        if failed_seq == 1 {
+            send_segment_with_window(&client, 43, 0, 1, true, &chunks[0]).await;
+            expect_positive_ack(&mut rx, 43, 0).await;
+        }
+        send_segment_with_window(&client, 43, failed_seq, 1, true, &[0; 1477]).await;
+        assert!(matches!(recv_apdu(&mut rx, "unsaveable segment").await,
+            Apdu::Abort(abort) if abort.sent_by_server && abort.invoke_id == 43
+                && abort.abort_reason == AbortReason::BUFFER_OVERFLOW));
+        send_segment_with_window(&client, 43, 1, 1, false, &chunks[1]).await;
+        assert!(
+            matches!(recv_apdu(&mut rx, "failed save cannot sustain state").await,
+            Apdu::Abort(abort) if abort.sent_by_server && abort.invoke_id == 43
+                && abort.abort_reason == AbortReason::INVALID_APDU_IN_THIS_STATE)
+        );
+        assert_eq!(present_value(&server).await, initial_value);
+    }
+    send_segment_with_window(&client, 43, 0, 1, true, &chunks[0]).await;
+    expect_positive_ack(&mut rx, 43, 0).await;
+    send_segment_with_window(&client, 43, 1, 1, false, &chunks[1]).await;
+    expect_positive_ack(&mut rx, 43, 1).await;
+    assert!(
+        matches!(recv_apdu(&mut rx, "new successful incarnation").await,
+        Apdu::SimpleAck(ack) if ack.invoke_id == 43)
+    );
+    assert_eq!(present_value(&server).await, "only-successful-saves");
+}

--- a/crates/bacnet-server/src/server/segmentation_tests/request_progress_expiry.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/request_progress_expiry.rs
@@ -1,0 +1,152 @@
+//! Explicit-time tests of the production expiry boundary, without a test clock.
+
+use super::*;
+use crate::server::segmented_receive::expire_segmented_requests;
+use std::sync::atomic::AtomicUsize;
+
+struct RetainedPayload {
+    data: [u8; 8],
+    drops: Arc<AtomicUsize>,
+}
+
+impl AsRef<[u8]> for RetainedPayload {
+    fn as_ref(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+impl Drop for RetainedPayload {
+    fn drop(&mut self) {
+        self.drops.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn saved_state(last_progress: Instant, last_activity: Instant) -> SegmentedRequestState {
+    let first_req = ConfirmedRequestPdu {
+        segmented: true,
+        more_follows: true,
+        segmented_response_accepted: true,
+        max_segments: None,
+        max_apdu_length: 1476,
+        invoke_id: 0,
+        sequence_number: Some(0),
+        proposed_window_size: Some(3),
+        service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        service_request: Bytes::from_static(b"first"),
+    };
+    let mut receiver = SegmentReceiver::new();
+    receiver
+        .receive(0, first_req.service_request.clone())
+        .unwrap();
+    SegmentedRequestState {
+        receiver,
+        first_req,
+        last_activity,
+        last_progress,
+        expected_seq: 1,
+        initial_sequence_number: 0,
+        duplicate_count: 0,
+        last_acked_seq: 0,
+        window_pos: 1,
+        actual_window_size: 3,
+        accepted_segments: 1,
+    }
+}
+
+#[test]
+fn request_progress_expiry_before_exact_and_after_16_seconds() {
+    let start = Instant::now();
+    let key = (test_mac(1), None, 0);
+    for (elapsed, survives) in [
+        (Duration::from_nanos(15_999_999_999), true),
+        (Duration::from_secs(16), false),
+        (Duration::from_nanos(16_000_000_001), false),
+    ] {
+        let now = start + elapsed;
+        // Activity is fresh even at the exact progress expiry boundary.
+        let mut receivers = HashMap::from([(key.clone(), saved_state(start, now))]);
+        expire_segmented_requests(&mut receivers, now);
+        assert_eq!(
+            receivers.contains_key(&key),
+            survives,
+            "elapsed {elapsed:?}"
+        );
+    }
+}
+
+#[test]
+fn request_progress_expiry_preserves_exact_4_second_inactivity_boundary() {
+    let now = Instant::now();
+    let key = (test_mac(1), None, 0);
+    for (idle, survives) in [
+        (Duration::from_nanos(3_999_999_999), true),
+        (Duration::from_secs(4), false),
+        (Duration::from_nanos(4_000_000_001), false),
+    ] {
+        let mut receivers = HashMap::from([(key.clone(), saved_state(now, now - idle))]);
+        expire_segmented_requests(&mut receivers, now);
+        assert_eq!(receivers.contains_key(&key), survives, "idle {idle:?}");
+    }
+}
+
+#[test]
+fn request_progress_expiry_keeps_mixed_fresh_survivors_and_releases_all_payload_owners() {
+    let now = Instant::now();
+    let drops = Arc::new(AtomicUsize::new(0));
+    let mut stale = saved_state(now - Duration::from_secs(16), now);
+    // Two owners: the initial payload shared by first_req and the receiver,
+    // and a later segment owned only by the receiver. Both must drop now.
+    stale.first_req.service_request = Bytes::from_owner(RetainedPayload {
+        data: [1; 8],
+        drops: Arc::clone(&drops),
+    });
+    stale
+        .receiver
+        .receive(0, stale.first_req.service_request.clone())
+        .unwrap();
+    stale
+        .receiver
+        .receive(
+            1,
+            Bytes::from_owner(RetainedPayload {
+                data: [2; 8],
+                drops: Arc::clone(&drops),
+            }),
+        )
+        .unwrap();
+    let stale_key = (test_mac(1), None, 0);
+    let fresh_key = (test_mac(2), None, 0);
+    let idle_key = (test_mac(3), None, 0);
+    let mut receivers = HashMap::from([
+        (stale_key.clone(), stale),
+        (
+            fresh_key.clone(),
+            saved_state(now - Duration::from_secs(15), now),
+        ),
+        (
+            idle_key.clone(),
+            saved_state(now, now - Duration::from_secs(4)),
+        ),
+    ]);
+    assert_eq!(drops.load(Ordering::SeqCst), 0);
+    expire_segmented_requests(&mut receivers, now);
+    assert!(!receivers.contains_key(&stale_key));
+    assert!(!receivers.contains_key(&idle_key));
+    assert_eq!(receivers.len(), 1);
+    assert_eq!(
+        receivers[&fresh_key].receiver.reassemble(1).unwrap(),
+        b"first"
+    );
+    assert_eq!(
+        drops.load(Ordering::SeqCst),
+        2,
+        "cleanup must drop ownership synchronously"
+    );
+    expire_segmented_requests(&mut receivers, now);
+    assert_eq!(receivers.len(), 1);
+    assert_eq!(
+        drops.load(Ordering::SeqCst),
+        2,
+        "repeated cleanup is harmless"
+    );
+}

--- a/crates/bacnet-server/src/server/segmented_receive.rs
+++ b/crates/bacnet-server/src/server/segmented_receive.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+/// Private defensive limit, not a normative SegmentTimer or total-request age.
+const SEG_RECEIVER_PROGRESS_TIMEOUT: Duration = Duration::from_secs(16);
+
+/// Drop stale incarnations and all their retained payload ownership before input.
+/// Cleanup is silent and synchronous; idle or blocked dispatch is not reclaimed.
+pub(super) fn expire_segmented_requests(
+    receivers: &mut HashMap<SegKey, SegmentedRequestState>,
+    now: Instant,
+) {
+    receivers.retain(|_key, state| {
+        now.duration_since(state.last_activity) < SEG_RECEIVER_TIMEOUT
+            && now.duration_since(state.last_progress) < SEG_RECEIVER_PROGRESS_TIMEOUT
+    });
+}
+
 pub(super) fn reassembled_confirmed_request(
     first: &ConfirmedRequestPdu,
     service_request: Bytes,


### PR DESCRIPTION
## Summary
- Add a private 16-second no-forward-progress budget for server segmented-request reassembly, independent of the unchanged activity/SegmentTimer handling.
- Reset progress only after a new in-order segment is successfully saved; silently drop stale state and all retained payload ownership before the next dispatch-dequeued APDU is decoded or admitted.
- Add six tests covering full 128-slot exhaustion and 129th admission, progressing transfers beyond 16 seconds, failed saves, exact expiry boundaries, and synchronous payload release.

Refs #527 — intentionally Partial, not closing the issue. PR #538 is separate and remains unmerged.

## Contract and limits
The owner approved this bounded defensive policy. It is not a standards-defined timeout or a conformance claim. Duplicate/gap activity refreshes, ACK/NAK behavior, current sequence-zero reopening, 256/257 segment bounds, and existing abort routing remain unchanged. Cleanup emits no new Abort traffic.

Slowly retrying transfers may be discarded. Reclamation occurs only before the next input is processed, not while dispatch is idle or blocked. Per-peer quotas, aggregate byte accounting, cumulative duplicate-event budgets, public counters/configuration, total-transaction-age limits, scheduled cleanup and reopening suppression remain follow-ups. No public API, dependency, CI, or support-claim changes.

## Source traceability
Local Standard 135-2020, section 5.4.5.2 (printed pp. 46–48 / PDF pp. 48–50): preserve new/duplicate/out-of-order SegmentTimer handling and existing segmented-request processing. Section 18.10 (printed pp. 800–801 / PDF pp. 802–803) distinguishes Abort reasons; no new reason is introduced. The separate 16-second policy comes from the explicit owner decision, not a normative mandate. Licensed text is not reproduced.

## Validation
- Test-first production-dispatch regression: before the fix, request 129 received BUFFER_OVERFLOW after 17 seconds of stalled-session activity; identical test passes after the fix.
- Six progress tests, 46 segmentation tests, and bacnet-server 806 unit + 3 integration tests passed.
- Workspace tests: 3,968 passed; 2 doc tests ignored; zero failures.
- Passed: formatting, repository-policy workspace Clippy, rusty-bacnet test compilation, conformance-doc generation check, 700-LOC gate, no-secret scan, and diff whitespace check.
- Hosted exact-head CI run 33942692898 and all five required jobs passed. Holistic/dataflow reviews and independent final assessment followed by same-task reconciliation passed at 0009b2f04b2fa0f84bffaf7589264fa3230856ea; zero findings or repairs. Heavy/release jobs were skipped, not claimed green.
