### PR TITLE
feat(server): bound inbound request handler admission

### DIFF
--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -1,3 +1,4 @@
+use super::request_admission::{Class, Rejection};
 use super::*;
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
@@ -102,7 +103,29 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     ) {
         match apdu {
             Apdu::ConfirmedRequest(req) => {
-                let reply_tx = received.reply_tx.take();
+                let pending = match confirmed_request_tracker.begin(
+                    source_mac,
+                    received.source_network.as_ref(),
+                    req.clone(),
+                ) {
+                    ConfirmedRequestAdmission::Duplicate => return,
+                    ConfirmedRequestAdmission::New(pending) => pending,
+                };
+                if comm_state.load(Ordering::Acquire) == 1
+                    && req.service_choice != ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL
+                    && req.service_choice != ConfirmedServiceChoice::REINITIALIZE_DEVICE
+                {
+                    // Preserve the existing DCC discard and duplicate retention.
+                    pending.complete();
+                    return;
+                }
+                let invoke_id = req.invoke_id;
+                let service_choice = req.service_choice;
+                let abort_comm_state = Arc::clone(comm_state);
+                let abort_network = Arc::clone(network);
+                let abort_mac = MacAddr::from_slice(source_mac);
+                let abort_source = received.source_network.clone();
+                let mut reply_tx = received.reply_tx.take();
                 let db = Arc::clone(db);
                 let network = Arc::clone(network);
                 let cov_table = Arc::clone(cov_table);
@@ -111,7 +134,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let cov_in_flight = Arc::clone(cov_in_flight);
                 let server_tsm = Arc::clone(server_tsm);
                 let notification_transactions = Arc::clone(notification_transactions);
-                let confirmed_request_tracker = Arc::clone(confirmed_request_tracker);
                 let device_bindings = Arc::clone(device_bindings);
                 let comm_state = Arc::clone(comm_state);
                 let dcc_timer = Arc::clone(dcc_timer);
@@ -119,29 +141,61 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let source_mac = MacAddr::from_slice(source_mac);
                 let source_network = received.source_network.clone();
                 let descendants = request_tasks.spawner();
-                request_tasks.spawn(async move {
-                    Self::handle_confirmed_request(
-                        &db,
-                        &network,
-                        &cov_table,
-                        &seg_ack_senders,
-                        &seg_send_permits,
-                        &cov_in_flight,
-                        &server_tsm,
-                        &notification_transactions,
-                        &confirmed_request_tracker,
-                        &device_bindings,
-                        &comm_state,
-                        &dcc_timer,
-                        &config,
-                        &descendants,
-                        &source_mac,
-                        source_network,
-                        req,
-                        reply_tx,
-                    )
-                    .await;
+                let result = request_tasks.try_spawn(Class::Confirmed, || {
+                    let reply_tx = reply_tx.take();
+                    async move {
+                        Self::handle_admitted_confirmed_request(
+                            &db,
+                            &network,
+                            &cov_table,
+                            &seg_ack_senders,
+                            &seg_send_permits,
+                            &cov_in_flight,
+                            &server_tsm,
+                            &notification_transactions,
+                            &device_bindings,
+                            &comm_state,
+                            &dcc_timer,
+                            &config,
+                            &descendants,
+                            &source_mac,
+                            source_network,
+                            req,
+                            reply_tx,
+                        )
+                        .await;
+                        pending.complete();
+                    }
                 });
+                if result == Err(Rejection::Overloaded) {
+                    // ASHRAE 135-2020 §§5.4.5.3, 18.10: resource exhaustion
+                    // before service execution is reported by a server Abort.
+                    // Eight owned sends bound this response work. If all are
+                    // busy, the counted silent drop is a known local limitation.
+                    let _ = request_tasks.try_spawn(Class::Abort, || async move {
+                        // Match the handler's first-poll DCC check as well as
+                        // dispatch's precheck if DCC changed after registration.
+                        if abort_comm_state.load(Ordering::Acquire) == 1
+                            && service_choice
+                                != ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL
+                            && service_choice != ConfirmedServiceChoice::REINITIALIZE_DEVICE
+                        {
+                            return;
+                        }
+                        requests::confirmed_response::send_overload_response(
+                            &abort_network,
+                            &Apdu::Abort(AbortPdu {
+                                sent_by_server: true,
+                                invoke_id,
+                                abort_reason: AbortReason::OUT_OF_RESOURCES,
+                            }),
+                            &abort_mac,
+                            abort_source.as_ref(),
+                            reply_tx,
+                        )
+                        .await;
+                    });
+                }
             }
             Apdu::UnconfirmedRequest(req) => {
                 let comm = comm_state.load(Ordering::Acquire);
@@ -203,7 +257,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let comm_state = Arc::clone(comm_state);
                 let device_bindings = Arc::clone(device_bindings);
                 let discovery_limiter = Arc::clone(discovery_limiter);
-                request_tasks.spawn(async move {
+                let _ = request_tasks.try_spawn(Class::Unconfirmed, || async move {
                     Self::handle_unconfirmed_request(
                         &db,
                         &network,

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -43,6 +43,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             ))
         })?;
         validate_max_apdu_length(max_apdu)?;
+        let request_tasks = super::request_tasks::RequestTasks::for_server(&config)?;
 
         if config.vendor_id == 0 {
             warn!("vendor_id is 0 (ASHRAE reserved); set a valid vendor ID for production use");
@@ -106,7 +107,6 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let clock_dispatch = clock.clone();
         let discovery_limiter_dispatch = Arc::clone(&discovery_limiter);
 
-        let request_tasks = Arc::new(super::request_tasks::RequestTasks::default());
         let requests = Arc::clone(&request_tasks);
         let dispatch_task = tokio::spawn(async move {
             let mut seg_receivers: HashMap<SegKey, SegmentedRequestState> = HashMap::new();

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -367,6 +367,8 @@ pub struct ServerConfig {
     pub discovery_policy: DiscoveryPolicy,
     /// COV quota, rate accounting, and notification work budget policy.
     pub cov_policy: CovPolicy,
+    /// Positive independent top-level request handler limits.
+    pub request_admission_policy: RequestAdmissionPolicy,
 }
 
 impl std::fmt::Debug for ServerConfig {
@@ -418,6 +420,7 @@ impl std::fmt::Debug for ServerConfig {
             )
             .field("discovery_policy", &self.discovery_policy)
             .field("cov_policy", &self.cov_policy)
+            .field("request_admission_policy", &self.request_admission_policy)
             .finish()
     }
 }
@@ -444,6 +447,7 @@ impl Default for ServerConfig {
             event_enrollment_interval_secs: 10,
             discovery_policy: DiscoveryPolicy::default(),
             cov_policy: CovPolicy::default(),
+            request_admission_policy: RequestAdmissionPolicy::default(),
         }
     }
 }
@@ -873,7 +877,9 @@ mod segmentation;
 mod segmented_receive;
 mod segmented_send;
 pub(crate) use segmented_send::*;
+mod request_admission;
 mod request_tasks;
+pub use request_admission::{RequestAdmissionCounters, RequestAdmissionPolicy};
 mod shutdown;
 
 #[cfg(test)]

--- a/crates/bacnet-server/src/server/request_admission.rs
+++ b/crates/bacnet-server/src/server/request_admission.rs
@@ -1,0 +1,204 @@
+//! Local fail-fast handler policy, not a protocol or throughput guarantee.
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use bacnet_types::error::Error;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+/// Global, independent top-level handler limits. Zero is invalid.
+/// Defaults are provisional owner policy, not benchmark-derived values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RequestAdmissionPolicy {
+    /// Maximum concurrent confirmed handlers (default 64).
+    pub max_confirmed_in_flight: usize,
+    /// Maximum concurrent unconfirmed handlers (default 32).
+    pub max_unconfirmed_in_flight: usize,
+}
+
+impl Default for RequestAdmissionPolicy {
+    fn default() -> Self {
+        Self {
+            max_confirmed_in_flight: 64,
+            max_unconfirmed_in_flight: 32,
+        }
+    }
+}
+
+impl RequestAdmissionPolicy {
+    /// Reject zero and limits that the underlying semaphore cannot represent.
+    pub fn validate(&self) -> Result<(), Error> {
+        for (name, value) in [
+            ("max_confirmed_in_flight", self.max_confirmed_in_flight),
+            ("max_unconfirmed_in_flight", self.max_unconfirmed_in_flight),
+        ] {
+            if value == 0 || value > Semaphore::MAX_PERMITS {
+                return Err(Error::Encoding(format!(
+                    "{name} must be in 1..={}",
+                    Semaphore::MAX_PERMITS
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Independently sampled counters for one server lifetime, not an atomic aggregate.
+/// Admitted totals count registrations, not successful responses. Active counts
+/// include registered futures not yet polled and exclude completed unreaped tasks.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RequestAdmissionCounters {
+    /// Live confirmed handlers.
+    pub confirmed_active: usize,
+    /// Confirmed handlers registered since startup.
+    pub confirmed_admitted_total: u64,
+    /// Confirmed requests rejected for exhausted handler capacity.
+    pub confirmed_overloaded_total: u64,
+    /// Confirmed registrations rejected after shutdown sealed the owner.
+    pub confirmed_shutdown_rejected_total: u64,
+    /// Live unconfirmed handlers.
+    pub unconfirmed_active: usize,
+    /// Unconfirmed handlers registered since startup.
+    pub unconfirmed_admitted_total: u64,
+    /// Unconfirmed requests dropped for exhausted handler capacity.
+    pub unconfirmed_overloaded_total: u64,
+    /// Unconfirmed registrations rejected after shutdown sealed the owner.
+    pub unconfirmed_shutdown_rejected_total: u64,
+    /// Live overload Abort send workers (private fixed capacity 8).
+    pub abort_active: usize,
+    /// Overload Abort workers registered, not necessarily successfully sent.
+    pub abort_admitted_total: u64,
+    /// Confirmed overloads silently dropped because all Abort workers were busy.
+    pub confirmed_fallback_dropped_total: u64,
+    /// Abort registrations rejected after shutdown sealed the owner.
+    pub abort_shutdown_rejected_total: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum Class {
+    Confirmed = 0,
+    Unconfirmed = 1,
+    Abort = 2,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum Rejection {
+    Closed,
+    Overloaded,
+}
+
+pub(super) struct Admission {
+    pools: [Arc<Pool>; 3],
+}
+
+struct Pool {
+    permits: Arc<Semaphore>,
+    active: AtomicUsize,
+    admitted: AtomicU64,
+    overloaded: AtomicU64,
+    closed: AtomicU64,
+}
+
+impl Pool {
+    fn new(limit: usize) -> Arc<Self> {
+        Arc::new(Self {
+            permits: Arc::new(Semaphore::new(limit)),
+            active: AtomicUsize::new(0),
+            admitted: AtomicU64::new(0),
+            overloaded: AtomicU64::new(0),
+            closed: AtomicU64::new(0),
+        })
+    }
+}
+
+pub(super) struct Guard {
+    pool: Arc<Pool>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        self.pool.active.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl Admission {
+    pub(super) fn new(policy: RequestAdmissionPolicy) -> Result<Self, Error> {
+        policy.validate()?;
+        Ok(Self {
+            pools: [
+                Pool::new(policy.max_confirmed_in_flight),
+                Pool::new(policy.max_unconfirmed_in_flight),
+                Pool::new(8),
+            ],
+        })
+    }
+
+    // Called under the task owner's spawn/close lock. No capacity waiters exist.
+    pub(super) fn try_enter(&self, class: Class, closed: bool) -> Result<Guard, Rejection> {
+        let pool = &self.pools[class as usize];
+        if closed {
+            pool.closed.fetch_add(1, Ordering::Relaxed);
+            return Err(Rejection::Closed);
+        }
+        let permit = Arc::clone(&pool.permits).try_acquire_owned().map_err(|_| {
+            pool.overloaded.fetch_add(1, Ordering::Relaxed);
+            Rejection::Overloaded
+        })?;
+        pool.active.fetch_add(1, Ordering::Relaxed);
+        pool.admitted.fetch_add(1, Ordering::Relaxed);
+        Ok(Guard {
+            pool: Arc::clone(pool),
+            _permit: permit,
+        })
+    }
+
+    pub(super) fn snapshot(&self) -> RequestAdmissionCounters {
+        let [c, u, a] = &self.pools;
+        RequestAdmissionCounters {
+            confirmed_active: c.active.load(Ordering::Relaxed),
+            confirmed_admitted_total: c.admitted.load(Ordering::Relaxed),
+            confirmed_overloaded_total: c.overloaded.load(Ordering::Relaxed),
+            confirmed_shutdown_rejected_total: c.closed.load(Ordering::Relaxed),
+            unconfirmed_active: u.active.load(Ordering::Relaxed),
+            unconfirmed_admitted_total: u.admitted.load(Ordering::Relaxed),
+            unconfirmed_overloaded_total: u.overloaded.load(Ordering::Relaxed),
+            unconfirmed_shutdown_rejected_total: u.closed.load(Ordering::Relaxed),
+            abort_active: a.active.load(Ordering::Relaxed),
+            abort_admitted_total: a.admitted.load(Ordering::Relaxed),
+            confirmed_fallback_dropped_total: a.overloaded.load(Ordering::Relaxed),
+            abort_shutdown_rejected_total: a.closed.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl<T: super::TransportPort + 'static> super::ServerBuilder<T> {
+    /// Set positive global handler limits, validated before transport startup.
+    pub fn request_admission_policy(mut self, policy: RequestAdmissionPolicy) -> Self {
+        self.config.request_admission_policy = policy;
+        self
+    }
+}
+
+impl super::BipServerBuilder {
+    /// Set positive global handler limits, validated before transport startup.
+    pub fn request_admission_policy(mut self, policy: RequestAdmissionPolicy) -> Self {
+        self.config.request_admission_policy = policy;
+        self
+    }
+}
+
+#[cfg(feature = "sc-tls")]
+impl super::ScServerBuilder {
+    /// Set positive global handler limits, validated before TLS dialing.
+    pub fn request_admission_policy(mut self, policy: RequestAdmissionPolicy) -> Self {
+        self.config.request_admission_policy = policy;
+        self
+    }
+}
+
+impl<T: super::TransportPort + 'static> super::BACnetServer<T> {
+    /// Sample admission counters. Available after stop; active counts then are zero.
+    pub fn request_admission_counters(&self) -> RequestAdmissionCounters {
+        self.request_tasks.counters()
+    }
+}

--- a/crates/bacnet-server/src/server/request_admission_tests.rs
+++ b/crates/bacnet-server/src/server/request_admission_tests.rs
@@ -1,0 +1,606 @@
+use super::*;
+use crate::server::request_admission::{Class, Rejection};
+
+async fn small_fixture() -> (
+    BACnetServer<HeldTransport>,
+    mpsc::Sender<ReceivedNpdu>,
+    mpsc::UnboundedReceiver<oneshot::Receiver<()>>,
+) {
+    fixture_with_config(
+        "admission",
+        ServerConfig {
+            request_admission_policy: RequestAdmissionPolicy {
+                max_confirmed_in_flight: 1,
+                max_unconfirmed_in_flight: 1,
+            },
+            discovery_policy: DiscoveryPolicy::unlimited(),
+            segmentation_supported: Segmentation::BOTH,
+            ..ServerConfig::default()
+        },
+    )
+    .await
+}
+
+async fn dispatch(
+    server: &BACnetServer<HeldTransport>,
+    apdu: Apdu,
+    source: Option<NpduAddress>,
+    reply_tx: Option<oneshot::Sender<Bytes>>,
+) {
+    BACnetServer::dispatch(
+        &server.db,
+        &server.network,
+        &server.cov_table,
+        &server.seg_ack_senders,
+        &server.seg_send_permits,
+        &server.cov_in_flight,
+        &server.server_tsm,
+        &server.notification_transactions,
+        &server.confirmed_request_tracker,
+        &server.device_bindings,
+        &server.comm_state,
+        &server.dcc_timer,
+        &Arc::new(server.config.clone()),
+        &server._clock,
+        &server.discovery_limiter,
+        &server.request_tasks,
+        &[1],
+        apdu,
+        bacnet_network::layer::ReceivedApdu {
+            apdu: Bytes::new(),
+            source_mac: MacAddr::from_slice(&[1]),
+            source_network: source,
+            link_layer_group: false,
+            is_group: false,
+            data_attributes: Vec::new(),
+            reply_tx,
+        },
+    )
+    .await;
+}
+
+fn who_is() -> Apdu {
+    Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
+        service_choice: UnconfirmedServiceChoice::WHO_IS,
+        service_request: Bytes::new(),
+    })
+}
+
+async fn observed(
+    started: &mut mpsc::UnboundedReceiver<oneshot::Receiver<()>>,
+) -> oneshot::Receiver<()> {
+    tokio::time::timeout(Duration::from_secs(2), started.recv())
+        .await
+        .unwrap()
+        .unwrap()
+}
+
+fn request(id: u8) -> Apdu {
+    let Apdu::ConfirmedRequest(mut req) = confirmed(false) else {
+        unreachable!()
+    };
+    req.invoke_id = id;
+    Apdu::ConfirmedRequest(req)
+}
+
+#[tokio::test]
+async fn admission_default_confirmed_limit_rejects_before_handler() {
+    let (mut server, tx, mut started) = fixture().await;
+    for id in 0..65 {
+        inject(&tx, request(id)).await;
+        tokio::time::timeout(Duration::from_secs(2), started.recv())
+            .await
+            .unwrap()
+            .unwrap();
+    }
+    {
+        let frames = server.network.transport().frames.lock().unwrap();
+        assert_eq!(frames.len(), 65);
+        assert!(
+            matches!(&frames[64], Apdu::Abort(abort)
+            if abort.sent_by_server && abort.invoke_id == 64
+                && abort.abort_reason == AbortReason::OUT_OF_RESOURCES),
+            "65th held confirmed request must not execute: {:?}",
+            frames[64]
+        );
+    }
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn admission_independent_handlers_and_eight_owned_abort_workers_never_queue() {
+    let (mut server, _tx, mut started) = small_fixture().await;
+    dispatch(&server, request(1), None, None).await;
+    let original = observed(&mut started).await;
+    dispatch(&server, who_is(), None, None).await;
+    let unconfirmed = observed(&mut started).await;
+    dispatch(&server, who_is(), None, None).await;
+    for id in 2..=9 {
+        dispatch(&server, request(id), None, None).await;
+        observed(&mut started).await;
+    }
+    dispatch(&server, request(10), None, None).await;
+    let counters = server.request_admission_counters();
+    assert_eq!(counters.confirmed_active, 1);
+    assert_eq!(counters.unconfirmed_active, 1);
+    assert_eq!(counters.confirmed_admitted_total, 1);
+    assert_eq!(counters.unconfirmed_admitted_total, 1);
+    assert_eq!(counters.confirmed_overloaded_total, 9);
+    assert_eq!(counters.unconfirmed_overloaded_total, 1);
+    assert_eq!(counters.abort_active, 8);
+    assert_eq!(counters.abort_admitted_total, 8);
+    assert_eq!(counters.confirmed_fallback_dropped_total, 1);
+    // Real outgoing notification transactions still finish inline while both
+    // handler classes and every overload response worker are saturated.
+    for kind in 0..4 {
+        let service_choice = ConfirmedServiceChoice::CONFIRMED_COV_NOTIFICATION;
+        let (operation, mut completed) = server
+            .notification_transactions
+            .reserve(
+                crate::server::notification_transactions::canonical_direct_peer(&[1]),
+                service_choice,
+            )
+            .unwrap();
+        let invoke_id = operation.invoke_id();
+        let terminal = match kind {
+            0 => Apdu::SimpleAck(SimpleAck {
+                invoke_id,
+                service_choice,
+            }),
+            1 => Apdu::Error(ErrorPdu {
+                invoke_id,
+                service_choice,
+                error_class: ErrorClass::SERVICES,
+                error_code: ErrorCode::OTHER,
+                error_data: Bytes::new(),
+            }),
+            2 => Apdu::Reject(RejectPdu {
+                invoke_id,
+                reject_reason: RejectReason::OTHER,
+            }),
+            _ => Apdu::Abort(AbortPdu {
+                invoke_id,
+                sent_by_server: false,
+                abort_reason: AbortReason::OTHER,
+            }),
+        };
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            dispatch(&server, terminal, None, None),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            completed.try_recv(),
+            Ok(if kind == 0 {
+                CovAckResult::Ack
+            } else {
+                CovAckResult::Error
+            })
+        );
+        drop(operation);
+    }
+    assert_eq!(server.request_admission_counters(), counters);
+    assert!(started.try_recv().is_err());
+    assert_eq!(server.network.transport().frames.lock().unwrap().len(), 10);
+    server.network.transport().release.notify_waiters();
+    original.await.unwrap();
+    unconfirmed.await.unwrap();
+    wait_reaped(&server).await;
+    // Denied work never starts after release. All ten prior frames are final.
+    assert_eq!(server.network.transport().frames.lock().unwrap().len(), 10);
+    assert_eq!(server.request_admission_counters().confirmed_active, 0);
+    assert_eq!(server.request_admission_counters().unconfirmed_active, 0);
+    assert_eq!(server.request_admission_counters().abort_active, 0);
+    dispatch(&server, request(10), None, None).await;
+    observed(&mut started).await;
+    assert_eq!(
+        server.request_admission_counters().confirmed_admitted_total,
+        2
+    );
+    server.stop().await.unwrap();
+    assert_eq!(server.request_admission_counters().confirmed_active, 0);
+}
+
+#[tokio::test]
+async fn admission_pending_and_completed_duplicates_at_capacity_have_no_abort() {
+    let (mut server, _tx, mut started) = small_fixture().await;
+    dispatch(&server, request(1), None, None).await;
+    let original = observed(&mut started).await;
+    // Exact duplicate detection already works before another task is polled.
+    dispatch(&server, request(1), None, None).await;
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .confirmed_overloaded_total,
+        0
+    );
+    server.network.transport().release.notify_one();
+    original.await.unwrap();
+    wait_reaped(&server).await;
+    dispatch(&server, request(2), None, None).await;
+    observed(&mut started).await;
+    dispatch(&server, request(1), None, None).await;
+    dispatch(&server, request(2), None, None).await;
+    assert_eq!(
+        server.request_admission_counters().confirmed_admitted_total,
+        2
+    );
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .confirmed_overloaded_total,
+        0
+    );
+    assert_eq!(server.request_admission_counters().abort_admitted_total, 0);
+    assert_eq!(server.network.transport().frames.lock().unwrap().len(), 2);
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn admission_abort_reply_channel_preserves_routed_npdu_and_wire_fields() {
+    let (mut server, _tx, mut started) = small_fixture().await;
+    dispatch(&server, request(1), None, None).await;
+    observed(&mut started).await;
+    for source in [
+        None,
+        Some(NpduAddress {
+            network: 42,
+            mac_address: MacAddr::from_slice(&[7]),
+        }),
+    ] {
+        let (tx, rx) = oneshot::channel();
+        dispatch(&server, request(2), source.clone(), Some(tx)).await;
+        let wire = tokio::time::timeout(Duration::from_secs(2), rx)
+            .await
+            .unwrap()
+            .unwrap();
+        let npdu = decode_npdu(wire).unwrap();
+        assert_eq!(npdu.destination, source);
+        assert!(!npdu.expecting_reply);
+        assert!(
+            matches!(apdu::decode_apdu(npdu.payload).unwrap(), Apdu::Abort(a)
+            if a.sent_by_server && a.invoke_id == 2 && a.abort_reason == AbortReason::OUT_OF_RESOURCES)
+        );
+    }
+    assert_eq!(server.network.transport().frames.lock().unwrap().len(), 1);
+    server.stop().await.unwrap();
+    assert_eq!(server.request_admission_counters().abort_active, 0);
+}
+
+#[tokio::test]
+async fn admission_stop_seals_classes_without_overload_and_joins_abort_workers() {
+    let (mut server, _tx, mut started) = small_fixture().await;
+    dispatch(&server, request(1), None, None).await;
+    let mut original = observed(&mut started).await;
+    dispatch(&server, request(2), None, None).await;
+    let mut abort = observed(&mut started).await;
+    server.stop().await.unwrap();
+    assert_eq!(original.try_recv(), Ok(()));
+    assert_eq!(abort.try_recv(), Ok(()));
+    dispatch(&server, request(3), None, None).await;
+    dispatch(&server, who_is(), None, None).await;
+    let c = server.request_admission_counters();
+    assert_eq!(
+        c.confirmed_active + c.unconfirmed_active + c.abort_active,
+        0
+    );
+    assert_eq!(c.confirmed_overloaded_total, 1);
+    assert_eq!(c.unconfirmed_overloaded_total, 0);
+    assert_eq!(c.confirmed_shutdown_rejected_total, 1);
+    assert_eq!(c.unconfirmed_shutdown_rejected_total, 1);
+}
+
+#[tokio::test]
+async fn admission_panic_releases_real_handler_and_abort_and_allows_retry() {
+    let (mut server, tx, mut started) = small_fixture().await;
+    for id in [1, 1] {
+        inject(&tx, request(id)).await;
+        let released = observed(&mut started).await;
+        server
+            .network
+            .transport()
+            .panic_next
+            .store(true, Ordering::Release);
+        server.network.transport().release.notify_one();
+        released.await.unwrap();
+        wait_reaped(&server).await;
+        assert_eq!(server.request_admission_counters().confirmed_active, 0);
+    }
+    dispatch(&server, request(3), None, None).await;
+    observed(&mut started).await;
+    dispatch(&server, request(4), None, None).await;
+    observed(&mut started).await;
+    // Cancellation, including never-polled futures, is owned by the same set.
+    server.stop().await.unwrap();
+    assert_eq!(server.request_admission_counters().abort_active, 0);
+}
+
+#[tokio::test]
+async fn admission_guards_not_joinset_length_and_closed_not_overload() {
+    let owner = crate::server::request_tasks::RequestTasks::new(RequestAdmissionPolicy {
+        max_confirmed_in_flight: 1,
+        max_unconfirmed_in_flight: 1,
+    })
+    .unwrap();
+    for class in [Class::Confirmed, Class::Unconfirmed, Class::Abort] {
+        let (tx, rx) = oneshot::channel();
+        owner
+            .try_spawn(class, || async move {
+                tx.send(()).unwrap();
+            })
+            .unwrap();
+        rx.await.unwrap();
+        // One yield lets the guard drop, but deliberately never reap the set.
+        tokio::task::yield_now().await;
+        owner.try_spawn(class, || async {}).unwrap();
+    }
+    owner.close();
+    while !owner.is_empty() {
+        owner.join_next().await;
+    }
+    for class in [Class::Confirmed, Class::Unconfirmed, Class::Abort] {
+        assert_eq!(
+            owner.try_spawn(class, || async { panic!("closed task ran") }),
+            Err(Rejection::Closed)
+        );
+    }
+    let c = owner.counters();
+    assert_eq!(c.confirmed_admitted_total, 2);
+    assert_eq!(
+        c.confirmed_overloaded_total
+            + c.unconfirmed_overloaded_total
+            + c.confirmed_fallback_dropped_total,
+        0
+    );
+    assert_eq!(
+        c.confirmed_active + c.unconfirmed_active + c.abort_active,
+        0
+    );
+}
+
+#[test]
+fn admission_policy_validates_zero_upper_bound_and_defaults() {
+    let defaults = RequestAdmissionPolicy::default();
+    assert_eq!(
+        (
+            defaults.max_confirmed_in_flight,
+            defaults.max_unconfirmed_in_flight
+        ),
+        (64, 32)
+    );
+    for bad in [0, Semaphore::MAX_PERMITS + 1, usize::MAX] {
+        for policy in [
+            RequestAdmissionPolicy {
+                max_confirmed_in_flight: bad,
+                ..defaults
+            },
+            RequestAdmissionPolicy {
+                max_unconfirmed_in_flight: bad,
+                ..defaults
+            },
+        ] {
+            assert!(policy.validate().is_err());
+        }
+    }
+    RequestAdmissionPolicy {
+        max_confirmed_in_flight: Semaphore::MAX_PERMITS,
+        max_unconfirmed_in_flight: 1,
+    }
+    .validate()
+    .unwrap();
+}
+
+#[tokio::test]
+async fn admission_direct_and_routed_abort_send_release_on_error_and_panic() {
+    let (mut server, _tx, mut started) = small_fixture().await;
+    let db = Arc::clone(&server.db);
+    let held_db = db.write().await;
+    dispatch(&server, request(1), None, None).await;
+    let source = NpduAddress {
+        network: 42,
+        mac_address: MacAddr::from_slice(&[7]),
+    };
+    for (id, route, panic) in [(2, None, false), (3, Some(source.clone()), true)] {
+        dispatch(&server, request(id), route.clone(), None).await;
+        let released = observed(&mut started).await;
+        assert_eq!(
+            server
+                .network
+                .transport()
+                .routes
+                .lock()
+                .unwrap()
+                .last()
+                .unwrap(),
+            &(route, MacAddr::from_slice(&[1]))
+        );
+        server
+            .network
+            .transport()
+            .panic_next
+            .store(panic, Ordering::Release);
+        server
+            .network
+            .transport()
+            .fail_next
+            .store(!panic, Ordering::Release);
+        server.network.transport().release.notify_one();
+        released.await.unwrap();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while server.request_admission_counters().abort_active != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(server.request_admission_counters().confirmed_active, 1);
+    }
+    assert_eq!(server.request_admission_counters().abort_admitted_total, 2);
+    drop(held_db);
+    server.stop().await.unwrap();
+    assert_eq!(server.request_admission_counters().abort_active, 0);
+}
+
+#[tokio::test]
+async fn admission_dcc_prechecks_and_duplicate_before_first_poll() {
+    let (mut server, _tx, mut started) = small_fixture().await;
+    dispatch(&server, request(1), None, None).await;
+    dispatch(&server, request(1), None, None).await;
+    assert_eq!(
+        server.request_admission_counters().confirmed_admitted_total,
+        1
+    );
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .confirmed_overloaded_total,
+        0
+    );
+    observed(&mut started).await;
+    server.comm_state.store(1, Ordering::Release);
+    dispatch(&server, request(2), None, None).await;
+    dispatch(&server, who_is(), None, None).await;
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .confirmed_overloaded_total,
+        0
+    );
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .unconfirmed_admitted_total,
+        0
+    );
+    assert_eq!(server.request_admission_counters().abort_active, 0);
+    server.stop().await.unwrap();
+}
+
+struct NeverStart(Arc<AtomicBool>);
+impl TransportPort for NeverStart {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        self.0.store(true, Ordering::Release);
+        panic!("invalid admission must not start transport");
+    }
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+        unreachable!()
+    }
+    async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+        unreachable!()
+    }
+    fn local_mac(&self) -> &[u8] {
+        &[1]
+    }
+}
+
+#[tokio::test]
+async fn admission_invalid_direct_generic_bip_before_transport_start() {
+    for bad in [0, usize::MAX] {
+        let policy = RequestAdmissionPolicy {
+            max_confirmed_in_flight: bad,
+            max_unconfirmed_in_flight: 1,
+        };
+        let started = Arc::new(AtomicBool::new(false));
+        let error = BACnetServer::start(
+            ServerConfig {
+                request_admission_policy: policy,
+                ..Default::default()
+            },
+            ObjectDatabase::new(),
+            NeverStart(Arc::clone(&started)),
+        )
+        .await
+        .err()
+        .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("max_confirmed_in_flight")));
+        let error = BACnetServer::generic_builder()
+            .transport(NeverStart(Arc::clone(&started)))
+            .request_admission_policy(policy)
+            .build()
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("max_confirmed_in_flight")));
+        assert!(!started.load(Ordering::Acquire));
+        let error = BACnetServer::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .request_admission_policy(policy)
+            .build()
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("max_confirmed_in_flight")));
+    }
+}
+
+#[tokio::test]
+async fn admission_default_unconfirmed_limit_is_32_without_waiters() {
+    let (mut server, _tx, mut started) = fixture_with_config(
+        "admission",
+        ServerConfig {
+            discovery_policy: DiscoveryPolicy::unlimited(),
+            ..Default::default()
+        },
+    )
+    .await;
+    // Hold the real database seam, rather than expecting every Who-Is to reach
+    // its send: a periodic writer can queue between readers of this fair RwLock.
+    let db = Arc::clone(&server.db);
+    let held_db = db.write().await;
+    for _ in 0..32 {
+        dispatch(&server, who_is(), None, None).await;
+    }
+    tokio::task::yield_now().await;
+    dispatch(&server, who_is(), None, None).await;
+    let c = server.request_admission_counters();
+    assert_eq!(c.unconfirmed_active, 32);
+    assert_eq!(c.unconfirmed_admitted_total, 32);
+    assert_eq!(c.unconfirmed_overloaded_total, 1);
+    assert!(started.try_recv().is_err());
+    drop(held_db);
+    server.stop().await.unwrap();
+    assert_eq!(server.request_admission_counters().unconfirmed_active, 0);
+}
+
+#[tokio::test]
+async fn admission_every_class_releases_on_panic_and_before_first_poll_cancellation() {
+    for class in [Class::Confirmed, Class::Unconfirmed, Class::Abort] {
+        let owner = crate::server::request_tasks::RequestTasks::default();
+        owner
+            .try_spawn(class, || async { panic!("injected class panic") })
+            .unwrap();
+        assert!(owner.join_next().await.unwrap().unwrap_err().is_panic());
+        owner.try_spawn(class, std::future::pending).unwrap();
+        owner.close();
+        assert!(owner.join_next().await.unwrap().unwrap_err().is_cancelled());
+        let c = owner.counters();
+        assert_eq!(
+            c.confirmed_active + c.unconfirmed_active + c.abort_active,
+            0
+        );
+    }
+}
+
+#[tokio::test]
+async fn admission_abort_rechecks_dcc_when_first_polled() {
+    let (mut server, _tx, mut started) = small_fixture().await;
+    dispatch(&server, request(1), None, None).await;
+    observed(&mut started).await;
+    dispatch(&server, request(2), None, None).await;
+    server.comm_state.store(1, Ordering::Release);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while server.request_admission_counters().abort_active != 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert!(started.try_recv().is_err());
+    assert_eq!(server.request_admission_counters().abort_admitted_total, 1);
+    server.stop().await.unwrap();
+}

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -1,11 +1,18 @@
+use super::request_admission::{Admission, Class, Rejection};
+use super::{RequestAdmissionCounters, RequestAdmissionPolicy};
 use std::future::{poll_fn, Future};
 use std::sync::{Arc, Mutex, Weak};
 use tokio::task::{JoinError, JoinSet};
 
 /// Owns inbound request handlers and their independent segmented responses,
 /// not timers or notification workers started by services.
