### PR TITLE
fix(server): rate-limit Who-Is and Who-Has response amplification (#534)

### DIFF
--- a/crates/bacnet-server/src/server/device_bindings_tests.rs
+++ b/crates/bacnet-server/src/server/device_bindings_tests.rs
@@ -320,6 +320,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
     let config = ServerConfig::default();
     let comm_state = Arc::new(AtomicU8::new(0));
     let bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
+    let discovery_limiter = Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None));
     let local_device = device(100);
     let routed_device = device(101);
 
@@ -330,6 +331,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         None,
         &comm_state,
         &bindings,
+        &discovery_limiter,
         i_am_request(local_device),
         &received(LOCAL_PEER, None),
     )
@@ -341,6 +343,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         None,
         &comm_state,
         &bindings,
+        &discovery_limiter,
         i_am_request(routed_device),
         &received(
             ROUTER,
@@ -379,6 +382,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         None,
         &comm_state,
         &bindings,
+        &discovery_limiter,
         i_am_request(ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap()),
         &received(LOCAL_PEER, None),
     )
@@ -390,6 +394,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         None,
         &comm_state,
         &bindings,
+        &discovery_limiter,
         UnconfirmedRequestPdu {
             service_choice: UnconfirmedServiceChoice::I_AM,
             service_request: Bytes::from_static(&[0xFF]),
@@ -407,6 +412,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         None,
         &comm_state,
         &bindings,
+        &discovery_limiter,
         i_am_request(local_device),
         &received(UPDATED_PEER, None),
     )
@@ -418,6 +424,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         None,
         &comm_state,
         &bindings,
+        &discovery_limiter,
         i_am_request(device(102)),
         &received(LOCAL_PEER, None),
     )

