### PR TITLE
fix(bip): make BBMD foreign-device registration explicit, fair, and bounded

### DIFF
--- a/benchmarks/src/bin/bacnet_bbmd.rs
+++ b/benchmarks/src/bin/bacnet_bbmd.rs
@@ -8,7 +8,7 @@ use std::net::Ipv4Addr;
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_objects::device::{DeviceConfig, DeviceObject};
 use bacnet_server::server::BACnetServer;
-use bacnet_transport::bbmd::BdtEntry;
+use bacnet_transport::bbmd::{BdtEntry, ForeignDevicePolicy};
 use bacnet_transport::bip::BipTransport;
 use clap::Parser;
 
@@ -71,6 +71,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut transport = BipTransport::new(interface, args.port, broadcast);
     transport.enable_bbmd(bdt);
+    transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
 
     // Minimal device database
     let mut db = ObjectDatabase::new();

--- a/benchmarks/src/stress/bbmd.rs
+++ b/benchmarks/src/stress/bbmd.rs
@@ -6,6 +6,7 @@
 use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
+use bacnet_transport::bbmd::ForeignDevicePolicy;
 use bacnet_transport::bip::{BipTransport, ForeignDeviceConfig};
 use bacnet_transport::bvll::decode_bip_mac;
 use bacnet_transport::port::TransportPort;
@@ -21,6 +22,13 @@ pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
         // Start BBMD
         let mut bbmd = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
         bbmd.enable_bbmd(vec![]);
+        bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+            max_entries_per_source: 256,
+            max_fdt_fanout: 128,
+            registration_rate_per_source: 1000,
+            registration_rate_global: 2000,
+            ..Default::default()
+        });
         let _bbmd_rx = bbmd.start().await.unwrap();
         let bbmd_mac = bbmd.local_mac().to_vec();
         let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();

--- a/crates/bacnet-transport/src/bbmd.rs
+++ b/crates/bacnet-transport/src/bbmd.rs
@@ -10,6 +10,10 @@ use bacnet_types::enums::BvlcResultCode;
 use bacnet_types::error::Error;
 use bytes::{BufMut, BytesMut};
 
+mod policy;
+use policy::ForeignDeviceRateTracker;
+pub use policy::{FdtCounters, ForeignDevicePolicy};
+
 /// BDT entry wire format size: IP(4) + port(2) + mask(4) = 10 bytes.
 pub const BDT_ENTRY_SIZE: usize = 10;
 
@@ -37,17 +41,27 @@ impl FdtEntry {
     /// Grace period in seconds added beyond TTL before expiry.
     const GRACE_PERIOD: u64 = 30;
 
+    /// Whether this entry has expired (TTL + grace period) relative to `now`.
+    pub fn is_expired_at(&self, now: Instant) -> bool {
+        let total = Duration::from_secs(self.ttl as u64 + Self::GRACE_PERIOD);
+        now.saturating_duration_since(self.registered_at) > total
+    }
+
     /// Whether this entry has expired (TTL + grace period).
     pub fn is_expired(&self) -> bool {
+        self.is_expired_at(Instant::now())
+    }
+
+    /// Seconds remaining including the 30-second grace period relative to `now`.
+    pub fn seconds_remaining_at(&self, now: Instant) -> u16 {
+        let elapsed = now.saturating_duration_since(self.registered_at).as_secs();
         let total = self.ttl as u64 + Self::GRACE_PERIOD;
-        self.registered_at.elapsed() > Duration::from_secs(total)
+        total.saturating_sub(elapsed).min(u16::MAX as u64) as u16
     }
 
     /// Seconds remaining including the 30-second grace period.
     pub fn seconds_remaining(&self) -> u16 {
-        let elapsed = self.registered_at.elapsed().as_secs();
-        let total = self.ttl as u64 + Self::GRACE_PERIOD;
-        total.saturating_sub(elapsed).min(u16::MAX as u64) as u16
+        self.seconds_remaining_at(Instant::now())
     }
 }
 
@@ -158,6 +172,11 @@ pub struct BbmdState {
     /// Allowed source IPs for Delete-Foreign-Device-Table-Entry.
     /// Empty means deny all (fail closed).
     management_acl: Vec<[u8; 4]>,
+    /// Explicit policy for foreign device registrations.
+    /// None means fail closed (deny all registrations).
+    foreign_device_policy: Option<ForeignDevicePolicy>,
+    rate_tracker: ForeignDeviceRateTracker,
+    counters: FdtCounters,
 }
 
 impl BbmdState {
@@ -169,7 +188,30 @@ impl BbmdState {
             local_ip,
             local_port,
             management_acl: Vec::new(),
+            foreign_device_policy: None,
+            rate_tracker: ForeignDeviceRateTracker::new(),
+            counters: FdtCounters::default(),
         }
+    }
+
+    /// Enable foreign device registration with the specified policy.
+    pub fn enable_foreign_device_registration(&mut self, policy: ForeignDevicePolicy) {
+        self.foreign_device_policy = Some(policy);
+    }
+
+    /// Set or clear the foreign device registration policy.
+    pub fn set_foreign_device_policy(&mut self, policy: Option<ForeignDevicePolicy>) {
+        self.foreign_device_policy = policy;
+    }
+
+    /// Current foreign device registration policy, if enabled.
+    pub fn foreign_device_policy(&self) -> Option<&ForeignDevicePolicy> {
+        self.foreign_device_policy.as_ref()
+    }
+
+    /// Operational counters for Foreign Device Table management.
+    pub fn fdt_counters(&self) -> FdtCounters {
+        self.counters
     }
 
     // -----------------------------------------------------------------------
