### PR TITLE
chore: align Codex workflows with Astra CLI setup

### DIFF
--- a/.agents/skills/architecture-design-review/SKILL.md
+++ b/.agents/skills/architecture-design-review/SKILL.md
@@ -25,12 +25,12 @@ Do not rewrite the system. Do not optimize for style-only preferences. Anchor de
 
 ## Subagent orchestration rules
 
-Use subagents when the task benefits from context isolation, parallel exploration, independent verification, or specialized expertise. Do not spawn subagents for a one-shot formatting task.
+Delegate bounded independent questions in parallel when useful root work can proceed alongside them. Use only the roles needed for the decision; the list below is a menu, not a mandatory panel. Handle small or tightly coupled work locally. Children do not delegate. Use configured models and the running harness's supported collaboration tools.
 
 When spawning subagents, pass this minimum packet:
 
 1. Objective: one sentence describing the question to answer.
-2. Scope: files, folders, PR diff, services, packages, or docs to inspect.
+2. Scope: exact revision and files/symbols or supplied artifact; include the root-resolved Codebase Memory project/root and coverage notes for repository source work, otherwise mark it not applicable.
 3. Constraints: read-only vs write, commands allowed, network/doc lookup allowed, and timeout.
 4. Required evidence: exact files/symbols/commands/sources to cite.
 5. Output schema: use the schema requested by the skill.
@@ -38,7 +38,7 @@ When spawning subagents, pass this minimum packet:
 Parent-agent responsibilities:
 
 - Assign non-overlapping scopes when possible.
-- Wait for all requested subagents unless a blocking failure makes remaining work irrelevant.
+- Advance independent root work while agents run; collect required results before dependent decisions. Reuse compatible agents and successful exact-target validation; do not duplicate builds or run competing benchmarks.
 - Cross-check subagent conclusions against each other.
 - Resolve conflicts explicitly. Do not silently choose the more confident subagent.
 - Produce one synthesized result with a risk-ranked decision, not a paste of raw subagent notes.
@@ -101,14 +101,6 @@ Use severity labels consistently:
 1. ...
 ```
 
-## Useful shared references
+## Local references
 
-When this package is copied whole, use these templates as needed:
-
-- `shared/references/evidence-ledger-template.md`
-- `shared/references/review-report-template.md`
-- `shared/references/research-brief-template.md`
-- `shared/references/spec-compliance-matrix-template.md`
-- `shared/references/benchmark-report-template.md`
-- `shared/references/review-severity-rubric.md`
-- `shared/references/safe-research-practices.md`
+Use [output contracts](references/output-contracts.md) and the [severity rubric](references/severity-rubric.md) when useful. For delivery review, the active `pr-gate-loop` target, severity vocabulary, and stopping rules take precedence.

--- a/.agents/skills/codebase-research-pass/SKILL.md
+++ b/.agents/skills/codebase-research-pass/SKILL.md
@@ -25,12 +25,12 @@ Do not make code changes. Do not produce implementation plans before mapping the
 
 ## Subagent orchestration rules
 
-Use subagents when the task benefits from context isolation, parallel exploration, independent verification, or specialized expertise. Do not spawn subagents for a one-shot formatting task.
+Delegate bounded independent questions in parallel when useful root work can proceed alongside them. Use only the roles needed for the decision; the list below is a menu, not a mandatory panel. Handle small or tightly coupled work locally. Children do not delegate. Use configured models and the running harness's supported collaboration tools.
 
 When spawning subagents, pass this minimum packet:
 
 1. Objective: one sentence describing the question to answer.
-2. Scope: files, folders, PR diff, services, packages, or docs to inspect.
+2. Scope: exact revision and files/symbols or supplied artifact; include the root-resolved Codebase Memory project/root and coverage notes for repository source work, otherwise mark it not applicable.
 3. Constraints: read-only vs write, commands allowed, network/doc lookup allowed, and timeout.
 4. Required evidence: exact files/symbols/commands/sources to cite.
 5. Output schema: use the schema requested by the skill.
@@ -38,7 +38,7 @@ When spawning subagents, pass this minimum packet:
 Parent-agent responsibilities:
 
 - Assign non-overlapping scopes when possible.
-- Wait for all requested subagents unless a blocking failure makes remaining work irrelevant.
+- Advance independent root work while agents run; collect required results before dependent decisions. Reuse compatible agents and successful exact-target validation; do not duplicate builds or run competing benchmarks.
 - Cross-check subagent conclusions against each other.
 - Resolve conflicts explicitly. Do not silently choose the more confident subagent.
 - Produce one synthesized result with a risk-ranked decision, not a paste of raw subagent notes.
@@ -54,7 +54,7 @@ Parent-agent responsibilities:
 
 1. Charter the research: objective, codebase root, target subsystem, expected deliverable, and hard constraints.
 2. Discover repository shape: languages, packages, entry points, CI, test runners, generated code, docs, deployment surface, and ownership signals.
-3. Spawn scoped subagents. Keep at least one subagent read-only and one subagent focused on validation/test evidence.
+3. Delegate independent mapping or validation questions when warranted; otherwise inspect them locally. Keep research read-only and reuse the grounding record.
 4. Synthesize a map: key paths, data flows, public APIs, invariants, and dependency boundaries.
 5. Produce a research brief with confidence levels and follow-up questions.
 
@@ -107,14 +107,6 @@ Use severity labels consistently:
 1. ...
 ```
 
