### PR TITLE
fix(server): retain producer handles across cancelled stop

### DIFF
--- a/crates/bacnet-server/src/server/producer_shutdown_tests.rs
+++ b/crates/bacnet-server/src/server/producer_shutdown_tests.rs
@@ -1,0 +1,154 @@
+use super::request_tasks_tests::{fixture, HeldTransport};
+use super::*;
+use std::future::{pending, poll_fn, Future};
+use std::task::Poll;
+use tokio::sync::oneshot;
+
+struct Released(Option<oneshot::Sender<()>>);
+
+impl Drop for Released {
+    fn drop(&mut self) {
+        let _ = self.0.take().unwrap().send(());
+    }
+}
+
+fn slots(server: &mut BACnetServer<HeldTransport>) -> [&mut Option<JoinHandle<()>>; 7] {
+    [
+        &mut server.fault_detection_task,
+        &mut server.event_enrollment_task,
+        &mut server.trend_log_task,
+        &mut server.schedule_tick_task,
+        &mut server.intrinsic_reporting_task,
+        &mut server.binary_lighting_operation_task,
+        &mut server.cov_purge_task,
+    ]
+}
+
+async fn cancelled_at(position: usize) {
+    let (mut server, _ingress, _sends) = fixture().await;
+    // Join every original production task before replacing any slot. The test
+    // then drives the actual stop seam with no dispatch/DCC join in its way.
+    server.stop().await.unwrap();
+    let mut released = Vec::new();
+    let mut ids = Vec::new();
+    for slot in slots(&mut server) {
+        assert!(slot.is_none());
+        let (tx, rx) = oneshot::channel();
+        let guard = Released(Some(tx));
+        let task = tokio::spawn(async move {
+            let _guard = guard;
+            pending::<()>().await;
+        });
+        ids.push(task.id());
+        released.push(rx);
+        *slot = Some(task);
+    }
+    // Make earlier joins ready without consuming their handles. Current and
+    // later tasks remain pending; the single-thread runtime cannot process an
+    // abort between the synchronous stop poll and the slot assertions below.
+    for slot in slots(&mut server).into_iter().take(position) {
+        slot.as_ref().unwrap().abort();
+    }
+    while slots(&mut server)
+        .into_iter()
+        .take(position)
+        .any(|slot| !slot.as_ref().unwrap().is_finished())
+    {
+        tokio::task::yield_now().await;
+    }
+    {
+        let mut stop = std::pin::pin!(server.stop());
+        poll_fn(|cx| {
+            assert!(stop.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+    }
+    for (index, slot) in slots(&mut server).into_iter().enumerate() {
+        if index < position {
+            assert!(slot.is_none(), "completed slot {index} must be cleared");
+        } else {
+            assert_eq!(
+                slot.as_ref().map(JoinHandle::id),
+                Some(ids[index]),
+                "cancelled stop lost producer slot {index} at join {position}"
+            );
+            assert!(!slot.as_ref().unwrap().is_finished());
+        }
+        assert_eq!(
+            released[index].try_recv(),
+            if index < position {
+                Ok(())
+            } else {
+                Err(oneshot::error::TryRecvError::Empty)
+            }
+        );
+    }
+    // Let the requested abort finish without polling its join. Later producers
+    // must still be live, proving stop has not eagerly aborted past this slot.
+    while !slots(&mut server)[position].as_ref().unwrap().is_finished() {
+        tokio::task::yield_now().await;
+    }
+    for slot in slots(&mut server).into_iter().skip(position + 1) {
+        assert!(!slot.as_ref().unwrap().is_finished());
+    }
+    server.stop().await.unwrap();
+    assert!(slots(&mut server).into_iter().all(|slot| slot.is_none()));
+    for resource in released.iter_mut().skip(position) {
+        assert_eq!(resource.try_recv(), Ok(()));
+    }
+    server.stop().await.unwrap();
+}
+
+macro_rules! cancellation_test {
+    ($name:ident, $position:expr) => {
+        #[tokio::test(start_paused = true)]
+        async fn $name() {
+            cancelled_at($position).await;
+        }
+    };
+}
+
+cancellation_test!(producer_shutdown_cancel_fault_detection, 0);
+cancellation_test!(producer_shutdown_cancel_event_enrollment, 1);
+cancellation_test!(producer_shutdown_cancel_trend_log, 2);
+cancellation_test!(producer_shutdown_cancel_schedule_tick, 3);
+cancellation_test!(producer_shutdown_cancel_intrinsic_reporting, 4);
+cancellation_test!(producer_shutdown_cancel_binary_lighting, 5);
+cancellation_test!(producer_shutdown_cancel_cov_purge, 6);
+
+#[tokio::test(start_paused = true)]
+async fn producer_shutdown_completed_panicked_and_absent_slots_are_idempotent() {
+    let (mut server, _ingress, _sends) = fixture().await;
+    server.stop().await.unwrap();
+    // Rotate so every slot is exercised with each terminal/absent state.
+    for rotation in 0..3 {
+        let mut released = Vec::new();
+        for (index, slot) in slots(&mut server).into_iter().enumerate() {
+            assert!(slot.is_none());
+            let state = (index + rotation) % 3;
+            if state == 0 {
+                continue;
+            }
+            let (tx, rx) = oneshot::channel();
+            let guard = Released(Some(tx));
+            *slot = Some(tokio::spawn(async move {
+                let _guard = guard;
+                assert_ne!(state, 2, "injected producer panic");
+            }));
+            released.push(rx);
+        }
+        while slots(&mut server)
+            .into_iter()
+            .any(|slot| slot.as_ref().is_some_and(|task| !task.is_finished()))
+        {
+            tokio::task::yield_now().await;
+        }
+        server.stop().await.unwrap();
+        assert!(slots(&mut server).into_iter().all(|slot| slot.is_none()));
+        for mut resource in released {
+            assert_eq!(resource.try_recv(), Ok(()));
+        }
+        server.stop().await.unwrap();
+    }
+}

--- a/crates/bacnet-server/src/server/request_tasks_tests.rs
+++ b/crates/bacnet-server/src/server/request_tasks_tests.rs
@@ -24,7 +24,7 @@ impl Drop for SendGuard {
     }
 }
 
-struct HeldTransport {
+pub(super) struct HeldTransport {
     incoming: Option<mpsc::Receiver<ReceivedNpdu>>,
     started: mpsc::UnboundedSender<oneshot::Receiver<()>>,
     release: Arc<Notify>,
@@ -75,7 +75,7 @@ impl TransportPort for HeldTransport {
     }
 }
 
-async fn fixture() -> (
+pub(super) async fn fixture() -> (
     BACnetServer<HeldTransport>,
     mpsc::Sender<ReceivedNpdu>,
     mpsc::UnboundedReceiver<oneshot::Receiver<()>>,

--- a/crates/bacnet-server/src/server/shutdown.rs
+++ b/crates/bacnet-server/src/server/shutdown.rs
@@ -4,6 +4,20 @@ use super::*;
 #[path = "request_tasks_tests.rs"]
 mod request_tasks_tests;
 
+#[cfg(test)]
+#[path = "producer_shutdown_tests.rs"]
+mod producer_shutdown_tests;
+
+async fn stop_producer(slot: &mut Option<JoinHandle<()>>) {
+    // Borrow across the join so cancellation leaves the handle recoverable.
+    // Clear synchronously after completion: a later stop must not poll it twice.
+    if let Some(task) = slot.as_mut() {
+        task.abort();
+        let _ = task.await;
+    }
+    *slot = None;
+}
+
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Stop the server.
     pub async fn stop(&mut self) -> Result<(), Error> {
@@ -25,34 +39,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             let mut timer = self.dcc_timer.lock().await;
             super::dcc_timer::cancel(&mut timer).await;
         }
-        if let Some(task) = self.fault_detection_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
-        if let Some(task) = self.event_enrollment_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
-        if let Some(task) = self.trend_log_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
-        if let Some(task) = self.schedule_tick_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
-        if let Some(task) = self.intrinsic_reporting_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
-        if let Some(task) = self.binary_lighting_operation_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
-        if let Some(task) = self.cov_purge_task.take() {
-            task.abort();
-            let _ = task.await;
-        }
+        stop_producer(&mut self.fault_detection_task).await;
+        stop_producer(&mut self.event_enrollment_task).await;
+        stop_producer(&mut self.trend_log_task).await;
+        stop_producer(&mut self.schedule_tick_task).await;
+        stop_producer(&mut self.intrinsic_reporting_task).await;
+        stop_producer(&mut self.binary_lighting_operation_task).await;
+        stop_producer(&mut self.cov_purge_task).await;
         // Dispatch has relinquished the sole join-consumer role. Retain the
         // set in self across await so a cancelled stop can finish this drain.
         while let Some(result) = self.notification_transactions.join_next().await {


### PR DESCRIPTION
## Summary
- Retain each of the seven periodic producer handles in the server while aborting and awaiting completion.
- Clear each slot synchronously after its join completes, so cancelled stop can be retried without losing ownership or polling a consumed handle.
- Preserve the existing shutdown order, producer intervals, and request/DCC/notification lifecycle behavior.

Refs #521 (partial; do not close). #522 unchanged.

## Validation
- Seven all-position shutdown cancellation regressions failed on baseline and passed after the fix.
- Eight focused tests pass, covering all seven slots plus completed, panicked, absent, retry, and repeated-stop cases. Original production tasks are joined before synthetic fixture injection.
- Request-task tests 24 passed; DCC 26 passed; notification workers 11 passed; binary lighting 18 passed; event enrollment 167 passed.
- cargo test -p bacnet-server --locked: 907 unit and 3 integration tests passed.
- cargo test --workspace --exclude rusty-bacnet --locked: 4,228 passed, 0 failed, 3 ignored (macOS).
- cargo fmt --all --check; cargo clippy --workspace --exclude rusty-bacnet --all-targets --locked (warnings); file-size; no-secret; git diff --check: PASS. Root reran staged gates including the new file.
- Exact-head five lean CI checks and independent reviews pending; heavy/release qualification outside this feature-to-dev slice.

## Boundaries
This is cancellation recovery for the seven known producer join slots, not admission limits, fairness, overload handling, work/response budgets, transport shutdown, restart, async Drop joining, rollback, arbitrary blocking preemption, or an all-server-work termination guarantee. No API, dependency, configuration, protocol, or CI changes.

Optional Codebase Memory coverage unavailable; native exact source verification used. No licensed specification excerpts or new normative claims.