--- a/crates/bacnet-server/src/server/discovery.rs
+++ b/crates/bacnet-server/src/server/discovery.rs
@@ -81,24 +81,19 @@ impl DiscoveryPolicy {
             global_burst_capacity: u32::MAX,
             source_burst_capacity: u32::MAX,
             reserved_capacity: 0,
-            reserved_sources: Vec::new(),
             coalesce_window: Duration::ZERO,
             prefer_directed_responses: false,
-            max_tracked_sources: 256,
+            ..Default::default()
         }
     }
 
     /// Return a sanitized copy with valid burst and capacity bounds.
     pub fn sanitized(&self) -> Self {
         let mut policy = self.clone();
-        if policy.max_responses_per_sec_global > 0
-            && policy.max_responses_per_sec_global != u32::MAX
-        {
+        if (1..u32::MAX).contains(&policy.max_responses_per_sec_global) {
             policy.global_burst_capacity = policy.global_burst_capacity.max(1);
         }
-        if policy.max_responses_per_sec_per_source > 0
-            && policy.max_responses_per_sec_per_source != u32::MAX
-        {
+        if (1..u32::MAX).contains(&policy.max_responses_per_sec_per_source) {
             policy.source_burst_capacity = policy.source_burst_capacity.max(1);
         }
         policy.reserved_capacity = policy.reserved_capacity.min(policy.global_burst_capacity);
@@ -159,30 +154,8 @@ impl AtomicDiscoveryCounters {
     }
 
     #[inline]
-    pub(crate) fn inc_who_is(&self) {
-        self.who_is_received.fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub(crate) fn inc_who_has(&self) {
-        self.who_has_received.fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub(crate) fn inc_coalesced(&self) {
-        self.requests_coalesced.fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub(crate) fn inc_throttled_source(&self) {
-        self.responses_throttled_source
-            .fetch_add(1, Ordering::Relaxed);
-    }
-
-    #[inline]
-    pub(crate) fn inc_throttled_global(&self) {
-        self.responses_throttled_global
-            .fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn inc(&self, c: &AtomicU64) {
+        c.fetch_add(1, Ordering::Relaxed);
     }
 
     pub(crate) fn record_sent(&self, bytes: usize, directed: bool, is_who_is: bool) {
@@ -214,8 +187,8 @@ pub(crate) struct SourceKey {
 }
 
 impl SourceKey {
-    pub(crate) fn from_received(received: &ReceivedApdu) -> Self {
-        if let Some(ref net) = received.source_network {
+    pub(crate) fn from_parts(source_mac: &MacAddr, source_network: Option<&NpduAddress>) -> Self {
+        if let Some(ref net) = source_network {
             if (1..=0xFFFE).contains(&net.network) && !net.mac_address.is_empty() {
                 return Self {
                     network: net.network,
@@ -225,8 +198,12 @@ impl SourceKey {
         }
         Self {
             network: 0,
-            mac: received.source_mac.clone(),
+            mac: source_mac.clone(),
         }
+    }
+
+    pub(crate) fn from_received(received: &ReceivedApdu) -> Self {
+        Self::from_parts(&received.source_mac, received.source_network.as_ref())
     }
 }
 
@@ -249,16 +226,18 @@ fn refill_bucket(
     burst: u32,
     now: Instant,
 ) {
-    if rate == u32::MAX {
-        *tokens = burst as f64;
-        *byte_tokens = byte_rate as f64;
-        *last_refill = now;
-        return;
-    }
     let elapsed = now.saturating_duration_since(*last_refill).as_secs_f64();
     if elapsed > 0.0 {
-        *tokens = (*tokens + elapsed * (rate as f64)).min(burst as f64);
-        *byte_tokens = (*byte_tokens + elapsed * (byte_rate as f64)).min(byte_rate as f64);
+        *tokens = if rate == u32::MAX {
+            burst as f64
+        } else {
+            (*tokens + elapsed * (rate as f64)).min(burst as f64)
+        };
+        *byte_tokens = if byte_rate == usize::MAX {
+            byte_rate as f64
+        } else {
+            (*byte_tokens + elapsed * (byte_rate as f64)).min(byte_rate as f64)
+        };
         *last_refill = now;
     }
 }
@@ -277,15 +256,16 @@ impl SourceState {
     }
 
     fn has_capacity(&self, policy: &DiscoveryPolicy, bytes: usize) -> bool {
-        if policy.max_responses_per_sec_per_source == u32::MAX {
-            return true;
-        }
-        self.byte_tokens >= bytes as f64 && self.tokens >= 1.0
+        (policy.max_responses_per_sec_per_source == u32::MAX || self.tokens >= 1.0)
+            && (policy.max_bytes_per_sec_per_source == usize::MAX
+                || self.byte_tokens >= bytes as f64)
     }
 
     fn deduct(&mut self, policy: &DiscoveryPolicy, bytes: usize) {
         if policy.max_responses_per_sec_per_source != u32::MAX {
             self.tokens -= 1.0;
+        }
+        if policy.max_bytes_per_sec_per_source != usize::MAX {
             self.byte_tokens -= bytes as f64;
         }
     }
@@ -321,23 +301,24 @@ impl DiscoveryState {
         is_reserved: bool,
         bytes: usize,
     ) -> bool {
-        if policy.max_responses_per_sec_global == u32::MAX {
-            return true;
-        }
-        if self.global_byte_tokens < bytes as f64 {
-            return false;
-        }
-        let required = if is_reserved {
-            1.0
-        } else {
-            1.0 + policy.reserved_capacity as f64
+        let count_ok = policy.max_responses_per_sec_global == u32::MAX || {
+            let req = if is_reserved {
+                1.0
+            } else {
+                1.0 + policy.reserved_capacity as f64
+            };
+            self.global_tokens >= req
         };
-        self.global_tokens >= required
+        count_ok
+            && (policy.max_bytes_per_sec_global == usize::MAX
+                || self.global_byte_tokens >= bytes as f64)
     }
 
     fn deduct_global(&mut self, policy: &DiscoveryPolicy, bytes: usize) {
         if policy.max_responses_per_sec_global != u32::MAX {
             self.global_tokens -= 1.0;
+        }
+        if policy.max_bytes_per_sec_global != usize::MAX {
             self.global_byte_tokens -= bytes as f64;
         }
     }
@@ -348,7 +329,9 @@ impl DiscoveryState {
         key: &SourceKey,
         now: Instant,
     ) -> &mut SourceState {
-        ensure_source_capacity(self, policy, now);
+        if !self.sources.contains_key(key) {
+            ensure_source_capacity(self, policy, now);
+        }
         let src = self
             .sources
             .entry(key.clone())
@@ -375,15 +358,18 @@ impl DiscoveryState {
         if policy.coalesce_window.is_zero() {
             return false;
         }
-        let is_recent = |opt: Option<&Instant>| {
-            opt.is_some_and(|ts| now.saturating_duration_since(*ts) < policy.coalesce_window)
-        };
-        is_recent(self.negative_who_has.get(target))
-            || (is_broadcast && is_recent(self.last_broadcast_who_has.get(target)))
+        let is_recent = |ts: &Instant| now.saturating_duration_since(*ts) < policy.coalesce_window;
+        self.negative_who_has.get(target).is_some_and(is_recent)
+            || (is_broadcast
+                && self
+                    .last_broadcast_who_has
+                    .get(target)
+                    .is_some_and(is_recent))
             || self
                 .sources
                 .get(key)
-                .is_some_and(|s| is_recent(s.last_who_has.get(target)))
+                .and_then(|s| s.last_who_has.get(target))
+                .is_some_and(is_recent)
     }
 }
 
@@ -394,19 +380,14 @@ impl AtomicDeviceInstance {
     const PRESENT_BIT: u64 = 0x1_0000_0000;
 
     fn new(opt: Option<u32>) -> Self {
-        Self(AtomicU64::new(match opt {
-            Some(i) => Self::PRESENT_BIT | (i as u64),
-            None => 0,
-        }))
+        Self(AtomicU64::new(
+            opt.map_or(0, |i| Self::PRESENT_BIT | (i as u64)),
+        ))
     }
 
     fn load(&self, order: Ordering) -> Option<u32> {
         let val = self.0.load(order);
-        if val & Self::PRESENT_BIT != 0 {
-            Some(val as u32)
-        } else {
-            None
-        }
+        (val & Self::PRESENT_BIT != 0).then_some(val as u32)
     }
 }
 
@@ -458,9 +439,29 @@ impl DiscoveryLimiter {
         &self.policy
     }
 
+    #[cfg(test)]
+    pub(crate) fn negative_who_has_count(&self) -> usize {
+        self.state.lock().unwrap().negative_who_has.len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn source_byte_tokens(
+        &self,
+        source_mac: &MacAddr,
+        source_network: Option<&NpduAddress>,
+    ) -> Option<f64> {
+        let key = SourceKey::from_parts(source_mac, source_network);
+        self.state
+            .lock()
+            .unwrap()
+            .sources
+            .get(&key)
+            .map(|s| s.byte_tokens)
+    }
+
     fn check_instance_in_range(&self, low: Option<u32>, high: Option<u32>) -> bool {
         match (self.device_instance.load(Ordering::Acquire), low, high) {
-            (Some(inst), Some(low), Some(high)) => inst >= low && inst <= high,
+            (Some(inst), Some(l), Some(h)) => inst >= l && inst <= h,
             (Some(_), _, _) => true,
             (None, _, _) => false,
         }
@@ -477,7 +478,7 @@ impl DiscoveryLimiter {
             Err(_) => return PreCheckDecision::DecodeError,
         };
 
-        self.counters.inc_who_is();
+        self.counters.inc(&self.counters.who_is_received);
 
         if !self.check_instance_in_range(who_is.low_limit, who_is.high_limit) {
             return PreCheckDecision::OutOfRange;
@@ -489,18 +490,16 @@ impl DiscoveryLimiter {
 
         // 1. Coalescing check
         if !self.policy.coalesce_window.is_zero() {
-            let is_recent = |opt: Option<Instant>| {
-                opt.is_some_and(|ts| {
-                    now.saturating_duration_since(ts) < self.policy.coalesce_window
-                })
-            };
-            if (is_broadcast && is_recent(state.last_broadcast_who_is))
-                || state
-                    .sources
-                    .get(&source_key)
-                    .is_some_and(|s| is_recent(s.last_who_is))
-            {
-                self.counters.inc_coalesced();
+            let is_recent =
+                |ts: &Instant| now.saturating_duration_since(*ts) < self.policy.coalesce_window;
+            let bcast = is_broadcast && state.last_broadcast_who_is.as_ref().is_some_and(is_recent);
+            let src = state
+                .sources
+                .get(&source_key)
+                .and_then(|s| s.last_who_is.as_ref())
+                .is_some_and(is_recent);
+            if bcast || src {
+                self.counters.inc(&self.counters.requests_coalesced);
                 return PreCheckDecision::Coalesced;
             }
         }
@@ -511,22 +510,20 @@ impl DiscoveryLimiter {
         const ESTIMATED_I_AM_BYTES: usize = 64;
 
         if !state.has_global_capacity(&self.policy, is_reserved, ESTIMATED_I_AM_BYTES) {
-            self.counters.inc_throttled_global();
+            self.counters.inc(&self.counters.responses_throttled_global);
             return PreCheckDecision::ThrottledGlobal;
         }
 
-        let policy = self.policy.clone();
-        let src = state.get_or_create_source_mut(&policy, &source_key, now);
-        if !src.has_capacity(&policy, ESTIMATED_I_AM_BYTES) {
-            self.counters.inc_throttled_source();
+        let src = state.get_or_create_source_mut(&self.policy, &source_key, now);
+        if !src.has_capacity(&self.policy, ESTIMATED_I_AM_BYTES) {
+            self.counters.inc(&self.counters.responses_throttled_source);
             return PreCheckDecision::ThrottledSource;
         }
 
-        state.deduct_global(&policy, ESTIMATED_I_AM_BYTES);
-        let src = state.get_or_create_source_mut(&policy, &source_key, now);
-        src.deduct(&policy, ESTIMATED_I_AM_BYTES);
+        src.deduct(&self.policy, ESTIMATED_I_AM_BYTES);
         src.last_activity = now;
         src.last_who_is = Some(now);
+        state.deduct_global(&self.policy, ESTIMATED_I_AM_BYTES);
         if is_broadcast && !self.policy.prefer_directed_responses {
             state.last_broadcast_who_is = Some(now);
         }
@@ -548,15 +545,12 @@ impl DiscoveryLimiter {
         let delta = (actual_bytes as f64) - (ESTIMATED_I_AM_BYTES as f64);
         let mut state = self.state.lock().unwrap();
         if delta != 0.0 {
-            if self.policy.max_responses_per_sec_global != u32::MAX {
+            if self.policy.max_bytes_per_sec_global != usize::MAX {
                 state.global_byte_tokens = (state.global_byte_tokens - delta).max(0.0);
             }
-            let key = SourceKey {
-                network: source_network.map(|n| n.network).unwrap_or(0),
-                mac: source_mac.clone(),
-            };
+            let key = SourceKey::from_parts(source_mac, source_network);
             if let Some(src) = state.sources.get_mut(&key) {
-                if self.policy.max_responses_per_sec_per_source != u32::MAX {
+                if self.policy.max_bytes_per_sec_per_source != usize::MAX {
                     src.byte_tokens = (src.byte_tokens - delta).max(0.0);
                 }
             }
@@ -577,15 +571,15 @@ impl DiscoveryLimiter {
             Err(_) => return PreCheckDecision::DecodeError,
         };
 
-        self.counters.inc_who_has();
+        self.counters.inc(&self.counters.who_has_received);
 
         if !self.check_instance_in_range(who_has.low_limit, who_has.high_limit) {
             return PreCheckDecision::OutOfRange;
         }
 
-        let target = match &who_has.object {
-            WhoHasObject::Identifier(oid) => WhoHasTarget::Id(*oid),
-            WhoHasObject::Name(name) => WhoHasTarget::Name(name.clone()),
+        let target = match who_has.object {
+            WhoHasObject::Identifier(oid) => WhoHasTarget::Id(oid),
+            WhoHasObject::Name(name) => WhoHasTarget::Name(name),
         };
 
         let is_broadcast = received.is_group || received.link_layer_group;
@@ -593,7 +587,7 @@ impl DiscoveryLimiter {
         let mut state = self.state.lock().unwrap();
 
         if state.is_coalesced_who_has(&self.policy, &target, &source_key, is_broadcast, now) {
-            self.counters.inc_coalesced();
+            self.counters.inc(&self.counters.requests_coalesced);
             return PreCheckDecision::Coalesced;
         }
 
@@ -602,14 +596,13 @@ impl DiscoveryLimiter {
         const ESTIMATED_I_HAVE_BYTES: usize = 64;
 
         if !state.has_global_capacity(&self.policy, is_reserved, ESTIMATED_I_HAVE_BYTES) {
-            self.counters.inc_throttled_global();
+            self.counters.inc(&self.counters.responses_throttled_global);
             return PreCheckDecision::ThrottledGlobal;
         }
 
-        let policy = self.policy.clone();
-        let src = state.get_or_create_source_mut(&policy, &source_key, now);
-        if !src.has_capacity(&policy, ESTIMATED_I_HAVE_BYTES) {
-            self.counters.inc_throttled_source();
+        let src = state.get_or_create_source_mut(&self.policy, &source_key, now);
+        if !src.has_capacity(&self.policy, ESTIMATED_I_HAVE_BYTES) {
+            self.counters.inc(&self.counters.responses_throttled_source);
             return PreCheckDecision::ThrottledSource;
         }
 
@@ -630,12 +623,24 @@ impl DiscoveryLimiter {
     }
 
     pub(crate) fn record_negative_who_has(&self, target: WhoHasTarget, now: Instant) {
+        const MAX_NEGATIVE_WHO_HAS: usize = 512;
         let mut state = self.state.lock().unwrap();
-        if state.negative_who_has.len() > 512 {
+        if state.negative_who_has.len() >= MAX_NEGATIVE_WHO_HAS {
             let window = self.policy.coalesce_window;
             state
                 .negative_who_has
                 .retain(|_, ts| now.saturating_duration_since(*ts) < window);
+        }
+        while state.negative_who_has.len() >= MAX_NEGATIVE_WHO_HAS {
+            let Some(oldest) = state
+                .negative_who_has
+                .iter()
+                .min_by_key(|(_, ts)| *ts)
+                .map(|(k, _)| k.clone())
+            else {
+                break;
+            };
+            state.negative_who_has.remove(&oldest);
         }
         state.negative_who_has.insert(target, now);
     }
@@ -652,7 +657,7 @@ impl DiscoveryLimiter {
         let is_broadcast = received.is_group || received.link_layer_group;
 
         if state.is_coalesced_who_has(&self.policy, target, &source_key, is_broadcast, now) {
-            self.counters.inc_coalesced();
+            self.counters.inc(&self.counters.requests_coalesced);
             return false;
         }
 
@@ -660,22 +665,20 @@ impl DiscoveryLimiter {
         let is_reserved = is_source_reserved(&self.policy, &source_key, received);
 
         if !state.has_global_capacity(&self.policy, is_reserved, response_bytes) {
-            self.counters.inc_throttled_global();
+            self.counters.inc(&self.counters.responses_throttled_global);
             return false;
         }
 
-        let policy = self.policy.clone();
-        let src = state.get_or_create_source_mut(&policy, &source_key, now);
-        if !src.has_capacity(&policy, response_bytes) {
-            self.counters.inc_throttled_source();
+        let src = state.get_or_create_source_mut(&self.policy, &source_key, now);
+        if !src.has_capacity(&self.policy, response_bytes) {
+            self.counters.inc(&self.counters.responses_throttled_source);
             return false;
         }
 
-        state.deduct_global(&policy, response_bytes);
-        let src = state.get_or_create_source_mut(&policy, &source_key, now);
-        src.deduct(&policy, response_bytes);
+        src.deduct(&self.policy, response_bytes);
         src.last_activity = now;
         src.last_who_has.insert(target.clone(), now);
+        state.deduct_global(&self.policy, response_bytes);
         if is_broadcast && !self.policy.prefer_directed_responses {
             state.last_broadcast_who_has.insert(target.clone(), now);
         }
@@ -701,15 +704,11 @@ impl DiscoveryLimiter {
     }
 }
 
-fn is_source_reserved(
-    policy: &DiscoveryPolicy,
-    source_key: &SourceKey,
-    received: &ReceivedApdu,
-) -> bool {
+fn is_source_reserved(policy: &DiscoveryPolicy, key: &SourceKey, recv: &ReceivedApdu) -> bool {
     policy
         .reserved_sources
         .iter()
-        .any(|r| r == &source_key.mac || r == &received.source_mac)
+        .any(|r| r == &key.mac || r == &recv.source_mac)
 }
 
 fn ensure_source_capacity(state: &mut DiscoveryState, policy: &DiscoveryPolicy, now: Instant) {
@@ -720,16 +719,15 @@ fn ensure_source_capacity(state: &mut DiscoveryState, policy: &DiscoveryPolicy, 
         now.saturating_duration_since(src.last_activity) < Duration::from_secs(10)
     });
     while state.sources.len() >= policy.max_tracked_sources {
-        let oldest = state
+        let Some(key) = state
             .sources
             .iter()
             .min_by_key(|(_, src)| src.last_activity)
-            .map(|(k, _)| k.clone());
-        if let Some(key) = oldest {
-            state.sources.remove(&key);
-        } else {
+            .map(|(k, _)| k.clone())
+        else {
             break;
-        }
+        };
+        state.sources.remove(&key);
     }
 }
 

--- a/crates/bacnet-server/src/server/discovery.rs
+++ b/crates/bacnet-server/src/server/discovery.rs
@@ -1,0 +1,795 @@
+//! Discovery rate-limiting, duplicate suppression, and directed response handling.
+//!
+//! Controls response amplification for unconfirmed discovery services (Who-Is
+//! and Who-Has) per ASHRAE 135-2020 Clauses 16.9 and 16.10.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use bytes::BytesMut;
+
+use bacnet_encoding::apdu::{encode_apdu, Apdu, UnconfirmedRequest as UnconfirmedRequestPdu};
+use bacnet_encoding::npdu::NpduAddress;
+use bacnet_network::layer::{NetworkLayer, ReceivedApdu};
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_services::who_has::{WhoHasObject, WhoHasRequest};
+use bacnet_services::who_is::{IAmRequest, WhoIsRequest};
+use bacnet_transport::port::TransportPort;
+use bacnet_types::enums::{NetworkPriority, ObjectType, UnconfirmedServiceChoice};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+use tokio::sync::RwLock;
+
+use super::{BACnetServer, IAmBroadcaster, ServerConfig};
+
+/// Configuration policy for discovery rate limiting and duplicate suppression.
+#[derive(Debug, Clone)]
+pub struct DiscoveryPolicy {
+    /// Maximum discovery responses emitted globally per second (default 64).
+    pub max_responses_per_sec_global: u32,
+    /// Maximum discovery response bytes emitted globally per second (default 65,536).
+    pub max_bytes_per_sec_global: usize,
+    /// Maximum discovery responses emitted per source per second (default 16).
+    pub max_responses_per_sec_per_source: u32,
+    /// Maximum discovery response bytes emitted per source per second (default 16,384).
+    pub max_bytes_per_sec_per_source: usize,
+    /// Maximum burst capacity for global discovery responses (default 64).
+    pub global_burst_capacity: u32,
+    /// Maximum burst capacity for per-source discovery responses (default 16).
+    pub source_burst_capacity: u32,
+    /// Headroom reserved exclusively for configured reserved sources (default 8).
+    pub reserved_capacity: u32,
+    /// Sources permitted to consume from reserved capacity.
+    pub reserved_sources: Vec<MacAddr>,
+    /// Coalescing window for duplicate discovery request suppression (default 200ms).
+    pub coalesce_window: Duration,
+    /// Prefer directed unicast responses over network broadcast (default true).
+    pub prefer_directed_responses: bool,
+    /// Maximum number of distinct discovery sources tracked concurrently (default 256).
+    pub max_tracked_sources: usize,
+}
+
+impl Default for DiscoveryPolicy {
+    fn default() -> Self {
+        Self {
+            max_responses_per_sec_global: 64,
+            max_bytes_per_sec_global: 65_536,
+            max_responses_per_sec_per_source: 16,
+            max_bytes_per_sec_per_source: 16_384,
+            global_burst_capacity: 64,
+            source_burst_capacity: 16,
+            reserved_capacity: 8,
+            reserved_sources: Vec::new(),
+            coalesce_window: Duration::from_millis(200),
+            prefer_directed_responses: true,
+            max_tracked_sources: 256,
+        }
+    }
+}
+
+impl DiscoveryPolicy {
+    /// Create an unlimited discovery policy with all rate limits disabled.
+    pub fn unlimited() -> Self {
+        Self {
+            max_responses_per_sec_global: u32::MAX,
+            max_bytes_per_sec_global: usize::MAX,
+            max_responses_per_sec_per_source: u32::MAX,
+            max_bytes_per_sec_per_source: usize::MAX,
+            global_burst_capacity: u32::MAX,
+            source_burst_capacity: u32::MAX,
+            reserved_capacity: 0,
+            reserved_sources: Vec::new(),
+            coalesce_window: Duration::ZERO,
+            prefer_directed_responses: false,
+            max_tracked_sources: 256,
+        }
+    }
+
+    /// Return a sanitized copy with valid burst and capacity bounds.
+    pub fn sanitized(&self) -> Self {
+        let mut policy = self.clone();
+        if policy.max_responses_per_sec_global > 0
+            && policy.max_responses_per_sec_global != u32::MAX
+        {
+            policy.global_burst_capacity = policy.global_burst_capacity.max(1);
+        }
+        if policy.max_responses_per_sec_per_source > 0
+            && policy.max_responses_per_sec_per_source != u32::MAX
+        {
+            policy.source_burst_capacity = policy.source_burst_capacity.max(1);
+        }
+        policy.reserved_capacity = policy.reserved_capacity.min(policy.global_burst_capacity);
+        policy.max_tracked_sources = policy.max_tracked_sources.max(1);
+        policy
+    }
+}
+
+/// Operational counters for discovery requests and responses.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct DiscoveryCounters {
+    /// Total Who-Is requests received.
+    pub who_is_received: u64,
+    /// Total Who-Has requests received.
+    pub who_has_received: u64,
+    /// Total I-Am responses sent.
+    pub i_am_sent: u64,
+    /// Total I-Have responses sent.
+    pub i_have_sent: u64,
+    /// Total response bytes sent for discovery.
+    pub response_bytes_sent: u64,
+    /// Total duplicate or cached requests coalesced without sending responses.
+    pub requests_coalesced: u64,
+    /// Responses throttled by per-source rate or burst limits.
+    pub responses_throttled_source: u64,
+    /// Responses throttled by global rate or reserved capacity limits.
+    pub responses_throttled_global: u64,
+    /// Total directed unicast discovery responses sent.
+    pub directed_responses_sent: u64,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct AtomicDiscoveryCounters {
+    pub(crate) who_is_received: AtomicU64,
+    pub(crate) who_has_received: AtomicU64,
+    pub(crate) i_am_sent: AtomicU64,
+    pub(crate) i_have_sent: AtomicU64,
+    pub(crate) response_bytes_sent: AtomicU64,
+    pub(crate) requests_coalesced: AtomicU64,
+    pub(crate) responses_throttled_source: AtomicU64,
+    pub(crate) responses_throttled_global: AtomicU64,
+    pub(crate) directed_responses_sent: AtomicU64,
+}
+
+impl AtomicDiscoveryCounters {
+    pub(crate) fn snapshot(&self) -> DiscoveryCounters {
+        DiscoveryCounters {
+            who_is_received: self.who_is_received.load(Ordering::Relaxed),
+            who_has_received: self.who_has_received.load(Ordering::Relaxed),
+            i_am_sent: self.i_am_sent.load(Ordering::Relaxed),
+            i_have_sent: self.i_have_sent.load(Ordering::Relaxed),
+            response_bytes_sent: self.response_bytes_sent.load(Ordering::Relaxed),
+            requests_coalesced: self.requests_coalesced.load(Ordering::Relaxed),
+            responses_throttled_source: self.responses_throttled_source.load(Ordering::Relaxed),
+            responses_throttled_global: self.responses_throttled_global.load(Ordering::Relaxed),
+            directed_responses_sent: self.directed_responses_sent.load(Ordering::Relaxed),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn inc_who_is(&self) {
+        self.who_is_received.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn inc_who_has(&self) {
+        self.who_has_received.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn inc_coalesced(&self) {
+        self.requests_coalesced.fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn inc_throttled_source(&self) {
+        self.responses_throttled_source
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    #[inline]
+    pub(crate) fn inc_throttled_global(&self) {
+        self.responses_throttled_global
+            .fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_sent(&self, bytes: usize, directed: bool, is_who_is: bool) {
+        if is_who_is {
+            self.i_am_sent.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.i_have_sent.fetch_add(1, Ordering::Relaxed);
+        }
+        self.response_bytes_sent
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+        if directed {
+            self.directed_responses_sent.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Target of a Who-Has query.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) enum WhoHasTarget {
+    Id(ObjectIdentifier),
+    Name(String),
+}
+
+/// Network-aware identity of a discovery requester.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct SourceKey {
+    pub(crate) network: u16,
+    pub(crate) mac: MacAddr,
+}
+
+impl SourceKey {
+    pub(crate) fn from_received(received: &ReceivedApdu) -> Self {
+        if let Some(ref net) = received.source_network {
+            if (1..=0xFFFE).contains(&net.network) && !net.mac_address.is_empty() {
+                return Self {
+                    network: net.network,
+                    mac: MacAddr::from_slice(&net.mac_address),
+                };
+            }
+        }
+        Self {
+            network: 0,
+            mac: received.source_mac.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SourceState {
+    tokens: f64,
+    byte_tokens: f64,
+    last_refill: Instant,
+    last_activity: Instant,
+    last_who_is: Option<Instant>,
+    last_who_has: HashMap<WhoHasTarget, Instant>,
+}
+
+fn refill_bucket(
+    tokens: &mut f64,
+    byte_tokens: &mut f64,
+    last_refill: &mut Instant,
+    rate: u32,
+    byte_rate: usize,
+    burst: u32,
+    now: Instant,
+) {
+    if rate == u32::MAX {
+        *tokens = burst as f64;
+        *byte_tokens = byte_rate as f64;
+        *last_refill = now;
+        return;
+    }
+    let elapsed = now.saturating_duration_since(*last_refill).as_secs_f64();
+    if elapsed > 0.0 {
+        *tokens = (*tokens + elapsed * (rate as f64)).min(burst as f64);
+        *byte_tokens = (*byte_tokens + elapsed * (byte_rate as f64)).min(byte_rate as f64);
+        *last_refill = now;
+    }
+}
+
+impl SourceState {
+    fn refill(&mut self, policy: &DiscoveryPolicy, now: Instant) {
+        refill_bucket(
+            &mut self.tokens,
+            &mut self.byte_tokens,
+            &mut self.last_refill,
+            policy.max_responses_per_sec_per_source,
+            policy.max_bytes_per_sec_per_source,
+            policy.source_burst_capacity,
+            now,
+        );
+    }
+
+    fn has_capacity(&self, policy: &DiscoveryPolicy, bytes: usize) -> bool {
+        if policy.max_responses_per_sec_per_source == u32::MAX {
+            return true;
+        }
+        self.byte_tokens >= bytes as f64 && self.tokens >= 1.0
+    }
+
+    fn deduct(&mut self, policy: &DiscoveryPolicy, bytes: usize) {
+        if policy.max_responses_per_sec_per_source != u32::MAX {
+            self.tokens -= 1.0;
+            self.byte_tokens -= bytes as f64;
+        }
+    }
+}
+
+#[derive(Debug)]
+struct DiscoveryState {
+    global_tokens: f64,
+    global_byte_tokens: f64,
+    global_last_refill: Instant,
+    last_broadcast_who_is: Option<Instant>,
+    last_broadcast_who_has: HashMap<WhoHasTarget, Instant>,
+    negative_who_has: HashMap<WhoHasTarget, Instant>,
+    sources: HashMap<SourceKey, SourceState>,
+}
+
+impl DiscoveryState {
+    fn refill_global(&mut self, policy: &DiscoveryPolicy, now: Instant) {
+        refill_bucket(
+            &mut self.global_tokens,
+            &mut self.global_byte_tokens,
+            &mut self.global_last_refill,
+            policy.max_responses_per_sec_global,
+            policy.max_bytes_per_sec_global,
+            policy.global_burst_capacity,
+            now,
+        );
+    }
+
+    fn has_global_capacity(
+        &self,
+        policy: &DiscoveryPolicy,
+        is_reserved: bool,
+        bytes: usize,
+    ) -> bool {
+        if policy.max_responses_per_sec_global == u32::MAX {
+            return true;
+        }
+        if self.global_byte_tokens < bytes as f64 {
+            return false;
+        }
+        let required = if is_reserved {
+            1.0
+        } else {
+            1.0 + policy.reserved_capacity as f64
+        };
+        self.global_tokens >= required
+    }
+
+    fn deduct_global(&mut self, policy: &DiscoveryPolicy, bytes: usize) {
+        if policy.max_responses_per_sec_global != u32::MAX {
+            self.global_tokens -= 1.0;
+            self.global_byte_tokens -= bytes as f64;
+        }
+    }
+
+    fn get_or_create_source_mut(
+        &mut self,
+        policy: &DiscoveryPolicy,
+        key: &SourceKey,
+        now: Instant,
+    ) -> &mut SourceState {
+        ensure_source_capacity(self, policy, now);
+        let src = self
+            .sources
+            .entry(key.clone())
+            .or_insert_with(|| SourceState {
+                tokens: policy.source_burst_capacity as f64,
+                byte_tokens: policy.max_bytes_per_sec_per_source as f64,
+                last_refill: now,
+                last_activity: now,
+                last_who_is: None,
+                last_who_has: HashMap::new(),
+            });
+        src.refill(policy, now);
+        src
+    }
+
+    fn is_coalesced_who_has(
+        &self,
+        policy: &DiscoveryPolicy,
+        target: &WhoHasTarget,
+        key: &SourceKey,
+        is_broadcast: bool,
+        now: Instant,
+    ) -> bool {
+        if policy.coalesce_window.is_zero() {
+            return false;
+        }
+        let is_recent = |opt: Option<&Instant>| {
+            opt.is_some_and(|ts| now.saturating_duration_since(*ts) < policy.coalesce_window)
+        };
+        is_recent(self.negative_who_has.get(target))
+            || (is_broadcast && is_recent(self.last_broadcast_who_has.get(target)))
+            || self
+                .sources
+                .get(key)
+                .is_some_and(|s| is_recent(s.last_who_has.get(target)))
+    }
+}
+
+#[derive(Debug)]
+struct AtomicDeviceInstance(AtomicU64);
+
+impl AtomicDeviceInstance {
+    const PRESENT_BIT: u64 = 0x1_0000_0000;
+
+    fn new(opt: Option<u32>) -> Self {
+        Self(AtomicU64::new(match opt {
+            Some(i) => Self::PRESENT_BIT | (i as u64),
+            None => 0,
+        }))
+    }
+
+    fn load(&self, order: Ordering) -> Option<u32> {
+        let val = self.0.load(order);
+        if val & Self::PRESENT_BIT != 0 {
+            Some(val as u32)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PreCheckDecision {
+    Admit,
+    OutOfRange,
+    Coalesced,
+    ThrottledSource,
+    ThrottledGlobal,
+    DecodeError,
+}
+
+/// Thread-safe rate limiter, duplicate coalescer, and negative query cache.
+#[derive(Debug)]
+pub(crate) struct DiscoveryLimiter {
+    policy: DiscoveryPolicy,
+    counters: AtomicDiscoveryCounters,
+    device_instance: AtomicDeviceInstance,
+    state: Mutex<DiscoveryState>,
+}
+
+impl DiscoveryLimiter {
+    pub(crate) fn new(policy: DiscoveryPolicy, device_instance: Option<u32>) -> Self {
+        let now = Instant::now();
+        let state = DiscoveryState {
+            global_tokens: policy.global_burst_capacity as f64,
+            global_byte_tokens: policy.max_bytes_per_sec_global as f64,
+            global_last_refill: now,
+            last_broadcast_who_is: None,
+            last_broadcast_who_has: HashMap::new(),
+            negative_who_has: HashMap::new(),
+            sources: HashMap::new(),
+        };
+        Self {
+            policy,
+            counters: AtomicDiscoveryCounters::default(),
+            device_instance: AtomicDeviceInstance::new(device_instance),
+            state: Mutex::new(state),
+        }
+    }
+
+    pub(crate) fn counters(&self) -> DiscoveryCounters {
+        self.counters.snapshot()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn policy(&self) -> &DiscoveryPolicy {
+        &self.policy
+    }
+
+    fn check_instance_in_range(&self, low: Option<u32>, high: Option<u32>) -> bool {
+        match (self.device_instance.load(Ordering::Acquire), low, high) {
+            (Some(inst), Some(low), Some(high)) => inst >= low && inst <= high,
+            (Some(_), _, _) => true,
+            (None, _, _) => false,
+        }
+    }
+
+    pub(crate) fn pre_check_who_is(
+        &self,
+        req_bytes: &[u8],
+        received: &ReceivedApdu,
+        now: Instant,
+    ) -> PreCheckDecision {
+        let who_is = match WhoIsRequest::decode(req_bytes) {
+            Ok(w) => w,
+            Err(_) => return PreCheckDecision::DecodeError,
+        };
+
+        self.counters.inc_who_is();
+
+        if !self.check_instance_in_range(who_is.low_limit, who_is.high_limit) {
+            return PreCheckDecision::OutOfRange;
+        }
+
+        let is_broadcast = received.is_group || received.link_layer_group;
+        let source_key = SourceKey::from_received(received);
+        let mut state = self.state.lock().unwrap();
+
+        // 1. Coalescing check
+        if !self.policy.coalesce_window.is_zero() {
+            let is_recent = |opt: Option<Instant>| {
+                opt.is_some_and(|ts| {
+                    now.saturating_duration_since(ts) < self.policy.coalesce_window
+                })
+            };
+            if (is_broadcast && is_recent(state.last_broadcast_who_is))
+                || state
+                    .sources
+                    .get(&source_key)
+                    .is_some_and(|s| is_recent(s.last_who_is))
+            {
+                self.counters.inc_coalesced();
+                return PreCheckDecision::Coalesced;
+            }
+        }
+
+        // 2. Refill & Rate limits
+        state.refill_global(&self.policy, now);
+        let is_reserved = is_source_reserved(&self.policy, &source_key, received);
+        const ESTIMATED_I_AM_BYTES: usize = 64;
+
+        if !state.has_global_capacity(&self.policy, is_reserved, ESTIMATED_I_AM_BYTES) {
+            self.counters.inc_throttled_global();
+            return PreCheckDecision::ThrottledGlobal;
+        }
+
+        let policy = self.policy.clone();
+        let src = state.get_or_create_source_mut(&policy, &source_key, now);
+        if !src.has_capacity(&policy, ESTIMATED_I_AM_BYTES) {
+            self.counters.inc_throttled_source();
+            return PreCheckDecision::ThrottledSource;
+        }
+
+        state.deduct_global(&policy, ESTIMATED_I_AM_BYTES);
+        let src = state.get_or_create_source_mut(&policy, &source_key, now);
+        src.deduct(&policy, ESTIMATED_I_AM_BYTES);
+        src.last_activity = now;
+        src.last_who_is = Some(now);
+        if is_broadcast && !self.policy.prefer_directed_responses {
+            state.last_broadcast_who_is = Some(now);
+        }
+
+        PreCheckDecision::Admit
+    }
+
+    pub(crate) fn record_i_am_sent(
+        &self,
+        actual_bytes: usize,
+        directed: bool,
+        source_mac: &MacAddr,
+        source_network: Option<&NpduAddress>,
+        now: Instant,
+    ) {
+        self.counters.record_sent(actual_bytes, directed, true);
+
+        const ESTIMATED_I_AM_BYTES: usize = 64;
+        let delta = (actual_bytes as f64) - (ESTIMATED_I_AM_BYTES as f64);
+        let mut state = self.state.lock().unwrap();
+        if delta != 0.0 {
+            if self.policy.max_responses_per_sec_global != u32::MAX {
+                state.global_byte_tokens = (state.global_byte_tokens - delta).max(0.0);
+            }
+            let key = SourceKey {
+                network: source_network.map(|n| n.network).unwrap_or(0),
+                mac: source_mac.clone(),
+            };
+            if let Some(src) = state.sources.get_mut(&key) {
+                if self.policy.max_responses_per_sec_per_source != u32::MAX {
+                    src.byte_tokens = (src.byte_tokens - delta).max(0.0);
+                }
+            }
+        }
+        if !directed {
+            state.last_broadcast_who_is = Some(now);
+        }
+    }
+
+    pub(crate) fn pre_check_who_has(
+        &self,
+        req_bytes: &[u8],
+        received: &ReceivedApdu,
+        now: Instant,
+    ) -> PreCheckDecision {
+        let who_has = match WhoHasRequest::decode(req_bytes) {
+            Ok(w) => w,
+            Err(_) => return PreCheckDecision::DecodeError,
+        };
+
+        self.counters.inc_who_has();
+
+        if !self.check_instance_in_range(who_has.low_limit, who_has.high_limit) {
+            return PreCheckDecision::OutOfRange;
+        }
+
+        let target = match &who_has.object {
+            WhoHasObject::Identifier(oid) => WhoHasTarget::Id(*oid),
+            WhoHasObject::Name(name) => WhoHasTarget::Name(name.clone()),
+        };
+
+        let is_broadcast = received.is_group || received.link_layer_group;
+        let source_key = SourceKey::from_received(received);
+        let mut state = self.state.lock().unwrap();
+
+        if state.is_coalesced_who_has(&self.policy, &target, &source_key, is_broadcast, now) {
+            self.counters.inc_coalesced();
+            return PreCheckDecision::Coalesced;
+        }
+
+        state.refill_global(&self.policy, now);
+        let is_reserved = is_source_reserved(&self.policy, &source_key, received);
+        const ESTIMATED_I_HAVE_BYTES: usize = 64;
+
+        if !state.has_global_capacity(&self.policy, is_reserved, ESTIMATED_I_HAVE_BYTES) {
+            self.counters.inc_throttled_global();
+            return PreCheckDecision::ThrottledGlobal;
+        }
+
+        let policy = self.policy.clone();
+        let src = state.get_or_create_source_mut(&policy, &source_key, now);
+        if !src.has_capacity(&policy, ESTIMATED_I_HAVE_BYTES) {
+            self.counters.inc_throttled_source();
+            return PreCheckDecision::ThrottledSource;
+        }
+
+        src.last_activity = now;
+        PreCheckDecision::Admit
+    }
+
+    pub(crate) fn is_negative_who_has(&self, target: &WhoHasTarget, now: Instant) -> bool {
+        if self.policy.coalesce_window.is_zero() {
+            return false;
+        }
+        let state = self.state.lock().unwrap();
+        if let Some(ts) = state.negative_who_has.get(target) {
+            now.saturating_duration_since(*ts) < self.policy.coalesce_window
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn record_negative_who_has(&self, target: WhoHasTarget, now: Instant) {
+        let mut state = self.state.lock().unwrap();
+        if state.negative_who_has.len() > 512 {
+            let window = self.policy.coalesce_window;
+            state
+                .negative_who_has
+                .retain(|_, ts| now.saturating_duration_since(*ts) < window);
+        }
+        state.negative_who_has.insert(target, now);
+    }
+
+    pub(crate) fn try_consume_who_has_response(
+        &self,
+        target: &WhoHasTarget,
+        received: &ReceivedApdu,
+        response_bytes: usize,
+        now: Instant,
+    ) -> bool {
+        let source_key = SourceKey::from_received(received);
+        let mut state = self.state.lock().unwrap();
+        let is_broadcast = received.is_group || received.link_layer_group;
+
+        if state.is_coalesced_who_has(&self.policy, target, &source_key, is_broadcast, now) {
+            self.counters.inc_coalesced();
+            return false;
+        }
+
+        state.refill_global(&self.policy, now);
+        let is_reserved = is_source_reserved(&self.policy, &source_key, received);
+
+        if !state.has_global_capacity(&self.policy, is_reserved, response_bytes) {
+            self.counters.inc_throttled_global();
+            return false;
+        }
+
+        let policy = self.policy.clone();
+        let src = state.get_or_create_source_mut(&policy, &source_key, now);
+        if !src.has_capacity(&policy, response_bytes) {
+            self.counters.inc_throttled_source();
+            return false;
+        }
+
+        state.deduct_global(&policy, response_bytes);
+        let src = state.get_or_create_source_mut(&policy, &source_key, now);
+        src.deduct(&policy, response_bytes);
+        src.last_activity = now;
+        src.last_who_has.insert(target.clone(), now);
+        if is_broadcast && !self.policy.prefer_directed_responses {
+            state.last_broadcast_who_has.insert(target.clone(), now);
+        }
+
+        true
+    }
+
+    pub(crate) fn record_i_have_sent(
+        &self,
+        actual_bytes: usize,
+        directed: bool,
+        target: &WhoHasTarget,
+        _source_mac: &MacAddr,
+        _source_network: Option<&NpduAddress>,
+        now: Instant,
+    ) {
+        self.counters.record_sent(actual_bytes, directed, false);
+
+        if !directed {
+            let mut state = self.state.lock().unwrap();
+            state.last_broadcast_who_has.insert(target.clone(), now);
+        }
+    }
+}
+
+fn is_source_reserved(
+    policy: &DiscoveryPolicy,
+    source_key: &SourceKey,
+    received: &ReceivedApdu,
+) -> bool {
+    policy
+        .reserved_sources
+        .iter()
+        .any(|r| r == &source_key.mac || r == &received.source_mac)
+}
+
+fn ensure_source_capacity(state: &mut DiscoveryState, policy: &DiscoveryPolicy, now: Instant) {
+    if state.sources.len() < policy.max_tracked_sources {
+        return;
+    }
+    state.sources.retain(|_, src| {
+        now.saturating_duration_since(src.last_activity) < Duration::from_secs(10)
+    });
+    while state.sources.len() >= policy.max_tracked_sources {
+        let oldest = state
+            .sources
+            .iter()
+            .min_by_key(|(_, src)| src.last_activity)
+            .map(|(k, _)| k.clone());
+        if let Some(key) = oldest {
+            state.sources.remove(&key);
+        } else {
+            break;
+        }
+    }
+}
+
+pub(crate) async fn broadcast_i_am_from<T: TransportPort + 'static>(
+    config: &ServerConfig,
+    db: &Arc<RwLock<ObjectDatabase>>,
+    network: &Arc<NetworkLayer<T>>,
+    limiter: Option<&Arc<DiscoveryLimiter>>,
+) -> Result<(), Error> {
+    let device_oid = db
+        .read()
+        .await
+        .list_objects()
+        .into_iter()
+        .find(|oid| oid.object_type() == ObjectType::DEVICE)
+        .ok_or_else(|| Error::Encoding("no Device object in database".into()))?;
+
+    let mut service_buf = BytesMut::new();
+    IAmRequest {
+        object_identifier: device_oid,
+        max_apdu_length: config.max_apdu_length,
+        segmentation_supported: config.segmentation_supported,
+        vendor_id: config.vendor_id,
+    }
+    .encode(&mut service_buf);
+
+    let mut buf = BytesMut::new();
+    encode_apdu(
+        &mut buf,
+        &Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
+            service_choice: UnconfirmedServiceChoice::I_AM,
+            service_request: service_buf.freeze(),
+        }),
+    )?;
+
+    if let Some(limiter) = limiter {
+        limiter.record_i_am_sent(buf.len(), false, &MacAddr::new(), None, Instant::now());
+    }
+
+    network
+        .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
+        .await
+}
+
+impl<T: TransportPort + 'static> BACnetServer<T> {
+    /// Broadcast an I-Am for this server's Device object using the bound transport socket.
+    pub async fn broadcast_i_am(&self) -> Result<(), Error> {
+        broadcast_i_am_from(
+            &self.config,
+            &self.db,
+            &self.network,
+            Some(&self.discovery_limiter),
+        )
+        .await
+    }
+}
+
+impl<T: TransportPort + 'static> IAmBroadcaster<T> {
+    /// Broadcast an I-Am for this server's Device object using the bound transport socket.
+    pub async fn broadcast_i_am(&self) -> Result<(), Error> {
+        broadcast_i_am_from(&self.config, &self.db, &self.network, None).await
+    }
+}

--- a/crates/bacnet-server/src/server/discovery_tests.rs
+++ b/crates/bacnet-server/src/server/discovery_tests.rs
@@ -1,0 +1,652 @@
+//! Comprehensive tests for discovery rate limiting, duplicate suppression,
+//! and directed responses (Issue #534).
+
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
+use std::time::Duration;
+
+use bytes::{Bytes, BytesMut};
+use tokio::sync::mpsc;
+
+use bacnet_encoding::apdu::{
+    decode_apdu, encode_apdu, Apdu, ConfirmedRequest as ConfirmedRequestPdu,
+    UnconfirmedRequest as UnconfirmedRequestPdu,
+};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu, NpduAddress};
+use bacnet_objects::analog::AnalogInputObject;
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_services::read_property::ReadPropertyRequest;
+use bacnet_services::who_has::{WhoHasObject, WhoHasRequest};
+use bacnet_services::who_is::WhoIsRequest;
+use bacnet_transport::port::{ReceivedNpdu, TransportPort};
+use bacnet_types::enums::{
+    ConfirmedServiceChoice, NetworkPriority, PropertyIdentifier, UnconfirmedServiceChoice,
+};
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+
+use super::*;
+
+type CapturedUnicasts = StdArc<StdMutex<Vec<(Vec<u8>, Bytes)>>>;
+
+#[derive(Clone)]
+struct MockDiscoveryTransport {
+    inbound_rx: StdArc<StdMutex<Option<mpsc::Receiver<ReceivedNpdu>>>>,
+    unicasts: CapturedUnicasts,
+    broadcasts: StdArc<StdMutex<Vec<Bytes>>>,
+}
+
+impl MockDiscoveryTransport {
+    fn new() -> (Self, mpsc::Sender<ReceivedNpdu>) {
+        let (tx, rx) = mpsc::channel(256);
+        let transport = Self {
+            inbound_rx: StdArc::new(StdMutex::new(Some(rx))),
+            unicasts: StdArc::new(StdMutex::new(Vec::new())),
+            broadcasts: StdArc::new(StdMutex::new(Vec::new())),
+        };
+        (transport, tx)
+    }
+
+    fn unicast_count(&self) -> usize {
+        self.unicasts.lock().unwrap().len()
+    }
+
+    fn broadcast_count(&self) -> usize {
+        self.broadcasts.lock().unwrap().len()
+    }
+}
+
+impl TransportPort for MockDiscoveryTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        self.inbound_rx
+            .lock()
+            .unwrap()
+            .take()
+            .ok_or_else(|| Error::Encoding("MockDiscoveryTransport started twice".into()))
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
+        self.unicasts
+            .lock()
+            .unwrap()
+            .push((mac.to_vec(), Bytes::copy_from_slice(npdu)));
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, npdu: &[u8]) -> Result<(), Error> {
+        self.broadcasts
+            .lock()
+            .unwrap()
+            .push(Bytes::copy_from_slice(npdu));
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &[0x0A, 0x00, 0x00, 0x01]
+    }
+}
+
+fn build_who_is_npdu(
+    low: Option<u32>,
+    high: Option<u32>,
+    source_mac: &[u8],
+    routed: Option<(u16, &[u8])>,
+) -> ReceivedNpdu {
+    let mut apdu_buf = BytesMut::new();
+    let who_is = WhoIsRequest {
+        low_limit: low,
+        high_limit: high,
+    };
+    let mut service_buf = BytesMut::new();
+    who_is.encode(&mut service_buf);
+    let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
+        service_choice: UnconfirmedServiceChoice::WHO_IS,
+        service_request: service_buf.freeze(),
+    });
+    encode_apdu(&mut apdu_buf, &pdu).unwrap();
+
+    let npdu = Npdu {
+        is_network_message: false,
+        expecting_reply: false,
+        priority: NetworkPriority::NORMAL,
+        destination: None,
+        source: routed.map(|(net, mac)| NpduAddress {
+            network: net,
+            mac_address: MacAddr::from_slice(mac),
+        }),
+        hop_count: 255,
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut raw_buf = BytesMut::new();
+    encode_npdu(&mut raw_buf, &npdu).unwrap();
+
+    ReceivedNpdu {
+        npdu: raw_buf.freeze(),
+        source_mac: MacAddr::from_slice(source_mac),
+        link_layer_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
+fn build_who_has_npdu(
+    object: WhoHasObject,
+    low: Option<u32>,
+    high: Option<u32>,
+    source_mac: &[u8],
+    routed: Option<(u16, &[u8])>,
+) -> ReceivedNpdu {
+    let who_has = WhoHasRequest {
+        low_limit: low,
+        high_limit: high,
+        object,
+    };
+    let mut service_buf = BytesMut::new();
+    who_has.encode(&mut service_buf).unwrap();
+    let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
+        service_choice: UnconfirmedServiceChoice::WHO_HAS,
+        service_request: service_buf.freeze(),
+    });
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &pdu).unwrap();
+
+    let npdu = Npdu {
+        is_network_message: false,
+        expecting_reply: false,
+        priority: NetworkPriority::NORMAL,
+        destination: None,
+        source: routed.map(|(net, mac)| NpduAddress {
+            network: net,
+            mac_address: MacAddr::from_slice(mac),
+        }),
+        hop_count: 255,
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut raw_buf = BytesMut::new();
+    encode_npdu(&mut raw_buf, &npdu).unwrap();
+
+    ReceivedNpdu {
+        npdu: raw_buf.freeze(),
+        source_mac: MacAddr::from_slice(source_mac),
+        link_layer_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
+async fn spawn_test_server(
+    policy: DiscoveryPolicy,
+) -> (
+    BACnetServer<MockDiscoveryTransport>,
+    MockDiscoveryTransport,
+    mpsc::Sender<ReceivedNpdu>,
+) {
+    let (transport, tx) = MockDiscoveryTransport::new();
+    let transport_clone = transport.clone();
+
+    let mut db = ObjectDatabase::new();
+    let dev = DeviceObject::new(DeviceConfig {
+        instance: 1234,
+        name: "TestDevice".into(),
+        vendor_id: 42,
+        ..Default::default()
+    })
+    .unwrap();
+    db.add(Box::new(dev)).unwrap();
+
+    let ai = AnalogInputObject::new(1, "Zone Temp", 62).unwrap();
+    db.add(Box::new(ai)).unwrap();
+
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(transport)
+        .discovery_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    (server, transport_clone, tx)
+}
+
+#[tokio::test]
+async fn test_controlled_burst_from_one_source_throttled() {
+    let policy = DiscoveryPolicy {
+        max_responses_per_sec_per_source: 4,
+        source_burst_capacity: 4,
+        max_responses_per_sec_global: 64,
+        global_burst_capacity: 64,
+        coalesce_window: Duration::ZERO,
+        prefer_directed_responses: true,
+        ..Default::default()
+    };
+    let (mut server, transport, tx) = spawn_test_server(policy).await;
+    let src = &[0x0A, 0x00, 0x00, 0x02];
+
+    for _ in 0..10 {
+        tx.send(build_who_is_npdu(None, None, src, None))
+            .await
+            .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let c = server.discovery_counters();
+    assert_eq!(c.who_is_received, 10);
+    assert_eq!(c.i_am_sent, 4);
+    assert_eq!(c.responses_throttled_source, 6);
+    assert_eq!(c.responses_throttled_global, 0);
+    assert_eq!(transport.unicast_count(), 4);
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_source_fairness_while_first_source_throttled() {
+    let policy = DiscoveryPolicy {
+        max_responses_per_sec_per_source: 3,
+        source_burst_capacity: 3,
+        max_responses_per_sec_global: 64,
+        global_burst_capacity: 64,
+        coalesce_window: Duration::ZERO,
+        prefer_directed_responses: true,
+        ..Default::default()
+    };
+    let (mut server, _transport, tx) = spawn_test_server(policy).await;
+    let src1 = &[0x0A, 0x00, 0x00, 0x02];
+    let src2 = &[0x0A, 0x00, 0x00, 0x03];
+
+    for _ in 0..6 {
+        tx.send(build_who_is_npdu(None, None, src1, None))
+            .await
+            .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    for _ in 0..2 {
+        tx.send(build_who_is_npdu(None, None, src2, None))
+            .await
+            .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let c = server.discovery_counters();
+    assert_eq!(c.who_is_received, 8);
+    assert_eq!(c.i_am_sent, 5); // 3 from src1, 2 from src2
+    assert_eq!(c.responses_throttled_source, 3);
+    assert_eq!(c.responses_throttled_global, 0);
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_reserved_capacity_preserved_under_global_load() {
+    let reserved_mac = MacAddr::from_slice(&[0x0A, 0x00, 0x00, 0x99]);
+    let policy = DiscoveryPolicy {
+        global_burst_capacity: 5,
+        max_responses_per_sec_global: 5,
+        reserved_capacity: 2,
+        reserved_sources: vec![reserved_mac.clone()],
+        source_burst_capacity: 10,
+        max_responses_per_sec_per_source: 10,
+        coalesce_window: Duration::ZERO,
+        prefer_directed_responses: true,
+        ..Default::default()
+    };
+    let (mut server, _transport, tx) = spawn_test_server(policy).await;
+    let unreserved = &[0x0A, 0x00, 0x00, 0x02];
+
+    for _ in 0..5 {
+        tx.send(build_who_is_npdu(None, None, unreserved, None))
+            .await
+            .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let c = server.discovery_counters();
+    assert_eq!(c.i_am_sent, 3); // 5 - 2 reserved = 3
+    assert_eq!(c.responses_throttled_global, 2);
+
+    // Reserved source can consume from the reserved 2 tokens
+    for _ in 0..2 {
+        tx.send(build_who_is_npdu(None, None, reserved_mac.as_slice(), None))
+            .await
+            .unwrap();
+    }
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let c = server.discovery_counters();
+    assert_eq!(c.i_am_sent, 5); // 3 + 2
+
+    // Unreserved source is still throttled
+    tx.send(build_who_is_npdu(None, None, unreserved, None))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    let c = server.discovery_counters();
+    assert_eq!(c.responses_throttled_global, 3);
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_duplicate_scans_coalesced_within_window() {
+    let policy = DiscoveryPolicy {
+        coalesce_window: Duration::from_millis(200),
+        prefer_directed_responses: true,
+        ..Default::default()
+    };
+    let (mut server, _transport, tx) = spawn_test_server(policy).await;
+    let src = &[0x0A, 0x00, 0x00, 0x02];
+
+    // First Who-Is -> sent
+    tx.send(build_who_is_npdu(None, None, src, None))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Duplicate Who-Is within 200ms -> coalesced
+    tx.send(build_who_is_npdu(None, None, src, None))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let c = server.discovery_counters();
+    assert_eq!(c.who_is_received, 2);
+    assert_eq!(c.i_am_sent, 1);
+    assert_eq!(c.requests_coalesced, 1);
+
+    // Who-Has for existing object by Name -> sent
+    let who_has_name = WhoHasObject::Name("Zone Temp".into());
+    tx.send(build_who_has_npdu(
+        who_has_name.clone(),
+        None,
+        None,
+        src,
+        None,
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Duplicate Who-Has -> coalesced
+    tx.send(build_who_has_npdu(who_has_name, None, None, src, None))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let c = server.discovery_counters();
+    assert_eq!(c.who_has_received, 2);
+    assert_eq!(c.i_have_sent, 1);
+    assert_eq!(c.requests_coalesced, 2);
+
+    // Who-Has for non-existent object -> negative cache recorded
+    let missing = WhoHasObject::Name("Missing Sensor".into());
+    tx.send(build_who_has_npdu(missing.clone(), None, None, src, None))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Repeated query for non-existent object -> negative cache hit coalesced!
+    tx.send(build_who_has_npdu(missing, None, None, src, None))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    let c = server.discovery_counters();
+    assert_eq!(c.who_has_received, 4);
+    assert_eq!(c.i_have_sent, 1);
+    assert_eq!(c.requests_coalesced, 3);
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_confirmed_traffic_latency_bounded_during_discovery_flood() {
+    let policy = DiscoveryPolicy {
+        max_responses_per_sec_per_source: 2,
+        source_burst_capacity: 2,
+        coalesce_window: Duration::from_millis(100),
+        ..Default::default()
+    };
+    let (mut server, transport, tx) = spawn_test_server(policy).await;
+    let flood_src = &[0x0A, 0x00, 0x00, 0x02];
+
+    for _ in 0..50 {
+        tx.send(build_who_is_npdu(None, None, flood_src, None))
+            .await
+            .unwrap();
+    }
+
+    // Simultaneously send a ConfirmedReadProperty request
+    let client_mac = &[0x0A, 0x00, 0x00, 0x05];
+    let rp = ReadPropertyRequest {
+        object_identifier: ObjectIdentifier::new(bacnet_types::enums::ObjectType::ANALOG_INPUT, 1)
+            .unwrap(),
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+    };
+    let mut s_buf = BytesMut::new();
+    rp.encode(&mut s_buf);
+    let pdu = Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 1476,
+        invoke_id: 1,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_request: s_buf.freeze(),
+    });
+    let mut apdu_buf = BytesMut::new();
+    encode_apdu(&mut apdu_buf, &pdu).unwrap();
+    let npdu = Npdu {
+        is_network_message: false,
+        expecting_reply: true,
+        priority: NetworkPriority::NORMAL,
+        destination: None,
+        source: None,
+        hop_count: 255,
+        payload: apdu_buf.freeze(),
+        ..Npdu::default()
+    };
+    let mut raw_buf = BytesMut::new();
+    encode_npdu(&mut raw_buf, &npdu).unwrap();
+
+    let t0 = std::time::Instant::now();
+    tx.send(ReceivedNpdu {
+        npdu: raw_buf.freeze(),
+        source_mac: MacAddr::from_slice(client_mac),
+        link_layer_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    })
+    .await
+    .unwrap();
+
+    // Poll until response arrives
+    let mut found_ack = false;
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        let unicasts = transport.unicasts.lock().unwrap();
+        for (dest, raw) in unicasts.iter() {
+            if dest == client_mac {
+                if let Ok(np) = decode_npdu(raw.clone()) {
+                    if let Ok(Apdu::ComplexAck(ack)) = decode_apdu(np.payload) {
+                        if ack.invoke_id == 1 {
+                            found_ack = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        if found_ack {
+            break;
+        }
+    }
+    let elapsed = t0.elapsed();
+    assert!(found_ack, "Confirmed response was not received");
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "Confirmed request delayed by discovery flood: took {elapsed:?}"
+    );
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_who_is_range_and_who_has_matching_correctness() {
+    let policy = DiscoveryPolicy::unlimited();
+    let (mut server, _transport, tx) = spawn_test_server(policy).await;
+    let src = &[0x0A, 0x00, 0x00, 0x02];
+
+    // Device instance is 1234
+    // Out of range Who-Is: 2000..=3000 -> no response
+    tx.send(build_who_is_npdu(Some(2000), Some(3000), src, None))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(server.discovery_counters().i_am_sent, 0);
+
+    // In-range Who-Is: 1000..=2000 -> responds
+    tx.send(build_who_is_npdu(Some(1000), Some(2000), src, None))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(server.discovery_counters().i_am_sent, 1);
+
+    // Who-Has by ID out of range device limits -> no response
+    let ai_oid = ObjectIdentifier::new(bacnet_types::enums::ObjectType::ANALOG_INPUT, 1).unwrap();
+    tx.send(build_who_has_npdu(
+        WhoHasObject::Identifier(ai_oid),
+        Some(2000),
+        Some(3000),
+        src,
+        None,
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(server.discovery_counters().i_have_sent, 0);
+
+    // Who-Has by ID matching -> responds with I-Have
+    tx.send(build_who_has_npdu(
+        WhoHasObject::Identifier(ai_oid),
+        Some(1000),
+        Some(2000),
+        src,
+        None,
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(server.discovery_counters().i_have_sent, 1);
+
+    // Who-Has by Name matching -> responds with I-Have
+    tx.send(build_who_has_npdu(
+        WhoHasObject::Name("Zone Temp".into()),
+        None,
+        None,
+        src,
+        None,
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(server.discovery_counters().i_have_sent, 2);
+
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_directed_vs_broadcast_and_routed_npdu() {
+    // Part A: prefer_directed_responses = true (default)
+    let policy = DiscoveryPolicy {
+        prefer_directed_responses: true,
+        coalesce_window: Duration::ZERO,
+        ..Default::default()
+    };
+    let (mut server, transport, tx) = spawn_test_server(policy).await;
+    let local_src = &[0x0A, 0x00, 0x00, 0x02];
+
+    // Local Who-Is produces directed unicast response
+    tx.send(build_who_is_npdu(None, None, local_src, None))
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(transport.unicast_count(), 1);
+    assert_eq!(transport.broadcast_count(), 0);
+    assert_eq!(server.discovery_counters().directed_responses_sent, 1);
+
+    // Routed Who-Is produces routed unicast response
+    let router_mac = &[0x0A, 0x00, 0x00, 0xFE];
+    let remote_peer = &[0x11, 0x22];
+    tx.send(build_who_is_npdu(
+        None,
+        None,
+        router_mac,
+        Some((200, remote_peer)),
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(transport.unicast_count(), 2);
+    assert_eq!(server.discovery_counters().directed_responses_sent, 2);
+
+    // Routed Who-Has produces routed unicast I-Have (verifying routed Who-Has bug fix!)
+    let ai_oid = ObjectIdentifier::new(bacnet_types::enums::ObjectType::ANALOG_INPUT, 1).unwrap();
+    tx.send(build_who_has_npdu(
+        WhoHasObject::Identifier(ai_oid),
+        None,
+        None,
+        router_mac,
+        Some((200, remote_peer)),
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(transport.unicast_count(), 3);
+    assert_eq!(transport.broadcast_count(), 0);
+    assert_eq!(server.discovery_counters().directed_responses_sent, 3);
+    assert_eq!(server.discovery_counters().i_have_sent, 1);
+
+    server.stop().await.unwrap();
+
+    // Part B: prefer_directed_responses = false
+    let policy_bcast = DiscoveryPolicy {
+        prefer_directed_responses: false,
+        coalesce_window: Duration::ZERO,
+        ..Default::default()
+    };
+    let (mut server2, transport2, tx2) = spawn_test_server(policy_bcast).await;
+
+    // Local Who-Is with link_layer_group / broadcast produces broadcast response
+    let mut req = build_who_is_npdu(None, None, local_src, None);
+    req.link_layer_group = true;
+    tx2.send(req).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(transport2.broadcast_count(), 1);
+    assert_eq!(transport2.unicast_count(), 0);
+    assert_eq!(server2.discovery_counters().directed_responses_sent, 0);
+
+    // Routed Who-Is still routes back unicast even when prefer_directed_responses is false!
+    tx2.send(build_who_is_npdu(
+        None,
+        None,
+        router_mac,
+        Some((200, remote_peer)),
+    ))
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_eq!(transport2.unicast_count(), 1);
+    assert_eq!(server2.discovery_counters().directed_responses_sent, 1);
+
+    server2.stop().await.unwrap();
+}

--- a/crates/bacnet-server/src/server/discovery_tests.rs
+++ b/crates/bacnet-server/src/server/discovery_tests.rs
@@ -2,7 +2,7 @@
 //! and directed responses (Issue #534).
 
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use bytes::{Bytes, BytesMut};
 use tokio::sync::mpsc;
@@ -19,7 +19,8 @@ use bacnet_services::who_has::{WhoHasObject, WhoHasRequest};
 use bacnet_services::who_is::WhoIsRequest;
 use bacnet_transport::port::{ReceivedNpdu, TransportPort};
 use bacnet_types::enums::{
-    ConfirmedServiceChoice, NetworkPriority, PropertyIdentifier, UnconfirmedServiceChoice,
+    ConfirmedServiceChoice, NetworkPriority, ObjectType, PropertyIdentifier,
+    UnconfirmedServiceChoice,
 };
 use bacnet_types::primitives::ObjectIdentifier;
 use bacnet_types::MacAddr;
@@ -89,6 +90,31 @@ impl TransportPort for MockDiscoveryTransport {
     }
 }
 
+fn wrap_apdu(apdu: Bytes, source_mac: &[u8], routed: Option<(u16, &[u8])>) -> ReceivedNpdu {
+    let npdu = Npdu {
+        is_network_message: false,
+        expecting_reply: false,
+        priority: NetworkPriority::NORMAL,
+        destination: None,
+        source: routed.map(|(net, mac)| NpduAddress {
+            network: net,
+            mac_address: MacAddr::from_slice(mac),
+        }),
+        hop_count: 255,
+        payload: apdu,
+        ..Npdu::default()
+    };
+    let mut raw_buf = BytesMut::new();
+    encode_npdu(&mut raw_buf, &npdu).unwrap();
+    ReceivedNpdu {
+        npdu: raw_buf.freeze(),
+        source_mac: MacAddr::from_slice(source_mac),
+        link_layer_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
 fn build_who_is_npdu(
     low: Option<u32>,
     high: Option<u32>,
@@ -107,30 +133,7 @@ fn build_who_is_npdu(
         service_request: service_buf.freeze(),
     });
     encode_apdu(&mut apdu_buf, &pdu).unwrap();
-
-    let npdu = Npdu {
-        is_network_message: false,
-        expecting_reply: false,
-        priority: NetworkPriority::NORMAL,
-        destination: None,
-        source: routed.map(|(net, mac)| NpduAddress {
-            network: net,
-            mac_address: MacAddr::from_slice(mac),
-        }),
-        hop_count: 255,
-        payload: apdu_buf.freeze(),
-        ..Npdu::default()
-    };
-    let mut raw_buf = BytesMut::new();
-    encode_npdu(&mut raw_buf, &npdu).unwrap();
-
-    ReceivedNpdu {
-        npdu: raw_buf.freeze(),
-        source_mac: MacAddr::from_slice(source_mac),
-        link_layer_group: false,
-        data_attributes: Vec::new(),
-        reply_tx: None,
-    }
+    wrap_apdu(apdu_buf.freeze(), source_mac, routed)
 }
 
 fn build_who_has_npdu(
@@ -153,30 +156,7 @@ fn build_who_has_npdu(
     });
     let mut apdu_buf = BytesMut::new();
     encode_apdu(&mut apdu_buf, &pdu).unwrap();
-
-    let npdu = Npdu {
-        is_network_message: false,
-        expecting_reply: false,
-        priority: NetworkPriority::NORMAL,
-        destination: None,
-        source: routed.map(|(net, mac)| NpduAddress {
-            network: net,
-            mac_address: MacAddr::from_slice(mac),
-        }),
-        hop_count: 255,
-        payload: apdu_buf.freeze(),
-        ..Npdu::default()
-    };
-    let mut raw_buf = BytesMut::new();
-    encode_npdu(&mut raw_buf, &npdu).unwrap();
-
-    ReceivedNpdu {
-        npdu: raw_buf.freeze(),
-        source_mac: MacAddr::from_slice(source_mac),
-        link_layer_group: false,
-        data_attributes: Vec::new(),
-        reply_tx: None,
-    }
+    wrap_apdu(apdu_buf.freeze(), source_mac, routed)
 }
 
 async fn spawn_test_server(
@@ -649,4 +629,167 @@ async fn test_directed_vs_broadcast_and_routed_npdu() {
     assert_eq!(server2.discovery_counters().directed_responses_sent, 1);
 
     server2.stop().await.unwrap();
+}
+
+fn mock_received(
+    source_mac: &[u8],
+    routed: Option<(u16, &[u8])>,
+) -> bacnet_network::layer::ReceivedApdu {
+    bacnet_network::layer::ReceivedApdu {
+        apdu: Bytes::new(),
+        source_mac: MacAddr::from_slice(source_mac),
+        source_network: routed.map(|(net, mac)| NpduAddress {
+            network: net,
+            mac_address: MacAddr::from_slice(mac),
+        }),
+        link_layer_group: false,
+        is_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
+fn encode_who_is_req(low: Option<u32>, high: Option<u32>) -> Vec<u8> {
+    let mut buf = BytesMut::new();
+    WhoIsRequest {
+        low_limit: low,
+        high_limit: high,
+    }
+    .encode(&mut buf);
+    buf.to_vec()
+}
+
+#[test]
+fn test_exhausted_source_throttled_when_max_tracked_sources_reached() {
+    let policy = DiscoveryPolicy {
+        source_burst_capacity: 1,
+        max_responses_per_sec_per_source: 1,
+        max_tracked_sources: 2,
+        coalesce_window: Duration::ZERO,
+        ..DiscoveryPolicy::default()
+    };
+    let limiter = DiscoveryLimiter::new(policy, Some(100));
+    let req = encode_who_is_req(None, None);
+    let now = Instant::now();
+    let src_a = mock_received(&[0x0A, 0x00, 0x00, 0x01], None);
+    let src_b = mock_received(&[0x0A, 0x00, 0x00, 0x02], None);
+
+    assert_eq!(
+        limiter.pre_check_who_is(&req, &src_a, now),
+        PreCheckDecision::Admit
+    );
+    assert_eq!(
+        limiter.pre_check_who_is(&req, &src_b, now),
+        PreCheckDecision::Admit
+    );
+    assert_eq!(
+        limiter.pre_check_who_is(&req, &src_a, now),
+        PreCheckDecision::ThrottledSource
+    );
+    assert_eq!(limiter.counters().responses_throttled_source, 1);
+}
+
+#[test]
+fn test_routed_who_is_byte_accounting_uses_remote_mac() {
+    let policy = DiscoveryPolicy {
+        max_bytes_per_sec_per_source: 100,
+        source_burst_capacity: 10,
+        max_responses_per_sec_per_source: 10,
+        coalesce_window: Duration::ZERO,
+        ..DiscoveryPolicy::default()
+    };
+    let limiter = DiscoveryLimiter::new(policy, Some(100));
+    let req = encode_who_is_req(None, None);
+    let now = Instant::now();
+    let routed = mock_received(&[0x0A, 0x00, 0x00, 0xFE], Some((200, &[0x11, 0x22])));
+
+    assert_eq!(
+        limiter.pre_check_who_is(&req, &routed, now),
+        PreCheckDecision::Admit
+    );
+    limiter.record_i_am_sent(
+        34,
+        true,
+        &routed.source_mac,
+        routed.source_network.as_ref(),
+        now,
+    );
+
+    let byte_tokens = limiter
+        .source_byte_tokens(&routed.source_mac, routed.source_network.as_ref())
+        .expect("routed source state must exist");
+    assert!(
+        (byte_tokens - 66.0).abs() < 1e-4,
+        "Expected 66 byte tokens, got {byte_tokens}"
+    );
+}
+
+#[test]
+fn test_independent_byte_tokens_enforced_when_response_count_unlimited() {
+    let now = Instant::now();
+    let src = mock_received(&[0x0A, 0x00, 0x00, 0x01], None);
+    let req = encode_who_is_req(None, None);
+
+    let check = |max_g, b_g, max_s, b_s| {
+        let lim = DiscoveryLimiter::new(
+            DiscoveryPolicy {
+                max_responses_per_sec_global: max_g,
+                max_bytes_per_sec_global: b_g,
+                max_responses_per_sec_per_source: max_s,
+                max_bytes_per_sec_per_source: b_s,
+                global_burst_capacity: max_g,
+                source_burst_capacity: max_s,
+                reserved_capacity: 0,
+                coalesce_window: Duration::ZERO,
+                ..DiscoveryPolicy::default()
+            },
+            Some(100),
+        );
+        (
+            lim.pre_check_who_is(&req, &src, now),
+            lim.pre_check_who_is(&req, &src, now),
+        )
+    };
+
+    // 1. Unlimited count, per-source byte limited
+    assert_eq!(
+        check(u32::MAX, usize::MAX, u32::MAX, 100),
+        (PreCheckDecision::Admit, PreCheckDecision::ThrottledSource)
+    );
+    // 2. Unlimited count, global byte limited
+    assert_eq!(
+        check(u32::MAX, 100, u32::MAX, usize::MAX),
+        (PreCheckDecision::Admit, PreCheckDecision::ThrottledGlobal)
+    );
+    // 3. Unlimited bytes, global count limited
+    assert_eq!(
+        check(1, usize::MAX, u32::MAX, usize::MAX),
+        (PreCheckDecision::Admit, PreCheckDecision::ThrottledGlobal)
+    );
+}
+
+#[test]
+fn test_negative_who_has_cache_strictly_bounded_to_512() {
+    let limiter = DiscoveryLimiter::new(
+        DiscoveryPolicy {
+            coalesce_window: Duration::from_secs(60),
+            ..DiscoveryPolicy::default()
+        },
+        Some(100),
+    );
+    let base = Instant::now();
+
+    for i in 0..600 {
+        let target = WhoHasTarget::Id(ObjectIdentifier::new(ObjectType::ANALOG_INPUT, i).unwrap());
+        limiter.record_negative_who_has(target, base + Duration::from_millis(i as u64));
+    }
+
+    assert_eq!(limiter.negative_who_has_count(), 512);
+
+    let check_time = base + Duration::from_millis(600);
+    let target_0 = WhoHasTarget::Id(ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 0).unwrap());
+    assert!(!limiter.is_negative_who_has(&target_0, check_time));
+    let target_599 =
+        WhoHasTarget::Id(ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 599).unwrap());
+    assert!(limiter.is_negative_who_has(&target_599, check_time));
 }

--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -94,6 +94,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
         config: &Arc<ServerConfig>,
         clock: &Option<Arc<ServerClock>>,
+        discovery_limiter: &Arc<DiscoveryLimiter>,
         source_mac: &[u8],
         apdu: Apdu,
         mut received: bacnet_network::layer::ReceivedApdu,
@@ -140,12 +141,65 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 });
             }
             Apdu::UnconfirmedRequest(req) => {
+                let comm = comm_state.load(Ordering::Acquire);
+                if comm == 1 {
+                    debug!("Dropping unconfirmed service: DCC is DISABLE");
+                    return;
+                }
+
+                let now = Instant::now();
+                if req.service_choice == UnconfirmedServiceChoice::WHO_IS {
+                    match discovery_limiter.pre_check_who_is(&req.service_request, &received, now) {
+                        PreCheckDecision::Admit => {}
+                        PreCheckDecision::OutOfRange => {
+                            debug!("WhoIs instance range does not include local device; dropped");
+                            return;
+                        }
+                        PreCheckDecision::Coalesced => {
+                            debug!("WhoIs duplicate coalesced within window");
+                            return;
+                        }
+                        PreCheckDecision::ThrottledSource => {
+                            debug!("WhoIs throttled: source rate/byte limit exceeded");
+                            return;
+                        }
+                        PreCheckDecision::ThrottledGlobal => {
+                            debug!("WhoIs throttled: global rate/byte limit exceeded");
+                            return;
+                        }
+                        PreCheckDecision::DecodeError => {}
+                    }
+                } else if req.service_choice == UnconfirmedServiceChoice::WHO_HAS {
+                    match discovery_limiter.pre_check_who_has(&req.service_request, &received, now)
+                    {
+                        PreCheckDecision::Admit => {}
+                        PreCheckDecision::OutOfRange => {
+                            debug!("WhoHas instance range does not include local device; dropped");
+                            return;
+                        }
+                        PreCheckDecision::Coalesced => {
+                            debug!("WhoHas duplicate/negative coalesced within window");
+                            return;
+                        }
+                        PreCheckDecision::ThrottledSource => {
+                            debug!("WhoHas throttled: source rate/byte limit exceeded");
+                            return;
+                        }
+                        PreCheckDecision::ThrottledGlobal => {
+                            debug!("WhoHas throttled: global rate/byte limit exceeded");
+                            return;
+                        }
+                        PreCheckDecision::DecodeError => {}
+                    }
+                }
+
                 let db = Arc::clone(db);
                 let network = Arc::clone(network);
                 let config = Arc::clone(config);
                 let clock = clock.clone();
                 let comm_state = Arc::clone(comm_state);
                 let device_bindings = Arc::clone(device_bindings);
+                let discovery_limiter = Arc::clone(discovery_limiter);
                 tokio::spawn(async move {
                     Self::handle_unconfirmed_request(
                         &db,
@@ -154,6 +208,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         clock.as_ref(),
                         &comm_state,
                         &device_bindings,
+                        &discovery_limiter,
                         req,
                         &received,
                     )

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -258,6 +258,7 @@ impl Harness {
             &Arc::new(Mutex::new(None::<JoinHandle<()>>)),
             &Arc::new(ServerConfig::default()),
             &None,
+            &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
             source_mac,
             apdu,
             bacnet_network::layer::ReceivedApdu {

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -64,6 +64,15 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let local_mac = MacAddr::from_slice(network.local_mac());
 
         let network = Arc::new(network);
+        let device_instance = db
+            .list_objects()
+            .into_iter()
+            .find(|oid| oid.object_type() == ObjectType::DEVICE)
+            .map(|oid| oid.instance_number());
+        let discovery_limiter = Arc::new(DiscoveryLimiter::new(
+            config.discovery_policy.sanitized(),
+            device_instance,
+        ));
         let db = Arc::new(RwLock::new(db));
         let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
         let seg_ack_senders: Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>> =
@@ -92,6 +101,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let dcc_timer_dispatch = Arc::clone(&dcc_timer);
         let config_dispatch = Arc::new(config.clone());
         let clock_dispatch = clock.clone();
+        let discovery_limiter_dispatch = Arc::clone(&discovery_limiter);
 
         let dispatch_task = tokio::spawn(async move {
             let mut apdu_rx = apdu_rx;
@@ -405,36 +415,37 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                                     "Reassembled segmented ConfirmedRequest"
                                                 );
                                                 Self::dispatch(
-	                                                    &db_dispatch,
-	                                                    &network_dispatch,
-                                    &cov_dispatch,
-                                    &seg_ack_dispatch,
-                                    &seg_send_permits_dispatch,
-                                    &cov_in_flight_dispatch,
-                                    &server_tsm_dispatch,
+                                                    &db_dispatch,
+                                                    &network_dispatch,
+                                                    &cov_dispatch,
+                                                    &seg_ack_dispatch,
+                                                    &seg_send_permits_dispatch,
+                                                    &cov_in_flight_dispatch,
+                                                    &server_tsm_dispatch,
                                                     &notification_transactions_dispatch,
-	                                                    &confirmed_request_tracker_dispatch,
-	                                                    &device_bindings_dispatch,
-	                                                    &comm_state_dispatch,
-	                                                    &dcc_timer_dispatch,
-	                                                    &config_dispatch,
-	                                                    &clock_dispatch,
-	                                                    &source_mac,
-	                                                    Apdu::ConfirmedRequest(reassembled),
-	                                                    received.take().unwrap_or_else(|| {
-	                                                        warn!("received consumed twice - using empty fallback");
-	                                                        bacnet_network::layer::ReceivedApdu {
-	                                                            apdu: bytes::Bytes::new(),
-	                                                            source_mac: bacnet_types::MacAddr::new(),
-	                                                            source_network: None,
-	                                                            link_layer_group: false,
-	                                                            is_group: false,
-	                                                            data_attributes: Vec::new(),
-	                                                            reply_tx: None,
-	                                                        }
-	                                                    }),
-	                                                )
-	                                                .await;
+                                                    &confirmed_request_tracker_dispatch,
+                                                    &device_bindings_dispatch,
+                                                    &comm_state_dispatch,
+                                                    &dcc_timer_dispatch,
+                                                    &config_dispatch,
+                                                    &clock_dispatch,
+                                                    &discovery_limiter_dispatch,
+                                                    &source_mac,
+                                                    Apdu::ConfirmedRequest(reassembled),
+                                                    received.take().unwrap_or_else(|| {
+                                                        warn!("received consumed twice - using empty fallback");
+                                                        bacnet_network::layer::ReceivedApdu {
+                                                            apdu: bytes::Bytes::new(),
+                                                            source_mac: bacnet_types::MacAddr::new(),
+                                                            source_network: None,
+                                                            link_layer_group: false,
+                                                            is_group: false,
+                                                            data_attributes: Vec::new(),
+                                                            reply_tx: None,
+                                                        }
+                                                    }),
+                                                )
+                                                .await;
                                             }
                                             Err(e) => {
                                                 warn!(
@@ -470,6 +481,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 &dcc_timer_dispatch,
                                 &config_dispatch,
                                 &clock_dispatch,
+                                &discovery_limiter_dispatch,
                                 &source_mac,
                                 decoded,
                                 received.take().unwrap_or_else(|| {
@@ -701,6 +713,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
         let server = Self {
             config,
+            discovery_limiter,
             _clock: clock,
             network,
             db,
@@ -810,52 +823,4 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let db = self.db.read().await;
         crate::pics::PicsGenerator::new(&db, &self.config, pics_config).generate()
     }
-
-    /// Broadcast an I-Am for this server's Device object using the bound transport socket.
-    pub async fn broadcast_i_am(&self) -> Result<(), Error> {
-        broadcast_i_am_from(&self.config, &self.db, &self.network).await
-    }
-}
-
-impl<T: TransportPort + 'static> IAmBroadcaster<T> {
-    /// Broadcast an I-Am for this server's Device object using the bound transport socket.
-    pub async fn broadcast_i_am(&self) -> Result<(), Error> {
-        broadcast_i_am_from(&self.config, &self.db, &self.network).await
-    }
-}
-
-async fn broadcast_i_am_from<T: TransportPort + 'static>(
-    config: &ServerConfig,
-    db: &Arc<RwLock<ObjectDatabase>>,
-    network: &Arc<NetworkLayer<T>>,
-) -> Result<(), Error> {
-    let device_oid = {
-        let db = db.read().await;
-        db.list_objects()
-            .into_iter()
-            .find(|oid| oid.object_type() == ObjectType::DEVICE)
-            .ok_or_else(|| Error::Encoding("no Device object in database".into()))?
-    };
-
-    let i_am = IAmRequest {
-        object_identifier: device_oid,
-        max_apdu_length: config.max_apdu_length,
-        segmentation_supported: config.segmentation_supported,
-        vendor_id: config.vendor_id,
-    };
-
-    let mut service_buf = BytesMut::new();
-    i_am.encode(&mut service_buf);
-
-    let pdu = Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
-        service_choice: UnconfirmedServiceChoice::I_AM,
-        service_request: service_buf.freeze(),
-    });
-
-    let mut buf = BytesMut::new();
-    encode_apdu(&mut buf, &pdu)?;
-
-    network
-        .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
-        .await
 }

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -6,7 +6,9 @@
 
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
-use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU8, Ordering};
+#[cfg(test)]
+pub(crate) use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -360,6 +362,8 @@ pub struct ServerConfig {
     /// A value of `0` is clamped to one second. Ignored when
     /// [`enable_event_enrollment`](Self::enable_event_enrollment) is false.
     pub event_enrollment_interval_secs: u64,
+    /// Discovery rate-limiting and duplicate suppression policy.
+    pub discovery_policy: DiscoveryPolicy,
 }
 
 impl std::fmt::Debug for ServerConfig {
@@ -409,6 +413,7 @@ impl std::fmt::Debug for ServerConfig {
                 "event_enrollment_interval_secs",
                 &self.event_enrollment_interval_secs,
             )
+            .field("discovery_policy", &self.discovery_policy)
             .finish()
     }
 }
@@ -433,6 +438,7 @@ impl Default for ServerConfig {
             enable_fault_detection: false,
             enable_event_enrollment: true,
             event_enrollment_interval_secs: 10,
+            discovery_policy: DiscoveryPolicy::default(),
         }
     }
 }
@@ -548,6 +554,12 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
     /// Set the vendor identifier (used in IAm responses and protocol operations).
     pub fn vendor_id(mut self, id: u16) -> Self {
         self.config.vendor_id = id;
+        self
+    }
+
+    /// Set the discovery rate-limiting and duplicate suppression policy.
+    pub fn discovery_policy(mut self, policy: DiscoveryPolicy) -> Self {
+        self.config.discovery_policy = policy;
         self
     }
 
@@ -692,6 +704,12 @@ impl BipServerBuilder {
         self
     }
 
+    /// Set the discovery rate-limiting and duplicate suppression policy.
+    pub fn discovery_policy(mut self, policy: DiscoveryPolicy) -> Self {
+        self.config.discovery_policy = policy;
+        self
+    }
+
     /// Build and start the server, constructing a BipTransport from the config.
     pub async fn build(self) -> Result<BACnetServer<BipTransport>, Error> {
         let transport = BipTransport::new(
@@ -710,161 +728,10 @@ impl BipServerBuilder {
     }
 }
 
-/// Key for tracking segmented transactions by peer and invoke ID.
-type SegKey = (MacAddr, Option<NpduAddress>, u8);
-
-fn segmented_transaction_key(
-    source_mac: &[u8],
-    source_network: Option<&NpduAddress>,
-    invoke_id: u8,
-) -> SegKey {
-    match source_network {
-        Some(address)
-            if (1..=0xFFFE).contains(&address.network) && !address.mac_address.is_empty() =>
-        {
-            (MacAddr::new(), Some(address.clone()), invoke_id)
-        }
-        _ => (
-            MacAddr::from_slice(source_mac),
-            source_network.cloned(),
-            invoke_id,
-        ),
-    }
-}
-
-#[derive(Debug)]
-enum SegmentedSendEvent {
-    SegmentAck(SegmentAckPdu),
-    Abort(AbortPdu),
-}
-
-#[derive(Debug, Clone)]
-enum SegmentedSendControlEvent {
-    Abort(AbortPdu),
-    Cancel,
-}
-
-struct SegmentedSendHandle {
-    segment_ack_tx: mpsc::Sender<SegmentAckPdu>,
-    control_tx: watch::Sender<Option<SegmentedSendControlEvent>>,
-    closed: AtomicBool,
-    current_sequence: AtomicU16,
-    total_segments: usize,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SegmentAckDisposition {
-    Advance,
-    Retransmit,
-}
-
-fn segment_ack_disposition(
-    ack: &SegmentAckPdu,
-    current: usize,
-    total_segments: usize,
-) -> Option<SegmentAckDisposition> {
-    if current >= total_segments {
-        return None;
-    }
-
-    let ack_seq = ack.sequence_number as usize;
-    if ack_seq >= total_segments {
-        return None;
-    }
-
-    // Clause 5.4.4.2 treats either ACK flavor's sequence number as the last
-    // segment accepted. A NAK for the preceding segment asks for `current`
-    // again; a NAK for `current` confirms it and advances the send window.
-    if ack_seq == current {
-        Some(SegmentAckDisposition::Advance)
-    } else if ack.negative_ack && current.checked_sub(1) == Some(ack_seq) {
-        Some(SegmentAckDisposition::Retransmit)
-    } else {
-        None
-    }
-}
-
-impl SegmentedSendHandle {
-    fn new(
-        segment_ack_tx: mpsc::Sender<SegmentAckPdu>,
-        control_tx: watch::Sender<Option<SegmentedSendControlEvent>>,
-        total_segments: usize,
-    ) -> Self {
-        Self {
-            segment_ack_tx,
-            control_tx,
-            closed: AtomicBool::new(false),
-            current_sequence: AtomicU16::new(u16::MAX),
-            total_segments,
-        }
-    }
-
-    fn accepts_segment_ack(&self, ack: &SegmentAckPdu) -> bool {
-        if ack.sent_by_server || self.closed.load(Ordering::Acquire) {
-            return false;
-        }
-
-        let current = self.current_sequence.load(Ordering::Acquire) as usize;
-        if current >= self.total_segments {
-            return false;
-        }
-
-        segment_ack_disposition(ack, current, self.total_segments).is_some()
-    }
-
-    fn send_control(&self, event: SegmentedSendControlEvent) {
-        self.closed.store(true, Ordering::Release);
-        self.control_tx.send_replace(Some(event));
-    }
-
-    fn same_channel(&self, sender: &mpsc::Sender<SegmentAckPdu>) -> bool {
-        self.segment_ack_tx.same_channel(sender)
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct SegmentedSendOptions {
-    segment_timeout: Duration,
-    max_retries: u8,
-}
-
-impl Default for SegmentedSendOptions {
-    fn default() -> Self {
-        Self {
-            segment_timeout: DEFAULT_APDU_SEGMENT_TIMEOUT,
-            max_retries: DEFAULT_APDU_SEGMENT_RETRIES,
-        }
-    }
-}
-
-struct SegmentedRequestState {
-    payload: segmented_receive::RequestPayload,
-    last_activity: Instant,
-    /// Last successfully saved new in-order segment, independent of SegmentTimer.
-    last_progress: Instant,
-    expected_seq: u8,
-    /// Last sequence number in the previously completed receive window.
-    initial_sequence_number: u8,
-    /// Duplicates silently discarded in the current receive window.
-    duplicate_count: u8,
-    /// Last segment accepted in order (Clause 5.4.2 LastSequenceNumber).
-    last_acked_seq: u8,
-    window_pos: u8,
-    actual_window_size: u8,
-    /// Monotonic count of segments accepted in order (#364).
-    ///
-    /// The reassembly total. `expected_seq` cannot serve: Clause 20.1.2.7
-    /// makes the sequence number modulo 256, so a 260-segment request ends at
-    /// sequence 3 and `seq + 1` names a four-segment total. This counter also
-    /// carries the overrun cap — acceptance is strictly in order, so it
-    /// reaches [`MAX_REQUEST_SEGMENTS`] exactly when the sequence number is
-    /// about to wrap onto stored segment 0.
-    accepted_segments: usize,
-}
-
 /// BACnet server with APDU dispatch and service handling.
 pub struct BACnetServer<T: TransportPort> {
     config: ServerConfig,
+    discovery_limiter: Arc<DiscoveryLimiter>,
     /// Server-owned clock controller; absent in explicit clockless mode.
     _clock: Option<Arc<ServerClock>>,
     /// Shared network layer (also held by dispatch task; read by
@@ -958,6 +825,9 @@ mod cov_encoding;
 mod cov_notifications;
 mod cov_snapshot;
 mod device_bindings;
+mod discovery;
+pub use discovery::{DiscoveryCounters, DiscoveryPolicy};
+pub(crate) use discovery::{DiscoveryLimiter, PreCheckDecision, WhoHasTarget};
 mod dispatch;
 mod event_enrollment_lifecycle;
 mod event_message_policy;
@@ -982,6 +852,8 @@ pub use sc_builder::ScServerBuilder;
 mod responses;
 mod segmentation;
 mod segmented_receive;
+mod segmented_send;
+pub(crate) use segmented_send::*;
 mod shutdown;
 
 #[cfg(test)]
@@ -998,6 +870,8 @@ mod dcc_event_detection_tests;
 mod device_bindings_tests;
 #[cfg(test)]
 mod device_recipient_routing_tests;
+#[cfg(test)]
+mod discovery_tests;
 #[cfg(test)]
 mod event_confirmed_routing_tests;
 #[cfg(test)]
@@ -1029,5 +903,10 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             transport: None,
             configured_device_bindings: Vec::new(),
         }
+    }
+
+    /// Get a snapshot of discovery rate-limiting counters.
+    pub fn discovery_counters(&self) -> DiscoveryCounters {
+        self.discovery_limiter.counters()
     }
 }

--- a/crates/bacnet-server/src/server/notification_transactions_tests.rs
+++ b/crates/bacnet-server/src/server/notification_transactions_tests.rs
@@ -404,6 +404,7 @@ async fn dispatch_keeps_segment_and_complex_acks_out_of_notification_completion(
             &dcc_timer,
             &config,
             &None,
+            &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
             source_mac.as_slice(),
             apdu,
             bacnet_network::layer::ReceivedApdu {

--- a/crates/bacnet-server/src/server/requests/unconfirmed.rs
+++ b/crates/bacnet-server/src/server/requests/unconfirmed.rs
@@ -5,6 +5,7 @@
 
 use super::super::*;
 use bacnet_services::device_mgmt::TimeSynchronizationRequest;
+use bacnet_services::who_has::{WhoHasObject, WhoHasRequest};
 
 #[cfg(test)]
 /// Every unconfirmed service choice with an inbound execution arm in
@@ -22,6 +23,7 @@ pub(crate) const EXECUTED_UNCONFIRMED: &[UnconfirmedServiceChoice] = &[
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Handle an unconfirmed request (e.g., WhoIs).
+    #[allow(clippy::too_many_arguments)]
     pub(in crate::server) async fn handle_unconfirmed_request(
         db: &Arc<RwLock<ObjectDatabase>>,
         network: &Arc<NetworkLayer<T>>,
@@ -29,6 +31,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         clock: Option<&Arc<ServerClock>>,
         comm_state: &Arc<AtomicU8>,
         device_bindings: &Arc<RwLock<DeviceBindingTable>>,
+        discovery_limiter: &Arc<DiscoveryLimiter>,
         req: UnconfirmedRequestPdu,
         received: &bacnet_network::layer::ReceivedApdu,
     ) {
@@ -106,29 +109,75 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     let mut buf = BytesMut::new();
                     encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
-                    if let Some(ref source_net) = received.source_network {
-                        if let Err(e) = network
-                            .send_apdu_routed(
-                                &buf,
-                                source_net.network,
-                                &source_net.mac_address,
-                                &received.source_mac,
-                                false,
-                                NetworkPriority::NORMAL,
-                            )
-                            .await
-                        {
-                            warn!(error = %e, "Failed to route IAm back to remote requester");
-                        }
-                    } else if let Err(e) = network
-                        .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
-                        .await
-                    {
-                        warn!(error = %e, "Failed to send IAm broadcast");
+                    let now = Instant::now();
+                    let is_unicast = !received.is_group && !received.link_layer_group;
+                    let (res, directed) = if let Some(ref source_net) = received.source_network {
+                        (
+                            network
+                                .send_apdu_routed(
+                                    &buf,
+                                    source_net.network,
+                                    &source_net.mac_address,
+                                    &received.source_mac,
+                                    false,
+                                    NetworkPriority::NORMAL,
+                                )
+                                .await,
+                            true,
+                        )
+                    } else if config.discovery_policy.prefer_directed_responses || is_unicast {
+                        (
+                            network
+                                .send_apdu(
+                                    &buf,
+                                    &received.source_mac,
+                                    false,
+                                    NetworkPriority::NORMAL,
+                                )
+                                .await,
+                            true,
+                        )
+                    } else {
+                        (
+                            network
+                                .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
+                                .await,
+                            false,
+                        )
+                    };
+
+                    if let Err(e) = res {
+                        warn!(error = %e, directed, "Failed to send IAm");
+                    } else {
+                        discovery_limiter.record_i_am_sent(
+                            buf.len(),
+                            directed,
+                            &received.source_mac,
+                            received.source_network.as_ref(),
+                            now,
+                        );
                     }
                 }
             }
         } else if req.service_choice == UnconfirmedServiceChoice::WHO_HAS {
+            let who_has = match WhoHasRequest::decode(&req.service_request) {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(error = %e, "Failed to decode WhoHas");
+                    return;
+                }
+            };
+
+            let target = match &who_has.object {
+                WhoHasObject::Identifier(oid) => WhoHasTarget::Id(*oid),
+                WhoHasObject::Name(name) => WhoHasTarget::Name(name.clone()),
+            };
+
+            let now = Instant::now();
+            if discovery_limiter.is_negative_who_has(&target, now) {
+                return;
+            }
+
             let db = db.read().await;
             let device_oid = db
                 .list_objects()
@@ -150,15 +199,71 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             let mut buf = BytesMut::new();
                             encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
-                            if let Err(e) = network
-                                .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
-                                .await
-                            {
-                                warn!(error = %e, "Failed to send IHave broadcast");
+                            if !discovery_limiter.try_consume_who_has_response(
+                                &target,
+                                received,
+                                buf.len(),
+                                now,
+                            ) {
+                                return;
+                            }
+
+                            let is_unicast = !received.is_group && !received.link_layer_group;
+                            let (res, directed) =
+                                if let Some(ref source_net) = received.source_network {
+                                    (
+                                        network
+                                            .send_apdu_routed(
+                                                &buf,
+                                                source_net.network,
+                                                &source_net.mac_address,
+                                                &received.source_mac,
+                                                false,
+                                                NetworkPriority::NORMAL,
+                                            )
+                                            .await,
+                                        true,
+                                    )
+                                } else if config.discovery_policy.prefer_directed_responses
+                                    || is_unicast
+                                {
+                                    (
+                                        network
+                                            .send_apdu(
+                                                &buf,
+                                                &received.source_mac,
+                                                false,
+                                                NetworkPriority::NORMAL,
+                                            )
+                                            .await,
+                                        true,
+                                    )
+                                } else {
+                                    (
+                                        network
+                                            .broadcast_apdu(&buf, false, NetworkPriority::NORMAL)
+                                            .await,
+                                        false,
+                                    )
+                                };
+
+                            if let Err(e) = res {
+                                warn!(error = %e, directed, "Failed to send IHave");
+                            } else {
+                                discovery_limiter.record_i_have_sent(
+                                    buf.len(),
+                                    directed,
+                                    &target,
+                                    &received.source_mac,
+                                    received.source_network.as_ref(),
+                                    now,
+                                );
                             }
                         }
                     }
-                    Ok(None) => {}
+                    Ok(None) => {
+                        discovery_limiter.record_negative_who_has(target, now);
+                    }
                     Err(e) => {
                         warn!(error = %e, "Failed to decode WhoHas");
                     }

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -293,6 +293,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
         &dcc_timer,
         &config,
         &None,
+        &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
         source_mac.as_slice(),
         apdu,
         bacnet_network::layer::ReceivedApdu {

--- a/crates/bacnet-server/src/server/segmented_receive.rs
+++ b/crates/bacnet-server/src/server/segmented_receive.rs
@@ -29,7 +29,7 @@ fn payload_fits(saved: Option<usize>, additional: usize) -> bool {
 /// Owns all active payload storage and its accounting. The mutable encoding
 /// receiver never escapes: server saves are append-only, ordered, and charged
 /// exactly once, while the first request template contains metadata only.
-pub(super) struct RequestPayload {
+pub(crate) struct RequestPayload {
     receiver: SegmentReceiver,
     first: ConfirmedRequestPdu,
     saved_payload_bytes: usize,

--- a/crates/bacnet-server/src/server/segmented_send.rs
+++ b/crates/bacnet-server/src/server/segmented_send.rs
@@ -1,0 +1,163 @@
+use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::time::{Duration, Instant};
+
+use tokio::sync::{mpsc, watch};
+
+use bacnet_encoding::apdu::{AbortPdu, SegmentAck as SegmentAckPdu};
+use bacnet_encoding::npdu::NpduAddress;
+use bacnet_types::MacAddr;
+
+use super::segmented_receive::RequestPayload;
+use super::{DEFAULT_APDU_SEGMENT_RETRIES, DEFAULT_APDU_SEGMENT_TIMEOUT};
+
+/// Key for tracking segmented transactions by peer and invoke ID.
+pub(crate) type SegKey = (MacAddr, Option<NpduAddress>, u8);
+
+pub(crate) fn segmented_transaction_key(
+    source_mac: &[u8],
+    source_network: Option<&NpduAddress>,
+    invoke_id: u8,
+) -> SegKey {
+    match source_network {
+        Some(address)
+            if (1..=0xFFFE).contains(&address.network) && !address.mac_address.is_empty() =>
+        {
+            (MacAddr::new(), Some(address.clone()), invoke_id)
+        }
+        _ => (
+            MacAddr::from_slice(source_mac),
+            source_network.cloned(),
+            invoke_id,
+        ),
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum SegmentedSendEvent {
+    SegmentAck(SegmentAckPdu),
+    Abort(AbortPdu),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SegmentedSendControlEvent {
+    Abort(AbortPdu),
+    Cancel,
+}
+
+pub(crate) struct SegmentedSendHandle {
+    pub(crate) segment_ack_tx: mpsc::Sender<SegmentAckPdu>,
+    pub(crate) control_tx: watch::Sender<Option<SegmentedSendControlEvent>>,
+    pub(crate) closed: AtomicBool,
+    pub(crate) current_sequence: AtomicU16,
+    pub(crate) total_segments: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SegmentAckDisposition {
+    Advance,
+    Retransmit,
+}
+
+pub(crate) fn segment_ack_disposition(
+    ack: &SegmentAckPdu,
+    current: usize,
+    total_segments: usize,
+) -> Option<SegmentAckDisposition> {
+    if current >= total_segments {
+        return None;
+    }
+
+    let ack_seq = ack.sequence_number as usize;
+    if ack_seq >= total_segments {
+        return None;
+    }
+
+    // Clause 5.4.4.2 treats either ACK flavor's sequence number as the last
+    // segment accepted. A NAK for the preceding segment asks for `current`
+    // again; a NAK for `current` confirms it and advances the send window.
+    if ack_seq == current {
+        Some(SegmentAckDisposition::Advance)
+    } else if ack.negative_ack && current.checked_sub(1) == Some(ack_seq) {
+        Some(SegmentAckDisposition::Retransmit)
+    } else {
+        None
+    }
+}
+
+impl SegmentedSendHandle {
+    pub(crate) fn new(
+        segment_ack_tx: mpsc::Sender<SegmentAckPdu>,
+        control_tx: watch::Sender<Option<SegmentedSendControlEvent>>,
+        total_segments: usize,
+    ) -> Self {
+        Self {
+            segment_ack_tx,
+            control_tx,
+            closed: AtomicBool::new(false),
+            current_sequence: AtomicU16::new(u16::MAX),
+            total_segments,
+        }
+    }
+
+    pub(crate) fn accepts_segment_ack(&self, ack: &SegmentAckPdu) -> bool {
+        if ack.sent_by_server || self.closed.load(Ordering::Acquire) {
+            return false;
+        }
+
+        let current = self.current_sequence.load(Ordering::Acquire) as usize;
+        if current >= self.total_segments {
+            return false;
+        }
+
+        segment_ack_disposition(ack, current, self.total_segments).is_some()
+    }
+
+    pub(crate) fn send_control(&self, event: SegmentedSendControlEvent) {
+        self.closed.store(true, Ordering::Release);
+        self.control_tx.send_replace(Some(event));
+    }
+
+    pub(crate) fn same_channel(&self, sender: &mpsc::Sender<SegmentAckPdu>) -> bool {
+        self.segment_ack_tx.same_channel(sender)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SegmentedSendOptions {
+    pub(crate) segment_timeout: Duration,
+    pub(crate) max_retries: u8,
+}
+
+impl Default for SegmentedSendOptions {
+    fn default() -> Self {
+        Self {
+            segment_timeout: DEFAULT_APDU_SEGMENT_TIMEOUT,
+            max_retries: DEFAULT_APDU_SEGMENT_RETRIES,
+        }
+    }
+}
+
+pub(crate) struct SegmentedRequestState {
+    pub(crate) payload: RequestPayload,
+    pub(crate) last_activity: Instant,
+    /// Last successfully saved new in-order segment, independent of SegmentTimer.
+    pub(crate) last_progress: Instant,
+    pub(crate) expected_seq: u8,
+    /// Last sequence number in the previously completed receive window.
+    pub(crate) initial_sequence_number: u8,
+    /// Duplicates silently discarded in the current receive window.
+    pub(crate) duplicate_count: u8,
+    /// Last segment accepted in order (Clause 5.4.2 LastSequenceNumber).
+    pub(crate) last_acked_seq: u8,
+    pub(crate) window_pos: u8,
+    pub(crate) actual_window_size: u8,
+    /// Monotonic count of segments accepted in order (#364).
+    ///
+    /// The reassembly total. `expected_seq` cannot serve: Clause 20.1.2.7
+    /// makes the sequence number modulo 256, so a 260-segment request ends at
+    /// sequence 3 and `seq + 1` names a four-segment total. This counter also
+    /// carries the overrun cap — acceptance is strictly in order, so it
+    /// reaches [`MAX_REQUEST_SEGMENTS`] exactly when the sequence number is
+    /// about to wrap onto stored segment 0.
+    pub(crate) accepted_segments: usize,
+}

--- a/crates/bacnet-server/src/server/unconfirmed_audit_notification_tests.rs
+++ b/crates/bacnet-server/src/server/unconfirmed_audit_notification_tests.rs
@@ -67,6 +67,7 @@ async fn dispatch_unconfirmed(
 ) {
     let network = Arc::new(NetworkLayer::new(CountingTransport { sends }));
     let bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
+    let discovery_limiter = Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None));
     BACnetServer::<CountingTransport>::handle_unconfirmed_request(
         db,
         &network,
@@ -74,6 +75,7 @@ async fn dispatch_unconfirmed(
         None,
         comm_state,
         &bindings,
+        &discovery_limiter,
         UnconfirmedRequestPdu {
             service_choice: UnconfirmedServiceChoice::UNCONFIRMED_AUDIT_NOTIFICATION,
             service_request,


### PR DESCRIPTION
## Summary of Changes
Addresses Issue #534 ("Security: rate-limit Who-Is and Who-Has response amplification"):
1. **Discovery Rate Limiting & Token/Byte Budgets**:
   - Implemented `DiscoveryPolicy` with configurable global and per-source packet and byte rate limits, burst capacities, and source quotas.
   - Enforced windowed token-bucket rate limiting on discovery responses (I-Am and I-Have), preventing amplification storms from unconfirmed discovery floods.
   - Preserved `reserved_capacity` ensuring diagnostic and commissioning stations are never starved even under sustained discovery floods.
2. **Duplicate Scan Coalescing & Negative Caching**:
   - Added duplicate scan suppression within configurable `coalesce_window` for Who-Is and Who-Has.
   - Implemented negative Who-Has caching to avoid repeated full database scans when querying non-existent objects.
3. **Directed Responses & Standards Compliance (Clauses 16.9 and 16.10)**:
   - Avoids unnecessary local network broadcasts by replying with directed unicast (`send_apdu`) when receiving unicast discovery queries or when `prefer_directed_responses` is active.
   - Routes unicast I-Have responses (`send_apdu_routed`) back to remote requesters on routed networks, resolving an issue where Who-Has previously broadcasted unconditionally.
4. **Fast Dispatch Rejection**:
   - Added fast synchronous filter in `dispatch` for DCC disable, throttled discovery, and coalesced duplicate scans, preventing task sprawl and database lock contention.
   - Verified confirmed traffic latency remains bounded during active discovery floods.
5. **Telemetry & Modularity**:
   - Exposed `DiscoveryCounters` via `BACnetServer::discovery_counters()`.
   - Extracted `segmented_send.rs` to keep `server/mod.rs` and all other source files strictly within the 700 LOC cap.

Closes #534.