-## Useful shared references
+## Local references
 
-When this package is copied whole, use these templates as needed:
-
-- `shared/references/evidence-ledger-template.md`
-- `shared/references/review-report-template.md`
-- `shared/references/research-brief-template.md`
-- `shared/references/spec-compliance-matrix-template.md`
-- `shared/references/benchmark-report-template.md`
-- `shared/references/review-severity-rubric.md`
-- `shared/references/safe-research-practices.md`
+Use [output contracts](references/output-contracts.md) and the [severity rubric](references/severity-rubric.md) when useful. For delivery review, the active `pr-gate-loop` target, severity vocabulary, and stopping rules take precedence.

--- a/.agents/skills/external-source-research/SKILL.md
+++ b/.agents/skills/external-source-research/SKILL.md
@@ -25,12 +25,12 @@ Do not edit code. Do not quote long copyrighted passages. Do not treat blog post
 
 ## Subagent orchestration rules
 
-Use subagents when the task benefits from context isolation, parallel exploration, independent verification, or specialized expertise. Do not spawn subagents for a one-shot formatting task.
+Delegate bounded independent questions in parallel when useful root work can proceed alongside them. Use only the roles needed for the decision; the list below is a menu, not a mandatory panel. Handle small or tightly coupled work locally. Children do not delegate. Use configured models and the running harness's supported collaboration tools.
 
 When spawning subagents, pass this minimum packet:
 
 1. Objective: one sentence describing the question to answer.
-2. Scope: files, folders, PR diff, services, packages, or docs to inspect.
+2. Scope: exact revision and files/symbols or supplied artifact; include the root-resolved Codebase Memory project/root and coverage notes for repository source work, otherwise mark it not applicable.
 3. Constraints: read-only vs write, commands allowed, network/doc lookup allowed, and timeout.
 4. Required evidence: exact files/symbols/commands/sources to cite.
 5. Output schema: use the schema requested by the skill.
@@ -38,7 +38,7 @@ When spawning subagents, pass this minimum packet:
 Parent-agent responsibilities:
 
 - Assign non-overlapping scopes when possible.
-- Wait for all requested subagents unless a blocking failure makes remaining work irrelevant.
+- Advance independent root work while agents run; collect required results before dependent decisions. Reuse compatible agents and successful exact-target validation; do not duplicate builds or run competing benchmarks.
 - Cross-check subagent conclusions against each other.
 - Resolve conflicts explicitly. Do not silently choose the more confident subagent.
 - Produce one synthesized result with a risk-ranked decision, not a paste of raw subagent notes.
