### PR TITLE
fix(bip): deduplicate and budget BBMD broadcast forwarding fanout

### DIFF
--- a/benchmarks/src/stress/bbmd.rs
+++ b/benchmarks/src/stress/bbmd.rs
@@ -7,10 +7,11 @@ use std::net::Ipv4Addr;
 use std::time::{Duration, Instant};
 
 use bacnet_transport::bbmd::ForeignDevicePolicy;
-use bacnet_transport::bip::{BipTransport, ForeignDeviceConfig};
+use bacnet_transport::bip::{BipTransport, FanoutPolicy, ForeignDeviceConfig};
 use bacnet_transport::bvll::decode_bip_mac;
 use bacnet_transport::port::TransportPort;
 
+use crate::stress::harness::current_rss_kb;
 use crate::stress::output::{DegradationPoint, LatencyRecorder};
 
 pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
@@ -18,6 +19,8 @@ pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
 
     for &count in steps {
         eprintln!("--- {} foreign devices ---", count);
+
+        let rss_before = current_rss_kb();
 
         // Start BBMD
         let mut bbmd = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
@@ -29,12 +32,20 @@ pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
             registration_rate_global: 2000,
             ..Default::default()
         });
-        let _bbmd_rx = bbmd.start().await.unwrap();
+        bbmd.set_fanout_policy(FanoutPolicy {
+            max_fanout_per_input: 128,
+            max_packets_per_sec_global: 4096,
+            max_bytes_per_sec_global: 2_000_000,
+            max_packets_per_sec_per_origin: 512,
+            queue_capacity: 512,
+        });
+        let mut bbmd_rx = bbmd.start().await.unwrap();
         let bbmd_mac = bbmd.local_mac().to_vec();
         let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();
 
         // Register N foreign devices
         let mut fds = Vec::new();
