### PR TITLE
fix(bip): fail closed BBMD management

### DIFF
--- a/crates/bacnet-transport/src/bbmd.rs
+++ b/crates/bacnet-transport/src/bbmd.rs
@@ -106,8 +106,8 @@ pub struct BbmdState {
     fdt: Vec<FdtEntry>,
     local_ip: [u8; 4],
     local_port: u16,
-    /// Allowed source IPs for management operations (Write-BDT, Delete-FDT).
-    /// Empty = all sources allowed (legacy/default behavior).
+    /// Allowed source IPs for Delete-Foreign-Device-Table-Entry.
+    /// Empty means deny all (fail closed).
     management_acl: Vec<[u8; 4]>,
 }
 
@@ -309,14 +309,13 @@ impl BbmdState {
     // Management ACL
     // -----------------------------------------------------------------------
 
-    /// Check whether a source IP is allowed to perform management operations
-    /// (Write-BDT, Delete-FDT-Entry). Returns `true` if the ACL is empty
-    /// (all allowed) or the IP is in the ACL.
+    /// Check whether a source IP is allowed to perform Delete-FDT-Entry.
+    /// An empty ACL denies all sources (fail closed).
     pub fn is_management_allowed(&self, source_ip: &[u8; 4]) -> bool {
-        self.management_acl.is_empty() || self.management_acl.contains(source_ip)
+        self.management_acl.contains(source_ip)
     }
 
-    /// Set the management ACL. An empty list means all sources are allowed.
+    /// Set the Delete-FDT-Entry management ACL. An empty list denies all sources.
     pub fn set_management_acl(&mut self, acl: Vec<[u8; 4]>) {
         self.management_acl = acl;
     }
@@ -765,10 +764,10 @@ mod tests {
     }
 
     #[test]
-    fn management_acl_empty_allows_all() {
+    fn management_acl_empty_denies_all() {
         let bbmd = make_bbmd();
-        assert!(bbmd.is_management_allowed(&[10, 0, 0, 1]));
-        assert!(bbmd.is_management_allowed(&[192, 168, 1, 1]));
+        assert!(!bbmd.is_management_allowed(&[10, 0, 0, 1]));
+        assert!(!bbmd.is_management_allowed(&[192, 168, 1, 1]));
     }
 
     #[test]
@@ -834,11 +833,12 @@ mod tests {
     }
 
     #[test]
-    fn management_acl_clear_restores_open() {
+    fn management_acl_clear_denies_all() {
         let mut bbmd = make_bbmd();
         bbmd.set_management_acl(vec![[10, 0, 0, 1]]);
         assert!(!bbmd.is_management_allowed(&[10, 0, 0, 2]));
         bbmd.set_management_acl(Vec::new());
-        assert!(bbmd.is_management_allowed(&[10, 0, 0, 2]));
+        assert!(!bbmd.is_management_allowed(&[10, 0, 0, 2]));
+        assert!(!bbmd.is_management_allowed(&[10, 0, 0, 1]));
     }
 }

--- a/crates/bacnet-transport/src/bip/acl_tests.rs
+++ b/crates/bacnet-transport/src/bip/acl_tests.rs
@@ -1,9 +1,14 @@
 use super::*;
 
 #[tokio::test]
-async fn management_acl_allows_listed_sender_write_bdt_and_delete_fdt() {
+async fn management_acl_allows_listed_sender_delete_fdt_but_write_bdt_always_naks() {
+    let initial_bdt = BdtEntry {
+        ip: [10, 10, 0, 9],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 0],
+    };
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
-    bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_bbmd(vec![initial_bdt.clone()]);
     bbmd_transport.set_bbmd_management_acl(vec![[127, 0, 0, 1]]);
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
@@ -11,19 +16,32 @@ async fn management_acl_allows_listed_sender_write_bdt_and_delete_fdt() {
     let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     let _client_rx = client_transport.start().await.unwrap();
 
-    let bdt_entry = BdtEntry {
+    // Inbound Write-BDT always answers not-supported, even for a listed sender,
+    // and leaves BDT memory unchanged.
+    let replacement = BdtEntry {
         ip: [192, 168, 40, 10],
         port: 0xBAC0,
         broadcast_mask: [255, 255, 255, 0],
     };
     let result = client_transport
-        .write_bdt(&bbmd_mac, std::slice::from_ref(&bdt_entry))
+        .write_bdt(&bbmd_mac, std::slice::from_ref(&replacement))
         .await
         .unwrap();
-    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+    assert_eq!(
+        result,
+        BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK
+    );
     let bdt = client_transport.read_bdt(&bbmd_mac).await.unwrap();
-    assert!(bdt.iter().any(|entry| entry == &bdt_entry));
+    assert!(
+        bdt.iter().any(|entry| entry == &initial_bdt),
+        "rejected Write-BDT must preserve the prior BDT"
+    );
+    assert!(
+        !bdt.iter().any(|entry| entry == &replacement),
+        "rejected Write-BDT must not apply the replacement BDT"
+    );
 
+    // The same listed sender remains authorized for Delete-FDT-Entry.
     let result = client_transport
         .register_foreign_device_bvlc(&bbmd_mac, 60)
         .await
@@ -62,6 +80,8 @@ async fn management_acl_denies_unlisted_sender_and_preserves_bdt_and_fdt() {
     let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     let _client_rx = client_transport.start().await.unwrap();
 
+    // Write-BDT NAKs unconditionally; the BDT check below proves memory
+    // non-mutation for the unlisted sender as well.
     let replacement_bdt = [BdtEntry {
         ip: [192, 168, 40, 20],
         port: 0xBAC0,
@@ -84,6 +104,41 @@ async fn management_acl_denies_unlisted_sender_and_preserves_bdt_and_fdt() {
         !bdt.iter().any(|entry| entry == &replacement_bdt[0]),
         "denied Write-BDT must not apply the replacement BDT"
     );
+
+    let result = client_transport
+        .register_foreign_device_bvlc(&bbmd_mac, 60)
+        .await
+        .unwrap();
+    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+    let (fd_ip, fd_port) = decode_bip_mac(client_transport.local_mac()).unwrap();
+
+    let result = client_transport
+        .delete_fdt_entry(&bbmd_mac, fd_ip, fd_port)
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        BvlcResultCode::DELETE_FOREIGN_DEVICE_TABLE_ENTRY_NAK
+    );
+    let fdt = client_transport.read_fdt(&bbmd_mac).await.unwrap();
+    assert_eq!(fdt.len(), 1);
+    assert_eq!(fdt[0].ip, fd_ip);
+    assert_eq!(fdt[0].port, fd_port);
+
+    client_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn empty_management_acl_denies_delete_fdt_and_preserves_entry() {
+    // Default fail-closed policy: no ACL authorizes nobody.
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![]);
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
 
     let result = client_transport
         .register_foreign_device_bvlc(&bbmd_mac, 60)

--- a/crates/bacnet-transport/src/bip/bdt_persistence_tests.rs
+++ b/crates/bacnet-transport/src/bip/bdt_persistence_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use bytes::BytesMut;
+use tokio::time::{timeout, Duration};
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -32,14 +34,45 @@ impl Drop for TempBdtFile {
     }
 }
 
+async fn raw_bvlc_request(target: &[u8], function: BvlcFunction, payload: &[u8]) -> BvllMessage {
+    let socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let (ip, port) = decode_bip_mac(target).unwrap();
+    let dest = SocketAddrV4::new(Ipv4Addr::from(ip), port);
+
+    let mut buf = BytesMut::new();
+    encode_bvll(&mut buf, function, payload).unwrap();
+    socket.send_to(&buf, dest).await.unwrap();
+
+    let mut recv_buf = [0u8; 2048];
+    let (len, _addr) = timeout(Duration::from_secs(2), socket.recv_from(&mut recv_buf))
+        .await
+        .expect("timed out waiting for BVLC response")
+        .unwrap();
+    decode_bvll(&recv_buf[..len]).unwrap()
+}
+
 #[tokio::test]
-async fn write_bdt_persists_wire_format_and_restart_loads_it() {
+async fn seeded_persisted_bdt_loads_on_startup_and_network_write_bdt_mutates_neither_memory_nor_disk(
+) {
     let persist = TempBdtFile::new("bdt-restart");
     let fallback_entry = BdtEntry {
         ip: [10, 20, 30, 40],
         port: 0xBAC0,
         broadcast_mask: [255, 255, 255, 0],
     };
+    let seeded_entry = BdtEntry {
+        ip: [192, 0, 2, 44],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 0],
+    };
+
+    // Seed a valid wire-format BDT file directly; network Write-BDT no longer
+    // creates or updates this file.
+    let mut seed_buf = BytesMut::new();
+    bbmd::encode_bdt_entries(std::slice::from_ref(&seeded_entry), &mut seed_buf);
+    fs::write(persist.path(), &seed_buf).unwrap();
 
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![fallback_entry.clone()]);
@@ -51,30 +84,73 @@ async fn write_bdt_persists_wire_format_and_restart_loads_it() {
     let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     let _client_rx = client_transport.start().await.unwrap();
 
-    let persisted_entry = BdtEntry {
-        ip: [192, 0, 2, 44],
+    // Startup prefers the seeded file over the configured fallback.
+    let startup_bdt = client_transport.read_bdt(&bbmd_mac).await.unwrap();
+    assert!(
+        startup_bdt.iter().any(|entry| entry == &seeded_entry),
+        "restart must load the seeded BDT entry"
+    );
+    assert!(
+        !startup_bdt.iter().any(|entry| entry == &fallback_entry),
+        "restart must prefer valid persisted BDT data over configured fallback"
+    );
+    let file_before = fs::read(persist.path()).unwrap();
+
+    // Valid inbound Write-BDT NAKs and mutates neither memory nor disk.
+    let replacement = BdtEntry {
+        ip: [203, 0, 113, 7],
         port: 0xBAC0,
         broadcast_mask: [255, 255, 255, 0],
     };
     let result = client_transport
-        .write_bdt(&bbmd_mac, std::slice::from_ref(&persisted_entry))
+        .write_bdt(&bbmd_mac, std::slice::from_ref(&replacement))
         .await
         .unwrap();
-    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
-
-    let persisted_bytes = fs::read(persist.path()).unwrap();
-    let persisted_bdt = BbmdState::decode_bdt(&persisted_bytes).unwrap();
+    assert_eq!(
+        result,
+        BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK
+    );
+    let bdt = client_transport.read_bdt(&bbmd_mac).await.unwrap();
     assert!(
-        persisted_bdt.iter().any(|entry| entry == &persisted_entry),
-        "persisted BDT must contain the successful Write-BDT entry"
+        bdt.iter().any(|entry| entry == &seeded_entry),
+        "rejected Write-BDT must preserve seeded BDT memory"
     );
     assert!(
-        !persisted_bdt.iter().any(|entry| entry == &fallback_entry),
-        "persisted BDT must reflect the replacement table, not the startup fallback"
+        !bdt.iter().any(|entry| entry == &replacement),
+        "rejected Write-BDT must not apply the replacement entry"
+    );
+    assert_eq!(
+        fs::read(persist.path()).unwrap(),
+        file_before,
+        "rejected valid Write-BDT must not change the persisted file"
+    );
+
+    // Malformed inbound Write-BDT NAKs and likewise changes nothing.
+    let response = raw_bvlc_request(
+        &bbmd_mac,
+        BvlcFunction::WRITE_BROADCAST_DISTRIBUTION_TABLE,
+        &[0; bbmd::BDT_ENTRY_SIZE - 1],
+    )
+    .await;
+    assert_eq!(
+        decode_bvlc_result_code(&response).unwrap(),
+        BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK
+    );
+    let bdt = client_transport.read_bdt(&bbmd_mac).await.unwrap();
+    assert!(
+        bdt.iter().any(|entry| entry == &seeded_entry),
+        "malformed Write-BDT must preserve seeded BDT memory"
+    );
+    assert_eq!(
+        fs::read(persist.path()).unwrap(),
+        file_before,
+        "malformed Write-BDT must not change the persisted file"
     );
 
     bbmd_transport.stop().await.unwrap();
 
+    // Restart still loads the seeded file, proving the rejected writes did not
+    // mutate the persisted state.
     let mut restarted_bbmd = BipTransport::new(Ipv4Addr::LOCALHOST, bbmd_port, Ipv4Addr::BROADCAST);
     restarted_bbmd.enable_bbmd(vec![fallback_entry.clone()]);
     restarted_bbmd.set_bdt_persist_path(persist.path().to_path_buf());
@@ -83,12 +159,12 @@ async fn write_bdt_persists_wire_format_and_restart_loads_it() {
 
     let restarted_bdt = client_transport.read_bdt(&bbmd_mac).await.unwrap();
     assert!(
-        restarted_bdt.iter().any(|entry| entry == &persisted_entry),
-        "restart must load the persisted BDT entry"
+        restarted_bdt.iter().any(|entry| entry == &seeded_entry),
+        "restart must still load the seeded BDT entry"
     );
     assert!(
-        !restarted_bdt.iter().any(|entry| entry == &fallback_entry),
-        "restart must prefer valid persisted BDT data over configured fallback"
+        !restarted_bdt.iter().any(|entry| entry == &replacement),
+        "restart must not contain the rejected replacement entry"
     );
 
     client_transport.stop().await.unwrap();

--- a/crates/bacnet-transport/src/bip/dbtn_tests.rs
+++ b/crates/bacnet-transport/src/bip/dbtn_tests.rs
@@ -72,7 +72,6 @@ async fn dbtn_registered_foreign_device_fans_out_without_origin_echo() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        bdt_persist_path: None,
         force_dbtn_forward_failure: false,
     };
     let sender = (Ipv4Addr::LOCALHOST.octets(), origin_fd_port);
@@ -146,7 +145,6 @@ async fn dbtn_registered_foreign_device_naks_when_forwarding_fails() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        bdt_persist_path: None,
         force_dbtn_forward_failure: true,
     };
     let sender = (Ipv4Addr::LOCALHOST.octets(), origin_fd_port);

--- a/crates/bacnet-transport/src/bip/forwarded_tests.rs
+++ b/crates/bacnet-transport/src/bip/forwarded_tests.rs
@@ -64,7 +64,6 @@ async fn forwarded_npdu_from_bdt_peer_uses_originating_source_mac() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        bdt_persist_path: None,
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {
@@ -150,7 +149,6 @@ async fn forwarded_npdu_from_non_bdt_sender_is_rejected_without_delivery() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        bdt_persist_path: None,
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {
@@ -225,7 +223,6 @@ async fn forwarded_npdu_from_directed_broadcast_peer_skips_local_rebroadcast() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        bdt_persist_path: None,
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -78,7 +78,6 @@ pub(super) struct RecvContext {
     pub(super) broadcast_addr: Ipv4Addr,
     pub(super) broadcast_port: u16,
     pub(super) pending_bvlc_response: Arc<Mutex<Option<PendingBvlcResponse>>>,
-    pub(super) bdt_persist_path: Option<std::path::PathBuf>,
     #[cfg(test)]
     pub(super) force_dbtn_forward_failure: bool,
 }
@@ -379,77 +378,14 @@ pub(super) async fn handle_bvll_message(
         }
 
         f if f == BvlcFunction::WRITE_BROADCAST_DISTRIBUTION_TABLE => {
-            if let Some(bbmd) = &ctx.bbmd {
-                // Check management ACL before accepting Write-BDT
-                let allowed = {
-                    let state = bbmd.lock().await;
-                    state.is_management_allowed(&sender.0)
-                };
-                if !allowed {
-                    debug!(
-                        "Rejecting Write-BDT from non-ACL sender {:?}:{}",
-                        Ipv4Addr::from(sender.0),
-                        sender.1
-                    );
-                    send_bvlc_result(
-                        &ctx.socket,
-                        sender,
-                        BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK,
-                    )
-                    .await;
-                } else {
-                    match BbmdState::decode_bdt(&msg.payload) {
-                        Ok(entries) => {
-                            let mut state = bbmd.lock().await;
-                            match state.set_bdt(entries) {
-                                Ok(()) => {
-                                    // Persist BDT to disk if configured
-                                    if let Some(ref path) = ctx.bdt_persist_path {
-                                        let mut buf = BytesMut::new();
-                                        state.encode_bdt(&mut buf);
-                                        if let Err(e) = std::fs::write(path, &buf) {
-                                            warn!(
-                                                error = %e,
-                                                path = %path.display(),
-                                                "Failed to persist BDT"
-                                            );
-                                        }
-                                    }
-                                    send_bvlc_result(
-                                        &ctx.socket,
-                                        sender,
-                                        BvlcResultCode::SUCCESSFUL_COMPLETION,
-                                    )
-                                    .await;
-                                }
-                                Err(_) => {
-                                    send_bvlc_result(
-                                        &ctx.socket,
-                                        sender,
-                                        BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK,
-                                    )
-                                    .await;
-                                }
-                            }
-                        }
-                        Err(_) => {
-                            send_bvlc_result(
-                                &ctx.socket,
-                                sender,
-                                BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK,
-                            )
-                            .await;
-                        }
-                    }
-                }
-            } else {
-                send_bvlc_result(
-                    &ctx.socket,
-                    sender,
-                    BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK,
-                )
-                .await;
-            }
+            // Annex J.4.4.2 requires receivers to answer Write-BDT with the
+            // not-supported result. No decoding, state change, or persistence.
+            send_bvlc_result(
+                &ctx.socket,
+                sender,
+                BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK,
+            )
+            .await;
         }
 
         f if f == BvlcFunction::READ_FOREIGN_DEVICE_TABLE => {

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -135,7 +135,9 @@ pub struct BipTransport {
     registration_task: Option<JoinHandle<()>>,
     /// Pending BVLC management response, including the expected sender and response kind.
     pending_bvlc_response: Arc<Mutex<Option<PendingBvlcResponse>>>,
-    /// Optional path for persisting the BDT across restarts.
+    /// Optional path for loading an externally provisioned persisted BDT
+    /// (wire format, 10 bytes per entry) at startup. Inbound Write-BDT does
+    /// not update this file.
     bdt_persist_path: Option<std::path::PathBuf>,
 }
 
@@ -172,15 +174,17 @@ impl BipTransport {
         });
     }
 
-    /// Set the path for persisting the BDT across restarts.
-    /// Must be called before `start()`. The BDT is stored using the wire encoding
-    /// (10 bytes per entry) — no additional serialization dependencies needed.
+    /// Set the path for loading an externally provisioned persisted BDT
+    /// (wire format, 10 bytes per entry) at startup.
+    /// Must be called before `start()`. Inbound Write-BDT does not update
+    /// this file — no additional serialization dependencies needed.
     pub fn set_bdt_persist_path(&mut self, path: std::path::PathBuf) {
         self.bdt_persist_path = Some(path);
     }
 
-    /// Set the management ACL for BBMD mode.
+    /// Set the management ACL for BBMD Delete-FDT-Entry.
     /// Must be called after `enable_bbmd()` and before `start()`.
+    /// An empty ACL denies all Delete-FDT-Entry senders (fail closed).
     pub fn set_bbmd_management_acl(&mut self, acl: Vec<[u8; 4]>) {
         if let Some(config) = &mut self.bbmd_config {
             config.management_acl = acl;
@@ -315,6 +319,9 @@ impl BipTransport {
     }
 
     /// Send Write-Broadcast-Distribution-Table and return the result code.
+    ///
+    /// Outbound client helper only. A conforming 135-2020 receiver answers
+    /// with the not-supported result and leaves its table unchanged.
     pub async fn write_bdt(
         &self,
         target: &[u8],
@@ -514,7 +521,6 @@ impl TransportPort for BipTransport {
             broadcast_addr: self.broadcast_address,
             broadcast_port: self.port,
             pending_bvlc_response: self.pending_bvlc_response.clone(),
-            bdt_persist_path: self.bdt_persist_path.clone(),
             #[cfg(test)]
             force_dbtn_forward_failure: false,
         };

--- a/crates/bacnet-transport/src/bip/original_tests.rs
+++ b/crates/bacnet-transport/src/bip/original_tests.rs
@@ -140,7 +140,6 @@ async fn original_unicast_npdu_uses_udp_sender_source_mac_and_ignores_self() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        bdt_persist_path: None,
         force_dbtn_forward_failure: false,
     };
     let sender = ([192, 0, 2, 30], 0xBAC0);
@@ -216,7 +215,6 @@ async fn original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        bdt_persist_path: None,
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {

--- a/crates/bacnet-transport/src/bip/tests.rs
+++ b/crates/bacnet-transport/src/bip/tests.rs
@@ -117,7 +117,6 @@ async fn pending_bvlc_response_requires_sender_and_expected_function() {
         broadcast_addr: Ipv4Addr::BROADCAST,
         broadcast_port: 47808,
         pending_bvlc_response: pending_bvlc_response.clone(),
-        bdt_persist_path: None,
         force_dbtn_forward_failure: false,
     };
 
@@ -322,7 +321,7 @@ async fn read_fdt_from_non_bbmd_surfaces_typed_nak() {
 }
 
 #[tokio::test]
-async fn write_bdt_to_bbmd() {
+async fn write_bdt_to_bbmd_always_naks_and_preserves_table() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     let old_bdt_entry = BdtEntry {
         ip: [10, 0, 0, 1],
@@ -330,6 +329,8 @@ async fn write_bdt_to_bbmd() {
         broadcast_mask: [255, 255, 255, 0],
     };
     bbmd_transport.enable_bbmd(vec![old_bdt_entry.clone()]);
+    // Even an explicitly listed sender must observe the not-supported result.
+    bbmd_transport.set_bbmd_management_acl(vec![[127, 0, 0, 1]]);
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -345,16 +346,21 @@ async fn write_bdt_to_bbmd() {
         .write_bdt(&bbmd_mac, &new_bdt)
         .await
         .unwrap();
-    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+    assert_eq!(
+        result,
+        BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK
+    );
 
-    // Verify by reading back — includes written entry plus auto-inserted self
+    // Verify memory is unchanged: prior entry remains, replacement absent.
     let bdt = client_transport.read_bdt(&bbmd_mac).await.unwrap();
-    assert!(bdt
-        .iter()
-        .any(|e| e.ip == [192, 168, 1, 1] && e.port == 0xBAC0));
     assert!(
-        !bdt.iter().any(|e| e == &old_bdt_entry),
-        "Write-BDT must replace the prior configured BDT entries"
+        bdt.iter().any(|e| e == &old_bdt_entry),
+        "rejected Write-BDT must preserve the prior BDT"
+    );
+    assert!(
+        !bdt.iter()
+            .any(|e| e.ip == [192, 168, 1, 1] && e.port == 0xBAC0),
+        "rejected Write-BDT must not apply the replacement entry"
     );
 
     client_transport.stop().await.unwrap();
@@ -408,6 +414,18 @@ async fn write_bdt_to_non_bbmd_surfaces_typed_nak() {
     let result = client_transport.write_bdt(&server_mac, &[]).await.unwrap();
     assert_eq!(
         result,
+        BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK
+    );
+
+    // A malformed payload to a non-BBMD answers the same not-supported result.
+    let response = raw_bvlc_request(
+        &server_mac,
+        BvlcFunction::WRITE_BROADCAST_DISTRIBUTION_TABLE,
+        &[0; bbmd::BDT_ENTRY_SIZE - 1],
+    )
+    .await;
+    assert_eq!(
+        decode_bvlc_result_code(&response).unwrap(),
         BvlcResultCode::WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK
     );
 
@@ -556,6 +574,7 @@ async fn delete_fdt_entry_to_non_bbmd_surfaces_typed_nak() {
 async fn delete_fdt_entry_removes_registered_foreign_device() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.set_bbmd_management_acl(vec![[127, 0, 0, 1]]);
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -586,6 +605,7 @@ async fn delete_fdt_entry_removes_registered_foreign_device() {
 async fn delete_fdt_entry_rejects_malformed_payload_and_preserves_entry() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.set_bbmd_management_acl(vec![[127, 0, 0, 1]]);
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 


### PR DESCRIPTION
Refs #529

## Summary
- always return the Write-BDT not-supported BVLC result on inbound B/IP, without decoding, mutating the BDT, or touching the startup BDT file
- make an empty Delete-FDT management ACL deny all while preserving explicitly listed source-IP behavior
- retain the outbound `write_bdt` helper and startup loading of an externally provisioned wire-format BDT

## Source contract
- ANSI/ASHRAE 135-2020 Annex J.4.4.2: receivers answer Write-BDT with the not-supported result
- default-deny Delete-FDT is repository security policy, not a normative claim

References are intentionally lean because the source is licensed; no Standard text is reproduced here.

## Behavior and compatibility
- legacy peers that remotely configured this BBMD through Write-BDT now receive `WRITE_BROADCAST_DISTRIBUTION_TABLE_NAK`
- deployments that need Delete-FDT must configure a non-empty management ACL
- Read-BDT, Read-FDT, foreign registration, forwarding, and the outbound Write-BDT client API are unchanged

## Red / green evidence
- RED: `cargo test -p bacnet-transport --locked red_probe_ -- --nocapture` failed both probes on the baseline: allowed Write-BDT returned success and empty-ACL Delete-FDT returned success
- GREEN: `cargo test -p bacnet-transport --locked` passed 395 unit and 2 integration tests; one doctest remains intentionally ignored

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

All passed locally. Hosted Linux feature CI passed on run 34049723935.

## Scope limits
This is the first #529 slice. It does not select BDT address/mask validation or dedup policy, add rate limits or counters, introduce a Network Port configuration path, or include #528/#530/#531 work. The issue remains open for those follow-ups.

## Exact-head review gate
- cycle 1 base: `c9f36c48baa0444ce8c1c6f7889424a1630f2ca5`
- cycle 1 head: `7b2836aab8f2860ecc4e1624a3f250f9b772a8cc`
- architecture review: PASS
- runtime/verification review: PASS
- dataflow/integration/recovery review: PASS
- confirmed findings: none; repairs: 0
- required hosted CI: PASS ([run 34049723935](https://github.com/jscott3201/rusty-bacnet/actions/runs/34049723935))