### PR TITLE
fix(server): own and join confirmed notification workers

### DIFF
--- a/crates/bacnet-server/src/server/cov_notifications.rs
+++ b/crates/bacnet-server/src/server/cov_notifications.rs
@@ -555,7 +555,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let sub = sub.clone();
                 let apdu_timeout = Duration::from_millis(config.cov_retry_timeout_ms);
                 let apdu_retries = DEFAULT_APDU_RETRIES;
-                tokio::spawn(async move {
+                notification_transactions.spawn(async move {
                     let _guard = guard;
                     let result = run_notification_worker(
                         operation,

--- a/crates/bacnet-server/src/server/cov_notifications/multiple.rs
+++ b/crates/bacnet-server/src/server/cov_notifications/multiple.rs
@@ -345,7 +345,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let sub = representative.clone();
             let apdu_timeout = Duration::from_millis(config.cov_retry_timeout_ms);
             let apdu_retries = DEFAULT_APDU_RETRIES;
-            tokio::spawn(async move {
+            notification_transactions.spawn(async move {
                 let _guard = guard;
                 let result = run_notification_worker(
                     operation,

--- a/crates/bacnet-server/src/server/event_notifications.rs
+++ b/crates/bacnet-server/src/server/event_notifications.rs
@@ -562,7 +562,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let tsm = Arc::clone(server_tsm);
                 let timeout = Duration::from_millis(retry_timeout_ms);
                 let apdu_retries = DEFAULT_APDU_RETRIES;
-                tokio::spawn(async move {
+                notification_transactions.spawn(async move {
                     let result = run_notification_worker(
                         operation,
                         result_rx,

--- a/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_recipient_routing_tests.rs
@@ -164,12 +164,13 @@ pub(super) async fn distribute_from_database_with_bindings(
 
     let db = Arc::new(RwLock::new(db));
     let oid = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let notifications = NotificationTransactions::new();
     BACnetServer::<RoutingTransport>::build_and_send_event_notification_with_bindings(
         &db,
         &network,
         &comm_state,
         &server_tsm,
-        &NotificationTransactions::new(),
+        &notifications,
         &device_bindings,
         &oid,
         (
@@ -188,6 +189,10 @@ pub(super) async fn distribute_from_database_with_bindings(
     // Yield until the spawned task has reached its first send.
     for _ in 0..16 {
         tokio::task::yield_now().await;
+    }
+    notifications.close();
+    while let Some(result) = notifications.join_next().await {
+        NotificationTransactions::observe(Some(result));
     }
 
     let broadcasts = broadcasts.lock().unwrap().clone();

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -111,9 +111,15 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let dispatch_task = tokio::spawn(async move {
             let mut apdu_rx = apdu_rx;
             let mut seg_receivers: HashMap<SegKey, SegmentedRequestState> = HashMap::new();
+            let mut notifications_open = true;
 
             loop {
                 let received = tokio::select! {
+                    result = notification_transactions_dispatch.join_next(), if notifications_open => {
+                        notifications_open = result.is_some();
+                        NotificationTransactions::observe(result);
+                        continue;
+                    }
                     result = requests.join_next(), if !requests.is_empty() => {
                         super::request_tasks::RequestTasks::observe(result);
                         continue;

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -60,7 +60,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         db.set_monotonic_clock_internal(Some(monotonic_clock));
 
         let mut network = NetworkLayer::new(transport);
-        let apdu_rx = network.start().await?;
+        let mut apdu_rx = network.start().await?;
         let local_mac = MacAddr::from_slice(network.local_mac());
 
         let network = Arc::new(network);
@@ -109,9 +109,9 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let request_tasks = Arc::new(super::request_tasks::RequestTasks::default());
         let requests = Arc::clone(&request_tasks);
         let dispatch_task = tokio::spawn(async move {
-            let mut apdu_rx = apdu_rx;
             let mut seg_receivers: HashMap<SegKey, SegmentedRequestState> = HashMap::new();
             let mut notifications_open = true;
+            let mut ingress_open = true;
 
             loop {
                 let received = tokio::select! {
@@ -124,10 +124,17 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         super::request_tasks::RequestTasks::observe(result);
                         continue;
                     }
-                    received = apdu_rx.recv() => match received {
+                    received = apdu_rx.recv(), if ingress_open => match received {
                         Some(received) => received,
-                        None => break,
+                        None => {
+                            // Local/periodic notification producers outlive ingress.
+                            // Keep both join consumers active, but never poll EOF again.
+                            ingress_open = false;
+                            seg_receivers.clear();
+                            continue;
+                        }
                     },
+                    else => break,
                 };
                 let now = Instant::now();
                 super::segmented_receive::expire_segmented_requests(&mut seg_receivers, now);
@@ -527,9 +534,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         warn!(error = %e, "Server failed to decode received APDU");
                     }
                 }
-            }
-            while let Some(result) = requests.join_next().await {
-                super::request_tasks::RequestTasks::observe(Some(result));
             }
         });
 

--- a/crates/bacnet-server/src/server/notification_transactions.rs
+++ b/crates/bacnet-server/src/server/notification_transactions.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::fmt;
-use std::future::Future;
+use std::future::{poll_fn, Future};
 use std::sync::{Arc, Mutex};
+use std::task::{Poll, Waker};
 
 use bacnet_encoding::apdu::Apdu;
 use bacnet_encoding::npdu::NpduAddress;
@@ -11,9 +12,14 @@ use bacnet_endpoint_core::coordinator::{
 };
 use bacnet_types::enums::ConfirmedServiceChoice;
 use tokio::sync::oneshot;
+use tokio::task::{JoinError, JoinSet};
 use tokio::time::Duration;
 
 use super::CovAckResult;
+
+#[cfg(test)]
+#[path = "notification_worker_owner_tests.rs"]
+mod notification_worker_owner_tests;
 
 #[derive(Debug)]
 pub(super) enum NotificationReserveError {
@@ -48,6 +54,19 @@ struct NotificationState {
 }
 
 pub(super) struct NotificationTransactions {
+    core: Arc<NotificationCore>,
+    workers: Mutex<NotificationWorkers>,
+}
+
+#[derive(Default)]
+struct NotificationWorkers {
+    closed: bool,
+    tasks: JoinSet<()>,
+    waiter: Option<Waker>,
+}
+
+// Operations retain transaction state, never the owner of their JoinSet.
+struct NotificationCore {
     coordinator: Arc<OutboundTransactionCoordinator>,
     state: Mutex<NotificationState>,
 }
@@ -59,14 +78,122 @@ impl NotificationTransactions {
 
     pub(super) fn with_coordinator(coordinator: Arc<OutboundTransactionCoordinator>) -> Arc<Self> {
         Arc::new(Self {
-            coordinator,
-            state: Mutex::new(NotificationState {
-                closed: false,
-                pending: HashMap::new(),
+            core: Arc::new(NotificationCore {
+                coordinator,
+                state: Mutex::new(NotificationState {
+                    closed: false,
+                    pending: HashMap::new(),
+                }),
             }),
+            workers: Mutex::new(NotificationWorkers::default()),
         })
     }
 
+    pub(super) fn spawn(&self, task: impl Future<Output = ()> + Send + 'static) {
+        let mut workers = self.workers.lock().unwrap();
+        if workers.closed {
+            // A rejected future may own an operation and resource guards.
+            drop(workers);
+            drop(task);
+            return;
+        }
+        workers.tasks.spawn(task);
+        let waiter = workers.waiter.take();
+        drop(workers);
+        if let Some(waiter) = waiter {
+            waiter.wake();
+        }
+    }
+
+    pub(super) fn close(&self) {
+        let mut workers = self.workers.lock().unwrap();
+        // Serialize worker registration with transaction sealing. Reservation
+        // uses only the core; no future can bypass closed worker admission.
+        self.core.close();
+        workers.closed = true;
+        workers.tasks.abort_all();
+        let waiter = workers.waiter.take();
+        drop(workers);
+        if let Some(waiter) = waiter {
+            waiter.wake();
+        }
+    }
+
+    /// Dispatch is the sole consumer until joined by stop. An empty open set
+    /// waits for producer admission, including when ingress is idle. Cancelling
+    /// this future retains every outstanding join in the owner.
+    pub(super) async fn join_next(&self) -> Option<Result<(), JoinError>> {
+        poll_fn(|cx| {
+            let mut workers = self.workers.lock().unwrap();
+            match workers.tasks.poll_join_next(cx) {
+                Poll::Ready(None) if !workers.closed => {
+                    workers.waiter = Some(cx.waker().clone());
+                    Poll::Pending
+                }
+                result => result,
+            }
+        })
+        .await
+    }
+
+    pub(super) fn observe(result: Option<Result<(), JoinError>>) {
+        if let Some(Err(error)) = result {
+            if !error.is_cancelled() {
+                tracing::warn!(%error, "Confirmed notification worker failed");
+            }
+        }
+    }
+
+    pub(super) fn reserve(
+        &self,
+        peer: CanonicalPeer,
+        service_choice: ConfirmedServiceChoice,
+    ) -> Result<(NotificationOperation, oneshot::Receiver<CovAckResult>), NotificationReserveError>
+    {
+        self.core.reserve(peer, service_choice)
+    }
+
+    pub(super) fn admit_terminal(
+        &self,
+        immediate_source: &[u8],
+        routed_source: Option<&NpduAddress>,
+        apdu: &Apdu,
+    ) -> bool {
+        self.core
+            .admit_terminal(immediate_source, routed_source, apdu)
+    }
+
+    #[cfg(test)]
+    pub(super) fn complete_pre_admitted(&self, admission: Admission, apdu: &Apdu) -> bool {
+        self.core.complete_pre_admitted(admission, apdu)
+    }
+
+    #[cfg(test)]
+    pub(super) fn workers_empty(&self) -> bool {
+        self.workers.lock().unwrap().tasks.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(super) fn active_count(&self) -> usize {
+        self.core.coordinator.active_count().unwrap_or(usize::MAX)
+    }
+
+    #[cfg(test)]
+    pub(super) fn is_closed(&self) -> bool {
+        self.core
+            .state
+            .lock()
+            .map(|state| state.closed)
+            .unwrap_or(true)
+    }
+
+    #[cfg(test)]
+    pub(super) fn release_token_for_test(&self, token: LeaseToken) {
+        self.core.release(token);
+    }
+}
+
+impl NotificationCore {
     pub(super) fn reserve(
         self: &Arc<Self>,
         peer: CanonicalPeer,
@@ -205,21 +332,6 @@ impl NotificationTransactions {
         }
         let _ = self.coordinator.cancel(token);
     }
-
-    #[cfg(test)]
-    pub(super) fn active_count(&self) -> usize {
-        self.coordinator.active_count().unwrap_or(usize::MAX)
-    }
-
-    #[cfg(test)]
-    pub(super) fn is_closed(&self) -> bool {
-        self.state.lock().map(|state| state.closed).unwrap_or(true)
-    }
-
-    #[cfg(test)]
-    pub(super) fn release_token_for_test(&self, token: LeaseToken) {
-        self.release(token);
-    }
 }
 
 impl Drop for NotificationTransactions {
@@ -229,7 +341,7 @@ impl Drop for NotificationTransactions {
 }
 
 pub(super) struct NotificationOperation {
-    transactions: Arc<NotificationTransactions>,
+    transactions: Arc<NotificationCore>,
     token: LeaseToken,
     active: bool,
 }

--- a/crates/bacnet-server/src/server/notification_worker_owner_tests.rs
+++ b/crates/bacnet-server/src/server/notification_worker_owner_tests.rs
@@ -1,0 +1,154 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::sync::{Barrier, Semaphore};
+
+struct CountDrop(Arc<AtomicUsize>);
+impl Drop for CountDrop {
+    fn drop(&mut self) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn reserve(owner: &NotificationTransactions) -> NotificationOperation {
+    owner
+        .reserve(
+            canonical_direct_peer(&[1]),
+            ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION,
+        )
+        .unwrap()
+        .0
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn notification_worker_spawn_close_race_releases_all_resources() {
+    let owner = NotificationTransactions::new();
+    let count = Arc::new(AtomicUsize::new(0));
+    let permits = Arc::new(Semaphore::new(64));
+    let barrier = Arc::new(Barrier::new(65));
+    let mut producers = JoinSet::new();
+    for _ in 0..64 {
+        let operation = reserve(&owner);
+        let permit = permits.clone().try_acquire_owned().unwrap();
+        let guard = CountDrop(count.clone());
+        let owner = owner.clone();
+        let barrier = barrier.clone();
+        producers.spawn(async move {
+            barrier.wait().await;
+            owner.spawn(async move {
+                let _resources = (operation, permit, guard);
+                std::future::pending::<()>().await;
+            });
+        });
+    }
+    barrier.wait().await;
+    owner.close();
+    while let Some(result) = producers.join_next().await {
+        result.unwrap();
+    }
+    while let Some(result) = owner.join_next().await {
+        assert!(result.unwrap_err().is_cancelled());
+    }
+    assert!(owner.workers_empty());
+    assert_eq!(owner.active_count(), 0);
+    assert_eq!(permits.available_permits(), 64);
+    assert_eq!(count.load(Ordering::SeqCst), 64);
+    assert!(matches!(
+        owner.reserve(
+            canonical_direct_peer(&[1]),
+            ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION
+        ),
+        Err(NotificationReserveError::Closed)
+    ));
+}
+
+#[tokio::test]
+async fn notification_worker_post_close_rejects_outside_owner_lock() {
+    struct ReentrantDrop(std::sync::Weak<NotificationTransactions>);
+    impl Drop for ReentrantDrop {
+        fn drop(&mut self) {
+            assert!(self.0.upgrade().unwrap().workers_empty());
+        }
+    }
+    let owner = NotificationTransactions::new();
+    let operation = reserve(&owner);
+    let reentrant = ReentrantDrop(Arc::downgrade(&owner));
+    let count = Arc::new(AtomicUsize::new(0));
+    let guard = CountDrop(count.clone());
+    owner.close();
+    owner.spawn(async move {
+        let _resources = (operation, reentrant, guard);
+        panic!("a post-close future must never be polled");
+    });
+    assert_eq!(count.load(Ordering::SeqCst), 1);
+    assert!(owner.workers_empty());
+    assert_eq!(owner.active_count(), 0);
+}
+
+#[tokio::test]
+async fn notification_worker_empty_wait_wakes_and_cancelled_join_retains_task() {
+    let owner = NotificationTransactions::new();
+    // Register an empty-set consumer before an independent producer spawns.
+    let (polled, ready) = oneshot::channel();
+    let consumer_owner = owner.clone();
+    let consumer = tokio::spawn(async move {
+        let mut join = std::pin::pin!(consumer_owner.join_next());
+        poll_fn(|cx| {
+            assert!(join.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+        polled.send(()).unwrap();
+        join.await.unwrap().unwrap();
+    });
+    ready.await.unwrap();
+    owner.spawn(async {});
+    tokio::time::timeout(Duration::from_secs(2), consumer)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(owner.workers_empty());
+
+    let (release, held) = oneshot::channel::<()>();
+    owner.spawn(async move {
+        let _ = held.await;
+    });
+    {
+        let mut join = std::pin::pin!(owner.join_next());
+        poll_fn(|cx| {
+            assert!(join.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+    }
+    assert!(!owner.workers_empty());
+    release.send(()).unwrap();
+    owner.join_next().await.unwrap().unwrap();
+    assert!(owner.workers_empty());
+}
+
+#[tokio::test]
+async fn notification_worker_operation_does_not_retain_owner() {
+    let owner = NotificationTransactions::new();
+    let weak = Arc::downgrade(&owner);
+    let operation = reserve(&owner);
+    let core = Arc::downgrade(&operation.transactions);
+    let (dropped, observed) = oneshot::channel();
+    struct NotifyDrop(Option<oneshot::Sender<()>>);
+    impl Drop for NotifyDrop {
+        fn drop(&mut self) {
+            let _ = self.0.take().unwrap().send(());
+        }
+    }
+    let guard = NotifyDrop(Some(dropped));
+    owner.spawn(async move {
+        let _resources = (operation, guard);
+        std::future::pending::<()>().await;
+    });
+    drop(owner);
+    assert!(
+        weak.upgrade().is_none(),
+        "worker retained its owning JoinSet"
+    );
+    observed.await.unwrap();
+    assert!(core.upgrade().is_none());
+}

--- a/crates/bacnet-server/src/server/notification_worker_tests.rs
+++ b/crates/bacnet-server/src/server/notification_worker_tests.rs
@@ -1,6 +1,104 @@
 use super::*;
 use bacnet_objects::analog::AnalogOutputObject;
 
+async fn reap_after_ingress_closure(hold_request: bool) {
+    let (mut server, ingress, mut started) = fixture().await;
+    let mut request_released = if hold_request {
+        inject(&ingress, confirmed(false)).await;
+        Some(started.recv().await.unwrap())
+    } else {
+        None
+    };
+    // Close the real NPDU input, which closes the network layer's APDU sender.
+    // Keep the server and its outbound producers alive.
+    drop(ingress);
+    server
+        .network
+        .transport()
+        .pass_cov
+        .store(true, Ordering::Release);
+    for batch in 0..2 {
+        tokio::time::pause();
+        if batch == 0 {
+            fire_cov(&server, CovNotificationKind::Single).await;
+        } else {
+            server
+                .write_local(
+                    &ObjectIdentifier::new(ObjectType::ANALOG_OUTPUT, 1).unwrap(),
+                    PropertyIdentifier::PRESENT_VALUE,
+                    None,
+                    PropertyValue::Real(42.0),
+                    Some(16),
+                )
+                .await
+                .unwrap();
+        }
+        // No ACK can arrive after ingress closure. Drive the unchanged retry
+        // sequence to ordinary exhaustion, observing every real transport send.
+        for _ in 0..=DEFAULT_APDU_RETRIES {
+            let released = tokio::time::timeout(Duration::from_secs(2), started.recv())
+                .await
+                .unwrap()
+                .expect("outbound COV admission stopped with ingress");
+            released.await.unwrap();
+            assert!(
+                matches!(server.network.transport().frames.lock().unwrap().last(),
+                Some(Apdu::ConfirmedRequest(request))
+                    if request.service_choice == ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION)
+            );
+            tokio::time::advance(Duration::from_millis(server.config.cov_retry_timeout_ms)).await;
+        }
+        tokio::time::resume();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !server.notification_transactions.workers_empty() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("completed notification retained after ingress closure");
+        assert_eq!(server.notification_transactions.active_count(), 0);
+        assert_eq!(server.cov_in_flight.available_permits(), 255);
+        assert_eq!(
+            server
+                .cov_table
+                .read()
+                .await
+                .in_flight_tracker()
+                .active_peer_count(),
+            0
+        );
+        assert!(!server.notification_transactions.is_closed());
+        assert!(!server.dispatch_task.as_ref().unwrap().is_finished());
+        if let Some(released) = request_released.as_mut() {
+            assert!(matches!(
+                released.try_recv(),
+                Err(oneshot::error::TryRecvError::Empty)
+            ));
+            assert!(
+                !server.request_tasks.is_empty(),
+                "request must remain blocked during notification reaping"
+            );
+        }
+    }
+    if let Some(released) = request_released {
+        server.network.transport().release.notify_one();
+        released.await.unwrap();
+        wait_reaped(&server).await;
+    }
+    server.stop().await.unwrap();
+    assert!(server.notification_transactions.workers_empty());
+}
+
+#[tokio::test]
+async fn notification_worker_reaps_after_ingress_closure() {
+    reap_after_ingress_closure(false).await;
+}
+
+#[tokio::test]
+async fn notification_worker_reaps_after_ingress_closure_with_blocked_request() {
+    reap_after_ingress_closure(true).await;
+}
+
 async fn fire_event(server: &BACnetServer<HeldTransport>) {
     use crate::server::event_recipient_routing_tests::{address_recipient, destination_for};
     use bacnet_objects::analog::AnalogInputObject;

--- a/crates/bacnet-server/src/server/notification_worker_tests.rs
+++ b/crates/bacnet-server/src/server/notification_worker_tests.rs
@@ -1,0 +1,253 @@
+use super::*;
+use bacnet_objects::analog::AnalogOutputObject;
+
+async fn fire_event(server: &BACnetServer<HeldTransport>) {
+    use crate::server::event_recipient_routing_tests::{address_recipient, destination_for};
+    use bacnet_objects::analog::AnalogInputObject;
+    use bacnet_objects::event::EventStateChange;
+    use bacnet_objects::notification_class::NotificationClass;
+    use bacnet_types::enums::{EventState, EventType};
+
+    let mut db = crate::server::clocked_test_database();
+    db.add(Box::new(DeviceObject::new(Default::default()).unwrap()))
+        .unwrap();
+    let mut nc = NotificationClass::new(0, "NC-0").unwrap();
+    nc.add_destination(destination_for(address_recipient(0, &[1]), true));
+    db.add(Box::new(nc)).unwrap();
+    db.add(Box::new(AnalogInputObject::new(1, "AI-1", 0).unwrap()))
+        .unwrap();
+    BACnetServer::<HeldTransport>::build_and_send_event_notification_with_bindings(
+        &Arc::new(RwLock::new(db)),
+        &server.network,
+        &server.comm_state,
+        &server.server_tsm,
+        &server.notification_transactions,
+        &server.device_bindings,
+        &ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+        (
+            EventStateChange {
+                from: EventState::NORMAL,
+                to: EventState::HIGH_LIMIT,
+            },
+            EventType::OUT_OF_RANGE,
+        ),
+        3000,
+    )
+    .await;
+}
+
+async fn fire_cov(server: &BACnetServer<HeldTransport>, kind: CovNotificationKind) {
+    let oid = ObjectIdentifier::new(ObjectType::ANALOG_OUTPUT, 1).unwrap();
+    server
+        .db
+        .write()
+        .await
+        .add(Box::new(AnalogOutputObject::new(1, "AO-1", 62).unwrap()))
+        .unwrap();
+    server.cov_table.write().await.subscribe(CovSubscription {
+        subscriber_mac: MacAddr::from_slice(&[1]),
+        subscriber_network: None,
+        subscriber_process_identifier: 7,
+        monitored_object_identifier: oid,
+        issue_confirmed_notifications: true,
+        expires_at: None,
+        last_notified_value: None,
+        monitored_property: Some(PropertyIdentifier::PRESENT_VALUE),
+        monitored_property_array_index: None,
+        cov_increment: None,
+        notification_kind: kind,
+        timestamped: false,
+    });
+    BACnetServer::<HeldTransport>::fire_cov_notifications(
+        &server.db,
+        &server.network,
+        &server.cov_table,
+        &server.cov_in_flight,
+        &server.notification_transactions,
+        &server.comm_state,
+        &server.config,
+        &oid,
+    )
+    .await;
+}
+
+async fn stop_cov(kind: CovNotificationKind, service: ConfirmedServiceChoice) {
+    let (mut server, _ingress, mut started) = fixture().await;
+    fire_cov(&server, kind).await;
+    let mut released = tokio::time::timeout(Duration::from_secs(2), started.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        matches!(server.network.transport().frames.lock().unwrap().last(),
+        Some(Apdu::ConfirmedRequest(request)) if request.service_choice == service)
+    );
+    assert_eq!(server.notification_transactions.active_count(), 1);
+    assert_eq!(server.cov_in_flight.available_permits(), 254);
+    assert_eq!(
+        server
+            .cov_table
+            .read()
+            .await
+            .in_flight_tracker()
+            .active_peer_count(),
+        1
+    );
+    server.stop().await.unwrap();
+    assert_eq!(
+        released.try_recv(),
+        Ok(()),
+        "stop returned with a live notification send"
+    );
+    assert_eq!(server.notification_transactions.active_count(), 0);
+    assert!(server.notification_transactions.workers_empty());
+    assert_eq!(server.cov_in_flight.available_permits(), 255);
+    assert_eq!(
+        server
+            .cov_table
+            .read()
+            .await
+            .in_flight_tracker()
+            .active_peer_count(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn notification_worker_stop_single_cov() {
+    stop_cov(
+        CovNotificationKind::Single,
+        ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn notification_worker_stop_multiple_cov() {
+    stop_cov(
+        CovNotificationKind::Multiple,
+        ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION_MULTIPLE,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn notification_worker_stop_event() {
+    let (mut server, _ingress, mut started) = fixture().await;
+    fire_event(&server).await;
+    let mut released = tokio::time::timeout(Duration::from_secs(2), started.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        matches!(server.network.transport().frames.lock().unwrap().last(),
+        Some(Apdu::ConfirmedRequest(request)) if request.service_choice == ConfirmedServiceChoice::CONFIRMED_EVENT_NOTIFICATION)
+    );
+    assert_eq!(server.notification_transactions.active_count(), 1);
+    server.stop().await.unwrap();
+    assert_eq!(released.try_recv(), Ok(()));
+    assert!(server.notification_transactions.workers_empty());
+    assert_eq!(server.notification_transactions.active_count(), 0);
+}
+
+#[tokio::test]
+async fn notification_worker_cancelled_stop_retains_joins() {
+    use std::future::Future;
+    use std::task::Poll;
+    let (mut server, _ingress, mut started) = fixture().await;
+    fire_cov(&server, CovNotificationKind::Single).await;
+    let mut released = started.recv().await.unwrap();
+    {
+        let mut stop = std::pin::pin!(server.stop());
+        std::future::poll_fn(|cx| {
+            assert!(stop.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+    }
+    assert!(server.notification_transactions.is_closed());
+    assert!(!server.notification_transactions.workers_empty());
+    server.stop().await.unwrap();
+    assert_eq!(released.try_recv(), Ok(()));
+    assert!(server.notification_transactions.workers_empty());
+    assert_eq!(server.cov_in_flight.available_permits(), 255);
+}
+
+#[tokio::test]
+async fn notification_worker_reaps_all_families_success_panic_idle_active() {
+    use bacnet_encoding::apdu::SimpleAck;
+    for family in 0..3 {
+        for panic in [false, true] {
+            for active in [false, true] {
+                let (mut server, ingress, mut started) = fixture().await;
+                match family {
+                    0 => fire_cov(&server, CovNotificationKind::Single).await,
+                    1 => fire_cov(&server, CovNotificationKind::Multiple).await,
+                    _ => fire_event(&server).await,
+                }
+                let released = started.recv().await.unwrap();
+                let request = match server
+                    .network
+                    .transport()
+                    .frames
+                    .lock()
+                    .unwrap()
+                    .last()
+                    .unwrap()
+                {
+                    Apdu::ConfirmedRequest(request) => request.clone(),
+                    other => panic!("unexpected notification: {other:?}"),
+                };
+                if active {
+                    inject(&ingress, confirmed(false)).await;
+                    let _held_request =
+                        tokio::time::timeout(Duration::from_secs(2), started.recv())
+                            .await
+                            .unwrap()
+                            .unwrap();
+                }
+                server
+                    .network
+                    .transport()
+                    .panic_next
+                    .store(panic, Ordering::Release);
+                server.network.transport().release.notify_one();
+                released.await.unwrap();
+                if !panic {
+                    inject(
+                        &ingress,
+                        Apdu::SimpleAck(SimpleAck {
+                            invoke_id: request.invoke_id,
+                            service_choice: request.service_choice,
+                        }),
+                    )
+                    .await;
+                }
+                // Keep ordinary request ingress active while dispatch also reaps.
+                tokio::time::timeout(Duration::from_secs(2), async {
+                    while !server.notification_transactions.workers_empty() {
+                        if active {
+                            inject(&ingress, confirmed(false)).await;
+                        }
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .expect("notification completion was not reaped");
+                assert_eq!(server.notification_transactions.active_count(), 0);
+                assert_eq!(server.cov_in_flight.available_permits(), 255);
+                assert_eq!(
+                    server
+                        .cov_table
+                        .read()
+                        .await
+                        .in_flight_tracker()
+                        .active_peer_count(),
+                    0
+                );
+                assert!(!server.dispatch_task.as_ref().unwrap().is_finished());
+                server.stop().await.unwrap();
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/request_tasks_tests.rs
+++ b/crates/bacnet-server/src/server/request_tasks_tests.rs
@@ -29,6 +29,7 @@ struct HeldTransport {
     started: mpsc::UnboundedSender<oneshot::Receiver<()>>,
     release: Arc<Notify>,
     panic_next: AtomicBool,
+    pass_cov: AtomicBool,
     frames: std::sync::Mutex<Vec<Apdu>>,
 }
 
@@ -45,6 +46,8 @@ impl TransportPort for HeldTransport {
         let decoded = decode_npdu(Bytes::copy_from_slice(npdu)).unwrap();
         let apdu = apdu::decode_apdu(decoded.payload).unwrap();
         let segment_ack = matches!(apdu, Apdu::SegmentAck(_));
+        let cov = matches!(&apdu, Apdu::ConfirmedRequest(request)
+            if request.service_choice == ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION);
         self.frames.lock().unwrap().push(apdu);
         if segment_ack {
             return Ok(());
@@ -52,6 +55,9 @@ impl TransportPort for HeldTransport {
         let (tx, rx) = oneshot::channel();
         let _guard = SendGuard(Some(tx));
         self.started.send(rx).unwrap();
+        if cov && self.pass_cov.load(Ordering::Acquire) {
+            return Ok(());
+        }
         self.release.notified().await;
         assert!(
             !self.panic_next.swap(false, Ordering::AcqRel),
@@ -91,6 +97,7 @@ async fn fixture_with_name(
         started,
         release: Arc::new(Notify::new()),
         panic_next: AtomicBool::new(false),
+        pass_cov: AtomicBool::new(false),
         frames: std::sync::Mutex::new(Vec::new()),
     };
     let mut db = ObjectDatabase::new();

--- a/crates/bacnet-server/src/server/request_tasks_tests.rs
+++ b/crates/bacnet-server/src/server/request_tasks_tests.rs
@@ -11,6 +11,9 @@ mod segmented_worker_tests;
 #[path = "dcc_timer_tests.rs"]
 mod dcc_timer_tests;
 
+#[path = "notification_worker_tests.rs"]
+mod notification_worker_tests;
+
 struct SendGuard(Option<oneshot::Sender<()>>);
 
 impl Drop for SendGuard {

--- a/crates/bacnet-server/src/server/shutdown.rs
+++ b/crates/bacnet-server/src/server/shutdown.rs
@@ -8,6 +8,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Stop the server.
     pub async fn stop(&mut self) -> Result<(), Error> {
         self.request_tasks.close();
+        // Seal both reservations and worker admission before quiescing any
+        // producer; abort also interrupts workers suspended in async send.
         self.notification_transactions.close();
         // Keep the handle in self until joined: cancellation must not detach
         // dispatch and allow a later stop to race its join consumer.
@@ -50,6 +52,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         if let Some(task) = self.cov_purge_task.take() {
             task.abort();
             let _ = task.await;
+        }
+        // Dispatch has relinquished the sole join-consumer role. Retain the
+        // set in self across await so a cancelled stop can finish this drain.
+        while let Some(result) = self.notification_transactions.join_next().await {
+            NotificationTransactions::observe(Some(result));
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Own all three confirmed notification worker families: single COV, COV Multiple, and EventNotification.
- Seal reservation/worker admission and abort workers before producer shutdown; join retained workers before explicit stop returns, including workers blocked in cooperative async transport sends.
- Reap success/panic completions while ingress is idle or active. Keep operations in a separate transaction core to avoid retaining their task owner through a cycle.
- Retain joins across cancelled cleanup; drop rejected futures outside the owner mutex.

Refs #521 (partial; do not close). #522 unchanged.

## Validation
- Production single-COV and COV-Multiple shutdown regressions failed on baseline then passed. A detached-event mutation was also detected and restored.
- Nine new tests pass, including a 12-case family/success/panic/ingress matrix, close/spawn races, cancellation-safe joining and lease/global/per-peer COV resource recovery.
- Server notification 99 passed; COV 124 passed; request-task lifecycle 22 passed; DCC 26 passed; segmentation 69 passed; integration COV 10 passed; integration DCC 4 passed.
- cargo test --workspace --exclude rusty-bacnet --locked: 4,218 passed, 0 failed, 3 ignored (macOS).
- cargo fmt --all --check; cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked (warnings); file-size; no-secret; git diff --check: PASS. Root reran staged-file gates including new fixtures.
- Exact-head five lean CI checks and independent reviews pending; heavy/release qualification outside this feature-to-dev slice.

## Scope limits
Retry timing/count, invoke-ID reuse, ACK matching, routing/freshness/priority, transaction and COV limits/counters remain unchanged. Unconfirmed sends remain inline. No new admission/fairness/overload policy, response/work budgets, auth/SC, transport shutdown, restart, async Drop joining, rollback or arbitrary synchronous-blocking preemption. Existing broader producer-stop cancellation behavior is unchanged; this is not an all-server-work termination claim.

Native exact source verification governed while optional Codebase Memory coverage was unavailable. No licensed specification excerpts or new normative claims.