### PR TITLE
fix(server): reject deprecated DCC DISABLE requests

### DIFF
--- a/crates/bacnet-integration-tests/tests/server/dcc.rs
+++ b/crates/bacnet-integration-tests/tests/server/dcc.rs
@@ -1,26 +1,28 @@
 use super::*;
 
 // ---------------------------------------------------------------------------
-// DeviceCommunicationControl enforcement tests (Clause 16.4.3)
+// DeviceCommunicationControl enforcement tests (Clause 16.1)
 // ---------------------------------------------------------------------------
 
 /// DCC DISABLE (deprecated in 2020 spec) is rejected with SERVICE_REQUEST_DENIED.
 #[tokio::test]
-async fn dcc_disable_sets_comm_state() {
+async fn dcc_disable_rejected_without_changing_comm_state() {
     use bacnet_types::enums::EnableDisable;
 
     let mut server = make_server().await;
     let mut client = make_client().await;
     let server_mac = server.local_mac().to_vec();
 
-    // Clause 16.1: DISABLE sets comm_state to 1 (per spec, all three values are supported)
+    // Clause 16.1: the deprecated DISABLE request is ignored with an error.
     let result = client
         .device_communication_control(&server_mac, EnableDisable::DISABLE, None, None)
         .await;
-    assert!(result.is_ok(), "DCC DISABLE should succeed per Clause 16.1");
-
-    // Server should be in DISABLE state (1)
-    assert_eq!(server.comm_state(), 1);
+    assert!(
+        matches!(result, Err(bacnet_types::error::Error::Protocol { class, code })
+        if class == bacnet_types::enums::ErrorClass::SERVICES.to_raw() as u32
+            && code == bacnet_types::enums::ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32)
+    );
+    assert_eq!(server.comm_state(), 0);
 
     // Re-enable should work (DCC is allowed even when disabled)
     let result = client

--- a/crates/bacnet-server/src/handlers/device_mgmt.rs
+++ b/crates/bacnet-server/src/handlers/device_mgmt.rs
@@ -46,7 +46,12 @@ pub fn handle_device_communication_control(
     let new_state = if request.enable_disable == EnableDisable::ENABLE {
         0u8
     } else if request.enable_disable == EnableDisable::DISABLE {
-        1u8
+        // ASHRAE 135-2020 Clause 16.1: reject deprecated DISABLE after
+        // password validation, without changing state or the caller's timer.
+        return Err(Error::Protocol {
+            class: ErrorClass::SERVICES.to_raw() as u32,
+            code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+        });
     } else if request.enable_disable == EnableDisable::DISABLE_INITIATION {
         2u8
     } else {

--- a/crates/bacnet-server/src/handlers/tests/passwords.rs
+++ b/crates/bacnet-server/src/handlers/tests/passwords.rs
@@ -1,8 +1,69 @@
 use super::*;
 
 // -----------------------------------------------------------------------
-// Password validation tests (Clause 16.4.1 / 16.4.2)
+// Password validation tests (DCC: Clause 16.1)
 // -----------------------------------------------------------------------
+
+#[test]
+fn dcc_disable_rejection_preserves_state_and_password_precedence() {
+    for initial in [0, 1, 2] {
+        for duration in [None, Some(0), Some(5)] {
+            for (configured, supplied, class, code) in [
+                (
+                    None,
+                    None,
+                    ErrorClass::SERVICES,
+                    ErrorCode::SERVICE_REQUEST_DENIED,
+                ),
+                (
+                    None,
+                    Some("anything"),
+                    ErrorClass::SERVICES,
+                    ErrorCode::SERVICE_REQUEST_DENIED,
+                ),
+                (
+                    Some("secret"),
+                    Some("secret"),
+                    ErrorClass::SERVICES,
+                    ErrorCode::SERVICE_REQUEST_DENIED,
+                ),
+                (
+                    Some("secret"),
+                    None,
+                    ErrorClass::SECURITY,
+                    ErrorCode::PASSWORD_FAILURE,
+                ),
+                (
+                    Some("secret"),
+                    Some("wrong"),
+                    ErrorClass::SECURITY,
+                    ErrorCode::PASSWORD_FAILURE,
+                ),
+            ] {
+                let comm_state = AtomicU8::new(initial);
+                let request = DeviceCommunicationControlRequest {
+                    time_duration: duration,
+                    enable_disable: EnableDisable::DISABLE,
+                    password: supplied.map(str::to_owned),
+                };
+                let mut buf = BytesMut::new();
+                request.encode(&mut buf).unwrap();
+                let err = handle_device_communication_control(
+                    &buf,
+                    &comm_state,
+                    &configured.map(str::to_owned),
+                )
+                .unwrap_err();
+                assert!(
+                    matches!(err, Error::Protocol { class: actual_class, code: actual_code }
+                    if actual_class == class.to_raw() as u32 && actual_code == code.to_raw() as u32),
+                    "unexpected error: {err:?}"
+                );
+                assert_eq!(comm_state.load(Ordering::Acquire), initial);
+            }
+        }
+    }
+}
 
 #[test]
 fn dcc_correct_password_accepted() {

--- a/crates/bacnet-server/src/server/requests/confirmed.rs
+++ b/crates/bacnet-server/src/server/requests/confirmed.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+#[cfg(test)]
+#[path = "dcc_tests.rs"]
+mod dcc_tests;
+
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Atomically admit a confirmed request before DCC, service decoding,
     /// authorization, mutation, side effects, or response construction.

--- a/crates/bacnet-server/src/server/requests/dcc_tests.rs
+++ b/crates/bacnet-server/src/server/requests/dcc_tests.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+use bacnet_encoding::{apdu::decode_apdu, npdu::decode_npdu};
+use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
+use bacnet_types::enums::EnableDisable;
+use tokio::time::{advance, Duration};
+
+async fn dispatch(
+    comm_state: &Arc<AtomicU8>,
+    dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
+    mode: EnableDisable,
+    duration: Option<u16>,
+) -> Apdu {
+    let network = Arc::new(NetworkLayer::new(BipTransport::new(
+        Ipv4Addr::LOCALHOST,
+        0,
+        Ipv4Addr::BROADCAST,
+    )));
+    let mut data = BytesMut::new();
+    DeviceCommunicationControlRequest {
+        time_duration: duration,
+        enable_disable: mode,
+        password: None,
+    }
+    .encode(&mut data)
+    .unwrap();
+    let request = ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 480,
+        invoke_id: 42,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+        service_request: data.freeze(),
+    };
+    let (tx, rx) = oneshot::channel();
+    BACnetServer::<BipTransport>::handle_confirmed_request(
+        &Arc::new(RwLock::new(ObjectDatabase::new())),
+        &network,
+        &Arc::new(RwLock::new(CovSubscriptionTable::new())),
+        &Arc::new(Mutex::new(HashMap::new())),
+        &Arc::new(Semaphore::new(MAX_SEG_SENDERS)),
+        &Arc::new(Semaphore::new(1)),
+        &Arc::new(Mutex::new(ServerTsm::new())),
+        &NotificationTransactions::new(),
+        &Arc::new(ConfirmedRequestTracker::default()),
+        &Arc::new(RwLock::new(DeviceBindingTable::new())),
+        comm_state,
+        dcc_timer,
+        &ServerConfig::default(),
+        &[127, 0, 0, 1, 0xba, 0xc0],
+        None,
+        request,
+        Some(tx),
+    )
+    .await;
+    let npdu = decode_npdu(rx.await.unwrap()).unwrap();
+    decode_apdu(npdu.payload).unwrap()
+}
+
+fn assert_denied(apdu: Apdu) {
+    let Apdu::Error(error) = apdu else {
+        panic!("expected Error, got {apdu:?}")
+    };
+    assert_eq!(error.invoke_id, 42);
+    assert_eq!(
+        error.service_choice,
+        ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL
+    );
+    assert_eq!(error.error_class, ErrorClass::SERVICES);
+    assert_eq!(error.error_code, ErrorCode::SERVICE_REQUEST_DENIED);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_disable_does_not_replace_cancel_or_extend_active_timer() {
+    for rejected_duration in [None, Some(0), Some(1), Some(5)] {
+        let state = Arc::new(AtomicU8::new(0));
+        let timer = Arc::new(Mutex::new(None));
+        assert!(matches!(
+            dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, Some(1)).await,
+            Apdu::SimpleAck(_)
+        ));
+        tokio::task::yield_now().await;
+        let timer_id = timer.lock().await.as_ref().unwrap().id();
+        advance(Duration::from_secs(30)).await;
+        assert_denied(dispatch(&state, &timer, EnableDisable::DISABLE, rejected_duration).await);
+        assert_eq!(state.load(Ordering::Acquire), 2);
+        assert_eq!(timer.lock().await.as_ref().unwrap().id(), timer_id);
+        advance(Duration::from_secs(29)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(state.load(Ordering::Acquire), 2);
+        advance(Duration::from_secs(1)).await;
+        timer.lock().await.take().unwrap().await.unwrap();
+        assert_eq!(state.load(Ordering::Acquire), 0);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_disable_does_not_create_timer_in_any_state() {
+    for initial in [0, 1, 2] {
+        let state = Arc::new(AtomicU8::new(initial));
+        let timer = Arc::new(Mutex::new(None));
+        assert_denied(dispatch(&state, &timer, EnableDisable::DISABLE, Some(1)).await);
+        assert!(timer.lock().await.is_none());
+        advance(Duration::from_secs(61)).await;
+        assert_eq!(state.load(Ordering::Acquire), initial);
+    }
+}

--- a/crates/bacnet-services/src/device_mgmt.rs
+++ b/crates/bacnet-services/src/device_mgmt.rs
@@ -1,6 +1,6 @@
 //! Device management services per ASHRAE 135-2020 Clauses 15-16.
 //!
-//! - DeviceCommunicationControl (Clause 15.4)
+//! - DeviceCommunicationControl (Clause 16.1)
 //! - ReinitializeDevice (Clause 15.4)
 //! - TimeSynchronization (§16.7)
 //! - UTCTimeSynchronization (§16.8)

--- a/crates/bacnet-types/src/enums/object_level.rs
+++ b/crates/bacnet-types/src/enums/object_level.rs
@@ -90,7 +90,7 @@ bacnet_enum! {
 }
 
 bacnet_enum! {
-    /// BACnet enable/disable (Clause 16.4).
+    /// BACnet enable/disable (Clause 16.1).
     pub struct EnableDisable(u32);
 
     const ENABLE = 0;


### PR DESCRIPTION
## Summary
- Reject otherwise-valid deprecated DCC DISABLE requests with SERVICES / SERVICE_REQUEST_DENIED (Standard 135-2020, Clause 16.1; paraphrased behavior).
- Preserve password-validation precedence, communication state, and any active re-enable timer.
- Correct DCC clause citations and add handler, wire-response, and paused-time regressions.

## Scope
Refs #522 — partial completion only. Default-deny authorization, source/SC identity, auditing, and rate limiting remain outside this PR. Password-optional configuration and valid ENABLE / DISABLE_INITIATION behavior are unchanged. No broader conformance claim.

## Validation
- Red/green: new handler regression failed before the fix and passed afterward.
- Focused: 18 server DCC tests, 3 handler-name tests, 4 integration tests passed.
- Handler matrix covers 45 state/duration/password combinations; request tests verify exact wire errors and unchanged timer identity/expiry.
- cargo test --workspace --exclude rusty-bacnet --locked: 4,187 passed, 3 ignored, no failures.
- cargo fmt --all --check: passed.
- cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked: passed with warnings.
- File-size, no-secret, and diff checks passed, including after staging.
- Native validation ran on macOS; Linux feature validation is provided by required lean CI.

## Review
Independent immutable-head reviews and exact-head CI are required before merge. No licensed source text or excerpts are included.