@@ -100,14 +100,6 @@ Use severity labels consistently:
 ## Recommended next steps
 ```
 
-## Useful shared references
+## Local references
 
-When this package is copied whole, use these templates as needed:
-
-- `shared/references/evidence-ledger-template.md`
-- `shared/references/review-report-template.md`
-- `shared/references/research-brief-template.md`
-- `shared/references/spec-compliance-matrix-template.md`
-- `shared/references/benchmark-report-template.md`
-- `shared/references/review-severity-rubric.md`
-- `shared/references/safe-research-practices.md`
+Use [output contracts](references/output-contracts.md) and the [severity rubric](references/severity-rubric.md) when useful. For delivery review, the active `pr-gate-loop` target, severity vocabulary, and stopping rules take precedence.

--- a/.agents/skills/multi-agent-pr-review/SKILL.md
+++ b/.agents/skills/multi-agent-pr-review/SKILL.md
@@ -25,12 +25,12 @@ Do not nitpick style unless it hides a real defect. Do not rubber-stamp. Do not 
 
 ## Subagent orchestration rules
 
-Use subagents when the task benefits from context isolation, parallel exploration, independent verification, or specialized expertise. Do not spawn subagents for a one-shot formatting task.
+Delegate bounded independent questions in parallel when useful root work can proceed alongside them. Use only the roles needed for the decision; the list below is a menu, not a mandatory panel. Handle small or tightly coupled work locally. Children do not delegate. Use configured models and the running harness's supported collaboration tools.
 
 When spawning subagents, pass this minimum packet:
 
 1. Objective: one sentence describing the question to answer.
-2. Scope: files, folders, PR diff, services, packages, or docs to inspect.
+2. Scope: exact revision and files/symbols or supplied artifact; include the root-resolved Codebase Memory project/root and coverage notes for repository source work, otherwise mark it not applicable.
 3. Constraints: read-only vs write, commands allowed, network/doc lookup allowed, and timeout.
 4. Required evidence: exact files/symbols/commands/sources to cite.
 5. Output schema: use the schema requested by the skill.
@@ -38,7 +38,7 @@ When spawning subagents, pass this minimum packet:
 Parent-agent responsibilities:
 
 - Assign non-overlapping scopes when possible.
-- Wait for all requested subagents unless a blocking failure makes remaining work irrelevant.
+- Advance independent root work while agents run; collect required results before dependent decisions. Reuse compatible agents and successful exact-target validation; do not duplicate builds or run competing benchmarks.
 - Cross-check subagent conclusions against each other.
 - Resolve conflicts explicitly. Do not silently choose the more confident subagent.
 - Produce one synthesized result with a risk-ranked decision, not a paste of raw subagent notes.
@@ -56,7 +56,7 @@ Parent-agent responsibilities:
 
 1. Establish base and head. If a VCS is available, identify changed files and commits; otherwise review the supplied patch.
 2. Classify the change type: feature, fix, refactor, dependency, config, migration, docs, test, release, or mixed.
-3. Spawn subagents with non-overlapping review lenses and concrete output schemas.
+3. For a supplied PR delivery target, use `pr-gate-loop` and its required immutable reviewers; do not start a second review cycle here. For local diffs or review-only work, use only independent review lenses justified by the change and never invent PR metadata.
 4. Deduplicate findings, discard speculative issues without evidence, and escalate only actionable risks.
 5. Return review findings in severity order with exact reproduction or verification steps.
 
@@ -104,14 +104,6 @@ approve | request changes | comment only | inconclusive
 |---|---|---|
 ```
 
-## Useful shared references
+## Local references
 
-When this package is copied whole, use these templates as needed:
-
-- `shared/references/evidence-ledger-template.md`
-- `shared/references/review-report-template.md`
-- `shared/references/research-brief-template.md`
-- `shared/references/spec-compliance-matrix-template.md`
-- `shared/references/benchmark-report-template.md`
-- `shared/references/review-severity-rubric.md`
-- `shared/references/safe-research-practices.md`
+Use [output contracts](references/output-contracts.md) and the [severity rubric](references/severity-rubric.md) when useful. For delivery review, the active `pr-gate-loop` target, severity vocabulary, and stopping rules take precedence.

--- a/.agents/skills/performance-ab-benchmark-review/SKILL.md
+++ b/.agents/skills/performance-ab-benchmark-review/SKILL.md
@@ -25,12 +25,12 @@ Do not optimize without a baseline. Do not accept benchmark wins without correct
 
 ## Subagent orchestration rules
 
-Use subagents when the task benefits from context isolation, parallel exploration, independent verification, or specialized expertise. Do not spawn subagents for a one-shot formatting task.
+Delegate bounded independent questions in parallel when useful root work can proceed alongside them. Use only the roles needed for the decision; the list below is a menu, not a mandatory panel. Handle small or tightly coupled work locally. Children do not delegate. Use configured models and the running harness's supported collaboration tools.
 
 When spawning subagents, pass this minimum packet:
 
 1. Objective: one sentence describing the question to answer.
-2. Scope: files, folders, PR diff, services, packages, or docs to inspect.
+2. Scope: exact revision and files/symbols or supplied artifact; include the root-resolved Codebase Memory project/root and coverage notes for repository source work, otherwise mark it not applicable.
 3. Constraints: read-only vs write, commands allowed, network/doc lookup allowed, and timeout.
 4. Required evidence: exact files/symbols/commands/sources to cite.
 5. Output schema: use the schema requested by the skill.
@@ -38,7 +38,7 @@ When spawning subagents, pass this minimum packet:
 Parent-agent responsibilities:
 
 - Assign non-overlapping scopes when possible.
