### PR TITLE
fix(bip): bound Read-BDT and Read-FDT response amplification

### DIFF
--- a/crates/bacnet-transport/src/bbmd.rs
+++ b/crates/bacnet-transport/src/bbmd.rs
@@ -131,6 +131,11 @@ pub fn decode_fdt(data: &[u8]) -> Result<Vec<FdtEntryWire>, Error> {
         ));
     }
     let count = data.len() / FDT_ENTRY_SIZE;
+    if count > BbmdState::MAX_FDT_ENTRIES {
+        let max = BbmdState::MAX_FDT_ENTRIES;
+        let msg = format!("FDT entry count {count} exceeds maximum of {max}");
+        return Err(Error::decoding(0, msg));
+    }
     let mut entries = Vec::with_capacity(count);
     for chunk in data.chunks_exact(FDT_ENTRY_SIZE) {
         entries.push(FdtEntryWire {
@@ -285,7 +290,7 @@ impl BbmdState {
     // -----------------------------------------------------------------------
 
     /// Maximum number of entries in the Foreign Device Table.
-    const MAX_FDT_ENTRIES: usize = 512;
+    pub const MAX_FDT_ENTRIES: usize = 128;
 
     /// Register or re-register a foreign device.
     pub fn register_foreign_device(&mut self, ip: [u8; 4], port: u16, ttl: u16) -> BvlcResultCode {

--- a/crates/bacnet-transport/src/bip/dbtn_tests.rs
+++ b/crates/bacnet-transport/src/bip/dbtn_tests.rs
@@ -72,7 +72,7 @@ async fn dbtn_registered_foreign_device_fans_out_without_origin_echo() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: false,
     };
     let sender = (Ipv4Addr::LOCALHOST.octets(), origin_fd_port);
@@ -146,7 +146,7 @@ async fn dbtn_registered_foreign_device_naks_when_forwarding_fails() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: true,
     };
     let sender = (Ipv4Addr::LOCALHOST.octets(), origin_fd_port);

--- a/crates/bacnet-transport/src/bip/forwarded_tests.rs
+++ b/crates/bacnet-transport/src/bip/forwarded_tests.rs
@@ -64,7 +64,7 @@ async fn forwarded_npdu_from_bdt_peer_uses_originating_source_mac() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {
@@ -150,7 +150,7 @@ async fn forwarded_npdu_from_non_bdt_sender_is_rejected_without_delivery() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {
@@ -225,7 +225,7 @@ async fn forwarded_npdu_from_directed_broadcast_peer_skips_local_rebroadcast() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -79,7 +79,7 @@ pub(super) struct RecvContext {
     pub(super) broadcast_addr: Ipv4Addr,
     pub(super) broadcast_port: u16,
     pub(super) pending_bvlc_response: Arc<Mutex<Option<PendingBvlcResponse>>>,
-    pub(super) management_limiter: std::sync::Mutex<ManagementRateLimiter>,
+    pub(super) management_limiter: Arc<std::sync::Mutex<ManagementRateLimiter>>,
     #[cfg(test)]
     pub(super) force_dbtn_forward_failure: bool,
 }
@@ -375,7 +375,23 @@ pub(super) async fn handle_bvll_message(
                 let state = bbmd.lock().await;
                 let mut payload = BytesMut::new();
                 state.encode_bdt(&mut payload);
-                let mut buf = BytesMut::with_capacity(4 + payload.len());
+                drop(state);
+                let resp_len = 4 + payload.len();
+                let allowed = match ctx.management_limiter.lock() {
+                    Ok(mut limiter) => limiter.check_and_record_bdt_response(sender.0, resp_len),
+                    Err(poison) => poison
+                        .into_inner()
+                        .check_and_record_bdt_response(sender.0, resp_len),
+                };
+                if !allowed {
+                    debug!(
+                        ip = %Ipv4Addr::from(sender.0),
+                        bytes = resp_len,
+                        "Throttling Read-BDT response due to amplification budget"
+                    );
+                    return;
+                }
+                let mut buf = BytesMut::with_capacity(resp_len);
                 match encode_bvll(
                     &mut buf,
                     BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK,
@@ -414,7 +430,22 @@ pub(super) async fn handle_bvll_message(
                 let mut payload = BytesMut::new();
                 state.encode_fdt(&mut payload);
                 drop(state);
-                let mut buf = BytesMut::with_capacity(4 + payload.len());
+                let resp_len = 4 + payload.len();
+                let allowed = match ctx.management_limiter.lock() {
+                    Ok(mut limiter) => limiter.check_and_record_fdt_response(sender.0, resp_len),
+                    Err(poison) => poison
+                        .into_inner()
+                        .check_and_record_fdt_response(sender.0, resp_len),
+                };
+                if !allowed {
+                    debug!(
+                        ip = %Ipv4Addr::from(sender.0),
+                        bytes = resp_len,
+                        "Throttling Read-FDT response due to amplification budget"
+                    );
+                    return;
+                }
+                let mut buf = BytesMut::with_capacity(resp_len);
                 match encode_bvll(
                     &mut buf,
                     BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK,

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -27,6 +27,7 @@ use io::{
     handle_bvll_message, original_destination_matches, resolve_local_ip,
     send_register_foreign_device, RecvContext,
 };
+pub use rate_limit::ManagementCounters;
 use rate_limit::ManagementRateLimiter;
 
 /// Default BACnet/IP port (0xBAC0 = 47808).
@@ -141,6 +142,8 @@ pub struct BipTransport {
     /// (wire format, 10 bytes per entry) at startup. Inbound Write-BDT does
     /// not update this file.
     bdt_persist_path: Option<std::path::PathBuf>,
+    /// Management request and response rate limiter.
+    management_limiter: Arc<std::sync::Mutex<ManagementRateLimiter>>,
 }
 
 impl BipTransport {
@@ -164,6 +167,7 @@ impl BipTransport {
             registration_task: None,
             pending_bvlc_response: Arc::new(Mutex::new(None)),
             bdt_persist_path: None,
+            management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         }
     }
 
@@ -206,6 +210,14 @@ impl BipTransport {
     /// Get the BBMD state (if BBMD mode is enabled).
     pub fn bbmd_state(&self) -> Option<&Arc<Mutex<BbmdState>>> {
         self.bbmd.as_ref()
+    }
+
+    /// Return the operational BBMD management counters.
+    pub fn management_counters(&self) -> ManagementCounters {
+        match self.management_limiter.lock() {
+            Ok(limiter) => limiter.counters(),
+            Err(poison) => poison.into_inner().counters(),
+        }
     }
 
     /// Timeout for BVLC management response waiting.
@@ -535,7 +547,7 @@ impl TransportPort for BipTransport {
             broadcast_addr: self.broadcast_address,
             broadcast_port: self.port,
             pending_bvlc_response: self.pending_bvlc_response.clone(),
-            management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+            management_limiter: Arc::clone(&self.management_limiter),
             #[cfg(test)]
             force_dbtn_forward_failure: false,
         };
@@ -713,5 +725,7 @@ mod npdu_addressing_tests;
 mod original_tests;
 #[cfg(test)]
 mod rate_limit_tests;
+#[cfg(test)]
+mod response_amplification_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-transport/src/bip/original_tests.rs
+++ b/crates/bacnet-transport/src/bip/original_tests.rs
@@ -140,7 +140,7 @@ async fn original_unicast_npdu_uses_udp_sender_source_mac_and_ignores_self() {
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: false,
     };
     let sender = ([192, 0, 2, 30], 0xBAC0);
@@ -216,7 +216,7 @@ async fn original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {

--- a/crates/bacnet-transport/src/bip/rate_limit.rs
+++ b/crates/bacnet-transport/src/bip/rate_limit.rs
@@ -17,6 +17,31 @@ pub(super) const MANAGEMENT_RATE_PER_SOURCE_IP: u32 = 16;
 pub(super) const MANAGEMENT_RATE_GLOBAL: u32 = 256;
 /// Maximum distinct source IPv4 addresses tracked per window.
 pub(super) const MANAGEMENT_RATE_MAX_SOURCES: usize = 256;
+/// Maximum management response bytes admitted per source IPv4 address per window.
+pub(super) const MANAGEMENT_RESPONSE_BYTES_PER_SOURCE_IP: usize = 4096;
+/// Maximum management response bytes admitted globally per transport per window.
+pub(super) const MANAGEMENT_RESPONSE_BYTES_GLOBAL: usize = 32768;
+
+/// Operational counters for BACnet/IP BBMD management traffic.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ManagementCounters {
+    /// Number of Read-BDT-ACK responses sent.
+    pub read_bdt_responses: u64,
+    /// Number of Read-FDT-ACK responses sent.
+    pub read_fdt_responses: u64,
+    /// Total bytes of Read-BDT-ACK and Read-FDT-ACK responses sent.
+    pub response_bytes_sent: u64,
+    /// Number of management responses throttled due to byte budget exhaustion.
+    pub response_throttled: u64,
+}
+
+/// Tracking entry for a source IPv4 address within the current window.
+#[derive(Clone, Copy, Debug, Default)]
+struct SourceQuota {
+    ip: [u8; 4],
+    requests: u32,
+    response_bytes: usize,
+}
 
 /// Whether an inbound BVLC function shares the combined management quota.
 ///
@@ -42,8 +67,10 @@ pub(super) fn is_covered_management_request(function: BvlcFunction) -> bool {
 pub(super) struct ManagementRateLimiter {
     window_start: Option<Instant>,
     admitted: u32,
-    entries: [([u8; 4], u32); MANAGEMENT_RATE_MAX_SOURCES],
+    response_bytes_in_window: usize,
+    entries: [SourceQuota; MANAGEMENT_RATE_MAX_SOURCES],
     len: usize,
+    counters: ManagementCounters,
 }
 
 impl ManagementRateLimiter {
@@ -51,16 +78,18 @@ impl ManagementRateLimiter {
         Self {
             window_start: None,
             admitted: 0,
-            entries: [([0, 0, 0, 0], 0); MANAGEMENT_RATE_MAX_SOURCES],
+            response_bytes_in_window: 0,
+            entries: [SourceQuota {
+                ip: [0; 4],
+                requests: 0,
+                response_bytes: 0,
+            }; MANAGEMENT_RATE_MAX_SOURCES],
             len: 0,
+            counters: ManagementCounters::default(),
         }
     }
 
-    /// Admit (`true`) or silently discard (`false`) one covered request.
-    ///
-    /// Keyed by source IPv4 address only. Rejected requests leave all
-    /// accounting unchanged and never create tracking entries.
-    pub(super) fn check(&mut self, ip: [u8; 4], now: Instant) -> bool {
+    fn roll_window_if_expired(&mut self, now: Instant) {
         match self.window_start {
             None => {
                 self.window_start = Some(now);
@@ -69,21 +98,30 @@ impl ManagementRateLimiter {
                 if now.saturating_duration_since(start) >= MANAGEMENT_RATE_WINDOW {
                     self.window_start = Some(now);
                     self.admitted = 0;
+                    self.response_bytes_in_window = 0;
                     self.len = 0;
                 }
             }
         }
+    }
+
+    /// Admit (`true`) or silently discard (`false`) one covered request.
+    ///
+    /// Keyed by source IPv4 address only. Rejected requests leave all
+    /// accounting unchanged and never create tracking entries.
+    pub(super) fn check(&mut self, ip: [u8; 4], now: Instant) -> bool {
+        self.roll_window_if_expired(now);
 
         if self.admitted >= MANAGEMENT_RATE_GLOBAL {
             return false;
         }
 
         for i in 0..self.len {
-            if self.entries[i].0 == ip {
-                if self.entries[i].1 >= MANAGEMENT_RATE_PER_SOURCE_IP {
+            if self.entries[i].ip == ip {
+                if self.entries[i].requests >= MANAGEMENT_RATE_PER_SOURCE_IP {
                     return false;
                 }
-                self.entries[i].1 += 1;
+                self.entries[i].requests += 1;
                 self.admitted += 1;
                 return true;
             }
@@ -92,7 +130,11 @@ impl ManagementRateLimiter {
         if self.len >= MANAGEMENT_RATE_MAX_SOURCES {
             return false;
         }
-        self.entries[self.len] = (ip, 1);
+        self.entries[self.len] = SourceQuota {
+            ip,
+            requests: 1,
+            response_bytes: 0,
+        };
         self.len += 1;
         self.admitted += 1;
         true
@@ -103,6 +145,96 @@ impl ManagementRateLimiter {
         self.check(ip, Instant::now())
     }
 
+    /// Admit (`true`) or throttle (`false`) response bytes for a source IPv4 address.
+    ///
+    /// Enforces per-source and global response byte budgets within the current window.
+    pub(super) fn check_response(&mut self, ip: [u8; 4], bytes: usize, now: Instant) -> bool {
+        self.roll_window_if_expired(now);
+
+        if self.response_bytes_in_window.saturating_add(bytes) > MANAGEMENT_RESPONSE_BYTES_GLOBAL {
+            return false;
+        }
+
+        for i in 0..self.len {
+            if self.entries[i].ip == ip {
+                if self.entries[i].response_bytes.saturating_add(bytes)
+                    > MANAGEMENT_RESPONSE_BYTES_PER_SOURCE_IP
+                {
+                    return false;
+                }
+                self.entries[i].response_bytes += bytes;
+                self.response_bytes_in_window += bytes;
+                return true;
+            }
+        }
+
+        if bytes > MANAGEMENT_RESPONSE_BYTES_PER_SOURCE_IP {
+            return false;
+        }
+
+        if self.len >= MANAGEMENT_RATE_MAX_SOURCES {
+            return false;
+        }
+
+        self.entries[self.len] = SourceQuota {
+            ip,
+            requests: 0,
+            response_bytes: bytes,
+        };
+        self.len += 1;
+        self.response_bytes_in_window += bytes;
+        true
+    }
+
+    /// Check response byte admission using monotonic time.
+    pub(super) fn check_response_now(&mut self, ip: [u8; 4], bytes: usize) -> bool {
+        self.check_response(ip, bytes, Instant::now())
+    }
+
+    /// Record an admitted Read-BDT-ACK response.
+    pub(super) fn record_read_bdt_response(&mut self, bytes: usize) {
+        self.counters.read_bdt_responses += 1;
+        self.counters.response_bytes_sent += bytes as u64;
+    }
+
+    /// Record an admitted Read-FDT-ACK response.
+    pub(super) fn record_read_fdt_response(&mut self, bytes: usize) {
+        self.counters.read_fdt_responses += 1;
+        self.counters.response_bytes_sent += bytes as u64;
+    }
+
+    /// Record a throttled management response.
+    pub(super) fn record_response_throttled(&mut self) {
+        self.counters.response_throttled += 1;
+    }
+
+    /// Check response budget and record counters for a Read-BDT-ACK response.
+    pub(super) fn check_and_record_bdt_response(&mut self, ip: [u8; 4], bytes: usize) -> bool {
+        if self.check_response_now(ip, bytes) {
+            self.record_read_bdt_response(bytes);
+            true
+        } else {
+            self.record_response_throttled();
+            false
+        }
+    }
+
+    /// Check response budget and record counters for a Read-FDT-ACK response.
+    pub(super) fn check_and_record_fdt_response(&mut self, ip: [u8; 4], bytes: usize) -> bool {
+        if self.check_response_now(ip, bytes) {
+            self.record_read_fdt_response(bytes);
+            true
+        } else {
+            self.record_response_throttled();
+            false
+        }
+    }
+
+    /// Query the cumulative management counters.
+    pub(super) fn counters(&self) -> ManagementCounters {
+        self.counters
+    }
+
     #[cfg(test)]
     pub(super) fn tracked_source_count(&self) -> usize {
         self.len
@@ -111,6 +243,11 @@ impl ManagementRateLimiter {
     #[cfg(test)]
     pub(super) fn admitted_in_window(&self) -> u32 {
         self.admitted
+    }
+
+    #[cfg(test)]
+    pub(super) fn response_bytes_in_window(&self) -> usize {
+        self.response_bytes_in_window
     }
 }
 

--- a/crates/bacnet-transport/src/bip/rate_limit_tests.rs
+++ b/crates/bacnet-transport/src/bip/rate_limit_tests.rs
@@ -53,7 +53,7 @@ fn test_ctx(
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: false,
     }
 }
@@ -314,7 +314,7 @@ async fn rate_limit_discards_malformed_and_unauthorized_before_normal_handling()
         broadcast_addr: Ipv4Addr::LOCALHOST,
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: false,
     };
 

--- a/crates/bacnet-transport/src/bip/response_amplification_tests.rs
+++ b/crates/bacnet-transport/src/bip/response_amplification_tests.rs
@@ -1,0 +1,385 @@
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::time::{Duration, Instant};
+
+use bytes::BytesMut;
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+
+use super::rate_limit::{ManagementRateLimiter, MANAGEMENT_RESPONSE_BYTES_GLOBAL};
+use super::*;
+use crate::bbmd::{self, BbmdState, BdtEntry, BDT_ENTRY_SIZE, FDT_ENTRY_SIZE};
+use crate::bvll::{decode_bip_mac, decode_bvll, encode_bip_mac, encode_bvll};
+use bacnet_types::enums::{BvlcFunction, BvlcResultCode};
+
+#[test]
+fn test_bdt_empty_and_max_response_sizes() {
+    // Empty BDT payload -> 4-byte BVLC header only
+    let mut empty_payload = BytesMut::new();
+    bbmd::encode_bdt_entries(&[], &mut empty_payload);
+    assert_eq!(empty_payload.len(), 0);
+    let mut empty_buf = BytesMut::new();
+    encode_bvll(
+        &mut empty_buf,
+        BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK,
+        &empty_payload,
+    )
+    .unwrap();
+    assert_eq!(empty_buf.len(), 4, "Empty Read-BDT-ACK must be 4 bytes");
+
+    // Maximum BDT (128 entries): 128 * 10 = 1280 payload bytes -> 1284 total
+    let entries: Vec<BdtEntry> = (0..BbmdState::MAX_BDT_ENTRIES)
+        .map(|i| BdtEntry {
+            ip: [10, 0, (i / 256) as u8, (i % 256) as u8],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        })
+        .collect();
+    assert_eq!(entries.len(), 128);
+    let mut max_payload = BytesMut::new();
+    bbmd::encode_bdt_entries(&entries, &mut max_payload);
+    assert_eq!(max_payload.len(), 128 * BDT_ENTRY_SIZE);
+    let mut max_buf = BytesMut::new();
+    encode_bvll(
+        &mut max_buf,
+        BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK,
+        &max_payload,
+    )
+    .unwrap();
+    assert_eq!(
+        max_buf.len(),
+        1284,
+        "Maximum Read-BDT-ACK (128 entries) must be 1,284 bytes"
+    );
+
+    let decoded = BbmdState::decode_bdt(&max_payload).unwrap();
+    assert_eq!(decoded.len(), 128);
+}
+
+#[test]
+fn test_fdt_empty_and_max_response_sizes() {
+    let mut state = BbmdState::new([127, 0, 0, 1], 0xBAC0);
+
+    // Empty FDT payload -> 4-byte BVLC header only
+    let mut empty_payload = BytesMut::new();
+    state.encode_fdt(&mut empty_payload);
+    assert_eq!(empty_payload.len(), 0);
+    let mut empty_buf = BytesMut::new();
+    encode_bvll(
+        &mut empty_buf,
+        BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK,
+        &empty_payload,
+    )
+    .unwrap();
+    assert_eq!(empty_buf.len(), 4, "Empty Read-FDT-ACK must be 4 bytes");
+
+    // Maximum FDT (128 entries): 128 * 10 = 1280 payload bytes -> 1284 total
+    for i in 0..BbmdState::MAX_FDT_ENTRIES {
+        let ip = [10, 0, (i / 256) as u8, (i % 256) as u8];
+        let port = 0xBAC0 + (i as u16);
+        assert_eq!(
+            state.register_foreign_device(ip, port, 60),
+            BvlcResultCode::SUCCESSFUL_COMPLETION
+        );
+    }
+    // Attempting 129th entry must be rejected
+    assert_eq!(
+        state.register_foreign_device([10, 1, 0, 1], 0xBAC0, 60),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+    assert_eq!(state.fdt().len(), 128);
+
+    let mut max_payload = BytesMut::new();
+    state.encode_fdt(&mut max_payload);
+    assert_eq!(max_payload.len(), 128 * FDT_ENTRY_SIZE);
+    let mut max_buf = BytesMut::new();
+    encode_bvll(
+        &mut max_buf,
+        BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK,
+        &max_payload,
+    )
+    .unwrap();
+    assert_eq!(
+        max_buf.len(),
+        1284,
+        "Maximum Read-FDT-ACK (128 entries) must be 1,284 bytes"
+    );
+
+    let decoded = bbmd::decode_fdt(&max_payload).unwrap();
+    assert_eq!(decoded.len(), 128);
+}
+
+#[test]
+fn test_decode_fdt_rejects_exceeding_max_entries() {
+    let wire_bytes_129 = vec![0u8; 129 * FDT_ENTRY_SIZE];
+    let err = bbmd::decode_fdt(&wire_bytes_129).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("exceeds maximum of 128"),
+        "error must cite maximum of 128: {msg}"
+    );
+
+    // 128 entries is accepted
+    let wire_bytes_128 = vec![0u8; 128 * FDT_ENTRY_SIZE];
+    assert!(bbmd::decode_fdt(&wire_bytes_128).is_ok());
+}
+
+#[tokio::test]
+async fn test_max_fdt_response_accepted_by_bip_client() {
+    let server = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let server_port = server.local_addr().unwrap().port();
+    let server_mac = encode_bip_mac(Ipv4Addr::LOCALHOST.octets(), server_port);
+
+    // Responder sends a 128-entry (1,284 bytes) Read-FDT-ACK
+    let responder = tokio::spawn(async move {
+        let mut recv_buf = [0u8; 2048];
+        let (_len, client_addr) = timeout(Duration::from_secs(2), server.recv_from(&mut recv_buf))
+            .await
+            .expect("timed out waiting for management request")
+            .unwrap();
+
+        let mut payload = BytesMut::with_capacity(128 * FDT_ENTRY_SIZE);
+        for i in 0..128u16 {
+            payload.extend_from_slice(&[10, 0, (i / 256) as u8, (i % 256) as u8]);
+            payload.extend_from_slice(&(0xBAC0 + i).to_be_bytes());
+            payload.extend_from_slice(&60u16.to_be_bytes());
+            payload.extend_from_slice(&60u16.to_be_bytes());
+        }
+        let mut response = BytesMut::with_capacity(4 + payload.len());
+        encode_bvll(
+            &mut response,
+            BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK,
+            &payload,
+        )
+        .unwrap();
+        assert_eq!(response.len(), 1284);
+        server.send_to(&response, client_addr).await.unwrap();
+    });
+
+    let mut client = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client.start().await.unwrap();
+
+    let entries = client.read_fdt(&server_mac).await.unwrap();
+    assert_eq!(entries.len(), 128);
+
+    client.stop().await.unwrap();
+    responder.await.unwrap();
+}
+
+#[test]
+fn test_response_budget_per_source_throttling() {
+    let t0 = Instant::now();
+    let mut limiter = ManagementRateLimiter::new();
+    let ip = [192, 0, 2, 50];
+
+    // Response of 1,284 bytes:
+    // 1st: 1,284 <= 4,096 -> ok
+    assert!(limiter.check_response(ip, 1284, t0));
+    limiter.record_read_bdt_response(1284);
+    assert_eq!(limiter.response_bytes_in_window(), 1284);
+
+    // 2nd: 2,568 <= 4,096 -> ok
+    assert!(limiter.check_response(ip, 1284, t0));
+    limiter.record_read_bdt_response(1284);
+    assert_eq!(limiter.response_bytes_in_window(), 2568);
+
+    // 3rd: 3,852 <= 4,096 -> ok
+    assert!(limiter.check_response(ip, 1284, t0));
+    limiter.record_read_bdt_response(1284);
+    assert_eq!(limiter.response_bytes_in_window(), 3852);
+
+    // 4th: 3,852 + 1,284 = 5,136 > 4,096 -> throttled!
+    assert!(!limiter.check_response(ip, 1284, t0));
+    limiter.record_response_throttled();
+    assert_eq!(limiter.response_bytes_in_window(), 3852);
+
+    let counters = limiter.counters();
+    assert_eq!(counters.read_bdt_responses, 3);
+    assert_eq!(counters.response_bytes_sent, 3852);
+    assert_eq!(counters.response_throttled, 1);
+
+    // Window rollover restores budget
+    let later = t0 + Duration::from_millis(1001);
+    assert!(limiter.check_response(ip, 1284, later));
+    assert_eq!(limiter.response_bytes_in_window(), 1284);
+}
+
+#[test]
+fn test_response_budget_global_throttling() {
+    let t0 = Instant::now();
+    let mut limiter = ManagementRateLimiter::new();
+
+    // 8 distinct sources each take 4,096 bytes: 8 * 4096 = 32,768 (MANAGEMENT_RESPONSE_BYTES_GLOBAL)
+    for i in 0..8u8 {
+        let ip = [10, 0, 0, i];
+        assert!(limiter.check_response(ip, 4096, t0));
+    }
+    assert_eq!(
+        limiter.response_bytes_in_window(),
+        MANAGEMENT_RESPONSE_BYTES_GLOBAL
+    );
+
+    // 9th source is rejected globally even for a small 4-byte response
+    let new_ip = [10, 0, 0, 99];
+    assert!(!limiter.check_response(new_ip, 4, t0));
+}
+
+#[tokio::test]
+async fn test_bbmd_wire_read_bdt_throttling_and_npdu_traffic() {
+    // Set up BBMD with 127 peer BDT entries; self-entry auto-insertion reaches 128 entries (1,284 bytes)
+    let entries: Vec<BdtEntry> = (0..(BbmdState::MAX_BDT_ENTRIES - 1))
+        .map(|i| BdtEntry {
+            ip: [10, 0, (i / 256) as u8, (i % 256) as u8],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        })
+        .collect();
+
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(entries);
+    let mut bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+    let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();
+    let bbmd_dest = SocketAddrV4::new(Ipv4Addr::from(bbmd_ip), bbmd_port);
+
+    let client_socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+
+    let mut req_buf = BytesMut::new();
+    encode_bvll(
+        &mut req_buf,
+        BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE,
+        &[],
+    )
+    .unwrap();
+
+    // Requests 1, 2, 3 should succeed (3 * 1,284 = 3,852 <= 4,096)
+    for _ in 0..3 {
+        client_socket.send_to(&req_buf, bbmd_dest).await.unwrap();
+        let mut recv_buf = [0u8; 2048];
+        let (len, _) = timeout(
+            Duration::from_millis(500),
+            client_socket.recv_from(&mut recv_buf),
+        )
+        .await
+        .expect("expected Read-BDT-ACK response")
+        .unwrap();
+        let msg = decode_bvll(&recv_buf[..len]).unwrap();
+        assert_eq!(
+            msg.function,
+            BvlcFunction::READ_BROADCAST_DISTRIBUTION_TABLE_ACK
+        );
+        assert_eq!(len, 1284);
+    }
+
+    // Request 4 should be throttled (3,852 + 1,284 = 5,136 > 4,096) -> no response sent
+    client_socket.send_to(&req_buf, bbmd_dest).await.unwrap();
+    let mut recv_buf = [0u8; 2048];
+    let timeout_result = timeout(
+        Duration::from_millis(300),
+        client_socket.recv_from(&mut recv_buf),
+    )
+    .await;
+    assert!(
+        timeout_result.is_err(),
+        "4th Read-BDT request must be throttled and yield no response"
+    );
+
+    // Verify operational counters on BBMD
+    let counters = bbmd_transport.management_counters();
+    assert_eq!(counters.read_bdt_responses, 3);
+    assert_eq!(counters.response_bytes_sent, 3852);
+    assert_eq!(counters.response_throttled, 1);
+
+    // Verify NPDU traffic from the same client is NOT starved or affected
+    let mut npdu_buf = BytesMut::new();
+    let npdu_payload = [0x01, 0x04, 0xDE, 0xAD, 0xBE, 0xEF];
+    encode_bvll(
+        &mut npdu_buf,
+        BvlcFunction::ORIGINAL_UNICAST_NPDU,
+        &npdu_payload,
+    )
+    .unwrap();
+    client_socket.send_to(&npdu_buf, bbmd_dest).await.unwrap();
+
+    let received = timeout(Duration::from_millis(500), bbmd_rx.recv())
+        .await
+        .expect("NPDU must not be blocked by management rate limiting")
+        .expect("NPDU channel must be open");
+    assert_eq!(received.npdu.as_ref(), &npdu_payload);
+
+    bbmd_transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_bbmd_wire_read_fdt_throttling() {
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    // Register 128 foreign devices directly in BBMD state
+    {
+        let mut state = BbmdState::new([127, 0, 0, 1], 0xBAC0);
+        for i in 0..BbmdState::MAX_FDT_ENTRIES {
+            let ip = [10, 0, (i / 256) as u8, (i % 256) as u8];
+            state.register_foreign_device(ip, 0xBAC0 + (i as u16), 300);
+        }
+        bbmd_transport.enable_bbmd(state.bdt().to_vec());
+    }
+
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+    let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();
+    let bbmd_dest = SocketAddrV4::new(Ipv4Addr::from(bbmd_ip), bbmd_port);
+
+    // Populate the running BBMD's FDT with 128 entries
+    if let Some(bbmd_arc) = bbmd_transport.bbmd_state() {
+        let mut state = bbmd_arc.lock().await;
+        for i in 0..BbmdState::MAX_FDT_ENTRIES {
+            let ip = [10, 0, (i / 256) as u8, (i % 256) as u8];
+            state.register_foreign_device(ip, 0xBAC0 + (i as u16), 300);
+        }
+    }
+
+    let client_socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+
+    let mut req_buf = BytesMut::new();
+    encode_bvll(&mut req_buf, BvlcFunction::READ_FOREIGN_DEVICE_TABLE, &[]).unwrap();
+
+    // Requests 1, 2, 3 should succeed
+    for _ in 0..3 {
+        client_socket.send_to(&req_buf, bbmd_dest).await.unwrap();
+        let mut recv_buf = [0u8; 2048];
+        let (len, _) = timeout(
+            Duration::from_millis(500),
+            client_socket.recv_from(&mut recv_buf),
+        )
+        .await
+        .expect("expected Read-FDT-ACK response")
+        .unwrap();
+        let msg = decode_bvll(&recv_buf[..len]).unwrap();
+        assert_eq!(msg.function, BvlcFunction::READ_FOREIGN_DEVICE_TABLE_ACK);
+        assert_eq!(len, 1284);
+    }
+
+    // Request 4 should be throttled
+    client_socket.send_to(&req_buf, bbmd_dest).await.unwrap();
+    let mut recv_buf = [0u8; 2048];
+    let timeout_result = timeout(
+        Duration::from_millis(300),
+        client_socket.recv_from(&mut recv_buf),
+    )
+    .await;
+    assert!(
+        timeout_result.is_err(),
+        "4th Read-FDT request must be throttled"
+    );
+
+    let counters = bbmd_transport.management_counters();
+    assert_eq!(counters.read_fdt_responses, 3);
+    assert_eq!(counters.response_bytes_sent, 3852);
+    assert_eq!(counters.response_throttled, 1);
+
+    bbmd_transport.stop().await.unwrap();
+}

--- a/crates/bacnet-transport/src/bip/tests.rs
+++ b/crates/bacnet-transport/src/bip/tests.rs
@@ -117,7 +117,7 @@ async fn pending_bvlc_response_requires_sender_and_expected_function() {
         broadcast_addr: Ipv4Addr::BROADCAST,
         broadcast_port: 47808,
         pending_bvlc_response: pending_bvlc_response.clone(),
-        management_limiter: std::sync::Mutex::new(ManagementRateLimiter::new()),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
         force_dbtn_forward_failure: false,
     };
 


### PR DESCRIPTION
Refs #530

## Summary
- reduce `BbmdState::MAX_FDT_ENTRIES` from 512 to 128 (matching `MAX_BDT_ENTRIES = 128`), ensuring maximum `Read-FDT-ACK` datagrams are 1,284 bytes (comfortably within standard 1,500-byte Ethernet MTU and the 2,048-byte B/IP receive buffer)
- add entry count validation to `decode_fdt`, rejecting FDT payloads exceeding `MAX_FDT_ENTRIES`
- add per-source (4,096 bytes/sec) and global (32,768 bytes/sec) response byte budgeting in `ManagementRateLimiter`
- silently throttle over-budget Read-BDT and Read-FDT responses in `bip/io.rs` before transmission to eliminate UDP reflection/amplification vectors
- expose `ManagementCounters` operational telemetry on `BipTransport` to track responses and throttled events
- add exhaustive test coverage proving encoded bounds, local receive loop acceptance, throttling behavior, non-starvation of ordinary unicast NPDU traffic, and counter accuracy

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-transport --locked` (431 unit + 2 integration passed; 1 doctest ignored)
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked` (all workspace crate tests passed)
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`