### PR TITLE
fix(server): retain and join DCC timers on replacement and stop

### DIFF
--- a/crates/bacnet-server/src/server/dcc_timer.rs
+++ b/crates/bacnet-server/src/server/dcc_timer.rs
@@ -1,0 +1,48 @@
+use super::*;
+
+// Borrow the handle in its owning slot through the join. Cancelling the caller
+// leaves the (possibly already aborted) handle available for the next cleanup.
+pub(super) async fn cancel(slot: &mut Option<JoinHandle<()>>) {
+    if let Some(task) = slot.as_mut() {
+        task.abort();
+        let _ = task.await;
+    }
+    *slot = None;
+}
+
+pub(super) async fn replace(
+    timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
+    comm_state: &Arc<AtomicU8>,
+    service_data: &[u8],
+    password: &Option<String>,
+) -> Result<(), Error> {
+    // The synchronous handler validates and writes only this temporary state.
+    // Preserve its public contract and validation precedence, without changing
+    // live state before an await that cancellation could interrupt.
+    let proposed = AtomicU8::new(0);
+    let (_, duration) =
+        handlers::handle_device_communication_control(service_data, &proposed, password)?;
+    let mut slot = timer.lock().await;
+    cancel(&mut slot).await;
+    // Replacement, expiry, and shutdown share this linearization boundary.
+    // No suspension between the live commit and installing the new owner.
+    comm_state.store(proposed.load(Ordering::Acquire), Ordering::Release);
+    if let Some(minutes) = duration {
+        let owner = Arc::downgrade(timer);
+        let comm = Arc::clone(comm_state);
+        *slot = Some(tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(minutes as u64 * 60)).await;
+            if let Some(owner) = owner.upgrade() {
+                // An old task waiting here can be aborted and joined while a
+                // replacement holds the slot; it never joins or removes itself.
+                let _slot = owner.lock().await;
+                comm.store(0, Ordering::Release);
+                debug!(
+                    "DCC timer expired after {} min, state reverted to ENABLE",
+                    minutes
+                );
+            }
+        }));
+    }
+    Ok(())
+}

