### PR TITLE
fix(server): add per-peer COV quotas and notification work budgets (#533)

### DIFF
--- a/crates/bacnet-server/src/cov.rs
+++ b/crates/bacnet-server/src/cov.rs
@@ -1,12 +1,21 @@
 //! COV subscription engine — tracks SubscribeCOV subscriptions and their lifetimes.
 
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 use std::time::Instant;
 
 use bacnet_encoding::npdu::NpduAddress;
-use bacnet_types::enums::PropertyIdentifier;
+use bacnet_types::enums::{ErrorClass, ErrorCode, PropertyIdentifier};
+use bacnet_types::error::Error;
 use bacnet_types::primitives::ObjectIdentifier;
 use bacnet_types::MacAddr;
+
+mod policy;
+pub use policy::*;
+
+#[cfg(test)]
+mod tests;
 
 /// An active COV subscription.
 #[derive(Debug, Clone)]
@@ -38,6 +47,13 @@ pub struct CovSubscription {
     pub timestamped: bool,
 }
 
+impl CovSubscription {
+    /// Derive the canonical peer identity for this subscription.
+    pub fn peer_key(&self) -> CovPeerKey {
+        CovPeerKey::from_endpoint(&self.subscriber_mac, self.subscriber_network.as_ref())
+    }
+}
+
 /// COV notification service family for a stored subscription.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CovNotificationKind {
@@ -60,16 +76,63 @@ type SubKey = (
 );
 
 /// Table of active COV subscriptions.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CovSubscriptionTable {
     subs: HashMap<SubKey, CovSubscription>,
+    peer_counts: HashMap<CovPeerKey, usize>,
+    peer_indefinite_counts: HashMap<CovPeerKey, usize>,
+    policy: CovPolicy,
+    counters: Arc<AtomicCovCounters>,
+    in_flight: Arc<CovInFlightTracker>,
+}
+
+impl Default for CovSubscriptionTable {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CovSubscriptionTable {
+    /// Create a new COV subscription table with default policy and counters.
     pub fn new() -> Self {
+        Self::with_policy(CovPolicy::default(), Arc::new(AtomicCovCounters::default()))
+    }
+
+    /// Create a new COV subscription table with a custom policy and counters.
+    pub fn with_policy(policy: CovPolicy, counters: Arc<AtomicCovCounters>) -> Self {
         Self {
             subs: HashMap::new(),
+            peer_counts: HashMap::new(),
+            peer_indefinite_counts: HashMap::new(),
+            policy: policy.sanitized(),
+            counters,
+            in_flight: Arc::new(CovInFlightTracker::default()),
         }
+    }
+
+    /// Get a reference to the active COV policy.
+    pub fn policy(&self) -> &CovPolicy {
+        &self.policy
+    }
+
+    /// Get a reference to the atomic counters.
+    pub fn counters(&self) -> &Arc<AtomicCovCounters> {
+        &self.counters
+    }
+
+    /// Get a reference to the in-flight confirmed notification tracker.
+    pub fn in_flight_tracker(&self) -> &Arc<CovInFlightTracker> {
+        &self.in_flight
+    }
+
+    /// Get the number of active subscriptions for a peer.
+    pub fn peer_subscription_count(&self, peer: &CovPeerKey) -> usize {
+        self.peer_counts.get(peer).copied().unwrap_or(0)
+    }
+
+    /// Get the number of active indefinite subscriptions for a peer.
+    pub fn peer_indefinite_count(&self, peer: &CovPeerKey) -> usize {
+        self.peer_indefinite_counts.get(peer).copied().unwrap_or(0)
     }
 
     /// Add or update a subscription.
@@ -81,7 +144,50 @@ impl CovSubscriptionTable {
             sub.monitored_object_identifier,
             sub.monitored_property,
         );
-        self.subs.insert(key, sub);
+        let peer = sub.peer_key();
+        let new_indefinite = sub.expires_at.is_none();
+        if let Some(old) = self.subs.insert(key, sub) {
+            let old_indefinite = old.expires_at.is_none();
+            if old_indefinite != new_indefinite {
+                if new_indefinite {
+                    *self.peer_indefinite_counts.entry(peer).or_default() += 1;
+                } else if let Some(count) = self.peer_indefinite_counts.get_mut(&peer) {
+                    *count = count.saturating_sub(1);
+                    if *count == 0 {
+                        self.peer_indefinite_counts.remove(&peer);
+                    }
+                }
+            }
+        } else {
+            *self.peer_counts.entry(peer.clone()).or_default() += 1;
+            if new_indefinite {
+                *self.peer_indefinite_counts.entry(peer).or_default() += 1;
+            }
+            self.counters
+                .subscriptions_created
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.counters
+            .subscriptions_active
+            .store(self.subs.len() as u64, Ordering::Relaxed);
+    }
+
+    /// Get an active subscription by exact key if present.
+    pub fn get_subscription(
+        &self,
+        mac: &MacAddr,
+        network: Option<&NpduAddress>,
+        process_id: u32,
+        monitored_object: ObjectIdentifier,
+        monitored_property: Option<PropertyIdentifier>,
+    ) -> Option<&CovSubscription> {
+        self.subs.get(&(
+            mac.clone(),
+            network.cloned(),
+            process_id,
+            monitored_object,
+            monitored_property,
+        ))
     }
 
     /// Whether a subscription key is already present.
@@ -93,13 +199,45 @@ impl CovSubscriptionTable {
         monitored_object: ObjectIdentifier,
         monitored_property: Option<PropertyIdentifier>,
     ) -> bool {
-        self.subs.contains_key(&(
-            mac.clone(),
-            network.cloned(),
+        self.get_subscription(
+            mac,
+            network,
             process_id,
             monitored_object,
             monitored_property,
-        ))
+        )
+        .is_some()
+    }
+
+    fn remove_internal(&mut self, key: &SubKey, was_cancelled: bool) -> bool {
+        if let Some(sub) = self.subs.remove(key) {
+            let peer = sub.peer_key();
+            if let Some(count) = self.peer_counts.get_mut(&peer) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    self.peer_counts.remove(&peer);
+                }
+            }
+            if sub.expires_at.is_none() {
+                if let Some(count) = self.peer_indefinite_counts.get_mut(&peer) {
+                    *count = count.saturating_sub(1);
+                    if *count == 0 {
+                        self.peer_indefinite_counts.remove(&peer);
+                    }
+                }
+            }
+            if was_cancelled {
+                self.counters
+                    .subscriptions_cancelled
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+            self.counters
+                .subscriptions_active
+                .store(self.subs.len() as u64, Ordering::Relaxed);
+            true
+        } else {
+            false
+        }
     }
 
     /// Remove a subscription by subscriber MAC, process identifier, and monitored object.
@@ -127,7 +265,7 @@ impl CovSubscriptionTable {
             monitored_object,
             None,
         );
-        self.subs.remove(&key).is_some()
+        self.remove_internal(&key, true)
     }
 
     /// Unsubscribe a per-property subscription.
@@ -157,7 +295,7 @@ impl CovSubscriptionTable {
             monitored_object,
             Some(monitored_property),
         );
-        self.subs.remove(&key).is_some()
+        self.remove_internal(&key, true)
     }
 
     /// Remove every COV-multiple subscription in a subscriber context.
@@ -169,13 +307,21 @@ impl CovSubscriptionTable {
         confirmed: bool,
     ) {
         let mac = MacAddr::from_slice(mac);
-        self.subs.retain(|_, sub| {
-            !(sub.notification_kind == CovNotificationKind::Multiple
-                && sub.subscriber_mac == mac
-                && sub.subscriber_network == network.cloned()
-                && sub.subscriber_process_identifier == process_id
-                && sub.issue_confirmed_notifications == confirmed)
-        });
+        let to_remove: Vec<_> = self
+            .subs
+            .iter()
+            .filter(|(_, sub)| {
+                sub.notification_kind == CovNotificationKind::Multiple
+                    && sub.subscriber_mac == mac
+                    && sub.subscriber_network == network.cloned()
+                    && sub.subscriber_process_identifier == process_id
+                    && sub.issue_confirmed_notifications == confirmed
+            })
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in to_remove {
+            self.remove_internal(&key, true);
+        }
     }
 
     /// Remove one property from a COV-multiple subscriber context.
@@ -189,15 +335,23 @@ impl CovSubscriptionTable {
         monitored_property: PropertyIdentifier,
     ) {
         let mac = MacAddr::from_slice(mac);
-        self.subs.retain(|_, sub| {
-            !(sub.notification_kind == CovNotificationKind::Multiple
-                && sub.subscriber_mac == mac
-                && sub.subscriber_network == network.cloned()
-                && sub.subscriber_process_identifier == process_id
-                && sub.issue_confirmed_notifications == confirmed
-                && sub.monitored_object_identifier == monitored_object
-                && sub.monitored_property == Some(monitored_property))
-        });
+        let to_remove: Vec<_> = self
+            .subs
+            .iter()
+            .filter(|(_, sub)| {
+                sub.notification_kind == CovNotificationKind::Multiple
+                    && sub.subscriber_mac == mac
+                    && sub.subscriber_network == network.cloned()
+                    && sub.subscriber_process_identifier == process_id
+                    && sub.issue_confirmed_notifications == confirmed
+                    && sub.monitored_object_identifier == monitored_object
+                    && sub.monitored_property == Some(monitored_property)
+            })
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in to_remove {
+            self.remove_internal(&key, true);
+        }
     }
 
     /// Refresh the lifetime for an existing COV-multiple subscriber context.
