### PR TITLE
fix(bip): validate BDT configuration

### DIFF
--- a/crates/bacnet-transport/src/bbmd.rs
+++ b/crates/bacnet-transport/src/bbmd.rs
@@ -3,6 +3,7 @@
 //! Manages the Broadcast Distribution Table (BDT) and Foreign Device Table
 //! (FDT) per ASHRAE 135-2020 Annex J. Pure state/logic — no async or I/O.
 
+use std::collections::{hash_map::Entry, HashMap};
 use std::time::{Duration, Instant};
 
 use bacnet_types::enums::BvlcResultCode;
@@ -47,6 +48,49 @@ impl FdtEntry {
         let elapsed = self.registered_at.elapsed().as_secs();
         let total = self.ttl as u64 + Self::GRACE_PERIOD;
         total.saturating_sub(elapsed).min(u16::MAX as u64) as u16
+    }
+}
+
+/// Prefix length of a contiguous IPv4 netmask, or `None` when non-contiguous.
+fn bdt_mask_prefix_len(mask: [u8; 4]) -> Option<u32> {
+    let m = u32::from_be_bytes(mask);
+    let inv = !m;
+    (inv & inv.wrapping_add(1) == 0).then_some(m.count_ones())
+}
+
+fn bdt_invalid(e: &BdtEntry, reason: &str) -> Error {
+    Error::Encoding(format!("BDT {reason}: {e:?}"))
+}
+
+/// Validate one BDT candidate entry against the issue #529 security policy.
+fn validate_bdt_entry(e: &BdtEntry) -> Result<(), Error> {
+    let mask = u32::from_be_bytes(e.broadcast_mask);
+    let ip = u32::from_be_bytes(e.ip);
+    let host = !mask;
+    let prefix = bdt_mask_prefix_len(e.broadcast_mask).unwrap_or(33);
+    let reason = if e.port == 0 {
+        "invalid port 0"
+    } else if e.ip == [0, 0, 0, 0] {
+        "unspecified IP"
+    } else if e.ip == [255, 255, 255, 255] {
+        "limited-broadcast"
+    } else if (224..=239).contains(&e.ip[0]) {
+        "multicast IP"
+    } else if prefix == 33 {
+        "non-contiguous mask"
+    } else if prefix < 32 && ip & host == 0 {
+        "subnet network address"
+    } else if prefix < 32 && ip | mask == u32::MAX {
+        "subnet directed-broadcast"
+    } else if ip | host == u32::MAX {
+        "limited-broadcast target"
+    } else {
+        ""
+    };
+    if reason.is_empty() {
+        Ok(())
+    } else {
+        Err(bdt_invalid(e, reason))
     }
 }
 
@@ -132,21 +176,42 @@ impl BbmdState {
 
     /// Replace the entire BDT.
     ///
-    /// Returns an error if the number of entries exceeds `MAX_BDT_ENTRIES`.
+    /// Central commit choke point for issue #529: validates and canonicalizes
+    /// the complete candidate before changing `self.bdt`. Byte-identical
+    /// duplicates collapse in stable first-seen order; the same `(ip, port)`
+    /// with different masks rejects the whole candidate. The local BBMD is
+    /// auto-inserted as `/32` when absent. Any invalid, conflicting, or
+    /// over-capacity candidate returns `Error::Encoding` and preserves the
+    /// previously committed table exactly.
     pub fn set_bdt(&mut self, entries: Vec<BdtEntry>) -> Result<(), Error> {
-        let needs_self = !entries
+        let cap = entries.len().min(Self::MAX_BDT_ENTRIES);
+        let mut seen: HashMap<([u8; 4], u16), [u8; 4]> = HashMap::with_capacity(cap);
+        let mut canonical: Vec<BdtEntry> = Vec::with_capacity(cap);
+        for entry in entries {
+            validate_bdt_entry(&entry)?;
+            match seen.entry((entry.ip, entry.port)) {
+                Entry::Occupied(o) => {
+                    if *o.get() != entry.broadcast_mask {
+                        return Err(bdt_invalid(&entry, "conflicting masks"));
+                    }
+                }
+                Entry::Vacant(v) => {
+                    v.insert(entry.broadcast_mask);
+                    canonical.push(entry);
+                }
+            }
+        }
+        let has_self = canonical
             .iter()
             .any(|e| e.ip == self.local_ip && e.port == self.local_port);
-        let effective_len = entries.len() + usize::from(needs_self);
-
+        let effective_len = canonical.len() + usize::from(!has_self);
         if effective_len > Self::MAX_BDT_ENTRIES {
             return Err(Error::Encoding(format!(
-                "BDT size {} exceeds maximum of {} after self-entry insertion",
-                effective_len,
+                "BDT size {effective_len} exceeds maximum of {} after self-entry insertion",
                 Self::MAX_BDT_ENTRIES
             )));
         }
-        self.bdt = entries;
+        self.bdt = canonical;
         self.ensure_self_in_bdt();
         Ok(())
     }
@@ -384,6 +449,9 @@ impl BbmdState {
         targets
     }
 }
