### PR TITLE
fix(server): own inbound request handler task lifecycles

### DIFF
--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -95,6 +95,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         config: &Arc<ServerConfig>,
         clock: &Option<Arc<ServerClock>>,
         discovery_limiter: &Arc<DiscoveryLimiter>,
+        request_tasks: &super::request_tasks::RequestTasks,
         source_mac: &[u8],
         apdu: Apdu,
         mut received: bacnet_network::layer::ReceivedApdu,
@@ -117,7 +118,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let config = Arc::clone(config);
                 let source_mac = MacAddr::from_slice(source_mac);
                 let source_network = received.source_network.clone();
-                tokio::spawn(async move {
+                request_tasks.spawn(async move {
                     Self::handle_confirmed_request(
                         &db,
                         &network,
@@ -200,7 +201,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let comm_state = Arc::clone(comm_state);
                 let device_bindings = Arc::clone(device_bindings);
                 let discovery_limiter = Arc::clone(discovery_limiter);
-                tokio::spawn(async move {
+                request_tasks.spawn(async move {
                     Self::handle_unconfirmed_request(
                         &db,
                         &network,

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -259,6 +259,7 @@ impl Harness {
             &Arc::new(ServerConfig::default()),
             &None,
             &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
+            &super::request_tasks::RequestTasks::default(),
             source_mac,
             apdu,
             bacnet_network::layer::ReceivedApdu {

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -107,11 +107,23 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let clock_dispatch = clock.clone();
         let discovery_limiter_dispatch = Arc::clone(&discovery_limiter);
 
+        let request_tasks = Arc::new(super::request_tasks::RequestTasks::default());
+        let requests = Arc::clone(&request_tasks);
         let dispatch_task = tokio::spawn(async move {
             let mut apdu_rx = apdu_rx;
             let mut seg_receivers: HashMap<SegKey, SegmentedRequestState> = HashMap::new();
 
-            while let Some(received) = apdu_rx.recv().await {
+            loop {
+                let received = tokio::select! {
+                    result = requests.join_next(), if !requests.is_empty() => {
+                        super::request_tasks::RequestTasks::observe(result);
+                        continue;
+                    }
+                    received = apdu_rx.recv() => match received {
+                        Some(received) => received,
+                        None => break,
+                    },
+                };
                 let now = Instant::now();
                 super::segmented_receive::expire_segmented_requests(&mut seg_receivers, now);
 
@@ -434,6 +446,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                                     &config_dispatch,
                                                     &clock_dispatch,
                                                     &discovery_limiter_dispatch,
+                                                    &requests,
                                                     &source_mac,
                                                     Apdu::ConfirmedRequest(reassembled),
                                                     received.take().unwrap_or_else(|| {
@@ -486,6 +499,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 &config_dispatch,
                                 &clock_dispatch,
                                 &discovery_limiter_dispatch,
+                                &requests,
                                 &source_mac,
                                 decoded,
                                 received.take().unwrap_or_else(|| {
@@ -508,6 +522,9 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         warn!(error = %e, "Server failed to decode received APDU");
                     }
                 }
+            }
+            while let Some(result) = requests.join_next().await {
+                super::request_tasks::RequestTasks::observe(Some(result));
             }
         });
 
@@ -733,6 +750,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             comm_state,
             dcc_timer,
             dispatch_task: Some(dispatch_task),
+            request_tasks,
             cov_purge_task: Some(cov_purge_task),
             fault_detection_task,
             event_enrollment_task,

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -786,6 +786,7 @@ pub struct BACnetServer<T: TransportPort> {
     #[allow(dead_code)]
     dcc_timer: Arc<Mutex<Option<JoinHandle<()>>>>,
     dispatch_task: Option<JoinHandle<()>>,
+    request_tasks: Arc<request_tasks::RequestTasks>,
     cov_purge_task: Option<JoinHandle<()>>,
     fault_detection_task: Option<JoinHandle<()>>,
     event_enrollment_task: Option<JoinHandle<()>>,
@@ -872,6 +873,7 @@ mod segmentation;
 mod segmented_receive;
 mod segmented_send;
 pub(crate) use segmented_send::*;
+mod request_tasks;
 mod shutdown;
 
 #[cfg(test)]

--- a/crates/bacnet-server/src/server/notification_transactions_tests.rs
+++ b/crates/bacnet-server/src/server/notification_transactions_tests.rs
@@ -405,6 +405,7 @@ async fn dispatch_keeps_segment_and_complex_acks_out_of_notification_completion(
             &config,
             &None,
             &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
+            &super::request_tasks::RequestTasks::default(),
             source_mac.as_slice(),
             apdu,
             bacnet_network::layer::ReceivedApdu {

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -1,0 +1,49 @@
+use std::future::{poll_fn, Future};
+use std::sync::Mutex;
+use tokio::task::{JoinError, JoinSet};
+
+/// Owns only the top-level inbound request handlers, not independent timers,
+/// notification workers or segmented-response workers started by services.
+#[derive(Default)]
+pub(super) struct RequestTasks(Mutex<State>);
+
+#[derive(Default)]
+struct State {
+    closed: bool,
+    tasks: JoinSet<()>,
+}
+
+impl RequestTasks {
+    pub(super) fn spawn(&self, task: impl Future<Output = ()> + Send + 'static) {
+        let mut state = self.0.lock().unwrap();
+        // Admission and registration are one synchronous critical section.
+        if !state.closed {
+            state.tasks.spawn(task);
+        }
+    }
+
+    pub(super) fn close(&self) {
+        let mut state = self.0.lock().unwrap();
+        state.closed = true;
+        state.tasks.abort_all();
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.0.lock().unwrap().tasks.is_empty()
+    }
+
+    /// One join consumer at a time: dispatch while running, stop after dispatch
+    /// is joined. No handle or mutex guard is held across an await, so cancelling
+    /// stop leaves the remaining joins in this server-owned set.
+    pub(super) async fn join_next(&self) -> Option<Result<(), JoinError>> {
+        poll_fn(|cx| self.0.lock().unwrap().tasks.poll_join_next(cx)).await
+    }
+
+    pub(super) fn observe(result: Option<Result<(), JoinError>>) {
+        if let Some(Err(error)) = result {
+            if !error.is_cancelled() {
+                tracing::warn!(%error, "Inbound request handler failed");
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/request_tasks_tests.rs
+++ b/crates/bacnet-server/src/server/request_tasks_tests.rs
@@ -1,0 +1,317 @@
+use super::*;
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_objects::device::DeviceObject;
+use bacnet_transport::port::ReceivedNpdu;
+use bytes::Bytes;
+use tokio::sync::{mpsc, oneshot, Notify};
+
+struct SendGuard(Option<oneshot::Sender<()>>);
+
+impl Drop for SendGuard {
+    fn drop(&mut self) {
+        if let Some(tx) = self.0.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+struct HeldTransport {
+    incoming: Option<mpsc::Receiver<ReceivedNpdu>>,
+    started: mpsc::UnboundedSender<oneshot::Receiver<()>>,
+    release: Arc<Notify>,
+    panic_next: AtomicBool,
+}
+
+impl TransportPort for HeldTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        Ok(self.incoming.take().unwrap())
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        let decoded = decode_npdu(Bytes::copy_from_slice(npdu)).unwrap();
+        if matches!(
+            apdu::decode_apdu(decoded.payload).unwrap(),
+            Apdu::SegmentAck(_)
+        ) {
+            return Ok(());
+        }
+        let (tx, rx) = oneshot::channel();
+        let _guard = SendGuard(Some(tx));
+        self.started.send(rx).unwrap();
+        self.release.notified().await;
+        assert!(
+            !self.panic_next.swap(false, Ordering::AcqRel),
+            "injected handler panic"
+        );
+        Ok(())
+    }
+
+    async fn send_broadcast(&self, npdu: &[u8]) -> Result<(), Error> {
+        self.send_unicast(npdu, &[]).await
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &[2]
+    }
+}
+
+async fn fixture() -> (
+    BACnetServer<HeldTransport>,
+    mpsc::Sender<ReceivedNpdu>,
+    mpsc::UnboundedReceiver<oneshot::Receiver<()>>,
+) {
+    let (tx, rx) = mpsc::channel(16);
+    let (started, observations) = mpsc::unbounded_channel();
+    let transport = HeldTransport {
+        incoming: Some(rx),
+        started,
+        release: Arc::new(Notify::new()),
+        panic_next: AtomicBool::new(false),
+    };
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(DeviceObject::new(Default::default()).unwrap()))
+        .unwrap();
+    let config = ServerConfig {
+        segmentation_supported: Segmentation::BOTH,
+        ..ServerConfig::default()
+    };
+    let server = BACnetServer::start(config, db, transport).await.unwrap();
+    (server, tx, observations)
+}
+
+async fn inject(tx: &mpsc::Sender<ReceivedNpdu>, apdu: Apdu) {
+    let mut payload = BytesMut::new();
+    encode_apdu(&mut payload, &apdu).unwrap();
+    let mut npdu = BytesMut::new();
+    encode_npdu(
+        &mut npdu,
+        &Npdu {
+            payload: payload.freeze(),
+            ..Npdu::default()
+        },
+    )
+    .unwrap();
+    tx.send(ReceivedNpdu {
+        npdu: npdu.freeze(),
+        source_mac: MacAddr::from_slice(&[1]),
+        link_layer_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    })
+    .await
+    .unwrap();
+}
+
+fn confirmed(segmented: bool) -> Apdu {
+    Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+        segmented,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 1476,
+        invoke_id: 1,
+        sequence_number: segmented.then_some(0),
+        proposed_window_size: segmented.then_some(1),
+        service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+        service_request: Bytes::new(), // A malformed request still has an owned error response.
+    })
+}
+
+async fn stop_releases_handler(request: Apdu) {
+    let (mut server, tx, mut started) = fixture().await;
+    inject(&tx, request).await;
+    let mut released = tokio::time::timeout(Duration::from_secs(2), started.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        released.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    ));
+    server.stop().await.unwrap();
+    assert_eq!(
+        released.try_recv(),
+        Ok(()),
+        "stop returned with a live handler resource"
+    );
+}
+
+#[tokio::test]
+async fn request_tasks_stop_joins_confirmed_handler() {
+    stop_releases_handler(confirmed(false)).await;
+}
+
+#[tokio::test]
+async fn request_tasks_stop_joins_unconfirmed_handler() {
+    stop_releases_handler(Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
+        service_choice: UnconfirmedServiceChoice::WHO_IS,
+        service_request: Bytes::new(),
+    }))
+    .await;
+}
+
+#[tokio::test]
+async fn request_tasks_stop_joins_reassembled_handler() {
+    stop_releases_handler(confirmed(true)).await;
+}
+
+async fn wait_reaped(server: &BACnetServer<HeldTransport>) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !server.request_tasks.is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("completed handler was not reaped while ingress was idle");
+}
+
+#[tokio::test]
+async fn request_tasks_reap_success_and_panic_without_killing_dispatch() {
+    let (mut server, tx, mut started) = fixture().await;
+    for (invoke_id, panic) in [(1, false), (2, true), (3, false)] {
+        let Apdu::ConfirmedRequest(mut request) = confirmed(false) else {
+            unreachable!()
+        };
+        request.invoke_id = invoke_id;
+        inject(&tx, Apdu::ConfirmedRequest(request)).await;
+        let released = tokio::time::timeout(Duration::from_secs(2), started.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        server
+            .network
+            .transport()
+            .panic_next
+            .store(panic, Ordering::Release);
+        server.network.transport().release.notify_one();
+        released.await.unwrap();
+        wait_reaped(&server).await;
+        assert!(!server.dispatch_task.as_ref().unwrap().is_finished());
+    }
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn request_tasks_cancelled_stop_retains_ownership_for_next_stop() {
+    use std::future::Future;
+    use std::task::Poll;
+
+    let (mut server, tx, mut started) = fixture().await;
+    inject(&tx, confirmed(false)).await;
+    let mut released = tokio::time::timeout(Duration::from_secs(2), started.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    {
+        let mut stop = std::pin::pin!(server.stop());
+        std::future::poll_fn(|cx| {
+            assert!(stop.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+    }
+    assert!(server.dispatch_task.is_some());
+    assert!(!server.request_tasks.is_empty());
+    server.stop().await.unwrap();
+    assert_eq!(released.try_recv(), Ok(()));
+    assert!(server.request_tasks.is_empty());
+    server.stop().await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_tasks_spawn_stop_boundary_releases_every_admitted_or_rejected_future() {
+    let (mut server, _tx, _started) = fixture().await;
+    let owner = Arc::clone(&server.request_tasks);
+    let barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let producer_barrier = Arc::clone(&barrier);
+    let producer = tokio::spawn(async move {
+        producer_barrier.wait().await;
+        let mut resources = Vec::new();
+        for _ in 0..128 {
+            let (tx, rx) = oneshot::channel();
+            resources.push(rx);
+            let guard = SendGuard(Some(tx));
+            owner.spawn(async move {
+                let _guard = guard;
+                std::future::pending::<()>().await;
+            });
+        }
+        resources
+    });
+    barrier.wait().await;
+    server.stop().await.unwrap();
+    for mut resource in producer.await.unwrap() {
+        assert_eq!(resource.try_recv(), Ok(()));
+    }
+    assert!(server.request_tasks.is_empty());
+    // Explicitly prove the post-stop side of admission, regardless of which
+    // side won the concurrent race above.
+    let (tx, mut rx) = oneshot::channel();
+    let guard = SendGuard(Some(tx));
+    server.request_tasks.spawn(async move {
+        let _guard = guard;
+        panic!("closed owner admitted a handler");
+    });
+    assert_eq!(rx.try_recv(), Ok(()));
+    assert!(server.request_tasks.is_empty());
+}
+
+#[tokio::test]
+async fn request_tasks_reap_with_active_control_ingress() {
+    let (mut server, tx, mut started) = fixture().await;
+    inject(&tx, confirmed(false)).await;
+    let released = tokio::time::timeout(Duration::from_secs(2), started.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    server.network.transport().release.notify_one();
+    let ingress = async {
+        for invoke_id in 0..128 {
+            inject(
+                &tx,
+                Apdu::SimpleAck(SimpleAck {
+                    invoke_id,
+                    service_choice: ConfirmedServiceChoice::READ_PROPERTY,
+                }),
+            )
+            .await;
+        }
+    };
+    tokio::join!(ingress, async {
+        released.await.unwrap();
+        wait_reaped(&server).await;
+    });
+    assert!(!server.dispatch_task.as_ref().unwrap().is_finished());
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn request_tasks_cancelled_join_keeps_aborted_child_owned() {
+    use std::future::Future;
+    use std::task::Poll;
+
+    let owner = super::super::request_tasks::RequestTasks::default();
+    let (tx, mut rx) = oneshot::channel();
+    let guard = SendGuard(Some(tx));
+    owner.spawn(async move {
+        let _guard = guard;
+        std::future::pending::<()>().await;
+    });
+    owner.close();
+    {
+        let mut join = std::pin::pin!(owner.join_next());
+        std::future::poll_fn(|cx| {
+            assert!(join.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+    }
+    assert!(!owner.is_empty());
+    assert!(owner.join_next().await.unwrap().unwrap_err().is_cancelled());
+    assert_eq!(rx.try_recv(), Ok(()));
+    assert!(owner.is_empty());
+}

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -294,6 +294,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
         &config,
         &None,
         &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
+        &super::request_tasks::RequestTasks::default(),
         source_mac.as_slice(),
         apdu,
         bacnet_network::layer::ReceivedApdu {

--- a/crates/bacnet-server/src/server/shutdown.rs
+++ b/crates/bacnet-server/src/server/shutdown.rs
@@ -1,9 +1,24 @@
 use super::*;
 
+#[cfg(test)]
+#[path = "request_tasks_tests.rs"]
+mod request_tasks_tests;
+
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Stop the server.
     pub async fn stop(&mut self) -> Result<(), Error> {
+        self.request_tasks.close();
         self.notification_transactions.close();
+        // Keep the handle in self until joined: cancellation must not detach
+        // dispatch and allow a later stop to race its join consumer.
+        if let Some(task) = self.dispatch_task.as_mut() {
+            task.abort();
+            let _ = task.await;
+        }
+        self.dispatch_task = None;
+        while let Some(result) = self.request_tasks.join_next().await {
+            super::request_tasks::RequestTasks::observe(Some(result));
+        }
         if let Some(task) = self.fault_detection_task.take() {
             task.abort();
             let _ = task.await;
@@ -29,10 +44,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let _ = task.await;
         }
         if let Some(task) = self.cov_purge_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
-        if let Some(task) = self.dispatch_task.take() {
             task.abort();
             let _ = task.await;
         }


### PR DESCRIPTION
## Summary
- Own top-level inbound confirmed and unconfirmed handlers in a private task set, including reassembled requests.
- Seal admission and cancel/join handlers during explicit stop; retain ownership across cancellation of stop.
- Reap successful and panicked handlers during normal operation without changing inline ACK/control handling.

## Scope limits
Refs #521 (partial; do not close). This does not add admission limits, peer fairness, overload policy, response budgets, authorization, or transport shutdown ownership. Independent segmented-response workers, DCC timers, and notification/background tasks are outside this task owner. Cancellation does not undo completed mutations or preempt blocking callbacks. #522 remains unchanged and partial.

## Validation
- Three shutdown regressions failed before the fix and pass afterward.
- Eight lifecycle tests pass: confirmed/unconfirmed/reassembled cancellation, normal/panic reaping, spawn/stop race, cancelled stop/join ownership.
- Segmentation: 69 passed; server DCC: 18 passed; integration DCC: 4 passed.
- cargo test --workspace --exclude rusty-bacnet --locked: 4,195 passed, 0 failed, 3 ignored (macOS).
- cargo fmt --all --check; cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked (warnings); file-size cap; no-secret scan; git diff --check: PASS.
- Exact-head lean CI and independent reviews pending. Heavy/release qualification is outside this feature-to-dev slice.

No licensed specification excerpts are included.