@@ -224,18 +378,186 @@ impl CovSubscriptionTable {
 
     /// Remove all subscriptions for a given object (used on DeleteObject).
     pub fn remove_for_object(&mut self, oid: ObjectIdentifier) {
-        self.subs.retain(|k, _| k.3 != oid);
+        let to_remove: Vec<_> = self
+            .subs
+            .iter()
+            .filter(|(k, _)| k.3 == oid)
+            .map(|(k, _)| k.clone())
+            .collect();
+        for key in to_remove {
+            self.remove_internal(&key, false);
+        }
+    }
+
+    /// Purge all subscriptions for a peer and deterministically release its quota.
+    pub fn remove_peer_subscriptions(
+        &mut self,
+        mac: &[u8],
+        network: Option<&NpduAddress>,
+    ) -> usize {
+        let target = CovPeerKey::from_endpoint(&MacAddr::from_slice(mac), network);
+        let to_remove: Vec<_> = self
+            .subs
+            .iter()
+            .filter(|(_, sub)| sub.peer_key() == target)
+            .map(|(k, _)| k.clone())
+            .collect();
+        let count = to_remove.len();
+        for key in to_remove {
+            self.remove_internal(&key, true);
+        }
+        count
+    }
+
+    /// Remove all expired subscriptions. Returns the number removed.
+    pub fn purge_expired(&mut self) -> usize {
+        let now = Instant::now();
+        let mut purged_count = 0;
+        let mut to_remove = Vec::new();
+        for (k, sub) in &self.subs {
+            if sub.expires_at.is_some_and(|exp| exp <= now) {
+                to_remove.push(k.clone());
+            }
+        }
+        for key in to_remove {
+            if let Some(sub) = self.subs.remove(&key) {
+                let peer = sub.peer_key();
+                if let Some(count) = self.peer_counts.get_mut(&peer) {
+                    *count = count.saturating_sub(1);
+                    if *count == 0 {
+                        self.peer_counts.remove(&peer);
+                    }
+                }
+                purged_count += 1;
+            }
+        }
+        if purged_count > 0 {
+            self.counters
+                .subscriptions_purged
+                .fetch_add(purged_count as u64, Ordering::Relaxed);
+            self.counters
+                .subscriptions_active
+                .store(self.subs.len() as u64, Ordering::Relaxed);
+        }
+        purged_count
     }
 
     /// Get all active (non-expired) subscriptions for a given object.
     pub fn subscriptions_for(&mut self, oid: &ObjectIdentifier) -> Vec<&CovSubscription> {
-        let now = Instant::now();
-        self.subs
-            .retain(|_, sub| sub.expires_at.is_none_or(|exp| exp > now));
+        self.purge_expired();
         self.subs
             .values()
             .filter(|sub| sub.monitored_object_identifier == *oid)
             .collect()
+    }
+
+    /// Check admission for a single subscription request against policy quotas.
+    pub fn check_admission(
+        &self,
+        peer: &CovPeerKey,
+        is_indefinite: bool,
+        existing: Option<&CovSubscription>,
+    ) -> Result<(), Error> {
+        if is_indefinite && !self.policy.allow_indefinite_subscriptions {
+            self.counters
+                .subscriptions_rejected_indefinite
+                .fetch_add(1, Ordering::Relaxed);
+            return Err(Error::Protocol {
+                class: ErrorClass::SERVICES.to_raw() as u32,
+                code: ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw() as u32,
+            });
+        }
+
+        let (new_count, new_indefinite) = match existing {
+            Some(sub) => {
+                let was_indefinite = sub.expires_at.is_none();
+                let add_indefinite = if is_indefinite && !was_indefinite {
+                    1
+                } else {
+                    0
+                };
+                (0, add_indefinite)
+            }
+            None => {
+                let add_indefinite = if is_indefinite { 1 } else { 0 };
+                (1, add_indefinite)
+            }
+        };
+
+        self.check_admission_multiple(peer, new_count, new_indefinite)
+    }
+
+    /// Check admission for a batch of subscriptions against policy quotas.
+    pub fn check_admission_multiple(
+        &self,
+        peer: &CovPeerKey,
+        new_count: usize,
+        new_indefinite: usize,
+    ) -> Result<(), Error> {
+        if new_indefinite > 0 {
+            if !self.policy.allow_indefinite_subscriptions {
+                self.counters
+                    .subscriptions_rejected_indefinite
+                    .fetch_add(1, Ordering::Relaxed);
+                return Err(Error::Protocol {
+                    class: ErrorClass::SERVICES.to_raw() as u32,
+                    code: ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw() as u32,
+                });
+            }
+            let current_indefinite = self.peer_indefinite_counts.get(peer).copied().unwrap_or(0);
+            if current_indefinite + new_indefinite > self.policy.max_indefinite_per_peer {
+                self.counters
+                    .subscriptions_rejected_indefinite
+                    .fetch_add(1, Ordering::Relaxed);
+                return Err(Error::Protocol {
+                    class: ErrorClass::RESOURCES.to_raw() as u32,
+                    code: ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32,
+                });
+            }
+        }
+
+        if new_count == 0 {
+            return Ok(());
+        }
+
+        let current_peer = self.peer_counts.get(peer).copied().unwrap_or(0);
+        if current_peer + new_count > self.policy.max_subscriptions_per_peer {
+            self.counters
+                .subscriptions_rejected_quota
+                .fetch_add(1, Ordering::Relaxed);
+            return Err(Error::Protocol {
+                class: ErrorClass::RESOURCES.to_raw() as u32,
+                code: ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32,
+            });
+        }
+
+        if self.subs.len() + new_count > self.policy.max_subscriptions_global {
+            self.counters
+                .subscriptions_rejected_capacity
+                .fetch_add(1, Ordering::Relaxed);
+            return Err(Error::Protocol {
+                class: ErrorClass::RESOURCES.to_raw() as u32,
+                code: ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32,
+            });
+        }
+
+        if !self.policy.is_peer_reserved(peer) {
+            let unreserved_capacity = self
+                .policy
+                .max_subscriptions_global
+                .saturating_sub(self.policy.reserved_capacity);
+            if self.subs.len() + new_count > unreserved_capacity {
+                self.counters
+                    .subscriptions_rejected_capacity
+                    .fetch_add(1, Ordering::Relaxed);
+                return Err(Error::Protocol {
+                    class: ErrorClass::RESOURCES.to_raw() as u32,
+                    code: ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32,
+                });
+            }
+        }
+
+        Ok(())
     }
 
     /// Update the last-notified value for a subscription.
@@ -291,271 +613,5 @@ impl CovSubscriptionTable {
     /// Whether the table is empty.
     pub fn is_empty(&self) -> bool {
         self.subs.is_empty()
-    }
-
-    /// Remove all expired subscriptions. Returns the number removed.
-    pub fn purge_expired(&mut self) -> usize {
-        let before = self.subs.len();
-        let now = Instant::now();
-        self.subs
-            .retain(|_, sub| sub.expires_at.is_none_or(|exp| exp > now));
-        before - self.subs.len()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use bacnet_types::enums::ObjectType;
-    use std::time::Duration;
-
-    fn ai1() -> ObjectIdentifier {
-        ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap()
-    }
-
-    fn ai2() -> ObjectIdentifier {
-        ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 2).unwrap()
-    }
-
-    fn make_sub(mac: &[u8], process_id: u32, oid: ObjectIdentifier) -> CovSubscription {
-        CovSubscription {
-            subscriber_mac: MacAddr::from_slice(mac),
-            subscriber_network: None,
-            subscriber_process_identifier: process_id,
-            monitored_object_identifier: oid,
-            issue_confirmed_notifications: false,
-            expires_at: None,
-            last_notified_value: None,
-            monitored_property: None,
-            monitored_property_array_index: None,
-            cov_increment: None,
-            notification_kind: CovNotificationKind::Single,
-            timestamped: false,
-        }
-    }
-
-    #[test]
-    fn subscribe_and_lookup() {
-        let mut table = CovSubscriptionTable::new();
-        table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
-        assert_eq!(table.len(), 1);
-        assert_eq!(table.subscriptions_for(&ai1()).len(), 1);
-        assert_eq!(table.subscriptions_for(&ai2()).len(), 0);
-    }
-
-    #[test]
-    fn unsubscribe() {
-        let mut table = CovSubscriptionTable::new();
-        table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
-        assert!(table.unsubscribe(&[1, 2, 3], 1, ai1()));
-        assert!(!table.unsubscribe(&[1, 2, 3], 1, ai1())); // already removed
-        assert!(table.is_empty());
-    }
-
-    #[test]
-    fn expired_subscriptions_purged_on_lookup() {
-        let mut table = CovSubscriptionTable::new();
-        let mut sub = make_sub(&[1, 2, 3], 1, ai1());
-        sub.expires_at = Some(Instant::now() - Duration::from_secs(1)); // already expired
-        table.subscribe(sub);
-        assert_eq!(table.subscriptions_for(&ai1()).len(), 0);
-        assert!(table.is_empty());
-    }
-
-    #[test]
-    fn multiple_subscribers_same_object() {
-        let mut table = CovSubscriptionTable::new();
-        table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
-        table.subscribe(make_sub(&[4, 5, 6], 2, ai1()));
-        assert_eq!(table.subscriptions_for(&ai1()).len(), 2);
-    }
-
-    #[test]
-    fn should_notify_no_increment_always_fires() {
-        let sub = make_sub(&[1, 2, 3], 1, ai1());
-        // Binary/multi-state objects have no COV_Increment
-        assert!(CovSubscriptionTable::should_notify(&sub, Some(1.0), None));
-    }
-
-    #[test]
-    fn should_notify_first_notification_always_fires() {
-        let sub = make_sub(&[1, 2, 3], 1, ai1());
-        // First notification (last_notified_value = None)
-        assert!(CovSubscriptionTable::should_notify(
-            &sub,
-            Some(72.5),
-            Some(1.0)
-        ));
-    }
-
-    #[test]
-    fn should_notify_change_exceeds_increment() {
-        let mut sub = make_sub(&[1, 2, 3], 1, ai1());
-        sub.last_notified_value = Some(70.0);
-        // Change of 2.5 >= increment of 1.0
-        assert!(CovSubscriptionTable::should_notify(
-            &sub,
-            Some(72.5),
-            Some(1.0)
-        ));
-    }
-
-    #[test]
-    fn should_notify_change_below_increment() {
-        let mut sub = make_sub(&[1, 2, 3], 1, ai1());
-        sub.last_notified_value = Some(72.0);
-        // Change of 0.3 < increment of 1.0
-        assert!(!CovSubscriptionTable::should_notify(
-            &sub,
-            Some(72.3),
-            Some(1.0)
-        ));
-    }
-
-    #[test]
-    fn should_notify_exact_increment() {
-        let mut sub = make_sub(&[1, 2, 3], 1, ai1());
-        sub.last_notified_value = Some(70.0);
-        // Change of exactly 1.0 == increment of 1.0 → fires
-        assert!(CovSubscriptionTable::should_notify(
-            &sub,
-            Some(71.0),
-            Some(1.0)
-        ));
-    }
-
-    #[test]
-    fn should_notify_zero_increment_always_fires() {
-        let mut sub = make_sub(&[1, 2, 3], 1, ai1());
-        sub.last_notified_value = Some(72.0);
-        // COV_Increment = 0.0 means any change fires
-        assert!(CovSubscriptionTable::should_notify(
-            &sub,
-            Some(72.001),
-            Some(0.0)
-        ));
-    }
-
-    #[test]
-    fn set_last_notified_value_updates() {
-        let mut table = CovSubscriptionTable::new();
-        table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
-        table.set_last_notified_value(&[1, 2, 3], None, 1, ai1(), None, 72.5);
-
-        let subs = table.subscriptions_for(&ai1());
-        assert_eq!(subs[0].last_notified_value, Some(72.5));
-    }
-
-    #[test]
-    fn upsert_replaces_existing() {
-        let mut table = CovSubscriptionTable::new();
-        let mut sub = make_sub(&[1, 2, 3], 1, ai1());
-        sub.issue_confirmed_notifications = false;
-        table.subscribe(sub);
-        // Same (mac, process_id, object) key — replaces the existing entry
-        let mut sub2 = make_sub(&[1, 2, 3], 1, ai1());
-        sub2.issue_confirmed_notifications = true;
-        table.subscribe(sub2);
-        assert_eq!(table.len(), 1);
-        let subs = table.subscriptions_for(&ai1());
-        assert!(subs[0].issue_confirmed_notifications);
-    }
-
-    #[test]
-    fn same_subscriber_different_objects_both_exist() {
-        let mut table = CovSubscriptionTable::new();
-        // Same (mac, process_id) but different monitored objects
-        table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
-        table.subscribe(make_sub(&[1, 2, 3], 1, ai2()));
-        assert_eq!(table.len(), 2);
-        assert_eq!(table.subscriptions_for(&ai1()).len(), 1);
-        assert_eq!(table.subscriptions_for(&ai2()).len(), 1);
-    }
-
-    #[test]
-    fn purge_expired_removes_stale_subscriptions() {
-        let mut table = CovSubscriptionTable::new();
-        let mut sub1 = make_sub(&[1, 2, 3], 1, ai1());
-        sub1.expires_at = Some(Instant::now() - Duration::from_secs(10));
-        table.subscribe(sub1);
-
-        let mut sub2 = make_sub(&[4, 5, 6], 2, ai1());
-        sub2.expires_at = None; // infinite lifetime
-        table.subscribe(sub2);
-
-        let purged = table.purge_expired();
-        assert_eq!(purged, 1);
-        assert_eq!(table.len(), 1);
-    }
-
-    #[test]
-    fn cov_multiple_context_lifetime_refreshes_and_expires() {
-        let mut table = CovSubscriptionTable::new();
-        let original_expiry = Instant::now() + Duration::from_secs(30);
-        let refreshed_expiry = Instant::now() + Duration::from_secs(60);
-
-        let mut present_value = make_sub(&[1, 2, 3], 1, ai1());
-        present_value.notification_kind = CovNotificationKind::Multiple;
-        present_value.monitored_property = Some(PropertyIdentifier::PRESENT_VALUE);
-        present_value.expires_at = Some(original_expiry);
-        table.subscribe(present_value);
-
-        let mut status_flags = make_sub(&[1, 2, 3], 1, ai1());
-        status_flags.notification_kind = CovNotificationKind::Multiple;
-        status_flags.monitored_property = Some(PropertyIdentifier::STATUS_FLAGS);
-        status_flags.expires_at = Some(original_expiry);
-        table.subscribe(status_flags);
-
-        let mut single = make_sub(&[1, 2, 3], 1, ai1());
-        single.expires_at = Some(original_expiry);
-        table.subscribe(single);
-
-        table.refresh_cov_multiple_context_lifetime(
-            &[1, 2, 3],
-            None,
-            1,
-            false,
-            Some(refreshed_expiry),
-        );
-
-        let multiple_expiries: Vec<_> = table
-            .subs
-            .values()
-            .filter(|sub| sub.notification_kind == CovNotificationKind::Multiple)
-            .map(|sub| sub.expires_at)
-            .collect();
-        assert_eq!(
-            multiple_expiries,
-            vec![Some(refreshed_expiry), Some(refreshed_expiry)]
-        );
-        assert!(table
-            .subs
-            .values()
-            .any(|sub| sub.notification_kind == CovNotificationKind::Single
-                && sub.expires_at == Some(original_expiry)));
-
-        table.refresh_cov_multiple_context_lifetime(
-            &[1, 2, 3],
-            None,
-            1,
-            false,
-            Some(Instant::now() - Duration::from_secs(1)),
-        );
-
-        assert_eq!(table.purge_expired(), 2);
-        assert_eq!(table.len(), 1);
-        assert!(table.subs.values().all(|sub| {
-            sub.notification_kind == CovNotificationKind::Single
-                && sub.expires_at == Some(original_expiry)
-        }));
-    }
-
-    #[test]
-    fn purge_expired_returns_zero_when_none_expired() {
-        let mut table = CovSubscriptionTable::new();
-        table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
-        let purged = table.purge_expired();
-        assert_eq!(purged, 0);
-        assert_eq!(table.len(), 1);
     }
 }

--- a/crates/bacnet-server/src/cov.rs
+++ b/crates/bacnet-server/src/cov.rs
@@ -84,6 +84,7 @@ pub struct CovSubscriptionTable {
     policy: CovPolicy,
     counters: Arc<AtomicCovCounters>,
     in_flight: Arc<CovInFlightTracker>,
+    dispatch_turn: usize,
 }
 
 impl Default for CovSubscriptionTable {
@@ -107,7 +108,15 @@ impl CovSubscriptionTable {
             policy: policy.sanitized(),
             counters,
             in_flight: Arc::new(CovInFlightTracker::default()),
+            dispatch_turn: 0,
         }
+    }
+
+    /// Return the next notification dispatch turn counter (wrapping).
+    pub(crate) fn next_dispatch_turn(&mut self) -> usize {
+        let turn = self.dispatch_turn;
+        self.dispatch_turn = self.dispatch_turn.wrapping_add(1);
+        turn
     }
 
     /// Get a reference to the active COV policy.
@@ -453,11 +462,13 @@ impl CovSubscriptionTable {
 
     /// Check admission for a single subscription request against policy quotas.
     pub fn check_admission(
-        &self,
+        &mut self,
         peer: &CovPeerKey,
         is_indefinite: bool,
         existing: Option<&CovSubscription>,
     ) -> Result<(), Error> {
+        self.purge_expired();
+
         if is_indefinite && !self.policy.allow_indefinite_subscriptions {
             self.counters
                 .subscriptions_rejected_indefinite
@@ -489,11 +500,13 @@ impl CovSubscriptionTable {
 
     /// Check admission for a batch of subscriptions against policy quotas.
     pub fn check_admission_multiple(
-        &self,
+        &mut self,
         peer: &CovPeerKey,
         new_count: usize,
         new_indefinite: usize,
     ) -> Result<(), Error> {
+        self.purge_expired();
+
         if new_indefinite > 0 {
             if !self.policy.allow_indefinite_subscriptions {
                 self.counters
@@ -542,10 +555,7 @@ impl CovSubscriptionTable {
         }
 
         if !self.policy.is_peer_reserved(peer) {
-            let unreserved_capacity = self
-                .policy
-                .max_subscriptions_global
-                .saturating_sub(self.policy.reserved_capacity);
+            let unreserved_capacity = self.policy.effective_unreserved_capacity();
             if self.subs.len() + new_count > unreserved_capacity {
                 self.counters
                     .subscriptions_rejected_capacity

--- a/crates/bacnet-server/src/cov/policy.rs
+++ b/crates/bacnet-server/src/cov/policy.rs
@@ -17,8 +17,10 @@ pub struct CovPolicy {
     pub max_subscriptions_per_peer: usize,
     /// Number of subscription slots reserved for reserved peers.
     pub reserved_capacity: usize,
-    /// List of MAC addresses of peers permitted to use reserved subscription capacity.
+    /// List of MAC addresses of direct peers permitted to use reserved subscription capacity.
     pub reserved_peers: Vec<MacAddr>,
+    /// List of canonical peer keys permitted to use reserved subscription capacity.
+    pub reserved_peer_keys: Vec<CovPeerKey>,
     /// Whether indefinite (infinite lifetime) subscriptions are permitted.
     pub allow_indefinite_subscriptions: bool,
     /// Maximum number of indefinite subscriptions allowed for a single peer.
@@ -38,6 +40,7 @@ impl Default for CovPolicy {
             max_subscriptions_per_peer: 64,
             reserved_capacity: 64,
             reserved_peers: Vec::new(),
+            reserved_peer_keys: Vec::new(),
             allow_indefinite_subscriptions: true,
             max_indefinite_per_peer: 16,
             max_notifications_per_event: 64,
@@ -55,6 +58,7 @@ impl CovPolicy {
             max_subscriptions_per_peer: usize::MAX,
             reserved_capacity: 0,
             reserved_peers: Vec::new(),
+            reserved_peer_keys: Vec::new(),
             allow_indefinite_subscriptions: true,
             max_indefinite_per_peer: usize::MAX,
             max_notifications_per_event: usize::MAX,
@@ -77,15 +81,24 @@ impl CovPolicy {
 
     /// Check if a peer is in the reserved peers list.
     pub fn is_peer_reserved(&self, peer: &CovPeerKey) -> bool {
-        self.reserved_peers.contains(peer.mac())
+        if self.reserved_peer_keys.contains(peer) {
+            return true;
+        }
+        match peer {
+            CovPeerKey::Direct(mac) => self.reserved_peers.contains(mac),
+            CovPeerKey::Routed(_, _) => false,
+        }
     }
 
     /// Return the effective unreserved capacity available to unreserved peers.
     ///
-    /// When `reserved_peers` is empty or `reserved_capacity` is 0, no capacity is
-    /// set aside, and the entire global capacity is available to unreserved peers.
+    /// When neither `reserved_peers` nor `reserved_peer_keys` is configured or
+    /// `reserved_capacity` is 0, no capacity is set aside, and the entire global
+    /// capacity is available to unreserved peers.
     pub fn effective_unreserved_capacity(&self) -> usize {
-        if self.reserved_peers.is_empty() || self.reserved_capacity == 0 {
+        if (self.reserved_peers.is_empty() && self.reserved_peer_keys.is_empty())
+            || self.reserved_capacity == 0
+        {
             self.max_subscriptions_global
         } else {
             self.max_subscriptions_global
@@ -219,6 +232,12 @@ impl CovPeerKey {
             Self::Direct(mac) => mac,
             Self::Routed(_, mac) => mac,
         }
+    }
+}
+
+impl From<MacAddr> for CovPeerKey {
+    fn from(mac: MacAddr) -> Self {
+        Self::Direct(mac)
     }
 }
 

--- a/crates/bacnet-server/src/cov/policy.rs
+++ b/crates/bacnet-server/src/cov/policy.rs
@@ -79,6 +79,19 @@ impl CovPolicy {
     pub fn is_peer_reserved(&self, peer: &CovPeerKey) -> bool {
         self.reserved_peers.contains(peer.mac())
     }
+
+    /// Return the effective unreserved capacity available to unreserved peers.
+    ///
+    /// When `reserved_peers` is empty or `reserved_capacity` is 0, no capacity is
+    /// set aside, and the entire global capacity is available to unreserved peers.
+    pub fn effective_unreserved_capacity(&self) -> usize {
+        if self.reserved_peers.is_empty() || self.reserved_capacity == 0 {
+            self.max_subscriptions_global
+        } else {
+            self.max_subscriptions_global
+                .saturating_sub(self.reserved_capacity)
+        }
+    }
 }
 
 /// Telemetry counters for COV operations.
@@ -231,6 +244,14 @@ pub struct CovInFlightGuard {
     _global_permit: OwnedSemaphorePermit,
 }
 
+impl std::fmt::Debug for CovInFlightGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CovInFlightGuard")
+            .field("peer", &self.peer)
+            .finish()
+    }
+}
+
 impl Drop for CovInFlightGuard {
     fn drop(&mut self) {
         self.tracker.release(&self.peer);
@@ -246,20 +267,25 @@ impl CovInFlightTracker {
         global_semaphore: &Arc<Semaphore>,
     ) -> Result<CovInFlightGuard, InFlightAcquireError> {
         let mut guard = self.peer_in_flight.lock().unwrap();
-        let current = guard.entry(peer.clone()).or_insert(0);
-        if *current >= max_per_peer {
+        let current = guard.get(&peer).copied().unwrap_or(0);
+        if current >= max_per_peer {
             return Err(InFlightAcquireError::PeerLimitExceeded);
         }
         let global_permit = match global_semaphore.clone().try_acquire_owned() {
             Ok(permit) => permit,
             Err(_) => return Err(InFlightAcquireError::GlobalPoolExhausted),
         };
-        *current += 1;
+        guard.insert(peer.clone(), current + 1);
         Ok(CovInFlightGuard {
             peer,
             tracker: Arc::clone(self),
             _global_permit: global_permit,
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn active_peer_count(&self) -> usize {
+        self.peer_in_flight.lock().unwrap().len()
     }
 
     fn release(&self, peer: &CovPeerKey) {

--- a/crates/bacnet-server/src/cov/policy.rs
+++ b/crates/bacnet-server/src/cov/policy.rs
@@ -1,0 +1,274 @@
+//! COV policies, rate accounting keys, and telemetry counters.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use bacnet_encoding::npdu::NpduAddress;
+use bacnet_types::MacAddr;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// Configuration policy for COV subscriptions and notification work budgets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CovPolicy {
+    /// Global maximum number of active COV subscriptions across all peers.
+    pub max_subscriptions_global: usize,
+    /// Maximum number of active COV subscriptions allowed for a single peer.
+    pub max_subscriptions_per_peer: usize,
+    /// Number of subscription slots reserved for reserved peers.
+    pub reserved_capacity: usize,
+    /// List of MAC addresses of peers permitted to use reserved subscription capacity.
+    pub reserved_peers: Vec<MacAddr>,
+    /// Whether indefinite (infinite lifetime) subscriptions are permitted.
+    pub allow_indefinite_subscriptions: bool,
+    /// Maximum number of indefinite subscriptions allowed for a single peer.
+    pub max_indefinite_per_peer: usize,
+    /// Maximum notifications emitted per single COV event (fanout budget).
+    pub max_notifications_per_event: usize,
+    /// Maximum bytes across all notifications emitted per single COV event.
+    pub max_notification_bytes_per_event: usize,
+    /// Maximum in-flight confirmed COV notifications per peer.
+    pub max_confirmed_in_flight_per_peer: usize,
+}
+
+impl Default for CovPolicy {
+    fn default() -> Self {
+        Self {
+            max_subscriptions_global: 1024,
+            max_subscriptions_per_peer: 64,
+            reserved_capacity: 64,
+            reserved_peers: Vec::new(),
+            allow_indefinite_subscriptions: true,
+            max_indefinite_per_peer: 16,
+            max_notifications_per_event: 64,
+            max_notification_bytes_per_event: 65_536,
+            max_confirmed_in_flight_per_peer: 16,
+        }
+    }
+}
+
+impl CovPolicy {
+    /// Return an unlimited policy with maximum quotas and no restrictions.
+    pub fn unlimited() -> Self {
+        Self {
+            max_subscriptions_global: usize::MAX,
+            max_subscriptions_per_peer: usize::MAX,
+            reserved_capacity: 0,
+            reserved_peers: Vec::new(),
+            allow_indefinite_subscriptions: true,
+            max_indefinite_per_peer: usize::MAX,
+            max_notifications_per_event: usize::MAX,
+            max_notification_bytes_per_event: usize::MAX,
+            max_confirmed_in_flight_per_peer: usize::MAX,
+        }
+    }
+
+    /// Return a sanitized copy with valid bounds.
+    pub fn sanitized(&self) -> Self {
+        let mut policy = self.clone();
+        policy.reserved_capacity = policy
+            .reserved_capacity
+            .min(policy.max_subscriptions_global);
+        policy.max_indefinite_per_peer = policy
+            .max_indefinite_per_peer
+            .min(policy.max_subscriptions_per_peer);
+        policy
+    }
+
+    /// Check if a peer is in the reserved peers list.
+    pub fn is_peer_reserved(&self, peer: &CovPeerKey) -> bool {
+        self.reserved_peers.contains(peer.mac())
+    }
+}
+
+/// Telemetry counters for COV operations.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct CovCounters {
+    /// Number of currently active subscriptions.
+    pub subscriptions_active: u64,
+    /// Total number of subscriptions created.
+    pub subscriptions_created: u64,
+    /// Total number of subscriptions rejected due to per-peer quota.
+    pub subscriptions_rejected_quota: u64,
+    /// Total number of subscriptions rejected due to global or reserved capacity.
+    pub subscriptions_rejected_capacity: u64,
+    /// Total number of subscriptions rejected due to indefinite policy or quota.
+    pub subscriptions_rejected_indefinite: u64,
+    /// Total number of subscriptions explicitly cancelled.
+    pub subscriptions_cancelled: u64,
+    /// Total number of expired subscriptions purged.
+    pub subscriptions_purged: u64,
+    /// Total number of COV notifications sent (confirmed + unconfirmed).
+    pub notifications_sent: u64,
+    /// Total number of confirmed COV notifications sent.
+    pub notifications_confirmed: u64,
+    /// Total number of unconfirmed COV notifications sent.
+    pub notifications_unconfirmed: u64,
+    /// Total number of notification payload bytes sent.
+    pub notification_bytes_sent: u64,
+    /// Total number of notifications throttled due to per-event fanout or byte budget.
+    pub notifications_throttled_fanout: u64,
+    /// Total number of notifications throttled due to peer in-flight confirmed limit.
+    pub notifications_throttled_peer: u64,
+}
+
+/// Atomic storage for COV telemetry counters.
+#[derive(Debug, Default)]
+pub struct AtomicCovCounters {
+    /// Number of currently active subscriptions.
+    pub subscriptions_active: AtomicU64,
+    /// Total number of subscriptions created.
+    pub subscriptions_created: AtomicU64,
+    /// Total number of subscriptions rejected due to per-peer quota.
+    pub subscriptions_rejected_quota: AtomicU64,
+    /// Total number of subscriptions rejected due to global or reserved capacity.
+    pub subscriptions_rejected_capacity: AtomicU64,
+    /// Total number of subscriptions rejected due to indefinite policy or quota.
+    pub subscriptions_rejected_indefinite: AtomicU64,
+    /// Total number of subscriptions explicitly cancelled.
+    pub subscriptions_cancelled: AtomicU64,
+    /// Total number of expired subscriptions purged.
+    pub subscriptions_purged: AtomicU64,
+    /// Total number of COV notifications sent (confirmed + unconfirmed).
+    pub notifications_sent: AtomicU64,
+    /// Total number of confirmed COV notifications sent.
+    pub notifications_confirmed: AtomicU64,
+    /// Total number of unconfirmed COV notifications sent.
+    pub notifications_unconfirmed: AtomicU64,
+    /// Total number of notification payload bytes sent.
+    pub notification_bytes_sent: AtomicU64,
+    /// Total number of notifications throttled due to per-event fanout or byte budget.
+    pub notifications_throttled_fanout: AtomicU64,
+    /// Total number of notifications throttled due to peer in-flight confirmed limit.
+    pub notifications_throttled_peer: AtomicU64,
+}
+
+impl AtomicCovCounters {
+    /// Return an instantaneous snapshot of all counters.
+    pub fn snapshot(&self) -> CovCounters {
+        CovCounters {
+            subscriptions_active: self.subscriptions_active.load(Ordering::Relaxed),
+            subscriptions_created: self.subscriptions_created.load(Ordering::Relaxed),
+            subscriptions_rejected_quota: self.subscriptions_rejected_quota.load(Ordering::Relaxed),
+            subscriptions_rejected_capacity: self
+                .subscriptions_rejected_capacity
+                .load(Ordering::Relaxed),
+            subscriptions_rejected_indefinite: self
+                .subscriptions_rejected_indefinite
+                .load(Ordering::Relaxed),
+            subscriptions_cancelled: self.subscriptions_cancelled.load(Ordering::Relaxed),
+            subscriptions_purged: self.subscriptions_purged.load(Ordering::Relaxed),
+            notifications_sent: self.notifications_sent.load(Ordering::Relaxed),
+            notifications_confirmed: self.notifications_confirmed.load(Ordering::Relaxed),
+            notifications_unconfirmed: self.notifications_unconfirmed.load(Ordering::Relaxed),
+            notification_bytes_sent: self.notification_bytes_sent.load(Ordering::Relaxed),
+            notifications_throttled_fanout: self
+                .notifications_throttled_fanout
+                .load(Ordering::Relaxed),
+            notifications_throttled_peer: self.notifications_throttled_peer.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// Canonical representation of peer identity for COV quota and rate accounting.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CovPeerKey {
+    /// Directly connected peer identified by its local MAC address.
+    Direct(MacAddr),
+    /// Routed peer identified by its network number and remote MAC address.
+    Routed(u16, MacAddr),
+}
+
+impl CovPeerKey {
+    /// Create a direct peer key.
+    pub fn direct(mac: MacAddr) -> Self {
+        Self::Direct(mac)
+    }
+
+    /// Create a routed peer key.
+    pub fn routed(network: u16, mac: MacAddr) -> Self {
+        Self::Routed(network, mac)
+    }
+
+    /// Derive canonical peer key from local MAC and optional routed network address.
+    pub fn from_endpoint(mac: &MacAddr, network: Option<&NpduAddress>) -> Self {
+        match network {
+            Some(dest) if !dest.mac_address.is_empty() => {
+                Self::Routed(dest.network, MacAddr::from_slice(&dest.mac_address))
+            }
+            _ => Self::Direct(mac.clone()),
+        }
+    }
+
+    /// Get a reference to the underlying MAC address.
+    pub fn mac(&self) -> &MacAddr {
+        match self {
+            Self::Direct(mac) => mac,
+            Self::Routed(_, mac) => mac,
+        }
+    }
+}
+
+/// Error returned when acquiring an in-flight confirmed notification slot fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InFlightAcquireError {
+    /// In-flight limit for this peer was exceeded.
+    PeerLimitExceeded,
+    /// Global pool of confirmed notification permits was exhausted.
+    GlobalPoolExhausted,
+}
+
+/// Tracker for concurrent in-flight confirmed notifications per peer.
+#[derive(Debug, Default)]
+pub struct CovInFlightTracker {
+    peer_in_flight: Mutex<HashMap<CovPeerKey, usize>>,
+}
+
+/// RAII permit for an in-flight confirmed notification holding both a peer slot and a global permit.
+pub struct CovInFlightGuard {
+    peer: CovPeerKey,
+    tracker: Arc<CovInFlightTracker>,
+    _global_permit: OwnedSemaphorePermit,
+}
+
+impl Drop for CovInFlightGuard {
+    fn drop(&mut self) {
+        self.tracker.release(&self.peer);
+    }
+}
+
+impl CovInFlightTracker {
+    /// Attempt to acquire an in-flight confirmed notification slot.
+    pub fn try_acquire(
+        self: &Arc<Self>,
+        peer: CovPeerKey,
+        max_per_peer: usize,
+        global_semaphore: &Arc<Semaphore>,
+    ) -> Result<CovInFlightGuard, InFlightAcquireError> {
+        let mut guard = self.peer_in_flight.lock().unwrap();
+        let current = guard.entry(peer.clone()).or_insert(0);
+        if *current >= max_per_peer {
+            return Err(InFlightAcquireError::PeerLimitExceeded);
+        }
+        let global_permit = match global_semaphore.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => return Err(InFlightAcquireError::GlobalPoolExhausted),
+        };
+        *current += 1;
+        Ok(CovInFlightGuard {
+            peer,
+            tracker: Arc::clone(self),
+            _global_permit: global_permit,
+        })
+    }
+
+    fn release(&self, peer: &CovPeerKey) {
+        let mut guard = self.peer_in_flight.lock().unwrap();
+        if let Some(count) = guard.get_mut(peer) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                guard.remove(peer);
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/cov/tests.rs
+++ b/crates/bacnet-server/src/cov/tests.rs
@@ -245,3 +245,91 @@ fn purge_expired_returns_zero_when_none_expired() {
     assert_eq!(purged, 0);
     assert_eq!(table.len(), 1);
 }
+
+#[test]
+fn default_policy_allows_1024th_subscription() {
+    let mut table = CovSubscriptionTable::new();
+    let oid = ai1();
+    // 16 peers * 64 subscriptions each = 1024 subscriptions
+    for peer_idx in 0..16u8 {
+        let mac = [192, 168, 1, peer_idx];
+        let peer_key = CovPeerKey::direct(MacAddr::from_slice(&mac));
+        for proc_id in 0..64u32 {
+            table
+                .check_admission(&peer_key, false, None)
+                .expect("subscription admitted");
+            let mut sub = make_sub(&mac, proc_id, oid);
+            sub.expires_at = Some(Instant::now() + Duration::from_secs(300));
+            table.subscribe(sub);
+        }
+    }
+    assert_eq!(table.len(), 1024);
+
+    // 1025th subscription from a 17th peer fails due to global capacity
+    let mac17 = [192, 168, 1, 17];
+    let peer17 = CovPeerKey::direct(MacAddr::from_slice(&mac17));
+    assert!(table.check_admission(&peer17, false, None).is_err());
+}
+
+#[test]
+fn effective_unreserved_capacity_respects_reserved_peers() {
+    let mut policy = CovPolicy {
+        max_subscriptions_global: 100,
+        reserved_capacity: 20,
+        reserved_peers: Vec::new(),
+        ..Default::default()
+    };
+    // No reserved peers -> full global capacity available
+    assert_eq!(policy.effective_unreserved_capacity(), 100);
+
+    // With reserved peers -> reserved capacity is deducted
+    policy.reserved_peers.push(MacAddr::from_slice(&[1, 2, 3]));
+    assert_eq!(policy.effective_unreserved_capacity(), 80);
+
+    // If reserved_capacity is 0 -> full global capacity
+    policy.reserved_capacity = 0;
+    assert_eq!(policy.effective_unreserved_capacity(), 100);
+}
+
+#[test]
+fn in_flight_tracker_does_not_leak_zero_count_entries_on_failure() {
+    let tracker = Arc::new(CovInFlightTracker::default());
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+    let peer = CovPeerKey::direct(MacAddr::from_slice(&[1, 2, 3, 4]));
+
+    // Acquisition fails due to global pool exhausted
+    let err = tracker
+        .try_acquire(peer.clone(), 10, &semaphore)
+        .unwrap_err();
+    assert_eq!(err, InFlightAcquireError::GlobalPoolExhausted);
+    assert_eq!(tracker.active_peer_count(), 0);
+
+    // Acquisition fails due to peer limit exceeded (max_per_peer = 0)
+    let semaphore2 = Arc::new(tokio::sync::Semaphore::new(10));
+    let peer2 = CovPeerKey::direct(MacAddr::from_slice(&[5, 6, 7, 8]));
+    let err2 = tracker.try_acquire(peer2, 0, &semaphore2).unwrap_err();
+    assert_eq!(err2, InFlightAcquireError::PeerLimitExceeded);
+    assert_eq!(tracker.active_peer_count(), 0);
+}
+
+#[test]
+fn expired_subscriptions_immediately_release_quota_on_admission() {
+    let policy = CovPolicy {
+        max_subscriptions_per_peer: 1,
+        ..Default::default()
+    };
+    let mut table =
+        CovSubscriptionTable::with_policy(policy, Arc::new(AtomicCovCounters::default()));
+    let peer = CovPeerKey::direct(MacAddr::from_slice(&[1, 2, 3]));
+
+    // Create a subscription with an expiry in the past
+    let mut sub = make_sub(&[1, 2, 3], 1, ai1());
+    sub.expires_at = Some(Instant::now() - Duration::from_secs(5));
+    table.subscribe(sub);
+    assert_eq!(table.len(), 1);
+
+    // Admitting a new subscription from the same peer immediately purges the expired subscription
+    // and succeeds, rather than being rejected by per-peer quota!
+    assert!(table.check_admission(&peer, false, None).is_ok());
+    assert_eq!(table.len(), 0);
+}

--- a/crates/bacnet-server/src/cov/tests.rs
+++ b/crates/bacnet-server/src/cov/tests.rs
@@ -1,0 +1,247 @@
+use super::*;
+use bacnet_types::enums::ObjectType;
+use std::time::Duration;
+
+fn ai1() -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap()
+}
+
+fn ai2() -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 2).unwrap()
+}
+
+fn make_sub(mac: &[u8], process_id: u32, oid: ObjectIdentifier) -> CovSubscription {
+    CovSubscription {
+        subscriber_mac: MacAddr::from_slice(mac),
+        subscriber_network: None,
+        subscriber_process_identifier: process_id,
+        monitored_object_identifier: oid,
+        issue_confirmed_notifications: false,
+        expires_at: None,
+        last_notified_value: None,
+        monitored_property: None,
+        monitored_property_array_index: None,
+        cov_increment: None,
+        notification_kind: CovNotificationKind::Single,
+        timestamped: false,
+    }
+}
+
+#[test]
+fn subscribe_and_lookup() {
+    let mut table = CovSubscriptionTable::new();
+    table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
+    assert_eq!(table.len(), 1);
+    assert_eq!(table.subscriptions_for(&ai1()).len(), 1);
+    assert_eq!(table.subscriptions_for(&ai2()).len(), 0);
+}
+
+#[test]
+fn unsubscribe() {
+    let mut table = CovSubscriptionTable::new();
+    table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
+    assert!(table.unsubscribe(&[1, 2, 3], 1, ai1()));
+    assert!(!table.unsubscribe(&[1, 2, 3], 1, ai1())); // already removed
+    assert!(table.is_empty());
+}
+
+#[test]
+fn expired_subscriptions_purged_on_lookup() {
+    let mut table = CovSubscriptionTable::new();
+    let mut sub = make_sub(&[1, 2, 3], 1, ai1());
+    sub.expires_at = Some(Instant::now() - Duration::from_secs(1)); // already expired
+    table.subscribe(sub);
+    assert_eq!(table.subscriptions_for(&ai1()).len(), 0);
+    assert!(table.is_empty());
+}
+
+#[test]
+fn multiple_subscribers_same_object() {
+    let mut table = CovSubscriptionTable::new();
+    table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
+    table.subscribe(make_sub(&[4, 5, 6], 2, ai1()));
+    assert_eq!(table.subscriptions_for(&ai1()).len(), 2);
+}
+
+#[test]
+fn should_notify_no_increment_always_fires() {
+    let sub = make_sub(&[1, 2, 3], 1, ai1());
+    // Binary/multi-state objects have no COV_Increment
+    assert!(CovSubscriptionTable::should_notify(&sub, Some(1.0), None));
+}
+
+#[test]
+fn should_notify_first_notification_always_fires() {
+    let sub = make_sub(&[1, 2, 3], 1, ai1());
+    // First notification (last_notified_value = None)
+    assert!(CovSubscriptionTable::should_notify(
+        &sub,
+        Some(72.5),
+        Some(1.0)
+    ));
+}
+
+#[test]
+fn should_notify_change_exceeds_increment() {
+    let mut sub = make_sub(&[1, 2, 3], 1, ai1());
+    sub.last_notified_value = Some(70.0);
+    // Change of 2.5 >= increment of 1.0
+    assert!(CovSubscriptionTable::should_notify(
+        &sub,
+        Some(72.5),
+        Some(1.0)
+    ));
+}
+
+#[test]
+fn should_notify_change_below_increment() {
+    let mut sub = make_sub(&[1, 2, 3], 1, ai1());
+    sub.last_notified_value = Some(72.0);
+    // Change of 0.3 < increment of 1.0
+    assert!(!CovSubscriptionTable::should_notify(
+        &sub,
+        Some(72.3),
+        Some(1.0)
+    ));
+}
+
+#[test]
+fn should_notify_exact_increment() {
+    let mut sub = make_sub(&[1, 2, 3], 1, ai1());
+    sub.last_notified_value = Some(70.0);
+    // Change of exactly 1.0 == increment of 1.0 → fires
+    assert!(CovSubscriptionTable::should_notify(
+        &sub,
+        Some(71.0),
+        Some(1.0)
+    ));
+}
+
+#[test]
+fn should_notify_zero_increment_always_fires() {
+    let mut sub = make_sub(&[1, 2, 3], 1, ai1());
+    sub.last_notified_value = Some(72.0);
+    // COV_Increment = 0.0 means any change fires
+    assert!(CovSubscriptionTable::should_notify(
+        &sub,
+        Some(72.001),
+        Some(0.0)
+    ));
+}
+
+#[test]
+fn set_last_notified_value_updates() {
+    let mut table = CovSubscriptionTable::new();
+    table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
+    table.set_last_notified_value(&[1, 2, 3], None, 1, ai1(), None, 72.5);
+
+    let subs = table.subscriptions_for(&ai1());
+    assert_eq!(subs[0].last_notified_value, Some(72.5));
+}
+
+#[test]
+fn upsert_replaces_existing() {
+    let mut table = CovSubscriptionTable::new();
+    let mut sub = make_sub(&[1, 2, 3], 1, ai1());
+    sub.issue_confirmed_notifications = false;
+    table.subscribe(sub);
+    // Same (mac, process_id, object) key — replaces the existing entry
+    let mut sub2 = make_sub(&[1, 2, 3], 1, ai1());
+    sub2.issue_confirmed_notifications = true;
+    table.subscribe(sub2);
+    assert_eq!(table.len(), 1);
+    let subs = table.subscriptions_for(&ai1());
+    assert!(subs[0].issue_confirmed_notifications);
+}
+
+#[test]
+fn same_subscriber_different_objects_both_exist() {
+    let mut table = CovSubscriptionTable::new();
+    // Same (mac, process_id) but different monitored objects
+    table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
+    table.subscribe(make_sub(&[1, 2, 3], 1, ai2()));
+    assert_eq!(table.len(), 2);
+    assert_eq!(table.subscriptions_for(&ai1()).len(), 1);
+    assert_eq!(table.subscriptions_for(&ai2()).len(), 1);
+}
+
+#[test]
+fn purge_expired_removes_stale_subscriptions() {
+    let mut table = CovSubscriptionTable::new();
+    let mut sub1 = make_sub(&[1, 2, 3], 1, ai1());
+    sub1.expires_at = Some(Instant::now() - Duration::from_secs(10));
+    table.subscribe(sub1);
+
+    let mut sub2 = make_sub(&[4, 5, 6], 2, ai1());
+    sub2.expires_at = None; // infinite lifetime
+    table.subscribe(sub2);
+
+    let purged = table.purge_expired();
+    assert_eq!(purged, 1);
+    assert_eq!(table.len(), 1);
+}
+
+#[test]
+fn cov_multiple_context_lifetime_refreshes_and_expires() {
+    let mut table = CovSubscriptionTable::new();
+    let original_expiry = Instant::now() + Duration::from_secs(30);
+    let refreshed_expiry = Instant::now() + Duration::from_secs(60);
+
+    let mut present_value = make_sub(&[1, 2, 3], 1, ai1());
+    present_value.notification_kind = CovNotificationKind::Multiple;
+    present_value.monitored_property = Some(PropertyIdentifier::PRESENT_VALUE);
+    present_value.expires_at = Some(original_expiry);
+    table.subscribe(present_value);
+
+    let mut status_flags = make_sub(&[1, 2, 3], 1, ai1());
+    status_flags.notification_kind = CovNotificationKind::Multiple;
+    status_flags.monitored_property = Some(PropertyIdentifier::STATUS_FLAGS);
+    status_flags.expires_at = Some(original_expiry);
+    table.subscribe(status_flags);
+
+    let mut single = make_sub(&[1, 2, 3], 1, ai1());
+    single.expires_at = Some(original_expiry);
+    table.subscribe(single);
+
+    table.refresh_cov_multiple_context_lifetime(&[1, 2, 3], None, 1, false, Some(refreshed_expiry));
+
+    let multiple_expiries: Vec<_> = table
+        .subs
+        .values()
+        .filter(|sub| sub.notification_kind == CovNotificationKind::Multiple)
+        .map(|sub| sub.expires_at)
+        .collect();
+    assert_eq!(
+        multiple_expiries,
+        vec![Some(refreshed_expiry), Some(refreshed_expiry)]
+    );
+    assert!(table
+        .subs
+        .values()
+        .any(|sub| sub.notification_kind == CovNotificationKind::Single
+            && sub.expires_at == Some(original_expiry)));
+
+    table.refresh_cov_multiple_context_lifetime(
+        &[1, 2, 3],
+        None,
+        1,
+        false,
+        Some(Instant::now() - Duration::from_secs(1)),
+    );
+
+    assert_eq!(table.purge_expired(), 2);
+    assert_eq!(table.len(), 1);
+    assert!(table.subs.values().all(|sub| {
+        sub.notification_kind == CovNotificationKind::Single
+            && sub.expires_at == Some(original_expiry)
+    }));
+}
+
+#[test]
+fn purge_expired_returns_zero_when_none_expired() {
+    let mut table = CovSubscriptionTable::new();
+    table.subscribe(make_sub(&[1, 2, 3], 1, ai1()));
+    let purged = table.purge_expired();
+    assert_eq!(purged, 0);
+    assert_eq!(table.len(), 1);
+}

--- a/crates/bacnet-server/src/cov/tests.rs
+++ b/crates/bacnet-server/src/cov/tests.rs
@@ -333,3 +333,27 @@ fn expired_subscriptions_immediately_release_quota_on_admission() {
     assert!(table.check_admission(&peer, false, None).is_ok());
     assert_eq!(table.len(), 0);
 }
+
+#[test]
+fn is_peer_reserved_checks_canonical_peer_identity() {
+    let direct_mac = MacAddr::from_slice(&[1, 2, 3]);
+    let policy = CovPolicy {
+        reserved_peers: vec![direct_mac.clone()],
+        reserved_peer_keys: vec![CovPeerKey::routed(10, direct_mac.clone())],
+        ..Default::default()
+    };
+
+    // Direct peer matching reserved_peers is reserved
+    assert!(policy.is_peer_reserved(&CovPeerKey::direct(direct_mac.clone())));
+
+    // Routed peer on network 10 matching reserved_peer_keys is reserved
+    assert!(policy.is_peer_reserved(&CovPeerKey::routed(10, direct_mac.clone())));
+
+    // Routed peer on different network (20) with same MAC is NOT reserved
+    assert!(!policy.is_peer_reserved(&CovPeerKey::routed(20, direct_mac.clone())));
+
+    // Unconfigured direct peer is NOT reserved
+    let other_mac = MacAddr::from_slice(&[4, 5, 6]);
+    assert!(!policy.is_peer_reserved(&CovPeerKey::direct(other_mac.clone())));
+    assert!(!policy.is_peer_reserved(&CovPeerKey::routed(10, other_mac)));
+}

--- a/crates/bacnet-server/src/handlers/cov.rs
+++ b/crates/bacnet-server/src/handlers/cov.rs
@@ -353,6 +353,7 @@ pub(crate) fn handle_subscribe_cov_property_multiple_request_endpoint(
     }
     let expires_at = Some(Instant::now() + Duration::from_secs(lifetime as u64));
     let subscriber_mac = MacAddr::from_slice(source_mac);
+    table.purge_expired();
     let mut subscriptions = Vec::new();
     let mut new_keys = HashSet::new();
 
@@ -424,8 +425,6 @@ pub(crate) fn handle_subscribe_cov_property_multiple_request_endpoint(
         ))
     });
     subscriptions.reverse();
-
-    table.purge_expired();
 
     let peer_key = CovPeerKey::from_endpoint(&subscriber_mac, source_network);
     table.check_admission_multiple(&peer_key, new_keys.len(), 0)?;

--- a/crates/bacnet-server/src/handlers/cov.rs
+++ b/crates/bacnet-server/src/handlers/cov.rs
@@ -1,7 +1,5 @@
 use super::*;
 
-const MAX_COV_SUBSCRIPTIONS: usize = 1024;
-
 fn cov_property_error(code: ErrorCode) -> Error {
     Error::Protocol {
         class: ErrorClass::PROPERTY.to_raw() as u32,
@@ -87,21 +85,6 @@ pub(crate) fn handle_subscribe_cov_with_initial_endpoint(
         _ => {}
     }
 
-    if table.len() >= MAX_COV_SUBSCRIPTIONS
-        && !table.contains(
-            &MacAddr::from_slice(source_mac),
-            source_network,
-            request.subscriber_process_identifier,
-            request.monitored_object_identifier,
-            None,
-        )
-    {
-        return Err(Error::Protocol {
-            class: ErrorClass::RESOURCES.to_raw() as u32,
-            code: ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32,
-        });
-    }
-
     let expires_at = request.lifetime.and_then(|secs| {
         if secs == 0 {
             None
@@ -109,6 +92,17 @@ pub(crate) fn handle_subscribe_cov_with_initial_endpoint(
             Some(Instant::now() + Duration::from_secs(secs as u64))
         }
     });
+
+    let existing = table.get_subscription(
+        &MacAddr::from_slice(source_mac),
+        source_network,
+        request.subscriber_process_identifier,
+        request.monitored_object_identifier,
+        None,
+    );
+    let peer_key = CovPeerKey::from_endpoint(&MacAddr::from_slice(source_mac), source_network);
+    let is_indefinite = expires_at.is_none();
+    table.check_admission(&peer_key, is_indefinite, existing)?;
 
     let subscription = CovSubscription {
         subscriber_mac: MacAddr::from_slice(source_mac),
@@ -192,21 +186,6 @@ pub(crate) fn handle_subscribe_cov_property_with_initial_endpoint(
         request.monitored_property_array_index,
     )?;
 
-    if table.len() >= MAX_COV_SUBSCRIPTIONS
-        && !table.contains(
-            &MacAddr::from_slice(source_mac),
-            source_network,
-            request.subscriber_process_identifier,
-            request.monitored_object_identifier,
-            Some(request.monitored_property_identifier),
-        )
-    {
-        return Err(Error::Protocol {
-            class: ErrorClass::RESOURCES.to_raw() as u32,
-            code: ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32,
-        });
-    }
-
     let expires_at = request.lifetime.and_then(|secs| {
         if secs == 0 {
             None
@@ -214,6 +193,17 @@ pub(crate) fn handle_subscribe_cov_property_with_initial_endpoint(
             Some(Instant::now() + Duration::from_secs(secs as u64))
         }
     });
+
+    let existing = table.get_subscription(
+        &MacAddr::from_slice(source_mac),
+        source_network,
+        request.subscriber_process_identifier,
+        request.monitored_object_identifier,
+        Some(request.monitored_property_identifier),
+    );
+    let peer_key = CovPeerKey::from_endpoint(&MacAddr::from_slice(source_mac), source_network);
+    let is_indefinite = expires_at.is_none();
+    table.check_admission(&peer_key, is_indefinite, existing)?;
 
     let subscription = CovSubscription {
         subscriber_mac: MacAddr::from_slice(source_mac),
@@ -427,12 +417,8 @@ pub(crate) fn handle_subscribe_cov_property_multiple_request_endpoint(
     });
     subscriptions.reverse();
 
-    if table.len() + new_keys.len() > MAX_COV_SUBSCRIPTIONS {
-        return Err(Error::Protocol {
-            class: ErrorClass::RESOURCES.to_raw() as u32,
-            code: ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32,
-        });
-    }
+    let peer_key = CovPeerKey::from_endpoint(&subscriber_mac, source_network);
+    table.check_admission_multiple(&peer_key, new_keys.len(), 0)?;
 
     table.refresh_cov_multiple_context_lifetime(
         source_mac,

--- a/crates/bacnet-server/src/handlers/cov.rs
+++ b/crates/bacnet-server/src/handlers/cov.rs
@@ -93,16 +93,20 @@ pub(crate) fn handle_subscribe_cov_with_initial_endpoint(
         }
     });
 
-    let existing = table.get_subscription(
-        &MacAddr::from_slice(source_mac),
-        source_network,
-        request.subscriber_process_identifier,
-        request.monitored_object_identifier,
-        None,
-    );
+    table.purge_expired();
+
+    let existing = table
+        .get_subscription(
+            &MacAddr::from_slice(source_mac),
+            source_network,
+            request.subscriber_process_identifier,
+            request.monitored_object_identifier,
+            None,
+        )
+        .cloned();
     let peer_key = CovPeerKey::from_endpoint(&MacAddr::from_slice(source_mac), source_network);
     let is_indefinite = expires_at.is_none();
-    table.check_admission(&peer_key, is_indefinite, existing)?;
+    table.check_admission(&peer_key, is_indefinite, existing.as_ref())?;
 
     let subscription = CovSubscription {
         subscriber_mac: MacAddr::from_slice(source_mac),
@@ -194,16 +198,20 @@ pub(crate) fn handle_subscribe_cov_property_with_initial_endpoint(
         }
     });
 
-    let existing = table.get_subscription(
-        &MacAddr::from_slice(source_mac),
-        source_network,
-        request.subscriber_process_identifier,
-        request.monitored_object_identifier,
-        Some(request.monitored_property_identifier),
-    );
+    table.purge_expired();
+
+    let existing = table
+        .get_subscription(
+            &MacAddr::from_slice(source_mac),
+            source_network,
+            request.subscriber_process_identifier,
+            request.monitored_object_identifier,
+            Some(request.monitored_property_identifier),
+        )
+        .cloned();
     let peer_key = CovPeerKey::from_endpoint(&MacAddr::from_slice(source_mac), source_network);
     let is_indefinite = expires_at.is_none();
-    table.check_admission(&peer_key, is_indefinite, existing)?;
+    table.check_admission(&peer_key, is_indefinite, existing.as_ref())?;
 
     let subscription = CovSubscription {
         subscriber_mac: MacAddr::from_slice(source_mac),
@@ -416,6 +424,8 @@ pub(crate) fn handle_subscribe_cov_property_multiple_request_endpoint(
         ))
     });
     subscriptions.reverse();
+
+    table.purge_expired();
 
     let peer_key = CovPeerKey::from_endpoint(&subscriber_mac, source_network);
     table.check_admission_multiple(&peer_key, new_keys.len(), 0)?;

--- a/crates/bacnet-server/src/handlers/mod.rs
+++ b/crates/bacnet-server/src/handlers/mod.rs
@@ -34,7 +34,7 @@ use bacnet_types::MacAddr;
 
 use bytes::BytesMut;
 
-use crate::cov::{CovNotificationKind, CovSubscription, CovSubscriptionTable};
+use crate::cov::{CovNotificationKind, CovPeerKey, CovSubscription, CovSubscriptionTable};
 
 mod alarm_event;
 mod audit_log_query;

--- a/crates/bacnet-server/src/handlers/tests/write_cov_who.rs
+++ b/crates/bacnet-server/src/handlers/tests/write_cov_who.rs
@@ -92,9 +92,16 @@ fn subscribe_cov_property_handler_returns_initial_subscription() {
 
 #[test]
 fn subscribe_cov_update_existing_entry_allowed_at_capacity() {
+    use crate::cov::{AtomicCovCounters, CovPolicy};
     let db = make_db_with_ai();
-    let mut table = CovSubscriptionTable::new();
     let mac = vec![192, 168, 1, 1, 0xBA, 0xC0];
+    let mut table = CovSubscriptionTable::with_policy(
+        CovPolicy {
+            reserved_peers: vec![MacAddr::from_slice(&mac)],
+            ..Default::default()
+        },
+        std::sync::Arc::new(AtomicCovCounters::default()),
+    );
     let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
 
     for instance in 0..1023 {

--- a/crates/bacnet-server/src/server/cov_budget_tests.rs
+++ b/crates/bacnet-server/src/server/cov_budget_tests.rs
@@ -1,0 +1,301 @@
+use super::*;
+use crate::cov::AtomicCovCounters;
+use bacnet_encoding::apdu::decode_apdu;
+use bacnet_encoding::npdu::decode_npdu;
+use bacnet_objects::analog::AnalogOutputObject;
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_types::enums::ObjectType;
+use bytes::Bytes;
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
+use tokio::sync::mpsc;
+
+#[derive(Clone, Default)]
+struct RecordingTransport {
+    sent_unicast: StdArc<StdMutex<Vec<(Bytes, MacAddr)>>>,
+    local_mac: Vec<u8>,
+}
+
+impl RecordingTransport {
+    fn new(sent_unicast: StdArc<StdMutex<Vec<(Bytes, MacAddr)>>>) -> Self {
+        Self {
+            sent_unicast,
+            local_mac: vec![127, 0, 0, 1, 0xBA, 0xC0],
+        }
+    }
+}
+
+impl TransportPort for RecordingTransport {
+    async fn start(
+        &mut self,
+    ) -> Result<mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+        let (_tx, rx) = mpsc::channel(1);
+        Ok(rx)
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
+        self.sent_unicast
+            .lock()
+            .unwrap()
+            .push((Bytes::copy_from_slice(npdu), MacAddr::from_slice(mac)));
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &self.local_mac
+    }
+}
+
+fn test_db_with_ao() -> (Arc<RwLock<ObjectDatabase>>, ObjectIdentifier) {
+    let device_oid = ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap();
+    let ao_oid = ObjectIdentifier::new(ObjectType::ANALOG_OUTPUT, 1).unwrap();
+    let mut db = ObjectDatabase::new();
+    let mut device = DeviceObject::new(DeviceConfig {
+        instance: 1234,
+        name: "COV-Test".into(),
+        ..DeviceConfig::default()
+    })
+    .unwrap();
+    device.set_object_list(vec![device_oid, ao_oid]);
+    db.add(Box::new(device)).unwrap();
+    db.add(Box::new(AnalogOutputObject::new(1, "AO-1", 62).unwrap()))
+        .unwrap();
+    (Arc::new(RwLock::new(db)), ao_oid)
+}
+
+#[tokio::test]
+async fn in_flight_failure_does_not_consume_event_budget() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let (db, ao_oid) = test_db_with_ao();
+    let policy = CovPolicy {
+        max_notifications_per_event: 2,
+        max_confirmed_in_flight_per_peer: 1,
+        ..Default::default()
+    };
+    let config = ServerConfig {
+        cov_policy: policy,
+        ..ServerConfig::default()
+    };
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::with_policy(
+        config.cov_policy.clone(),
+        Arc::new(AtomicCovCounters::default()),
+    )));
+    let cov_in_flight = Arc::new(Semaphore::new(255));
+    let transactions = NotificationTransactions::new();
+
+    let peer1_mac = MacAddr::from_slice(&[10, 0, 0, 1]);
+
+    {
+        let mut table = cov_table.write().await;
+        // Peer 1 has 3 confirmed subscriptions (max in-flight per peer is 1)
+        for i in 1..=3 {
+            table.subscribe(CovSubscription {
+                subscriber_mac: peer1_mac.clone(),
+                subscriber_network: None,
+                subscriber_process_identifier: i,
+                monitored_object_identifier: ao_oid,
+                issue_confirmed_notifications: true,
+                expires_at: None,
+                last_notified_value: None,
+                monitored_property: None,
+                monitored_property_array_index: None,
+                cov_increment: None,
+                notification_kind: CovNotificationKind::Single,
+                timestamped: false,
+            });
+        }
+    }
+
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+
+    BACnetServer::<RecordingTransport>::fire_cov_notifications(
+        &db,
+        &network,
+        &cov_table,
+        &cov_in_flight,
+        &transactions,
+        &Arc::new(AtomicU8::new(0)),
+        &config,
+        &ao_oid,
+    )
+    .await;
+
+    let counters = cov_table.read().await.counters().snapshot();
+    // 1 confirmed sent, 2 throttled due to in-flight peer limit.
+    // In-flight failures did NOT burn event budget (max 2), so fanout throttled is 0!
+    assert_eq!(counters.notifications_confirmed, 1);
+    assert_eq!(counters.notifications_throttled_peer, 2);
+    assert_eq!(counters.notifications_sent, 1);
+    assert_eq!(counters.notifications_throttled_fanout, 0);
+}
+
+#[tokio::test]
+async fn fair_distribution_between_single_and_multiple_notifications() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let (db, ao_oid) = test_db_with_ao();
+    let policy = CovPolicy {
+        max_notifications_per_event: 2,
+        ..Default::default()
+    };
+    let config = ServerConfig {
+        cov_policy: policy,
+        ..ServerConfig::default()
+    };
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::with_policy(
+        config.cov_policy.clone(),
+        Arc::new(AtomicCovCounters::default()),
+    )));
+    let cov_in_flight = Arc::new(Semaphore::new(255));
+    let transactions = NotificationTransactions::new();
+
+    {
+        let mut table = cov_table.write().await;
+        // 2 Single subscriptions
+        for i in 1..=2 {
+            table.subscribe(CovSubscription {
+                subscriber_mac: MacAddr::from_slice(&[10, 0, 0, i]),
+                subscriber_network: None,
+                subscriber_process_identifier: i as u32,
+                monitored_object_identifier: ao_oid,
+                issue_confirmed_notifications: false,
+                expires_at: None,
+                last_notified_value: None,
+                monitored_property: None,
+                monitored_property_array_index: None,
+                cov_increment: None,
+                notification_kind: CovNotificationKind::Single,
+                timestamped: false,
+            });
+        }
+        // 2 Multiple subscriptions for different peers (2 groups)
+        for i in 3..=4 {
+            table.subscribe(CovSubscription {
+                subscriber_mac: MacAddr::from_slice(&[10, 0, 0, i]),
+                subscriber_network: None,
+                subscriber_process_identifier: i as u32,
+                monitored_object_identifier: ao_oid,
+                issue_confirmed_notifications: false,
+                expires_at: None,
+                last_notified_value: None,
+                monitored_property: Some(PropertyIdentifier::PRESENT_VALUE),
+                monitored_property_array_index: None,
+                cov_increment: None,
+                notification_kind: CovNotificationKind::Multiple,
+                timestamped: false,
+            });
+        }
+    }
+
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+
+    BACnetServer::<RecordingTransport>::fire_cov_notifications(
+        &db,
+        &network,
+        &cov_table,
+        &cov_in_flight,
+        &transactions,
+        &Arc::new(AtomicU8::new(0)),
+        &config,
+        &ao_oid,
+    )
+    .await;
+
+    let sent_frames = sent.lock().unwrap();
+    assert_eq!(sent_frames.len(), 2);
+    let mut saw_single = false;
+    let mut saw_multiple = false;
+    for (frame, _) in sent_frames.iter() {
+        let npdu = decode_npdu(frame.clone()).unwrap();
+        if let Apdu::UnconfirmedRequest(req) = decode_apdu(npdu.payload).unwrap() {
+            if req.service_choice == UnconfirmedServiceChoice::UNCONFIRMED_COV_NOTIFICATION {
+                saw_single = true;
+            } else if req.service_choice
+                == UnconfirmedServiceChoice::UNCONFIRMED_COV_NOTIFICATION_MULTIPLE
+            {
+                saw_multiple = true;
+            }
+        }
+    }
+    assert!(saw_single, "single notifications must not starve multiples");
+    assert!(saw_multiple, "multiples must receive fair budget share");
+}
+
+#[tokio::test]
+async fn expired_subscription_releases_quota_on_handle_subscribe_cov() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let device_oid = ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap();
+    let ao_oid = ObjectIdentifier::new(ObjectType::ANALOG_OUTPUT, 1).unwrap();
+    let mut db = ObjectDatabase::new();
+    let mut device = DeviceObject::new(DeviceConfig {
+        instance: 1234,
+        name: "COV-Test".into(),
+        ..DeviceConfig::default()
+    })
+    .unwrap();
+    device.set_object_list(vec![device_oid, ao_oid]);
+    db.add(Box::new(device)).unwrap();
+    db.add(Box::new(AnalogOutputObject::new(1, "AO-1", 62).unwrap()))
+        .unwrap();
+
+    let policy = CovPolicy {
+        max_subscriptions_per_peer: 1,
+        ..Default::default()
+    };
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .cov_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let peer = vec![10, 0, 0, 1, 0xBA, 0xC0];
+
+    // Pre-populate 1 expired subscription for this peer
+    {
+        let mut table = server.cov_table.write().await;
+        table.subscribe(CovSubscription {
+            subscriber_mac: MacAddr::from_slice(&peer),
+            subscriber_network: None,
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ao_oid,
+            issue_confirmed_notifications: false,
+            expires_at: Some(Instant::now() - Duration::from_secs(1)),
+            last_notified_value: None,
+            monitored_property: None,
+            monitored_property_array_index: None,
+            cov_increment: None,
+            notification_kind: CovNotificationKind::Single,
+            timestamped: false,
+        });
+    }
+
+    // Now send a subscribe request for a different process ID
+    let req = bacnet_services::cov::SubscribeCOVRequest {
+        subscriber_process_identifier: 2,
+        monitored_object_identifier: ao_oid,
+        issue_confirmed_notifications: Some(false),
+        lifetime: Some(300),
+    };
+    let mut buf = bytes::BytesMut::new();
+    req.encode(&mut buf);
+    let mut table = server.cov_table.write().await;
+    let db = server.db.read().await;
+    let res = crate::handlers::handle_subscribe_cov(&mut table, &db, &peer, &buf);
+    assert!(
+        res.is_ok(),
+        "expected admission to succeed after purging expired, got {res:?}"
+    );
+    assert_eq!(table.len(), 1);
+}

--- a/crates/bacnet-server/src/server/cov_budget_tests.rs
+++ b/crates/bacnet-server/src/server/cov_budget_tests.rs
@@ -4,6 +4,11 @@ use bacnet_encoding::apdu::decode_apdu;
 use bacnet_encoding::npdu::decode_npdu;
 use bacnet_objects::analog::AnalogOutputObject;
 use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_objects::life_safety::LifeSafetyPointObject;
+use bacnet_services::common::PropertyReference;
+use bacnet_services::cov_multiple::{
+    COVReference, COVSubscriptionSpecification, SubscribeCOVPropertyMultipleRequest,
+};
 use bacnet_types::enums::ObjectType;
 use bytes::Bytes;
 use std::sync::{Arc as StdArc, Mutex as StdMutex};
@@ -298,4 +303,298 @@ async fn expired_subscription_releases_quota_on_handle_subscribe_cov() {
         "expected admission to succeed after purging expired, got {res:?}"
     );
     assert_eq!(table.len(), 1);
+}
+
+#[tokio::test]
+async fn expired_subscription_purged_before_cov_property_multiple_admission() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let device_oid = ObjectIdentifier::new(ObjectType::DEVICE, 1234).unwrap();
+    let ao_oid = ObjectIdentifier::new(ObjectType::ANALOG_OUTPUT, 1).unwrap();
+    let mut db = ObjectDatabase::new();
+    let mut device = DeviceObject::new(DeviceConfig {
+        instance: 1234,
+        name: "COV-Test".into(),
+        ..DeviceConfig::default()
+    })
+    .unwrap();
+    device.set_object_list(vec![device_oid, ao_oid]);
+    db.add(Box::new(device)).unwrap();
+    db.add(Box::new(AnalogOutputObject::new(1, "AO-1", 62).unwrap()))
+        .unwrap();
+
+    let policy = CovPolicy {
+        max_subscriptions_per_peer: 1,
+        ..Default::default()
+    };
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .cov_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let peer = vec![10, 0, 0, 1, 0xBA, 0xC0];
+
+    // Pre-populate 1 expired subscription for this peer matching PRESENT_VALUE
+    {
+        let mut table = server.cov_table.write().await;
+        table.subscribe(CovSubscription {
+            subscriber_mac: MacAddr::from_slice(&peer),
+            subscriber_network: None,
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ao_oid,
+            issue_confirmed_notifications: false,
+            expires_at: Some(Instant::now() - Duration::from_secs(1)),
+            last_notified_value: None,
+            monitored_property: Some(PropertyIdentifier::PRESENT_VALUE),
+            monitored_property_array_index: None,
+            cov_increment: None,
+            notification_kind: CovNotificationKind::Multiple,
+            timestamped: false,
+        });
+    }
+
+    // Send a SubscribeCOVPropertyMultiple request for 2 properties:
+    // PRESENT_VALUE (matching the expired key) and STATUS_FLAGS.
+    // Expired subscriptions must be purged before evaluating new keys,
+    // so both properties are counted as new (2), which exceeds max_subscriptions_per_peer (1).
+    let request = SubscribeCOVPropertyMultipleRequest {
+        subscriber_process_identifier: 1,
+        issue_confirmed_notifications: false,
+        lifetime: Some(300),
+        max_notification_delay: Some(10),
+        list_of_cov_subscription_specifications: vec![COVSubscriptionSpecification {
+            monitored_object_identifier: ao_oid,
+            list_of_cov_references: vec![
+                COVReference {
+                    monitored_property: PropertyReference {
+                        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+                        property_array_index: None,
+                    },
+                    cov_increment: None,
+                    timestamped: false,
+                },
+                COVReference {
+                    monitored_property: PropertyReference {
+                        property_identifier: PropertyIdentifier::STATUS_FLAGS,
+                        property_array_index: None,
+                    },
+                    cov_increment: None,
+                    timestamped: false,
+                },
+            ],
+        }],
+    };
+    let mut buf = bytes::BytesMut::new();
+    request.encode(&mut buf);
+
+    let mut table = server.cov_table.write().await;
+    let db = server.db.read().await;
+    let res = crate::handlers::handle_subscribe_cov_property_multiple_with_initial(
+        &mut table, &db, &peer, &buf,
+    );
+    assert!(
+        res.is_err(),
+        "expected admission rejection when new keys exceed peer quota, got {res:?}"
+    );
+    // Expired subscription was purged and over-quota request rejected
+    assert_eq!(table.len(), 0);
+}
+
+#[tokio::test]
+async fn unlimited_policy_half_cap_computation_does_not_overflow() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let (db, ao_oid) = test_db_with_ao();
+    let config = ServerConfig {
+        cov_policy: CovPolicy::unlimited(),
+        ..ServerConfig::default()
+    };
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::with_policy(
+        config.cov_policy.clone(),
+        Arc::new(AtomicCovCounters::default()),
+    )));
+    let cov_in_flight = Arc::new(Semaphore::new(255));
+    let transactions = NotificationTransactions::new();
+
+    {
+        let mut table = cov_table.write().await;
+        table.subscribe(CovSubscription {
+            subscriber_mac: MacAddr::from_slice(&[10, 0, 0, 1]),
+            subscriber_network: None,
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ao_oid,
+            issue_confirmed_notifications: false,
+            expires_at: None,
+            last_notified_value: None,
+            monitored_property: None,
+            monitored_property_array_index: None,
+            cov_increment: None,
+            notification_kind: CovNotificationKind::Single,
+            timestamped: false,
+        });
+        table.subscribe(CovSubscription {
+            subscriber_mac: MacAddr::from_slice(&[10, 0, 0, 2]),
+            subscriber_network: None,
+            subscriber_process_identifier: 2,
+            monitored_object_identifier: ao_oid,
+            issue_confirmed_notifications: false,
+            expires_at: None,
+            last_notified_value: None,
+            monitored_property: Some(PropertyIdentifier::PRESENT_VALUE),
+            monitored_property_array_index: None,
+            cov_increment: None,
+            notification_kind: CovNotificationKind::Multiple,
+            timestamped: false,
+        });
+    }
+
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+
+    // Under CovPolicy::unlimited(), remaining_notifications is usize::MAX.
+    // The previous computation `(remaining_notifications + 1) / 2` panicked on overflow.
+    // This must complete without panicking and dispatch both families.
+    BACnetServer::<RecordingTransport>::fire_cov_notifications(
+        &db,
+        &network,
+        &cov_table,
+        &cov_in_flight,
+        &transactions,
+        &Arc::new(AtomicU8::new(0)),
+        &config,
+        &ao_oid,
+    )
+    .await;
+
+    let sent_frames = sent.lock().unwrap();
+    assert_eq!(sent_frames.len(), 2);
+    let mut saw_single = false;
+    let mut saw_multiple = false;
+    for (frame, _) in sent_frames.iter() {
+        let npdu = decode_npdu(frame.clone()).unwrap();
+        if let Apdu::UnconfirmedRequest(req) = decode_apdu(npdu.payload).unwrap() {
+            if req.service_choice == UnconfirmedServiceChoice::UNCONFIRMED_COV_NOTIFICATION {
+                saw_single = true;
+            } else if req.service_choice
+                == UnconfirmedServiceChoice::UNCONFIRMED_COV_NOTIFICATION_MULTIPLE
+            {
+                saw_multiple = true;
+            }
+        }
+    }
+    assert!(
+        saw_single,
+        "single notification must be dispatched under unlimited policy"
+    );
+    assert!(
+        saw_multiple,
+        "multiple notification must be dispatched under unlimited policy"
+    );
+}
+
+#[tokio::test]
+async fn life_safety_fair_budget_partitioning_between_single_and_multiple() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let point_oid = ObjectIdentifier::new(ObjectType::LIFE_SAFETY_POINT, 1).unwrap();
+    let mut db = ObjectDatabase::new();
+    let lsp = LifeSafetyPointObject::new(1, "point").unwrap();
+    db.add(Box::new(lsp)).unwrap();
+    let db = Arc::new(RwLock::new(db));
+
+    let policy = CovPolicy {
+        max_notifications_per_event: 2,
+        ..Default::default()
+    };
+    let config = ServerConfig {
+        cov_policy: policy,
+        ..ServerConfig::default()
+    };
+    let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::with_policy(
+        config.cov_policy.clone(),
+        Arc::new(AtomicCovCounters::default()),
+    )));
+    let cov_in_flight = Arc::new(Semaphore::new(255));
+    let transactions = NotificationTransactions::new();
+
+    {
+        let mut table = cov_table.write().await;
+        // 2 Single subscriptions
+        for i in 1..=2 {
+            table.subscribe(CovSubscription {
+                subscriber_mac: MacAddr::from_slice(&[10, 0, 0, i]),
+                subscriber_network: None,
+                subscriber_process_identifier: i as u32,
+                monitored_object_identifier: point_oid,
+                issue_confirmed_notifications: false,
+                expires_at: None,
+                last_notified_value: None,
+                monitored_property: None,
+                monitored_property_array_index: None,
+                cov_increment: None,
+                notification_kind: CovNotificationKind::Single,
+                timestamped: false,
+            });
+        }
+        // 2 Multiple subscriptions for different peers
+        for i in 3..=4 {
+            table.subscribe(CovSubscription {
+                subscriber_mac: MacAddr::from_slice(&[10, 0, 0, i]),
+                subscriber_network: None,
+                subscriber_process_identifier: i as u32,
+                monitored_object_identifier: point_oid,
+                issue_confirmed_notifications: false,
+                expires_at: None,
+                last_notified_value: None,
+                monitored_property: Some(PropertyIdentifier::PRESENT_VALUE),
+                monitored_property_array_index: None,
+                cov_increment: None,
+                notification_kind: CovNotificationKind::Multiple,
+                timestamped: false,
+            });
+        }
+    }
+
+    let network = Arc::new(NetworkLayer::new(RecordingTransport::new(StdArc::clone(
+        &sent,
+    ))));
+
+    BACnetServer::<RecordingTransport>::fire_life_safety_cov_notifications(
+        &db,
+        &network,
+        &cov_table,
+        &cov_in_flight,
+        &transactions,
+        &Arc::new(AtomicU8::new(0)),
+        &config,
+        &point_oid,
+        &[PropertyIdentifier::PRESENT_VALUE],
+    )
+    .await;
+
+    let sent_frames = sent.lock().unwrap();
+    assert_eq!(sent_frames.len(), 2);
+    let mut saw_single = false;
+    let mut saw_multiple = false;
+    for (frame, _) in sent_frames.iter() {
+        let npdu = decode_npdu(frame.clone()).unwrap();
+        if let Apdu::UnconfirmedRequest(req) = decode_apdu(npdu.payload).unwrap() {
+            if req.service_choice == UnconfirmedServiceChoice::UNCONFIRMED_COV_NOTIFICATION {
+                saw_single = true;
+            } else if req.service_choice
+                == UnconfirmedServiceChoice::UNCONFIRMED_COV_NOTIFICATION_MULTIPLE
+            {
+                saw_multiple = true;
+            }
+        }
+    }
+    assert!(
+        saw_single,
+        "single notifications must not starve multiples in life safety"
+    );
+    assert!(
+        saw_multiple,
+        "multiples must receive fair share in life safety"
+    );
 }

--- a/crates/bacnet-server/src/server/cov_notifications.rs
+++ b/crates/bacnet-server/src/server/cov_notifications.rs
@@ -1,7 +1,39 @@
-use super::cov_clock::{cov_multiple_datetime, cov_multiple_time_remaining};
 use super::*;
+use crate::cov::{AtomicCovCounters, CovInFlightTracker, InFlightAcquireError};
 
 mod life_safety;
+mod multiple;
+
+#[derive(Debug)]
+pub(super) struct EventBudget {
+    max_notifications: usize,
+    max_bytes: usize,
+    notifications_sent: usize,
+    bytes_sent: usize,
+}
+
+impl EventBudget {
+    pub(super) fn new(policy: &CovPolicy) -> Self {
+        Self {
+            max_notifications: policy.max_notifications_per_event,
+            max_bytes: policy.max_notification_bytes_per_event,
+            notifications_sent: 0,
+            bytes_sent: 0,
+        }
+    }
+
+    pub(super) fn try_consume(&mut self, bytes: usize) -> bool {
+        if self.notifications_sent >= self.max_notifications {
+            return false;
+        }
+        if self.bytes_sent.saturating_add(bytes) > self.max_bytes {
+            return false;
+        }
+        self.notifications_sent += 1;
+        self.bytes_sent = self.bytes_sent.saturating_add(bytes);
+        true
+    }
+}
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
     pub(super) async fn send_cov_apdu(
@@ -89,9 +121,17 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         if comm_state.load(Ordering::Acquire) >= 1 {
             return;
         }
-        let subs: Vec<CovSubscription> = {
+        let (subs, counters, in_flight_tracker) = {
             let mut table = cov_table.write().await;
-            table.subscriptions_for(oid).into_iter().cloned().collect()
+            (
+                table
+                    .subscriptions_for(oid)
+                    .into_iter()
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                Arc::clone(table.counters()),
+                Arc::clone(table.in_flight_tracker()),
+            )
         };
 
         if subs.is_empty() {
@@ -102,16 +142,21 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             .into_iter()
             .partition(|sub| sub.notification_kind == CovNotificationKind::Single);
 
+        let mut budget = EventBudget::new(&config.cov_policy);
+
         Self::fire_cov_notifications_for_subscriptions(
             db,
             network,
             cov_table,
             cov_in_flight,
+            &in_flight_tracker,
+            &counters,
             notification_transactions,
             config,
             oid,
             &single_subs,
             snapshot,
+            &mut budget,
         )
         .await;
 
@@ -120,12 +165,15 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             network,
             cov_table,
             cov_in_flight,
+            &in_flight_tracker,
+            &counters,
             notification_transactions,
             comm_state,
             config,
             Some(oid),
             &multiple_subs,
             snapshot,
+            &mut budget,
         )
         .await;
     }
@@ -147,388 +195,46 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             return;
         }
 
+        let (counters, in_flight_tracker) = {
+            let table = cov_table.read().await;
+            (
+                Arc::clone(table.counters()),
+                Arc::clone(table.in_flight_tracker()),
+            )
+        };
+        let mut budget = EventBudget::new(&config.cov_policy);
+
         Self::fire_cov_notifications_for_subscriptions(
             db,
             network,
             cov_table,
             cov_in_flight,
+            &in_flight_tracker,
+            &counters,
             notification_transactions,
             config,
             &subscription.monitored_object_identifier,
             std::slice::from_ref(subscription),
             None,
+            &mut budget,
         )
         .await;
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn fire_cov_notification_multiple_for_subscriptions(
+    pub(super) async fn fire_cov_notifications_for_subscriptions(
         db: &Arc<RwLock<ObjectDatabase>>,
         network: &Arc<NetworkLayer<T>>,
         cov_table: &Arc<RwLock<CovSubscriptionTable>>,
         cov_in_flight: &Arc<Semaphore>,
-        notification_transactions: &Arc<NotificationTransactions>,
-        comm_state: &Arc<AtomicU8>,
-        config: &ServerConfig,
-        changed_oid: Option<&ObjectIdentifier>,
-        subscriptions: &[CovSubscription],
-        snapshot: Option<&dyn bacnet_objects::traits::BACnetObject>,
-    ) {
-        if comm_state.load(Ordering::Acquire) >= 1 || subscriptions.is_empty() {
-            return;
-        }
-
-        let mut grouped: HashMap<(TsmPeer, u32, bool), Vec<CovSubscription>> = HashMap::new();
-
-        if let Some(oid) = changed_oid {
-            let (current_pv, cov_increment) = {
-                let db = db.read().await;
-                let object = match snapshot.or_else(|| db.get(oid)) {
-                    Some(object) => object,
-                    None => return,
-                };
-
-                let current_pv = match object.read_property(PropertyIdentifier::PRESENT_VALUE, None)
-                {
-                    Ok(PropertyValue::Real(value)) => Some(value),
-                    _ => None,
-                };
-
-                (current_pv, object.cov_increment())
-            };
-
-            for sub in subscriptions {
-                if CovSubscriptionTable::should_notify(
-                    sub,
-                    current_pv,
-                    sub.cov_increment.or(cov_increment),
-                ) {
-                    grouped
-                        .entry((
-                            Self::cov_peer(sub),
-                            sub.subscriber_process_identifier,
-                            sub.issue_confirmed_notifications,
-                        ))
-                        .or_default()
-                        .push(sub.clone());
-                }
-            }
-        } else {
-            for sub in subscriptions {
-                grouped
-                    .entry((
-                        Self::cov_peer(sub),
-                        sub.subscriber_process_identifier,
-                        sub.issue_confirmed_notifications,
-                    ))
-                    .or_default()
-                    .push(sub.clone());
-            }
-        }
-
-        for subs in grouped.values() {
-            Self::send_cov_notification_multiple(
-                db,
-                network,
-                cov_table,
-                cov_in_flight,
-                notification_transactions,
-                config,
-                subs,
-                snapshot,
-            )
-            .await;
-        }
-    }
-
-    /// Fire the initial COVNotificationMultiple for a newly accepted
-    /// SubscribeCOVPropertyMultiple request.
-    #[allow(clippy::too_many_arguments)]
-    pub(super) async fn fire_initial_cov_notification_multiple(
-        db: &Arc<RwLock<ObjectDatabase>>,
-        network: &Arc<NetworkLayer<T>>,
-        cov_table: &Arc<RwLock<CovSubscriptionTable>>,
-        cov_in_flight: &Arc<Semaphore>,
-        notification_transactions: &Arc<NotificationTransactions>,
-        comm_state: &Arc<AtomicU8>,
-        config: &ServerConfig,
-        subscriptions: &[CovSubscription],
-    ) {
-        Self::fire_cov_notification_multiple_for_subscriptions(
-            db,
-            network,
-            cov_table,
-            cov_in_flight,
-            notification_transactions,
-            comm_state,
-            config,
-            None,
-            subscriptions,
-            None,
-        )
-        .await;
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn send_cov_notification_multiple(
-        db: &Arc<RwLock<ObjectDatabase>>,
-        network: &Arc<NetworkLayer<T>>,
-        cov_table: &Arc<RwLock<CovSubscriptionTable>>,
-        cov_in_flight: &Arc<Semaphore>,
-        notification_transactions: &Arc<NotificationTransactions>,
-        config: &ServerConfig,
-        subscriptions: &[CovSubscription],
-        snapshot: Option<&dyn bacnet_objects::traits::BACnetObject>,
-    ) {
-        if subscriptions.is_empty() {
-            return;
-        }
-
-        let representative = &subscriptions[0];
-        let (device_oid, timestamp) = {
-            let db = db.read().await;
-            let device_oid = db
-                .list_objects()
-                .into_iter()
-                .find(|o| o.object_type() == ObjectType::DEVICE)
-                .unwrap_or_else(|| ObjectIdentifier::new(ObjectType::DEVICE, 0).unwrap());
-            let timestamp = if subscriptions.iter().any(|sub| sub.timestamped) {
-                match db.clock_frame() {
-                    Some(clock_frame) if clock_frame.is_valid_actual_datetime() => {
-                        Some(cov_multiple_datetime(clock_frame))
-                    }
-                    _ => {
-                        warn!(
-                            "Skipping timestamped COVNotificationMultiple without a valid Device clock"
-                        );
-                        return;
-                    }
-                }
-            } else {
-                None
-            };
-
-            (device_oid, timestamp)
-        };
-        let (items, last_notified) = {
-            let db = if snapshot.is_none() {
-                Some(db.read().await)
-            } else {
-                None
-            };
-            let mut items: Vec<COVNotificationItem> = Vec::new();
-            let mut last_notified = Vec::new();
-
-            for sub in subscriptions {
-                let Some(property_identifier) = sub.monitored_property else {
-                    continue;
-                };
-                let Some(object) = snapshot
-                    .filter(|object| object.object_identifier() == sub.monitored_object_identifier)
-                    .or_else(|| db.as_deref()?.get(&sub.monitored_object_identifier))
-                else {
-                    continue;
-                };
-
-                let Ok(property_value) =
-                    object.read_property(property_identifier, sub.monitored_property_array_index)
-                else {
-                    continue;
-                };
-                let mut value_buf = BytesMut::new();
-                if encode_property_value(&mut value_buf, &property_value).is_err() {
-                    continue;
-                }
-
-                if let Ok(PropertyValue::Real(pv)) =
-                    object.read_property(PropertyIdentifier::PRESENT_VALUE, None)
-                {
-                    last_notified.push((
-                        sub.subscriber_mac.clone(),
-                        sub.subscriber_network.clone(),
-                        sub.subscriber_process_identifier,
-                        sub.monitored_object_identifier,
-                        sub.monitored_property,
-                        pv,
-                    ));
-                }
-
-                let value = COVNotificationValue {
-                    property_identifier,
-                    property_array_index: sub.monitored_property_array_index,
-                    value: value_buf.to_vec(),
-                    time_of_change: if sub.timestamped {
-                        timestamp.map(|(_, time)| time)
-                    } else {
-                        None
-                    },
-                };
-
-                if let Some(item) = items.iter_mut().find(|item| {
-                    item.monitored_object_identifier == sub.monitored_object_identifier
-                }) {
-                    item.list_of_values.push(value);
-                } else {
-                    items.push(COVNotificationItem {
-                        monitored_object_identifier: sub.monitored_object_identifier,
-                        list_of_values: vec![value],
-                    });
-                }
-            }
-
-            if let Some(db) = db.as_deref() {
-                life_safety::append_status_flags(db, subscriptions, timestamp, &mut items);
-            }
-
-            (items, last_notified)
-        };
-
-        if items.is_empty() {
-            return;
-        }
-
-        let time_remaining = cov_multiple_time_remaining(representative.expires_at);
-
-        let notification = COVNotificationMultipleRequest {
-            subscriber_process_identifier: representative.subscriber_process_identifier,
-            initiating_device_identifier: device_oid,
-            time_remaining,
-            timestamp,
-            list_of_cov_notifications: items,
-        };
-
-        if representative.issue_confirmed_notifications {
-            let permit = match cov_in_flight.clone().try_acquire_owned() {
-                Ok(permit) => permit,
-                Err(_) => {
-                    warn!("255 confirmed COV notifications in-flight, skipping COVNotificationMultiple");
-                    return;
-                }
-            };
-
-            let (operation, result_rx) = match notification_transactions.reserve(
-                Self::canonical_cov_peer(representative),
-                ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION_MULTIPLE,
-            ) {
-                Ok(reservation) => reservation,
-                Err(error) => {
-                    warn!(%error, "No free invoke ID for confirmed COVNotificationMultiple");
-                    return;
-                }
-            };
-            let id = operation.invoke_id();
-
-            let buf = match Self::encode_confirmed_cov_multiple_apdu(
-                &notification,
-                id,
-                config.max_apdu_length as u16,
-            ) {
-                Ok(buf) => buf,
-                Err(e) => {
-                    warn!(error = %e, "Failed to encode confirmed COVNotificationMultiple");
-                    return;
-                }
-            };
-
-            {
-                let mut table = cov_table.write().await;
-                for (mac, network, process_id, object_id, property_id, pv) in &last_notified {
-                    table.set_last_notified_value(
-                        mac,
-                        network.as_ref(),
-                        *process_id,
-                        *object_id,
-                        *property_id,
-                        *pv,
-                    );
-                }
-            }
-
-            let network = Arc::clone(network);
-            let sub = representative.clone();
-            let apdu_timeout = Duration::from_millis(config.cov_retry_timeout_ms);
-            let apdu_retries = DEFAULT_APDU_RETRIES;
-            tokio::spawn(async move {
-                let _permit = permit;
-                let result = run_notification_worker(
-                    operation,
-                    result_rx,
-                    apdu_timeout,
-                    apdu_retries,
-                    |attempt| {
-                        let network = Arc::clone(&network);
-                        let buf = buf.clone();
-                        let sub = sub.clone();
-                        async move {
-                            let result = Self::send_cov_apdu(&network, &buf, &sub, true).await;
-                            match &result {
-                                Ok(()) => debug!(
-                                    invoke_id = id,
-                                    attempt, "Confirmed COVNotificationMultiple sent"
-                                ),
-                                Err(error) => warn!(
-                                    %error,
-                                    attempt, "COVNotificationMultiple send failed"
-                                ),
-                            }
-                            result
-                        }
-                    },
-                )
-                .await;
-                match result {
-                    NotificationWorkerResult::Ack => {
-                        debug!(invoke_id = id, "COVNotificationMultiple acknowledged");
-                    }
-                    NotificationWorkerResult::Error => warn!(
-                        invoke_id = id,
-                        "COVNotificationMultiple rejected by subscriber"
-                    ),
-                    NotificationWorkerResult::Exhausted => warn!(
-                        invoke_id = id,
-                        "COVNotificationMultiple failed after {} retries", apdu_retries
-                    ),
-                    NotificationWorkerResult::Closed => {}
-                }
-            });
-        } else {
-            let buf = match Self::encode_unconfirmed_cov_multiple_apdu(&notification) {
-                Ok(buf) => buf,
-                Err(e) => {
-                    warn!(error = %e, "Failed to encode unconfirmed COVNotificationMultiple");
-                    return;
-                }
-            };
-
-            if let Err(e) = Self::send_cov_apdu(network, &buf, representative, false).await {
-                warn!(error = %e, "Failed to send COVNotificationMultiple");
-            } else {
-                let mut table = cov_table.write().await;
-                for (mac, network, process_id, object_id, property_id, pv) in &last_notified {
-                    table.set_last_notified_value(
-                        mac,
-                        network.as_ref(),
-                        *process_id,
-                        *object_id,
-                        *property_id,
-                        *pv,
-                    );
-                }
-            }
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    async fn fire_cov_notifications_for_subscriptions(
-        db: &Arc<RwLock<ObjectDatabase>>,
-        network: &Arc<NetworkLayer<T>>,
-        cov_table: &Arc<RwLock<CovSubscriptionTable>>,
-        cov_in_flight: &Arc<Semaphore>,
+        in_flight_tracker: &Arc<CovInFlightTracker>,
+        counters: &Arc<AtomicCovCounters>,
         notification_transactions: &Arc<NotificationTransactions>,
         config: &ServerConfig,
         oid: &ObjectIdentifier,
         subs: &[CovSubscription],
         snapshot: Option<&dyn bacnet_objects::traits::BACnetObject>,
+        budget: &mut EventBudget,
     ) {
         let device_oid = {
             let db = db.read().await;
@@ -633,17 +339,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             notification.encode(&mut service_buf);
 
             if sub.issue_confirmed_notifications {
-                let permit = match cov_in_flight.clone().try_acquire_owned() {
-                    Ok(permit) => permit,
-                    Err(_) => {
-                        warn!(
-                            object = ?oid,
-                            "255 confirmed COV notifications in-flight, skipping notification"
-                        );
-                        continue;
-                    }
-                };
-
                 let (operation, result_rx) = match notification_transactions.reserve(
                     Self::canonical_cov_peer(sub),
                     ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION,
@@ -676,6 +371,42 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let mut buf = BytesMut::new();
                 encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
 
+                if !budget.try_consume(buf.len()) {
+                    counters
+                        .notifications_throttled_fanout
+                        .fetch_add(1, Ordering::Relaxed);
+                    continue;
+                }
+
+                let guard = match in_flight_tracker.try_acquire(
+                    sub.peer_key(),
+                    config.cov_policy.max_confirmed_in_flight_per_peer,
+                    cov_in_flight,
+                ) {
+                    Ok(guard) => guard,
+                    Err(InFlightAcquireError::PeerLimitExceeded) => {
+                        counters
+                            .notifications_throttled_peer
+                            .fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    }
+                    Err(InFlightAcquireError::GlobalPoolExhausted) => {
+                        warn!(
+                            object = ?oid,
+                            "255 confirmed COV notifications in-flight, skipping notification"
+                        );
+                        continue;
+                    }
+                };
+
+                counters.notifications_sent.fetch_add(1, Ordering::Relaxed);
+                counters
+                    .notifications_confirmed
+                    .fetch_add(1, Ordering::Relaxed);
+                counters
+                    .notification_bytes_sent
+                    .fetch_add(buf.len() as u64, Ordering::Relaxed);
+
                 if let Some(pv) = current_pv {
                     let mut table = cov_table.write().await;
                     table.set_last_notified_value(
@@ -693,7 +424,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let apdu_timeout = Duration::from_millis(config.cov_retry_timeout_ms);
                 let apdu_retries = DEFAULT_APDU_RETRIES;
                 tokio::spawn(async move {
-                    let _permit = permit;
+                    let _guard = guard;
                     let result = run_notification_worker(
                         operation,
                         result_rx,
@@ -742,6 +473,21 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
                 let mut buf = BytesMut::new();
                 encode_apdu(&mut buf, &pdu).expect("valid APDU encoding");
+
+                if !budget.try_consume(buf.len()) {
+                    counters
+                        .notifications_throttled_fanout
+                        .fetch_add(1, Ordering::Relaxed);
+                    continue;
+                }
+
+                counters.notifications_sent.fetch_add(1, Ordering::Relaxed);
+                counters
+                    .notifications_unconfirmed
+                    .fetch_add(1, Ordering::Relaxed);
+                counters
+                    .notification_bytes_sent
+                    .fetch_add(buf.len() as u64, Ordering::Relaxed);
 
                 if let Err(e) = Self::send_cov_apdu(network, &buf, sub, false).await {
                     warn!(error = %e, "Failed to send COV notification");

--- a/crates/bacnet-server/src/server/cov_notifications.rs
+++ b/crates/bacnet-server/src/server/cov_notifications.rs
@@ -22,6 +22,33 @@ impl EventBudget {
         }
     }
 
+    pub(super) fn with_limits(max_notifications: usize, max_bytes: usize) -> Self {
+        Self {
+            max_notifications,
+            max_bytes,
+            notifications_sent: 0,
+            bytes_sent: 0,
+        }
+    }
+
+    pub(super) fn remaining_notifications(&self) -> usize {
+        self.max_notifications
+            .saturating_sub(self.notifications_sent)
+    }
+
+    pub(super) fn remaining_bytes(&self) -> usize {
+        self.max_bytes.saturating_sub(self.bytes_sent)
+    }
+
+    pub(super) fn is_exhausted(&self) -> bool {
+        self.notifications_sent >= self.max_notifications || self.bytes_sent >= self.max_bytes
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn has_capacity(&self) -> bool {
+        !self.is_exhausted()
+    }
+
     pub(super) fn try_consume(&mut self, bytes: usize) -> bool {
         if self.notifications_sent >= self.max_notifications {
             return false;
@@ -32,6 +59,19 @@ impl EventBudget {
         self.notifications_sent += 1;
         self.bytes_sent = self.bytes_sent.saturating_add(bytes);
         true
+    }
+
+    #[allow(dead_code)]
+    pub(super) fn refund(&mut self, bytes: usize) {
+        self.notifications_sent = self.notifications_sent.saturating_sub(1);
+        self.bytes_sent = self.bytes_sent.saturating_sub(bytes);
+    }
+
+    pub(super) fn consume_sub_budget(&mut self, sub_budget: &EventBudget) {
+        self.notifications_sent = self
+            .notifications_sent
+            .saturating_add(sub_budget.notifications_sent);
+        self.bytes_sent = self.bytes_sent.saturating_add(sub_budget.bytes_sent);
     }
 }
 
@@ -121,7 +161,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         if comm_state.load(Ordering::Acquire) >= 1 {
             return;
         }
-        let (subs, counters, in_flight_tracker) = {
+        let (subs, counters, in_flight_tracker, dispatch_turn) = {
             let mut table = cov_table.write().await;
             (
                 table
@@ -131,6 +171,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     .collect::<Vec<_>>(),
                 Arc::clone(table.counters()),
                 Arc::clone(table.in_flight_tracker()),
+                table.next_dispatch_turn(),
             )
         };
 
@@ -144,38 +185,115 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 
         let mut budget = EventBudget::new(&config.cov_policy);
 
-        Self::fire_cov_notifications_for_subscriptions(
-            db,
-            network,
-            cov_table,
-            cov_in_flight,
-            &in_flight_tracker,
-            &counters,
-            notification_transactions,
-            config,
-            oid,
-            &single_subs,
-            snapshot,
-            &mut budget,
-        )
-        .await;
+        if single_subs.is_empty() {
+            Self::fire_cov_notification_multiple_for_subscriptions(
+                db,
+                network,
+                cov_table,
+                cov_in_flight,
+                &in_flight_tracker,
+                &counters,
+                notification_transactions,
+                comm_state,
+                config,
+                Some(oid),
+                &multiple_subs,
+                snapshot,
+                &mut budget,
+            )
+            .await;
+        } else if multiple_subs.is_empty() {
+            Self::fire_cov_notifications_for_subscriptions(
+                db,
+                network,
+                cov_table,
+                cov_in_flight,
+                &in_flight_tracker,
+                &counters,
+                notification_transactions,
+                config,
+                oid,
+                &single_subs,
+                snapshot,
+                &mut budget,
+            )
+            .await;
+        } else {
+            let single_first = dispatch_turn % 2 == 0;
+            let first_notif_cap = (budget.remaining_notifications() + 1) / 2;
+            let first_bytes_cap = (budget.remaining_bytes() + 1) / 2;
+            let mut first_budget = EventBudget::with_limits(first_notif_cap, first_bytes_cap);
 
-        Self::fire_cov_notification_multiple_for_subscriptions(
-            db,
-            network,
-            cov_table,
-            cov_in_flight,
-            &in_flight_tracker,
-            &counters,
-            notification_transactions,
-            comm_state,
-            config,
-            Some(oid),
-            &multiple_subs,
-            snapshot,
-            &mut budget,
-        )
-        .await;
+            if single_first {
+                Self::fire_cov_notifications_for_subscriptions(
+                    db,
+                    network,
+                    cov_table,
+                    cov_in_flight,
+                    &in_flight_tracker,
+                    &counters,
+                    notification_transactions,
+                    config,
+                    oid,
+                    &single_subs,
+                    snapshot,
+                    &mut first_budget,
+                )
+                .await;
+                budget.consume_sub_budget(&first_budget);
+
+                Self::fire_cov_notification_multiple_for_subscriptions(
+                    db,
+                    network,
+                    cov_table,
+                    cov_in_flight,
+                    &in_flight_tracker,
+                    &counters,
+                    notification_transactions,
+                    comm_state,
+                    config,
+                    Some(oid),
+                    &multiple_subs,
+                    snapshot,
+                    &mut budget,
+                )
+                .await;
+            } else {
+                Self::fire_cov_notification_multiple_for_subscriptions(
+                    db,
+                    network,
+                    cov_table,
+                    cov_in_flight,
+                    &in_flight_tracker,
+                    &counters,
+                    notification_transactions,
+                    comm_state,
+                    config,
+                    Some(oid),
+                    &multiple_subs,
+                    snapshot,
+                    &mut first_budget,
+                )
+                .await;
+                budget.consume_sub_budget(&first_budget);
+
+                Self::fire_cov_notifications_for_subscriptions(
+                    db,
+                    network,
+                    cov_table,
+                    cov_in_flight,
+                    &in_flight_tracker,
+                    &counters,
+                    notification_transactions,
+                    config,
+                    oid,
+                    &single_subs,
+                    snapshot,
+                    &mut budget,
+                )
+                .await;
+            }
+        }
     }
 
     /// Fire the initial COV notification for a newly accepted subscription.
@@ -236,6 +354,10 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         snapshot: Option<&dyn bacnet_objects::traits::BACnetObject>,
         budget: &mut EventBudget,
     ) {
+        if budget.is_exhausted() {
+            return;
+        }
+
         let device_oid = {
             let db = db.read().await;
             db.list_objects()
@@ -299,6 +421,14 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             ) {
                 continue;
             }
+
+            if budget.is_exhausted() {
+                counters
+                    .notifications_throttled_fanout
+                    .fetch_add(1, Ordering::Relaxed);
+                continue;
+            }
+
             let time_remaining = sub.expires_at.map_or(0, |exp| {
                 exp.saturating_duration_since(Instant::now()).as_secs() as u32
             });
@@ -339,6 +469,27 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             notification.encode(&mut service_buf);
 
             if sub.issue_confirmed_notifications {
+                let guard = match in_flight_tracker.try_acquire(
+                    sub.peer_key(),
+                    config.cov_policy.max_confirmed_in_flight_per_peer,
+                    cov_in_flight,
+                ) {
+                    Ok(guard) => guard,
+                    Err(InFlightAcquireError::PeerLimitExceeded) => {
+                        counters
+                            .notifications_throttled_peer
+                            .fetch_add(1, Ordering::Relaxed);
+                        continue;
+                    }
+                    Err(InFlightAcquireError::GlobalPoolExhausted) => {
+                        warn!(
+                            object = ?oid,
+                            "255 confirmed COV notifications in-flight, skipping notification"
+                        );
+                        continue;
+                    }
+                };
+
                 let (operation, result_rx) = match notification_transactions.reserve(
                     Self::canonical_cov_peer(sub),
                     ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION,
@@ -377,27 +528,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         .fetch_add(1, Ordering::Relaxed);
                     continue;
                 }
-
-                let guard = match in_flight_tracker.try_acquire(
-                    sub.peer_key(),
-                    config.cov_policy.max_confirmed_in_flight_per_peer,
-                    cov_in_flight,
-                ) {
-                    Ok(guard) => guard,
-                    Err(InFlightAcquireError::PeerLimitExceeded) => {
-                        counters
-                            .notifications_throttled_peer
-                            .fetch_add(1, Ordering::Relaxed);
-                        continue;
-                    }
-                    Err(InFlightAcquireError::GlobalPoolExhausted) => {
-                        warn!(
-                            object = ?oid,
-                            "255 confirmed COV notifications in-flight, skipping notification"
-                        );
-                        continue;
-                    }
-                };
 
                 counters.notifications_sent.fetch_add(1, Ordering::Relaxed);
                 counters

--- a/crates/bacnet-server/src/server/cov_notifications.rs
+++ b/crates/bacnet-server/src/server/cov_notifications.rs
@@ -220,8 +220,10 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             .await;
         } else {
             let single_first = dispatch_turn % 2 == 0;
-            let first_notif_cap = (budget.remaining_notifications() + 1) / 2;
-            let first_bytes_cap = (budget.remaining_bytes() + 1) / 2;
+            let rem_notifs = budget.remaining_notifications();
+            let first_notif_cap = (rem_notifs / 2) + (rem_notifs % 2);
+            let rem_bytes = budget.remaining_bytes();
+            let first_bytes_cap = (rem_bytes / 2) + (rem_bytes % 2);
             let mut first_budget = EventBudget::with_limits(first_notif_cap, first_bytes_cap);
 
             if single_first {

--- a/crates/bacnet-server/src/server/cov_notifications/life_safety.rs
+++ b/crates/bacnet-server/src/server/cov_notifications/life_safety.rs
@@ -23,65 +23,146 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             return;
         }
         let status_changed = changed_properties.contains(&PropertyIdentifier::STATUS_FLAGS);
-        let subs: Vec<CovSubscription> = {
+        let (subs, counters, in_flight_tracker, dispatch_turn) = {
             let mut table = cov_table.write().await;
-            table
-                .subscriptions_for(oid)
-                .into_iter()
-                .filter(|sub| match sub.monitored_property {
-                    Some(property) => status_changed || changed_properties.contains(&property),
-                    None => {
-                        status_changed
-                            || changed_properties.contains(&PropertyIdentifier::PRESENT_VALUE)
-                    }
-                })
-                .cloned()
-                .collect()
+            (
+                table
+                    .subscriptions_for(oid)
+                    .into_iter()
+                    .filter(|sub| match sub.monitored_property {
+                        Some(property) => status_changed || changed_properties.contains(&property),
+                        None => {
+                            status_changed
+                                || changed_properties.contains(&PropertyIdentifier::PRESENT_VALUE)
+                        }
+                    })
+                    .cloned()
+                    .collect::<Vec<_>>(),
+                Arc::clone(table.counters()),
+                Arc::clone(table.in_flight_tracker()),
+                table.next_dispatch_turn(),
+            )
         };
+        if subs.is_empty() {
+            return;
+        }
         let (single_subs, multiple_subs): (Vec<_>, Vec<_>) = subs
             .into_iter()
             .partition(|sub| sub.notification_kind == CovNotificationKind::Single);
 
-        let (counters, in_flight_tracker) = {
-            let table = cov_table.read().await;
-            (
-                Arc::clone(table.counters()),
-                Arc::clone(table.in_flight_tracker()),
-            )
-        };
         let mut budget = EventBudget::new(&config.cov_policy);
 
-        Self::fire_cov_notifications_for_subscriptions(
-            db,
-            network,
-            cov_table,
-            cov_in_flight,
-            &in_flight_tracker,
-            &counters,
-            notification_transactions,
-            config,
-            oid,
-            &single_subs,
-            None,
-            &mut budget,
-        )
-        .await;
-        Self::fire_cov_notification_multiple_for_subscriptions(
-            db,
-            network,
-            cov_table,
-            cov_in_flight,
-            &in_flight_tracker,
-            &counters,
-            notification_transactions,
-            comm_state,
-            config,
-            Some(oid),
-            &multiple_subs,
-            None,
-            &mut budget,
-        )
-        .await;
+        if single_subs.is_empty() {
+            Self::fire_cov_notification_multiple_for_subscriptions(
+                db,
+                network,
+                cov_table,
+                cov_in_flight,
+                &in_flight_tracker,
+                &counters,
+                notification_transactions,
+                comm_state,
+                config,
+                Some(oid),
+                &multiple_subs,
+                None,
+                &mut budget,
+            )
+            .await;
+        } else if multiple_subs.is_empty() {
+            Self::fire_cov_notifications_for_subscriptions(
+                db,
+                network,
+                cov_table,
+                cov_in_flight,
+                &in_flight_tracker,
+                &counters,
+                notification_transactions,
+                config,
+                oid,
+                &single_subs,
+                None,
+                &mut budget,
+            )
+            .await;
+        } else {
+            let single_first = dispatch_turn % 2 == 0;
+            let rem_notifs = budget.remaining_notifications();
+            let first_notif_cap = (rem_notifs / 2) + (rem_notifs % 2);
+            let rem_bytes = budget.remaining_bytes();
+            let first_bytes_cap = (rem_bytes / 2) + (rem_bytes % 2);
+            let mut first_budget = EventBudget::with_limits(first_notif_cap, first_bytes_cap);
+
+            if single_first {
+                Self::fire_cov_notifications_for_subscriptions(
+                    db,
+                    network,
+                    cov_table,
+                    cov_in_flight,
+                    &in_flight_tracker,
+                    &counters,
+                    notification_transactions,
+                    config,
+                    oid,
+                    &single_subs,
+                    None,
+                    &mut first_budget,
+                )
+                .await;
+                budget.consume_sub_budget(&first_budget);
+
+                Self::fire_cov_notification_multiple_for_subscriptions(
+                    db,
+                    network,
+                    cov_table,
+                    cov_in_flight,
+                    &in_flight_tracker,
+                    &counters,
+                    notification_transactions,
+                    comm_state,
+                    config,
+                    Some(oid),
+                    &multiple_subs,
+                    None,
+                    &mut budget,
+                )
+                .await;
+            } else {
+                Self::fire_cov_notification_multiple_for_subscriptions(
+                    db,
+                    network,
+                    cov_table,
+                    cov_in_flight,
+                    &in_flight_tracker,
+                    &counters,
+                    notification_transactions,
+                    comm_state,
+                    config,
+                    Some(oid),
+                    &multiple_subs,
+                    None,
+                    &mut first_budget,
+                )
+                .await;
+                budget.consume_sub_budget(&first_budget);
+
+                Self::fire_cov_notifications_for_subscriptions(
+                    db,
+                    network,
+                    cov_table,
+                    cov_in_flight,
+                    &in_flight_tracker,
+                    &counters,
+                    notification_transactions,
+                    config,
+                    oid,
+                    &single_subs,
+                    None,
+                    &mut budget,
+                )
+                .await;
+            }
+        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/bacnet-server/src/server/cov_notifications/life_safety.rs
+++ b/crates/bacnet-server/src/server/cov_notifications/life_safety.rs
@@ -42,16 +42,28 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             .into_iter()
             .partition(|sub| sub.notification_kind == CovNotificationKind::Single);
 
+        let (counters, in_flight_tracker) = {
+            let table = cov_table.read().await;
+            (
+                Arc::clone(table.counters()),
+                Arc::clone(table.in_flight_tracker()),
+            )
+        };
+        let mut budget = EventBudget::new(&config.cov_policy);
+
         Self::fire_cov_notifications_for_subscriptions(
             db,
             network,
             cov_table,
             cov_in_flight,
+            &in_flight_tracker,
+            &counters,
             notification_transactions,
             config,
             oid,
             &single_subs,
             None,
+            &mut budget,
         )
         .await;
         Self::fire_cov_notification_multiple_for_subscriptions(
@@ -59,12 +71,15 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             network,
             cov_table,
             cov_in_flight,
+            &in_flight_tracker,
+            &counters,
             notification_transactions,
             comm_state,
             config,
             Some(oid),
             &multiple_subs,
             None,
+            &mut budget,
         )
         .await;
     }

--- a/crates/bacnet-server/src/server/cov_notifications/multiple.rs
+++ b/crates/bacnet-server/src/server/cov_notifications/multiple.rs
@@ -61,6 +61,10 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             return;
         }
 
+        if budget.is_exhausted() {
+            return;
+        }
+
         let mut grouped: HashMap<(TsmPeer, u32, bool), Vec<CovSubscription>> = HashMap::new();
 
         if let Some(oid) = changed_oid {
@@ -142,6 +146,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         budget: &mut EventBudget,
     ) {
         if subscriptions.is_empty() {
+            return;
+        }
+
+        if budget.is_exhausted() {
+            counters
+                .notifications_throttled_fanout
+                .fetch_add(1, Ordering::Relaxed);
             return;
         }
 
@@ -259,6 +270,24 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         };
 
         if representative.issue_confirmed_notifications {
+            let guard = match in_flight_tracker.try_acquire(
+                representative.peer_key(),
+                config.cov_policy.max_confirmed_in_flight_per_peer,
+                cov_in_flight,
+            ) {
+                Ok(guard) => guard,
+                Err(InFlightAcquireError::PeerLimitExceeded) => {
+                    counters
+                        .notifications_throttled_peer
+                        .fetch_add(1, Ordering::Relaxed);
+                    return;
+                }
+                Err(InFlightAcquireError::GlobalPoolExhausted) => {
+                    warn!("255 confirmed COV notifications in-flight, skipping COVNotificationMultiple");
+                    return;
+                }
+            };
+
             let (operation, result_rx) = match notification_transactions.reserve(
                 Self::canonical_cov_peer(representative),
                 ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION_MULTIPLE,
@@ -289,24 +318,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     .fetch_add(1, Ordering::Relaxed);
                 return;
             }
-
-            let guard = match in_flight_tracker.try_acquire(
-                representative.peer_key(),
-                config.cov_policy.max_confirmed_in_flight_per_peer,
-                cov_in_flight,
-            ) {
-                Ok(guard) => guard,
-                Err(InFlightAcquireError::PeerLimitExceeded) => {
-                    counters
-                        .notifications_throttled_peer
-                        .fetch_add(1, Ordering::Relaxed);
-                    return;
-                }
-                Err(InFlightAcquireError::GlobalPoolExhausted) => {
-                    warn!("255 confirmed COV notifications in-flight, skipping COVNotificationMultiple");
-                    return;
-                }
-            };
 
             counters.notifications_sent.fetch_add(1, Ordering::Relaxed);
             counters

--- a/crates/bacnet-server/src/server/cov_notifications/multiple.rs
+++ b/crates/bacnet-server/src/server/cov_notifications/multiple.rs
@@ -1,0 +1,421 @@
+use super::cov_clock::{cov_multiple_datetime, cov_multiple_time_remaining};
+use super::*;
+
+impl<T: TransportPort + 'static> BACnetServer<T> {
+    /// Fire the initial COVNotificationMultiple for a newly accepted
+    /// SubscribeCOVPropertyMultiple request.
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::server) async fn fire_initial_cov_notification_multiple(
+        db: &Arc<RwLock<ObjectDatabase>>,
+        network: &Arc<NetworkLayer<T>>,
+        cov_table: &Arc<RwLock<CovSubscriptionTable>>,
+        cov_in_flight: &Arc<Semaphore>,
+        notification_transactions: &Arc<NotificationTransactions>,
+        comm_state: &Arc<AtomicU8>,
+        config: &ServerConfig,
+        subscriptions: &[CovSubscription],
+    ) {
+        let (counters, in_flight_tracker) = {
+            let table = cov_table.read().await;
+            (
+                Arc::clone(table.counters()),
+                Arc::clone(table.in_flight_tracker()),
+            )
+        };
+        let mut budget = EventBudget::new(&config.cov_policy);
+        Self::fire_cov_notification_multiple_for_subscriptions(
+            db,
+            network,
+            cov_table,
+            cov_in_flight,
+            &in_flight_tracker,
+            &counters,
+            notification_transactions,
+            comm_state,
+            config,
+            None,
+            subscriptions,
+            None,
+            &mut budget,
+        )
+        .await;
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::server) async fn fire_cov_notification_multiple_for_subscriptions(
+        db: &Arc<RwLock<ObjectDatabase>>,
+        network: &Arc<NetworkLayer<T>>,
+        cov_table: &Arc<RwLock<CovSubscriptionTable>>,
+        cov_in_flight: &Arc<Semaphore>,
+        in_flight_tracker: &Arc<CovInFlightTracker>,
+        counters: &Arc<AtomicCovCounters>,
+        notification_transactions: &Arc<NotificationTransactions>,
+        comm_state: &Arc<AtomicU8>,
+        config: &ServerConfig,
+        changed_oid: Option<&ObjectIdentifier>,
+        subscriptions: &[CovSubscription],
+        snapshot: Option<&dyn bacnet_objects::traits::BACnetObject>,
+        budget: &mut EventBudget,
+    ) {
+        if comm_state.load(Ordering::Acquire) >= 1 || subscriptions.is_empty() {
+            return;
+        }
+
+        let mut grouped: HashMap<(TsmPeer, u32, bool), Vec<CovSubscription>> = HashMap::new();
+
+        if let Some(oid) = changed_oid {
+            let (current_pv, cov_increment) = {
+                let db = db.read().await;
+                let object = match snapshot.or_else(|| db.get(oid)) {
+                    Some(object) => object,
+                    None => return,
+                };
+
+                let current_pv = match object.read_property(PropertyIdentifier::PRESENT_VALUE, None)
+                {
+                    Ok(PropertyValue::Real(value)) => Some(value),
+                    _ => None,
+                };
+
+                (current_pv, object.cov_increment())
+            };
+
+            for sub in subscriptions {
+                if CovSubscriptionTable::should_notify(
+                    sub,
+                    current_pv,
+                    sub.cov_increment.or(cov_increment),
+                ) {
+                    grouped
+                        .entry((
+                            Self::cov_peer(sub),
+                            sub.subscriber_process_identifier,
+                            sub.issue_confirmed_notifications,
+                        ))
+                        .or_default()
+                        .push(sub.clone());
+                }
+            }
+        } else {
+            for sub in subscriptions {
+                grouped
+                    .entry((
+                        Self::cov_peer(sub),
+                        sub.subscriber_process_identifier,
+                        sub.issue_confirmed_notifications,
+                    ))
+                    .or_default()
+                    .push(sub.clone());
+            }
+        }
+
+        for subs in grouped.values() {
+            Self::send_cov_notification_multiple(
+                db,
+                network,
+                cov_table,
+                cov_in_flight,
+                in_flight_tracker,
+                counters,
+                notification_transactions,
+                config,
+                subs,
+                snapshot,
+                budget,
+            )
+            .await;
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn send_cov_notification_multiple(
+        db: &Arc<RwLock<ObjectDatabase>>,
+        network: &Arc<NetworkLayer<T>>,
+        cov_table: &Arc<RwLock<CovSubscriptionTable>>,
+        cov_in_flight: &Arc<Semaphore>,
+        in_flight_tracker: &Arc<CovInFlightTracker>,
+        counters: &Arc<AtomicCovCounters>,
+        notification_transactions: &Arc<NotificationTransactions>,
+        config: &ServerConfig,
+        subscriptions: &[CovSubscription],
+        snapshot: Option<&dyn bacnet_objects::traits::BACnetObject>,
+        budget: &mut EventBudget,
+    ) {
+        if subscriptions.is_empty() {
+            return;
+        }
+
+        let representative = &subscriptions[0];
+        let (device_oid, timestamp) = {
+            let db = db.read().await;
+            let device_oid = db
+                .list_objects()
+                .into_iter()
+                .find(|o| o.object_type() == ObjectType::DEVICE)
+                .unwrap_or_else(|| ObjectIdentifier::new(ObjectType::DEVICE, 0).unwrap());
+            let timestamp = if subscriptions.iter().any(|sub| sub.timestamped) {
+                match db.clock_frame() {
+                    Some(clock_frame) if clock_frame.is_valid_actual_datetime() => {
+                        Some(cov_multiple_datetime(clock_frame))
+                    }
+                    _ => {
+                        warn!(
+                            "Skipping timestamped COVNotificationMultiple without a valid Device clock"
+                        );
+                        return;
+                    }
+                }
+            } else {
+                None
+            };
+
+            (device_oid, timestamp)
+        };
+        let (items, last_notified) = {
+            let db = if snapshot.is_none() {
+                Some(db.read().await)
+            } else {
+                None
+            };
+            let mut items: Vec<COVNotificationItem> = Vec::new();
+            let mut last_notified = Vec::new();
+
+            for sub in subscriptions {
+                let Some(property_identifier) = sub.monitored_property else {
+                    continue;
+                };
+                let Some(object) = snapshot
+                    .filter(|object| object.object_identifier() == sub.monitored_object_identifier)
+                    .or_else(|| db.as_deref()?.get(&sub.monitored_object_identifier))
+                else {
+                    continue;
+                };
+
+                let Ok(property_value) =
+                    object.read_property(property_identifier, sub.monitored_property_array_index)
+                else {
+                    continue;
+                };
+                let mut value_buf = BytesMut::new();
+                if encode_property_value(&mut value_buf, &property_value).is_err() {
+                    continue;
+                }
+
+                if let Ok(PropertyValue::Real(pv)) =
+                    object.read_property(PropertyIdentifier::PRESENT_VALUE, None)
+                {
+                    last_notified.push((
+                        sub.subscriber_mac.clone(),
+                        sub.subscriber_network.clone(),
+                        sub.subscriber_process_identifier,
+                        sub.monitored_object_identifier,
+                        sub.monitored_property,
+                        pv,
+                    ));
+                }
+
+                let value = COVNotificationValue {
+                    property_identifier,
+                    property_array_index: sub.monitored_property_array_index,
+                    value: value_buf.to_vec(),
+                    time_of_change: if sub.timestamped {
+                        timestamp.map(|(_, time)| time)
+                    } else {
+                        None
+                    },
+                };
+
+                if let Some(item) = items.iter_mut().find(|item| {
+                    item.monitored_object_identifier == sub.monitored_object_identifier
+                }) {
+                    item.list_of_values.push(value);
+                } else {
+                    items.push(COVNotificationItem {
+                        monitored_object_identifier: sub.monitored_object_identifier,
+                        list_of_values: vec![value],
+                    });
+                }
+            }
+
+            if let Some(db) = db.as_deref() {
+                life_safety::append_status_flags(db, subscriptions, timestamp, &mut items);
+            }
+
+            (items, last_notified)
+        };
+
+        if items.is_empty() {
+            return;
+        }
+
+        let time_remaining = cov_multiple_time_remaining(representative.expires_at);
+
+        let notification = COVNotificationMultipleRequest {
+            subscriber_process_identifier: representative.subscriber_process_identifier,
+            initiating_device_identifier: device_oid,
+            time_remaining,
+            timestamp,
+            list_of_cov_notifications: items,
+        };
+
+        if representative.issue_confirmed_notifications {
+            let (operation, result_rx) = match notification_transactions.reserve(
+                Self::canonical_cov_peer(representative),
+                ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION_MULTIPLE,
+            ) {
+                Ok(reservation) => reservation,
+                Err(error) => {
+                    warn!(%error, "No free invoke ID for confirmed COVNotificationMultiple");
+                    return;
+                }
+            };
+            let id = operation.invoke_id();
+
+            let buf = match Self::encode_confirmed_cov_multiple_apdu(
+                &notification,
+                id,
+                config.max_apdu_length as u16,
+            ) {
+                Ok(buf) => buf,
+                Err(e) => {
+                    warn!(error = %e, "Failed to encode confirmed COVNotificationMultiple");
+                    return;
+                }
+            };
+
+            if !budget.try_consume(buf.len()) {
+                counters
+                    .notifications_throttled_fanout
+                    .fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+
+            let guard = match in_flight_tracker.try_acquire(
+                representative.peer_key(),
+                config.cov_policy.max_confirmed_in_flight_per_peer,
+                cov_in_flight,
+            ) {
+                Ok(guard) => guard,
+                Err(InFlightAcquireError::PeerLimitExceeded) => {
+                    counters
+                        .notifications_throttled_peer
+                        .fetch_add(1, Ordering::Relaxed);
+                    return;
+                }
+                Err(InFlightAcquireError::GlobalPoolExhausted) => {
+                    warn!("255 confirmed COV notifications in-flight, skipping COVNotificationMultiple");
+                    return;
+                }
+            };
+
+            counters.notifications_sent.fetch_add(1, Ordering::Relaxed);
+            counters
+                .notifications_confirmed
+                .fetch_add(1, Ordering::Relaxed);
+            counters
+                .notification_bytes_sent
+                .fetch_add(buf.len() as u64, Ordering::Relaxed);
+
+            {
+                let mut table = cov_table.write().await;
+                for (mac, network, process_id, object_id, property_id, pv) in &last_notified {
+                    table.set_last_notified_value(
+                        mac,
+                        network.as_ref(),
+                        *process_id,
+                        *object_id,
+                        *property_id,
+                        *pv,
+                    );
+                }
+            }
+
+            let network = Arc::clone(network);
+            let sub = representative.clone();
+            let apdu_timeout = Duration::from_millis(config.cov_retry_timeout_ms);
+            let apdu_retries = DEFAULT_APDU_RETRIES;
+            tokio::spawn(async move {
+                let _guard = guard;
+                let result = run_notification_worker(
+                    operation,
+                    result_rx,
+                    apdu_timeout,
+                    apdu_retries,
+                    |attempt| {
+                        let network = Arc::clone(&network);
+                        let buf = buf.clone();
+                        let sub = sub.clone();
+                        async move {
+                            let result = Self::send_cov_apdu(&network, &buf, &sub, true).await;
+                            match &result {
+                                Ok(()) => debug!(
+                                    invoke_id = id,
+                                    attempt, "Confirmed COVNotificationMultiple sent"
+                                ),
+                                Err(error) => warn!(
+                                    %error,
+                                    attempt, "COVNotificationMultiple send failed"
+                                ),
+                            }
+                            result
+                        }
+                    },
+                )
+                .await;
+                match result {
+                    NotificationWorkerResult::Ack => {
+                        debug!(invoke_id = id, "COVNotificationMultiple acknowledged");
+                    }
+                    NotificationWorkerResult::Error => warn!(
+                        invoke_id = id,
+                        "COVNotificationMultiple rejected by subscriber"
+                    ),
+                    NotificationWorkerResult::Exhausted => warn!(
+                        invoke_id = id,
+                        "COVNotificationMultiple failed after {} retries", apdu_retries
+                    ),
+                    NotificationWorkerResult::Closed => {}
+                }
+            });
+        } else {
+            let buf = match Self::encode_unconfirmed_cov_multiple_apdu(&notification) {
+                Ok(buf) => buf,
+                Err(e) => {
+                    warn!(error = %e, "Failed to encode unconfirmed COVNotificationMultiple");
+                    return;
+                }
+            };
+
+            if !budget.try_consume(buf.len()) {
+                counters
+                    .notifications_throttled_fanout
+                    .fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+
+            counters.notifications_sent.fetch_add(1, Ordering::Relaxed);
+            counters
+                .notifications_unconfirmed
+                .fetch_add(1, Ordering::Relaxed);
+            counters
+                .notification_bytes_sent
+                .fetch_add(buf.len() as u64, Ordering::Relaxed);
+
+            if let Err(e) = Self::send_cov_apdu(network, &buf, representative, false).await {
+                warn!(error = %e, "Failed to send COVNotificationMultiple");
+            } else {
+                let mut table = cov_table.write().await;
+                for (mac, network, process_id, object_id, property_id, pv) in &last_notified {
+                    table.set_last_notified_value(
+                        mac,
+                        network.as_ref(),
+                        *process_id,
+                        *object_id,
+                        *property_id,
+                        *pv,
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/cov_quota_tests.rs
+++ b/crates/bacnet-server/src/server/cov_quota_tests.rs
@@ -1,0 +1,747 @@
+use std::sync::{Arc as StdArc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
+
+use bytes::BytesMut;
+
+use bacnet_encoding::npdu::NpduAddress;
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_services::common::PropertyReference;
+use bacnet_services::cov::SubscribeCOVRequest;
+use bacnet_services::cov_multiple::{
+    COVReference, COVSubscriptionSpecification, SubscribeCOVPropertyMultipleRequest,
+};
+use bacnet_types::enums::{ErrorClass, ErrorCode, ObjectType, PropertyIdentifier};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::ObjectIdentifier;
+use bacnet_types::MacAddr;
+
+use super::cov_notifications_tests::RecordingTransport;
+use super::*;
+use crate::cov::{CovNotificationKind, CovPolicy, CovSubscription};
+use crate::handlers::{handle_subscribe_cov, handle_subscribe_cov_property_multiple_with_initial};
+
+fn ai(instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap()
+}
+
+fn create_database_with_ais(count: u32) -> ObjectDatabase {
+    let mut db = ObjectDatabase::new();
+    let dev = DeviceObject::new(DeviceConfig {
+        instance: 100,
+        name: "Device-100".to_string(),
+        ..Default::default()
+    })
+    .unwrap();
+    db.add(Box::new(dev)).unwrap();
+    for i in 1..=count {
+        let ai_obj =
+            bacnet_objects::analog::AnalogInputObject::new(i, format!("AI-{}", i), 95).unwrap();
+        db.add(Box::new(ai_obj)).unwrap();
+    }
+    db
+}
+
+// ---------------------------------------------------------------------------
+// 1. One peer reaching its quota does not prevent another peer from subscribing
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn peer_quota_isolation() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let db = create_database_with_ais(10);
+    let policy = CovPolicy {
+        max_subscriptions_per_peer: 2,
+        max_subscriptions_global: 10,
+        reserved_capacity: 0,
+        ..Default::default()
+    };
+
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .cov_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let peer_a = vec![10, 0, 0, 1, 0xBA, 0xC0];
+    let peer_b = vec![10, 0, 0, 2, 0xBA, 0xC0];
+
+    // Peer A subscribes to AI:1 and AI:2 (reaches its quota of 2)
+    for i in 1..=2 {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(i),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        handle_subscribe_cov(&mut table, &db, &peer_a, &buf).unwrap();
+    }
+
+    // Peer A attempts to subscribe to AI:3 -> rejected by quota
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(3),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        let err = handle_subscribe_cov(&mut table, &db, &peer_a, &buf).unwrap_err();
+        match err {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::RESOURCES.to_raw() as u32);
+                assert_eq!(
+                    code,
+                    ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32
+                );
+            }
+            other => panic!("expected RESOURCES / NO_SPACE_TO_ADD_LIST_ELEMENT, got {other:?}"),
+        }
+    }
+
+    // Telemetry: subscriptions_rejected_quota should be 1
+    assert_eq!(server.cov_counters().subscriptions_rejected_quota, 1);
+
+    // Peer B subscribes to AI:1 -> SUCCEEDS (not starved by Peer A reaching quota)
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(1),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        handle_subscribe_cov(&mut table, &db, &peer_b, &buf).unwrap();
+    }
+
+    let counters = server.cov_counters();
+    assert_eq!(counters.subscriptions_active, 3);
+    assert_eq!(counters.subscriptions_created, 3);
+    assert_eq!(counters.subscriptions_rejected_quota, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Reserved capacity is preserved: unreserved cannot consume; reserved can
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn reserved_capacity_preservation() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let db = create_database_with_ais(10);
+    let reserved_mac = MacAddr::from_slice(&[192, 168, 1, 99]);
+    let policy = CovPolicy {
+        max_subscriptions_global: 5,
+        reserved_capacity: 2,
+        max_subscriptions_per_peer: 10,
+        reserved_peers: vec![reserved_mac.clone()],
+        ..Default::default()
+    };
+
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .cov_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let unreserved_peer = vec![10, 0, 0, 1, 0xBA, 0xC0];
+
+    // Unreserved ceiling is 5 - 2 = 3. Fill the 3 unreserved slots.
+    for i in 1..=3 {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: i,
+            monitored_object_identifier: ai(i),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        handle_subscribe_cov(&mut table, &db, &unreserved_peer, &buf).unwrap();
+    }
+
+    // 4th subscription from unreserved peer is rejected (preserves reserved headroom)
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 4,
+            monitored_object_identifier: ai(4),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        let err = handle_subscribe_cov(&mut table, &db, &unreserved_peer, &buf).unwrap_err();
+        match err {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::RESOURCES.to_raw() as u32);
+                assert_eq!(
+                    code,
+                    ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32
+                );
+            }
+            other => panic!("expected RESOURCES / NO_SPACE_TO_ADD_LIST_ELEMENT, got {other:?}"),
+        }
+    }
+    assert_eq!(server.cov_counters().subscriptions_rejected_capacity, 1);
+
+    // Reserved peer CAN subscribe into the reserved headroom (slot 4 and slot 5)
+    for i in 4..=5 {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: i,
+            monitored_object_identifier: ai(i),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        handle_subscribe_cov(&mut table, &db, reserved_mac.as_slice(), &buf).unwrap();
+    }
+    assert_eq!(server.cov_counters().subscriptions_active, 5);
+
+    // Reserved peer attempts slot 6 -> rejected by global capacity
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 6,
+            monitored_object_identifier: ai(6),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        let err = handle_subscribe_cov(&mut table, &db, reserved_mac.as_slice(), &buf).unwrap_err();
+        match err {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::RESOURCES.to_raw() as u32);
+                assert_eq!(
+                    code,
+                    ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32
+                );
+            }
+            other => panic!("expected RESOURCES / NO_SPACE_TO_ADD_LIST_ELEMENT, got {other:?}"),
+        }
+    }
+    assert_eq!(server.cov_counters().subscriptions_rejected_capacity, 2);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Indefinite subscriptions follow explicit configured policy
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn indefinite_subscription_policy() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let db = create_database_with_ais(10);
+    let policy = CovPolicy {
+        allow_indefinite_subscriptions: false,
+        ..Default::default()
+    };
+
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .cov_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let peer = vec![10, 0, 0, 1, 0xBA, 0xC0];
+
+    // Indefinite subscription (lifetime: None) rejected when disallowed
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(1),
+            issue_confirmed_notifications: Some(false),
+            lifetime: None,
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        let err = handle_subscribe_cov(&mut table, &db, &peer, &buf).unwrap_err();
+        match err {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::SERVICES.to_raw() as u32);
+                assert_eq!(
+                    code,
+                    ErrorCode::OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED.to_raw() as u32
+                );
+            }
+            other => {
+                panic!("expected SERVICES / OPTIONAL_FUNCTIONALITY_NOT_SUPPORTED, got {other:?}")
+            }
+        }
+    }
+    assert_eq!(server.cov_counters().subscriptions_rejected_indefinite, 1);
+
+    // Definite subscription succeeds when indefinite is disallowed
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(1),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        handle_subscribe_cov(&mut table, &db, &peer, &buf).unwrap();
+    }
+    assert_eq!(server.cov_counters().subscriptions_active, 1);
+
+    // Now test max_indefinite_per_peer when allow_indefinite is true
+    let sent2 = StdArc::new(StdMutex::new(Vec::new()));
+    let db2 = create_database_with_ais(10);
+    let policy2 = CovPolicy {
+        allow_indefinite_subscriptions: true,
+        max_indefinite_per_peer: 1,
+        ..Default::default()
+    };
+    let server2 = BACnetServer::generic_builder()
+        .database(db2)
+        .transport(RecordingTransport::new(StdArc::clone(&sent2)))
+        .cov_policy(policy2)
+        .build()
+        .await
+        .unwrap();
+
+    // 1st indefinite succeeds
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(1),
+            issue_confirmed_notifications: Some(false),
+            lifetime: None,
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server2.cov_table.write().await;
+        let db = server2.db.read().await;
+        handle_subscribe_cov(&mut table, &db, &peer, &buf).unwrap();
+    }
+
+    // 2nd indefinite from same peer is rejected by indefinite quota
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 2,
+            monitored_object_identifier: ai(2),
+            issue_confirmed_notifications: Some(false),
+            lifetime: None,
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server2.cov_table.write().await;
+        let db = server2.db.read().await;
+        let err = handle_subscribe_cov(&mut table, &db, &peer, &buf).unwrap_err();
+        match err {
+            Error::Protocol { class, code } => {
+                assert_eq!(class, ErrorClass::RESOURCES.to_raw() as u32);
+                assert_eq!(
+                    code,
+                    ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32
+                );
+            }
+            other => panic!("expected RESOURCES / NO_SPACE_TO_ADD_LIST_ELEMENT, got {other:?}"),
+        }
+    }
+    assert_eq!(server2.cov_counters().subscriptions_rejected_indefinite, 1);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Disconnect/expiry cleanup releases quota deterministically
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn disconnect_and_expiry_cleanup_releases_quota() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let db = create_database_with_ais(10);
+    let policy = CovPolicy {
+        max_subscriptions_per_peer: 2,
+        ..Default::default()
+    };
+
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .cov_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let peer = vec![10, 0, 0, 1, 0xBA, 0xC0];
+
+    // Peer creates 2 subscriptions (reaches quota)
+    for i in 1..=2 {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: i,
+            monitored_object_identifier: ai(i),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        handle_subscribe_cov(&mut table, &db, &peer, &buf).unwrap();
+    }
+    assert_eq!(server.cov_counters().subscriptions_active, 2);
+
+    // 3rd subscription rejected
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 3,
+            monitored_object_identifier: ai(3),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        assert!(handle_subscribe_cov(&mut table, &db, &peer, &buf).is_err());
+    }
+
+    // Explicit disconnect cleanup releases all subscriptions for the peer
+    let removed = server.remove_peer_subscriptions(&peer, None).await;
+    assert_eq!(removed, 2);
+    assert_eq!(server.cov_counters().subscriptions_active, 0);
+    assert_eq!(server.cov_counters().subscriptions_cancelled, 2);
+
+    // Peer can immediately subscribe again
+    {
+        let req = SubscribeCOVRequest {
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(1),
+            issue_confirmed_notifications: Some(false),
+            lifetime: Some(300),
+        };
+        let mut buf = BytesMut::new();
+        req.encode(&mut buf);
+        let mut table = server.cov_table.write().await;
+        let db = server.db.read().await;
+        handle_subscribe_cov(&mut table, &db, &peer, &buf).unwrap();
+    }
+    assert_eq!(server.cov_counters().subscriptions_active, 1);
+
+    // Test routed peer isolation in remove_peer_subscriptions
+    let router_mac = vec![192, 168, 1, 1, 0xBA, 0xC0];
+    let routed_a = NpduAddress {
+        network: 10,
+        mac_address: MacAddr::from_slice(&[1]),
+    };
+    let routed_b = NpduAddress {
+        network: 10,
+        mac_address: MacAddr::from_slice(&[2]),
+    };
+
+    {
+        let mut table = server.cov_table.write().await;
+        table.subscribe(CovSubscription {
+            subscriber_mac: MacAddr::from_slice(&router_mac),
+            subscriber_network: Some(routed_a.clone()),
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(1),
+            issue_confirmed_notifications: false,
+            expires_at: None,
+            last_notified_value: None,
+            monitored_property: None,
+            monitored_property_array_index: None,
+            cov_increment: None,
+            notification_kind: CovNotificationKind::Single,
+            timestamped: false,
+        });
+        table.subscribe(CovSubscription {
+            subscriber_mac: MacAddr::from_slice(&router_mac),
+            subscriber_network: Some(routed_b.clone()),
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(1),
+            issue_confirmed_notifications: false,
+            expires_at: None,
+            last_notified_value: None,
+            monitored_property: None,
+            monitored_property_array_index: None,
+            cov_increment: None,
+            notification_kind: CovNotificationKind::Single,
+            timestamped: false,
+        });
+    }
+
+    // Removing routed_a removes only routed_a, preserving routed_b
+    let removed_routed = server
+        .remove_peer_subscriptions(&router_mac, Some(&routed_a))
+        .await;
+    assert_eq!(removed_routed, 1);
+
+    // Verify routed_b remains active
+    {
+        let table = server.cov_table.read().await;
+        assert!(table.contains(
+            &MacAddr::from_slice(&router_mac),
+            Some(&routed_b),
+            1,
+            ai(1),
+            None
+        ));
+    }
+
+    // Test expiry cleanup via purge_expired
+    {
+        let mut table = server.cov_table.write().await;
+        let sub = CovSubscription {
+            subscriber_mac: MacAddr::from_slice(&[10, 0, 0, 99]),
+            subscriber_network: None,
+            subscriber_process_identifier: 1,
+            monitored_object_identifier: ai(5),
+            issue_confirmed_notifications: false,
+            expires_at: Some(Instant::now() - Duration::from_secs(5)),
+            last_notified_value: None,
+            monitored_property: None,
+            monitored_property_array_index: None,
+            cov_increment: None,
+            notification_kind: CovNotificationKind::Single,
+            timestamped: false,
+        };
+        table.subscribe(sub);
+        let purged = table.purge_expired();
+        assert_eq!(purged, 1);
+        assert_eq!(server.cov_counters().subscriptions_purged, 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Maximum-fanout object change respects work/fanout budgets
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn fanout_and_work_budgets_enforced() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let db = create_database_with_ais(2);
+    let policy = CovPolicy {
+        max_notifications_per_event: 3,
+        max_notification_bytes_per_event: 65_536,
+        max_confirmed_in_flight_per_peer: 16,
+        ..Default::default()
+    };
+
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .cov_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    // Register 6 subscriptions on AI:1 from different peers
+    {
+        let mut table = server.cov_table.write().await;
+        for i in 1..=6 {
+            table.subscribe(CovSubscription {
+                subscriber_mac: MacAddr::from_slice(&[10, 0, 0, i, 0xBA, 0xC0]),
+                subscriber_network: None,
+                subscriber_process_identifier: 1,
+                monitored_object_identifier: ai(1),
+                issue_confirmed_notifications: false,
+                expires_at: None,
+                last_notified_value: None,
+                monitored_property: None,
+                monitored_property_array_index: None,
+                cov_increment: None,
+                notification_kind: CovNotificationKind::Single,
+                timestamped: false,
+            });
+        }
+    }
+
+    // Fire notifications for AI:1
+    BACnetServer::<RecordingTransport>::fire_cov_notifications(
+        &server.db,
+        &server.network,
+        &server.cov_table,
+        &server.cov_in_flight,
+        &server.notification_transactions,
+        &server.comm_state,
+        &server.config,
+        &ai(1),
+    )
+    .await;
+
+    let counters = server.cov_counters();
+    // Exactly 3 notifications emitted (fanout budget), 3 throttled
+    assert_eq!(counters.notifications_sent, 3);
+    assert_eq!(counters.notifications_unconfirmed, 3);
+    assert_eq!(counters.notifications_throttled_fanout, 3);
+    assert!(counters.notification_bytes_sent > 0);
+}
+
+// ---------------------------------------------------------------------------
+// 6. Confirmed notification in-flight per peer throttled
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn in_flight_confirmed_per_peer_throttled() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let db = create_database_with_ais(2);
+    let policy = CovPolicy {
+        max_notifications_per_event: 64,
+        max_confirmed_in_flight_per_peer: 2,
+        ..Default::default()
+    };
+
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .cov_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let peer = MacAddr::from_slice(&[10, 0, 0, 1, 0xBA, 0xC0]);
+
+    // 4 confirmed subscriptions for the same peer on AI:1 (distinct process IDs)
+    {
+        let mut table = server.cov_table.write().await;
+        for i in 1..=4 {
+            table.subscribe(CovSubscription {
+                subscriber_mac: peer.clone(),
+                subscriber_network: None,
+                subscriber_process_identifier: i,
+                monitored_object_identifier: ai(1),
+                issue_confirmed_notifications: true,
+                expires_at: None,
+                last_notified_value: None,
+                monitored_property: None,
+                monitored_property_array_index: None,
+                cov_increment: None,
+                notification_kind: CovNotificationKind::Single,
+                timestamped: false,
+            });
+        }
+    }
+
+    BACnetServer::<RecordingTransport>::fire_cov_notifications(
+        &server.db,
+        &server.network,
+        &server.cov_table,
+        &server.cov_in_flight,
+        &server.notification_transactions,
+        &server.comm_state,
+        &server.config,
+        &ai(1),
+    )
+    .await;
+
+    let counters = server.cov_counters();
+    // In-flight per peer was 2, so 2 spawned and 2 throttled due to peer in-flight limit
+    assert_eq!(counters.notifications_confirmed, 2);
+    assert_eq!(counters.notifications_throttled_peer, 2);
+}
+
+// ---------------------------------------------------------------------------
+// 7. Existing atomic multi-property capacity behavior remains intact
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn subscribe_cov_property_multiple_atomic_rejection() {
+    let sent = StdArc::new(StdMutex::new(Vec::new()));
+    let db = create_database_with_ais(5);
+    let policy = CovPolicy {
+        max_subscriptions_per_peer: 3,
+        max_subscriptions_global: 10,
+        ..Default::default()
+    };
+
+    let server = BACnetServer::generic_builder()
+        .database(db)
+        .transport(RecordingTransport::new(StdArc::clone(&sent)))
+        .cov_policy(policy)
+        .build()
+        .await
+        .unwrap();
+
+    let peer = vec![10, 0, 0, 1, 0xBA, 0xC0];
+
+    // Pre-populate 2 subscriptions for this peer
+    {
+        let mut table = server.cov_table.write().await;
+        for i in 1..=2 {
+            table.subscribe(CovSubscription {
+                subscriber_mac: MacAddr::from_slice(&peer),
+                subscriber_network: None,
+                subscriber_process_identifier: 1,
+                monitored_object_identifier: ai(i),
+                issue_confirmed_notifications: false,
+                expires_at: None,
+                last_notified_value: None,
+                monitored_property: Some(PropertyIdentifier::PRESENT_VALUE),
+                monitored_property_array_index: None,
+                cov_increment: None,
+                notification_kind: CovNotificationKind::Multiple,
+                timestamped: false,
+            });
+        }
+    }
+
+    // Now request 2 more properties in a batch (2 + 2 = 4 > max_subscriptions_per_peer = 3)
+    let request = SubscribeCOVPropertyMultipleRequest {
+        subscriber_process_identifier: 1,
+        issue_confirmed_notifications: false,
+        lifetime: Some(300),
+        max_notification_delay: Some(10),
+        list_of_cov_subscription_specifications: vec![COVSubscriptionSpecification {
+            monitored_object_identifier: ai(3),
+            list_of_cov_references: vec![
+                COVReference {
+                    monitored_property: PropertyReference {
+                        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+                        property_array_index: None,
+                    },
+                    cov_increment: None,
+                    timestamped: false,
+                },
+                COVReference {
+                    monitored_property: PropertyReference {
+                        property_identifier: PropertyIdentifier::STATUS_FLAGS,
+                        property_array_index: None,
+                    },
+                    cov_increment: None,
+                    timestamped: false,
+                },
+            ],
+        }],
+    };
+    let mut buf = BytesMut::new();
+    request.encode(&mut buf);
+
+    let mut table = server.cov_table.write().await;
+    let db = server.db.read().await;
+    let err = handle_subscribe_cov_property_multiple_with_initial(&mut table, &db, &peer, &buf)
+        .unwrap_err();
+
+    match err {
+        Error::Protocol { class, code } => {
+            assert_eq!(class, ErrorClass::RESOURCES.to_raw() as u32);
+            assert_eq!(
+                code,
+                ErrorCode::NO_SPACE_TO_ADD_LIST_ELEMENT.to_raw() as u32
+            );
+        }
+        other => panic!("expected RESOURCES / NO_SPACE_TO_ADD_LIST_ELEMENT, got {other:?}"),
+    }
+
+    // ATOMIC: Still exactly 2 subscriptions in the table (0 added from the failed batch)
+    assert_eq!(table.len(), 2);
+}

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -74,7 +74,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             device_instance,
         ));
         let db = Arc::new(RwLock::new(db));
-        let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::new()));
+        let cov_counters = Arc::new(crate::cov::AtomicCovCounters::default());
+        let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::with_policy(
+            config.cov_policy.clone(),
+            Arc::clone(&cov_counters),
+        )));
         let seg_ack_senders: Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let seg_send_permits = Arc::new(Semaphore::new(MAX_SEG_SENDERS));
@@ -718,6 +722,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             network,
             db,
             cov_table,
+            cov_counters,
             seg_ack_senders,
             seg_send_permits,
             cov_in_flight,

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -881,6 +881,8 @@ mod audit_log_query_tests;
 #[cfg(test)]
 mod binary_lighting_task_tests;
 #[cfg(test)]
+mod cov_budget_tests;
+#[cfg(test)]
 mod cov_notifications_tests;
 #[cfg(test)]
 mod cov_quota_tests;

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -56,6 +56,7 @@ use crate::audit_notification::{
     UnconfirmedAuditNotificationAuthorizationContext, UnconfirmedAuditNotificationAuthorizer,
     MAX_AUDIT_NOTIFICATIONS, MAX_AUDIT_NOTIFICATION_BYTES,
 };
+pub use crate::cov::{CovCounters, CovPolicy};
 use crate::cov::{CovNotificationKind, CovSubscription, CovSubscriptionTable};
 use crate::handlers;
 use crate::life_safety::{LifeSafetyOperationAuthorizationContext, LifeSafetyOperationAuthorizer};
@@ -364,6 +365,8 @@ pub struct ServerConfig {
     pub event_enrollment_interval_secs: u64,
     /// Discovery rate-limiting and duplicate suppression policy.
     pub discovery_policy: DiscoveryPolicy,
+    /// COV quota, rate accounting, and notification work budget policy.
+    pub cov_policy: CovPolicy,
 }
 
 impl std::fmt::Debug for ServerConfig {
@@ -414,6 +417,7 @@ impl std::fmt::Debug for ServerConfig {
                 &self.event_enrollment_interval_secs,
             )
             .field("discovery_policy", &self.discovery_policy)
+            .field("cov_policy", &self.cov_policy)
             .finish()
     }
 }
@@ -439,6 +443,7 @@ impl Default for ServerConfig {
             enable_event_enrollment: true,
             event_enrollment_interval_secs: 10,
             discovery_policy: DiscoveryPolicy::default(),
+            cov_policy: CovPolicy::default(),
         }
     }
 }
@@ -560,6 +565,12 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
     /// Set the discovery rate-limiting and duplicate suppression policy.
     pub fn discovery_policy(mut self, policy: DiscoveryPolicy) -> Self {
         self.config.discovery_policy = policy;
+        self
+    }
+
+    /// Set the COV quota and notification work budget policy.
+    pub fn cov_policy(mut self, policy: CovPolicy) -> Self {
+        self.config.cov_policy = policy;
         self
     }
 
@@ -710,6 +721,12 @@ impl BipServerBuilder {
         self
     }
 
+    /// Set the COV quota and notification work budget policy.
+    pub fn cov_policy(mut self, policy: CovPolicy) -> Self {
+        self.config.cov_policy = policy;
+        self
+    }
+
     /// Build and start the server, constructing a BipTransport from the config.
     pub async fn build(self) -> Result<BACnetServer<BipTransport>, Error> {
         let transport = BipTransport::new(
@@ -742,6 +759,7 @@ pub struct BACnetServer<T: TransportPort> {
     /// COV subscription table (also held by dispatch task; read by
     /// [`write_local`](Self::write_local) to fire post-write notifications).
     cov_table: Arc<RwLock<CovSubscriptionTable>>,
+    cov_counters: Arc<crate::cov::AtomicCovCounters>,
     /// Channels for routing segmented-send events to in-progress segmented sends.
     #[allow(dead_code)]
     seg_ack_senders: Arc<Mutex<HashMap<SegKey, Arc<SegmentedSendHandle>>>>,
@@ -865,6 +883,8 @@ mod binary_lighting_task_tests;
 #[cfg(test)]
 mod cov_notifications_tests;
 #[cfg(test)]
+mod cov_quota_tests;
+#[cfg(test)]
 mod dcc_event_detection_tests;
 #[cfg(test)]
 mod device_bindings_tests;
@@ -908,5 +928,20 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Get a snapshot of discovery rate-limiting counters.
     pub fn discovery_counters(&self) -> DiscoveryCounters {
         self.discovery_limiter.counters()
+    }
+
+    /// Get a snapshot of COV operational and telemetry counters.
+    pub fn cov_counters(&self) -> CovCounters {
+        self.cov_counters.snapshot()
+    }
+
+    /// Purge all active COV subscriptions for a peer, deterministically releasing its quota.
+    pub async fn remove_peer_subscriptions(
+        &self,
+        mac: &[u8],
+        network: Option<&NpduAddress>,
+    ) -> usize {
+        let mut table = self.cov_table.write().await;
+        table.remove_peer_subscriptions(mac, network)
     }
 }

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -156,6 +156,12 @@ impl ScServerBuilder {
         self
     }
 
+    /// Set the COV quota and notification work budget policy.
+    pub fn cov_policy(mut self, policy: CovPolicy) -> Self {
+        self.config.cov_policy = policy;
+        self
+    }
+
     /// Connect to the hub and start the server.
     ///
     /// Reconnect configuration is validated before binding-table construction,
@@ -277,5 +283,15 @@ mod tests {
                 Err(Error::Encoding(message)) if message == "SC server builder: tls_config is required"
             ));
         }
+    }
+
+    #[test]
+    fn sc_server_builder_cov_policy_configures_server_config() {
+        let policy = CovPolicy {
+            max_subscriptions_per_peer: 12,
+            ..CovPolicy::default()
+        };
+        let builder = BACnetServer::sc_builder().cov_policy(policy.clone());
+        assert_eq!(builder.config.cov_policy, policy);
     }
 }


### PR DESCRIPTION
## Summary of Changes
Addresses Issue #533 ("Security: add per-peer COV quotas and notification work budgets"):
1. **Per-Peer Subscriptions Quotas & Reserved Headroom**:
   - Added `CovPolicy` with configurable global subscription capacity, per-peer subscription limits (`max_subscriptions_per_peer`), and reserved capacity (`reserved_capacity`) for designated/critical peers (`reserved_peers`).
   - Quotas are keyed by `CovPeerKey`, discriminating direct peers by MAC and routed peers by `(network, mac_address)` to prevent router MAC conflation.
   - Enforced in `CovSubscriptionTable::check_admission` and `check_admission_multiple` across `SubscribeCOV`, `SubscribeCOVProperty`, and `SubscribeCOVPropertyMultiple`.
2. **Indefinite Lifetime Policy & Deterministic Quota Release**:
   - Added explicit policy for indefinite subscriptions (`allow_indefinite_subscriptions` and `max_indefinite_per_peer`).
   - Implemented `CovSubscriptionTable::remove_peer_subscriptions` and updated `purge_expired` to deterministically decrement peer counts and release quota immediately on disconnect or expiration.
3. **Per-Event Notification Work & Fanout Budgets**:
   - Added per-event packet and byte budgets (`max_notifications_per_event`, `max_notification_bytes_per_event`) in `cov_notifications` to prevent maximum-fanout object changes from starving ordinary reads and writes.
   - Added `CovInFlightTracker` bounding concurrent confirmed COV notifications per peer (`max_confirmed_in_flight_per_peer`).
4. **Telemetry & Modularity**:
   - Exposed operational telemetry via `CovCounters` and `BACnetServer::cov_counters()`.
   - Extracted `multiple.rs`, `policy.rs`, and `cov/tests.rs` to maintain strict compliance with the <= 700 LOC cap across all source files.

Closes #533.