+
+#[cfg(test)]
+mod validation_tests;
 
 #[cfg(test)]
 mod tests {
@@ -692,52 +760,6 @@ mod tests {
             !bbmd.fdt().is_empty(),
             "should still be alive during grace period"
         );
-    }
-
-    #[test]
-    fn is_bdt_peer_check() {
-        let mut bbmd = make_bbmd();
-        bbmd.set_bdt(vec![BdtEntry {
-            ip: [10, 0, 0, 1],
-            port: 0xBAC0,
-            broadcast_mask: [255, 255, 255, 255],
-        }])
-        .unwrap();
-        assert!(bbmd.is_bdt_peer([10, 0, 0, 1], 0xBAC0));
-        assert!(!bbmd.is_bdt_peer([10, 0, 0, 2], 0xBAC0));
-    }
-
-    #[test]
-    fn forwarded_npdu_needs_local_broadcast_for_unicast_peer() {
-        let mut bbmd = make_bbmd();
-        bbmd.set_bdt(vec![BdtEntry {
-            ip: [10, 0, 0, 1],
-            port: 0xBAC0,
-            broadcast_mask: [255, 255, 255, 255],
-        }])
-        .unwrap();
-
-        assert!(bbmd.forwarded_npdu_needs_local_broadcast([10, 0, 0, 1], 0xBAC0));
-    }
-
-    #[test]
-    fn forwarded_npdu_skips_local_broadcast_for_directed_broadcast_peer() {
-        let mut bbmd = make_bbmd();
-        bbmd.set_bdt(vec![BdtEntry {
-            ip: [10, 0, 0, 1],
-            port: 0xBAC0,
-            broadcast_mask: [255, 255, 255, 0],
-        }])
-        .unwrap();
-
-        assert!(!bbmd.forwarded_npdu_needs_local_broadcast([10, 0, 0, 1], 0xBAC0));
-    }
-
-    #[test]
-    fn forwarded_npdu_skips_local_broadcast_for_unknown_peer() {
-        let bbmd = make_bbmd();
-
-        assert!(!bbmd.forwarded_npdu_needs_local_broadcast([10, 0, 0, 1], 0xBAC0));
     }
 
     #[test]