-- Wait for all requested subagents unless a blocking failure makes remaining work irrelevant.
+- Advance independent root work while agents run; collect required results before dependent decisions. Reuse compatible agents and successful exact-target validation; do not duplicate builds or run competing benchmarks.
 - Cross-check subagent conclusions against each other.
 - Resolve conflicts explicitly. Do not silently choose the more confident subagent.
 - Produce one synthesized result with a risk-ranked decision, not a paste of raw subagent notes.
@@ -108,14 +108,6 @@ Use severity labels consistently:
 ## Follow-up benchmarks
 ```
 
-## Useful shared references
+## Local references
 
-When this package is copied whole, use these templates as needed:
-
-- `shared/references/evidence-ledger-template.md`
-- `shared/references/review-report-template.md`
-- `shared/references/research-brief-template.md`
-- `shared/references/spec-compliance-matrix-template.md`
-- `shared/references/benchmark-report-template.md`
-- `shared/references/review-severity-rubric.md`
-- `shared/references/safe-research-practices.md`
+Use [output contracts](references/output-contracts.md) and the [severity rubric](references/severity-rubric.md) when useful. For delivery review, the active `pr-gate-loop` target, severity vocabulary, and stopping rules take precedence.

--- a/.agents/skills/release-readiness-review/SKILL.md
+++ b/.agents/skills/release-readiness-review/SKILL.md
@@ -25,12 +25,12 @@ Do not claim readiness without verification evidence. Do not hide unresolved ris
 
 ## Subagent orchestration rules
 
-Use subagents when the task benefits from context isolation, parallel exploration, independent verification, or specialized expertise. Do not spawn subagents for a one-shot formatting task.
+Delegate bounded independent questions in parallel when useful root work can proceed alongside them. Use only the roles needed for the decision; the list below is a menu, not a mandatory panel. Handle small or tightly coupled work locally. Children do not delegate. Use configured models and the running harness's supported collaboration tools.
 
 When spawning subagents, pass this minimum packet:
 
 1. Objective: one sentence describing the question to answer.
-2. Scope: files, folders, PR diff, services, packages, or docs to inspect.
+2. Scope: exact revision and files/symbols or supplied artifact; include the root-resolved Codebase Memory project/root and coverage notes for repository source work, otherwise mark it not applicable.
 3. Constraints: read-only vs write, commands allowed, network/doc lookup allowed, and timeout.
 4. Required evidence: exact files/symbols/commands/sources to cite.
 5. Output schema: use the schema requested by the skill.
@@ -38,7 +38,7 @@ When spawning subagents, pass this minimum packet:
 Parent-agent responsibilities:
 
 - Assign non-overlapping scopes when possible.
-- Wait for all requested subagents unless a blocking failure makes remaining work irrelevant.
+- Advance independent root work while agents run; collect required results before dependent decisions. Reuse compatible agents and successful exact-target validation; do not duplicate builds or run competing benchmarks.
 - Cross-check subagent conclusions against each other.
 - Resolve conflicts explicitly. Do not silently choose the more confident subagent.
 - Produce one synthesized result with a risk-ranked decision, not a paste of raw subagent notes.
@@ -50,6 +50,8 @@ Parent-agent responsibilities:
 - `security-reliability-reviewer` — Review failure modes, secrets, access control, data handling, concurrency, and reliability hazards.
 - `release-risk-reviewer` — Assess release notes, migration/rollback plan, observability, config, compatibility, and docs needs.
 - `external-researcher` — Check external release/publish requirements or changelog constraints if relevant.
+
+A completed exact-target delivery review and passing gates are reusable evidence. Add a readiness lane only for an unresolved release risk; this skill does not mandate another panel or authorize publication.
 
 ## Workflow
 
@@ -106,14 +108,6 @@ ready | not ready | ready with risks | inconclusive
 - [ ] ...
 ```
 
-## Useful shared references
+## Local references
 
-When this package is copied whole, use these templates as needed:
-
-- `shared/references/evidence-ledger-template.md`
-- `shared/references/review-report-template.md`
-- `shared/references/research-brief-template.md`
-- `shared/references/spec-compliance-matrix-template.md`
-- `shared/references/benchmark-report-template.md`
-- `shared/references/review-severity-rubric.md`
-- `shared/references/safe-research-practices.md`
+Use [output contracts](references/output-contracts.md) and the [severity rubric](references/severity-rubric.md) when useful. For delivery review, the active `pr-gate-loop` target, severity vocabulary, and stopping rules take precedence.

