### PR TITLE
fix(server): bound segmented requests per peer

### DIFF
--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -280,16 +280,19 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                         continue;
                                     }
 
-                                    // This path runs only when no session
-                                    // exists for the key, so the map length
-                                    // is the whole capacity check.
-                                    if seg_receivers.len() >= MAX_SEG_RECEIVERS {
+                                    // New sessions only; global capacity precedes peer quota.
+                                    if let Some(reason) =
+                                        super::segmented_receive::segmented_request_admission_error(
+                                            &seg_receivers,
+                                            &key,
+                                        )
+                                    {
                                         Self::send_server_abort(
                                             &network_dispatch,
                                             &source_mac,
                                             source_network.as_ref(),
                                             req.invoke_id,
-                                            AbortReason::BUFFER_OVERFLOW,
+                                            reason,
                                         )
                                         .await;
                                         continue;

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -420,6 +420,8 @@ mod ack_window;
 mod control_limits;
 mod duplicate_window;
 mod get_event_information;
+mod request_peer_quota;
+mod request_peer_quota_state;
 mod request_progress;
 mod request_progress_expiry;
 mod request_reassembly;

--- a/crates/bacnet-server/src/server/segmentation_tests/request_peer_quota.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/request_peer_quota.rs
@@ -1,0 +1,343 @@
+//! Owner-policy partition: 16 active incoming requests per existing SegKey peer.
+
+use super::*;
+use request_reassembly::{
+    expect_positive_ack, inject_routed_segment, present_value, recv_apdu, send_apdu,
+    send_segment_with_window, sent_routed_frame, split_into, start_reassembly_server,
+    start_routed_reassembly_server, write_property_payload,
+};
+
+/// Consume a real wire reply, checking both routed and immediate destinations.
+pub(super) async fn next_routed_apdu(
+    sent: &SentFrames,
+    index: &mut usize,
+    router: &MacAddr,
+    remote: &NpduAddress,
+) -> Apdu {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while sent_count(sent) <= *index {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("timed out waiting for routed reply");
+    let (npdu, link_destination) = sent_routed_frame(sent, *index);
+    *index += 1;
+    assert_eq!(&link_destination, router);
+    assert_eq!(npdu.destination.as_ref(), Some(remote));
+    decode_apdu(npdu.payload).unwrap()
+}
+
+pub(super) fn assert_positive_ack(reply: Apdu, invoke_id: u8, seq: u8) {
+    match reply {
+        Apdu::SegmentAck(ack) => {
+            assert!(ack.sent_by_server && !ack.negative_ack);
+            assert_eq!(ack.invoke_id, invoke_id);
+            assert_eq!(ack.sequence_number, seq);
+            assert_eq!(ack.actual_window_size, 1);
+        }
+        other => panic!("expected positive SegmentAck, got {other:?}"),
+    }
+}
+
+pub(super) fn assert_server_abort(reply: Apdu, invoke_id: u8, reason: AbortReason) {
+    match reply {
+        Apdu::Abort(abort) => {
+            assert!(abort.sent_by_server);
+            assert_eq!(abort.invoke_id, invoke_id);
+            assert_eq!(abort.abort_reason, reason);
+        }
+        other => panic!("expected server Abort {reason:?}, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn request_peer_quota_sixteen_admitted_seventeenth_refused_other_peer_admitted() {
+    let (server, incoming, sent) = start_routed_reassembly_server().await;
+    let router_a = test_mac(30);
+    let router_b = test_mac(31);
+    let remote = routed_address(400, 0x40);
+    let other_peer = routed_address(400, 0x41);
+    let mut index = 0;
+    for invoke_id in 0..16 {
+        let router = if invoke_id % 2 == 0 {
+            &router_a
+        } else {
+            &router_b
+        };
+        inject_routed_segment(&incoming, router, &remote, invoke_id, 0, true, &[1]).await;
+        assert_positive_ack(
+            next_routed_apdu(&sent, &mut index, router, &remote).await,
+            invoke_id,
+            0,
+        );
+    }
+    for invoke_id in 16..24 {
+        let router = if invoke_id % 2 == 0 {
+            &router_b
+        } else {
+            &router_a
+        };
+        inject_routed_segment(&incoming, router, &remote, invoke_id, 0, true, &[2]).await;
+        assert_server_abort(
+            next_routed_apdu(&sent, &mut index, router, &remote).await,
+            invoke_id,
+            AbortReason::OUT_OF_RESOURCES,
+        );
+    }
+    inject_routed_segment(&incoming, &router_b, &other_peer, 16, 0, true, &[3]).await;
+    assert_positive_ack(
+        next_routed_apdu(&sent, &mut index, &router_b, &other_peer).await,
+        16,
+        0,
+    );
+    assert_eq!(present_value(&server).await, "");
+    assert_eq!(
+        sent_count(&sent),
+        index,
+        "no service response to partial requests"
+    );
+}
+
+#[tokio::test]
+async fn request_peer_quota_denial_is_stateless_and_active_transfers_complete() {
+    let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+    let text = "all-sixteen-survive-denial-and-duplicates";
+    let chunks = split_into(&write_property_payload(text), 3);
+    for invoke_id in 0..16 {
+        send_segment_with_window(&client, invoke_id, 0, 1, true, &chunks[0]).await;
+        expect_positive_ack(&mut rx, invoke_id, 0).await;
+    }
+    for invoke_id in 16..32 {
+        // Even a complete service payload in a final initial segment cannot
+        // evade admission, insert a receiver, or produce a service effect.
+        send_segment_with_window(
+            &client,
+            invoke_id,
+            0,
+            1,
+            false,
+            &write_property_payload("denied-write"),
+        )
+        .await;
+        assert_server_abort(
+            recv_apdu(&mut rx, "quota denial").await,
+            invoke_id,
+            AbortReason::OUT_OF_RESOURCES,
+        );
+        send_segment_with_window(&client, invoke_id, 1, 1, false, &chunks[2]).await;
+        assert_server_abort(
+            recv_apdu(&mut rx, "denied invoke has no state").await,
+            invoke_id,
+            AbortReason::INVALID_APDU_IN_THIS_STATE,
+        );
+    }
+    assert_eq!(present_value(&server).await, "");
+    for invoke_id in 0..16 {
+        send_segment_with_window(&client, invoke_id, 1, 1, true, &chunks[1]).await;
+        expect_positive_ack(&mut rx, invoke_id, 1).await;
+        send_segment_with_window(&client, invoke_id, 0, 1, true, &[0xEE]).await;
+        assert!(
+            matches!(recv_apdu(&mut rx, "duplicate zero at quota").await,
+            Apdu::SegmentAck(ack) if ack.sent_by_server && ack.negative_ack
+                && ack.invoke_id == invoke_id && ack.sequence_number == 1)
+        );
+    }
+    for invoke_id in 0..16 {
+        send_segment_with_window(&client, invoke_id, 2, 1, false, &chunks[2]).await;
+        expect_positive_ack(&mut rx, invoke_id, 2).await;
+        assert!(
+            matches!(recv_apdu(&mut rx, "unaffected active request completes").await,
+            Apdu::SimpleAck(ack) if ack.invoke_id == invoke_id)
+        );
+        assert_eq!(present_value(&server).await, text);
+        // Every completion releases one slot; refill it before the next one.
+        send_segment_with_window(&client, 100 + invoke_id, 0, 1, true, &chunks[0]).await;
+        expect_positive_ack(&mut rx, 100 + invoke_id, 0).await;
+        send_segment_with_window(&client, 200, 0, 1, true, &chunks[0]).await;
+        assert_server_abort(
+            recv_apdu(&mut rx, "refilled quota").await,
+            200,
+            AbortReason::OUT_OF_RESOURCES,
+        );
+    }
+    assert!(tokio::time::timeout(Duration::from_millis(100), rx.recv())
+        .await
+        .is_err());
+}
+
+#[tokio::test]
+async fn request_peer_quota_wrapped_zero_uses_existing_segment_cap_and_frees_slot() {
+    let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+    for invoke_id in 1..16 {
+        send_segment_with_window(&client, invoke_id, 0, 1, true, &[1]).await;
+        expect_positive_ack(&mut rx, invoke_id, 0).await;
+    }
+    for seq in 0..=255 {
+        send_segment_with_window(&client, 0, seq, 1, true, &[2]).await;
+        expect_positive_ack(&mut rx, 0, seq).await;
+    }
+    // This zero belongs to the existing 256-segment session, not admission.
+    send_segment_with_window(&client, 0, 0, 1, true, &[3]).await;
+    assert_server_abort(
+        recv_apdu(&mut rx, "wrapped zero at full peer quota").await,
+        0,
+        AbortReason::BUFFER_OVERFLOW,
+    );
+    send_segment_with_window(&client, 0, 1, 1, false, &[3]).await;
+    assert_server_abort(
+        recv_apdu(&mut rx, "overflow removed session").await,
+        0,
+        AbortReason::INVALID_APDU_IN_THIS_STATE,
+    );
+    send_segment_with_window(&client, 16, 0, 1, true, &[4]).await;
+    expect_positive_ack(&mut rx, 16, 0).await;
+    assert_eq!(present_value(&server).await, "");
+}
+
+#[tokio::test]
+async fn request_peer_quota_abort_and_save_failure_release_only_owned_slots() {
+    let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+    for invoke_id in 0..16 {
+        send_segment_with_window(&client, invoke_id, 0, 1, true, &[1]).await;
+        expect_positive_ack(&mut rx, invoke_id, 0).await;
+    }
+    for sent_by_server in [true, false] {
+        send_apdu(
+            &client,
+            &Apdu::Abort(AbortPdu {
+                sent_by_server,
+                invoke_id: 0,
+                abort_reason: AbortReason::OTHER,
+            }),
+        )
+        .await;
+        send_segment_with_window(&client, 16, 0, 1, true, &[2]).await;
+        let reply = recv_apdu(&mut rx, "admission after directional Abort").await;
+        if sent_by_server {
+            assert_server_abort(reply, 16, AbortReason::OUT_OF_RESOURCES);
+        } else {
+            assert_positive_ack(reply, 16, 0);
+        }
+    }
+    send_segment_with_window(&client, 0, 1, 1, true, &[2]).await;
+    assert_server_abort(
+        recv_apdu(&mut rx, "peer Abort removed inbound").await,
+        0,
+        AbortReason::INVALID_APDU_IN_THIS_STATE,
+    );
+
+    send_segment_with_window(&client, 1, 1, 1, true, &[0; 1477]).await;
+    assert_server_abort(
+        recv_apdu(&mut rx, "failed next save").await,
+        1,
+        AbortReason::BUFFER_OVERFLOW,
+    );
+    send_segment_with_window(&client, 1, 2, 1, true, &[2]).await;
+    assert_server_abort(
+        recv_apdu(&mut rx, "failed next save removed inbound").await,
+        1,
+        AbortReason::INVALID_APDU_IN_THIS_STATE,
+    );
+    // Fifteen slots remain. Repeated failed first saves must not consume the last.
+    for invoke_id in 17..20 {
+        send_segment_with_window(&client, invoke_id, 0, 1, true, &[0; 1477]).await;
+        assert_server_abort(
+            recv_apdu(&mut rx, "failed initial save").await,
+            invoke_id,
+            AbortReason::BUFFER_OVERFLOW,
+        );
+        send_segment_with_window(&client, invoke_id, 1, 1, true, &[2]).await;
+        assert_server_abort(
+            recv_apdu(&mut rx, "failed first save has no state").await,
+            invoke_id,
+            AbortReason::INVALID_APDU_IN_THIS_STATE,
+        );
+    }
+    send_segment_with_window(&client, 20, 0, 1, true, &[3]).await;
+    expect_positive_ack(&mut rx, 20, 0).await;
+    send_segment_with_window(&client, 21, 0, 1, true, &[0; 1477]).await;
+    assert_server_abort(
+        recv_apdu(&mut rx, "quota before attempted first save").await,
+        21,
+        AbortReason::OUT_OF_RESOURCES,
+    );
+    assert_eq!(present_value(&server).await, "");
+    assert!(tokio::time::timeout(Duration::from_millis(100), rx.recv())
+        .await
+        .is_err());
+}
+
+async fn send_initial_with_raw_window(
+    client: &bacnet_transport::loopback::LoopbackTransport,
+    invoke_id: u8,
+    window: u8,
+) {
+    use bacnet_encoding::npdu::{encode_npdu, Npdu};
+    let mut buf = BytesMut::new();
+    encode_apdu(
+        &mut buf,
+        &Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+            segmented: true,
+            more_follows: true,
+            segmented_response_accepted: true,
+            max_segments: None,
+            max_apdu_length: 1476,
+            invoke_id,
+            sequence_number: Some(0),
+            proposed_window_size: Some(1),
+            service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+            service_request: Bytes::from(vec![0; 1477]),
+        }),
+    )
+    .unwrap();
+    // The normal encoder rejects invalid windows. Inject a malformed wire field
+    // like the existing segmentation_rx integration test, not a fake dispatch.
+    buf[4] = window;
+    let npdu = Npdu {
+        payload: buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut buf = BytesMut::new();
+    encode_npdu(&mut buf, &npdu).unwrap();
+    client.send_unicast(&buf, &[0x02]).await.unwrap();
+}
+
+#[tokio::test]
+async fn request_peer_quota_preserves_window_and_support_precedence() {
+    let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+    for invoke_id in 0..16 {
+        send_segment_with_window(&client, invoke_id, 0, 1, true, &[1]).await;
+        expect_positive_ack(&mut rx, invoke_id, 0).await;
+    }
+    for window in [0, 128, 255] {
+        send_initial_with_raw_window(&client, 16, window).await;
+        assert_server_abort(
+            recv_apdu(&mut rx, "invalid window before quota").await,
+            16,
+            AbortReason::WINDOW_SIZE_OUT_OF_RANGE,
+        );
+    }
+    send_segment_with_window(&client, 16, 0, 127, true, &[1]).await;
+    assert_server_abort(
+        recv_apdu(&mut rx, "valid window reaches quota").await,
+        16,
+        AbortReason::OUT_OF_RESOURCES,
+    );
+    assert_eq!(present_value(&server).await, "");
+
+    // Unsupported devices cannot accumulate inbound sessions: their immutable
+    // advertisement rejects even invalid-window traffic before any admission.
+    for segmentation in [Segmentation::NONE, Segmentation::TRANSMIT] {
+        let (server, client, mut rx) = start_reassembly_server(segmentation).await;
+        for invoke_id in 0..=16 {
+            send_initial_with_raw_window(&client, invoke_id, 0).await;
+            assert_server_abort(
+                recv_apdu(&mut rx, "unsupported before window and quota").await,
+                invoke_id,
+                AbortReason::SEGMENTATION_NOT_SUPPORTED,
+            );
+        }
+        assert_eq!(present_value(&server).await, "");
+    }
+}

--- a/crates/bacnet-server/src/server/segmentation_tests/request_peer_quota_state.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/request_peer_quota_state.rs
@@ -1,0 +1,185 @@
+//! Exact identity and explicit-time checks of the production admission helper.
+
+use super::*;
+use crate::server::segmented_receive::{
+    expire_segmented_requests, segmented_request_admission_error,
+};
+
+fn saved_state(invoke_id: u8, now: Instant) -> SegmentedRequestState {
+    let first_req = ConfirmedRequestPdu {
+        segmented: true,
+        more_follows: true,
+        segmented_response_accepted: true,
+        max_segments: None,
+        max_apdu_length: 1476,
+        invoke_id,
+        sequence_number: Some(0),
+        proposed_window_size: Some(1),
+        service_choice: ConfirmedServiceChoice::WRITE_PROPERTY,
+        service_request: Bytes::from_static(b"retained"),
+    };
+    let mut receiver = SegmentReceiver::new();
+    receiver
+        .receive(0, first_req.service_request.clone())
+        .unwrap();
+    SegmentedRequestState {
+        receiver,
+        first_req,
+        last_activity: now,
+        last_progress: now,
+        expected_seq: 1,
+        initial_sequence_number: 0,
+        duplicate_count: 0,
+        last_acked_seq: 0,
+        window_pos: 0,
+        actual_window_size: 1,
+        accepted_segments: 1,
+    }
+}
+
+#[test]
+fn request_peer_quota_exact_segkey_projection_identity_matrix() {
+    let a = test_mac(1);
+    let b = test_mac(2);
+    let empty = |network| {
+        Some(NpduAddress {
+            network,
+            mac_address: MacAddr::new(),
+        })
+    };
+    // Named groups are an independent oracle, including invalid fallback
+    // partitions. The bool states whether the expected key drops the router MAC.
+    let sources = vec![
+        ("direct-a", &a, None, false),
+        ("direct-b", &b, None, false),
+        ("routed", &a, Some(routed_address(400, 10)), true),
+        ("routed", &b, Some(routed_address(400, 10)), true),
+        ("other-address", &a, Some(routed_address(400, 11)), true),
+        ("other-network", &a, Some(routed_address(401, 10)), true),
+        ("min-network", &a, Some(routed_address(1, 10)), true),
+        ("min-network", &b, Some(routed_address(1, 10)), true),
+        ("max-network", &a, Some(routed_address(0xFFFE, 10)), true),
+        ("max-network", &b, Some(routed_address(0xFFFE, 10)), true),
+        ("zero-net-a", &a, Some(routed_address(0, 10)), false),
+        ("zero-net-b", &b, Some(routed_address(0, 10)), false),
+        (
+            "zero-net-other-address",
+            &a,
+            Some(routed_address(0, 11)),
+            false,
+        ),
+        ("global-net-a", &a, Some(routed_address(0xFFFF, 10)), false),
+        ("global-net-b", &b, Some(routed_address(0xFFFF, 10)), false),
+        ("empty-valid-a", &a, empty(400), false),
+        ("empty-valid-b", &b, empty(400), false),
+        ("empty-zero", &a, empty(0), false),
+        ("empty-global", &a, empty(0xFFFF), false),
+    ];
+    let now = Instant::now();
+    for (group, mac, route, drops_router) in &sources {
+        let mut receivers = HashMap::new();
+        for invoke_id in 0..16 {
+            let key = segmented_transaction_key(mac, route.as_ref(), invoke_id);
+            let expected_mac = if *drops_router {
+                MacAddr::new()
+            } else {
+                (*mac).clone()
+            };
+            assert_eq!(key, (expected_mac, route.clone(), invoke_id), "{group}");
+            assert_eq!(segmented_request_admission_error(&receivers, &key), None);
+            receivers.insert(key, saved_state(invoke_id, now));
+        }
+        for (query_group, query_mac, query_route, _) in &sources {
+            let query = segmented_transaction_key(query_mac, query_route.as_ref(), 200);
+            assert_eq!(
+                segmented_request_admission_error(&receivers, &query),
+                if group == query_group {
+                    Some(AbortReason::OUT_OF_RESOURCES)
+                } else {
+                    None
+                },
+                "filled {group}, queried {query_group}"
+            );
+        }
+    }
+}
+
+#[test]
+fn request_peer_quota_repeated_denial_never_touches_live_state() {
+    let now = Instant::now();
+    let mac = test_mac(1);
+    let mut receivers = HashMap::new();
+    for invoke_id in 0..16 {
+        receivers.insert(
+            segmented_transaction_key(&mac, None, invoke_id),
+            saved_state(invoke_id, now),
+        );
+    }
+    for invoke_id in 16..=255 {
+        let key = segmented_transaction_key(&mac, None, invoke_id);
+        assert_eq!(
+            segmented_request_admission_error(&receivers, &key),
+            Some(AbortReason::OUT_OF_RESOURCES)
+        );
+        assert!(!receivers.contains_key(&key));
+    }
+    assert_eq!(receivers.len(), 16);
+    for (key, state) in &receivers {
+        assert_eq!(state.last_activity, now);
+        assert_eq!(state.last_progress, now);
+        assert_eq!(state.first_req.invoke_id, key.2);
+        assert_eq!(state.first_req.service_request.as_ref(), b"retained");
+        assert_eq!(state.receiver.reassemble(1).unwrap(), b"retained");
+        assert_eq!(state.accepted_segments, 1);
+        assert_eq!(state.expected_seq, 1);
+        assert_eq!(state.initial_sequence_number, 0);
+        assert_eq!(state.last_acked_seq, 0);
+        assert_eq!(state.window_pos, 0);
+        assert_eq!(state.duplicate_count, 0);
+        assert_eq!(state.actual_window_size, 1);
+    }
+}
+
+#[test]
+fn request_peer_quota_expiry_releases_slot_at_idle_and_progress_boundaries() {
+    let start = Instant::now();
+    let mac = test_mac(1);
+    for (elapsed, progress_expiry) in [(4, false), (16, true)] {
+        let now = start + Duration::from_secs(elapsed);
+        let recent = now - Duration::from_secs(1);
+        let mut receivers = HashMap::new();
+        for invoke_id in 0..16 {
+            receivers.insert(
+                segmented_transaction_key(&mac, None, invoke_id),
+                saved_state(invoke_id, recent),
+            );
+        }
+        let stale_key = segmented_transaction_key(&mac, None, 0);
+        let stale = receivers.get_mut(&stale_key).unwrap();
+        if progress_expiry {
+            stale.last_progress = start;
+        } else {
+            stale.last_activity = start;
+        }
+        let query = segmented_transaction_key(&mac, None, 200);
+        expire_segmented_requests(&mut receivers, now - Duration::from_nanos(1));
+        assert_eq!(
+            segmented_request_admission_error(&receivers, &query),
+            Some(AbortReason::OUT_OF_RESOURCES)
+        );
+        expire_segmented_requests(&mut receivers, now);
+        assert!(!receivers.contains_key(&stale_key));
+        assert_eq!(receivers.len(), 15);
+        assert_eq!(segmented_request_admission_error(&receivers, &query), None);
+        expire_segmented_requests(&mut receivers, now);
+        assert_eq!(receivers.len(), 15);
+        receivers.insert(query, saved_state(200, now));
+        assert_eq!(
+            segmented_request_admission_error(
+                &receivers,
+                &segmented_transaction_key(&mac, None, 201)
+            ),
+            Some(AbortReason::OUT_OF_RESOURCES)
+        );
+    }
+}

--- a/crates/bacnet-server/src/server/segmentation_tests/request_progress.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/request_progress.rs
@@ -1,26 +1,37 @@
 //! Private defensive no-progress cleanup (#527), not a SegmentTimer transition.
 
 use super::*;
+use request_peer_quota::{assert_positive_ack, next_routed_apdu};
 use request_reassembly::{
-    expect_positive_ack, present_value, recv_apdu, send_segment_with_window, split_into,
-    start_reassembly_server, write_property_payload,
+    expect_positive_ack, inject_routed_segment, present_value, recv_apdu, send_segment_with_window,
+    split_into, start_reassembly_server, start_routed_reassembly_server, write_property_payload,
 };
 use tokio::time::{sleep_until, timeout, Instant as TokioInstant};
 
 #[tokio::test]
 async fn request_progress_reclaims_128_stalled_slots_before_admission() {
     timeout(Duration::from_secs(25), async {
-        let (server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+        let (server, incoming, sent) = start_routed_reassembly_server().await;
+        let router = test_mac(30);
+        let remote = routed_address(400, 0);
+        let mut index = 0;
         let discarded = split_into(&write_property_payload("must-not-be-written"), 2);
         let initial_value = present_value(&server).await;
         for invoke_id in 0..128 {
-            send_segment_with_window(&client, invoke_id, 0, 1, true, &discarded[0]).await;
-            expect_positive_ack(&mut rx, invoke_id, 0).await;
+            // Eight canonical peers, not one peer bypassing the private quota.
+            let peer = routed_address(400, invoke_id / 16);
+            inject_routed_segment(&incoming, &router, &peer, invoke_id, 0, true, &discarded[0])
+                .await;
+            assert_positive_ack(
+                next_routed_apdu(&sent, &mut index, &router, &peer).await,
+                invoke_id,
+                0,
+            );
         }
         let started = TokioInstant::now();
         let admitted = split_into(&write_property_payload("admitted-after-cleanup"), 2);
-        send_segment_with_window(&client, 128, 0, 1, true, &admitted[0]).await;
-        match recv_apdu(&mut rx, "all 128 slots occupied").await {
+        inject_routed_segment(&incoming, &router, &remote, 128, 0, true, &admitted[0]).await;
+        match next_routed_apdu(&sent, &mut index, &router, &remote).await {
             Apdu::Abort(abort) => {
                 assert!(abort.sent_by_server);
                 assert_eq!(abort.invoke_id, 128);
@@ -35,9 +46,11 @@ async fn request_progress_reclaims_128_stalled_slots_before_admission() {
         for second in 1..=15 {
             sleep_until(started + Duration::from_secs(second)).await;
             for invoke_id in 0..128 {
+                let peer = routed_address(400, invoke_id / 16);
                 let seq = if second % 2 == 0 { 0 } else { 2 };
-                send_segment_with_window(&client, invoke_id, seq, 1, true, &[0xEE]).await;
-                match recv_apdu(&mut rx, "stalled session activity").await {
+                inject_routed_segment(&incoming, &router, &peer, invoke_id, seq, true, &[0xEE])
+                    .await;
+                match next_routed_apdu(&sent, &mut index, &router, &peer).await {
                     Apdu::SegmentAck(ack) => {
                         assert!(ack.negative_ack && ack.sent_by_server);
                         assert_eq!(ack.invoke_id, invoke_id);
@@ -56,14 +69,18 @@ async fn request_progress_reclaims_128_stalled_slots_before_admission() {
         // Protocol activity is only two seconds old. Under the old activity-only
         // policy all 128 slots are still occupied and this gets BUFFER_OVERFLOW.
         // No manually pruned map or test clock participates in this dispatch.
-        send_segment_with_window(&client, 128, 0, 1, true, &admitted[0]).await;
-        expect_positive_ack(&mut rx, 128, 0).await;
+        inject_routed_segment(&incoming, &router, &remote, 128, 0, true, &admitted[0]).await;
+        assert_positive_ack(
+            next_routed_apdu(&sent, &mut index, &router, &remote).await,
+            128,
+            0,
+        );
         assert_eq!(present_value(&server).await, initial_value);
 
         // Cleanup itself emits nothing. A current noninitial segment still gets
         // the existing invalid-state Abort, rather than resurrecting old data.
-        send_segment_with_window(&client, 0, 1, 1, false, &discarded[1]).await;
-        match recv_apdu(&mut rx, "noninitial after cleanup").await {
+        inject_routed_segment(&incoming, &router, &remote, 0, 1, false, &discarded[1]).await;
+        match next_routed_apdu(&sent, &mut index, &router, &remote).await {
             Apdu::Abort(abort) => {
                 assert!(abort.sent_by_server);
                 assert_eq!(abort.invoke_id, 0);
@@ -73,25 +90,44 @@ async fn request_progress_reclaims_128_stalled_slots_before_admission() {
         }
         assert_eq!(present_value(&server).await, initial_value);
 
-        send_segment_with_window(&client, 128, 1, 1, false, &admitted[1]).await;
-        expect_positive_ack(&mut rx, 128, 1).await;
-        assert!(matches!(recv_apdu(&mut rx, "admitted write").await,
-            Apdu::SimpleAck(ack) if ack.invoke_id == 128));
+        inject_routed_segment(&incoming, &router, &remote, 128, 1, false, &admitted[1]).await;
+        assert_positive_ack(
+            next_routed_apdu(&sent, &mut index, &router, &remote).await,
+            128,
+            1,
+        );
+        assert!(
+            matches!(next_routed_apdu(&sent, &mut index, &router, &remote).await,
+            Apdu::SimpleAck(ack) if ack.invoke_id == 128)
+        );
         assert_eq!(present_value(&server).await, "admitted-after-cleanup");
 
         // Same-key sequence zero can open a new incarnation: no tombstone or
         // fairness claim. Only its new payload may reach the service.
         let reopened = split_into(&write_property_payload("new-incarnation"), 2);
-        send_segment_with_window(&client, 0, 0, 1, true, &reopened[0]).await;
-        expect_positive_ack(&mut rx, 0, 0).await;
-        send_segment_with_window(&client, 0, 1, 1, false, &reopened[1]).await;
-        expect_positive_ack(&mut rx, 0, 1).await;
-        assert!(matches!(recv_apdu(&mut rx, "reopened write").await,
-            Apdu::SimpleAck(ack) if ack.invoke_id == 0));
+        inject_routed_segment(&incoming, &router, &remote, 0, 0, true, &reopened[0]).await;
+        assert_positive_ack(
+            next_routed_apdu(&sent, &mut index, &router, &remote).await,
+            0,
+            0,
+        );
+        inject_routed_segment(&incoming, &router, &remote, 0, 1, false, &reopened[1]).await;
+        assert_positive_ack(
+            next_routed_apdu(&sent, &mut index, &router, &remote).await,
+            0,
+            1,
+        );
+        assert!(
+            matches!(next_routed_apdu(&sent, &mut index, &router, &remote).await,
+            Apdu::SimpleAck(ack) if ack.invoke_id == 0)
+        );
         assert_eq!(present_value(&server).await, "new-incarnation");
-        assert!(timeout(Duration::from_millis(100), rx.recv())
-            .await
-            .is_err());
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            sent_count(&sent),
+            index,
+            "no extra cleanup or service output"
+        );
     })
     .await
     .expect("bounded hostile repetition test exceeded 25 seconds");

--- a/crates/bacnet-server/src/server/segmentation_tests/request_reassembly.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/request_reassembly.rs
@@ -26,7 +26,7 @@ const SERVER_MAC: &[u8] = &[0x02];
 const CLIENT_MAC: &[u8] = &[0x01];
 const CSV_INSTANCE: u32 = 1;
 
-struct RoutedInjectionTransport {
+pub(super) struct RoutedInjectionTransport {
     incoming: Option<mpsc::Receiver<ReceivedNpdu>>,
     sent_unicast: SentFrames,
     local_mac: MacAddr,
@@ -74,7 +74,7 @@ impl TransportPort for RoutedInjectionTransport {
     }
 }
 
-async fn start_routed_reassembly_server() -> (
+pub(super) async fn start_routed_reassembly_server() -> (
     BACnetServer<RoutedInjectionTransport>,
     mpsc::Sender<ReceivedNpdu>,
     SentFrames,
@@ -121,7 +121,7 @@ async fn inject_routed_apdu(
         .unwrap();
 }
 
-async fn inject_routed_segment(
+pub(super) async fn inject_routed_segment(
     incoming: &mpsc::Sender<ReceivedNpdu>,
     router_mac: &MacAddr,
     routed_source: &NpduAddress,
@@ -150,7 +150,7 @@ async fn inject_routed_segment(
     .await;
 }
 
-fn sent_routed_frame(sent: &SentFrames, index: usize) -> (Npdu, MacAddr) {
+pub(super) fn sent_routed_frame(sent: &SentFrames, index: usize) -> (Npdu, MacAddr) {
     let (npdu, link_destination) = {
         let sent = sent.lock().unwrap();
         sent[index].clone()
@@ -233,7 +233,7 @@ pub(super) fn split_into(payload: &[u8], count: usize) -> Vec<Vec<u8>> {
     chunks
 }
 
-async fn send_apdu(transport: &LoopbackTransport, apdu: &Apdu) {
+pub(super) async fn send_apdu(transport: &LoopbackTransport, apdu: &Apdu) {
     let mut apdu_buf = BytesMut::new();
     encode_apdu(&mut apdu_buf, apdu).unwrap();
     let npdu = Npdu {
@@ -696,20 +696,41 @@ async fn transmit_only_config_aborts_segmented_requests_as_unsupported() {
 /// in the branch reorder.
 #[tokio::test]
 async fn session_count_cap_refuses_the_129th_session() {
-    let (_server, client, mut rx) = start_reassembly_server(Segmentation::BOTH).await;
+    use super::request_peer_quota::{assert_positive_ack, assert_server_abort, next_routed_apdu};
 
+    let (server, incoming, sent) = start_routed_reassembly_server().await;
+    let router = test_mac(30);
+    let mut index = 0;
+    // Eight canonical peers share one router, each occupying all sixteen slots.
     for invoke_id in 0u8..128 {
-        send_segment(&client, invoke_id, 0, true, &[invoke_id; 8]).await;
-        expect_positive_ack(&mut rx, invoke_id, 0).await;
+        let remote = routed_address(400, invoke_id / 16);
+        inject_routed_segment(
+            &incoming,
+            &router,
+            &remote,
+            invoke_id,
+            0,
+            true,
+            &[invoke_id; 8],
+        )
+        .await;
+        assert_positive_ack(
+            next_routed_apdu(&sent, &mut index, &router, &remote).await,
+            invoke_id,
+            0,
+        );
     }
-    send_segment(&client, 128, 0, true, &[0x55; 8]).await;
-    expect_abort(
-        &mut rx,
+    let remote = routed_address(400, 0);
+    inject_routed_segment(&incoming, &router, &remote, 128, 0, true, &[0x55; 8]).await;
+    // Both caps are full: the global reason must still win.
+    assert_server_abort(
+        next_routed_apdu(&sent, &mut index, &router, &remote).await,
         128,
         AbortReason::BUFFER_OVERFLOW,
-        "the 129th concurrent session",
-    )
-    .await;
+    );
+    assert_eq!(index, 129);
+    assert_eq!(sent_count(&sent), 129);
+    assert_eq!(present_value(&server).await, "");
 }
 
 /// Clause 5.4.5.3 case (a): a device that does not support transmitting

--- a/crates/bacnet-server/src/server/segmented_receive.rs
+++ b/crates/bacnet-server/src/server/segmented_receive.rs
@@ -3,6 +3,29 @@ use super::*;
 /// Private defensive limit, not a normative SegmentTimer or total-request age.
 const SEG_RECEIVER_PROGRESS_TIMEOUT: Duration = Duration::from_secs(16);
 
+/// Private resource partition, not an authenticated-peer fairness guarantee.
+const MAX_SEG_RECEIVERS_PER_PEER: usize = 16;
+
+/// Only for a new, supported sequence-zero request with a valid window.
+/// Global capacity takes precedence; the bounded key scan ignores invoke ID.
+pub(super) fn segmented_request_admission_error(
+    receivers: &HashMap<SegKey, SegmentedRequestState>,
+    key: &SegKey,
+) -> Option<AbortReason> {
+    if receivers.len() >= MAX_SEG_RECEIVERS {
+        return Some(AbortReason::BUFFER_OVERFLOW);
+    }
+    if receivers
+        .keys()
+        .filter(|existing| existing.0 == key.0 && existing.1 == key.1)
+        .count()
+        >= MAX_SEG_RECEIVERS_PER_PEER
+    {
+        return Some(AbortReason::OUT_OF_RESOURCES);
+    }
+    None
+}
+
 /// Drop stale incarnations and all their retained payload ownership before input.
 /// Cleanup is silent and synchronous; idle or blocked dispatch is not reclaimed.
 pub(super) fn expire_segmented_requests(


### PR DESCRIPTION
## Summary
- Limit new incoming segmented-request reassembly to 16 active sessions per existing canonical peer address. Refuse excess admission with server Abort OUT_OF_RESOURCES before receiver creation or state insertion.
- Preserve the global 128-session cap and its BUFFER_OVERFLOW precedence, existing-session continuation, address identity, and #539 progress cleanup.
- Add eight tests for routed/direct identity, quota denial, unaffected active transfers, release paths, expiry, and error precedence. Migrate both existing capacity regressions to eight peers × sixteen while retaining all 128 admissions and 129th rejection.

Refs #527 — remains Partial, not closing.

## Policy and limits
Owner approved private Fixed 16 and global-cap precedence, then explicitly authorized the second existing capacity-test migration after a clean pre-implementation scope stop. Same writer and unchanged policy; no review budget consumed by that stop.

Peer identity is exactly SegKey fields 0 and 1, ignoring invoke ID. Valid routed peers share quota across alternate routers; different routed peers behind one router remain separate. Existing malformed-route fallback remains unchanged. Legitimate concurrency above 16 can be refused; this is not authenticated fairness or anti-spoofing.

No public configuration, counters, aggregate-byte accounting, cumulative packet-work budget, task, lock, dependency, CI, support or conformance claim changes. PR #538 stays parked.

## Source traceability
Local Standard 135-2020 section 5.4.5.1 (printed 45–46 / PDF 47–48) supports preserved initial-request and support/window handling. Section 18.10 (printed 800–801 / PDF 802–803) distinguishes buffer capacity from inability to start processing due to internal resources. OUT_OF_RESOURCES is the semantic fit for the chosen resource partition; the fixed quota and precedence are owner policy, not a standards mandate. Licensed text is not reproduced.

## Validation
- Test-first wire regression: baseline admitted request 17; identical test passes after the fix, including alternate-router grouping and another peer admitted.
- Eight quota tests, 54 segmentation tests, and package tests (814 unit + 3 integration) passed.
- Workspace: 3,976 tests passed; 2 doc tests ignored.
- Formatting, repository-policy Clippy, rusty-bacnet test compilation, conformance-doc check, file-size, no-secret and diff checks passed.
- Hosted exact-head CI 33946372607 and all five required jobs passed. Holistic/dataflow reviews, independent final ASSESSED and same-task reconciliation passed at 6590231f53fa5f4e0f2b3a2c3c9527eec6049abd with zero findings or review repairs. Heavy/release jobs skipped, not claimed green.