--- a/crates/bacnet-transport/src/bbmd/validation_tests.rs
+++ b/crates/bacnet-transport/src/bbmd/validation_tests.rs
@@ -1,0 +1,294 @@
+//! BDT validation regression tests for issue #529 (owner security policy).
+//!
+//! Exercises `BbmdState::set_bdt` as the central commit choke point:
+//! invalid or conflicting candidates must fail transactionally with an
+//! `Error::Encoding`-style error and preserve the committed table.
+
+use super::{BbmdState, BdtEntry};
+use bacnet_types::error::Error;
+
+const PORT: u16 = 0xBAC0;
+const MASK_32: [u8; 4] = [255, 255, 255, 255];
+const MASK_24: [u8; 4] = [255, 255, 255, 0];
+
+fn make_bbmd() -> BbmdState {
+    BbmdState::new([192, 168, 1, 1], PORT)
+}
+
+fn entry(ip: [u8; 4], port: u16, mask: [u8; 4]) -> BdtEntry {
+    BdtEntry {
+        ip,
+        port,
+        broadcast_mask: mask,
+    }
+}
+
+fn err_text(err: Error) -> String {
+    format!("{err}")
+}
+
+fn assert_encoding_error(err: Error, fragment: &str) -> String {
+    assert!(
+        matches!(err, Error::Encoding(_)),
+        "expected Error::Encoding, got: {err:?}"
+    );
+    let text = err_text(err);
+    assert!(
+        text.to_lowercase().contains(fragment),
+        "error text {text:?} must mention {fragment:?}"
+    );
+    text
+}
+
+#[test]
+fn rejects_zero_port_and_preserves_table() {
+    let mut bbmd = make_bbmd();
+    let committed = entry([10, 0, 0, 5], PORT, MASK_32);
+    bbmd.set_bdt(vec![committed.clone()]).unwrap();
+    let before = bbmd.bdt().to_vec();
+
+    let err = bbmd
+        .set_bdt(vec![entry([10, 0, 0, 6], 0, MASK_32)])
+        .unwrap_err();
+    assert_encoding_error(err, "port");
+    assert_eq!(bbmd.bdt(), before.as_slice());
+}
+
+#[test]
+fn rejects_unspecified_ip() {
+    let mut bbmd = make_bbmd();
+    let err = bbmd
+        .set_bdt(vec![entry([0, 0, 0, 0], PORT, MASK_32)])
+        .unwrap_err();
+    assert_encoding_error(err, "unspecified");
+    assert!(bbmd.bdt().is_empty());
+}
+
+#[test]
+fn rejects_multicast_ip() {
+    let mut bbmd = make_bbmd();
+    for ip in [[224, 0, 0, 1], [239, 255, 255, 250]] {
+        let err = bbmd.set_bdt(vec![entry(ip, PORT, MASK_32)]).unwrap_err();
+        assert_encoding_error(err, "multicast");
+        assert!(bbmd.bdt().is_empty(), "multicast {ip:?} must not commit");
+    }
+}
+
+#[test]
+fn rejects_limited_broadcast_ip() {
+    let mut bbmd = make_bbmd();
+    let err = bbmd
+        .set_bdt(vec![entry([255, 255, 255, 255], PORT, MASK_32)])
+        .unwrap_err();
+    assert_encoding_error(err, "limited");
+    assert!(bbmd.bdt().is_empty());
+}
+
+#[test]
+fn rejects_non_contiguous_mask() {
+    let mut bbmd = make_bbmd();
+    let err = bbmd
+        .set_bdt(vec![entry([10, 0, 0, 5], PORT, [255, 0, 255, 0])])
+        .unwrap_err();
+    assert_encoding_error(err, "contiguous");
+    assert!(bbmd.bdt().is_empty());
+}
+
+#[test]
+fn rejects_subnet_network_address() {
+    let mut bbmd = make_bbmd();
+    // 192.168.1.0/24 has all host bits zero.
+    let err = bbmd
+        .set_bdt(vec![entry([192, 168, 1, 0], PORT, MASK_24)])
+        .unwrap_err();
+    let text = assert_encoding_error(err, "network address");
+    assert!(
+        text.contains("192.168.1.0") || text.contains("network"),
+        "{text:?}"
+    );
+    assert!(bbmd.bdt().is_empty());
+}
+
+#[test]
+fn rejects_subnet_broadcast_address() {
+    let mut bbmd = make_bbmd();
+    // 192.168.1.255/24 has all host bits one.
+    let err = bbmd
+        .set_bdt(vec![entry([192, 168, 1, 255], PORT, MASK_24)])
+        .unwrap_err();
+    assert_encoding_error(err, "broadcast");
+    assert!(bbmd.bdt().is_empty());
+}
+
+#[test]
+fn rejects_slash_zero_derived_limited_broadcast() {
+    let mut bbmd = make_bbmd();
+    // /0 derives 255.255.255.255 for any peer IP and is unsafe.
+    let err = bbmd
+        .set_bdt(vec![entry([10, 0, 0, 5], PORT, [0, 0, 0, 0])])
+        .unwrap_err();
+    assert_encoding_error(err, "limited");
+    assert!(bbmd.bdt().is_empty());
+}
+
+#[test]
+fn rejects_same_endpoint_different_mask_conflict_and_preserves_table() {
+    let mut bbmd = make_bbmd();
+    let committed = entry([10, 0, 0, 5], PORT, MASK_32);
+    bbmd.set_bdt(vec![committed.clone()]).unwrap();
+    let before = bbmd.bdt().to_vec();
+
+    let conflicting = vec![
+        entry([10, 0, 0, 9], PORT, MASK_32),
+        entry([10, 0, 0, 9], PORT, MASK_24),
+    ];
+    let err = bbmd.set_bdt(conflicting).unwrap_err();
+    assert_encoding_error(err, "conflict");
+    assert_eq!(
+        bbmd.bdt(),
+        before.as_slice(),
+        "conflicting candidate must preserve the committed table"
+    );
+}
+
+#[test]
+fn exact_duplicates_collapse_stably_without_duplicate_targets() {
+    let mut bbmd = make_bbmd();
+    let first = entry([10, 0, 0, 5], PORT, MASK_32);
+    let second = entry([10, 0, 0, 6], PORT, MASK_32);
+    bbmd.set_bdt(vec![
+        first.clone(),
+        second.clone(),
+        first.clone(),
+        second.clone(),
+        first.clone(),
+    ])
+    .unwrap();
+    // Stable first-seen order plus the auto-inserted self entry.
+    assert_eq!(
+        bbmd.bdt().len(),
+        3,
+        "duplicates must collapse: {0:?}",
+        bbmd.bdt()
+    );
+    assert_eq!(bbmd.bdt()[0], first);
+    assert_eq!(bbmd.bdt()[1], second);
+
+    // Forwarding must not contain duplicate targets either.
+    let targets = bbmd.forwarding_targets([192, 168, 1, 200], PORT);
+    assert_eq!(targets.len(), 2);
+    assert!(targets.contains(&([10, 0, 0, 5], PORT)));
+    assert!(targets.contains(&([10, 0, 0, 6], PORT)));
+}
+
+#[test]
+fn duplicates_reduce_before_capacity_accounting() {
+    let mut bbmd = make_bbmd();
+    // Build MAX distinct peers would need self; instead build MAX-1 distinct
+    // peers and repeat them so the raw candidate exceeds MAX but the
+    // canonicalized table (plus self) still fits.
+    let mut distinct = Vec::new();
+    for i in 0..(BbmdState::MAX_BDT_ENTRIES - 1) {
+        // Avoid .0/.255 host endpoints and 0.0.0.0/multicast: use 10.x.y.z
+        // with nonzero host octets. i < 127 here so third octet stays 0 and
+        // last octet is 1..=127.
+        let last = (i + 1) as u8;
+        distinct.push(entry([10, 1, 0, last], PORT, MASK_32));
+    }
+    assert_eq!(distinct.len(), BbmdState::MAX_BDT_ENTRIES - 1);
+    let mut raw = distinct.clone();
+    raw.extend(distinct.iter().cloned());
+    assert!(raw.len() > BbmdState::MAX_BDT_ENTRIES);
+    bbmd.set_bdt(raw).unwrap();
+    assert_eq!(bbmd.bdt().len(), BbmdState::MAX_BDT_ENTRIES);
+}
+
+#[test]
+fn same_ip_different_port_remains_distinct() {
+    let mut bbmd = make_bbmd();
+    bbmd.set_bdt(vec![
+        entry([10, 0, 0, 5], PORT, MASK_32),
+        entry([10, 0, 0, 5], PORT + 1, MASK_32),
+    ])
+    .unwrap();
+    // Two distinct peers plus self.
+    assert_eq!(bbmd.bdt().len(), 3);
+    assert!(bbmd.is_bdt_peer([10, 0, 0, 5], PORT));
+    assert!(bbmd.is_bdt_peer([10, 0, 0, 5], PORT + 1));
+}
+
+#[test]
+fn allows_unicast_slash32_and_ordinary_slash24_peers() {
+    let mut bbmd = make_bbmd();
+    let unicast = entry([10, 0, 0, 5], PORT, MASK_32);
+    let subnet_peer = entry([192, 168, 2, 10], PORT, MASK_24);
+    let loopback_peer = entry([127, 0, 0, 2], PORT, MASK_32);
+    let link_local = entry([169, 254, 10, 20], PORT, MASK_32);
+    let documentation = entry([192, 0, 2, 44], PORT, MASK_24);
+    bbmd.set_bdt(vec![
+        unicast.clone(),
+        subnet_peer.clone(),
+        loopback_peer.clone(),
+        link_local.clone(),
+        documentation.clone(),
+    ])
+    .unwrap();
+    for wanted in [
+        &unicast,
+        &subnet_peer,
+        &loopback_peer,
+        &link_local,
+        &documentation,
+    ] {
+        assert!(
+            bbmd.bdt().contains(wanted),
+            "allowed peer missing: {wanted:?}"
+        );
+    }
+}
+
+#[test]
+fn distinct_peers_sharing_forwarding_destination_are_not_deduplicated() {
+    let mut bbmd = make_bbmd();
+    // Both derive 192.168.7.255 via /24 but are distinct configured peers.
+    let first = entry([192, 168, 7, 10], PORT, MASK_24);
+    let second = entry([192, 168, 7, 20], PORT, MASK_24);
+    bbmd.set_bdt(vec![first.clone(), second.clone()]).unwrap();
+    assert!(bbmd.bdt().contains(&first));
+    assert!(bbmd.bdt().contains(&second));
+    assert_eq!(bbmd.bdt().len(), 3, "both peers plus self must be stored");
+}
+
+// Relocated from `bbmd.rs` inline tests to keep that file under the 700 LOC
+// cap while preserving behavior. These peer-lookup tests use only valid
+// entries and must keep passing under the new validation policy.
+#[test]
+fn relocated_is_bdt_peer_check() {
+    let mut bbmd = make_bbmd();
+    bbmd.set_bdt(vec![entry([10, 0, 0, 1], PORT, MASK_32)])
+        .unwrap();
+    assert!(bbmd.is_bdt_peer([10, 0, 0, 1], PORT));
+    assert!(!bbmd.is_bdt_peer([10, 0, 0, 2], PORT));
+}
+
+#[test]
+fn relocated_forwarded_npdu_needs_local_broadcast_for_unicast_peer() {
+    let mut bbmd = make_bbmd();
+    bbmd.set_bdt(vec![entry([10, 0, 0, 1], PORT, MASK_32)])
+        .unwrap();
+    assert!(bbmd.forwarded_npdu_needs_local_broadcast([10, 0, 0, 1], PORT));
+}
+
+#[test]
+fn relocated_forwarded_npdu_skips_local_broadcast_for_directed_peer() {
+    let mut bbmd = make_bbmd();
+    bbmd.set_bdt(vec![entry([10, 0, 0, 1], PORT, MASK_24)])
+        .unwrap();
+    assert!(!bbmd.forwarded_npdu_needs_local_broadcast([10, 0, 0, 1], PORT));
+}
+
+#[test]
+fn relocated_forwarded_npdu_skips_local_broadcast_for_unknown_peer() {
+    let bbmd = make_bbmd();
+    assert!(!bbmd.forwarded_npdu_needs_local_broadcast([10, 0, 0, 1], PORT));
+}