@@ -292,27 +334,96 @@ impl BbmdState {
     /// Maximum number of entries in the Foreign Device Table.
     pub const MAX_FDT_ENTRIES: usize = 128;
 
-    /// Register or re-register a foreign device.
+    /// Register or re-register a foreign device at the current wall-clock instant.
     pub fn register_foreign_device(&mut self, ip: [u8; 4], port: u16, ttl: u16) -> BvlcResultCode {
-        if ttl == 0 {
+        self.register_foreign_device_at(ip, port, ttl, Instant::now())
+    }
+
+    /// Register or re-register a foreign device at the given `now` instant.
+    pub fn register_foreign_device_at(
+        &mut self,
+        ip: [u8; 4],
+        port: u16,
+        ttl: u16,
+        now: Instant,
+    ) -> BvlcResultCode {
+        let policy = match &self.foreign_device_policy {
+            Some(p) => p.clone(),
+            None => {
+                self.counters.registrations_rejected += 1;
+                return BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK;
+            }
+        };
+
+        // Purge expired entries before evaluating admission or capacity
+        self.purge_expired_at(now);
+
+        // Validate TTL bounds
+        if ttl == 0 || ttl < policy.min_ttl || ttl > policy.max_ttl {
+            self.counters.registrations_rejected += 1;
             return BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK;
         }
 
-        // Update existing or insert new
-        if let Some(entry) = self.fdt.iter_mut().find(|e| e.ip == ip && e.port == port) {
-            entry.ttl = ttl;
-            entry.registered_at = Instant::now();
-        } else {
-            if self.fdt.len() >= Self::MAX_FDT_ENTRIES {
+        // Check source ACL if configured
+        if let Some(allowed) = &policy.allowed_sources {
+            if !allowed.contains(&ip) {
+                self.counters.registrations_rejected += 1;
                 return BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK;
             }
+        }
+
+        // Check registration rate limits
+        if self.rate_tracker.is_rate_exceeded(
+            ip,
+            now,
+            policy.rate_window,
+            policy.registration_rate_per_source,
+            policy.registration_rate_global,
+        ) {
+            self.counters.registrations_rejected += 1;
+            return BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK;
+        }
+
+        let existing_idx = self.fdt.iter().position(|e| e.ip == ip && e.port == port);
+
+        if existing_idx.is_none() {
+            // Check per-source quota for new entries
+            let current_for_ip = self.fdt.iter().filter(|e| e.ip == ip).count();
+            if current_for_ip >= policy.max_entries_per_source {
+                self.counters.registrations_rejected += 1;
+                return BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK;
+            }
+
+            // Check capacity pressure and reserved capacity
+            let is_reserved = policy.reserved_sources.contains(&ip);
+            let effective_limit = if is_reserved {
+                Self::MAX_FDT_ENTRIES
+            } else {
+                Self::MAX_FDT_ENTRIES.saturating_sub(policy.reserved_capacity)
+            };
+
+            if self.fdt.len() >= effective_limit {
+                self.counters.capacity_exhausted += 1;
+                self.counters.registrations_rejected += 1;
+                return BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK;
+            }
+        }
+
+        // Admitted: record in rate tracker and mutate table
+        self.rate_tracker.record(ip);
+        if let Some(idx) = existing_idx {
+            self.fdt[idx].ttl = ttl;
+            self.fdt[idx].registered_at = now;
+        } else {
             self.fdt.push(FdtEntry {
                 ip,
                 port,
                 ttl,
-                registered_at: Instant::now(),
+                registered_at: now,
             });
         }
+
+        self.counters.registrations_accepted += 1;
         BvlcResultCode::SUCCESSFUL_COMPLETION
     }
 
@@ -327,11 +438,18 @@ impl BbmdState {
         }
     }
 
+    /// Purge expired FDT entries at the given instant and return the number removed.
+    pub fn purge_expired_at(&mut self, now: Instant) -> usize {
+        let before = self.fdt.len();
+        self.fdt.retain(|e| !e.is_expired_at(now));
+        let removed = before - self.fdt.len();
+        self.counters.registrations_expired += removed as u64;
+        removed
+    }
+
     /// Purge expired FDT entries and return the number removed.
     pub fn purge_expired(&mut self) -> usize {
-        let before = self.fdt.len();
-        self.fdt.retain(|e| !e.is_expired());
-        before - self.fdt.len()
+        self.purge_expired_at(Instant::now())
     }
 
     /// Get the current FDT (purges expired entries first).
@@ -423,7 +541,20 @@ impl BbmdState {
         exclude_ip: [u8; 4],
         exclude_port: u16,
     ) -> Vec<([u8; 4], u16)> {
-        self.purge_expired();
+        self.forwarding_targets_at(exclude_ip, exclude_port, Instant::now())
+    }
+
+    /// Get all (ip, port) targets for forwarding a broadcast relative to `now`,
+    /// excluding the source device and the local BBMD itself. BDT entries use directed
+    /// broadcast: `target = entry.ip | !entry.broadcast_mask`.
+    /// Purges expired FDT entries and caps FDT targets to `max_fdt_fanout`.
+    pub fn forwarding_targets_at(
+        &mut self,
+        exclude_ip: [u8; 4],
+        exclude_port: u16,
+        now: Instant,
+    ) -> Vec<([u8; 4], u16)> {
+        self.purge_expired_at(now);
         let mut targets = Vec::new();
 
         for entry in &self.bdt {
@@ -444,11 +575,22 @@ impl BbmdState {
             targets.push((directed_broadcast, entry.port));
         }
 
+        let max_fdt_fanout = self
+            .foreign_device_policy
+            .as_ref()
+            .map_or(32, |p| p.max_fdt_fanout);
+
+        let mut fdt_count = 0;
         for entry in &self.fdt {
             if entry.ip == exclude_ip && entry.port == exclude_port {
                 continue;
             }
+            if fdt_count >= max_fdt_fanout {
+                self.counters.fanout_budget_reached += 1;
+                break;
+            }
             targets.push((entry.ip, entry.port));
+            fdt_count += 1;
         }
 
         targets
@@ -456,416 +598,10 @@ impl BbmdState {
 }
 
 #[cfg(test)]
-mod validation_tests;
+mod foreign_device_tests;
 
 #[cfg(test)]
-mod tests {
-    use super::*;
+mod tests;
 
-    fn make_bbmd() -> BbmdState {
-        BbmdState::new([192, 168, 1, 1], 0xBAC0)
-    }
-
-    #[test]
-    fn bdt_set_and_get() {
-        let mut bbmd = make_bbmd();
-        let entries = vec![
-            BdtEntry {
-                ip: [192, 168, 1, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 255],
-            },
-            BdtEntry {
-                ip: [192, 168, 2, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 255],
-            },
-        ];
-        bbmd.set_bdt(entries.clone()).unwrap();
-        assert_eq!(bbmd.bdt().len(), 2);
-        assert_eq!(bbmd.bdt()[0], entries[0]);
-    }
-
-    #[test]
-    fn bdt_encode_decode_round_trip() {
-        let entries = vec![
-            BdtEntry {
-                ip: [10, 0, 1, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 0],
-            },
-            BdtEntry {
-                ip: [10, 0, 2, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 0],
-            },
-        ];
-        let mut bbmd = make_bbmd();
-        bbmd.set_bdt(entries.clone()).unwrap();
-        // set_bdt auto-inserts self, so 3 entries total
-        assert_eq!(bbmd.bdt().len(), 3);
-
-        let mut buf = BytesMut::new();
-        bbmd.encode_bdt(&mut buf);
-        assert_eq!(buf.len(), 30); // 3 * 10 bytes
-
-        let decoded = BbmdState::decode_bdt(&buf).unwrap();
-        assert_eq!(decoded.len(), 3);
-        assert!(decoded.contains(&entries[0]));
-        assert!(decoded.contains(&entries[1]));
-    }
-
-    #[test]
-    fn bdt_decode_invalid_length() {
-        assert!(BbmdState::decode_bdt(&[0; 7]).is_err());
-    }
-
-    #[test]
-    fn set_bdt_rejects_max_entries_when_self_insert_would_exceed_limit() {
-        let mut bbmd = make_bbmd();
-        let entries = (0..BbmdState::MAX_BDT_ENTRIES)
-            .map(|i| BdtEntry {
-                ip: [10, 0, (i / 256) as u8, i as u8],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 255],
-            })
-            .collect();
-
-        assert!(bbmd.set_bdt(entries).is_err());
-        assert!(bbmd.bdt().is_empty());
-    }
-
-    #[test]
-    fn register_and_lookup_foreign_device() {
-        let mut bbmd = make_bbmd();
-        let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
-        assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
-        assert_eq!(bbmd.fdt().len(), 1);
-        assert_eq!(bbmd.fdt()[0].ip, [10, 0, 0, 5]);
-        assert_eq!(bbmd.fdt()[0].ttl, 60);
-    }
-
-    #[test]
-    fn register_foreign_device_zero_ttl_naks() {
-        let mut bbmd = make_bbmd();
-        let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 0);
-        assert_eq!(result, BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK);
-        assert!(bbmd.fdt().is_empty());
-    }
-
-    #[test]
-    fn re_register_updates_existing() {
-        let mut bbmd = make_bbmd();
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 120);
-        assert_eq!(bbmd.fdt().len(), 1);
-        assert_eq!(bbmd.fdt()[0].ttl, 120);
-    }
-
-    #[test]
-    fn delete_foreign_device() {
-        let mut bbmd = make_bbmd();
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
-        let result = bbmd.delete_foreign_device([10, 0, 0, 5], 0xBAC0);
-        assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
-        assert!(bbmd.fdt().is_empty());
-    }
-
-    #[test]
-    fn delete_nonexistent_foreign_device_naks() {
-        let mut bbmd = make_bbmd();
-        let result = bbmd.delete_foreign_device([10, 0, 0, 5], 0xBAC0);
-        assert_eq!(
-            result,
-            BvlcResultCode::DELETE_FOREIGN_DEVICE_TABLE_ENTRY_NAK
-        );
-    }
-
-    #[test]
-    fn expired_entries_purged() {
-        let mut bbmd = make_bbmd();
-        // Insert an entry that's past TTL + grace period (0 + 30 = 30s, elapsed 40s)
-        bbmd.fdt.push(FdtEntry {
-            ip: [10, 0, 0, 5],
-            port: 0xBAC0,
-            ttl: 0,
-            registered_at: Instant::now() - Duration::from_secs(40),
-        });
-        assert!(bbmd.fdt().is_empty());
-    }
-
-    #[test]
-    fn fdt_encode() {
-        let mut bbmd = make_bbmd();
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
-        let mut buf = BytesMut::new();
-        bbmd.encode_fdt(&mut buf);
-        assert_eq!(buf.len(), FDT_ENTRY_SIZE);
-        // IP
-        assert_eq!(&buf[0..4], &[10, 0, 0, 5]);
-        // Port
-        assert_eq!(u16::from_be_bytes([buf[4], buf[5]]), 0xBAC0);
-        // TTL
-        assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 60);
-    }
-
-    #[test]
-    fn fdt_encode_caps_max_ttl_remaining_time() {
-        let mut bbmd = make_bbmd();
-        let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, u16::MAX);
-        assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
-
-        let mut buf = BytesMut::new();
-        bbmd.encode_fdt(&mut buf);
-
-        assert_eq!(buf.len(), FDT_ENTRY_SIZE);
-        assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), u16::MAX);
-        assert_eq!(u16::from_be_bytes([buf[8], buf[9]]), u16::MAX);
-    }
-
-    #[test]
-    fn forwarding_targets_excludes_source() {
-        let mut bbmd = BbmdState::new([192, 168, 1, 1], 0xBAC0);
-        bbmd.set_bdt(vec![
-            BdtEntry {
-                ip: [192, 168, 1, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 255],
-            },
-            BdtEntry {
-                ip: [192, 168, 2, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 255],
-            },
-        ])
-        .unwrap();
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
-
-        // Source is some device on our subnet (not us and not a BDT peer)
-        let targets = bbmd.forwarding_targets([192, 168, 1, 100], 0xBAC0);
-
-        assert_eq!(targets.len(), 2);
-        assert!(targets.contains(&([192, 168, 2, 1], 0xBAC0)));
-        assert!(targets.contains(&([10, 0, 0, 5], 0xBAC0)));
-    }
-
-    #[test]
-    fn forwarding_targets_uses_broadcast_mask() {
-        let mut bbmd = BbmdState::new([192, 168, 1, 1], 0xBAC0);
-        bbmd.set_bdt(vec![
-            BdtEntry {
-                ip: [192, 168, 1, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 0],
-            },
-            BdtEntry {
-                ip: [192, 168, 2, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 0],
-            },
-        ])
-        .unwrap();
-
-        let targets = bbmd.forwarding_targets([192, 168, 1, 100], 0xBAC0);
-        assert_eq!(targets.len(), 1);
-        assert!(targets.contains(&([192, 168, 2, 255], 0xBAC0)));
-    }
-
-    #[test]
-    fn forwarding_targets_unicast_with_full_mask() {
-        let mut bbmd = BbmdState::new([192, 168, 1, 1], 0xBAC0);
-        bbmd.set_bdt(vec![
-            BdtEntry {
-                ip: [192, 168, 1, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 255],
-            },
-            BdtEntry {
-                ip: [10, 0, 0, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 255],
-            },
-        ])
-        .unwrap();
-
-        let targets = bbmd.forwarding_targets([192, 168, 1, 100], 0xBAC0);
-        assert_eq!(targets.len(), 1);
-        assert!(targets.contains(&([10, 0, 0, 1], 0xBAC0)));
-    }
-
-    #[test]
-    fn forwarding_targets_excludes_originating_foreign_device_and_expired_entries() {
-        let mut bbmd = BbmdState::new([192, 168, 1, 1], 0xBAC0);
-        bbmd.set_bdt(vec![BdtEntry {
-            ip: [192, 168, 2, 1],
-            port: 0xBAC0,
-            broadcast_mask: [255, 255, 255, 255],
-        }])
-        .unwrap();
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
-        bbmd.fdt.push(FdtEntry {
-            ip: [10, 0, 0, 6],
-            port: 0xBAC0,
-            ttl: 60,
-            registered_at: Instant::now() - Duration::from_secs(91),
-        });
-
-        let targets = bbmd.forwarding_targets([10, 0, 0, 5], 0xBAC0);
-
-        assert_eq!(targets, vec![([192, 168, 2, 1], 0xBAC0)]);
-        assert_eq!(bbmd.fdt().len(), 1);
-    }
-
-    #[test]
-    fn ttl_accepted_as_is() {
-        let mut bbmd = make_bbmd();
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 1);
-        assert_eq!(bbmd.fdt()[0].ttl, 1);
-    }
-
-    #[test]
-    fn set_bdt_auto_inserts_self() {
-        let mut state = BbmdState::new([192, 168, 1, 1], 47808);
-        let entries = vec![BdtEntry {
-            ip: [192, 168, 1, 2],
-            port: 47808,
-            broadcast_mask: [255, 255, 255, 255],
-        }];
-        state.set_bdt(entries).unwrap();
-        assert_eq!(state.bdt().len(), 2);
-        assert!(state
-            .bdt()
-            .iter()
-            .any(|e| e.ip == [192, 168, 1, 1] && e.port == 47808));
-    }
-
-    #[test]
-    fn set_bdt_does_not_duplicate_self() {
-        let mut state = BbmdState::new([192, 168, 1, 1], 0xBAC0);
-        let entries = vec![BdtEntry {
-            ip: [192, 168, 1, 1],
-            port: 0xBAC0,
-            broadcast_mask: [255, 255, 255, 255],
-        }];
-        state.set_bdt(entries).unwrap();
-        assert_eq!(state.bdt().len(), 1); // self already present, no duplicate
-    }
-
-    #[test]
-    fn fdt_grace_period() {
-        let mut bbmd = make_bbmd();
-        // Insert entry that expired based on TTL alone but within grace period
-        bbmd.fdt.push(FdtEntry {
-            ip: [10, 0, 0, 5],
-            port: 0xBAC0,
-            ttl: 60,
-            registered_at: Instant::now() - Duration::from_secs(70), // 10s past TTL, but within 30s grace
-        });
-        assert!(
-            !bbmd.fdt().is_empty(),
-            "should still be alive during grace period"
-        );
-    }
-
-    #[test]
-    fn is_registered_foreign_device_check() {
-        let mut bbmd = make_bbmd();
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
-        assert!(bbmd.is_registered_foreign_device([10, 0, 0, 5], 0xBAC0));
-        assert!(!bbmd.is_registered_foreign_device([10, 0, 0, 6], 0xBAC0));
-    }
-
-    #[test]
-    fn seconds_remaining_includes_grace_period() {
-        let mut bbmd = make_bbmd();
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
-        let remaining = bbmd.fdt()[0].seconds_remaining();
-        assert!(
-            remaining <= 90, // TTL(60) + grace(30)
-            "seconds_remaining ({remaining}) must not exceed TTL+grace (90)"
-        );
-        assert!(
-            remaining > 60,
-            "should include grace period (got {remaining})"
-        );
-    }
-
-    #[test]
-    fn management_acl_empty_denies_all() {
-        let bbmd = make_bbmd();
-        assert!(!bbmd.is_management_allowed(&[10, 0, 0, 1]));
-        assert!(!bbmd.is_management_allowed(&[192, 168, 1, 1]));
-    }
-
-    #[test]
-    fn management_acl_restricts_to_listed_ips() {
-        let mut bbmd = make_bbmd();
-        bbmd.set_management_acl(vec![[10, 0, 0, 1], [10, 0, 0, 2]]);
-        assert!(bbmd.is_management_allowed(&[10, 0, 0, 1]));
-        assert!(bbmd.is_management_allowed(&[10, 0, 0, 2]));
-        assert!(!bbmd.is_management_allowed(&[10, 0, 0, 3]));
-        assert!(!bbmd.is_management_allowed(&[192, 168, 1, 1]));
-    }
-
-    #[test]
-    fn fdt_decode_round_trip() {
-        let mut bbmd = make_bbmd();
-        bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
-        let mut buf = BytesMut::new();
-        bbmd.encode_fdt(&mut buf);
-
-        let entries = decode_fdt(&buf).unwrap();
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].ip, [10, 0, 0, 5]);
-        assert_eq!(entries[0].port, 0xBAC0);
-        assert_eq!(entries[0].ttl, 60);
-        assert!(entries[0].seconds_remaining <= 90);
-    }
-
-    #[test]
-    fn fdt_decode_invalid_length() {
-        assert!(decode_fdt(&[0; 7]).is_err());
-    }
-
-    #[test]
-    fn encode_bdt_entries_matches_state() {
-        let mut entries = vec![
-            BdtEntry {
-                ip: [10, 0, 1, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 0],
-            },
-            BdtEntry {
-                ip: [10, 0, 2, 1],
-                port: 0xBAC0,
-                broadcast_mask: [255, 255, 255, 0],
-            },
-        ];
-
-        let mut buf_state = BytesMut::new();
-        let mut bbmd = make_bbmd();
-        bbmd.set_bdt(entries.clone()).unwrap();
-        bbmd.encode_bdt(&mut buf_state);
-
-        // set_bdt auto-inserts self, so include self in the expected entries
-        entries.push(BdtEntry {
-            ip: [192, 168, 1, 1],
-            port: 0xBAC0,
-            broadcast_mask: [255, 255, 255, 255],
-        });
-        let mut buf_fn = BytesMut::new();
-        encode_bdt_entries(&entries, &mut buf_fn);
-
-        assert_eq!(buf_state, buf_fn);
-    }
-
-    #[test]
-    fn management_acl_clear_denies_all() {
-        let mut bbmd = make_bbmd();
-        bbmd.set_management_acl(vec![[10, 0, 0, 1]]);
-        assert!(!bbmd.is_management_allowed(&[10, 0, 0, 2]));
-        bbmd.set_management_acl(Vec::new());
-        assert!(!bbmd.is_management_allowed(&[10, 0, 0, 2]));
-        assert!(!bbmd.is_management_allowed(&[10, 0, 0, 1]));
-    }
-}
+#[cfg(test)]
+mod validation_tests;

