### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,14 +289,15 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - run: sleep 30
 
-      - name: Publish bacnet-server
-        run: cargo publish -p bacnet-server --no-verify
+      # The server's versioned dev-dependency is retained when Cargo packages it.
+      - name: Publish bacnet-client
+        run: cargo publish -p bacnet-client --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - run: sleep 30
 
-      - name: Publish bacnet-client
-        run: cargo publish -p bacnet-client --no-verify
+      - name: Publish bacnet-server
+        run: cargo publish -p bacnet-server --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-09-06
+
+### Release highlights
+
+This pre-1.0 release includes breaking Rust, Python, and CLI API changes.
+BACnet conformance remains partial: the detailed entries and
+[conformance ledger](docs/conformance/bacnet-135-2020.json) describe the supported
+boundaries and remaining gaps. This release is not a full-conformance or BTL
+certification claim.
+
+- Native BACnet/SC adds bounded handshake and control-send work, WebSocket
+  resource budgets and selected I/O deadlines, heartbeat validation, and bounded
+  connection retirement during reconnect and failover. WebSocket reader and
+  outbound-wait policy work remains tracked in #525.
+- Routed request/reply correlation, peer APDU limits, and segmented transaction
+  timers, acknowledgments, and resource bounds now follow the peer's identity
+  and advertised capabilities more closely.
+- Intrinsic event history, exact BACnetTimeStamp handling, AcknowledgeAlarm
+  correlation, and acknowledgment notification delivery preserve committed
+  transition state across the supported object families.
+- Typed Rust and Python Audit clients complement durable Audit Log storage,
+  retained-record queries, policy-controlled notification receipt, and persisted
+  confirmed-receipt duplicate detection. Audit Reporting BIBBs remain unclaimed.
+- Python gains MS/TP transport configuration and trusted local input
+  `Present_Value` updates. File objects gain bounded resizing and pre-start
+  Python management; resident logs gain exact ReadRange selection; Staging gains
+  explicit configuration and local binary-target execution.
+
+### Migration notes
+
+- Replace the former stage-count-only `StagingObject::new` argument with a
+  complete `StagingConfig`; see the [Rust construction example](docs/rust-api.md#building-control-7).
+- Custom `AuditLogPersistence` implementations must preserve the new
+  `AuditLogSnapshot::completed_receipts` field in the same atomic commit as
+  records. The built-in file backend writes schema v2 and reads v1 with an empty
+  receipt ledger; see the [snapshot migration](docs/rust-api.md#audit-services).
+- Pass exact `--timestamp` and `--ack-time` values to CLI `ack-alarm` / `ack`.
+  Python callers should use `acknowledge_alarm_request`; the five-argument
+  `acknowledge_alarm` method is deprecated.
+- Update GetEnrollmentSummary `RecipientProcess` construction from `device` to
+  the `recipient: BACnetRecipient` CHOICE. Audit request models and the raw
+  Python `audit_log_query` signature also changed; use the typed helpers when
+  possible and consult the detailed changes below for other source migrations.
+- Remove dependencies on the withdrawn WASM crate, Notification Forwarder and
+  Channel constructors, and bundled-server WriteGroup execution. Retained wire
+  identifiers and client codecs do not imply those server capabilities.
+
 ### Changed
 
 - **Breaking CLI invocation:** one-shot and interactive `ack-alarm` (including
@@ -25,10 +72,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Rust-only, application-owned logical `Present_Value` updates for in-service
+- Application-owned logical `Present_Value` updates for in-service
   Analog Input, Binary Input, and Multi-state Input objects, using the existing
   server post-write intrinsic-event and COV processing. Out-of-service client
-  simulations remain protected; Python exposure remains tracked in #503.
+  simulations remain protected. Rust and Python expose this route through the
+  server's `set_present_value_local` method (#503, #510).
 
 - Correlated AcknowledgeAlarm validation, lossless Rust request construction,
   and bundled-server ACK notification distribution (#132, #170, #175). The
@@ -350,7 +398,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unavailable or invalid) and clear `Archive`, including direct preloads and
   equal-content or empty AtomicWriteFile writes (#416). Failed writes remain
   metadata-neutral; custom `FileStorage` implementations still own their
-  metadata, and File_Size/Record_Count network writes remain deferred to #417.
+  metadata. Conditional File_Size/Record_Count network writes were subsequently
+  added in #481, resolving #417 as described above.
 
 - Reliability evaluation now belongs to each `BACnetObject` through a defaulted
   opt-in hook. Enabling server fault detection invokes that hook for every
@@ -534,17 +583,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   obsolete `acknowledgment_filter` plus opaque query tail. This is a breaking
   Rust API change. Python's breaking `audit_log_query` signature now accepts a
   complete pre-encoded `service_data: bytes` payload instead of
-  `acknowledgment_filter` and `query_options_raw`; all three Audit methods are
-  explicitly raw outbound escape hatches and do not imply bundled-server
-  execution.
+  `acknowledgment_filter` and `query_options_raw`. The raw Python methods remain
+  outbound escape hatches; additive `_typed` methods now accept structured
+  mappings and return a decoded query ACK through the native typed clients
+  (#511). Explicitly backed Audit Log objects provide durable storage and
+  retained-record query execution (#458, #463), with separately authorized
+  confirmed and unconfirmed notification receipt (#466, #512). Successful
+  confirmed receipt persists its bounded duplicate ledger with the records
+  (#535).
 
   The query model deliberately implements Clause 21's
   `start-at-sequence-number Unsigned32` and `successful-actions-only BOOLEAN`.
   Clause 13.19 describes those fields as `Unsigned64` and
   `BACnetSuccessFilter`, respectively; that internal Standard conflict remains
   an interoperability limitation pending authoritative addendum or errata
-  resolution. Audit service handlers, persistence, query acknowledgments, and
-  PICS/BIBB support claims remain out of scope.
+  resolution. Query authorization, producer/report generation, forwarding,
+  failures-only filtering, and wrap-safe 64-bit continuation remain outside
+  this release's supported Audit boundary; no Audit Reporting BIBB is claimed.
 
 - COV Multiple wire models now match the Clause 13.16–13.18 and Clause 21
   productions (#342). `issue_confirmed_notifications` and each reference's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-client"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-endpoint-core",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-encoding"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-types",
  "bytes",
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-endpoint-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-network",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-integration-tests"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-network"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-transport",
@@ -349,7 +349,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-objects"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-server"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-services"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -387,7 +387,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-transport"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-encoding",
  "bacnet-types",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "bacnet-types"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.13.1",
  "serde",
@@ -2194,7 +2194,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-bacnet"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bacnet-client",
  "bacnet-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.93"
 license = "MIT"
@@ -53,15 +53,15 @@ keywords = ["bacnet", "building-automation", "ashrae", "iot", "protocol"]
 categories = ["network-programming", "embedded"]
 
 [workspace.dependencies]
-bacnet-types = { version = "0.10.1", path = "crates/bacnet-types" }
-bacnet-encoding = { version = "0.10.1", path = "crates/bacnet-encoding" }
-bacnet-services = { version = "0.10.1", path = "crates/bacnet-services" }
-bacnet-transport = { version = "0.10.1", path = "crates/bacnet-transport" }
-bacnet-network = { version = "0.10.1", path = "crates/bacnet-network" }
-bacnet-endpoint-core = { version = "0.10.1", path = "crates/bacnet-endpoint-core" }
-bacnet-client = { version = "0.10.1", path = "crates/bacnet-client" }
-bacnet-objects = { version = "0.10.1", path = "crates/bacnet-objects" }
-bacnet-server = { version = "0.10.1", path = "crates/bacnet-server" }
+bacnet-types = { version = "0.11.0", path = "crates/bacnet-types" }
+bacnet-encoding = { version = "0.11.0", path = "crates/bacnet-encoding" }
+bacnet-services = { version = "0.11.0", path = "crates/bacnet-services" }
+bacnet-transport = { version = "0.11.0", path = "crates/bacnet-transport" }
+bacnet-network = { version = "0.11.0", path = "crates/bacnet-network" }
+bacnet-endpoint-core = { version = "0.11.0", path = "crates/bacnet-endpoint-core" }
+bacnet-client = { version = "0.11.0", path = "crates/bacnet-client" }
+bacnet-objects = { version = "0.11.0", path = "crates/bacnet-objects" }
+bacnet-server = { version = "0.11.0", path = "crates/bacnet-server" }
 thiserror = "2"
 bitflags = "2"
 bytes = "1"

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -573,7 +573,12 @@ properties.
 
 Staging uses an explicit atomic configuration; the former stage-count-only
 constructor is intentionally removed because it could not create a valid
-ladder or target mapping:
+ladder or target mapping. To migrate to 0.11.0, replace that argument with a
+`StagingConfig` containing the initial value, minimum, units, priority, at least
+two ordered stages, and local target references. Each stage's `values` must
+have one entry per target; optional `stage_names` must have one name per stage.
+Construction returns an error for invalid configuration, so preserve the
+fallible result handling:
 
 ```rust
 use bacnet_objects::staging::{StagingConfig, StagingObject};
@@ -1007,9 +1012,21 @@ request tracker remains the pending/session guard.
 `AuditLogSnapshot::completed_receipts` is part of the public custom-persistence
 snapshot contract. `FileAuditLogPersistence` writes schema v2, reads schema v1
 as an empty receipt ledger, rejects unknown future versions, and retains the
-existing two-slot generation/checksum recovery policy. Unconfirmed receipt
-never emits a response and never writes the confirmed ledger. Synchronous
-persistence under the database writer is an intentional availability
+existing two-slot generation/checksum recovery policy. When migrating a custom
+`AuditLogPersistence` implementation to 0.11.0, add `completed_receipts: Vec::new()`
+to newly constructed snapshots and when decoding an older format without
+receipts. Thereafter, `commit` must durably store the supplied receipt ledger
+and records in the same atomic snapshot, and `load` must restore both. Dropping
+or separately committing the ledger loses confirmed-request duplicate
+protection after a reopen. The built-in file backend needs no separate v1
+conversion: it writes v2 on the next successful commit.
+
+Back up both `.slot0` and `.slot1` files before the first v2 commit. A reader that
+supports only v1 cannot read v2 snapshots; rolling back to such an implementation
+requires restoring a compatible backup and loses changes made after that backup.
+
+Unconfirmed receipt never emits a response and never writes the confirmed ledger.
+Synchronous persistence under the database writer is an intentional availability
 limitation. Query authorization, sustained rate limiting, producer/report
 generation, forwarding, multi-log routing policy, failures-only filtering, and
 a wrap-safe 64-bit continuation are not provided. Executed-service bit 46


### PR DESCRIPTION
Prepare the current development changes for the v0.11.0 feedback release. Update workspace/internal dependency versions and the lockfile, date the accumulated changelog, correct superseded Python/File/Audit notes, and document the Staging and Audit snapshot migrations. External dependency versions are unchanged.

Publish the client before the server in the existing release workflow: Cargo retains the server’s versioned client dev-dependency in its normalized package, so the former order could fail packaging before the matching client reached crates.io. All nine-library dependency edges are satisfied by the corrected order; no jobs, credentials, permissions, or release targets are added.

The release remains pre-1.0 with breaking Rust/Python/CLI APIs and partial BACnet conformance. Remaining roadmap issues are not closed by this version bump.

Validation:
- Rust 1.93 published-package MSRV check passed.
- Locked offline Cargo packaging passed for all nine published libraries; normalized manifests and dependency order inspected.
- Formatting, generated conformance docs, file-size cap, no-secret scan, and whitespace checks passed.
- Existing source validation at the unchanged product-code baseline includes 4,096 workspace tests and targeted BACnet/SC/binding checks. This metadata change adds no runtime behavior or external dependency upgrade.
- Both immutable cycle1 reviews passed with no findings; repairs: 0.
- [Hosted CI34001391642](https://github.com/jscott3201/rusty-bacnet/actions/runs/34001391642) passed all five preparation gates at `3c19e67034620f26969c479257ec4a25c346b739`, including the Linux workspace suite with serde/IPv6/SC-TLS/serial/Ethernet.
- Full audit/deny/cross-platform qualification runs on the subsequent dev-to-main promotion PR before tagging; publication and artifact verification follow through the existing release pipeline.