-#[derive(Default)]
-pub(super) struct RequestTasks(Mutex<State>);
+pub(super) struct RequestTasks(Mutex<State>, Admission);
+
+impl Default for RequestTasks {
+    fn default() -> Self {
+        Self::new(RequestAdmissionPolicy::default()).expect("valid defaults")
+    }
+}
 
 #[derive(Default)]
 struct State {
@@ -25,6 +32,37 @@ impl RequestTaskSpawner {
 }
 
 impl RequestTasks {
+    pub(super) fn for_server(
+        config: &super::ServerConfig,
+    ) -> Result<Arc<Self>, bacnet_types::error::Error> {
+        Self::new(config.request_admission_policy).map(Arc::new)
+    }
+
+    pub(super) fn new(policy: RequestAdmissionPolicy) -> Result<Self, bacnet_types::error::Error> {
+        Ok(Self(Mutex::new(State::default()), Admission::new(policy)?))
+    }
+
+    pub(super) fn counters(&self) -> RequestAdmissionCounters {
+        self.1.snapshot()
+    }
+
+    /// Acquire and register synchronously with close; construct the future only
+    /// on success. The guard lives in that future, including before its first poll.
+    pub(super) fn try_spawn<F: Future<Output = ()> + Send + 'static>(
+        &self,
+        class: Class,
+        make: impl FnOnce() -> F,
+    ) -> Result<(), Rejection> {
+        let mut state = self.0.lock().unwrap();
+        let guard = self.1.try_enter(class, state.closed)?;
+        let task = make();
+        state.tasks.spawn(async move {
+            let _guard = guard;
+            task.await;
+        });
+        Ok(())
+    }
+
     pub(super) fn spawner(self: &Arc<Self>) -> RequestTaskSpawner {
         RequestTaskSpawner(Arc::downgrade(self))
     }

--- a/crates/bacnet-server/src/server/request_tasks_tests.rs
+++ b/crates/bacnet-server/src/server/request_tasks_tests.rs
@@ -14,6 +14,9 @@ mod dcc_timer_tests;
 #[path = "notification_worker_tests.rs"]
 mod notification_worker_tests;
 
+#[path = "request_admission_tests.rs"]
+mod request_admission_tests;
+
 struct SendGuard(Option<oneshot::Sender<()>>);
 
 impl Drop for SendGuard {
@@ -29,8 +32,10 @@ pub(super) struct HeldTransport {
     started: mpsc::UnboundedSender<oneshot::Receiver<()>>,
     release: Arc<Notify>,
     panic_next: AtomicBool,
+    fail_next: AtomicBool,
     pass_cov: AtomicBool,
     frames: std::sync::Mutex<Vec<Apdu>>,
+    routes: std::sync::Mutex<Vec<(Option<NpduAddress>, MacAddr)>>,
 }
 
 impl TransportPort for HeldTransport {
@@ -42,8 +47,12 @@ impl TransportPort for HeldTransport {
         Ok(())
     }
 
-    async fn send_unicast(&self, npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+    async fn send_unicast(&self, npdu: &[u8], mac: &[u8]) -> Result<(), Error> {
         let decoded = decode_npdu(Bytes::copy_from_slice(npdu)).unwrap();
+        self.routes
+            .lock()
+            .unwrap()
+            .push((decoded.destination.clone(), MacAddr::from_slice(mac)));
         let apdu = apdu::decode_apdu(decoded.payload).unwrap();
         let segment_ack = matches!(apdu, Apdu::SegmentAck(_));
         let cov = matches!(&apdu, Apdu::ConfirmedRequest(request)
@@ -63,6 +72,9 @@ impl TransportPort for HeldTransport {
             !self.panic_next.swap(false, Ordering::AcqRel),
             "injected handler panic"
         );
+        if self.fail_next.swap(false, Ordering::AcqRel) {
+            return Err(Error::Encoding("injected send error".into()));
+        }
         Ok(())
     }
 
@@ -90,6 +102,24 @@ async fn fixture_with_name(
     mpsc::Sender<ReceivedNpdu>,
     mpsc::UnboundedReceiver<oneshot::Receiver<()>>,
 ) {
+    fixture_with_config(
+        name,
+        ServerConfig {
+            segmentation_supported: Segmentation::BOTH,
+            ..ServerConfig::default()
+        },
+    )
+    .await
+}
+
+async fn fixture_with_config(
+    name: &str,
+    config: ServerConfig,
+) -> (
+    BACnetServer<HeldTransport>,
+    mpsc::Sender<ReceivedNpdu>,
+    mpsc::UnboundedReceiver<oneshot::Receiver<()>>,
+) {
     let (tx, rx) = mpsc::channel(16);
     let (started, observations) = mpsc::unbounded_channel();
     let transport = HeldTransport {
@@ -97,8 +127,10 @@ async fn fixture_with_name(
         started,
         release: Arc::new(Notify::new()),
         panic_next: AtomicBool::new(false),
+        fail_next: AtomicBool::new(false),
         pass_cov: AtomicBool::new(false),
         frames: std::sync::Mutex::new(Vec::new()),
+        routes: std::sync::Mutex::new(Vec::new()),
     };
     let mut db = ObjectDatabase::new();
     db.add(Box::new(
@@ -109,10 +141,6 @@ async fn fixture_with_name(
         .unwrap(),
     ))
     .unwrap();
-    let config = ServerConfig {
-        segmentation_supported: Segmentation::BOTH,
-        ..ServerConfig::default()
-    };
     let server = BACnetServer::start(config, db, transport).await.unwrap();
     (server, tx, observations)
 }
@@ -157,6 +185,7 @@ fn confirmed(segmented: bool) -> Apdu {
 
 async fn stop_releases_handler(request: Apdu) {
     let (mut server, tx, mut started) = fixture().await;
+    let is_confirmed = matches!(request, Apdu::ConfirmedRequest(_));
     inject(&tx, request).await;
     let mut released = tokio::time::timeout(Duration::from_secs(2), started.recv())
         .await
@@ -166,7 +195,16 @@ async fn stop_releases_handler(request: Apdu) {
         released.try_recv(),
         Err(oneshot::error::TryRecvError::Empty)
     ));
+    let counters = server.request_admission_counters();
+    assert_eq!(counters.confirmed_admitted_total, u64::from(is_confirmed));
+    assert_eq!(
+        counters.unconfirmed_admitted_total,
+        u64::from(!is_confirmed)
+    );
+    assert_eq!(counters.confirmed_active + counters.unconfirmed_active, 1);
     server.stop().await.unwrap();
+    let counters = server.request_admission_counters();
+    assert_eq!(counters.confirmed_active + counters.unconfirmed_active, 0);
     assert_eq!(
         released.try_recv(),
         Ok(()),

--- a/crates/bacnet-server/src/server/requests/confirmed.rs
+++ b/crates/bacnet-server/src/server/requests/confirmed.rs
@@ -1,9 +1,11 @@
+#[cfg(test)]
 use super::*;
 
 #[cfg(test)]
 #[path = "dcc_tests.rs"]
 mod dcc_tests;
 
+#[cfg(test)]
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Atomically admit a confirmed request before DCC, service decoding,
     /// authorization, mutation, side effects, or response construction.

--- a/crates/bacnet-server/src/server/requests/confirmed_response.rs
+++ b/crates/bacnet-server/src/server/requests/confirmed_response.rs
@@ -53,12 +53,51 @@ pub(super) fn error_fields(error: &Error) -> (ErrorClass, ErrorCode) {
 
 /// Send one non-segmented confirmed-service response through its existing
 /// transport or reply-channel path.
-pub(super) async fn send_unsegmented_response<T: TransportPort + 'static>(
+pub(in crate::server) async fn send_unsegmented_response<T: TransportPort + 'static>(
     network: &NetworkLayer<T>,
     response: &Apdu,
     source_mac: &[u8],
     source_network: Option<&NpduAddress>,
     reply_tx: Option<tokio::sync::oneshot::Sender<Bytes>>,
+) {
+    send_response(
+        network,
+        response,
+        source_mac,
+        source_network,
+        reply_tx,
+        true,
+    )
+    .await;
+}
+
+/// Overload work shares the identical wire path without per-rejection error
+/// logging. Admission/fallback telemetry is bounded and does not imply send success.
+pub(in crate::server) async fn send_overload_response<T: TransportPort + 'static>(
+    network: &NetworkLayer<T>,
+    response: &Apdu,
+    source_mac: &[u8],
+    source_network: Option<&NpduAddress>,
+    reply_tx: Option<tokio::sync::oneshot::Sender<Bytes>>,
+) {
+    send_response(
+        network,
+        response,
+        source_mac,
+        source_network,
+        reply_tx,
+        false,
+    )
+    .await;
+}
+
+async fn send_response<T: TransportPort + 'static>(
+    network: &NetworkLayer<T>,
+    response: &Apdu,
+    source_mac: &[u8],
+    source_network: Option<&NpduAddress>,
+    reply_tx: Option<tokio::sync::oneshot::Sender<Bytes>>,
+    log_errors: bool,
 ) {
     let mut buf = BytesMut::new();
     encode_apdu(&mut buf, response).expect("valid APDU encoding");
@@ -81,7 +120,9 @@ pub(super) async fn send_unsegmented_response<T: TransportPort + 'static>(
                 let _ = tx.send(npdu_buf.freeze());
             }
             Err(error) => {
-                warn!(%error, "Failed to encode NPDU for MS/TP reply");
+                if log_errors {
+                    warn!(%error, "Failed to encode NPDU for MS/TP reply");
+                }
                 if let Err(error) = BACnetServer::<T>::send_confirmed_response_apdu(
                     network,
                     &apdu_bytes,
@@ -90,7 +131,9 @@ pub(super) async fn send_unsegmented_response<T: TransportPort + 'static>(
                 )
                 .await
                 {
-                    warn!(%error, "Failed to send response");
+                    if log_errors {
+                        warn!(%error, "Failed to send response");
+                    }
                 }
             }
         }
@@ -98,7 +141,9 @@ pub(super) async fn send_unsegmented_response<T: TransportPort + 'static>(
         BACnetServer::<T>::send_confirmed_response_apdu(network, &buf, source_mac, source_network)
             .await
     {
-        warn!(%error, "Failed to send response");
+        if log_errors {
+            warn!(%error, "Failed to send response");
+        }
     }
 }
 

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -3,7 +3,7 @@ use super::*;
 mod acknowledge_alarm;
 mod audit_notification;
 mod confirmed;
-mod confirmed_response;
+pub(super) mod confirmed_response;
 mod endpoint_responder;
 #[cfg(test)]
 #[path = "endpoint_shared_runtime_tests.rs"]
@@ -20,7 +20,7 @@ pub(crate) use self::{executed::EXECUTED_CONFIRMED, unconfirmed::EXECUTED_UNCONF
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Handle one admitted confirmed request.
     #[allow(clippy::too_many_arguments)]
-    async fn handle_admitted_confirmed_request(
+    pub(in crate::server) async fn handle_admitted_confirmed_request(
         db: &Arc<RwLock<ObjectDatabase>>,
         network: &Arc<NetworkLayer<T>>,
         cov_table: &Arc<RwLock<CovSubscriptionTable>>,

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -185,6 +185,8 @@ impl ScServerBuilder {
             .tls_config
             .ok_or_else(|| Error::Encoding("SC server builder: tls_config is required".into()))?;
 
+        self.config.request_admission_policy.validate()?;
+
         let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
             .await?;
 
@@ -293,5 +295,38 @@ mod tests {
         };
         let builder = BACnetServer::sc_builder().cov_policy(policy.clone());
         assert_eq!(builder.config.cov_policy, policy);
+    }
+
+    #[tokio::test]
+    async fn admission_sc_invalid_policy_precedes_dial_and_preserves_reconnect_precedence() {
+        for bad in [0, usize::MAX] {
+            let policy = RequestAdmissionPolicy {
+                max_confirmed_in_flight: 1,
+                max_unconfirmed_in_flight: bad,
+            };
+            let tls = tokio_rustls::rustls::ClientConfig::builder()
+                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+                .with_no_client_auth();
+            let error = BACnetServer::sc_builder()
+                .hub_url("not-a-websocket-url")
+                .tls_config(Arc::new(tls))
+                .request_admission_policy(policy)
+                .build()
+                .await
+                .err()
+                .unwrap();
+            assert!(matches!(error, Error::Encoding(m) if m.contains("max_unconfirmed_in_flight")));
+            let error = BACnetServer::sc_builder()
+                .request_admission_policy(policy)
+                .reconnect(ScReconnectConfig {
+                    initial_delay_ms: 0,
+                    ..Default::default()
+                })
+                .build()
+                .await
+                .err()
+                .unwrap();
+            assert!(matches!(error, Error::OutOfRange(m) if m.contains("reconnect")));
+        }
     }
 }

--- a/crates/bacnet-server/src/server/segmented_worker_tests.rs
+++ b/crates/bacnet-server/src/server/segmented_worker_tests.rs
@@ -170,6 +170,25 @@ async fn segmented_worker_blocked_send_does_not_block_inline_ack_or_abort() {
         .get(&segmented_transaction_key(&[1], None, 7))
         .unwrap()
         .clone();
+    assert_eq!(
+        server.request_admission_counters().confirmed_admitted_total,
+        1
+    );
+    assert_eq!(
+        server.request_admission_counters().confirmed_active,
+        0,
+        "segmented child must not retain or reacquire the top-level slot"
+    );
+    // Fill the confirmed class with held real handlers before routing controls.
+    for id in 20..84 {
+        let Apdu::ConfirmedRequest(mut request) = confirmed(false) else {
+            unreachable!()
+        };
+        request.invoke_id = id;
+        inject(&tx, Apdu::ConfirmedRequest(request)).await;
+        started_send(&mut started).await;
+    }
+    assert_eq!(server.request_admission_counters().confirmed_active, 64);
     inject(
         &tx,
         Apdu::SegmentAck(SegmentAckPdu {

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1724,6 +1724,21 @@ class BACnetClient:
 # Server
 # ---------------------------------------------------------------------------
 
+class RequestAdmissionCounters(TypedDict):
+    """Independent counter samples, not a transactionally atomic aggregate."""
+    confirmed_active: int
+    confirmed_admitted_total: int
+    confirmed_overloaded_total: int
+    confirmed_shutdown_rejected_total: int
+    unconfirmed_active: int
+    unconfirmed_admitted_total: int
+    unconfirmed_overloaded_total: int
+    unconfirmed_shutdown_rejected_total: int
+    abort_active: int
+    abort_admitted_total: int
+    confirmed_fallback_dropped_total: int
+    abort_shutdown_rejected_total: int
+
 class BACnetServer:
     """BACnet server that hosts objects and responds to client requests.
 
@@ -1758,6 +1773,8 @@ class BACnetServer:
         mstp_mac: int = 1,
         mstp_max_master: int = 127,
         mstp_max_info_frames: int = 1,
+        max_confirmed_in_flight: int = 64,
+        max_unconfirmed_in_flight: int = 32,
     ) -> None: ...
 
     # --- Analog objects ---
@@ -1949,6 +1966,13 @@ class BACnetServer:
 
     async def comm_state(self) -> int:
         """Get the DeviceCommunicationControl state (0=Enable, 1=Disable, 2=DisableInitiation)."""
+        ...
+
+    async def request_admission_counters(self) -> RequestAdmissionCounters:
+        """Sample counters; RuntimeError before start and after stop.
+
+        Admitted totals count registered work, not successful response sends.
+        """
         ...
 
 

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -101,6 +101,7 @@ pub struct BACnetServer {
     // Passwords
     dcc_password: Option<String>,
     reinit_password: Option<String>,
+    request_admission_policy: server::RequestAdmissionPolicy,
     /// Whether the server has been started.
     started: Arc<AtomicBool>,
     /// Objects to add before starting. Cleared after start.
@@ -135,4 +136,5 @@ mod server_methods {
     mod file_configuration;
     mod lifecycle;
     mod registration;
+    mod request_admission;
 }

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -202,6 +202,7 @@ mod tests {
             mstp_max_info_frames: 1,
             dcc_password: None,
             reinit_password: None,
+            request_admission_policy: server::RequestAdmissionPolicy::default(),
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         }

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -37,6 +37,7 @@ impl BACnetServer {
         let ipv6_interface = self.ipv6_interface.clone();
         let dcc_password = self.dcc_password.clone();
         let reinit_password = self.reinit_password.clone();
+        let request_admission_policy = self.request_admission_policy;
 
         let objects: Vec<Box<dyn BACnetObject + Send>> = {
             let mut guard = self.lock_pending()?;
@@ -140,6 +141,7 @@ impl BACnetServer {
 
             let mut builder = server::BACnetServer::generic_builder()
                 .database(db)
+                .request_admission_policy(request_admission_policy)
                 .transport(transport);
             if let Some(pw) = dcc_password {
                 builder = builder.dcc_password(pw);

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -25,7 +25,9 @@ impl BACnetServer {
         mstp_baud=38400,
         mstp_mac=1,
         mstp_max_master=127,
-        mstp_max_info_frames=1
+        mstp_max_info_frames=1,
+        max_confirmed_in_flight=64,
+        max_unconfirmed_in_flight=32
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -50,8 +52,17 @@ impl BACnetServer {
         mstp_mac: u8,
         mstp_max_master: u8,
         mstp_max_info_frames: u8,
-    ) -> Self {
-        Self {
+        max_confirmed_in_flight: usize,
+        max_unconfirmed_in_flight: usize,
+    ) -> PyResult<Self> {
+        let request_admission_policy = server::RequestAdmissionPolicy {
+            max_confirmed_in_flight,
+            max_unconfirmed_in_flight,
+        };
+        request_admission_policy
+            .validate()
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        Ok(Self {
             inner: Arc::new(Mutex::new(None)),
             device_instance,
             device_name: device_name.to_string(),
@@ -74,9 +85,10 @@ impl BACnetServer {
             mstp_max_info_frames,
             dcc_password,
             reinit_password,
+            request_admission_policy,
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
-        }
+        })
     }
 
     /// Test seam for verifying that fallible startup leaves registrations intact.

--- a/crates/rusty-bacnet/src/server/server_methods/request_admission.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/request_admission.rs
@@ -1,0 +1,58 @@
+use super::super::*;
+
+#[pymethods]
+impl BACnetServer {
+    /// Sample independent request-admission counters; not an atomic aggregate.
+    /// Like comm_state(), raises RuntimeError before start and after stop.
+    fn request_admission_counters<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let counters = {
+                let guard = inner.lock().await;
+                guard
+                    .as_ref()
+                    .ok_or_else(|| PyRuntimeError::new_err("server not started"))?
+                    .request_admission_counters()
+            };
+            // Owned Rust data only; no Python borrow or server guard escapes.
+            Ok(std::collections::HashMap::from([
+                ("confirmed_active", counters.confirmed_active as u64),
+                (
+                    "confirmed_admitted_total",
+                    counters.confirmed_admitted_total,
+                ),
+                (
+                    "confirmed_overloaded_total",
+                    counters.confirmed_overloaded_total,
+                ),
+                (
+                    "confirmed_shutdown_rejected_total",
+                    counters.confirmed_shutdown_rejected_total,
+                ),
+                ("unconfirmed_active", counters.unconfirmed_active as u64),
+                (
+                    "unconfirmed_admitted_total",
+                    counters.unconfirmed_admitted_total,
+                ),
+                (
+                    "unconfirmed_overloaded_total",
+                    counters.unconfirmed_overloaded_total,
+                ),
+                (
+                    "unconfirmed_shutdown_rejected_total",
+                    counters.unconfirmed_shutdown_rejected_total,
+                ),
+                ("abort_active", counters.abort_active as u64),
+                ("abort_admitted_total", counters.abort_admitted_total),
+                (
+                    "confirmed_fallback_dropped_total",
+                    counters.confirmed_fallback_dropped_total,
+                ),
+                (
+                    "abort_shutdown_rejected_total",
+                    counters.abort_shutdown_rejected_total,
+                ),
+            ]))
+        })
+    }
+}

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -61,6 +61,9 @@ MSTP_KEYWORD_ONLY = [
     "mstp_max_master",
     "mstp_max_info_frames",
 ]
+SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
+    "max_confirmed_in_flight", "max_unconfirmed_in_flight"
+]
 SUPPORTED_BAUD_RATES = (9_600, 19_200, 38_400, 57_600, 76_800, 115_200)
 SUPPORTED_BAUD_ERROR = (
     "mstp_baud must be one of 9600, 19200, 38400, 57600, 76800, or 115200"
@@ -149,12 +152,12 @@ class SignatureCompatibilityTests(unittest.TestCase):
 
     def test_runtime_and_stub_signatures_match_compatibility_contract(self) -> None:
         self.assert_signature(BACnetClient, CLIENT_POSITIONAL, MSTP_KEYWORD_ONLY)
-        self.assert_signature(BACnetServer, SERVER_POSITIONAL, MSTP_KEYWORD_ONLY)
+        self.assert_signature(BACnetServer, SERVER_POSITIONAL, SERVER_KEYWORD_ONLY)
         self.assertEqual(
             stub_signature("BACnetClient"), (CLIENT_POSITIONAL, MSTP_KEYWORD_ONLY)
         )
         self.assertEqual(
-            stub_signature("BACnetServer"), (SERVER_POSITIONAL, MSTP_KEYWORD_ONLY)
+            stub_signature("BACnetServer"), (SERVER_POSITIONAL, SERVER_KEYWORD_ONLY)
         )
 
     def test_old_positional_password_order_remains_accepted(self) -> None:

--- a/crates/rusty-bacnet/tests/test_request_admission.py
+++ b/crates/rusty-bacnet/tests/test_request_admission.py
@@ -1,0 +1,154 @@
+"""Installed native artifact admission tests; loopback UDP only, no hardware."""
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import socket
+import unittest
+from pathlib import Path
+from typing import Any
+
+import rusty_bacnet
+from rusty_bacnet import BACnetServer
+
+
+FIELDS = {
+    "confirmed_active", "confirmed_admitted_total", "confirmed_overloaded_total",
+    "confirmed_shutdown_rejected_total", "unconfirmed_active",
+    "unconfirmed_admitted_total", "unconfirmed_overloaded_total",
+    "unconfirmed_shutdown_rejected_total", "abort_active", "abort_admitted_total",
+    "confirmed_fallback_dropped_total", "abort_shutdown_rejected_total",
+}
+
+
+class AdmissionSignatureTests(unittest.TestCase):
+    def test_installed_stub_defaults_keyword_only_and_counter_fields(self):
+        stub = Path(rusty_bacnet.__file__).with_suffix(".pyi")
+        tree = ast.parse(stub.read_text())
+        classes = {n.name: n for n in tree.body if isinstance(n, ast.ClassDef)}
+        server = classes["BACnetServer"]
+        constructor = next(n for n in server.body if isinstance(n, ast.FunctionDef) and n.name == "__init__")
+        defaults = dict(zip((a.arg for a in constructor.args.kwonlyargs), constructor.args.kw_defaults))
+        signature = inspect.signature(BACnetServer)
+        for name, value in [("max_confirmed_in_flight", 64), ("max_unconfirmed_in_flight", 32)]:
+            self.assertEqual(signature.parameters[name].kind, inspect.Parameter.KEYWORD_ONLY)
+            self.assertEqual(signature.parameters[name].default, value)
+            default = defaults[name]
+            assert default is not None
+            self.assertEqual(ast.literal_eval(default), value)
+        fields = {n.target.id for n in classes["RequestAdmissionCounters"].body if isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name)}
+        self.assertEqual(fields, FIELDS)
+        method = next(n for n in server.body if isinstance(n, ast.AsyncFunctionDef) and n.name == "request_admission_counters")
+        assert method.returns is not None
+        self.assertEqual(ast.unparse(method.returns), "RequestAdmissionCounters")
+
+    def test_invalid_limits_rejected_at_constructor_for_all_transports(self):
+        for transport in ["bip", "ipv6", "sc", "mstp"]:
+            for name in ["max_confirmed_in_flight", "max_unconfirmed_in_flight"]:
+                for value, error in [(0, ValueError), (-1, OverflowError), (1 << 200, OverflowError), ((1 << 64) - 1, ValueError)]:
+                    with self.subTest(transport=transport, name=name, value=value):
+                        with self.assertRaises(error):
+                            invalid: dict[str, Any] = {name: value}
+                            BACnetServer(123, transport=transport, **invalid)
+                with self.assertRaises(TypeError):
+                    invalid = {name: 1.5}
+                    BACnetServer(123, transport=transport, **invalid)
+                valid: dict[str, Any] = {name: 2}
+                BACnetServer(123, transport=transport, **valid)
+
+
+def packet(apdu: bytes) -> bytes:
+    # Original-Unicast-NPDU, local normal-priority NPDU, independent APDU bytes.
+    npdu = b"\x01\x00" + apdu
+    return b"\x81\x0a" + (4 + len(npdu)).to_bytes(2, "big") + npdu
+
+
+class AdmissionRuntimeTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                  broadcast_address="127.0.0.1",
+                                  max_confirmed_in_flight=1, max_unconfirmed_in_flight=2)
+        self.server.add_analog_value(1, "Admission AV")
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.bind(("127.0.0.1", 0))
+        self.sock.setblocking(False)
+        self.loop = asyncio.get_running_loop()
+
+    async def asyncTearDown(self):
+        await self.server.stop()
+        self.sock.close()
+
+    async def send(self, apdu):
+        await self.loop.sock_sendto(self.sock, packet(apdu), self.address)
+
+    async def receive(self):
+        wire, _ = await asyncio.wait_for(self.loop.sock_recvfrom(self.sock, 2048), 2)
+        self.assertEqual(wire[:2], b"\x81\x0a")
+        self.assertEqual(int.from_bytes(wire[2:4], "big"), len(wire))
+        self.assertEqual(wire[4], 1)
+        return wire[6:]
+
+    async def counters_until(self, predicate):
+        async with asyncio.timeout(2):
+            while True:
+                counters = await self.server.request_admission_counters()
+                self.assertEqual(set(counters), FIELDS)
+                self.assertTrue(all(type(v) is int and v >= 0 for v in counters.values()))
+                if predicate(counters):
+                    return counters
+                await asyncio.sleep(0)
+
+    async def test_prestart_stopped_errors_and_zero_start_snapshot(self):
+        with self.assertRaisesRegex(RuntimeError, "server not started"):
+            await self.server.request_admission_counters()
+        await self.server.start()
+        counters = await self.server.request_admission_counters()
+        self.assertEqual(set(counters), FIELDS)
+        self.assertTrue(all(v == 0 for v in counters.values()))
+        await self.server.stop()
+        with self.assertRaisesRegex(RuntimeError, "server not started"):
+            await self.server.request_admission_counters()
+
+    async def test_real_udp_overload_counters_and_recovery(self):
+        await self.server.start()
+        ip, port = (await self.server.local_address()).rsplit(":", 1)
+        self.address = (ip, int(port))
+        # A bounded loopback burst of RPM work exercises the installed policy.
+        # Rust held-transport tests provide the deterministic barrier evidence;
+        # this artifact test deliberately does not claim exact UDP delivery counts.
+        counters = await self.server.request_admission_counters()
+        for batch in range(8):
+            body = b"\x0c\x02\x00\x00\x7b\x1e" + b"\x09\x4d" * (256 + batch) + b"\x1f"
+            for invoke in range(128):
+                await self.send(bytes([0, 5, invoke, 14]) + body)
+            counters = await self.server.request_admission_counters()
+            self.assertLessEqual(counters["confirmed_active"], 1)
+            if counters["confirmed_overloaded_total"]:
+                break
+        self.assertGreater(counters["confirmed_overloaded_total"], 0)
+        self.assertGreater(counters["confirmed_admitted_total"], 0)
+        self.assertLessEqual(counters["abort_active"], 8)
+        # At least one resource Abort is observable on the actual local wire.
+        async with asyncio.timeout(2):
+            while True:
+                response = await self.receive()
+                if response[0] == 0x71 and response[2] == 9:
+                    break
+        await self.counters_until(lambda c: c["confirmed_active"] == c["abort_active"] == 0)
+        # Drain existing replies before a distinct request used as a recovery probe.
+        while True:
+            try:
+                self.sock.recvfrom(2048)
+            except BlockingIOError:
+                break
+        await self.send(b"\x00\x05\xfa\x0c")
+        async with asyncio.timeout(2):
+            while True:
+                response = await self.receive()
+                if response[1] == 250:
+                    break
+        self.assertEqual(response[0] >> 4, 5)  # Error proves normal handler execution.
+        counters = await self.counters_until(lambda c: c["confirmed_active"] == c["abort_active"] == 0)
+        self.assertEqual(counters["confirmed_overloaded_total"],
+                         counters["abort_admitted_total"] + counters["confirmed_fallback_dropped_total"])

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1700,3 +1700,19 @@ server = BACnetServer(
 
 Production BACnet/SC clients validate the configured heartbeat interval as `3000..=300000`
 ms and require `sc_heartbeat_timeout_ms` to be greater than the interval.
+
+## Request admission limits
+
+`BACnetServer(...)` accepts keyword-only `max_confirmed_in_flight=64` and
+`max_unconfirmed_in_flight=32`. Both must be positive; zero is rejected during
+construction, before any transport opens. These provisional defaults bound
+top-level handler concurrency, not all server work or per-peer fairness.
+
+`await server.request_admission_counters()` returns a stable typed dictionary
+of independent active/admitted/overload/shutdown counters, including the
+separate eight-worker Abort pool and its counted confirmed-drop fallback.
+Like `comm_state()`, this accessor raises `RuntimeError` before start and after
+stop. Admission totals do not imply successful response sends.
+
+See [server request admission](request-admission.md) for exact fields, accepted
+ranges, overload behavior, and the known extreme-overload/conformance limitation.

--- a/docs/request-admission.md
+++ b/docs/request-admission.md
@@ -1,0 +1,92 @@
+# Server request admission
+
+Each running server has independent, global limits for **top-level inbound
+handlers**: 64 confirmed and 32 unconfirmed by default. These finite defaults
+are provisional owner policy, not benchmark results or normative BACnet limits.
+
+Rust exposes `server::RequestAdmissionPolicy` through
+`ServerConfig::request_admission_policy` and the generic, BIP, and SC builders'
+`request_admission_policy(policy)` method. Both fields,
+`max_confirmed_in_flight` and `max_unconfirmed_in_flight`, must be positive and
+no greater than `tokio::sync::Semaphore::MAX_PERMITS`. Invalid values return an
+error before server transport startup (and before SC TLS dialing). Validation
+does not undo work already performed by a caller constructing its own transport.
+Existing route, APDU, and SC reconnect validation precedence is retained.
+
+Python appends keyword-only `max_confirmed_in_flight=64` and
+`max_unconfirmed_in_flight=32` to `BACnetServer(...)`. Zero or a representable
+value above the semaphore bound raises `ValueError`; negative or integer values
+outside the native unsigned range raise `OverflowError`. Validation occurs in
+the constructor, before any transport startup, including synchronous MS/TP
+serial opening. There is no zero-as-disable or unlimited mode.
+
+## Admission and overload
+
+- Capacity is acquired synchronously before a handler is spawned. No queue of
+  rejected work or capacity-waiting tasks is created. A slot lasts through the
+  actual handler future, including awaited post-response work; completion,
+  panic, and cancellation release it, even if its completed task is not reaped.
+- Detectable exact pending/completed confirmed duplicates are discarded before
+  capacity admission. They do not count as admitted or overloaded. The existing
+  bounded duplicate retention, source canonicalization, and oversized untracked
+  fallback remain. A denied new request is not marked completed and may retry.
+- Confirmed overload schedules a server Abort with the original Invoke ID and
+  `OUT_OF_RESOURCES`, retaining direct, routed, and MS/TP reply-channel paths.
+  A separate private pool permits at most **eight owned Abort send workers**.
+  It does not consume either handler class's slots and never waits for capacity.
+  If that pool is also full, the confirmed request is silently dropped and the
+  fallback counter increments. Admission does not mean the send succeeded.
+- Unconfirmed overload is silently dropped and counted. DCC and discovery
+  prechecks continue to precede handler admission; disabled traffic does not
+  acquire a slot or provoke an inappropriate overload response.
+- Inline SimpleAck, Error, Reject, Abort, and SegmentAck handling does not acquire
+  these slots. Incoming reassembly retains its existing session/peer/byte bounds
+  and acquires one handler slot only on completed dispatch. Segmented ComplexAck
+  descendants remain owned and governed by their separate existing sender cap;
+  they are not charged another confirmed slot.
+- Explicit stop seals registration and cancels/joins owned handlers and overload
+  workers using the existing request-task owner. Shutdown rejection is distinct
+  from capacity exhaustion. This does not promise async Drop joining, arbitrary
+  blocking-code preemption, or rollback of effects already performed.
+
+The Abort reason follows the resource-exhaustion meaning in ASHRAE 135-2020
+§18.10, with local server Abort behavior described in §5.4.5.3. The ultimate
+silent-drop fallback is an owner-approved **known extreme-overload limitation**,
+not a claim that §5.4.5.1 permits silently dropping valid confirmed requests or
+that this policy establishes full protocol conformance.
+
+## Counter contract
+
+Rust `BACnetServer::request_admission_counters()` returns a
+`RequestAdmissionCounters` value. Python
+`await server.request_admission_counters()` returns a dictionary with the same
+stable fields, described by the shipped `RequestAdmissionCounters` TypedDict:
+
+| Fields | Meaning |
+| --- | --- |
+| `confirmed_active`, `unconfirmed_active` | Registered handler futures not yet finished/dropped |
+| `confirmed_admitted_total`, `unconfirmed_admitted_total` | Cumulative handler registrations |
+| `confirmed_overloaded_total`, `unconfirmed_overloaded_total` | Capacity-rejected requests; unconfirmed requests are dropped |
+| `confirmed_shutdown_rejected_total`, `unconfirmed_shutdown_rejected_total` | Registrations denied by the sealed task owner |
+| `abort_active` | Live overload Abort workers, at most eight |
+| `abort_admitted_total` | Cumulative Abort registrations, **not send completions** |
+| `confirmed_fallback_dropped_total` | Confirmed overloads dropped because all eight Abort workers were busy |
+| `abort_shutdown_rejected_total` | Abort registrations denied by the sealed owner |
+
+Fields are sampled independently from bounded atomic counters; the aggregate is
+not a transactionally consistent snapshot. Totals cover one server lifetime,
+without request history storage. Rust counters remain readable after successful
+stop, with active counts zero. Python follows its existing `comm_state()` and
+`local_address()` accessors: before start and after stop it raises
+`RuntimeError("server not started")`. Immediately after a traffic-free start,
+all counters are zero. No new restart semantics are promised.
+
+## Remaining limits
+
+There is no per-peer fairness or reserved critical-service capacity. A busy
+confirmed class can reject DeviceCommunicationControl or ReinitializeDevice;
+neither has a reserved slot. This bounds top-level handler concurrency, not
+every allocation, incoming byte, service effect, notification, transport task,
+or response budget. Work/response budgets remain deferred. Issue #521 remains
+partial; #522 is unchanged. No throughput, fairness, hardware timing, or full
+conformance claim follows from these limits.


### PR DESCRIPTION
## Approved policy and behavior
- Default to independent global limits of 64 confirmed and 32 unconfirmed top-level handlers, configurable through Rust config/generic/BIP/SC builders and additive Python keyword-only settings. Validate positive representable values before startup; zero is invalid.
- Use non-waiting admission before spawn. Preserve exact pending/completed duplicate suppression before overload decisions. Guards recover capacity on completion, panic, cancellation, and shutdown.
- Confirmed overload uses a separate fixed pool of eight owned server Abort / OUT_OF_RESOURCES send workers, preserving direct/routed/MS/TP reply-channel paths. If that pool is full, drop and count the request. Unconfirmed overload is dropped and counted.
- Expose matching Rust/Python counter snapshots. Inline ACK/Abort/SegmentAck handling is not charged; reassembly is charged once on completion and segmented response descendants retain their separate existing limit.

Refs #521 (partial; do not close). #522 unchanged.

## Explicit limitations
The owner approved finite defaults, bounded Abort with counted drop fallback, and Rust/Python parity. Numeric defaults are provisional and not benchmark-derived. Ultimate confirmed drop is a known extreme-overload/conformance limitation, not permission inferred from the Standard. Per-peer fairness, reserved critical-service capacity (including DCC/ReinitializeDevice), and work/response budgets are deferred. No all-server-work, transport shutdown, async Drop, rollback, or blocking-preemption claim.

Source verification: original paraphrases of ASHRAE 135-2020 sections 5.4.5.1, 5.4.5.3, and 18.10. No licensed excerpts reproduced. Detailed contract: docs/request-admission.md.

## Validation
- Baseline held request 65 executed; regression now verifies server Abort with matching Invoke ID and OUT_OF_RESOURCES.
- Rust admission 21 passed; duplicate/request tracker 8; request-task lifecycle 38; DCC 28; segmentation 69; server 921 unit plus 3 integration; integration crate 38.
- cargo test --workspace --exclude rusty-bacnet --locked: 4,243 passed, 0 failed, 3 ignored. Additional SC invalid-policy-before-dial test passed.
- Fmt, workspace Clippy (warnings), file-size, no-secret, and whitespace gates passed. Root inspected full diff and reran staged checks including new files.
- Binding cargo check/clippy passed with Python 3.12. Fresh locked macOS arm64 wheel built and installed into an isolated environment. Full Python suite: 33 passed and 189 subtests passed, no skips; root independently repeated it. Admission module passed ten repeated runs. Installed native origin and runtime/stub signatures verified.
- Wheel SHA256: 82aa8a6dc1e41fb2b29d49358798da3a69cc1164729ec16e93ca0ea15b0d8e5f. Wheel includes final production/binding sources; only tests/docs were edited afterward.
- Exact-head five lean CI checks and independent reviews pending. Heavy/release, other OS/Python versions, and physical MS/TP hardware remain unqualified by this slice.

Native exact source governed while optional Codebase Memory coverage was unavailable. No CI/dependency changes.