--- a/.agents/skills/spec-contract-compliance-review/SKILL.md
+++ b/.agents/skills/spec-contract-compliance-review/SKILL.md
@@ -25,12 +25,12 @@ Do not certify compliance. Report evidence and gaps. Do not assume untested path
 
 ## Subagent orchestration rules
 
-Use subagents when the task benefits from context isolation, parallel exploration, independent verification, or specialized expertise. Do not spawn subagents for a one-shot formatting task.
+Delegate bounded independent questions in parallel when useful root work can proceed alongside them. Use only the roles needed for the decision; the list below is a menu, not a mandatory panel. Handle small or tightly coupled work locally. Children do not delegate. Use configured models and the running harness's supported collaboration tools.
 
 When spawning subagents, pass this minimum packet:
 
 1. Objective: one sentence describing the question to answer.
-2. Scope: files, folders, PR diff, services, packages, or docs to inspect.
+2. Scope: exact revision and files/symbols or supplied artifact; include the root-resolved Codebase Memory project/root and coverage notes for repository source work, otherwise mark it not applicable.
 3. Constraints: read-only vs write, commands allowed, network/doc lookup allowed, and timeout.
 4. Required evidence: exact files/symbols/commands/sources to cite.
 5. Output schema: use the schema requested by the skill.
@@ -38,7 +38,7 @@ When spawning subagents, pass this minimum packet:
 Parent-agent responsibilities:
 
 - Assign non-overlapping scopes when possible.
-- Wait for all requested subagents unless a blocking failure makes remaining work irrelevant.
+- Advance independent root work while agents run; collect required results before dependent decisions. Reuse compatible agents and successful exact-target validation; do not duplicate builds or run competing benchmarks.
 - Cross-check subagent conclusions against each other.
 - Resolve conflicts explicitly. Do not silently choose the more confident subagent.
 - Produce one synthesized result with a risk-ranked decision, not a paste of raw subagent notes.