--- a/crates/bacnet-transport/src/bip/bdt_persistence_tests.rs
+++ b/crates/bacnet-transport/src/bip/bdt_persistence_tests.rs
@@ -199,3 +199,112 @@ async fn invalid_persisted_bdt_falls_back_to_configured_bdt() {
     client_transport.stop().await.unwrap();
     bbmd_transport.stop().await.unwrap();
 }
+
+#[tokio::test]
+async fn semantically_invalid_persisted_bdt_falls_back_to_configured_bdt() {
+    let persist = TempBdtFile::new("bdt-semantic-invalid");
+    // Structurally valid wire format (one 10-byte entry) but semantically
+    // invalid: UDP port 0 must be rejected before commit.
+    let invalid_entry = BdtEntry {
+        ip: [192, 0, 2, 44],
+        port: 0,
+        broadcast_mask: [255, 255, 255, 255],
+    };
+    let mut seed_buf = BytesMut::new();
+    bbmd::encode_bdt_entries(std::slice::from_ref(&invalid_entry), &mut seed_buf);
+    fs::write(persist.path(), &seed_buf).unwrap();
+
+    let fallback_entry = BdtEntry {
+        ip: [198, 51, 100, 12],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 0],
+    };
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![fallback_entry.clone()]);
+    bbmd_transport.set_bdt_persist_path(persist.path().to_path_buf());
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let bdt = client_transport.read_bdt(&bbmd_mac).await.unwrap();
+    assert!(
+        bdt.iter().any(|entry| entry == &fallback_entry),
+        "semantically invalid persisted BDT must fall back to the configured BDT"
+    );
+    assert!(
+        !bdt.iter().any(|entry| entry == &invalid_entry),
+        "semantically invalid persisted entry must not be committed"
+    );
+
+    client_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn conflicting_persisted_bdt_falls_back_to_configured_bdt() {
+    let persist = TempBdtFile::new("bdt-conflict");
+    // Same (ip, port) with different masks conflicts and must be rejected.
+    let first = BdtEntry {
+        ip: [192, 0, 2, 45],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 255],
+    };
+    let conflicting = BdtEntry {
+        ip: [192, 0, 2, 45],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 0],
+    };
+    let mut seed_buf = BytesMut::new();
+    bbmd::encode_bdt_entries(&[first.clone(), conflicting.clone()], &mut seed_buf);
+    fs::write(persist.path(), &seed_buf).unwrap();
+
+    let fallback_entry = BdtEntry {
+        ip: [198, 51, 100, 13],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 0],
+    };
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![fallback_entry.clone()]);
+    bbmd_transport.set_bdt_persist_path(persist.path().to_path_buf());
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let bdt = client_transport.read_bdt(&bbmd_mac).await.unwrap();
+    assert!(
+        bdt.iter().any(|entry| entry == &fallback_entry),
+        "conflicting persisted BDT must fall back to the configured BDT"
+    );
+    assert!(
+        !bdt.iter().any(|entry| entry == &first),
+        "conflicting persisted entries must not be committed"
+    );
+
+    client_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn invalid_configured_bdt_fails_startup() {
+    let invalid_entry = BdtEntry {
+        ip: [224, 0, 0, 1],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 255],
+    };
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![invalid_entry]);
+    let err = bbmd_transport.start().await.unwrap_err();
+    let text = format!("{err}");
+    assert!(
+        text.contains("BDT configuration error"),
+        "invalid configured BDT must fail startup, got: {text}"
+    );
+    assert!(
+        text.to_lowercase().contains("multicast"),
+        "invalid configured error must name the category, got: {text}"
+    );
+}

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -479,17 +479,29 @@ impl TransportPort for BipTransport {
 
         if let Some(config) = self.bbmd_config.take() {
             let mut state = BbmdState::new(local_ip.octets(), local_port);
-            // Try loading persisted BDT; fall back to initial config BDT
+            // Try loading persisted BDT; fall back to initial config BDT on
+            // missing/unreadable files, structural decode failure, or semantic
+            // validation/conflict failure. A valid persisted BDT wins; an
+            // invalid configured fallback fails startup via `set_bdt` below.
             let initial_bdt = if let Some(ref path) = self.bdt_persist_path {
                 match std::fs::read(path) {
                     Ok(data) => match BbmdState::decode_bdt(&data) {
                         Ok(entries) => {
-                            debug!(
-                                path = %path.display(),
-                                entries = entries.len(),
-                                "Loaded persisted BDT"
-                            );
-                            entries
+                            let mut probe = BbmdState::new(local_ip.octets(), local_port);
+                            match probe.set_bdt(entries) {
+                                Ok(()) => {
+                                    debug!(
+                                        path = %path.display(),
+                                        entries = probe.bdt().len(),
+                                        "Loaded persisted BDT"
+                                    );
+                                    probe.bdt().to_vec()
+                                }
+                                Err(e) => {
+                                    warn!(error = %e, "Persisted BDT invalid, using config");
+                                    config.initial_bdt
+                                }
+                            }
                         }
                         Err(e) => {
                             warn!(error = %e, "Failed to decode persisted BDT, using config");


### PR DESCRIPTION
Refs #529

## Summary
- validate and canonicalize complete BDT candidates transactionally at `BbmdState::set_bdt`
- reject zero-port, unspecified, multicast, limited-broadcast, invalid-mask, subnet endpoint, unsafe `/0`, and same-endpoint/conflicting-mask entries
- collapse byte-identical duplicates in stable first-seen order before capacity and local-self insertion
- treat semantically invalid persisted BDT data like malformed data and fall back to valid configured state

## Policy and compatibility
The owner selected the strict fail-closed option for this slice. These address, mask, conflict, and deduplication rules are repository security policy for issue #529, not a new Annex J conformance claim. Licensed source text is not reproduced.

Public `BdtEntry`, `set_bdt`, and `enable_bbmd` shapes are unchanged. `decode_bdt` remains structural so Read-BDT can observe remote responses, and outbound `write_bdt` remains unchanged. Previously accepted unsafe configuration now fails before BDT mutation; exact duplicates normalize, while distinct IP/port peers remain distinct.

## Red / green evidence
- RED: `cargo test -p bacnet-transport --locked bbmd::validation_tests` produced 11 intended failures before implementation
- RED: focused semantic-persisted, conflicting-persisted, and invalid-configured startup tests each failed before implementation
- GREEN: `cargo test -p bacnet-transport --locked bbmd::validation_tests` passed 18 tests
- GREEN: `cargo test -p bacnet-transport --locked bdt_persistence` passed 5 tests
- GREEN: `cargo test -p bacnet-transport --locked` passed 412 unit tests and 2 public API tests; one doctest remains intentionally ignored

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`

All passed locally.

## Scope limits
This is the second #529 slice. It does not add management rate limits, counters, authenticated administration, or the Network Port configuration path; alter strict inbound Write-BDT NAK behavior; deduplicate distinct peers sharing a forwarding destination; or include #528/#530/#531, dependency, CI, README, PICS, BIBB, or conformance-ledger work. Issue #529 remains open.