--- a/crates/bacnet-transport/src/bbmd.rs
+++ b/crates/bacnet-transport/src/bbmd.rs
@@ -575,22 +575,48 @@ impl BbmdState {
             targets.push((directed_broadcast, entry.port));
         }
 
+        targets.extend(self.fdt_forwarding_targets_at(exclude_ip, exclude_port, now));
+
+        targets
+    }
+
+    /// Get all (ip, port) FDT targets for forwarding, excluding `(exclude_ip, exclude_port)`.
+    /// Purges expired entries, caps results to `max_fdt_fanout`, and increments
+    /// `fanout_budget_reached` if capped.
+    pub fn fdt_forwarding_targets(
+        &mut self,
+        exclude_ip: [u8; 4],
+        exclude_port: u16,
+    ) -> Vec<([u8; 4], u16)> {
+        self.fdt_forwarding_targets_at(exclude_ip, exclude_port, Instant::now())
+    }
+
+    /// Get all (ip, port) FDT targets for forwarding relative to `now`, excluding `(exclude_ip, exclude_port)`.
+    /// Purges expired entries, caps results to `max_fdt_fanout`, and increments
+    /// `fanout_budget_reached` if capped.
+    pub fn fdt_forwarding_targets_at(
+        &mut self,
+        exclude_ip: [u8; 4],
+        exclude_port: u16,
+        now: Instant,
+    ) -> Vec<([u8; 4], u16)> {
+        self.purge_expired_at(now);
+
         let max_fdt_fanout = self
             .foreign_device_policy
             .as_ref()
             .map_or(32, |p| p.max_fdt_fanout);
 
-        let mut fdt_count = 0;
+        let mut targets = Vec::new();
         for entry in &self.fdt {
             if entry.ip == exclude_ip && entry.port == exclude_port {
                 continue;
             }
-            if fdt_count >= max_fdt_fanout {
+            if targets.len() >= max_fdt_fanout {
                 self.counters.fanout_budget_reached += 1;
                 break;
             }
             targets.push((entry.ip, entry.port));
-            fdt_count += 1;
         }
 
         targets

--- a/crates/bacnet-transport/src/bbmd/foreign_device_tests.rs
+++ b/crates/bacnet-transport/src/bbmd/foreign_device_tests.rs
@@ -341,3 +341,35 @@ fn counters_accurate_for_all_events() {
     assert_eq!(bbmd.fdt_counters().registrations_expired, 3);
     assert!(bbmd.fdt().is_empty());
 }
+
+#[test]
+fn fdt_forwarding_targets_fanout_budget_and_exclusion() {
+    let mut bbmd = make_unconfigured_bbmd();
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        max_fdt_fanout: 3,
+        max_entries_per_source: 10,
+        registration_rate_per_source: 100,
+        registration_rate_global: 100,
+        ..Default::default()
+    });
+
+    for i in 1..=5 {
+        assert_eq!(
+            bbmd.register_foreign_device([10, 0, 0, i], 0xBAC0, 60),
+            BvlcResultCode::SUCCESSFUL_COMPLETION
+        );
+    }
+
+    assert_eq!(bbmd.fdt_counters().fanout_budget_reached, 0);
+
+    // If originator is one of the foreign devices, exclude it and cap to 3
+    let targets = bbmd.fdt_forwarding_targets([10, 0, 0, 1], 0xBAC0);
+    assert_eq!(targets.len(), 3);
+    assert!(!targets.contains(&([10, 0, 0, 1], 0xBAC0)));
+    assert_eq!(bbmd.fdt_counters().fanout_budget_reached, 1);
+
+    // If originator is external, return 3 and increment counter again
+    let targets2 = bbmd.fdt_forwarding_targets([192, 168, 1, 1], 0xBAC0);
+    assert_eq!(targets2.len(), 3);
+    assert_eq!(bbmd.fdt_counters().fanout_budget_reached, 2);
+}