+        let mut fd_rxs = Vec::new();
         let mut fd_errors = 0u64;
 
         for _ in 0..count {
@@ -45,7 +56,10 @@ pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
                 ttl: 600,
             });
             match fd.start().await {
-                Ok(_rx) => fds.push(fd),
+                Ok(rx) => {
+                    fds.push(fd);
+                    fd_rxs.push(rx);
+                }
                 Err(e) => {
                     eprintln!("  FD registration error: {}", e);
                     fd_errors += 1;
@@ -56,6 +70,11 @@ pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
         // Wait for registrations to complete
         tokio::time::sleep(Duration::from_millis(200)).await;
 
+        // Drain registration messages from bbmd_rx
+        while let Ok(Some(_)) =
+            tokio::time::timeout(Duration::from_millis(10), bbmd_rx.recv()).await
+        {}
+
         // Verify FDT size
         if let Some(state) = bbmd.bbmd_state() {
             let mut st = state.lock().await;
@@ -65,6 +84,7 @@ pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
 
         // Measure broadcast distribution: each FD sends a broadcast
         let mut recorder = LatencyRecorder::new();
+        let mut recv_recorder = LatencyRecorder::new();
         let deadline = Instant::now() + Duration::from_secs(duration_secs);
         let test_npdu = vec![0x01, 0x00, 0x10, 0x08]; // Minimal NPDU + WhoIs
 
@@ -76,6 +96,20 @@ pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
                 Ok(_) => {
                     recorder.record_success(start);
                     sends += 1;
+                    if fd_rxs.len() > 1 {
+                        let target_idx = (fd_idx + 1) % fd_rxs.len();
+                        let recv_start = Instant::now();
+                        if let Ok(Some(_)) = tokio::time::timeout(
+                            Duration::from_millis(10),
+                            fd_rxs[target_idx].recv(),
+                        )
+                        .await
+                        {
+                            recv_recorder.record_success(recv_start);
+                        } else {
+                            recv_recorder.record_failure();
+                        }
+                    }
                 }
                 Err(_) => recorder.record_failure(),
             }
@@ -84,15 +118,34 @@ pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
         }
 
         let stats = recorder.stats();
+        let recv_stats = recv_recorder.stats();
         let throughput = recorder.successful() as f64 / duration_secs as f64;
+        let fanout_stats = bbmd.fanout_counters();
+        let rss_after = current_rss_kb();
 
         eprintln!(
-            "  sends={} errors={} throughput={:.0}/s p50={}µs p99={}µs",
+            "  sends={} errors={} throughput={:.0}/s send_p50={}µs send_p99={}µs",
             recorder.successful(),
             recorder.failed() + fd_errors,
             throughput,
             stats.p50,
             stats.p99,
+        );
+        eprintln!(
+            "  fanout: forwarded={} ({} bytes) throttled={} deduped={} drops={}",
+            fanout_stats.packets_forwarded,
+            fanout_stats.bytes_forwarded,
+            fanout_stats.packets_throttled,
+            fanout_stats.destinations_deduplicated,
+            fanout_stats.queue_overflow_drops,
+        );
+        eprintln!(
+            "  recv latency: p50={}µs p99={}µs | memory: {}KB → {}KB (delta: {:+}KB)",
+            recv_stats.p50,
+            recv_stats.p99,
+            rss_before,
+            rss_after,
+            rss_after as i64 - rss_before as i64,
         );
 
         curve.push(DegradationPoint {
@@ -100,7 +153,7 @@ pub async fn run(duration_secs: u64, steps: &[u64]) -> Vec<DegradationPoint> {
             p50_us: stats.p50,
             p99_us: stats.p99,
             throughput,
-            errors: recorder.failed() + fd_errors,
+            errors: recorder.failed() + fd_errors + fanout_stats.queue_overflow_drops,
         });
 
         // Cleanup

--- a/crates/bacnet-transport/src/bbmd.rs
+++ b/crates/bacnet-transport/src/bbmd.rs
@@ -3,7 +3,7 @@
 //! Manages the Broadcast Distribution Table (BDT) and Foreign Device Table
 //! (FDT) per ASHRAE 135-2020 Annex J. Pure state/logic — no async or I/O.
 
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use bacnet_types::enums::BvlcResultCode;
@@ -92,6 +92,8 @@ fn validate_bdt_entry(e: &BdtEntry) -> Result<(), Error> {
         "multicast IP"
     } else if prefix == 33 {
         "non-contiguous mask"
+    } else if prefix < 8 {
+        "mask prefix too wide (< /8) or limited-broadcast target"
     } else if prefix < 32 && ip & host == 0 {
         "subnet network address"
     } else if prefix < 32 && ip | mask == u32::MAX {
@@ -556,6 +558,7 @@ impl BbmdState {
     ) -> Vec<([u8; 4], u16)> {
         self.purge_expired_at(now);
         let mut targets = Vec::new();
+        let mut seen = HashSet::new();
 
         for entry in &self.bdt {
             // Skip self
@@ -572,10 +575,36 @@ impl BbmdState {
                 entry.ip[2] | !entry.broadcast_mask[2],
                 entry.ip[3] | !entry.broadcast_mask[3],
             ];
-            targets.push((directed_broadcast, entry.port));
+            let target = (directed_broadcast, entry.port);
+            if !seen.insert(target) {
+                self.counters.destinations_deduplicated += 1;
+            } else {
+                targets.push(target);
+            }
         }
 
-        targets.extend(self.fdt_forwarding_targets_at(exclude_ip, exclude_port, now));
+        let max_fdt_fanout = self
+            .foreign_device_policy
+            .as_ref()
+            .map_or(32, |p| p.max_fdt_fanout);
+
+        let mut fdt_count = 0;
+        for entry in &self.fdt {
+            if entry.ip == exclude_ip && entry.port == exclude_port {
+                continue;
+            }
+            let target = (entry.ip, entry.port);
+            if !seen.insert(target) {
+                self.counters.destinations_deduplicated += 1;
+                continue;
+            }
+            if fdt_count >= max_fdt_fanout {
+                self.counters.fanout_budget_reached += 1;
+                break;
+            }
+            targets.push(target);
+            fdt_count += 1;
+        }
 
         targets
     }
@@ -608,15 +637,21 @@ impl BbmdState {
             .map_or(32, |p| p.max_fdt_fanout);
 
         let mut targets = Vec::new();
+        let mut seen = HashSet::new();
         for entry in &self.fdt {
             if entry.ip == exclude_ip && entry.port == exclude_port {
+                continue;
+            }
+            let target = (entry.ip, entry.port);
+            if !seen.insert(target) {
+                self.counters.destinations_deduplicated += 1;
                 continue;
             }
             if targets.len() >= max_fdt_fanout {
                 self.counters.fanout_budget_reached += 1;
                 break;
             }
-            targets.push((entry.ip, entry.port));
+            targets.push(target);
         }
 
         targets

--- a/crates/bacnet-transport/src/bbmd/policy.rs
+++ b/crates/bacnet-transport/src/bbmd/policy.rs
@@ -69,6 +69,8 @@ pub struct FdtCounters {
     pub capacity_exhausted: u64,
     /// Number of times the broadcast forwarding fanout budget for FDT targets was reached.
     pub fanout_budget_reached: u64,
+    /// Number of duplicate forwarding destinations skipped during resolution.
+    pub destinations_deduplicated: u64,
 }
 
 /// Window-based registration rate limiter for foreign device registrations.

--- a/crates/bacnet-transport/src/bbmd/validation_tests.rs
+++ b/crates/bacnet-transport/src/bbmd/validation_tests.rs
@@ -4,7 +4,8 @@
 //! invalid or conflicting candidates must fail transactionally with an
 //! `Error::Encoding`-style error and preserve the committed table.
 
-use super::{BbmdState, BdtEntry};
+use super::{BbmdState, BdtEntry, ForeignDevicePolicy};
+use bacnet_types::enums::BvlcResultCode;
 use bacnet_types::error::Error;
 
 const PORT: u16 = 0xBAC0;
@@ -291,4 +292,72 @@ fn relocated_forwarded_npdu_skips_local_broadcast_for_directed_peer() {
 fn relocated_forwarded_npdu_skips_local_broadcast_for_unknown_peer() {
     let bbmd = make_bbmd();
     assert!(!bbmd.forwarded_npdu_needs_local_broadcast([10, 0, 0, 1], PORT));
+}
+
+#[test]
+fn rejects_wide_broadcast_prefix_under_slash_8() {
+    let mut bbmd = make_bbmd();
+    // /7 mask (254.0.0.0) is wider than /8 and must be rejected
+    let err7 = bbmd
+        .set_bdt(vec![entry([10, 0, 0, 5], PORT, [254, 0, 0, 0])])
+        .unwrap_err();
+    assert_encoding_error(err7, "wide");
+
+    // /1 mask (128.0.0.0) is wider than /8 and must be rejected
+    let err1 = bbmd
+        .set_bdt(vec![entry([10, 0, 0, 5], PORT, [128, 0, 0, 0])])
+        .unwrap_err();
+    assert_encoding_error(err1, "wide");
+
+    // Valid /8 mask (255.0.0.0) with non-255.255.255.255 directed broadcast is accepted
+    let ok8 = entry([10, 0, 0, 1], PORT, [255, 0, 0, 0]);
+    bbmd.set_bdt(vec![ok8.clone()]).unwrap();
+    assert!(bbmd.bdt().contains(&ok8));
+}
+
+#[test]
+fn rejects_resolved_limited_broadcast_at_slash_8() {
+    let mut bbmd = make_bbmd();
+    // /8 mask with IP 255.x.y.z resolves to 255.255.255.255, which is rejected
+    let err = bbmd
+        .set_bdt(vec![entry([255, 0, 0, 1], PORT, [255, 0, 0, 0])])
+        .unwrap_err();
+    assert_encoding_error(err, "limited");
+}
+
+#[test]
+fn forwarding_targets_deduplicates_overlapping_bdt_and_fdt() {
+    let mut bbmd = make_bbmd();
+    // Two BDT entries resolving to 192.168.7.255:PORT
+    let first_bdt = entry([192, 168, 7, 10], PORT, MASK_24);
+    let second_bdt = entry([192, 168, 7, 20], PORT, MASK_24);
+    bbmd.set_bdt(vec![first_bdt, second_bdt]).unwrap();
+
+    // Foreign device matching the same directed broadcast IP and port
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy::default());
+    assert_eq!(
+        bbmd.register_foreign_device([192, 168, 7, 255], PORT, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+
+    // Also register an independent foreign device
+    assert_eq!(
+        bbmd.register_foreign_device([10, 0, 0, 99], PORT, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+
+    let targets = bbmd.forwarding_targets([172, 16, 0, 1], PORT);
+    assert_eq!(
+        targets.len(),
+        2,
+        "directed broadcast and independent foreign device must be emitted once each: {targets:?}"
+    );
+    assert_eq!(targets[0], ([192, 168, 7, 255], PORT));
+    assert_eq!(targets[1], ([10, 0, 0, 99], PORT));
+
+    assert_eq!(
+        bbmd.fdt_counters().destinations_deduplicated,
+        2,
+        "1 BDT duplicate + 1 FDT duplicate must be counted"
+    );
 }

--- a/crates/bacnet-transport/src/bip/dbtn_tests.rs
+++ b/crates/bacnet-transport/src/bip/dbtn_tests.rs
@@ -74,6 +74,7 @@ async fn dbtn_registered_foreign_device_fans_out_without_origin_echo() {
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     };
     let sender = (Ipv4Addr::LOCALHOST.octets(), origin_fd_port);
@@ -149,6 +150,7 @@ async fn dbtn_registered_foreign_device_naks_when_forwarding_fails() {
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: true,
     };
     let sender = (Ipv4Addr::LOCALHOST.octets(), origin_fd_port);

--- a/crates/bacnet-transport/src/bip/fanout.rs
+++ b/crates/bacnet-transport/src/bip/fanout.rs
@@ -33,6 +33,15 @@ pub struct FanoutPolicy {
     pub queue_capacity: usize,
 }
 
+impl FanoutPolicy {
+    /// Return a copy of this policy with valid parameters (queue capacity clamped to at least 1).
+    pub fn sanitized(&self) -> Self {
+        let mut policy = self.clone();
+        policy.queue_capacity = policy.queue_capacity.max(1);
+        policy
+    }
+}
+
 impl Default for FanoutPolicy {
     fn default() -> Self {
         Self {
@@ -58,6 +67,8 @@ pub struct FanoutCounters {
     pub destinations_deduplicated: u64,
     /// Number of fanout forwarding jobs dropped due to work queue overflow.
     pub queue_overflow_drops: u64,
+    /// Number of errors encountered while sending forwarded packets.
+    pub send_errors: u64,
 }
 
 /// Atomic storage for thread-safe operational counters.
@@ -68,6 +79,7 @@ pub(crate) struct AtomicFanoutCounters {
     pub(crate) packets_throttled: AtomicU64,
     pub(crate) destinations_deduplicated: AtomicU64,
     pub(crate) queue_overflow_drops: AtomicU64,
+    pub(crate) send_errors: AtomicU64,
 }
 
 impl AtomicFanoutCounters {
@@ -78,6 +90,7 @@ impl AtomicFanoutCounters {
             packets_throttled: self.packets_throttled.load(Ordering::Relaxed),
             destinations_deduplicated: self.destinations_deduplicated.load(Ordering::Relaxed),
             queue_overflow_drops: self.queue_overflow_drops.load(Ordering::Relaxed),
+            send_errors: self.send_errors.load(Ordering::Relaxed),
         }
     }
 }
@@ -328,6 +341,7 @@ pub(crate) async fn run_fanout_worker(
                         .fetch_add(bytes_sent as u64, Ordering::Relaxed);
                 }
                 Err(e) => {
+                    counters.send_errors.fetch_add(1, Ordering::Relaxed);
                     warn!(error = %e, %dest, "BIP BBMD: failed to send forwarded NPDU");
                 }
             }

--- a/crates/bacnet-transport/src/bip/fanout.rs
+++ b/crates/bacnet-transport/src/bip/fanout.rs
@@ -1,0 +1,336 @@
+//! Broadcast forwarding fanout budgeting, deduplication, and work queue.
+//!
+//! Provides fair, bounded, non-blocking broadcast distribution for BBMD mode
+//! per Issue #531. Broadcast forwarding is offloaded from the UDP receive loop
+//! to an asynchronous worker task through a bounded work queue with per-origin
+//! and global packet and byte rate limits.
+
+use std::collections::HashMap;
+use std::net::SocketAddrV4;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bytes::Bytes;
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc;
+use tracing::warn;
+
+use crate::bvll::encode_bvll_forwarded;
+
+/// Policy governing broadcast forwarding fanout limits, rate budgets, and work queue capacity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FanoutPolicy {
+    /// Maximum forwarded packets emitted per input broadcast.
+    pub max_fanout_per_input: usize,
+    /// Global rate limit for forwarded packets per second.
+    pub max_packets_per_sec_global: u32,
+    /// Global rate limit for forwarded bytes per second.
+    pub max_bytes_per_sec_global: usize,
+    /// Per-origin rate limit for forwarded packets per second.
+    pub max_packets_per_sec_per_origin: u32,
+    /// Capacity of the bounded fanout forwarding work queue.
+    pub queue_capacity: usize,
+}
+
+impl Default for FanoutPolicy {
+    fn default() -> Self {
+        Self {
+            max_fanout_per_input: 64,
+            max_packets_per_sec_global: 1024,
+            max_bytes_per_sec_global: 512_000,
+            max_packets_per_sec_per_origin: 128,
+            queue_capacity: 256,
+        }
+    }
+}
+
+/// Operational telemetry counters for broadcast forwarding fanout.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct FanoutCounters {
+    /// Total forwarded packets emitted to the network.
+    pub packets_forwarded: u64,
+    /// Total forwarded bytes emitted to the network.
+    pub bytes_forwarded: u64,
+    /// Number of forwarded packets throttled or dropped due to fanout budgets/rate limits.
+    pub packets_throttled: u64,
+    /// Number of duplicate forwarding destinations skipped during resolution.
+    pub destinations_deduplicated: u64,
+    /// Number of fanout forwarding jobs dropped due to work queue overflow.
+    pub queue_overflow_drops: u64,
+}
+
+/// Atomic storage for thread-safe operational counters.
+#[derive(Debug, Default)]
+pub(crate) struct AtomicFanoutCounters {
+    pub(crate) packets_forwarded: AtomicU64,
+    pub(crate) bytes_forwarded: AtomicU64,
+    pub(crate) packets_throttled: AtomicU64,
+    pub(crate) destinations_deduplicated: AtomicU64,
+    pub(crate) queue_overflow_drops: AtomicU64,
+}
+
+impl AtomicFanoutCounters {
+    pub(crate) fn snapshot(&self) -> FanoutCounters {
+        FanoutCounters {
+            packets_forwarded: self.packets_forwarded.load(Ordering::Relaxed),
+            bytes_forwarded: self.bytes_forwarded.load(Ordering::Relaxed),
+            packets_throttled: self.packets_throttled.load(Ordering::Relaxed),
+            destinations_deduplicated: self.destinations_deduplicated.load(Ordering::Relaxed),
+            queue_overflow_drops: self.queue_overflow_drops.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Fixed-window rate limiter enforcing global and per-origin packet and byte budgets.
+#[derive(Debug)]
+pub(crate) struct FanoutRateLimiter {
+    policy: FanoutPolicy,
+    window_start: Option<Instant>,
+    rate_window: Duration,
+    global_packets_in_window: u32,
+    global_bytes_in_window: usize,
+    origin_packets_in_window: HashMap<[u8; 4], u32>,
+}
+
+impl FanoutRateLimiter {
+    /// Create a new rate limiter with the specified policy.
+    pub(crate) fn new(policy: FanoutPolicy) -> Self {
+        Self {
+            policy,
+            window_start: None,
+            rate_window: Duration::from_secs(1),
+            global_packets_in_window: 0,
+            global_bytes_in_window: 0,
+            origin_packets_in_window: HashMap::new(),
+        }
+    }
+
+    /// Update the fanout policy.
+    pub(crate) fn set_policy(&mut self, policy: FanoutPolicy) {
+        self.policy = policy;
+    }
+
+    fn roll_window_if_expired(&mut self, now: Instant) {
+        match self.window_start {
+            None => {
+                self.window_start = Some(now);
+            }
+            Some(start) => {
+                if now.saturating_duration_since(start) >= self.rate_window {
+                    self.window_start = Some(now);
+                    self.global_packets_in_window = 0;
+                    self.global_bytes_in_window = 0;
+                    self.origin_packets_in_window.clear();
+                }
+            }
+        }
+    }
+
+    /// Check and admit target destinations up to configured budgets.
+    ///
+    /// Returns `(admitted_count, throttled_count)`.
+    pub(crate) fn check_and_admit(
+        &mut self,
+        origin_ip: [u8; 4],
+        candidate_count: usize,
+        packet_bytes: usize,
+        now: Instant,
+    ) -> (usize, usize) {
+        if candidate_count == 0 {
+            return (0, 0);
+        }
+        self.roll_window_if_expired(now);
+
+        // 1. Cap to per-input budget
+        let per_input_capped = candidate_count.min(self.policy.max_fanout_per_input);
+        let per_input_excess = candidate_count.saturating_sub(per_input_capped);
+
+        // 2. Global packet budget remaining
+        let global_packets_remaining = (self
+            .policy
+            .max_packets_per_sec_global
+            .saturating_sub(self.global_packets_in_window))
+            as usize;
+
+        // 3. Global byte budget remaining
+        let global_bytes_remaining = self
+            .policy
+            .max_bytes_per_sec_global
+            .saturating_sub(self.global_bytes_in_window);
+        let global_packets_by_bytes = if packet_bytes > 0 {
+            global_bytes_remaining / packet_bytes
+        } else {
+            usize::MAX
+        };
+
+        // 4. Per-origin packet budget remaining
+        let current_origin = self
+            .origin_packets_in_window
+            .get(&origin_ip)
+            .copied()
+            .unwrap_or(0);
+        let origin_packets_remaining = (self
+            .policy
+            .max_packets_per_sec_per_origin
+            .saturating_sub(current_origin)) as usize;
+
+        let admitted = per_input_capped
+            .min(global_packets_remaining)
+            .min(global_packets_by_bytes)
+            .min(origin_packets_remaining);
+
+        let throttled = per_input_excess + (per_input_capped - admitted);
+
+        if admitted > 0 {
+            self.global_packets_in_window = self
+                .global_packets_in_window
+                .saturating_add(admitted as u32);
+            self.global_bytes_in_window = self
+                .global_bytes_in_window
+                .saturating_add(admitted.saturating_mul(packet_bytes));
+            let new_origin = current_origin.saturating_add(admitted as u32);
+            self.origin_packets_in_window.insert(origin_ip, new_origin);
+        }
+
+        (admitted, throttled)
+    }
+}
+
+/// A batched job queued for the background fanout worker.
+#[derive(Debug)]
+pub(crate) struct FanoutJob {
+    pub(crate) frame: Bytes,
+    pub(crate) targets: Vec<SocketAddrV4>,
+}
+
+/// Dispatcher used by the receive loop to enqueue fanout jobs without blocking.
+#[derive(Clone)]
+pub(crate) struct FanoutDispatcher {
+    tx: mpsc::Sender<FanoutJob>,
+    limiter: Arc<std::sync::Mutex<FanoutRateLimiter>>,
+    counters: Arc<AtomicFanoutCounters>,
+}
+
+impl FanoutDispatcher {
+    pub(crate) fn new(
+        tx: mpsc::Sender<FanoutJob>,
+        limiter: Arc<std::sync::Mutex<FanoutRateLimiter>>,
+        counters: Arc<AtomicFanoutCounters>,
+    ) -> Self {
+        Self {
+            tx,
+            limiter,
+            counters,
+        }
+    }
+
+    /// Dispatch pre-encoded frame to target destinations.
+    pub(crate) fn dispatch(
+        &self,
+        origin_ip: [u8; 4],
+        targets: Vec<SocketAddrV4>,
+        frame: Bytes,
+        dedup_count: u64,
+    ) -> bool {
+        if dedup_count > 0 {
+            self.counters
+                .destinations_deduplicated
+                .fetch_add(dedup_count, Ordering::Relaxed);
+        }
+        if targets.is_empty() {
+            return true;
+        }
+
+        let packet_bytes = frame.len();
+        let (admitted_count, throttled_count) = {
+            let mut limiter = match self.limiter.lock() {
+                Ok(l) => l,
+                Err(p) => p.into_inner(),
+            };
+            limiter.check_and_admit(origin_ip, targets.len(), packet_bytes, Instant::now())
+        };
+
+        if throttled_count > 0 {
+            self.counters
+                .packets_throttled
+                .fetch_add(throttled_count as u64, Ordering::Relaxed);
+        }
+
+        if admitted_count == 0 {
+            return false;
+        }
+
+        let mut job_targets = targets;
+        job_targets.truncate(admitted_count);
+
+        let job = FanoutJob {
+            frame,
+            targets: job_targets,
+        };
+
+        match self.tx.try_send(job) {
+            Ok(()) => true,
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.counters
+                    .queue_overflow_drops
+                    .fetch_add(1, Ordering::Relaxed);
+                warn!("BIP BBMD: fanout work queue full, dropping broadcast forwarding job");
+                false
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                warn!("BIP BBMD: fanout worker task closed");
+                false
+            }
+        }
+    }
+
+    /// Encode a Forwarded-NPDU and dispatch to target destinations.
+    pub(crate) fn dispatch_forwarded_npdu(
+        &self,
+        orig_ip: [u8; 4],
+        orig_port: u16,
+        npdu: &[u8],
+        targets: Vec<SocketAddrV4>,
+        dedup_count: u64,
+    ) -> bool {
+        if targets.is_empty() {
+            if dedup_count > 0 {
+                self.counters
+                    .destinations_deduplicated
+                    .fetch_add(dedup_count, Ordering::Relaxed);
+            }
+            return true;
+        }
+        let mut buf = bytes::BytesMut::with_capacity(10 + npdu.len());
+        if let Err(e) = encode_bvll_forwarded(&mut buf, orig_ip, orig_port, npdu) {
+            warn!(error = %e, "Failed to encode Forwarded-NPDU for fanout");
+            return false;
+        }
+        let frame = buf.freeze();
+        self.dispatch(orig_ip, targets, frame, dedup_count)
+    }
+}
+
+/// Background worker loop dequeuing fanout jobs and sending them asynchronously.
+pub(crate) async fn run_fanout_worker(
+    socket: Arc<UdpSocket>,
+    mut rx: mpsc::Receiver<FanoutJob>,
+    counters: Arc<AtomicFanoutCounters>,
+) {
+    while let Some(job) = rx.recv().await {
+        for dest in job.targets {
+            match socket.send_to(&job.frame, dest).await {
+                Ok(bytes_sent) => {
+                    counters.packets_forwarded.fetch_add(1, Ordering::Relaxed);
+                    counters
+                        .bytes_forwarded
+                        .fetch_add(bytes_sent as u64, Ordering::Relaxed);
+                }
+                Err(e) => {
+                    warn!(error = %e, %dest, "BIP BBMD: failed to send forwarded NPDU");
+                }
+            }
+        }
+    }
+}

--- a/crates/bacnet-transport/src/bip/fanout_tests.rs
+++ b/crates/bacnet-transport/src/bip/fanout_tests.rs
@@ -4,7 +4,7 @@ use std::net::{Ipv4Addr, SocketAddrV4};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use bytes::BytesMut;
+use bytes::{Bytes, BytesMut};
 use tokio::net::UdpSocket;
 use tokio::time::timeout;
 
@@ -13,7 +13,7 @@ use super::*;
 use crate::bbmd::{BdtEntry, ForeignDevicePolicy};
 use crate::bvll::{decode_bip_mac, decode_bvll, encode_bvll, BvllMessage};
 use crate::port::TransportPort;
-use bacnet_types::enums::BvlcFunction;
+use bacnet_types::enums::{BvlcFunction, BvlcResultCode};
 
 async fn recv_bvll(socket: &UdpSocket) -> BvllMessage {
     let mut recv_buf = [0u8; 2048];
@@ -386,4 +386,155 @@ async fn fanout_counters_accurately_track_all_metrics() {
     assert_eq!(counters.packets_throttled, 1);
 
     bbmd.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn dbtn_delivers_local_subnet_broadcast_under_tight_fanout_budget() {
+    let bbmd_socket = Arc::new(
+        UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap(),
+    );
+    let local_port = bbmd_socket.local_addr().unwrap().port();
+    let local_broadcast_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let local_broadcast_port = local_broadcast_sink.local_addr().unwrap().port();
+
+    let bdt_peer_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let bdt_peer_port = bdt_peer_sink.local_addr().unwrap().port();
+
+    let extra_bdt_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let extra_bdt_port = extra_bdt_sink.local_addr().unwrap().port();
+
+    let origin_fd_sink = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let origin_fd_port = origin_fd_sink.local_addr().unwrap().port();
+
+    let (npdu_tx, _npdu_rx) = mpsc::channel(1);
+
+    let mut state = BbmdState::new(Ipv4Addr::LOCALHOST.octets(), local_port);
+    state.enable_foreign_device_registration(ForeignDevicePolicy::default());
+    state
+        .set_bdt(vec![
+            BdtEntry {
+                ip: Ipv4Addr::LOCALHOST.octets(),
+                port: bdt_peer_port,
+                broadcast_mask: [255, 255, 255, 255],
+            },
+            BdtEntry {
+                ip: Ipv4Addr::LOCALHOST.octets(),
+                port: extra_bdt_port,
+                broadcast_mask: [255, 255, 255, 255],
+            },
+        ])
+        .unwrap();
+    assert_eq!(
+        state.register_foreign_device(Ipv4Addr::LOCALHOST.octets(), origin_fd_port, 60),
+        BvlcResultCode::SUCCESSFUL_COMPLETION
+    );
+
+    // Tight fanout policy: max 1 remote target per input broadcast
+    let policy = FanoutPolicy {
+        max_fanout_per_input: 1,
+        ..FanoutPolicy::default()
+    };
+    let (fanout_tx, fanout_rx) = mpsc::channel(policy.queue_capacity);
+    let fanout_counters = Arc::new(fanout::AtomicFanoutCounters::default());
+    let fanout_limiter = Arc::new(std::sync::Mutex::new(fanout::FanoutRateLimiter::new(
+        policy,
+    )));
+    let _worker_task = tokio::spawn(fanout::run_fanout_worker(
+        Arc::clone(&bbmd_socket),
+        fanout_rx,
+        Arc::clone(&fanout_counters),
+    ));
+    let fanout_dispatcher =
+        fanout::FanoutDispatcher::new(fanout_tx, fanout_limiter, Arc::clone(&fanout_counters));
+
+    let ctx = RecvContext {
+        local_mac: encode_bip_mac(Ipv4Addr::LOCALHOST.octets(), local_port),
+        socket: bbmd_socket,
+        npdu_tx,
+        bbmd: Some(Arc::new(Mutex::new(state))),
+        broadcast_addr: Ipv4Addr::LOCALHOST,
+        broadcast_port: local_broadcast_port,
+        pending_bvlc_response: Arc::new(Mutex::new(None)),
+        management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: Some(fanout_dispatcher),
+        force_dbtn_forward_failure: false,
+    };
+
+    let sender = (Ipv4Addr::LOCALHOST.octets(), origin_fd_port);
+    let msg = BvllMessage {
+        function: BvlcFunction::DISTRIBUTE_BROADCAST_TO_NETWORK,
+        payload: Bytes::from_static(&[0x01, 0x20, 0xDE, 0xAD, 0xBE, 0xEF]),
+        originating_ip: None,
+        originating_port: None,
+    };
+
+    handle_bvll_message(&msg, sender, &ctx).await;
+
+    // 1. Mandatory local subnet broadcast MUST be received
+    let local_frame = recv_bvll(&local_broadcast_sink).await;
+    assert_eq!(local_frame.function, BvlcFunction::FORWARDED_NPDU);
+    assert_eq!(local_frame.payload.as_ref(), msg.payload.as_ref());
+    assert_eq!(local_frame.originating_ip, Some(sender.0));
+    assert_eq!(local_frame.originating_port, Some(sender.1));
+
+    // 2. Exactly one remote BDT peer receives the frame (due to max_fanout_per_input: 1)
+    let peer_frame = recv_bvll(&bdt_peer_sink).await;
+    assert_eq!(peer_frame.function, BvlcFunction::FORWARDED_NPDU);
+    assert_eq!(peer_frame.payload.as_ref(), msg.payload.as_ref());
+
+    // 3. The second remote BDT peer was throttled
+    assert_no_bvll(&extra_bdt_sink, "extra BDT peer throttled").await;
+
+    // 4. Verify telemetry counters
+    let counters = fanout_counters.snapshot();
+    assert_eq!(counters.packets_forwarded, 1);
+    assert_eq!(counters.packets_throttled, 1);
+}
+
+#[tokio::test]
+async fn fanout_policy_zero_queue_capacity_does_not_panic() {
+    let policy = FanoutPolicy {
+        queue_capacity: 0,
+        ..FanoutPolicy::default()
+    };
+    assert_eq!(policy.sanitized().queue_capacity, 1);
+
+    let mut bbmd = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::LOCALHOST);
+    bbmd.set_fanout_policy(policy);
+    let start_res = bbmd.start().await;
+    assert!(
+        start_res.is_ok(),
+        "BipTransport::start() must not panic with queue_capacity: 0"
+    );
+    bbmd.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn fanout_worker_records_send_errors_in_telemetry() {
+    let socket = Arc::new(UdpSocket::bind("127.0.0.1:0").await.unwrap());
+    let (tx, rx) = mpsc::channel(4);
+    let counters = Arc::new(fanout::AtomicFanoutCounters::default());
+    let worker = tokio::spawn(fanout::run_fanout_worker(socket, rx, Arc::clone(&counters)));
+
+    let job = fanout::FanoutJob {
+        frame: bytes::Bytes::from_static(b"test"),
+        targets: vec![SocketAddrV4::new(Ipv4Addr::new(255, 255, 255, 255), 47808)],
+    };
+    tx.send(job).await.unwrap();
+    drop(tx);
+    worker.await.unwrap();
+
+    let snap = counters.snapshot();
+    assert_eq!(snap.send_errors, 1);
+    assert_eq!(snap.packets_forwarded, 0);
 }

--- a/crates/bacnet-transport/src/bip/fanout_tests.rs
+++ b/crates/bacnet-transport/src/bip/fanout_tests.rs
@@ -1,0 +1,389 @@
+//! Tests for broadcast forwarding fanout budgeting, deduplication, and non-starvation (Issue #531).
+
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use bytes::BytesMut;
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+
+use super::fanout::{FanoutPolicy, FanoutRateLimiter};
+use super::*;
+use crate::bbmd::{BdtEntry, ForeignDevicePolicy};
+use crate::bvll::{decode_bip_mac, decode_bvll, encode_bvll, BvllMessage};
+use crate::port::TransportPort;
+use bacnet_types::enums::BvlcFunction;
+
+async fn recv_bvll(socket: &UdpSocket) -> BvllMessage {
+    let mut recv_buf = [0u8; 2048];
+    let (len, _addr) = timeout(Duration::from_secs(2), socket.recv_from(&mut recv_buf))
+        .await
+        .expect("timed out waiting for BVLL frame")
+        .expect("recv_from error");
+    decode_bvll(&recv_buf[..len]).expect("valid BVLL message")
+}
+
+async fn assert_no_bvll(socket: &UdpSocket, label: &str) {
+    let mut recv_buf = [0u8; 2048];
+    assert!(
+        timeout(Duration::from_millis(100), socket.recv_from(&mut recv_buf))
+            .await
+            .is_err(),
+        "{label} received an unexpected extra BVLL frame"
+    );
+}
+
+#[test]
+fn fanout_rate_limiter_budgets_and_throttles() {
+    let policy = FanoutPolicy {
+        max_fanout_per_input: 4,
+        max_packets_per_sec_global: 10,
+        max_bytes_per_sec_global: 2000,
+        max_packets_per_sec_per_origin: 6,
+        queue_capacity: 128,
+    };
+    let mut limiter = FanoutRateLimiter::new(policy);
+    let t0 = Instant::now();
+    let origin_a = [10, 0, 0, 1];
+    let origin_b = [10, 0, 0, 2];
+    let packet_bytes = 100;
+
+    // Origin A: input with 8 candidates -> capped to per_input (4)
+    let (admitted, throttled) = limiter.check_and_admit(origin_a, 8, packet_bytes, t0);
+    assert_eq!(admitted, 4);
+    assert_eq!(throttled, 4);
+
+    // Origin A: 2nd input with 4 candidates -> origin budget remaining is 6 - 4 = 2
+    let (admitted, throttled) = limiter.check_and_admit(origin_a, 4, packet_bytes, t0);
+    assert_eq!(admitted, 2);
+    assert_eq!(throttled, 2);
+
+    // Origin A: 3rd input -> origin budget exhausted
+    let (admitted, throttled) = limiter.check_and_admit(origin_a, 4, packet_bytes, t0);
+    assert_eq!(admitted, 0);
+    assert_eq!(throttled, 4);
+
+    // Origin B: input with 6 candidates -> global remaining is 10 - 6 = 4
+    let (admitted, throttled) = limiter.check_and_admit(origin_b, 6, packet_bytes, t0);
+    assert_eq!(admitted, 4);
+    assert_eq!(throttled, 2);
+
+    // Global budget now exhausted (10 admitted)
+    let (admitted, throttled) = limiter.check_and_admit(origin_b, 4, packet_bytes, t0);
+    assert_eq!(admitted, 0);
+    assert_eq!(throttled, 4);
+
+    // After 1 second window roll, budgets restore
+    let t1 = t0 + Duration::from_millis(1100);
+    let (admitted, throttled) = limiter.check_and_admit(origin_a, 4, packet_bytes, t1);
+    assert_eq!(admitted, 4);
+    assert_eq!(throttled, 0);
+}
+
+#[tokio::test]
+async fn duplicate_bdt_and_fdt_entries_yield_exactly_one_send_per_destination() {
+    let mut bbmd = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::LOCALHOST);
+    let sink_socket = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let sink_port = sink_socket.local_addr().unwrap().port();
+
+    // BDT entry that points to the sink port (unicast /32)
+    bbmd.enable_bbmd(vec![BdtEntry {
+        ip: Ipv4Addr::LOCALHOST.octets(),
+        port: sink_port,
+        broadcast_mask: [255, 255, 255, 255],
+    }]);
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy::default());
+    let _bbmd_rx = bbmd.start().await.unwrap();
+    let bbmd_mac = bbmd.local_mac().to_vec();
+    let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();
+
+    // Register foreign device that also points to the same sink IP and port
+    let fd_reg = {
+        let mut buf = BytesMut::new();
+        encode_bvll(
+            &mut buf,
+            BvlcFunction::REGISTER_FOREIGN_DEVICE,
+            &60u16.to_be_bytes(),
+        )
+        .unwrap();
+        buf.freeze()
+    };
+    sink_socket
+        .send_to(
+            &fd_reg,
+            SocketAddrV4::new(Ipv4Addr::from(bbmd_ip), bbmd_port),
+        )
+        .await
+        .unwrap();
+    let reg_result = recv_bvll(&sink_socket).await;
+    assert_eq!(reg_result.function, BvlcFunction::BVLC_RESULT);
+
+    // Send Original-Broadcast-NPDU to the BBMD from a client
+    let client_sock = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let test_npdu = vec![0x01, 0x20, 0xCA, 0xFE];
+    let mut bcast_buf = BytesMut::new();
+    encode_bvll(
+        &mut bcast_buf,
+        BvlcFunction::ORIGINAL_BROADCAST_NPDU,
+        &test_npdu,
+    )
+    .unwrap();
+    client_sock
+        .send_to(
+            &bcast_buf,
+            SocketAddrV4::new(Ipv4Addr::from(bbmd_ip), bbmd_port),
+        )
+        .await
+        .unwrap();
+
+    // The sink must receive exactly ONE forwarded NPDU (not 2 copies)
+    let frame = recv_bvll(&sink_socket).await;
+    assert_eq!(frame.function, BvlcFunction::FORWARDED_NPDU);
+    assert_eq!(frame.payload.as_ref(), test_npdu.as_slice());
+    assert_no_bvll(&sink_socket, "sink deduplication check").await;
+
+    // Verify fanout counters
+    let counters = bbmd.fanout_counters();
+    assert_eq!(counters.packets_forwarded, 1);
+    assert_eq!(counters.destinations_deduplicated, 1);
+
+    bbmd.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn sustained_broadcast_input_does_not_starve_concurrent_unicast() {
+    let mut bbmd = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::LOCALHOST);
+    let mut bdt = Vec::new();
+    for i in 1..=8 {
+        bdt.push(BdtEntry {
+            ip: [192, 168, 1, i],
+            port: 47808,
+            broadcast_mask: [255, 255, 255, 255],
+        });
+    }
+    bbmd.enable_bbmd(bdt);
+    // Tight queue and rate limit
+    bbmd.set_fanout_policy(FanoutPolicy {
+        max_fanout_per_input: 8,
+        max_packets_per_sec_global: 16,
+        max_bytes_per_sec_global: 32_000,
+        max_packets_per_sec_per_origin: 16,
+        queue_capacity: 2,
+    });
+    let mut bbmd_rx = bbmd.start().await.unwrap();
+    let bbmd_mac = bbmd.local_mac().to_vec();
+    let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();
+    let bbmd_dest = SocketAddrV4::new(Ipv4Addr::from(bbmd_ip), bbmd_port);
+
+    // Flood BBMD with continuous broadcast traffic in background
+    let flood_sock = Arc::new(
+        UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap(),
+    );
+    let stop_flood = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_flood_clone = Arc::clone(&stop_flood);
+    let flood_handle = tokio::spawn(async move {
+        let mut buf = BytesMut::new();
+        encode_bvll(
+            &mut buf,
+            BvlcFunction::ORIGINAL_BROADCAST_NPDU,
+            &[0x01, 0x20, 0x11, 0x22],
+        )
+        .unwrap();
+        let frame = buf.freeze();
+        while !stop_flood_clone.load(std::sync::atomic::Ordering::Relaxed) {
+            let _ = flood_sock.send_to(&frame, bbmd_dest).await;
+            tokio::task::yield_now().await;
+        }
+    });
+
+    // Let flood start sending frames
+    tokio::time::sleep(Duration::from_millis(15)).await;
+
+    // Send concurrent unicast NPDU and ensure it is received promptly
+    let unicast_sock = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let unicast_npdu = vec![0x01, 0x00, 0x99, 0x88, 0x77];
+    let mut unicast_buf = BytesMut::new();
+    encode_bvll(
+        &mut unicast_buf,
+        BvlcFunction::ORIGINAL_UNICAST_NPDU,
+        &unicast_npdu,
+    )
+    .unwrap();
+
+    let start_time = Instant::now();
+    unicast_sock.send_to(&unicast_buf, bbmd_dest).await.unwrap();
+
+    // Loop until we find our unicast NPDU (broadcasts also deliver to npdu_rx)
+    let mut found_unicast = false;
+    while start_time.elapsed() < Duration::from_secs(2) {
+        if let Ok(Some(received)) = timeout(Duration::from_millis(100), bbmd_rx.recv()).await {
+            if received.npdu == unicast_npdu {
+                found_unicast = true;
+                break;
+            }
+        }
+    }
+
+    stop_flood.store(true, std::sync::atomic::Ordering::Relaxed);
+    let _ = flood_handle.await;
+
+    assert!(
+        found_unicast,
+        "concurrent unicast NPDU was starved or lost during sustained broadcast flood"
+    );
+    assert!(
+        start_time.elapsed() < Duration::from_millis(500),
+        "concurrent unicast NPDU took too long: {:?}",
+        start_time.elapsed()
+    );
+
+    // Queue overflow drops occurred during flood
+    let counters = bbmd.fanout_counters();
+    assert!(
+        counters.queue_overflow_drops > 0 || counters.packets_throttled > 0,
+        "flood must trigger fanout queue overflow or throttling: {counters:?}"
+    );
+
+    bbmd.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn fanout_semantics_for_original_forwarded_and_dbtn() {
+    let mut bbmd = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::BROADCAST);
+    let peer_bdt = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let peer_bdt_port = peer_bdt.local_addr().unwrap().port();
+    let peer_fd = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let _peer_fd_port = peer_fd.local_addr().unwrap().port();
+
+    bbmd.enable_bbmd(vec![BdtEntry {
+        ip: Ipv4Addr::LOCALHOST.octets(),
+        port: peer_bdt_port,
+        broadcast_mask: [255, 255, 255, 255],
+    }]);
+    bbmd.enable_foreign_device_registration(ForeignDevicePolicy::default());
+
+    let _bbmd_rx = bbmd.start().await.unwrap();
+    let bbmd_mac = bbmd.local_mac().to_vec();
+    let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();
+    let bbmd_dest = SocketAddrV4::new(Ipv4Addr::from(bbmd_ip), bbmd_port);
+
+    // 1. Register foreign device
+    let mut reg_buf = BytesMut::new();
+    encode_bvll(
+        &mut reg_buf,
+        BvlcFunction::REGISTER_FOREIGN_DEVICE,
+        &60u16.to_be_bytes(),
+    )
+    .unwrap();
+    peer_fd.send_to(&reg_buf, bbmd_dest).await.unwrap();
+    let reg_ack = recv_bvll(&peer_fd).await;
+    assert_eq!(reg_ack.function, BvlcFunction::BVLC_RESULT);
+
+    // 2. Test DBTN: from registered foreign device -> forwards to BDT peer
+    let dbtn_npdu = vec![0x01, 0x20, 0xAA, 0x11];
+    let mut dbtn_buf = BytesMut::new();
+    encode_bvll(
+        &mut dbtn_buf,
+        BvlcFunction::DISTRIBUTE_BROADCAST_TO_NETWORK,
+        &dbtn_npdu,
+    )
+    .unwrap();
+    peer_fd.send_to(&dbtn_buf, bbmd_dest).await.unwrap();
+
+    let dbtn_forwarded = recv_bvll(&peer_bdt).await;
+    assert_eq!(dbtn_forwarded.function, BvlcFunction::FORWARDED_NPDU);
+    assert_eq!(dbtn_forwarded.payload.as_ref(), dbtn_npdu.as_slice());
+    // DBTN does not echo back to sender
+    assert_no_bvll(&peer_fd, "DBTN sender").await;
+
+    // 3. Test Forwarded-NPDU from BDT peer -> forwards to foreign device
+    let fwd_npdu = vec![0x01, 0x20, 0xBB, 0x22];
+    let mut fwd_buf = BytesMut::new();
+    crate::bvll::encode_bvll_forwarded(&mut fwd_buf, [10, 1, 2, 3], 47808, &fwd_npdu).unwrap();
+    peer_bdt.send_to(&fwd_buf, bbmd_dest).await.unwrap();
+
+    let fwd_to_fd = recv_bvll(&peer_fd).await;
+    assert_eq!(fwd_to_fd.function, BvlcFunction::FORWARDED_NPDU);
+    assert_eq!(fwd_to_fd.payload.as_ref(), fwd_npdu.as_slice());
+    assert_eq!(fwd_to_fd.originating_ip, Some([10, 1, 2, 3]));
+
+    // 4. Test DBTN from unregistered sender -> returns NAK
+    let unreg_sock = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    unreg_sock.send_to(&dbtn_buf, bbmd_dest).await.unwrap();
+    let nak_res = recv_bvll(&unreg_sock).await;
+    assert_eq!(nak_res.function, BvlcFunction::BVLC_RESULT);
+    assert_eq!(
+        crate::bip::decode_bvlc_result_code(&nak_res).unwrap(),
+        bacnet_types::enums::BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK
+    );
+
+    bbmd.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn fanout_counters_accurately_track_all_metrics() {
+    let mut bbmd = BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::LOCALHOST);
+    let sink_a = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let port_a = sink_a.local_addr().unwrap().port();
+
+    bbmd.enable_bbmd(vec![BdtEntry {
+        ip: Ipv4Addr::LOCALHOST.octets(),
+        port: port_a,
+        broadcast_mask: [255, 255, 255, 255],
+    }]);
+    bbmd.set_fanout_policy(FanoutPolicy {
+        max_fanout_per_input: 1,
+        max_packets_per_sec_global: 10,
+        max_bytes_per_sec_global: 5000,
+        max_packets_per_sec_per_origin: 2,
+        queue_capacity: 16,
+    });
+    let _rx = bbmd.start().await.unwrap();
+    let bbmd_mac = bbmd.local_mac().to_vec();
+    let (bbmd_ip, bbmd_port) = decode_bip_mac(&bbmd_mac).unwrap();
+    let bbmd_dest = SocketAddrV4::new(Ipv4Addr::from(bbmd_ip), bbmd_port);
+
+    let client = UdpSocket::bind(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let npdu = vec![0x01, 0x20, 0x55, 0x66];
+    let mut buf = BytesMut::new();
+    encode_bvll(&mut buf, BvlcFunction::ORIGINAL_BROADCAST_NPDU, &npdu).unwrap();
+    let frame = buf.freeze();
+
+    // Send 1st broadcast: forwarded
+    client.send_to(&frame, bbmd_dest).await.unwrap();
+    let _ = recv_bvll(&sink_a).await;
+
+    // Send 2nd broadcast: forwarded (origin quota = 2)
+    client.send_to(&frame, bbmd_dest).await.unwrap();
+    let _ = recv_bvll(&sink_a).await;
+
+    // Send 3rd broadcast: throttled (origin quota exceeded)
+    client.send_to(&frame, bbmd_dest).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let counters = bbmd.fanout_counters();
+    assert_eq!(counters.packets_forwarded, 2);
+    assert!(counters.bytes_forwarded > 0);
+    assert_eq!(counters.packets_throttled, 1);
+
+    bbmd.stop().await.unwrap();
+}

--- a/crates/bacnet-transport/src/bip/forwarded_tests.rs
+++ b/crates/bacnet-transport/src/bip/forwarded_tests.rs
@@ -65,6 +65,7 @@ async fn forwarded_npdu_from_bdt_peer_uses_originating_source_mac() {
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {
@@ -152,6 +153,7 @@ async fn forwarded_npdu_from_non_bdt_sender_is_rejected_without_delivery() {
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {
@@ -228,6 +230,7 @@ async fn forwarded_npdu_from_directed_broadcast_peer_skips_local_rebroadcast() {
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {
@@ -325,6 +328,7 @@ async fn forwarded_npdu_fdt_fanout_respects_budget_and_increments_counter() {
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -13,6 +13,7 @@ use crate::bbmd::BbmdState;
 use crate::bvll::{self, encode_bip_mac, encode_bvll, encode_bvll_forwarded};
 use crate::port::ReceivedNpdu;
 
+use super::fanout::FanoutDispatcher;
 use super::rate_limit::{is_covered_management_request, ManagementRateLimiter};
 use super::{decode_bvlc_result_code, PendingBvlcResponse};
 
@@ -80,6 +81,7 @@ pub(super) struct RecvContext {
     pub(super) broadcast_port: u16,
     pub(super) pending_bvlc_response: Arc<Mutex<Option<PendingBvlcResponse>>>,
     pub(super) management_limiter: Arc<std::sync::Mutex<ManagementRateLimiter>>,
+    pub(super) fanout: Option<FanoutDispatcher>,
     #[cfg(test)]
     pub(super) force_dbtn_forward_failure: bool,
 }
@@ -169,11 +171,29 @@ pub(super) async fn handle_bvll_message(
 
             // If BBMD, forward as Forwarded-NPDU to BDT peers + FDT entries
             if let Some(bbmd) = &ctx.bbmd {
-                let targets = {
+                let (targets, dedup_count) = {
                     let mut state = bbmd.lock().await;
-                    state.forwarding_targets(sender.0, sender.1)
+                    let before = state.fdt_counters().destinations_deduplicated;
+                    let targets = state.forwarding_targets(sender.0, sender.1);
+                    let after = state.fdt_counters().destinations_deduplicated;
+                    (targets, after.saturating_sub(before))
                 };
-                let _ = forward_npdu(&ctx.socket, &msg.payload, sender.0, sender.1, &targets).await;
+                if let Some(fanout) = &ctx.fanout {
+                    let addrs = targets
+                        .into_iter()
+                        .map(|(ip, port)| SocketAddrV4::new(Ipv4Addr::from(ip), port))
+                        .collect();
+                    fanout.dispatch_forwarded_npdu(
+                        sender.0,
+                        sender.1,
+                        &msg.payload,
+                        addrs,
+                        dedup_count,
+                    );
+                } else {
+                    let _ =
+                        forward_npdu(&ctx.socket, &msg.payload, sender.0, sender.1, &targets).await;
+                }
             }
         }
 
@@ -226,19 +246,48 @@ pub(super) async fn handle_bvll_message(
                 let orig_port = msg.originating_port.unwrap();
 
                 // Forward to FDT entries (BDT peers don't need it — they got it directly)
-                let fdt_targets = {
+                let (fdt_targets, dedup_count) = {
                     let mut state = bbmd.lock().await;
-                    state.fdt_forwarding_targets(orig_ip, orig_port)
+                    let before = state.fdt_counters().destinations_deduplicated;
+                    let targets = state.fdt_forwarding_targets(orig_ip, orig_port);
+                    let after = state.fdt_counters().destinations_deduplicated;
+                    (targets, after.saturating_sub(before))
                 };
-                let _ =
-                    forward_npdu(&ctx.socket, &msg.payload, orig_ip, orig_port, &fdt_targets).await;
-
-                // Full-mask BDT peers forward by unicast; masked peers forward by directed broadcast.
-                if needs_local_broadcast {
-                    let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
+                if let Some(fanout) = &ctx.fanout {
+                    let mut addrs: Vec<SocketAddrV4> = fdt_targets
+                        .into_iter()
+                        .map(|(ip, port)| SocketAddrV4::new(Ipv4Addr::from(ip), port))
+                        .collect();
+                    if needs_local_broadcast {
+                        let local_dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
+                        if !addrs.contains(&local_dest) {
+                            addrs.push(local_dest);
+                        }
+                    }
+                    fanout.dispatch_forwarded_npdu(
+                        orig_ip,
+                        orig_port,
+                        &msg.payload,
+                        addrs,
+                        dedup_count,
+                    );
+                } else {
                     let _ =
-                        send_forwarded_npdu(&ctx.socket, dest, orig_ip, orig_port, &msg.payload)
+                        forward_npdu(&ctx.socket, &msg.payload, orig_ip, orig_port, &fdt_targets)
                             .await;
+
+                    // Full-mask BDT peers forward by unicast; masked peers forward by directed broadcast.
+                    if needs_local_broadcast {
+                        let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
+                        let _ = send_forwarded_npdu(
+                            &ctx.socket,
+                            dest,
+                            orig_ip,
+                            orig_port,
+                            &msg.payload,
+                        )
+                        .await;
+                    }
                 }
             } else {
                 // Non-BBMD: use originating address as source_mac (spec J.2.5).
@@ -296,29 +345,65 @@ pub(super) async fn handle_bvll_message(
                     warn!("BIP: NPDU channel full, dropping distributed broadcast frame");
                 }
 
-                let targets = {
+                let (targets, dedup_count) = {
                     let mut state = bbmd.lock().await;
-                    state.forwarding_targets(sender.0, sender.1)
+                    let before = state.fdt_counters().destinations_deduplicated;
+                    let targets = state.forwarding_targets(sender.0, sender.1);
+                    let after = state.fdt_counters().destinations_deduplicated;
+                    (targets, after.saturating_sub(before))
                 };
-                let mut forwarding_ok =
-                    forward_npdu(&ctx.socket, &msg.payload, sender.0, sender.1, &targets).await;
 
-                // Broadcast locally as Forwarded-NPDU
-                let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
-                forwarding_ok &= if should_force_dbtn_forward_failure(ctx) {
-                    warn!("Forced DBTN forwarding failure");
-                    false
+                if let Some(fanout) = &ctx.fanout {
+                    let mut addrs: Vec<SocketAddrV4> = targets
+                        .into_iter()
+                        .map(|(ip, port)| SocketAddrV4::new(Ipv4Addr::from(ip), port))
+                        .collect();
+                    let local_dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
+                    if !addrs.contains(&local_dest) {
+                        addrs.push(local_dest);
+                    }
+                    let forwarding_ok = if should_force_dbtn_forward_failure(ctx) {
+                        warn!("Forced DBTN forwarding failure");
+                        false
+                    } else {
+                        fanout.dispatch_forwarded_npdu(
+                            sender.0,
+                            sender.1,
+                            &msg.payload,
+                            addrs,
+                            dedup_count,
+                        )
+                    };
+                    if !forwarding_ok {
+                        send_bvlc_result(
+                            &ctx.socket,
+                            sender,
+                            BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK,
+                        )
+                        .await;
+                    }
                 } else {
-                    send_forwarded_npdu(&ctx.socket, dest, sender.0, sender.1, &msg.payload).await
-                };
+                    let mut forwarding_ok =
+                        forward_npdu(&ctx.socket, &msg.payload, sender.0, sender.1, &targets).await;
 
-                if !forwarding_ok {
-                    send_bvlc_result(
-                        &ctx.socket,
-                        sender,
-                        BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK,
-                    )
-                    .await;
+                    // Broadcast locally as Forwarded-NPDU
+                    let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
+                    forwarding_ok &= if should_force_dbtn_forward_failure(ctx) {
+                        warn!("Forced DBTN forwarding failure");
+                        false
+                    } else {
+                        send_forwarded_npdu(&ctx.socket, dest, sender.0, sender.1, &msg.payload)
+                            .await
+                    };
+
+                    if !forwarding_ok {
+                        send_bvlc_result(
+                            &ctx.socket,
+                            sender,
+                            BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK,
+                        )
+                        .await;
+                    }
                 }
             } else {
                 // Non-BBMD: reject with NAK (spec J.4.5)

--- a/crates/bacnet-transport/src/bip/io.rs
+++ b/crates/bacnet-transport/src/bip/io.rs
@@ -253,17 +253,22 @@ pub(super) async fn handle_bvll_message(
                     let after = state.fdt_counters().destinations_deduplicated;
                     (targets, after.saturating_sub(before))
                 };
+                if needs_local_broadcast {
+                    let local_dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
+                    let _ = send_forwarded_npdu(
+                        &ctx.socket,
+                        local_dest,
+                        orig_ip,
+                        orig_port,
+                        &msg.payload,
+                    )
+                    .await;
+                }
                 if let Some(fanout) = &ctx.fanout {
-                    let mut addrs: Vec<SocketAddrV4> = fdt_targets
+                    let addrs: Vec<SocketAddrV4> = fdt_targets
                         .into_iter()
                         .map(|(ip, port)| SocketAddrV4::new(Ipv4Addr::from(ip), port))
                         .collect();
-                    if needs_local_broadcast {
-                        let local_dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
-                        if !addrs.contains(&local_dest) {
-                            addrs.push(local_dest);
-                        }
-                    }
                     fanout.dispatch_forwarded_npdu(
                         orig_ip,
                         orig_port,
@@ -275,19 +280,6 @@ pub(super) async fn handle_bvll_message(
                     let _ =
                         forward_npdu(&ctx.socket, &msg.payload, orig_ip, orig_port, &fdt_targets)
                             .await;
-
-                    // Full-mask BDT peers forward by unicast; masked peers forward by directed broadcast.
-                    if needs_local_broadcast {
-                        let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
-                        let _ = send_forwarded_npdu(
-                            &ctx.socket,
-                            dest,
-                            orig_ip,
-                            orig_port,
-                            &msg.payload,
-                        )
-                        .await;
-                    }
                 }
             } else {
                 // Non-BBMD: use originating address as source_mac (spec J.2.5).
@@ -353,57 +345,39 @@ pub(super) async fn handle_bvll_message(
                     (targets, after.saturating_sub(before))
                 };
 
-                if let Some(fanout) = &ctx.fanout {
-                    let mut addrs: Vec<SocketAddrV4> = targets
+                let local_dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
+                let local_ok = if should_force_dbtn_forward_failure(ctx) {
+                    warn!("Forced DBTN forwarding failure");
+                    false
+                } else {
+                    send_forwarded_npdu(&ctx.socket, local_dest, sender.0, sender.1, &msg.payload)
+                        .await
+                };
+
+                let remote_ok = if let Some(fanout) = &ctx.fanout {
+                    let addrs: Vec<SocketAddrV4> = targets
                         .into_iter()
                         .map(|(ip, port)| SocketAddrV4::new(Ipv4Addr::from(ip), port))
                         .collect();
-                    let local_dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
-                    if !addrs.contains(&local_dest) {
-                        addrs.push(local_dest);
-                    }
-                    let forwarding_ok = if should_force_dbtn_forward_failure(ctx) {
-                        warn!("Forced DBTN forwarding failure");
-                        false
-                    } else {
-                        fanout.dispatch_forwarded_npdu(
-                            sender.0,
-                            sender.1,
-                            &msg.payload,
-                            addrs,
-                            dedup_count,
-                        )
-                    };
-                    if !forwarding_ok {
-                        send_bvlc_result(
-                            &ctx.socket,
-                            sender,
-                            BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK,
-                        )
-                        .await;
-                    }
+                    fanout.dispatch_forwarded_npdu(
+                        sender.0,
+                        sender.1,
+                        &msg.payload,
+                        addrs,
+                        dedup_count,
+                    )
                 } else {
-                    let mut forwarding_ok =
-                        forward_npdu(&ctx.socket, &msg.payload, sender.0, sender.1, &targets).await;
+                    forward_npdu(&ctx.socket, &msg.payload, sender.0, sender.1, &targets).await
+                };
 
-                    // Broadcast locally as Forwarded-NPDU
-                    let dest = SocketAddrV4::new(ctx.broadcast_addr, ctx.broadcast_port);
-                    forwarding_ok &= if should_force_dbtn_forward_failure(ctx) {
-                        warn!("Forced DBTN forwarding failure");
-                        false
-                    } else {
-                        send_forwarded_npdu(&ctx.socket, dest, sender.0, sender.1, &msg.payload)
-                            .await
-                    };
-
-                    if !forwarding_ok {
-                        send_bvlc_result(
-                            &ctx.socket,
-                            sender,
-                            BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK,
-                        )
-                        .await;
-                    }
+                let forwarding_ok = local_ok && remote_ok;
+                if !forwarding_ok {
+                    send_bvlc_result(
+                        &ctx.socket,
+                        sender,
+                        BvlcResultCode::DISTRIBUTE_BROADCAST_TO_NETWORK_NAK,
+                    )
+                    .await;
                 }
             } else {
                 // Non-BBMD: reject with NAK (spec J.4.5)

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -275,6 +275,7 @@ impl BipTransport {
 
     /// Set the broadcast forwarding fanout policy and rate limits.
     pub fn set_fanout_policy(&mut self, policy: FanoutPolicy) {
+        let policy = policy.sanitized();
         if let Ok(mut limiter) = self.fanout_limiter.lock() {
             limiter.set_policy(policy.clone());
         }
@@ -605,7 +606,7 @@ impl TransportPort for BipTransport {
 
         let (npdu_tx, rx) = mpsc::channel(NPDU_CHANNEL_CAPACITY);
 
-        let (fanout_tx, fanout_rx) = mpsc::channel(self.fanout_policy.queue_capacity);
+        let (fanout_tx, fanout_rx) = mpsc::channel(self.fanout_policy.queue_capacity.max(1));
         let fanout_task = tokio::spawn(fanout::run_fanout_worker(
             Arc::clone(&socket),
             fanout_rx,

--- a/crates/bacnet-transport/src/bip/mod.rs
+++ b/crates/bacnet-transport/src/bip/mod.rs
@@ -22,8 +22,10 @@ use crate::udp_metadata::{DestinationReceiver, IpVersion};
 use bacnet_types::enums::{BvlcFunction, BvlcResultCode};
 use bacnet_types::error::Error;
 
+mod fanout;
 mod io;
 mod rate_limit;
+pub use fanout::{FanoutCounters, FanoutPolicy};
 use io::{
     handle_bvll_message, original_destination_matches, resolve_local_ip,
     send_register_foreign_device, RecvContext,
@@ -146,6 +148,14 @@ pub struct BipTransport {
     bdt_persist_path: Option<std::path::PathBuf>,
     /// Management request and response rate limiter.
     management_limiter: Arc<std::sync::Mutex<ManagementRateLimiter>>,
+    /// Broadcast forwarding fanout policy.
+    fanout_policy: FanoutPolicy,
+    /// Background worker task for broadcast forwarding.
+    fanout_task: Option<JoinHandle<()>>,
+    /// Operational counters for broadcast forwarding fanout.
+    fanout_counters: Arc<fanout::AtomicFanoutCounters>,
+    /// Rate limiter for broadcast forwarding fanout.
+    fanout_limiter: Arc<std::sync::Mutex<fanout::FanoutRateLimiter>>,
 }
 
 impl BipTransport {
@@ -155,6 +165,11 @@ impl BipTransport {
     /// - `port`: UDP port (default 47808 / 0xBAC0)
     /// - `broadcast_address`: Directed broadcast address (e.g., `255.255.255.255`)
     pub fn new(interface: Ipv4Addr, port: u16, broadcast_address: Ipv4Addr) -> Self {
+        let fanout_policy = FanoutPolicy::default();
+        let fanout_limiter = Arc::new(std::sync::Mutex::new(fanout::FanoutRateLimiter::new(
+            fanout_policy.clone(),
+        )));
+        let fanout_counters = Arc::new(fanout::AtomicFanoutCounters::default());
         Self {
             interface,
             port,
@@ -170,6 +185,10 @@ impl BipTransport {
             pending_bvlc_response: Arc::new(Mutex::new(None)),
             bdt_persist_path: None,
             management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+            fanout_policy,
+            fanout_task: None,
+            fanout_counters,
+            fanout_limiter,
         }
     }
 
@@ -249,6 +268,19 @@ impl BipTransport {
         }
     }
 
+    /// Return the operational broadcast forwarding fanout counters.
+    pub fn fanout_counters(&self) -> FanoutCounters {
+        self.fanout_counters.snapshot()
+    }
+
+    /// Set the broadcast forwarding fanout policy and rate limits.
+    pub fn set_fanout_policy(&mut self, policy: FanoutPolicy) {
+        if let Ok(mut limiter) = self.fanout_limiter.lock() {
+            limiter.set_policy(policy.clone());
+        }
+        self.fanout_policy = policy;
+    }
+
     /// Timeout for BVLC management response waiting.
     const BVLC_RESPONSE_TIMEOUT: Duration = Duration::from_secs(3);
 
@@ -291,6 +323,10 @@ impl BipTransport {
             tasks.push(task);
         }
         if let Some(task) = self.bbmd_fdt_purge_task.take() {
+            task.abort();
+            tasks.push(task);
+        }
+        if let Some(task) = self.fanout_task.take() {
             task.abort();
             tasks.push(task);
         }
@@ -569,6 +605,20 @@ impl TransportPort for BipTransport {
 
         let (npdu_tx, rx) = mpsc::channel(NPDU_CHANNEL_CAPACITY);
 
+        let (fanout_tx, fanout_rx) = mpsc::channel(self.fanout_policy.queue_capacity);
+        let fanout_task = tokio::spawn(fanout::run_fanout_worker(
+            Arc::clone(&socket),
+            fanout_rx,
+            Arc::clone(&self.fanout_counters),
+        ));
+        self.fanout_task = Some(fanout_task);
+
+        let fanout_dispatcher = fanout::FanoutDispatcher::new(
+            fanout_tx,
+            Arc::clone(&self.fanout_limiter),
+            Arc::clone(&self.fanout_counters),
+        );
+
         let recv_ctx = RecvContext {
             local_mac: self.local_mac,
             socket: Arc::clone(&socket),
@@ -578,6 +628,7 @@ impl TransportPort for BipTransport {
             broadcast_port: self.port,
             pending_bvlc_response: self.pending_bvlc_response.clone(),
             management_limiter: Arc::clone(&self.management_limiter),
+            fanout: Some(fanout_dispatcher),
             #[cfg(test)]
             force_dbtn_forward_failure: false,
         };
@@ -743,6 +794,8 @@ mod acl_tests;
 mod bdt_persistence_tests;
 #[cfg(test)]
 mod dbtn_tests;
+#[cfg(test)]
+mod fanout_tests;
 #[cfg(test)]
 mod fdt_tests;
 #[cfg(test)]

--- a/crates/bacnet-transport/src/bip/original_tests.rs
+++ b/crates/bacnet-transport/src/bip/original_tests.rs
@@ -141,6 +141,7 @@ async fn original_unicast_npdu_uses_udp_sender_source_mac_and_ignores_self() {
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     };
     let sender = ([192, 0, 2, 30], 0xBAC0);
@@ -218,6 +219,7 @@ async fn original_broadcast_npdu_bbmd_forwards_to_bdt_and_fdt_without_local_echo
         broadcast_port: local_broadcast_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     };
     let msg = BvllMessage {

--- a/crates/bacnet-transport/src/bip/rate_limit_tests.rs
+++ b/crates/bacnet-transport/src/bip/rate_limit_tests.rs
@@ -54,6 +54,7 @@ fn test_ctx(
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     }
 }
@@ -320,6 +321,7 @@ async fn rate_limit_discards_malformed_and_unauthorized_before_normal_handling()
         broadcast_port: local_port,
         pending_bvlc_response: Arc::new(Mutex::new(None)),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     };
 

--- a/crates/bacnet-transport/src/bip/tests.rs
+++ b/crates/bacnet-transport/src/bip/tests.rs
@@ -118,6 +118,7 @@ async fn pending_bvlc_response_requires_sender_and_expected_function() {
         broadcast_port: 47808,
         pending_bvlc_response: pending_bvlc_response.clone(),
         management_limiter: Arc::new(std::sync::Mutex::new(ManagementRateLimiter::new())),
+        fanout: None,
         force_dbtn_forward_failure: false,
     };
 


### PR DESCRIPTION
Closes #531

## Summary
- **Destination Deduplication**: Deduplicate resolved `(ip, port)` forwarding targets across BDT and FDT in stable first-seen order, guaranteeing exactly one send per distinct remote destination and eliminating amplification from overlapping or multi-subnet entries.
- **Safe BDT Policy Validation**: Validate BDT candidate entries against unsafe/overly wide broadcast masks (rejecting prefix < 8) and prohibit directed broadcast destinations resolving to `255.255.255.255`.
- **Broadcast Fanout Policy & Rate Budgeting**: Added `FanoutPolicy` with per-input fanout limits (`max_fanout_per_input`), per-origin packet rate limits, global packet/byte budgets, and bounded queue capacity.
- **Bounded Fair Work Queue (Non-Starvation)**: Offload broadcast forwarding (`Original-Broadcast`, `Forwarded-NPDU`, `Distribute-Broadcast-To-Network`) from the UDP receive loop to an asynchronous background worker task via bounded non-blocking `try_send`. Broadcast flooding never blocks or starves concurrent unicast NPDUs or BVLC management traffic.
- **Operational Telemetry**: Added `FanoutCounters` (packets forwarded, bytes forwarded, packets throttled, destinations deduplicated, queue overflow drops) exposed via `fanout_counters(&self)` on `BipTransport`.
- **Benchmark Integration**: Updated BBMD stress benchmark to measure fanout throughput, receive latency, drops, and memory (RSS) under full tables.
- **Test Coverage**: Added comprehensive tests in `crates/bacnet-transport/src/bip/fanout_tests.rs` and `bbmd/validation_tests.rs` covering deduplication, per-input/window budgeting, non-starvation of concurrent unicast streams, and counter accuracy.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p bacnet-transport --locked` (449 unit + 2 integration passed)
- `cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked`
- `cargo test --workspace --exclude rusty-bacnet --locked` (611 tests passed)
- `cargo check -p rusty-bacnet --tests --locked`
- `python3 scripts/generate-conformance-docs.py --check`
- `bash .github/scripts/check-file-size.sh`
- `bash .github/scripts/check-no-secrets.sh`
- `git diff --check`