### PR TITLE
fix(mstp): correct Linux RS485 delays and verify readback

### DIFF
--- a/crates/bacnet-transport/src/mstp_serial.rs
+++ b/crates/bacnet-transport/src/mstp_serial.rs
@@ -24,6 +24,9 @@ use bacnet_types::error::Error;
 
 use crate::mstp::SerialPort;
 
+#[cfg(any(target_os = "linux", test))]
+mod kernel_rs485;
+
 /// Configuration for a serial port connection.
 pub struct SerialConfig {
     /// Serial port device name (e.g., "/dev/ttyUSB0" on Linux, "/dev/cu.usbserial-xxx" on macOS).
@@ -76,6 +79,15 @@ impl TokioSerialPort {
     ///   before transmitting. Covers transceiver enable time.
     /// - `delay_after_send_us`: Microseconds to wait after the last byte
     ///   before deasserting RTS. Covers last-byte drain time.
+    ///
+    /// Delays must be multiples of 1000 microseconds (zero is valid), because
+    /// Linux represents them in whole milliseconds. Other values are rejected
+    /// before any ioctl; delays are never rounded.
+    ///
+    /// After setting the configuration, `TIOCGRS485` must confirm RS-485 is
+    /// enabled with the requested RTS polarity and delays. A readback failure
+    /// or driver-sanitized mismatch returns an error even though the hardware
+    /// configuration may already have changed. No rollback or retry is attempted.
     #[cfg(target_os = "linux")]
     #[allow(unsafe_code)]
     pub fn enable_kernel_rs485(
@@ -86,41 +98,40 @@ impl TokioSerialPort {
     ) -> Result<(), Error> {
         use std::os::unix::io::AsRawFd;
 
+        #[cfg(not(any(target_arch = "sparc", target_arch = "sparc64")))]
+        use libc::{TIOCGRS485, TIOCSRS485};
+        // libc 0.2.189 does not export these on SPARC. Linux v6.12 UAPI:
+        // arch/sparc/include/uapi/asm/{ioctls,ioctl}.h encodes a 32-byte
+        // serial_rs485 with _IOR('T', 0x41, ...) and _IOWR('T', 0x42, ...).
+        #[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
+        const TIOCGRS485: libc::c_ulong = 0x4020_5441;
+        #[cfg(any(target_arch = "sparc", target_arch = "sparc64"))]
+        const TIOCSRS485: libc::c_ulong = 0xc020_5442;
+
         let stream = self.inner.try_lock().map_err(|_| {
             Error::Encoding("Cannot enable RS-485: serial port is in use".to_string())
         })?;
 
-        // struct serial_rs485 { u32 flags, u32 delay_rts_before_send, u32 delay_rts_after_send, u32[5] padding }
-        const SER_RS485_ENABLED: u32 = 1;
-        const SER_RS485_RTS_ON_SEND: u32 = 1 << 1;
-        const SER_RS485_RTS_AFTER_SEND: u32 = 1 << 2;
-
-        let mut flags = SER_RS485_ENABLED;
-        if invert_rts {
-            flags |= SER_RS485_RTS_AFTER_SEND;
-        } else {
-            flags |= SER_RS485_RTS_ON_SEND;
-        }
-
-        let mut buf = [0u32; 8];
-        buf[0] = flags;
-        buf[1] = delay_before_send_us;
-        buf[2] = delay_after_send_us;
-
-        // TIOCSRS485 = 0x542F
-        // SAFETY: `stream` is a live `TokioSerial` instance whose fd is open for the duration
-        // of the lock guard; `buf` is a `[u32; 8]` stack array sized to match the kernel's
-        // `serial_rs485` struct (8 * u32 = 32 bytes); pointer is valid for the call.
-        let ret = unsafe { libc::ioctl(stream.as_raw_fd(), 0x542F, buf.as_mut_ptr()) };
-        if ret < 0 {
-            return Err(Error::Encoding(format!(
-                "TIOCSRS485 ioctl failed: {}",
-                std::io::Error::last_os_error()
-            )));
-        }
-
-        tracing::info!("Kernel RS-485 mode enabled (invert_rts={invert_rts})");
-        Ok(())
+        kernel_rs485::configure(
+            invert_rts,
+            delay_before_send_us,
+            delay_after_send_us,
+            |request, config| {
+                let request = match request {
+                    kernel_rs485::Request::Set => TIOCSRS485,
+                    kernel_rs485::Request::Get => TIOCGRS485,
+                };
+                // SAFETY: The lock guard keeps the serial stream and its fd alive.
+                // `config` is a writable, initialized 32-byte Linux serial_rs485
+                // structure, and the pointer remains valid for this ioctl call.
+                let ret = unsafe { libc::ioctl(stream.as_raw_fd(), request, config as *mut _) };
+                if ret < 0 {
+                    Err(std::io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
+            },
+        )
     }
 }
 

--- a/crates/bacnet-transport/src/mstp_serial/kernel_rs485.rs
+++ b/crates/bacnet-transport/src/mstp_serial/kernel_rs485.rs
@@ -1,0 +1,276 @@
+use bacnet_types::error::Error;
+
+const SER_RS485_ENABLED: u32 = 1;
+const SER_RS485_RTS_ON_SEND: u32 = 1 << 1;
+const SER_RS485_RTS_AFTER_SEND: u32 = 1 << 2;
+
+// Linux UAPI serial_rs485; addressing features are unused and left zeroed.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct SerialRs485 {
+    flags: u32,
+    delay_rts_before_send: u32,
+    delay_rts_after_send: u32,
+    padding: [u32; 5],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Request {
+    Set,
+    Get,
+}
+
+pub(super) fn configure(
+    invert_rts: bool,
+    delay_before_send_us: u32,
+    delay_after_send_us: u32,
+    mut ioctl: impl FnMut(Request, &mut SerialRs485) -> std::io::Result<()>,
+) -> Result<(), Error> {
+    if !delay_before_send_us.is_multiple_of(1_000) || !delay_after_send_us.is_multiple_of(1_000) {
+        return Err(Error::Encoding(format!(
+            "Kernel RS-485 delays must be multiples of 1000 microseconds: \
+             delay_before_send_us={delay_before_send_us}, delay_after_send_us={delay_after_send_us}"
+        )));
+    }
+
+    let requested = SerialRs485 {
+        flags: SER_RS485_ENABLED
+            | if invert_rts {
+                SER_RS485_RTS_AFTER_SEND
+            } else {
+                SER_RS485_RTS_ON_SEND
+            },
+        delay_rts_before_send: delay_before_send_us / 1_000,
+        delay_rts_after_send: delay_after_send_us / 1_000,
+        ..SerialRs485::default()
+    };
+    // The set ioctl may replace the input with sanitized settings. Keep the
+    // original request separately so that sanitization cannot hide a mismatch.
+    let mut config = requested;
+    ioctl(Request::Set, &mut config)
+        .map_err(|e| Error::Encoding(format!("TIOCSRS485 ioctl failed: {e}")))?;
+    let mut effective = SerialRs485::default();
+    ioctl(Request::Get, &mut effective).map_err(|e| {
+        Error::Encoding(format!(
+            "TIOCGRS485 ioctl failed after setting RS-485: {e}; \
+             hardware configuration may have changed; no rollback was attempted"
+        ))
+    })?;
+    let required_flags = SER_RS485_ENABLED | SER_RS485_RTS_ON_SEND | SER_RS485_RTS_AFTER_SEND;
+    if effective.flags & required_flags != requested.flags
+        || effective.delay_rts_before_send != requested.delay_rts_before_send
+        || effective.delay_rts_after_send != requested.delay_rts_after_send
+    {
+        return Err(Error::Encoding(format!(
+            "RS-485 readback mismatch: effective flags={:#010x}, \
+             delay_before_send_ms={}, delay_after_send_ms={}; \
+             hardware configuration may have changed; no rollback was attempted",
+            effective.flags, effective.delay_rts_before_send, effective.delay_rts_after_send
+        )));
+    }
+    tracing::info!(
+        flags = effective.flags,
+        delay_before_send_ms = effective.delay_rts_before_send,
+        delay_after_send_ms = effective.delay_rts_after_send,
+        "Kernel RS-485 mode enabled"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_fractional_milliseconds_before_any_ioctl() {
+        for (before_us, after_us) in [
+            (1, 0),
+            (999, 0),
+            (1_001, 0),
+            (0, 1),
+            (0, 999),
+            (0, 1_001),
+            (u32::MAX, 0),
+            (0, u32::MAX),
+        ] {
+            let error = configure(false, before_us, after_us, |_, _| {
+                panic!("invalid delays must not reach the ioctl boundary")
+            })
+            .unwrap_err();
+            assert!(error.to_string().contains("multiples of 1000 microseconds"));
+        }
+    }
+
+    #[test]
+    fn requests_kernel_delays_in_milliseconds() {
+        let mut accepted = SerialRs485::default();
+        configure(false, 1_000, 2_000, |request, config| {
+            match request {
+                Request::Set => {
+                    assert_eq!(config.flags, 0b011);
+                    assert_eq!(config.delay_rts_before_send, 1);
+                    assert_eq!(config.delay_rts_after_send, 2);
+                    assert_eq!(config.padding, [0; 5]);
+                    accepted = *config;
+                }
+                Request::Get => *config = accepted,
+            }
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn reads_effective_settings_after_setting_them() {
+        let mut requests = Vec::new();
+        let mut accepted = SerialRs485::default();
+        configure(true, 0, 0, |request, config| {
+            requests.push(request);
+            match request {
+                Request::Set => {
+                    assert_eq!(config.flags, 0b101);
+                    assert_eq!(config.delay_rts_before_send, 0);
+                    assert_eq!(config.delay_rts_after_send, 0);
+                    accepted = *config;
+                }
+                Request::Get => {
+                    assert_eq!(*config, SerialRs485::default());
+                    *config = accepted;
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(requests, [Request::Set, Request::Get]);
+    }
+
+    #[test]
+    fn rejects_sanitized_flags_or_delays_without_retry_or_rollback() {
+        for (invert_rts, flags, before_ms, after_ms) in [
+            (false, 0b010, 1, 2), // RS-485 disabled
+            (false, 0b001, 1, 2), // RTS on send cleared
+            (false, 0b111, 1, 2), // RTS after send set
+            (true, 0b100, 1, 2),  // RS-485 disabled
+            (true, 0b111, 1, 2),  // RTS on send set
+            (true, 0b001, 1, 2),  // RTS after send cleared
+            (false, 0b011, 0, 2), // before-send delay clamped
+            (false, 0b011, 1, 0), // after-send delay clamped
+        ] {
+            let mut requests = Vec::new();
+            let error = configure(invert_rts, 1_000, 2_000, |request, config| {
+                requests.push(request);
+                // TIOCSRS485 can overwrite its input with sanitized settings.
+                *config = SerialRs485 {
+                    flags,
+                    delay_rts_before_send: before_ms,
+                    delay_rts_after_send: after_ms,
+                    ..SerialRs485::default()
+                };
+                Ok(())
+            })
+            .unwrap_err();
+            let message = error.to_string();
+            assert!(message.contains("RS-485 readback mismatch"));
+            assert!(message.contains(&format!("flags={flags:#010x}")));
+            assert!(message.contains(&format!("delay_before_send_ms={before_ms}")));
+            assert!(message.contains(&format!("delay_after_send_ms={after_ms}")));
+            assert!(message.contains("hardware configuration may have changed"));
+            assert!(message.contains("no rollback was attempted"));
+            assert_eq!(requests, [Request::Set, Request::Get]);
+        }
+    }
+
+    #[test]
+    fn propagates_set_failure_without_readback_or_retry() {
+        let mut requests = Vec::new();
+        let error = configure(false, 0, 0, |request, _| {
+            requests.push(request);
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "set rejected",
+            ))
+        })
+        .unwrap_err();
+        assert!(matches!(&error, Error::Encoding(_)));
+        assert!(error.to_string().contains("TIOCSRS485 ioctl failed"));
+        assert!(error.to_string().contains("set rejected"));
+        assert_eq!(requests, [Request::Set]);
+    }
+
+    #[test]
+    fn propagates_readback_failure_without_retry_or_rollback() {
+        let mut requests = Vec::new();
+        let error = configure(false, 0, 0, |request, _| {
+            requests.push(request);
+            match request {
+                Request::Set => Ok(()),
+                Request::Get => Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    "readback unavailable",
+                )),
+            }
+        })
+        .unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("TIOCGRS485 ioctl failed"));
+        assert!(message.contains("readback unavailable"));
+        assert!(message.contains("hardware configuration may have changed"));
+        assert!(message.contains("no rollback was attempted"));
+        assert_eq!(requests, [Request::Set, Request::Get]);
+    }
+
+    #[test]
+    fn accepts_exact_boundary_delays_and_preserves_both_rts_polarities() {
+        for (before_us, after_us, before_ms, after_ms) in [
+            (0, 0, 0, 0),
+            (0, 4_294_967_000, 0, 4_294_967),
+            (4_294_967_000, 0, 4_294_967, 0),
+        ] {
+            for (invert_rts, flags) in [(false, 0b011), (true, 0b101)] {
+                let expected = SerialRs485 {
+                    flags,
+                    delay_rts_before_send: before_ms,
+                    delay_rts_after_send: after_ms,
+                    padding: [0; 5],
+                };
+                configure(invert_rts, before_us, after_us, |request, config| {
+                    match request {
+                        Request::Set => assert_eq!(*config, expected),
+                        Request::Get => *config = expected,
+                    }
+                    Ok(())
+                })
+                .unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn allows_unrelated_readback_flags() {
+        let mut accepted = SerialRs485::default();
+        configure(false, 0, 0, |request, config| {
+            match request {
+                Request::Set => accepted = *config,
+                Request::Get => {
+                    *config = accepted;
+                    config.flags |= 1 << 5; // Driver-reported bus termination.
+                }
+            }
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn linux_serial_rs485_layout_matches_uapi() {
+        use std::mem::{align_of, offset_of, size_of};
+
+        assert_eq!(size_of::<SerialRs485>(), 32);
+        assert_eq!(align_of::<SerialRs485>(), 4);
+        assert_eq!(offset_of!(SerialRs485, flags), 0);
+        assert_eq!(offset_of!(SerialRs485, delay_rts_before_send), 4);
+        assert_eq!(offset_of!(SerialRs485, delay_rts_after_send), 8);
+        assert_eq!(offset_of!(SerialRs485, padding), 12);
+        assert_eq!(size_of::<[u32; 5]>(), 20);
+    }
+}

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -361,6 +361,19 @@ serial.enable_kernel_rs485(
 )?;
 ```
 
+Both delay arguments remain in microseconds but must be exact multiples of 1000:
+zero is valid, and `1000` requests one millisecond. The Linux ABI stores whole
+milliseconds, so fractional-millisecond requests return an error before any ioctl
+instead of being rounded.
+
+After applying the configuration, the method reads it back with `TIOCGRS485` and
+checks that RS-485 is enabled with the requested RTS polarity and delays. Drivers
+may reject or sanitize unsupported settings; set/readback failures and mismatches
+return an error. A mismatch reports the effective flags and millisecond delays.
+A readback or verification error can occur after the hardware configuration has
+changed; the method does not roll back or retry. Success logs the verified effective
+settings. See the [Linux RS-485 userspace ABI](https://cdn.kernel.org/doc/html/latest/driver-api/serial/serial-rs485.html).
+
 #### GPIO Direction Control (RS-485 Hats)
 
 For RS-485 hats where DE/RE is wired to a GPIO pin (e.g., Seeed Studio RS-485 Shield on Raspberry Pi with GPIO18), use `GpioDirectionPort` to wrap any `SerialPort`. Requires the `serial-gpio` feature.


### PR DESCRIPTION
`enable_kernel_rs485` documents microsecond arguments but passed them directly to Linux's millisecond delay fields. For example, requesting 1,000 µs configured 1,000 ms instead of 1 ms.

Preserve the existing Rust API and convert whole-millisecond requests exactly. Reject fractional milliseconds before configuring the device. After setting RS-485 mode, read the configuration back and verify the enable flag, RTS polarity, and delays. Driver-sanitized mismatches and ioctl failures return errors; mismatch diagnostics include the applied values. Documentation explains that verification can fail after the hardware configuration has changed, without rollback.

The adapter uses architecture-appropriate ioctl constants and retains zero-delay operation. The change is limited to the Linux RS-485 adapter, its hardware-free tests, and the matching Rust API example. GPIO timing, BACnet wire behavior, and conformance/support claims are unchanged.

Linux ABI evidence: [kernel RS-485 documentation](https://cdn.kernel.org/doc/html/latest/driver-api/serial/serial-rs485.html). Exact conversion and mismatch rejection are project choices to avoid silently applying different timing.

Validation:

- Four red/green regression cycles; nine hardware-free tests cover request units, polarity, invalid granularity before ioctl, readback sequencing, set/get failures, sanitized settings, and ABI layout.
- Linux x86-64 serial-feature cross-check passed.
- Serial package tests passed (378 unit + 2 integration); workspace tests passed (3,976, with 2 ignored).
- Formatting, serial-feature and workspace Clippy, Python-extension test compilation, conformance generation, and tracked-file size/secrets/diff checks passed.
- Hosted Linux CI is required before merge.

No physical UART or on-wire timing qualification was performed; Linux CI executes the hardware-free serial tests.

Closes #498.