--- a/crates/bacnet-transport/src/bbmd/foreign_device_tests.rs
+++ b/crates/bacnet-transport/src/bbmd/foreign_device_tests.rs
@@ -1,0 +1,343 @@
+use std::time::{Duration, Instant};
+
+use super::*;
+use bacnet_types::enums::BvlcResultCode;
+
+fn make_unconfigured_bbmd() -> BbmdState {
+    BbmdState::new([192, 168, 1, 1], 0xBAC0)
+}
+
+#[test]
+fn bbmd_without_policy_naks_registration_fail_closed() {
+    let mut bbmd = make_unconfigured_bbmd();
+    assert!(bbmd.foreign_device_policy().is_none());
+
+    let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+    assert_eq!(result, BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK);
+    assert!(bbmd.fdt().is_empty());
+
+    let counters = bbmd.fdt_counters();
+    assert_eq!(counters.registrations_rejected, 1);
+    assert_eq!(counters.registrations_accepted, 0);
+}
+
+#[test]
+fn allowed_sources_acl_enforces_membership_and_empty_denies_all() {
+    let mut bbmd = make_unconfigured_bbmd();
+    // Some([ip]) allows only listed IP
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        allowed_sources: Some(vec![[10, 0, 0, 1]]),
+        ..Default::default()
+    });
+
+    // Allowed source succeeds
+    let res1 = bbmd.register_foreign_device([10, 0, 0, 1], 0xBAC0, 60);
+    assert_eq!(res1, BvlcResultCode::SUCCESSFUL_COMPLETION);
+
+    // Unlisted source fails
+    let res2 = bbmd.register_foreign_device([10, 0, 0, 2], 0xBAC0, 60);
+    assert_eq!(res2, BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK);
+
+    // Empty list denies all (fail-closed)
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        allowed_sources: Some(vec![]),
+        ..Default::default()
+    });
+    let res3 = bbmd.register_foreign_device([10, 0, 0, 1], 0xBAC0, 60);
+    assert_eq!(res3, BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK);
+
+    // None allows any source
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        allowed_sources: None,
+        ..Default::default()
+    });
+    let res4 = bbmd.register_foreign_device([10, 0, 0, 2], 0xBAC0, 60);
+    assert_eq!(res4, BvlcResultCode::SUCCESSFUL_COMPLETION);
+}
+
+#[test]
+fn per_source_quota_does_not_deny_other_sources() {
+    let mut bbmd = make_unconfigured_bbmd();
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        max_entries_per_source: 3,
+        registration_rate_per_source: 10,
+        ..Default::default()
+    });
+
+    let src_a = [10, 0, 0, 1];
+    let src_b = [10, 0, 0, 2];
+
+    // Source A registers 3 distinct ports (filling quota)
+    assert_eq!(
+        bbmd.register_foreign_device(src_a, 0xBAC0, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(
+        bbmd.register_foreign_device(src_a, 0xBAC1, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(
+        bbmd.register_foreign_device(src_a, 0xBAC2, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+
+    // 4th port from Source A must be rejected
+    assert_eq!(
+        bbmd.register_foreign_device(src_a, 0xBAC3, 60),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+
+    // Re-registering existing (ip, port) does NOT consume new quota and succeeds
+    assert_eq!(
+        bbmd.register_foreign_device(src_a, 0xBAC0, 120),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+
+    // Source B can register up to its own quota unaffected by Source A
+    assert_eq!(
+        bbmd.register_foreign_device(src_b, 0xBAC0, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(
+        bbmd.register_foreign_device(src_b, 0xBAC1, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(bbmd.fdt().len(), 5);
+
+    let counters = bbmd.fdt_counters();
+    assert_eq!(counters.registrations_accepted, 6);
+    assert_eq!(counters.registrations_rejected, 1);
+}
+
+#[test]
+fn overlong_ttl_and_over_rate_rejected_without_mutating_existing_entries() {
+    let mut bbmd = make_unconfigured_bbmd();
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        min_ttl: 30,
+        max_ttl: 300,
+        registration_rate_per_source: 3,
+        registration_rate_global: 10,
+        rate_window: Duration::from_secs(10),
+        ..Default::default()
+    });
+
+    let t0 = Instant::now();
+    let ip = [10, 0, 0, 1];
+    let port = 0xBAC0;
+
+    // 1st registration: valid TTL 60 at t0
+    assert_eq!(
+        bbmd.register_foreign_device_at(ip, port, 60, t0),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(bbmd.fdt().len(), 1);
+    assert_eq!(bbmd.fdt()[0].ttl, 60);
+    assert_eq!(bbmd.fdt()[0].registered_at, t0);
+
+    let t1 = t0 + Duration::from_secs(1);
+
+    // Overlong TTL (500 > max_ttl 300) must NAK and preserve existing entry
+    assert_eq!(
+        bbmd.register_foreign_device_at(ip, port, 500, t1),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+    assert_eq!(bbmd.fdt()[0].ttl, 60);
+    assert_eq!(bbmd.fdt()[0].registered_at, t0);
+
+    // Below min_ttl (10 < min_ttl 30) must NAK and preserve existing entry
+    assert_eq!(
+        bbmd.register_foreign_device_at(ip, port, 10, t1),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+    assert_eq!(bbmd.fdt()[0].ttl, 60);
+    assert_eq!(bbmd.fdt()[0].registered_at, t0);
+
+    // Zero TTL must NAK and preserve existing entry
+    assert_eq!(
+        bbmd.register_foreign_device_at(ip, port, 0, t1),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+    assert_eq!(bbmd.fdt()[0].ttl, 60);
+    assert_eq!(bbmd.fdt()[0].registered_at, t0);
+
+    // 2nd valid registration within window at t1
+    assert_eq!(
+        bbmd.register_foreign_device_at(ip, port, 90, t1),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(bbmd.fdt()[0].ttl, 90);
+    assert_eq!(bbmd.fdt()[0].registered_at, t1);
+
+    // 3rd valid registration within window at t1 + 1s (hits per-source limit of 3)
+    let t2 = t1 + Duration::from_secs(1);
+    assert_eq!(
+        bbmd.register_foreign_device_at(ip, port, 120, t2),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(bbmd.fdt()[0].ttl, 120);
+    assert_eq!(bbmd.fdt()[0].registered_at, t2);
+
+    // 4th registration within same rate window exceeds rate limit -> NAK and preserve entry!
+    let t3 = t2 + Duration::from_secs(1);
+    assert_eq!(
+        bbmd.register_foreign_device_at(ip, port, 150, t3),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+    assert_eq!(bbmd.fdt()[0].ttl, 120);
+    assert_eq!(bbmd.fdt()[0].registered_at, t2);
+
+    // After rate window expires (t0 + 12s), registration is admitted again
+    let t4 = t0 + Duration::from_secs(12);
+    assert_eq!(
+        bbmd.register_foreign_device_at(ip, port, 180, t4),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(bbmd.fdt()[0].ttl, 180);
+    assert_eq!(bbmd.fdt()[0].registered_at, t4);
+}
+
+#[test]
+fn capacity_pressure_preserves_reserved_capacity() {
+    let mut bbmd = make_unconfigured_bbmd();
+    let reserved_ip = [10, 0, 0, 99];
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        reserved_capacity: 10,
+        reserved_sources: vec![reserved_ip],
+        max_entries_per_source: 128,
+        registration_rate_per_source: 200,
+        registration_rate_global: 200,
+        ..Default::default()
+    });
+
+    let unreserved_limit = BbmdState::MAX_FDT_ENTRIES - 10; // 118
+
+    // Fill unreserved capacity (118 entries) with unique IPs
+    for i in 0..unreserved_limit {
+        let ip = [10, 1, (i / 256) as u8, (i % 256) as u8];
+        assert_eq!(
+            bbmd.register_foreign_device(ip, 0xBAC0, 60),
+            BvlcResultCode::SUCCESSFUL_COMPLETION
+        );
+    }
+    assert_eq!(bbmd.fdt().len(), unreserved_limit);
+
+    // Attempting 119th entry from unreserved source must NAK due to capacity pressure
+    let unreserved_ip = [10, 2, 0, 1];
+    assert_eq!(
+        bbmd.register_foreign_device(unreserved_ip, 0xBAC0, 60),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+    assert_eq!(bbmd.fdt_counters().capacity_exhausted, 1);
+
+    // Reserved source is admitted into reserved slots
+    for i in 0..10 {
+        assert_eq!(
+            bbmd.register_foreign_device(reserved_ip, 0xBAC0 + (i as u16), 60),
+            BvlcResultCode::SUCCESSFUL_COMPLETION
+        );
+    }
+    assert_eq!(bbmd.fdt().len(), BbmdState::MAX_FDT_ENTRIES);
+
+    // Total table is now at MAX_FDT_ENTRIES (128). Even reserved source cannot exceed 128.
+    assert_eq!(
+        bbmd.register_foreign_device(reserved_ip, 0xFFF0, 60),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+    assert_eq!(bbmd.fdt_counters().capacity_exhausted, 2);
+}
+
+#[test]
+fn forwarding_targets_fanout_budget_capped_and_counted() {
+    let mut bbmd = make_unconfigured_bbmd();
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        max_fdt_fanout: 5,
+        max_entries_per_source: 128,
+        registration_rate_per_source: 200,
+        registration_rate_global: 200,
+        ..Default::default()
+    });
+
+    // Populate 12 foreign devices
+    for i in 0..12 {
+        let ip = [10, 0, 0, i as u8 + 1];
+        assert_eq!(
+            bbmd.register_foreign_device(ip, 0xBAC0, 60),
+            BvlcResultCode::SUCCESSFUL_COMPLETION
+        );
+    }
+
+    assert_eq!(bbmd.fdt_counters().fanout_budget_reached, 0);
+
+    // Forwarding broadcast from an external subnet device
+    let targets = bbmd.forwarding_targets([192, 168, 1, 100], 0xBAC0);
+    // BDT has self only, so 0 BDT targets; FDT targets capped to max_fdt_fanout (5)
+    assert_eq!(targets.len(), 5);
+    assert_eq!(bbmd.fdt_counters().fanout_budget_reached, 1);
+
+    // Second broadcast forwarding again increments counter
+    let targets2 = bbmd.forwarding_targets([192, 168, 1, 100], 0xBAC0);
+    assert_eq!(targets2.len(), 5);
+    assert_eq!(bbmd.fdt_counters().fanout_budget_reached, 2);
+}
+
+#[test]
+fn counters_accurate_for_all_events() {
+    let mut bbmd = make_unconfigured_bbmd();
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        min_ttl: 10,
+        max_ttl: 100,
+        max_entries_per_source: 2,
+        reserved_capacity: 1,
+        reserved_sources: vec![[10, 0, 0, 99]],
+        max_fdt_fanout: 2,
+        registration_rate_per_source: 5,
+        registration_rate_global: 10,
+        ..Default::default()
+    });
+
+    let t0 = Instant::now();
+
+    // 1. Accepted registration
+    assert_eq!(
+        bbmd.register_foreign_device_at([10, 0, 0, 1], 0xBAC0, 30, t0),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(bbmd.fdt_counters().registrations_accepted, 1);
+    assert_eq!(bbmd.fdt_counters().registrations_rejected, 0);
+
+    // 2. Rejected: TTL too short (< 10)
+    assert_eq!(
+        bbmd.register_foreign_device_at([10, 0, 0, 2], 0xBAC0, 5, t0),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+    assert_eq!(bbmd.fdt_counters().registrations_rejected, 1);
+
+    // 3. Rejected: Quota exceeded
+    assert_eq!(
+        bbmd.register_foreign_device_at([10, 0, 0, 1], 0xBAC1, 30, t0),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    assert_eq!(
+        bbmd.register_foreign_device_at([10, 0, 0, 1], 0xBAC2, 30, t0),
+        BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK
+    );
+    assert_eq!(bbmd.fdt_counters().registrations_rejected, 2);
+
+    // 4. Fanout budget reached
+    assert_eq!(
+        bbmd.register_foreign_device_at([10, 0, 0, 3], 0xBAC0, 30, t0),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+    // Now we have 3 entries in FDT, max_fdt_fanout is 2
+    let targets = bbmd.forwarding_targets_at([192, 168, 1, 100], 0xBAC0, t0);
+    assert_eq!(targets.len(), 2);
+    assert_eq!(bbmd.fdt_counters().fanout_budget_reached, 1);
+
+    // 5. Expired registration purged
+    // Entries have TTL 30 + grace 30 = 60s
+    let t_expired = t0 + Duration::from_secs(65);
+    let purged = bbmd.purge_expired_at(t_expired);
+    assert_eq!(purged, 3);
+    assert_eq!(bbmd.fdt_counters().registrations_expired, 3);
+    assert!(bbmd.fdt().is_empty());
+}

--- a/crates/bacnet-transport/src/bbmd/policy.rs
+++ b/crates/bacnet-transport/src/bbmd/policy.rs
@@ -1,0 +1,126 @@
+//! Foreign device registration policy, quotas, and operational counters.
+//!
+//! Implements explicit foreign device registration enablement, fail-closed
+//! admission, per-source quotas, reserved capacity, broadcast fanout bounding,
+//! and rate limiting per ASHRAE Standard 135-2020 Annex J.5.2.2.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Foreign device registration policy for a BBMD.
+///
+/// Controls admission, quotas, rate limiting, and fanout limits for foreign
+/// device registrations. By default, BBMD mode operates fail-closed with no
+/// policy enabled.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForeignDevicePolicy {
+    /// Minimum allowed TTL in seconds.
+    pub min_ttl: u16,
+    /// Maximum allowed TTL in seconds.
+    pub max_ttl: u16,
+    /// Maximum active FDT entries allowed per source IPv4 address.
+    pub max_entries_per_source: usize,
+    /// Optional ACL of allowed source IPv4 addresses.
+    /// `None` allows any source IP subject to quotas and rates.
+    /// `Some(list)` requires the source IP to be present in `list`; an empty
+    /// list denies all sources.
+    pub allowed_sources: Option<Vec<[u8; 4]>>,
+    /// Number of FDT slots reserved exclusively for `reserved_sources`.
+    pub reserved_capacity: usize,
+    /// Source IPv4 addresses authorized to use reserved capacity.
+    pub reserved_sources: Vec<[u8; 4]>,
+    /// Broadcast forwarding fanout budget for FDT targets.
+    pub max_fdt_fanout: usize,
+    /// Maximum registrations admitted per source IP per rate window.
+    pub registration_rate_per_source: u32,
+    /// Maximum registrations admitted globally per rate window.
+    pub registration_rate_global: u32,
+    /// Duration of the rate window.
+    pub rate_window: Duration,
+}
+
+impl Default for ForeignDevicePolicy {
+    fn default() -> Self {
+        Self {
+            min_ttl: 1,
+            max_ttl: 3600,
+            max_entries_per_source: 8,
+            allowed_sources: None,
+            reserved_capacity: 0,
+            reserved_sources: Vec::new(),
+            max_fdt_fanout: 32,
+            registration_rate_per_source: 8,
+            registration_rate_global: 64,
+            rate_window: Duration::from_secs(1),
+        }
+    }
+}
+
+/// Operational counters for BBMD Foreign Device Table management and traffic.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct FdtCounters {
+    /// Number of foreign device registrations successfully admitted.
+    pub registrations_accepted: u64,
+    /// Number of foreign device registrations rejected.
+    pub registrations_rejected: u64,
+    /// Number of expired foreign device registrations purged.
+    pub registrations_expired: u64,
+    /// Number of registrations rejected due to FDT capacity exhaustion.
+    pub capacity_exhausted: u64,
+    /// Number of times the broadcast forwarding fanout budget for FDT targets was reached.
+    pub fanout_budget_reached: u64,
+}
+
+/// Window-based registration rate limiter for foreign device registrations.
+#[derive(Debug, Clone)]
+pub(crate) struct ForeignDeviceRateTracker {
+    window_start: Option<Instant>,
+    global_count: u32,
+    source_counts: HashMap<[u8; 4], u32>,
+}
+
+impl ForeignDeviceRateTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            window_start: None,
+            global_count: 0,
+            source_counts: HashMap::new(),
+        }
+    }
+
+    /// Check whether admitting another registration from `ip` at `now` would
+    /// exceed either the per-source or global rate limit.
+    pub(crate) fn is_rate_exceeded(
+        &mut self,
+        ip: [u8; 4],
+        now: Instant,
+        rate_window: Duration,
+        max_per_source: u32,
+        max_global: u32,
+    ) -> bool {
+        match self.window_start {
+            None => {
+                self.window_start = Some(now);
+                self.global_count = 0;
+                self.source_counts.clear();
+            }
+            Some(start) => {
+                if now.saturating_duration_since(start) >= rate_window {
+                    self.window_start = Some(now);
+                    self.global_count = 0;
+                    self.source_counts.clear();
+                }
+            }
+        }
+
+        let source_count = self.source_counts.get(&ip).copied().unwrap_or(0);
+        source_count >= max_per_source || self.global_count >= max_global
+    }
+
+    /// Record an admitted registration.
+    pub(crate) fn record(&mut self, ip: [u8; 4]) {
+        self.global_count = self.global_count.saturating_add(1);
+        let entry = self.source_counts.entry(ip).or_insert(0);
+        *entry = entry.saturating_add(1);
+    }
+}

--- a/crates/bacnet-transport/src/bbmd/tests.rs
+++ b/crates/bacnet-transport/src/bbmd/tests.rs
@@ -1,0 +1,416 @@
+use super::*;
+
+fn make_bbmd() -> BbmdState {
+    let mut state = BbmdState::new([192, 168, 1, 1], 0xBAC0);
+    state.enable_foreign_device_registration(ForeignDevicePolicy::default());
+    state
+}
+
+#[test]
+fn bdt_set_and_get() {
+    let mut bbmd = make_bbmd();
+    let entries = vec![
+        BdtEntry {
+            ip: [192, 168, 1, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        },
+        BdtEntry {
+            ip: [192, 168, 2, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        },
+    ];
+    bbmd.set_bdt(entries.clone()).unwrap();
+    assert_eq!(bbmd.bdt().len(), 2);
+    assert_eq!(bbmd.bdt()[0], entries[0]);
+}
+
+#[test]
+fn bdt_encode_decode_round_trip() {
+    let entries = vec![
+        BdtEntry {
+            ip: [10, 0, 1, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 0],
+        },
+        BdtEntry {
+            ip: [10, 0, 2, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 0],
+        },
+    ];
+    let mut bbmd = make_bbmd();
+    bbmd.set_bdt(entries.clone()).unwrap();
+    // set_bdt auto-inserts self, so 3 entries total
+    assert_eq!(bbmd.bdt().len(), 3);
+
+    let mut buf = BytesMut::new();
+    bbmd.encode_bdt(&mut buf);
+    assert_eq!(buf.len(), 30); // 3 * 10 bytes
+
+    let decoded = BbmdState::decode_bdt(&buf).unwrap();
+    assert_eq!(decoded.len(), 3);
+    assert!(decoded.contains(&entries[0]));
+    assert!(decoded.contains(&entries[1]));
+}
+
+#[test]
+fn bdt_decode_invalid_length() {
+    assert!(BbmdState::decode_bdt(&[0; 7]).is_err());
+}
+
+#[test]
+fn set_bdt_rejects_max_entries_when_self_insert_would_exceed_limit() {
+    let mut bbmd = make_bbmd();
+    let entries = (0..BbmdState::MAX_BDT_ENTRIES)
+        .map(|i| BdtEntry {
+            ip: [10, 0, (i / 256) as u8, i as u8],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        })
+        .collect();
+
+    assert!(bbmd.set_bdt(entries).is_err());
+    assert!(bbmd.bdt().is_empty());
+}
+
+#[test]
+fn register_and_lookup_foreign_device() {
+    let mut bbmd = make_bbmd();
+    let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+    assert_eq!(bbmd.fdt().len(), 1);
+    assert_eq!(bbmd.fdt()[0].ip, [10, 0, 0, 5]);
+    assert_eq!(bbmd.fdt()[0].ttl, 60);
+}
+
+#[test]
+fn register_foreign_device_zero_ttl_naks() {
+    let mut bbmd = make_bbmd();
+    let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 0);
+    assert_eq!(result, BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK);
+    assert!(bbmd.fdt().is_empty());
+}
+
+#[test]
+fn re_register_updates_existing() {
+    let mut bbmd = make_bbmd();
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 120);
+    assert_eq!(bbmd.fdt().len(), 1);
+    assert_eq!(bbmd.fdt()[0].ttl, 120);
+}
+
+#[test]
+fn delete_foreign_device() {
+    let mut bbmd = make_bbmd();
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+    let result = bbmd.delete_foreign_device([10, 0, 0, 5], 0xBAC0);
+    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+    assert!(bbmd.fdt().is_empty());
+}
+
+#[test]
+fn delete_nonexistent_foreign_device_naks() {
+    let mut bbmd = make_bbmd();
+    let result = bbmd.delete_foreign_device([10, 0, 0, 5], 0xBAC0);
+    assert_eq!(
+        result,
+        BvlcResultCode::DELETE_FOREIGN_DEVICE_TABLE_ENTRY_NAK
+    );
+}
+
+#[test]
+fn expired_entries_purged() {
+    let mut bbmd = make_bbmd();
+    // Insert an entry that's past TTL + grace period (0 + 30 = 30s, elapsed 40s)
+    bbmd.fdt.push(FdtEntry {
+        ip: [10, 0, 0, 5],
+        port: 0xBAC0,
+        ttl: 0,
+        registered_at: Instant::now() - Duration::from_secs(40),
+    });
+    assert!(bbmd.fdt().is_empty());
+}
+
+#[test]
+fn fdt_encode() {
+    let mut bbmd = make_bbmd();
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+    let mut buf = BytesMut::new();
+    bbmd.encode_fdt(&mut buf);
+    assert_eq!(buf.len(), FDT_ENTRY_SIZE);
+    // IP
+    assert_eq!(&buf[0..4], &[10, 0, 0, 5]);
+    // Port
+    assert_eq!(u16::from_be_bytes([buf[4], buf[5]]), 0xBAC0);
+    // TTL
+    assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 60);
+}
+
+#[test]
+fn fdt_encode_caps_max_ttl_remaining_time() {
+    let mut bbmd = make_bbmd();
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy {
+        max_ttl: u16::MAX,
+        ..Default::default()
+    });
+    let result = bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, u16::MAX);
+    assert_eq!(result, BvlcResultCode::SUCCESSFUL_COMPLETION);
+
+    let mut buf = BytesMut::new();
+    bbmd.encode_fdt(&mut buf);
+
+    assert_eq!(buf.len(), FDT_ENTRY_SIZE);
+    assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), u16::MAX);
+    assert_eq!(u16::from_be_bytes([buf[8], buf[9]]), u16::MAX);
+}
+
+#[test]
+fn forwarding_targets_excludes_source() {
+    let mut bbmd = BbmdState::new([192, 168, 1, 1], 0xBAC0);
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy::default());
+    bbmd.set_bdt(vec![
+        BdtEntry {
+            ip: [192, 168, 1, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        },
+        BdtEntry {
+            ip: [192, 168, 2, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        },
+    ])
+    .unwrap();
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+
+    // Source is some device on our subnet (not us and not a BDT peer)
+    let targets = bbmd.forwarding_targets([192, 168, 1, 100], 0xBAC0);
+
+    assert_eq!(targets.len(), 2);
+    assert!(targets.contains(&([192, 168, 2, 1], 0xBAC0)));
+    assert!(targets.contains(&([10, 0, 0, 5], 0xBAC0)));
+}
+
+#[test]
+fn forwarding_targets_uses_broadcast_mask() {
+    let mut bbmd = BbmdState::new([192, 168, 1, 1], 0xBAC0);
+    bbmd.set_bdt(vec![
+        BdtEntry {
+            ip: [192, 168, 1, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 0],
+        },
+        BdtEntry {
+            ip: [192, 168, 2, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 0],
+        },
+    ])
+    .unwrap();
+
+    let targets = bbmd.forwarding_targets([192, 168, 1, 100], 0xBAC0);
+    assert_eq!(targets.len(), 1);
+    assert!(targets.contains(&([192, 168, 2, 255], 0xBAC0)));
+}
+
+#[test]
+fn forwarding_targets_unicast_with_full_mask() {
+    let mut bbmd = BbmdState::new([192, 168, 1, 1], 0xBAC0);
+    bbmd.set_bdt(vec![
+        BdtEntry {
+            ip: [192, 168, 1, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        },
+        BdtEntry {
+            ip: [10, 0, 0, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 255],
+        },
+    ])
+    .unwrap();
+
+    let targets = bbmd.forwarding_targets([192, 168, 1, 100], 0xBAC0);
+    assert_eq!(targets.len(), 1);
+    assert!(targets.contains(&([10, 0, 0, 1], 0xBAC0)));
+}
+
+#[test]
+fn forwarding_targets_excludes_originating_foreign_device_and_expired_entries() {
+    let mut bbmd = BbmdState::new([192, 168, 1, 1], 0xBAC0);
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy::default());
+    bbmd.set_bdt(vec![BdtEntry {
+        ip: [192, 168, 2, 1],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 255],
+    }])
+    .unwrap();
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+    bbmd.fdt.push(FdtEntry {
+        ip: [10, 0, 0, 6],
+        port: 0xBAC0,
+        ttl: 60,
+        registered_at: Instant::now() - Duration::from_secs(91),
+    });
+
+    let targets = bbmd.forwarding_targets([10, 0, 0, 5], 0xBAC0);
+
+    assert_eq!(targets, vec![([192, 168, 2, 1], 0xBAC0)]);
+    assert_eq!(bbmd.fdt().len(), 1);
+}
+
+#[test]
+fn ttl_accepted_as_is() {
+    let mut bbmd = make_bbmd();
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 1);
+    assert_eq!(bbmd.fdt()[0].ttl, 1);
+}
+
+#[test]
+fn set_bdt_auto_inserts_self() {
+    let mut state = BbmdState::new([192, 168, 1, 1], 47808);
+    let entries = vec![BdtEntry {
+        ip: [192, 168, 1, 2],
+        port: 47808,
+        broadcast_mask: [255, 255, 255, 255],
+    }];
+    state.set_bdt(entries).unwrap();
+    assert_eq!(state.bdt().len(), 2);
+    assert!(state
+        .bdt()
+        .iter()
+        .any(|e| e.ip == [192, 168, 1, 1] && e.port == 47808));
+}
+
+#[test]
+fn set_bdt_does_not_duplicate_self() {
+    let mut state = BbmdState::new([192, 168, 1, 1], 0xBAC0);
+    let entries = vec![BdtEntry {
+        ip: [192, 168, 1, 1],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 255],
+    }];
+    state.set_bdt(entries).unwrap();
+    assert_eq!(state.bdt().len(), 1); // self already present, no duplicate
+}
+
+#[test]
+fn fdt_grace_period() {
+    let mut bbmd = make_bbmd();
+    // Insert entry that expired based on TTL alone but within grace period
+    bbmd.fdt.push(FdtEntry {
+        ip: [10, 0, 0, 5],
+        port: 0xBAC0,
+        ttl: 60,
+        registered_at: Instant::now() - Duration::from_secs(70), // 10s past TTL, but within 30s grace
+    });
+    assert!(
+        !bbmd.fdt().is_empty(),
+        "should still be alive during grace period"
+    );
+}
+
+#[test]
+fn is_registered_foreign_device_check() {
+    let mut bbmd = make_bbmd();
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+    assert!(bbmd.is_registered_foreign_device([10, 0, 0, 5], 0xBAC0));
+    assert!(!bbmd.is_registered_foreign_device([10, 0, 0, 6], 0xBAC0));
+}
+
+#[test]
+fn seconds_remaining_includes_grace_period() {
+    let mut bbmd = make_bbmd();
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+    let remaining = bbmd.fdt()[0].seconds_remaining();
+    assert!(
+        remaining <= 90, // TTL(60) + grace(30)
+        "seconds_remaining ({remaining}) must not exceed TTL+grace (90)"
+    );
+    assert!(
+        remaining > 60,
+        "should include grace period (got {remaining})"
+    );
+}
+
+#[test]
+fn management_acl_empty_denies_all() {
+    let bbmd = make_bbmd();
+    assert!(!bbmd.is_management_allowed(&[10, 0, 0, 1]));
+    assert!(!bbmd.is_management_allowed(&[192, 168, 1, 1]));
+}
+
+#[test]
+fn management_acl_restricts_to_listed_ips() {
+    let mut bbmd = make_bbmd();
+    bbmd.set_management_acl(vec![[10, 0, 0, 1], [10, 0, 0, 2]]);
+    assert!(bbmd.is_management_allowed(&[10, 0, 0, 1]));
+    assert!(bbmd.is_management_allowed(&[10, 0, 0, 2]));
+    assert!(!bbmd.is_management_allowed(&[10, 0, 0, 3]));
+    assert!(!bbmd.is_management_allowed(&[192, 168, 1, 1]));
+}
+
+#[test]
+fn fdt_decode_round_trip() {
+    let mut bbmd = make_bbmd();
+    bbmd.register_foreign_device([10, 0, 0, 5], 0xBAC0, 60);
+    let mut buf = BytesMut::new();
+    bbmd.encode_fdt(&mut buf);
+
+    let entries = decode_fdt(&buf).unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].ip, [10, 0, 0, 5]);
+    assert_eq!(entries[0].port, 0xBAC0);
+    assert_eq!(entries[0].ttl, 60);
+    assert!(entries[0].seconds_remaining <= 90);
+}
+
+#[test]
+fn fdt_decode_invalid_length() {
+    assert!(decode_fdt(&[0; 7]).is_err());
+}
+
+#[test]
+fn encode_bdt_entries_matches_state() {
+    let mut entries = vec![
+        BdtEntry {
+            ip: [10, 0, 1, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 0],
+        },
+        BdtEntry {
+            ip: [10, 0, 2, 1],
+            port: 0xBAC0,
+            broadcast_mask: [255, 255, 255, 0],
+        },
+    ];
+
+    let mut buf_state = BytesMut::new();
+    let mut bbmd = make_bbmd();
+    bbmd.set_bdt(entries.clone()).unwrap();
+    bbmd.encode_bdt(&mut buf_state);
+
+    // set_bdt auto-inserts self, so include self in the expected entries
+    entries.push(BdtEntry {
+        ip: [192, 168, 1, 1],
+        port: 0xBAC0,
+        broadcast_mask: [255, 255, 255, 255],
+    });
+    let mut buf_fn = BytesMut::new();
+    encode_bdt_entries(&entries, &mut buf_fn);
+
+    assert_eq!(buf_state, buf_fn);
+}
+
+#[test]
+fn management_acl_clear_denies_all() {
+    let mut bbmd = make_bbmd();
+    bbmd.set_management_acl(vec![[10, 0, 0, 1]]);
+    assert!(!bbmd.is_management_allowed(&[10, 0, 0, 2]));
+    bbmd.set_management_acl(Vec::new());
+    assert!(!bbmd.is_management_allowed(&[10, 0, 0, 2]));
+    assert!(!bbmd.is_management_allowed(&[10, 0, 0, 1]));
+}

--- a/crates/bacnet-transport/src/bip/acl_tests.rs
+++ b/crates/bacnet-transport/src/bip/acl_tests.rs
@@ -10,6 +10,7 @@ async fn management_acl_allows_listed_sender_delete_fdt_but_write_bdt_always_nak
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![initial_bdt.clone()]);
     bbmd_transport.set_bbmd_management_acl(vec![[127, 0, 0, 1]]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -74,6 +75,7 @@ async fn management_acl_denies_unlisted_sender_and_preserves_bdt_and_fdt() {
     };
     bbmd_transport.enable_bbmd(vec![initial_bdt.clone()]);
     bbmd_transport.set_bbmd_management_acl(vec![[10, 0, 0, 1]]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -134,6 +136,7 @@ async fn empty_management_acl_denies_delete_fdt_and_preserves_entry() {
     // Default fail-closed policy: no ACL authorizes nobody.
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 

--- a/crates/bacnet-transport/src/bip/dbtn_tests.rs
+++ b/crates/bacnet-transport/src/bip/dbtn_tests.rs
@@ -48,6 +48,7 @@ async fn dbtn_registered_foreign_device_fans_out_without_origin_echo() {
     let (npdu_tx, mut npdu_rx) = mpsc::channel(1);
 
     let mut state = BbmdState::new(Ipv4Addr::LOCALHOST.octets(), local_port);
+    state.enable_foreign_device_registration(ForeignDevicePolicy::default());
     state
         .set_bdt(vec![BdtEntry {
             ip: Ipv4Addr::LOCALHOST.octets(),
@@ -133,6 +134,7 @@ async fn dbtn_registered_foreign_device_naks_when_forwarding_fails() {
     let (npdu_tx, _npdu_rx) = mpsc::channel(1);
 
     let mut state = BbmdState::new(Ipv4Addr::LOCALHOST.octets(), local_port);
+    state.enable_foreign_device_registration(ForeignDevicePolicy::default());
     assert_eq!(
         state.register_foreign_device(Ipv4Addr::LOCALHOST.octets(), origin_fd_port, 60),
         BvlcResultCode::SUCCESSFUL_COMPLETION

--- a/crates/bacnet-transport/src/bip/fdt_tests.rs
+++ b/crates/bacnet-transport/src/bip/fdt_tests.rs
@@ -23,6 +23,7 @@ async fn wait_for_fdt_len(transport: &BipTransport, expected: usize) {
 async fn bbmd_fdt_purge_task_clears_expired_entry_without_bvlc_request() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     assert!(bbmd_transport.bbmd_fdt_purge_task.is_some());
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
@@ -64,6 +65,7 @@ async fn register_foreign_device_resets_entry_before_purge_task_removes_it() {
 
     {
         let mut state = bbmd.lock().await;
+        state.enable_foreign_device_registration(ForeignDevicePolicy::default());
         assert_eq!(
             state.register_foreign_device(fd_ip, fd_port, 1),
             BvlcResultCode::SUCCESSFUL_COMPLETION
@@ -85,4 +87,32 @@ async fn register_foreign_device_resets_entry_before_purge_task_removes_it() {
 
     purge_task.abort();
     let _ = purge_task.await;
+}
+
+#[tokio::test]
+async fn bbmd_without_foreign_device_policy_naks_bvlc_registration() {
+    let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    bbmd_transport.enable_bbmd(vec![]);
+    // Do NOT call enable_foreign_device_registration
+    let _bbmd_rx = bbmd_transport.start().await.unwrap();
+    let bbmd_mac = bbmd_transport.local_mac().to_vec();
+
+    let mut client_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let _client_rx = client_transport.start().await.unwrap();
+
+    let result = client_transport
+        .register_foreign_device_bvlc(&bbmd_mac, 60)
+        .await
+        .unwrap();
+    assert_eq!(result, BvlcResultCode::REGISTER_FOREIGN_DEVICE_NAK);
+
+    let counters = bbmd_transport.fdt_counters().await.unwrap();
+    assert_eq!(counters.registrations_rejected, 1);
+    assert_eq!(counters.registrations_accepted, 0);
+
+    // Non-BBMD client returns None for fdt_counters
+    assert!(client_transport.fdt_counters().await.is_none());
+
+    client_transport.stop().await.unwrap();
+    bbmd_transport.stop().await.unwrap();
 }

--- a/crates/bacnet-transport/src/bip/forwarded_tests.rs
+++ b/crates/bacnet-transport/src/bip/forwarded_tests.rs
@@ -267,3 +267,92 @@ async fn forwarded_npdu_from_directed_broadcast_peer_skips_local_rebroadcast() {
         "Forwarded-NPDU from a BDT peer must not be re-forwarded to BDT peers"
     );
 }
+
+#[tokio::test]
+async fn forwarded_npdu_fdt_fanout_respects_budget_and_increments_counter() {
+    let bbmd_socket = Arc::new(
+        UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap(),
+    );
+    let local_port = bbmd_socket.local_addr().unwrap().port();
+    let local_broadcast_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let local_broadcast_port = local_broadcast_sink.local_addr().unwrap().port();
+
+    let mut fd_sockets = Vec::new();
+    let mut fd_ports = Vec::new();
+    for _ in 0..3 {
+        let sock = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
+        fd_ports.push(sock.local_addr().unwrap().port());
+        fd_sockets.push(sock);
+    }
+
+    let (npdu_tx, _npdu_rx) = mpsc::channel(1);
+    let peer = ([192, 0, 2, 10], 0xBAC0);
+    let origin = ([192, 0, 2, 20], 0xBAC1);
+
+    let mut state = BbmdState::new(Ipv4Addr::LOCALHOST.octets(), local_port);
+    state.enable_foreign_device_registration(ForeignDevicePolicy {
+        max_fdt_fanout: 2,
+        ..ForeignDevicePolicy::default()
+    });
+    state
+        .set_bdt(vec![BdtEntry {
+            ip: peer.0,
+            port: peer.1,
+            broadcast_mask: [255, 255, 255, 255],
+        }])
+        .unwrap();
+
+    for &port in &fd_ports {
+        assert_eq!(
+            state.register_foreign_device(Ipv4Addr::LOCALHOST.octets(), port, 60),
+            BvlcResultCode::SUCCESSFUL_COMPLETION
+        );
+    }
+
+    let bbmd_state = Arc::new(Mutex::new(state));
+    let ctx = RecvContext {
+        local_mac: encode_bip_mac(Ipv4Addr::LOCALHOST.octets(), local_port),
+        socket: bbmd_socket,
+        npdu_tx,
+        bbmd: Some(bbmd_state.clone()),
+        broadcast_addr: Ipv4Addr::LOCALHOST,
+        broadcast_port: local_broadcast_port,
+        pending_bvlc_response: Arc::new(Mutex::new(None)),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        force_dbtn_forward_failure: false,
+    };
+    let msg = BvllMessage {
+        function: BvlcFunction::FORWARDED_NPDU,
+        payload: Bytes::from_static(&[0x01, 0x00, 0xAA, 0xBB]),
+        originating_ip: Some(origin.0),
+        originating_port: Some(origin.1),
+    };
+
+    handle_bvll_message(&msg, peer, &ctx).await;
+
+    // First two foreign devices received the frame
+    let frame1 = recv_bvll(&fd_sockets[0]).await;
+    assert_eq!(frame1.function, BvlcFunction::FORWARDED_NPDU);
+    assert_eq!(frame1.originating_ip, Some(origin.0));
+    assert_eq!(frame1.originating_port, Some(origin.1));
+    assert_eq!(frame1.payload.as_ref(), msg.payload.as_ref());
+
+    let frame2 = recv_bvll(&fd_sockets[1]).await;
+    assert_eq!(frame2.function, BvlcFunction::FORWARDED_NPDU);
+    assert_eq!(frame2.originating_ip, Some(origin.0));
+    assert_eq!(frame2.originating_port, Some(origin.1));
+    assert_eq!(frame2.payload.as_ref(), msg.payload.as_ref());
+
+    // Third foreign device was capped and received nothing
+    assert_no_bvll(&fd_sockets[2], "third foreign device").await;
+
+    // Counter was incremented
+    let counters = bbmd_state.lock().await.fdt_counters();
+    assert_eq!(counters.fanout_budget_reached, 1);
+}

--- a/crates/bacnet-transport/src/bip/forwarded_tests.rs
+++ b/crates/bacnet-transport/src/bip/forwarded_tests.rs
@@ -130,6 +130,7 @@ async fn forwarded_npdu_from_non_bdt_sender_is_rejected_without_delivery() {
     let origin = ([192, 0, 2, 20], 0xBAC1);
 
     let mut state = BbmdState::new(Ipv4Addr::LOCALHOST.octets(), local_port);
+    state.enable_foreign_device_registration(ForeignDevicePolicy::default());
     state
         .set_bdt(vec![BdtEntry {
             ip: Ipv4Addr::LOCALHOST.octets(),
@@ -198,6 +199,7 @@ async fn forwarded_npdu_from_directed_broadcast_peer_skips_local_rebroadcast() {
     let peer = ([192, 0, 2, 10], 0xBAC0);
     let origin = ([192, 0, 2, 20], 0xBAC1);
     let mut state = BbmdState::new(Ipv4Addr::LOCALHOST.octets(), local_port);
+    state.enable_foreign_device_registration(ForeignDevicePolicy::default());
     state
         .set_bdt(vec![
             BdtEntry {

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -228,13 +228,7 @@ pub(super) async fn handle_bvll_message(
                 // Forward to FDT entries (BDT peers don't need it — they got it directly)
                 let fdt_targets = {
                     let mut state = bbmd.lock().await;
-                    state.purge_expired();
-                    state
-                        .fdt()
-                        .iter()
-                        .filter(|e| !(e.ip == orig_ip && e.port == orig_port))
-                        .map(|e| (e.ip, e.port))
-                        .collect::<Vec<_>>()
+                    state.fdt_forwarding_targets(orig_ip, orig_port)
                 };
                 let _ =
                     forward_npdu(&ctx.socket, &msg.payload, orig_ip, orig_port, &fdt_targets).await;

--- a/crates/bacnet-transport/src/bip/management_ack_tests.rs
+++ b/crates/bacnet-transport/src/bip/management_ack_tests.rs
@@ -105,6 +105,7 @@ async fn read_bdt_ack_encodes_bdt_entries_as_n10_payload() {
 async fn read_fdt_ack_encodes_fdt_entries_as_n10_payload() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -15,6 +15,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
 use crate::bbmd::{self, BbmdState, BdtEntry, FdtEntryWire};
+pub use crate::bbmd::{FdtCounters, ForeignDevicePolicy};
 use crate::bvll::{decode_bip_mac, decode_bvll, encode_bip_mac, encode_bvll, BvllMessage};
 use crate::port::{ReceivedNpdu, TransportPort};
 use crate::udp_metadata::{DestinationReceiver, IpVersion};
@@ -116,6 +117,7 @@ pub struct ForeignDeviceConfig {
 struct BbmdConfig {
     initial_bdt: Vec<BdtEntry>,
     management_acl: Vec<[u8; 4]>,
+    foreign_device_policy: Option<ForeignDevicePolicy>,
 }
 
 /// BACnet/IP transport over UDP.
@@ -177,7 +179,24 @@ impl BipTransport {
         self.bbmd_config = Some(BbmdConfig {
             initial_bdt: bdt,
             management_acl: Vec::new(),
+            foreign_device_policy: None,
         });
+    }
+
+    /// Enable foreign device registration on this BBMD with the given policy.
+    /// Must be called after `enable_bbmd()` and before `start()`.
+    pub fn enable_foreign_device_registration(&mut self, policy: ForeignDevicePolicy) {
+        if let Some(config) = &mut self.bbmd_config {
+            config.foreign_device_policy = Some(policy);
+        } else {
+            warn!("enable_foreign_device_registration called before enable_bbmd(); policy will be ignored");
+        }
+    }
+
+    /// Set foreign device registration policy on this BBMD.
+    /// Must be called after `enable_bbmd()` and before `start()`.
+    pub fn set_foreign_device_policy(&mut self, policy: ForeignDevicePolicy) {
+        self.enable_foreign_device_registration(policy);
     }
 
     /// Set the path for loading an externally provisioned persisted BDT
@@ -217,6 +236,16 @@ impl BipTransport {
         match self.management_limiter.lock() {
             Ok(limiter) => limiter.counters(),
             Err(poison) => poison.into_inner().counters(),
+        }
+    }
+
+    /// Return operational Foreign Device Table counters if BBMD mode is enabled.
+    pub async fn fdt_counters(&self) -> Option<FdtCounters> {
+        if let Some(bbmd) = &self.bbmd {
+            let state = bbmd.lock().await;
+            Some(state.fdt_counters())
+        } else {
+            None
         }
     }
 
@@ -531,6 +560,7 @@ impl TransportPort for BipTransport {
                 return Err(Error::Encoding(format!("BDT configuration error: {e}")));
             }
             state.set_management_acl(config.management_acl);
+            state.set_foreign_device_policy(config.foreign_device_policy);
             self.bbmd = Some(Arc::new(Mutex::new(state)));
         }
 

--- a/crates/bacnet-transport/src/bip/original_tests.rs
+++ b/crates/bacnet-transport/src/bip/original_tests.rs
@@ -196,6 +196,7 @@ async fn original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo
     let (npdu_tx, mut npdu_rx) = mpsc::channel(1);
     let sender = ([192, 0, 2, 40], 0xBAC1);
     let mut state = BbmdState::new(Ipv4Addr::LOCALHOST.octets(), local_port);
+    state.enable_foreign_device_registration(ForeignDevicePolicy::default());
     state
         .set_bdt(vec![BdtEntry {
             ip: Ipv4Addr::LOCALHOST.octets(),

--- a/crates/bacnet-transport/src/bip/rate_limit_tests.rs
+++ b/crates/bacnet-transport/src/bip/rate_limit_tests.rs
@@ -209,6 +209,11 @@ async fn rate_limit_silences_17th_register_from_same_ip() {
 async fn rate_limit_source_quota_ignores_udp_port() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy {
+        registration_rate_per_source: 32,
+        registration_rate_global: 256,
+        ..Default::default()
+    });
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
     let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();

--- a/crates/bacnet-transport/src/bip/response_amplification_tests.rs
+++ b/crates/bacnet-transport/src/bip/response_amplification_tests.rs
@@ -58,6 +58,11 @@ fn test_bdt_empty_and_max_response_sizes() {
 #[test]
 fn test_fdt_empty_and_max_response_sizes() {
     let mut state = BbmdState::new([127, 0, 0, 1], 0xBAC0);
+    state.enable_foreign_device_registration(ForeignDevicePolicy {
+        registration_rate_global: 256,
+        max_entries_per_source: 128,
+        ..Default::default()
+    });
 
     // Empty FDT payload -> 4-byte BVLC header only
     let mut empty_payload = BytesMut::new();
@@ -319,11 +324,21 @@ async fn test_bbmd_wire_read_fdt_throttling() {
     // Register 128 foreign devices directly in BBMD state
     {
         let mut state = BbmdState::new([127, 0, 0, 1], 0xBAC0);
+        state.enable_foreign_device_registration(ForeignDevicePolicy {
+            registration_rate_global: 256,
+            max_entries_per_source: 128,
+            ..Default::default()
+        });
         for i in 0..BbmdState::MAX_FDT_ENTRIES {
             let ip = [10, 0, (i / 256) as u8, (i % 256) as u8];
             state.register_foreign_device(ip, 0xBAC0 + (i as u16), 300);
         }
         bbmd_transport.enable_bbmd(state.bdt().to_vec());
+        bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy {
+            registration_rate_global: 256,
+            max_entries_per_source: 128,
+            ..Default::default()
+        });
     }
 
     let _bbmd_rx = bbmd_transport.start().await.unwrap();

--- a/crates/bacnet-transport/src/bip/tests.rs
+++ b/crates/bacnet-transport/src/bip/tests.rs
@@ -185,6 +185,7 @@ async fn bbmd_register_foreign_device() {
     // Start a BBMD
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
     let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();
@@ -249,6 +250,7 @@ async fn read_fdt_from_bbmd() {
     // Start a BBMD
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
     let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();
@@ -438,6 +440,7 @@ async fn write_bdt_to_non_bbmd_surfaces_typed_nak() {
 async fn register_foreign_device_via_bvlc() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -458,6 +461,7 @@ async fn register_foreign_device_via_bvlc() {
 async fn register_foreign_device_rejects_zero_ttl() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -484,6 +488,7 @@ async fn register_foreign_device_rejects_zero_ttl() {
 async fn register_foreign_device_rejects_malformed_ttl_payload_lengths() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -509,6 +514,10 @@ async fn register_foreign_device_rejects_malformed_ttl_payload_lengths() {
 async fn register_foreign_device_accepts_max_ttl_and_caps_remaining() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy {
+        max_ttl: u16::MAX,
+        ..Default::default()
+    });
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -572,10 +581,11 @@ async fn delete_fdt_entry_to_non_bbmd_surfaces_typed_nak() {
 }
 
 #[tokio::test]
-async fn delete_fdt_entry_removes_registered_foreign_device() {
+async fn delete_fdt_entry_via_bvlc() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
     bbmd_transport.set_bbmd_management_acl(vec![[127, 0, 0, 1]]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -607,6 +617,7 @@ async fn delete_fdt_entry_rejects_malformed_payload_and_preserves_entry() {
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
     bbmd_transport.set_bbmd_management_acl(vec![[127, 0, 0, 1]]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let _bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
 
@@ -651,6 +662,7 @@ async fn foreign_device_broadcast_via_bbmd() {
     // BBMD
     let mut bbmd_transport = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
     bbmd_transport.enable_bbmd(vec![]);
+    bbmd_transport.enable_foreign_device_registration(ForeignDevicePolicy::default());
     let mut bbmd_rx = bbmd_transport.start().await.unwrap();
     let bbmd_mac = bbmd_transport.local_mac().to_vec();
     let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();


### PR DESCRIPTION
Closes #528

## Summary
- **Explicit Foreign-Device Enablement & Fail-Closed Admission**: Require explicit ForeignDevicePolicy enablement on BBMD before foreign device registrations are admitted, returning REGISTER_FOREIGN_DEVICE_NAK fail-closed when unconfigured per ASHRAE 135-2020 Annex J.5.2.2.
- **TTL & Rate Bounds**: Enforce configurable min/max TTL limits (default 1s..3600s) and per-source/global registration rate limiting. Rejections leave existing registrations unmodified without mutating state.
- **Per-Source Quotas & Fair Allocation**: Enforce max_entries_per_source (default 8) to prevent a single IP from occupying table slots. Re-registrations refresh existing entries without consuming additional quota.
- **Capacity Pressure & Reserved Capacity**: Partition FDT capacity (128 slots) with configurable reserved_capacity and reserved_sources ACL, protecting critical/configured devices under capacity exhaustion.
- **Broadcast Fanout Budget**: Bound broadcast forwarding to at most max_fdt_fanout (default 32) FDT destinations per broadcast.
- **Operational Telemetry**: Track FdtCounters on BbmdState and expose fdt_counters(&self) -> Option<FdtCounters> on BipTransport.
- **Modularity & File Cap**: Extracted inline unit tests from bbmd.rs into bbmd/tests.rs to maintain strict compliance with the 700 LOC cap (445 LOC in bbmd.rs).
- **Test Coverage**: Added extensive unit and integration tests verifying fail-closed NAKs, ACL enforcement, source quota isolation, TTL and rate-limit rejection without mutation, reserved capacity protection, fanout capping, and operational counters.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-transport --locked` (439 unit + 2 integration passed)
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked`
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`