@@ -105,14 +105,6 @@ Use severity labels consistently:
 ## Next work items
 ```
 
-## Useful shared references
+## Local references
 
-When this package is copied whole, use these templates as needed:
-
-- `shared/references/evidence-ledger-template.md`
-- `shared/references/review-report-template.md`
-- `shared/references/research-brief-template.md`
-- `shared/references/spec-compliance-matrix-template.md`
-- `shared/references/benchmark-report-template.md`
-- `shared/references/review-severity-rubric.md`
-- `shared/references/safe-research-practices.md`
+Use [output contracts](references/output-contracts.md) and the [severity rubric](references/severity-rubric.md) when useful. For delivery review, the active `pr-gate-loop` target, severity vocabulary, and stopping rules take precedence.

--- a/.codex/agents/bacnet-data-link-reviewer.toml
+++ b/.codex/agents/bacnet-data-link-reviewer.toml
@@ -1,5 +1,7 @@
 name = "bacnet-data-link-reviewer"
 description = "Read-only reviewer for BACnet/IPv6, MS/TP, Ethernet, ARCNET, PTP, LonTalk, ZigBee, platform assumptions, and unsupported/deferred data-link rationale."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a BACnet data-link reviewer for rusty-bacnet.

--- a/.codex/agents/bacnet-ip-bvll-reviewer.toml
+++ b/.codex/agents/bacnet-ip-bvll-reviewer.toml
@@ -1,5 +1,7 @@
 name = "bacnet-ip-bvll-reviewer"
 description = "Read-only reviewer for Annex J, BVLL, BACnet/IP, BBMD, BDT, FDT, foreign devices, NAT/multicast, and B/IP benchmark scope."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a BACnet/IP and BVLL reviewer for rusty-bacnet.

--- a/.codex/agents/bacnet-performance-reviewer.toml
+++ b/.codex/agents/bacnet-performance-reviewer.toml
@@ -1,5 +1,7 @@
 name = "bacnet-performance-reviewer"
 description = "Benchmark reviewer for BACnet performance claims, A/B methodology, raw artifacts, workload validity, latency/throughput/memory deltas, and caveats."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """
 You are a BACnet performance and A/B benchmark reviewer for rusty-bacnet.

--- a/.codex/agents/bacnet-pr-packager.toml
+++ b/.codex/agents/bacnet-pr-packager.toml
@@ -1,5 +1,7 @@
 name = "bacnet-pr-packager"
 description = "Read-only PR evidence packager for BACnet compliance work: PR body completeness, clauses, tests, benchmarks, ledger updates, limitations, and follow-ups."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a BACnet PR packager for rusty-bacnet.

--- a/.codex/agents/bacnet-reference-researcher.toml
+++ b/.codex/agents/bacnet-reference-researcher.toml
@@ -1,5 +1,7 @@
 name = "bacnet-reference-researcher"
 description = "Read-only BACnet Standard reference researcher for protocol-impacting PRs, clause anchors, addenda/errata checks, and unsupported variants."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a BACnet reference research specialist for rusty-bacnet.
@@ -7,7 +9,7 @@ You are a BACnet reference research specialist for rusty-bacnet.
 Mission:
 - Ground protocol work in ANSI/ASHRAE Standard 135-2020 and the local compliance specs.
 - Identify exact clauses, annexes, tables, normative strength, and unsupported variants relevant to the scoped change.
-- Treat the local Standard PDF and `_spec/rusty_bacnet_compliance_specs_v1/` as evidence sources, while clearly marking any addenda or errata not checked.
+- Locate the local Standard PDF through `_spec/rusty-bacnet-compliance-execution-plan/STANDARD_NAVIGATION.md` and use the relevant current plan packet; clearly mark any unavailable source or addenda/errata not checked.
 
 Rules:
 - Do not edit files.

--- a/.codex/agents/bacnet-safety-interop-reviewer.toml
+++ b/.codex/agents/bacnet-safety-interop-reviewer.toml
@@ -1,5 +1,7 @@
 name = "bacnet-safety-interop-reviewer"
 description = "Read-only reviewer for malformed packets, fail-closed behavior, broadcast/routing safety, resource caps, timeouts, concurrency, and operational interop risks."
+model = "gpt-6-astra"
+model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a BACnet safety and interoperability reviewer for rusty-bacnet.

--- a/.codex/agents/bacnet-sc-security-reviewer.toml
+++ b/.codex/agents/bacnet-sc-security-reviewer.toml
@@ -1,5 +1,7 @@
 name = "bacnet-sc-security-reviewer"
 description = "Read-only reviewer for Annex AB BACnet/SC security, TLS/mTLS, WebSocket subprotocols, VMAC/UUID, heartbeat, failover, data options, and hub/direct behavior."
+model = "gpt-6-astra"
+model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a BACnet/SC security and conformance reviewer for rusty-bacnet.

--- a/.codex/agents/bacnet-services-objects-reviewer.toml
+++ b/.codex/agents/bacnet-services-objects-reviewer.toml
@@ -1,5 +1,7 @@
 name = "bacnet-services-objects-reviewer"
 description = "Read-only reviewer for BACnet services, object models, Device object, required properties, errors, PICS, BIBBs, and profile impact."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a BACnet services and objects reviewer for rusty-bacnet.

--- a/.codex/agents/bacnet-tsm-network-reviewer.toml
+++ b/.codex/agents/bacnet-tsm-network-reviewer.toml
@@ -1,5 +1,7 @@
 name = "bacnet-tsm-network-reviewer"
 description = "Read-only reviewer for Clause 5 APDU TSM/segmentation and Clause 6 NPDU/routing/network-message behavior."
+model = "gpt-6-astra"
+model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a BACnet TSM, segmentation, and network-layer reviewer for rusty-bacnet.

--- a/.codex/agents/codebase-mapper.toml
+++ b/.codex/agents/codebase-mapper.toml
@@ -1,5 +1,7 @@
 name = "codebase-mapper"
 description = "Read-only repository explorer for architecture, execution paths, ownership, dependencies, and validation surfaces. Use before planning, reviews, or edits."
+model = "gpt-5.6-luna"
+model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a read-only codebase mapping specialist.

--- a/.codex/agents/correctness-reviewer.toml
+++ b/.codex/agents/correctness-reviewer.toml
@@ -1,5 +1,7 @@
 name = "correctness-reviewer"
 description = "Read-only reviewer for functional correctness, behavior regressions, edge cases, compatibility, data model risks, and missing tests."
+model = "gpt-6-astra"
+model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a correctness reviewer.

--- a/.codex/agents/external-researcher.toml
+++ b/.codex/agents/external-researcher.toml
@@ -1,5 +1,7 @@
 name = "external-researcher"
 description = "Documentation and source researcher for external APIs, standards, dependencies, SDKs, protocols, release notes, and version-specific behavior."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are an external-source research specialist.

--- a/.codex/agents/performance-analyst.toml
+++ b/.codex/agents/performance-analyst.toml
@@ -1,5 +1,7 @@
 name = "performance-analyst"
 description = "Benchmark and profiling specialist for baseline discovery, A/B comparison, latency, throughput, memory, allocations, and workload validity."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """
 You are a performance and benchmark analyst.

--- a/.codex/agents/release-risk-reviewer.toml
+++ b/.codex/agents/release-risk-reviewer.toml
@@ -1,5 +1,7 @@
 name = "release-risk-reviewer"
 description = "Read-only release and operational risk reviewer for rollout, migration, compatibility, observability, docs, rollback, packaging, and support readiness."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a release and operational risk reviewer.

--- a/.codex/agents/security-reliability-reviewer.toml
+++ b/.codex/agents/security-reliability-reviewer.toml
@@ -1,5 +1,7 @@
 name = "security-reliability-reviewer"
 description = "Read-only reviewer for security, privacy, secrets, authz/authn, input validation, concurrency, resource exhaustion, error handling, and fail-closed behavior."
+model = "gpt-6-astra"
+model_reasoning_effort = "xhigh"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a security and reliability reviewer.

--- a/.codex/agents/spec-tracer.toml
+++ b/.codex/agents/spec-tracer.toml
@@ -1,5 +1,7 @@
 name = "spec-tracer"
 description = "Requirement tracer for specs, API contracts, protocols, policy docs, acceptance criteria, and compliance matrices."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """
 You are a spec and contract traceability specialist.

--- a/.codex/agents/test-verifier.toml
+++ b/.codex/agents/test-verifier.toml
@@ -1,5 +1,7 @@
 name = "test-verifier"
 description = "Verification specialist for tests, builds, lint, typecheck, CI gates, coverage gaps, flaky tests, and independent validation of completed work."
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """
 You are a skeptical test and verification specialist.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,7 +1,16 @@
-# Optional Codex project settings for subagent-heavy research/review workflows.
-# Copy or merge into your existing .codex/config.toml.
+# Codex CLI 0.153.4 baseline, verified 2026-09-05.
+# Project model choices; retain user-level permissions, providers and service tier.
+model = "gpt-6-astra"
+model_reasoning_effort = "high"
 
 [agents]
-max_threads = 8
-max_depth = 1
-job_max_runtime_seconds = 1800
+enabled = true
+# Counts spawned threads, excluding the root; use fewer for coupled work.
+max_concurrent_threads_per_session = 6
+default_subagent_model = "gpt-5.6-luna"
+default_subagent_reasoning_effort = "high"
+
+# Standalone .codex/agents/*.toml files pin specialist models and effort.
+# Recursion and task duration are bounded by task packets and AGENTS.md.
+# Sources: https://developers.openai.com/codex/subagents
+# https://learn.chatgpt.com/docs/config-file/config-reference

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,31 @@
 
 This repository uses focused skills and subagents for research and review. Prefer the installed skills under `.agents/skills/` and custom agents under `.codex/agents/`.
 
-Use local Codebase Memory as the first structural code-intelligence layer. The canonical project is `Users-justin-Development-rusty-bacnet`, rooted at `/Users/justin/Development/rusty-bacnet`; verify it with `list_projects` and `index_status` when entering a fresh repository context, then use focused graph tools and check coverage for cited scopes. Codebase Memory is not a durable work ledger. Long-running compliance continuity lives in the ignored `_spec/rusty-bacnet-compliance-execution-plan/{Handoff.md,CURRENT_STATUS.md,NEXT_HANDOFF.md}` documents, with `codex-overnight-status.md` retained as an additional local historical log. Refresh live Git/GitHub state before acting on those snapshots. No external memory service, agent identity, namespace, or team assertion is a prerequisite.
+Use local Codebase Memory as the first structural code-intelligence layer. The canonical project is `Users-justin-Development-rusty-bacnet`, rooted at `/Users/justin/Development/rusty-bacnet`; verify it once with `list_projects` and `index_status` when entering a fresh repository source context, then use focused graph tools and check coverage for cited scopes. Codebase Memory is not a durable work ledger. Long-running compliance continuity lives in the ignored `_spec/rusty-bacnet-compliance-execution-plan/{Handoff.md,CURRENT_STATUS.md,NEXT_HANDOFF.md}` documents, with `codex-overnight-status.md` retained as an additional local historical log. Refresh live Git/GitHub state before acting on those snapshots. No external memory service, agent identity, namespace, or team assertion is a prerequisite.
 
 Default behavior:
 
 - Use read-only exploration first.
-- Spawn subagents only for complex, parallel, or verification-heavy work.
+- Delegate independent research or verification questions in parallel when they materially improve speed or confidence and useful root work can proceed. Handle small, coupled tasks locally; the available roles are a menu, not a required panel.
 - Keep subagent prompts scoped and evidence-led.
-- Treat a READY review as final for that head SHA. If the head changes, rerun only review lanes affected by the new diff.
+- Reuse a completed review for its exact immutable target. If the head changes, follow `pr-gate-loop`: both required reviewers acknowledge the new target in the permitted final cycle, reusing unchanged evidence and focusing inspection on repair impact. A clean informational review does not reopen a stopped delivery gate.
 - Synthesize findings into a single decision or plan.
 - Record commands, files, symbols, and sources used as evidence.
 - Keep PRs small: one BACnet layer, state-machine family, or measured hotspot per PR.
 - Do not add new CI unless explicitly requested.
 - Do not broaden README or public support claims without conformance ledger rows, tests, and evidence.
-- Treat `_spec/rusty_bacnet_compliance_specs_v1/` as the active compliance work plan and `_spec/2020_ASHRAE_Standard-135-BACnet-Data-Communication-Protocol.pdf` as the local Standard 135-2020 reference.
+- Use `_spec/rusty-bacnet-compliance-execution-plan/` for the current roadmap: read the current block of `NEXT_HANDOFF.md`, then relevant `CURRENT_STATUS.md`, `WORK_QUEUE.md`, `DECISIONS.md`, and packet/gate files. Historical blocks preserve evidence, not current instructions. The older `_spec/rusty_bacnet_compliance_specs_v1/` path is absent in this checkout. Locate the licensed Standard through `STANDARD_NAVIGATION.md` before protocol work; never infer a missing source.
+
+
+## Codex CLI and Astra
+
+- Model and effort settings belong in `.codex/config.toml` and named-agent TOMLs. Use the advertised model catalog and role settings; do not substitute a model or raise every task to maximum effort. This repository selects Astra for root work and demanding review, with lighter roles for bounded mapping and source lookup.
+- Batch independent tool reads; keep dependent operations and Git/GitHub mutations sequential. Use the collaboration tools and context controls actually exposed by the running CLI. Supply a compact task packet instead of full history when supported.
+- Each packet names the objective, exact revision, paths/symbols, ownership, constraints, acceptance evidence, and expected result. Children do not delegate or rediscover the Codebase Memory project. The root resolves conflicting evidence and retains delivery authority.
+- Keep a small active team, usually two or three independent readers. The configured limit is a ceiling, not a target. Reuse compatible agents; release finished agents with the available lifecycle tool. Coordinate builds and tests to avoid duplicate Cargo work, shared fixtures, and port conflicts. Run performance measurements without competing workloads.
+- Ordinary product delivery uses one `implementer`. This repository permits up to two product writers only after an explicit `$parallel-portfolio` invocation and that skill's admission gate: disjoint ownership and contracts, isolated worktrees from one base, and root-owned integration. General requests for speed or parallel research do not admit a portfolio. If the skill is unavailable, continue serially.
+- Use the existing `pr-gate-loop` for delivery review; specialist reviews supply bounded evidence, not an extra approval cycle. Keep its repair limits and stopped-gate history intact. Standing merge authority applies only after the current delivery gate passes.
+- Validate configuration changes against the installed CLI and start a fresh CLI session to load changed settings and agent definitions. Do not restart another session or assume this running thread has reloaded them.
 
 Recommended skills:
 


### PR DESCRIPTION
The repository’s agent setup used obsolete concurrency keys, left specialist model selection implicit, and duplicated review procedures across skills. Configure Codex CLI 0.153.4 for Astra root/specialist work, lighter mapping/source roles, and a six-child concurrency ceiling.

Clarify when independent research/review benefits from parallel agents, keep ordinary product delivery with one writer, and permit an explicitly admitted two-lane portfolio. Consolidate immutable PR review under the existing bounded gate, reuse successful validation, fix dangling skill references, and point continuity at the current local roadmap. New settings require a fresh CLI session; this change does not claim to reload running agents.

Validation: all 18 TOML files parsed; seven repository skills passed the installed skill validator and local-reference checks; `codex app-server --strict-config --listen stdio://` exited successfully at EOF on CLI 0.153.4. An independent configuration audit exercised small docs work, parallel research, serial delivery, portfolio admission, and stopped-gate scenarios. Earlier fresh debug-prompt discovery verified instruction loading. Diff and tracked hygiene checks pass. Existing hosted CI remains required before merge.

Personal configuration changes and session workflow notes remain local. No product code, CI definitions, permissions, or BACnet support claims change. Portfolio discovery remains a fresh-session verification item because the installed personal skill was absent from this session’s advertised catalog; the documented fallback is serial implementation.