--- a/crates/bacnet-server/src/server/dcc_timer_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_timer_tests.rs
@@ -1,0 +1,113 @@
+use super::*;
+use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
+use bacnet_types::enums::EnableDisable;
+
+async fn activate(tx: &mpsc::Sender<ReceivedNpdu>) {
+    let mut data = BytesMut::new();
+    DeviceCommunicationControlRequest {
+        time_duration: Some(1),
+        enable_disable: EnableDisable::DISABLE_INITIATION,
+        password: None,
+    }
+    .encode(&mut data)
+    .unwrap();
+    let Apdu::ConfirmedRequest(mut request) = confirmed(false) else {
+        unreachable!()
+    };
+    request.service_choice = ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL;
+    request.service_request = data.freeze();
+    inject(tx, Apdu::ConfirmedRequest(request)).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_timer_stop_joins_live_duration_without_reset() {
+    let (mut server, tx, mut started) = fixture().await;
+    activate(&tx).await;
+    let mut response_resource = started.recv().await.unwrap();
+    tokio::task::yield_now().await;
+    let timer = server
+        .dcc_timer
+        .lock()
+        .await
+        .as_ref()
+        .unwrap()
+        .abort_handle();
+    assert_eq!(server.comm_state(), 2);
+    server.stop().await.unwrap();
+    assert_eq!(response_resource.try_recv(), Ok(()));
+    assert!(timer.is_finished(), "stop returned with a live DCC timer");
+    assert!(server.dcc_timer.lock().await.is_none());
+    assert_eq!(server.comm_state(), 2);
+    tokio::time::advance(Duration::from_secs(61)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(server.comm_state(), 2);
+    server.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_timer_cancelled_stop_retains_join_for_retry() {
+    let (mut server, _tx, _started) = fixture().await;
+    // Remove dispatch as an earlier suspension point, so the single poll below
+    // reaches the timer's pending join without scheduling its destruction.
+    let dispatch = server.dispatch_task.take().unwrap();
+    dispatch.abort();
+    let _ = dispatch.await;
+    let (released, mut resource) = oneshot::channel();
+    let guard = SendGuard(Some(released));
+    let task = tokio::spawn(async move {
+        let _guard = guard;
+        std::future::pending::<()>().await;
+    });
+    let id = task.id();
+    *server.dcc_timer.lock().await = Some(task);
+    server.comm_state.store(2, Ordering::Release);
+    {
+        let stop = server.stop();
+        tokio::pin!(stop);
+        std::future::poll_fn(|cx| {
+            assert!(std::future::Future::poll(stop.as_mut(), cx).is_pending());
+            std::task::Poll::Ready(())
+        })
+        .await;
+    }
+    assert_eq!(server.dcc_timer.lock().await.as_ref().unwrap().id(), id);
+    assert_eq!(
+        resource.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    );
+    assert_eq!(server.comm_state(), 2);
+    server.stop().await.unwrap();
+    assert_eq!(
+        resource.try_recv(),
+        Ok(()),
+        "cleanup must precede stop return"
+    );
+    assert!(server.dcc_timer.lock().await.is_none());
+    assert_eq!(server.comm_state(), 2);
+    server.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_timer_stop_handles_absent_and_completed_timer() {
+    let (mut server, tx, mut started) = fixture().await;
+    assert!(server.dcc_timer.lock().await.is_none());
+    activate(&tx).await;
+    let _response_resource = started.recv().await.unwrap();
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(60)).await;
+    tokio::task::yield_now().await;
+    assert!(server
+        .dcc_timer
+        .lock()
+        .await
+        .as_ref()
+        .unwrap()
+        .is_finished());
+    assert_eq!(server.comm_state(), 0);
+    server.stop().await.unwrap();
+    assert!(server.dcc_timer.lock().await.is_none());
+    server.stop().await.unwrap();
+    let (mut empty, _tx, _started) = fixture().await;
+    empty.stop().await.unwrap();
+    assert!(empty.dcc_timer.lock().await.is_none());
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -781,9 +781,8 @@ pub struct BACnetServer<T: TransportPort> {
     device_bindings: Arc<RwLock<DeviceBindingTable>>,
     /// Communication state: 0 = Enable, 1 = Disable, 2 = DisableInitiation.
     comm_state: Arc<AtomicU8>,
-    /// Handle for the DCC auto-re-enable timer. A new DCC request aborts
-    /// any previous timer.
-    #[allow(dead_code)]
+    /// DCC timer owner and replacement/expiry serialization boundary.
+    /// Valid replacement and explicit stop abort and join before clearing it.
     dcc_timer: Arc<Mutex<Option<JoinHandle<()>>>>,
     dispatch_task: Option<JoinHandle<()>>,
     request_tasks: Arc<request_tasks::RequestTasks>,
@@ -843,6 +842,7 @@ mod cov_clock;
 mod cov_encoding;
 mod cov_notifications;
 mod cov_snapshot;
+mod dcc_timer;
 mod device_bindings;
 mod discovery;
 pub use discovery::{DiscoveryCounters, DiscoveryPolicy};

--- a/crates/bacnet-server/src/server/request_tasks_tests.rs
+++ b/crates/bacnet-server/src/server/request_tasks_tests.rs
@@ -8,6 +8,9 @@ use tokio::sync::{mpsc, oneshot, Notify};
 #[path = "segmented_worker_tests.rs"]
 mod segmented_worker_tests;
 
+#[path = "dcc_timer_tests.rs"]
+mod dcc_timer_tests;
+
 struct SendGuard(Option<oneshot::Sender<()>>);
 
 impl Drop for SendGuard {

--- a/crates/bacnet-server/src/server/requests/dcc_tests.rs
+++ b/crates/bacnet-server/src/server/requests/dcc_tests.rs
@@ -11,6 +11,23 @@ async fn dispatch(
     mode: EnableDisable,
     duration: Option<u16>,
 ) -> Apdu {
+    dispatch_with_config(
+        comm_state,
+        dcc_timer,
+        mode,
+        duration,
+        &ServerConfig::default(),
+    )
+    .await
+}
+
+async fn dispatch_with_config(
+    comm_state: &Arc<AtomicU8>,
+    dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
+    mode: EnableDisable,
+    duration: Option<u16>,
+    config: &ServerConfig,
+) -> Apdu {
     let network = Arc::new(NetworkLayer::new(BipTransport::new(
         Ipv4Addr::LOCALHOST,
         0,
@@ -50,7 +67,7 @@ async fn dispatch(
         &Arc::new(RwLock::new(DeviceBindingTable::new())),
         comm_state,
         dcc_timer,
-        &ServerConfig::default(),
+        config,
         &Arc::new(crate::server::request_tasks::RequestTasks::default()).spawner(),
         &[127, 0, 0, 1, 0xba, 0xc0],
         None,
@@ -94,7 +111,8 @@ async fn dcc_disable_does_not_replace_cancel_or_extend_active_timer() {
         tokio::task::yield_now().await;
         assert_eq!(state.load(Ordering::Acquire), 2);
         advance(Duration::from_secs(1)).await;
-        timer.lock().await.take().unwrap().await.unwrap();
+        let handle = timer.lock().await.take().unwrap();
+        handle.await.unwrap();
         assert_eq!(state.load(Ordering::Acquire), 0);
     }
 }
@@ -108,5 +126,187 @@ async fn dcc_disable_does_not_create_timer_in_any_state() {
         assert!(timer.lock().await.is_none());
         advance(Duration::from_secs(61)).await;
         assert_eq!(state.load(Ordering::Acquire), initial);
+    }
+}
+
+fn held_timer() -> (JoinHandle<()>, oneshot::Receiver<()>) {
+    let (tx, rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        let _resource = tx;
+        std::future::pending::<()>().await;
+    });
+    (handle, rx)
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_rejection_preserves_pending_expiry_and_password_precedence() {
+    let state = Arc::new(AtomicU8::new(0));
+    let timer = Arc::new(Mutex::new(None));
+    dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, Some(1)).await;
+    tokio::task::yield_now().await;
+    let slot = timer.lock().await;
+    let id = slot.as_ref().unwrap().id();
+    advance(Duration::from_secs(60)).await;
+    tokio::task::yield_now().await;
+    assert_denied(dispatch(&state, &timer, EnableDisable::DISABLE, Some(5)).await);
+    let config = ServerConfig {
+        dcc_password: Some("required".into()),
+        ..Default::default()
+    };
+    let response =
+        dispatch_with_config(&state, &timer, EnableDisable::DISABLE, Some(5), &config).await;
+    let Apdu::Error(error) = response else {
+        panic!("expected password failure")
+    };
+    assert_eq!(error.error_class, ErrorClass::SECURITY);
+    assert_eq!(error.error_code, ErrorCode::PASSWORD_FAILURE);
+    assert_eq!(slot.as_ref().unwrap().id(), id);
+    assert_eq!(state.load(Ordering::Acquire), 2);
+    drop(slot);
+    let handle = timer.lock().await.take().unwrap();
+    handle.await.unwrap();
+    assert_eq!(state.load(Ordering::Acquire), 0);
+    // An expiry that wins first cannot undo a later accepted indefinite state.
+    dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, None).await;
+    advance(Duration::from_secs(301)).await;
+    assert_eq!(state.load(Ordering::Acquire), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_replacement_joins_resource_before_ack() {
+    let state = Arc::new(AtomicU8::new(2));
+    let (old, mut resource) = held_timer();
+    let finished = old.abort_handle();
+    let timer = Arc::new(Mutex::new(Some(old)));
+    assert!(matches!(
+        dispatch(&state, &timer, EnableDisable::ENABLE, None).await,
+        Apdu::SimpleAck(_)
+    ));
+    assert!(finished.is_finished());
+    assert_eq!(
+        resource.try_recv(),
+        Err(oneshot::error::TryRecvError::Closed)
+    );
+    assert!(timer.lock().await.is_none());
+    assert_eq!(state.load(Ordering::Acquire), 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_cancelled_replacement_retains_join_and_defers_state_commit() {
+    let state = Arc::new(AtomicU8::new(2));
+    let (old, mut resource) = held_timer();
+    let id = old.id();
+    let timer = Arc::new(Mutex::new(Some(old)));
+    {
+        let replacement = dispatch(&state, &timer, EnableDisable::ENABLE, Some(2));
+        tokio::pin!(replacement);
+        std::future::poll_fn(|cx| {
+            assert!(std::future::Future::poll(replacement.as_mut(), cx).is_pending());
+            std::task::Poll::Ready(())
+        })
+        .await;
+    }
+    assert_eq!(state.load(Ordering::Acquire), 2);
+    assert_eq!(timer.lock().await.as_ref().unwrap().id(), id);
+    assert_eq!(
+        resource.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    );
+    assert!(matches!(
+        dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, None).await,
+        Apdu::SimpleAck(_)
+    ));
+    assert_eq!(
+        resource.try_recv(),
+        Err(oneshot::error::TryRecvError::Closed)
+    );
+    assert!(timer.lock().await.is_none());
+    advance(Duration::from_secs(121)).await;
+    assert_eq!(state.load(Ordering::Acquire), 2);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_concurrent_replacements_serialize_with_pending_expiry() {
+    let state = Arc::new(AtomicU8::new(0));
+    let timer = Arc::new(Mutex::new(None));
+    dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, Some(1)).await;
+    tokio::task::yield_now().await;
+    let slot = timer.lock().await;
+    let old = slot.as_ref().unwrap().abort_handle();
+    let first = dispatch(&state, &timer, EnableDisable::ENABLE, Some(1));
+    let second = dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, Some(2));
+    tokio::pin!(first, second);
+    // Queue both replacements before expiry, with deterministic FIFO ordering.
+    std::future::poll_fn(|cx| {
+        assert!(std::future::Future::poll(first.as_mut(), cx).is_pending());
+        assert!(std::future::Future::poll(second.as_mut(), cx).is_pending());
+        std::task::Poll::Ready(())
+    })
+    .await;
+    advance(Duration::from_secs(60)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(
+        state.load(Ordering::Acquire),
+        2,
+        "expiry must share the slot lock"
+    );
+    drop(slot);
+    assert!(matches!(first.await, Apdu::SimpleAck(_)));
+    assert!(matches!(second.await, Apdu::SimpleAck(_)));
+    assert!(old.is_finished());
+    assert_eq!(
+        Arc::strong_count(&state),
+        2,
+        "only the final timer may retain state"
+    );
+    assert_eq!(state.load(Ordering::Acquire), 2);
+    tokio::task::yield_now().await;
+    advance(Duration::from_secs(60)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(state.load(Ordering::Acquire), 2);
+    advance(Duration::from_secs(60)).await;
+    let handle = timer.lock().await.take().unwrap();
+    handle.await.unwrap();
+    assert_eq!(state.load(Ordering::Acquire), 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_duration_extension_none_zero_and_enable_are_preserved() {
+    let state = Arc::new(AtomicU8::new(0));
+    let timer = Arc::new(Mutex::new(None));
+    dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, Some(1)).await;
+    tokio::task::yield_now().await;
+    advance(Duration::from_secs(30)).await;
+    dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, Some(2)).await;
+    tokio::task::yield_now().await;
+    advance(Duration::from_secs(119)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(state.load(Ordering::Acquire), 2);
+    advance(Duration::from_secs(1)).await;
+    let handle = timer.lock().await.take().unwrap();
+    handle.await.unwrap();
+    assert_eq!(state.load(Ordering::Acquire), 0);
+    for mode in [EnableDisable::DISABLE_INITIATION, EnableDisable::ENABLE] {
+        for duration in [Some(0), None, Some(1)] {
+            dispatch(&state, &timer, mode, duration).await;
+            assert_eq!(
+                state.load(Ordering::Acquire),
+                if mode == EnableDisable::ENABLE { 0 } else { 2 }
+            );
+            assert_eq!(timer.lock().await.is_some(), duration.is_some());
+            if let Some(minutes) = duration {
+                tokio::task::yield_now().await;
+                advance(Duration::from_secs(minutes as u64 * 60)).await;
+                let handle = timer.lock().await.take().unwrap();
+                handle.await.unwrap();
+                assert_eq!(state.load(Ordering::Acquire), 0);
+            } else {
+                advance(Duration::from_secs(121)).await;
+                assert_eq!(
+                    state.load(Ordering::Acquire),
+                    if mode == EnableDisable::ENABLE { 0 } else { 2 }
+                );
+            }
+        }
     }
 }

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -271,32 +271,15 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 }
             }
             s if s == ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL => {
-                match handlers::handle_device_communication_control(
-                    &req.service_request,
+                match super::dcc_timer::replace(
+                    dcc_timer,
                     comm_state,
+                    &req.service_request,
                     &config.dcc_password,
-                ) {
-                    Ok((_state, duration)) => {
-                        if let Some(prev) = dcc_timer.lock().await.take() {
-                            prev.abort();
-                        }
-                        if let Some(minutes) = duration {
-                            let comm = Arc::clone(comm_state);
-                            let handle = tokio::spawn(async move {
-                                tokio::time::sleep(std::time::Duration::from_secs(
-                                    minutes as u64 * 60,
-                                ))
-                                .await;
-                                comm.store(0, Ordering::Release);
-                                tracing::debug!(
-                                    "DCC timer expired after {} min, state reverted to ENABLE",
-                                    minutes
-                                );
-                            });
-                            *dcc_timer.lock().await = Some(handle);
-                        }
-                        simple_ack()
-                    }
+                )
+                .await
+                {
+                    Ok(()) => simple_ack(),
                     Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
                 }
             }

--- a/crates/bacnet-server/src/server/shutdown.rs
+++ b/crates/bacnet-server/src/server/shutdown.rs
@@ -19,6 +19,10 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         while let Some(result) = self.request_tasks.join_next().await {
             super::request_tasks::RequestTasks::observe(Some(result));
         }
+        {
+            let mut timer = self.dcc_timer.lock().await;
+            super::dcc_timer::cancel(&mut timer).await;
+        }
         if let Some(task) = self.fault_detection_task.take() {
             task.abort();
             let _ = task.await;


### PR DESCRIPTION
## Summary
- Retain the DCC duration timer handle through abort-and-join on valid replacement and explicit stop.
- Serialize expiry and replacement through the shared timer slot so stale expiry cannot overwrite a later accepted state or leave an orphaned timer.
- Validate against temporary state before awaiting old-timer cleanup; commit live state and install the replacement without another await. Preserve password/error precedence and duration behavior.
- Stop cancels and joins the timer after request-task shutdown; it does not force communication state to ENABLE.

Refs #521 (partial, do not close). #522 remains partial; no authorization claim.

## Validation
- Production timer-stop regression failed on baseline and passes after the fix.
- Abort-only mutation failed the replacement-join regression; restored join passes final tests.
- Eight new deterministic tests cover replacement/expiry ordering, cancelled replacement/stop ownership, resource cleanup, absence/completion, and unchanged duration/ENABLE/rejection behavior.
- Server DCC 26 passed; request-task lifecycle 17 passed; segmentation 69 passed; integration DCC 4 passed.
- cargo test --workspace --exclude rusty-bacnet --locked: 4,209 passed, 0 failed, 3 ignored (macOS).
- cargo fmt --all --check; cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked (warnings); file-size; no-secret; git diff --check: PASS. Root reran staged-file checks including both new files.
- Exact-head five lean CI checks and independent reviews pending. Heavy/release qualification is outside this feature-to-dev slice.

## Scope limits
Cancellation during replacement may abort the former timer, but retains its join handle and does not commit the proposed state. No rollback guarantee. Notification/background workers, admission/fairness/overload/counters/work budgets, authentication/SC, transport shutdown, restart and async Drop are excluded. No all-server-work termination or blocking-preemption claim.

Optional Codebase Memory coverage remained unavailable; native exact source verification governed. No licensed specification excerpts or new normative claims.