### PR TITLE
feat(server): add logical-peer request admission quotas

### DIFF
--- a/crates/bacnet-server/src/server/confirmed_request_tracker.rs
+++ b/crates/bacnet-server/src/server/confirmed_request_tracker.rs
@@ -2,9 +2,9 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use super::request_peer::{canonical_requester, CanonicalRequester};
 use bacnet_encoding::apdu::ConfirmedRequest;
 use bacnet_encoding::npdu::NpduAddress;
-use bacnet_types::MacAddr;
 
 /// Local retention and resource policy for exact confirmed-request detection.
 ///
@@ -17,12 +17,6 @@ use bacnet_types::MacAddr;
 const COMPLETED_RETENTION: Duration = Duration::from_secs(60);
 const MAX_ENTRIES: usize = 256;
 const MAX_TRACKED_SERVICE_REQUEST_BYTES: usize = 64 * 1024;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-enum CanonicalRequester {
-    Direct(MacAddr),
-    Routed(NpduAddress),
-}
 
 struct Entry {
     id: u64,
@@ -177,23 +171,13 @@ impl Drop for PendingConfirmedRequest {
     }
 }
 
-fn canonical_requester(
-    source_mac: &[u8],
-    source_network: Option<&NpduAddress>,
-) -> CanonicalRequester {
-    source_network
-        .filter(|source| (1..=0xfffe).contains(&source.network) && !source.mac_address.is_empty())
-        .cloned()
-        .map(CanonicalRequester::Routed)
-        .unwrap_or_else(|| CanonicalRequester::Direct(MacAddr::from_slice(source_mac)))
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Barrier;
 
     use bacnet_types::enums::ConfirmedServiceChoice;
+    use bacnet_types::MacAddr;
     use bytes::Bytes;
 
     use super::*;

--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -141,7 +141,9 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let source_mac = MacAddr::from_slice(source_mac);
                 let source_network = received.source_network.clone();
                 let descendants = request_tasks.spawner();
-                let result = request_tasks.try_spawn(Class::Confirmed, || {
+                let peer =
+                    super::request_peer::canonical_requester(&source_mac, source_network.as_ref());
+                let result = request_tasks.try_spawn(Class::Confirmed, peer.clone(), || {
                     let reply_tx = reply_tx.take();
                     async move {
                         Self::handle_admitted_confirmed_request(
@@ -172,7 +174,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     // before service execution is reported by a server Abort.
                     // Eight owned sends bound this response work. If all are
                     // busy, the counted silent drop is a known local limitation.
-                    let _ = request_tasks.try_spawn(Class::Abort, || async move {
+                    let _ = request_tasks.try_spawn(Class::Abort, peer, || async move {
                         // Match the handler's first-poll DCC check as well as
                         // dispatch's precheck if DCC changed after registration.
                         if abort_comm_state.load(Ordering::Acquire) == 1
@@ -257,7 +259,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let comm_state = Arc::clone(comm_state);
                 let device_bindings = Arc::clone(device_bindings);
                 let discovery_limiter = Arc::clone(discovery_limiter);
-                let _ = request_tasks.try_spawn(Class::Unconfirmed, || async move {
+                let peer = super::request_peer::canonical_requester(
+                    source_mac,
+                    received.source_network.as_ref(),
+                );
+                let _ = request_tasks.try_spawn(Class::Unconfirmed, peer, || async move {
                     Self::handle_unconfirmed_request(
                         &db,
                         &network,

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -878,6 +878,7 @@ mod segmented_receive;
 mod segmented_send;
 pub(crate) use segmented_send::*;
 mod request_admission;
+mod request_peer;
 mod request_tasks;
 pub use request_admission::{RequestAdmissionCounters, RequestAdmissionPolicy};
 mod shutdown;

--- a/crates/bacnet-server/src/server/peer_admission_tests.rs
+++ b/crates/bacnet-server/src/server/peer_admission_tests.rs
@@ -1,0 +1,416 @@
+use super::*;
+use crate::server::request_peer::canonical_requester;
+use crate::server::request_tasks::RequestTasks;
+
+#[tokio::test]
+async fn peer_admission_default_caps_before_handler_spawn() {
+    let (mut server, _tx, mut started) = fixture_with_config(
+        "peer admission",
+        ServerConfig {
+            discovery_policy: DiscoveryPolicy::unlimited(),
+            ..Default::default()
+        },
+    )
+    .await;
+    let db = Arc::clone(&server.db);
+    let held = db.write().await;
+    for id in 0..17 {
+        dispatch(&server, request(id), None, None).await;
+    }
+    for _ in 0..9 {
+        dispatch(&server, who_is(), None, None).await;
+    }
+    let c = server.request_admission_counters();
+    assert_eq!(c.confirmed_active, 16);
+    assert_eq!(c.unconfirmed_active, 8);
+    assert_eq!(c.confirmed_overloaded_total, 1);
+    assert_eq!(c.unconfirmed_overloaded_total, 1);
+    assert_eq!(c.confirmed_peer_overloaded_total, 1);
+    assert_eq!(c.unconfirmed_peer_overloaded_total, 1);
+    assert_eq!(
+        c.confirmed_global_overloaded_total + c.unconfirmed_global_overloaded_total,
+        0
+    );
+    observed(&mut started).await; // Only the rejected request's Abort can send.
+    assert!(started.try_recv().is_err());
+    drop(held);
+    server.stop().await.unwrap();
+    assert_eq!(server.request_tasks.peer_entries(), [0; 3]);
+}
+
+fn route(network: u16, mac: &[u8]) -> NpduAddress {
+    NpduAddress {
+        network,
+        mac_address: MacAddr::from_slice(mac),
+    }
+}
+
+#[tokio::test]
+async fn peer_admission_logical_identity_and_duplicate_fallback_matrix() {
+    use crate::server::confirmed_request_tracker::{
+        ConfirmedRequestAdmission, ConfirmedRequestTracker,
+    };
+    for source in [
+        None,
+        Some(route(0, b"origin")),
+        Some(route(65535, b"origin")),
+        Some(route(1, b"")),
+        Some(route(65534, b"")),
+        Some(route(1, b"origin")),
+        Some(route(65534, b"origin")),
+    ] {
+        let valid = source
+            .as_ref()
+            .is_some_and(|s| s.network != 0 && s.network != 65535 && !s.mac_address.is_empty());
+        let a = canonical_requester(b"router-a", source.as_ref());
+        let b = canonical_requester(b"router-b", source.as_ref());
+        assert_eq!(a == b, valid);
+        assert_eq!(a == canonical_requester(b"router-a", None), !valid);
+        let tracker = Arc::new(ConfirmedRequestTracker::default());
+        let Apdu::ConfirmedRequest(req) = request(1) else {
+            unreachable!()
+        };
+        let ConfirmedRequestAdmission::New(pending) =
+            tracker.begin(b"router-a", source.as_ref(), req.clone())
+        else {
+            panic!("new")
+        };
+        assert!(matches!(
+            tracker.begin(b"router-a", source.as_ref(), req.clone()),
+            ConfirmedRequestAdmission::Duplicate
+        ));
+        assert_eq!(
+            matches!(
+                tracker.begin(b"router-b", source.as_ref(), req),
+                ConfirmedRequestAdmission::Duplicate
+            ),
+            valid
+        );
+        let owner = RequestTasks::new(RequestAdmissionPolicy {
+            max_confirmed_in_flight_per_peer: 1,
+            ..Default::default()
+        })
+        .unwrap();
+        owner
+            .try_spawn(Class::Confirmed, a, std::future::pending)
+            .unwrap();
+        let result = owner.try_spawn(Class::Confirmed, b, std::future::pending);
+        assert_eq!(
+            result,
+            if valid {
+                Err(Rejection::Overloaded)
+            } else {
+                Ok(())
+            }
+        );
+        owner.close();
+        while !owner.is_empty() {
+            owner.join_next().await;
+        }
+        assert_eq!(owner.peer_entries(), [0; 3]);
+        drop(pending);
+    }
+}
+
+#[tokio::test]
+async fn peer_admission_independent_classes_origins_and_global_first() {
+    let owner = RequestTasks::new(RequestAdmissionPolicy {
+        max_confirmed_in_flight: 2,
+        max_unconfirmed_in_flight: 2,
+        max_confirmed_in_flight_per_peer: 1,
+        max_unconfirmed_in_flight_per_peer: 1,
+    })
+    .unwrap();
+    for class in [Class::Confirmed, Class::Unconfirmed] {
+        let peer = canonical_requester(b"router-a", Some(&route(7, b"a")));
+        owner
+            .try_spawn(class, peer.clone(), std::future::pending)
+            .unwrap();
+        assert_eq!(
+            owner.try_spawn(
+                class,
+                canonical_requester(b"router-b", Some(&route(7, b"a"))),
+                || async { panic!("denied ran") }
+            ),
+            Err(Rejection::Overloaded)
+        );
+        owner
+            .try_spawn(
+                class,
+                canonical_requester(b"router-a", Some(&route(7, b"b"))),
+                std::future::pending,
+            )
+            .unwrap();
+        assert_eq!(
+            owner.try_spawn(class, peer, || async { panic!("denied ran") }),
+            Err(Rejection::Overloaded)
+        );
+    }
+    let c = owner.counters();
+    assert_eq!((c.confirmed_active, c.unconfirmed_active), (2, 2));
+    assert_eq!(
+        (c.confirmed_admitted_total, c.unconfirmed_admitted_total),
+        (2, 2)
+    );
+    assert_eq!(
+        (
+            c.confirmed_global_overloaded_total,
+            c.confirmed_peer_overloaded_total
+        ),
+        (1, 1)
+    );
+    assert_eq!(
+        (
+            c.unconfirmed_global_overloaded_total,
+            c.unconfirmed_peer_overloaded_total
+        ),
+        (1, 1)
+    );
+    assert_eq!(
+        (c.confirmed_overloaded_total, c.unconfirmed_overloaded_total),
+        (2, 2)
+    );
+    assert_eq!(owner.peer_entries(), [2, 2, 0]);
+    owner.close();
+    while !owner.is_empty() {
+        owner.join_next().await;
+    }
+    assert_eq!(owner.peer_entries(), [0; 3]);
+}
+
+#[tokio::test]
+async fn peer_admission_guard_cleanup_normal_panic_never_polled_and_unique_stream() {
+    for class in [Class::Confirmed, Class::Unconfirmed, Class::Abort] {
+        let owner = RequestTasks::default();
+        let peer = canonical_requester(b"peer", None);
+        owner
+            .try_spawn(class, peer.clone(), || async { panic!("injected") })
+            .unwrap();
+        assert!(owner.join_next().await.unwrap().unwrap_err().is_panic());
+        assert_eq!(owner.peer_entries(), [0; 3]);
+        for id in 0u32..2048 {
+            owner
+                .try_spawn(
+                    class,
+                    canonical_requester(&id.to_be_bytes(), None),
+                    || async {},
+                )
+                .unwrap();
+            owner.join_next().await.unwrap().unwrap();
+            assert_eq!(owner.peer_entries(), [0; 3]);
+        }
+        owner
+            .try_spawn(class, peer.clone(), std::future::pending)
+            .unwrap();
+        owner.close(); // current-thread runtime: future has never been polled
+        assert_eq!(
+            owner.try_spawn(class, peer, || async { panic!("closed") }),
+            Err(Rejection::Closed)
+        );
+        assert!(owner.join_next().await.unwrap().unwrap_err().is_cancelled());
+        assert_eq!(owner.peer_entries(), [0; 3]);
+        let c = owner.counters();
+        assert_eq!(
+            c.confirmed_overloaded_total
+                + c.unconfirmed_overloaded_total
+                + c.confirmed_fallback_dropped_total,
+            0
+        );
+    }
+}
+
+#[tokio::test]
+async fn peer_admission_duplicates_denied_retry_and_shared_eight_abort_workers() {
+    let (mut server, _tx, mut started) = fixture_with_config(
+        "peer abort",
+        ServerConfig {
+            request_admission_policy: RequestAdmissionPolicy {
+                max_confirmed_in_flight_per_peer: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .await;
+    dispatch(&server, request(1), None, None).await;
+    observed(&mut started).await;
+    dispatch(&server, request(1), None, None).await;
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .confirmed_overloaded_total,
+        0
+    );
+    for id in 2..=9 {
+        dispatch(&server, request(id), None, None).await;
+        observed(&mut started).await;
+    }
+    dispatch(&server, request(10), None, None).await;
+    let c = server.request_admission_counters();
+    assert_eq!((c.confirmed_active, c.abort_active), (1, 8));
+    assert_eq!(
+        (
+            c.confirmed_peer_overloaded_total,
+            c.confirmed_global_overloaded_total
+        ),
+        (9, 0)
+    );
+    assert_eq!(
+        (c.abort_admitted_total, c.confirmed_fallback_dropped_total),
+        (8, 1)
+    );
+    assert_eq!(server.request_tasks.peer_entries(), [1, 0, 0]);
+    assert!(started.try_recv().is_err());
+    server.network.transport().release.notify_waiters();
+    wait_reaped(&server).await;
+    assert_eq!(server.request_tasks.peer_entries(), [0; 3]);
+    dispatch(&server, request(10), None, None).await;
+    observed(&mut started).await;
+    dispatch(&server, request(1), None, None).await; // completed duplicate at peer cap
+    assert_eq!(
+        server.request_admission_counters().confirmed_admitted_total,
+        2
+    );
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .confirmed_overloaded_total,
+        9
+    );
+    server.stop().await.unwrap();
+    assert_eq!(server.request_tasks.peer_entries(), [0; 3]);
+}
+
+#[tokio::test]
+async fn peer_admission_direct_routed_reply_abort_fields_unchanged() {
+    for source in [None, Some(route(42, &[7]))] {
+        for reply_channel in [false, true] {
+            let (mut server, _tx, mut started) = fixture_with_config(
+                "peer reply",
+                ServerConfig {
+                    request_admission_policy: RequestAdmissionPolicy {
+                        max_confirmed_in_flight_per_peer: 1,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .await;
+            dispatch(&server, request(1), source.clone(), None).await;
+            observed(&mut started).await;
+            let abort = if reply_channel {
+                let (tx, rx) = oneshot::channel();
+                dispatch(&server, request(2), source.clone(), Some(tx)).await;
+                let wire = tokio::time::timeout(Duration::from_secs(2), rx)
+                    .await
+                    .unwrap()
+                    .unwrap();
+                let npdu = decode_npdu(wire).unwrap();
+                assert_eq!(npdu.destination, source);
+                assert!(!npdu.expecting_reply);
+                apdu::decode_apdu(npdu.payload).unwrap()
+            } else {
+                dispatch(&server, request(2), source.clone(), None).await;
+                observed(&mut started).await;
+                assert_eq!(
+                    server
+                        .network
+                        .transport()
+                        .routes
+                        .lock()
+                        .unwrap()
+                        .last()
+                        .unwrap(),
+                    &(source.clone(), MacAddr::from_slice(&[1]))
+                );
+                server
+                    .network
+                    .transport()
+                    .frames
+                    .lock()
+                    .unwrap()
+                    .last()
+                    .unwrap()
+                    .clone()
+            };
+            assert!(
+                matches!(abort, Apdu::Abort(a) if a.sent_by_server && a.invoke_id == 2 && a.abort_reason == AbortReason::OUT_OF_RESOURCES)
+            );
+            assert_eq!(
+                server
+                    .request_admission_counters()
+                    .confirmed_peer_overloaded_total,
+                1
+            );
+            server.stop().await.unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn peer_admission_positive_validation_generic_bip_and_tiny_global() {
+    for confirmed in [true, false] {
+        for bad in [0, Semaphore::MAX_PERMITS + 1, usize::MAX] {
+            let mut policy = RequestAdmissionPolicy::default();
+            let name = if confirmed {
+                policy.max_confirmed_in_flight_per_peer = bad;
+                "max_confirmed_in_flight_per_peer"
+            } else {
+                policy.max_unconfirmed_in_flight_per_peer = bad;
+                "max_unconfirmed_in_flight_per_peer"
+            };
+            assert!(policy.validate().is_err());
+            let started = Arc::new(AtomicBool::new(false));
+            let error = BACnetServer::generic_builder()
+                .transport(NeverStart(Arc::clone(&started)))
+                .request_admission_policy(policy)
+                .build()
+                .await
+                .err()
+                .unwrap();
+            assert!(matches!(error, Error::Encoding(m) if m.contains(name)));
+            assert!(!started.load(Ordering::Acquire));
+            let error = BACnetServer::bip_builder()
+                .interface(Ipv4Addr::LOCALHOST)
+                .port(0)
+                .request_admission_policy(policy)
+                .build()
+                .await
+                .err()
+                .unwrap();
+            assert!(matches!(error, Error::Encoding(m) if m.contains(name)));
+        }
+    }
+    let owner = RequestTasks::new(RequestAdmissionPolicy {
+        max_confirmed_in_flight: 1,
+        max_unconfirmed_in_flight: 1,
+        ..Default::default()
+    })
+    .unwrap();
+    for class in [Class::Confirmed, Class::Unconfirmed] {
+        let peer = canonical_requester(b"peer", None);
+        owner
+            .try_spawn(class, peer.clone(), std::future::pending)
+            .unwrap();
+        assert_eq!(
+            owner.try_spawn(class, peer, std::future::pending),
+            Err(Rejection::Overloaded)
+        );
+    }
+    let c = owner.counters();
+    assert_eq!(
+        (
+            c.confirmed_global_overloaded_total,
+            c.unconfirmed_global_overloaded_total
+        ),
+        (1, 1)
+    );
+    assert_eq!(
+        c.confirmed_peer_overloaded_total + c.unconfirmed_peer_overloaded_total,
+        0
+    );
+    owner.close();
+    while !owner.is_empty() {
+        owner.join_next().await;
+    }
+}

--- a/crates/bacnet-server/src/server/request_admission.rs
+++ b/crates/bacnet-server/src/server/request_admission.rs
@@ -1,11 +1,14 @@
 //! Local fail-fast handler policy, not a protocol or throughput guarantee.
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+
+use super::request_peer::CanonicalRequester;
 
 use bacnet_types::error::Error;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-/// Global, independent top-level handler limits. Zero is invalid.
+/// Independent global and logical-peer top-level handler limits. Zero is invalid.
 /// Defaults are provisional owner policy, not benchmark-derived values.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RequestAdmissionPolicy {
@@ -13,6 +16,12 @@ pub struct RequestAdmissionPolicy {
     pub max_confirmed_in_flight: usize,
     /// Maximum concurrent unconfirmed handlers (default 32).
     pub max_unconfirmed_in_flight: usize,
+    /// Maximum concurrent confirmed handlers per logical peer (default 16).
+    /// The effective limit is the smaller of this and the global limit.
+    pub max_confirmed_in_flight_per_peer: usize,
+    /// Maximum concurrent unconfirmed handlers per logical peer (default 8).
+    /// This partitions capacity by identity; it does not guarantee fairness.
+    pub max_unconfirmed_in_flight_per_peer: usize,
 }
 
 impl Default for RequestAdmissionPolicy {
@@ -20,6 +29,8 @@ impl Default for RequestAdmissionPolicy {
         Self {
             max_confirmed_in_flight: 64,
             max_unconfirmed_in_flight: 32,
+            max_confirmed_in_flight_per_peer: 16,
+            max_unconfirmed_in_flight_per_peer: 8,
         }
     }
 }
@@ -30,6 +41,14 @@ impl RequestAdmissionPolicy {
         for (name, value) in [
             ("max_confirmed_in_flight", self.max_confirmed_in_flight),
             ("max_unconfirmed_in_flight", self.max_unconfirmed_in_flight),
+            (
+                "max_confirmed_in_flight_per_peer",
+                self.max_confirmed_in_flight_per_peer,
+            ),
+            (
+                "max_unconfirmed_in_flight_per_peer",
+                self.max_unconfirmed_in_flight_per_peer,
+            ),
         ] {
             if value == 0 || value > Semaphore::MAX_PERMITS {
                 return Err(Error::Encoding(format!(
@@ -53,6 +72,10 @@ pub struct RequestAdmissionCounters {
     pub confirmed_admitted_total: u64,
     /// Confirmed requests rejected for exhausted handler capacity.
     pub confirmed_overloaded_total: u64,
+    /// Confirmed capacity rejections classified global-first.
+    pub confirmed_global_overloaded_total: u64,
+    /// Confirmed capacity rejections with a global permit but no peer slot.
+    pub confirmed_peer_overloaded_total: u64,
     /// Confirmed registrations rejected after shutdown sealed the owner.
     pub confirmed_shutdown_rejected_total: u64,
     /// Live unconfirmed handlers.
@@ -61,6 +84,10 @@ pub struct RequestAdmissionCounters {
     pub unconfirmed_admitted_total: u64,
     /// Unconfirmed requests dropped for exhausted handler capacity.
     pub unconfirmed_overloaded_total: u64,
+    /// Unconfirmed capacity rejections classified global-first.
+    pub unconfirmed_global_overloaded_total: u64,
+    /// Unconfirmed capacity rejections with a global permit but no peer slot.
+    pub unconfirmed_peer_overloaded_total: u64,
     /// Unconfirmed registrations rejected after shutdown sealed the owner.
     pub unconfirmed_shutdown_rejected_total: u64,
     /// Live overload Abort send workers (private fixed capacity 8).
@@ -92,19 +119,27 @@ pub(super) struct Admission {
 
 struct Pool {
     permits: Arc<Semaphore>,
+    peer_limit: usize,
+    peers: Mutex<HashMap<CanonicalRequester, usize>>,
     active: AtomicUsize,
     admitted: AtomicU64,
     overloaded: AtomicU64,
+    global_overloaded: AtomicU64,
+    peer_overloaded: AtomicU64,
     closed: AtomicU64,
 }
 
 impl Pool {
-    fn new(limit: usize) -> Arc<Self> {
+    fn new(limit: usize, peer_limit: usize) -> Arc<Self> {
         Arc::new(Self {
             permits: Arc::new(Semaphore::new(limit)),
+            peer_limit: peer_limit.min(limit),
+            peers: Mutex::new(HashMap::new()),
             active: AtomicUsize::new(0),
             admitted: AtomicU64::new(0),
             overloaded: AtomicU64::new(0),
+            global_overloaded: AtomicU64::new(0),
+            peer_overloaded: AtomicU64::new(0),
             closed: AtomicU64::new(0),
         })
     }
@@ -112,29 +147,56 @@ impl Pool {
 
 pub(super) struct Guard {
     pool: Arc<Pool>,
+    peer: Option<CanonicalRequester>,
     _permit: OwnedSemaphorePermit,
 }
 
 impl Drop for Guard {
     fn drop(&mut self) {
+        // Remove registration before Rust drops _permit and releases global
+        // capacity. This lock never acquires the task owner's lock.
+        if let Some(peer) = &self.peer {
+            let mut peers = self.pool.peers.lock().unwrap_or_else(|e| e.into_inner());
+            let count = peers.get_mut(peer).expect("live peer registration");
+            *count -= 1;
+            if *count == 0 {
+                peers.remove(peer);
+            }
+        }
         self.pool.active.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
 impl Admission {
+    #[cfg(test)]
+    pub(super) fn peer_entries(&self) -> [usize; 3] {
+        std::array::from_fn(|i| self.pools[i].peers.lock().unwrap().len())
+    }
+
     pub(super) fn new(policy: RequestAdmissionPolicy) -> Result<Self, Error> {
         policy.validate()?;
         Ok(Self {
             pools: [
-                Pool::new(policy.max_confirmed_in_flight),
-                Pool::new(policy.max_unconfirmed_in_flight),
-                Pool::new(8),
+                Pool::new(
+                    policy.max_confirmed_in_flight,
+                    policy.max_confirmed_in_flight_per_peer,
+                ),
+                Pool::new(
+                    policy.max_unconfirmed_in_flight,
+                    policy.max_unconfirmed_in_flight_per_peer,
+                ),
+                Pool::new(8, 8),
             ],
         })
     }
 
     // Called under the task owner's spawn/close lock. No capacity waiters exist.
-    pub(super) fn try_enter(&self, class: Class, closed: bool) -> Result<Guard, Rejection> {
+    pub(super) fn try_enter(
+        &self,
+        class: Class,
+        peer: CanonicalRequester,
+        closed: bool,
+    ) -> Result<Guard, Rejection> {
         let pool = &self.pools[class as usize];
         if closed {
             pool.closed.fetch_add(1, Ordering::Relaxed);
@@ -142,12 +204,27 @@ impl Admission {
         }
         let permit = Arc::clone(&pool.permits).try_acquire_owned().map_err(|_| {
             pool.overloaded.fetch_add(1, Ordering::Relaxed);
+            pool.global_overloaded.fetch_add(1, Ordering::Relaxed);
             Rejection::Overloaded
         })?;
+        // Abort workers are global-only, with no peer registration or charge.
+        let peer = if matches!(class, Class::Abort) {
+            None
+        } else {
+            let mut peers = pool.peers.lock().unwrap_or_else(|e| e.into_inner());
+            if peers.get(&peer).copied().unwrap_or(0) >= pool.peer_limit {
+                pool.overloaded.fetch_add(1, Ordering::Relaxed);
+                pool.peer_overloaded.fetch_add(1, Ordering::Relaxed);
+                return Err(Rejection::Overloaded);
+            }
+            *peers.entry(peer.clone()).or_default() += 1;
+            Some(peer)
+        };
         pool.active.fetch_add(1, Ordering::Relaxed);
         pool.admitted.fetch_add(1, Ordering::Relaxed);
         Ok(Guard {
             pool: Arc::clone(pool),
+            peer,
             _permit: permit,
         })
     }
@@ -158,10 +235,14 @@ impl Admission {
             confirmed_active: c.active.load(Ordering::Relaxed),
             confirmed_admitted_total: c.admitted.load(Ordering::Relaxed),
             confirmed_overloaded_total: c.overloaded.load(Ordering::Relaxed),
+            confirmed_global_overloaded_total: c.global_overloaded.load(Ordering::Relaxed),
+            confirmed_peer_overloaded_total: c.peer_overloaded.load(Ordering::Relaxed),
             confirmed_shutdown_rejected_total: c.closed.load(Ordering::Relaxed),
             unconfirmed_active: u.active.load(Ordering::Relaxed),
             unconfirmed_admitted_total: u.admitted.load(Ordering::Relaxed),
             unconfirmed_overloaded_total: u.overloaded.load(Ordering::Relaxed),
+            unconfirmed_global_overloaded_total: u.global_overloaded.load(Ordering::Relaxed),
+            unconfirmed_peer_overloaded_total: u.peer_overloaded.load(Ordering::Relaxed),
             unconfirmed_shutdown_rejected_total: u.closed.load(Ordering::Relaxed),
             abort_active: a.active.load(Ordering::Relaxed),
             abort_admitted_total: a.admitted.load(Ordering::Relaxed),
@@ -172,7 +253,7 @@ impl Admission {
 }
 
 impl<T: super::TransportPort + 'static> super::ServerBuilder<T> {
-    /// Set positive global handler limits, validated before transport startup.
+    /// Set positive global and peer handler limits, validated before startup.
     pub fn request_admission_policy(mut self, policy: RequestAdmissionPolicy) -> Self {
         self.config.request_admission_policy = policy;
         self
@@ -180,7 +261,7 @@ impl<T: super::TransportPort + 'static> super::ServerBuilder<T> {
 }
 
 impl super::BipServerBuilder {
-    /// Set positive global handler limits, validated before transport startup.
+    /// Set positive global and peer handler limits, validated before startup.
     pub fn request_admission_policy(mut self, policy: RequestAdmissionPolicy) -> Self {
         self.config.request_admission_policy = policy;
         self
@@ -189,7 +270,7 @@ impl super::BipServerBuilder {
 
 #[cfg(feature = "sc-tls")]
 impl super::ScServerBuilder {
-    /// Set positive global handler limits, validated before TLS dialing.
+    /// Set positive global and peer handler limits, validated before TLS dialing.
     pub fn request_admission_policy(mut self, policy: RequestAdmissionPolicy) -> Self {
         self.config.request_admission_policy = policy;
         self

--- a/crates/bacnet-server/src/server/request_admission_tests.rs
+++ b/crates/bacnet-server/src/server/request_admission_tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::server::request_admission::{Class, Rejection};
 
+#[path = "peer_admission_tests.rs"]
+mod peer_admission_tests;
+
 async fn small_fixture() -> (
     BACnetServer<HeldTransport>,
     mpsc::Sender<ReceivedNpdu>,
@@ -12,6 +15,7 @@ async fn small_fixture() -> (
             request_admission_policy: RequestAdmissionPolicy {
                 max_confirmed_in_flight: 1,
                 max_unconfirmed_in_flight: 1,
+                ..Default::default()
             },
             discovery_policy: DiscoveryPolicy::unlimited(),
             segmentation_supported: Segmentation::BOTH,
@@ -85,7 +89,17 @@ fn request(id: u8) -> Apdu {
 
 #[tokio::test]
 async fn admission_default_confirmed_limit_rejects_before_handler() {
-    let (mut server, tx, mut started) = fixture().await;
+    let (mut server, tx, mut started) = fixture_with_config(
+        "global admission",
+        ServerConfig {
+            request_admission_policy: RequestAdmissionPolicy {
+                max_confirmed_in_flight_per_peer: 64,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .await;
     for id in 0..65 {
         inject(&tx, request(id)).await;
         tokio::time::timeout(Duration::from_secs(2), started.recv())
@@ -321,19 +335,30 @@ async fn admission_guards_not_joinset_length_and_closed_not_overload() {
     let owner = crate::server::request_tasks::RequestTasks::new(RequestAdmissionPolicy {
         max_confirmed_in_flight: 1,
         max_unconfirmed_in_flight: 1,
+        ..Default::default()
     })
     .unwrap();
     for class in [Class::Confirmed, Class::Unconfirmed, Class::Abort] {
         let (tx, rx) = oneshot::channel();
         owner
-            .try_spawn(class, || async move {
-                tx.send(()).unwrap();
-            })
+            .try_spawn(
+                class,
+                crate::server::request_peer::canonical_requester(&[1], None),
+                || async move {
+                    tx.send(()).unwrap();
+                },
+            )
             .unwrap();
         rx.await.unwrap();
         // One yield lets the guard drop, but deliberately never reap the set.
         tokio::task::yield_now().await;
-        owner.try_spawn(class, || async {}).unwrap();
+        owner
+            .try_spawn(
+                class,
+                crate::server::request_peer::canonical_requester(&[1], None),
+                || async {},
+            )
+            .unwrap();
     }
     owner.close();
     while !owner.is_empty() {
@@ -341,7 +366,11 @@ async fn admission_guards_not_joinset_length_and_closed_not_overload() {
     }
     for class in [Class::Confirmed, Class::Unconfirmed, Class::Abort] {
         assert_eq!(
-            owner.try_spawn(class, || async { panic!("closed task ran") }),
+            owner.try_spawn(
+                class,
+                crate::server::request_peer::canonical_requester(&[1], None),
+                || async { panic!("closed task ran") }
+            ),
             Err(Rejection::Closed)
         );
     }
@@ -386,6 +415,7 @@ fn admission_policy_validates_zero_upper_bound_and_defaults() {
     RequestAdmissionPolicy {
         max_confirmed_in_flight: Semaphore::MAX_PERMITS,
         max_unconfirmed_in_flight: 1,
+        ..Default::default()
     }
     .validate()
     .unwrap();
@@ -503,6 +533,7 @@ async fn admission_invalid_direct_generic_bip_before_transport_start() {
         let policy = RequestAdmissionPolicy {
             max_confirmed_in_flight: bad,
             max_unconfirmed_in_flight: 1,
+            ..Default::default()
         };
         let started = Arc::new(AtomicBool::new(false));
         let error = BACnetServer::start(
@@ -544,6 +575,10 @@ async fn admission_default_unconfirmed_limit_is_32_without_waiters() {
         "admission",
         ServerConfig {
             discovery_policy: DiscoveryPolicy::unlimited(),
+            request_admission_policy: RequestAdmissionPolicy {
+                max_unconfirmed_in_flight_per_peer: 32,
+                ..Default::default()
+            },
             ..Default::default()
         },
     )
@@ -572,10 +607,20 @@ async fn admission_every_class_releases_on_panic_and_before_first_poll_cancellat
     for class in [Class::Confirmed, Class::Unconfirmed, Class::Abort] {
         let owner = crate::server::request_tasks::RequestTasks::default();
         owner
-            .try_spawn(class, || async { panic!("injected class panic") })
+            .try_spawn(
+                class,
+                crate::server::request_peer::canonical_requester(&[1], None),
+                || async { panic!("injected class panic") },
+            )
             .unwrap();
         assert!(owner.join_next().await.unwrap().unwrap_err().is_panic());
-        owner.try_spawn(class, std::future::pending).unwrap();
+        owner
+            .try_spawn(
+                class,
+                crate::server::request_peer::canonical_requester(&[1], None),
+                std::future::pending,
+            )
+            .unwrap();
         owner.close();
         assert!(owner.join_next().await.unwrap().unwrap_err().is_cancelled());
         let c = owner.counters();

--- a/crates/bacnet-server/src/server/request_peer.rs
+++ b/crates/bacnet-server/src/server/request_peer.rs
@@ -1,0 +1,21 @@
+use bacnet_encoding::npdu::NpduAddress;
+use bacnet_types::MacAddr;
+
+/// Logical inbound source, not an authenticated principal (including on SC).
+/// Shared only by exact duplicate detection and top-level request admission.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(super) enum CanonicalRequester {
+    Direct(MacAddr),
+    Routed(NpduAddress),
+}
+
+pub(super) fn canonical_requester(
+    source_mac: &[u8],
+    source_network: Option<&NpduAddress>,
+) -> CanonicalRequester {
+    source_network
+        .filter(|source| (1..=0xfffe).contains(&source.network) && !source.mac_address.is_empty())
+        .cloned()
+        .map(CanonicalRequester::Routed)
+        .unwrap_or_else(|| CanonicalRequester::Direct(MacAddr::from_slice(source_mac)))
+}

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -32,6 +32,11 @@ impl RequestTaskSpawner {
 }
 
 impl RequestTasks {
+    #[cfg(test)]
+    pub(super) fn peer_entries(&self) -> [usize; 3] {
+        self.1.peer_entries()
+    }
+
     pub(super) fn for_server(
         config: &super::ServerConfig,
     ) -> Result<Arc<Self>, bacnet_types::error::Error> {
@@ -51,10 +56,11 @@ impl RequestTasks {
     pub(super) fn try_spawn<F: Future<Output = ()> + Send + 'static>(
         &self,
         class: Class,
+        peer: super::request_peer::CanonicalRequester,
         make: impl FnOnce() -> F,
     ) -> Result<(), Rejection> {
         let mut state = self.0.lock().unwrap();
-        let guard = self.1.try_enter(class, state.closed)?;
+        let guard = self.1.try_enter(class, peer, state.closed)?;
         let task = make();
         state.tasks.spawn(async move {
             let _guard = guard;

--- a/crates/bacnet-server/src/server/request_tasks_tests.rs
+++ b/crates/bacnet-server/src/server/request_tasks_tests.rs
@@ -202,9 +202,14 @@ async fn stop_releases_handler(request: Apdu) {
         u64::from(!is_confirmed)
     );
     assert_eq!(counters.confirmed_active + counters.unconfirmed_active, 1);
+    assert_eq!(
+        server.request_tasks.peer_entries(),
+        if is_confirmed { [1, 0, 0] } else { [0, 1, 0] }
+    );
     server.stop().await.unwrap();
     let counters = server.request_admission_counters();
     assert_eq!(counters.confirmed_active + counters.unconfirmed_active, 0);
+    assert_eq!(server.request_tasks.peer_entries(), [0; 3]);
     assert_eq!(
         released.try_recv(),
         Ok(()),

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -303,6 +303,7 @@ mod tests {
             let policy = RequestAdmissionPolicy {
                 max_confirmed_in_flight: 1,
                 max_unconfirmed_in_flight: bad,
+                ..Default::default()
             };
             let tls = tokio_rustls::rustls::ClientConfig::builder()
                 .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
@@ -327,6 +328,32 @@ mod tests {
                 .err()
                 .unwrap();
             assert!(matches!(error, Error::OutOfRange(m) if m.contains("reconnect")));
+        }
+    }
+
+    #[tokio::test]
+    async fn admission_sc_invalid_policy_peer_limits_precede_dial() {
+        for confirmed in [true, false] {
+            for bad in [0, usize::MAX] {
+                let mut policy = RequestAdmissionPolicy::default();
+                let name = if confirmed {
+                    policy.max_confirmed_in_flight_per_peer = bad;
+                    "max_confirmed_in_flight_per_peer"
+                } else {
+                    policy.max_unconfirmed_in_flight_per_peer = bad;
+                    "max_unconfirmed_in_flight_per_peer"
+                };
+                let tls = tokio_rustls::rustls::ClientConfig::builder()
+                    .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+                    .with_no_client_auth();
+                let builder = BACnetServer::sc_builder()
+                    .hub_url("not-a-websocket-url")
+                    .tls_config(Arc::new(tls))
+                    .request_admission_policy(policy);
+                assert_eq!(builder.config.request_admission_policy, policy);
+                let error = builder.build().await.err().unwrap();
+                assert!(matches!(error, Error::Encoding(m) if m.contains(name)));
+            }
         }
     }
 }

--- a/crates/bacnet-server/src/server/segmented_worker_tests.rs
+++ b/crates/bacnet-server/src/server/segmented_worker_tests.rs
@@ -161,7 +161,18 @@ async fn segmented_worker_production_panic_is_reaped_and_cleans_registry() {
 
 #[tokio::test]
 async fn segmented_worker_blocked_send_does_not_block_inline_ack_or_abort() {
-    let (mut server, tx, mut started) = fixture_with_name(&"x".repeat(100)).await;
+    let (mut server, tx, mut started) = fixture_with_config(
+        &"x".repeat(100),
+        ServerConfig {
+            segmentation_supported: Segmentation::BOTH,
+            request_admission_policy: RequestAdmissionPolicy {
+                max_confirmed_in_flight_per_peer: 64,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .await;
     inject(&tx, oversized_request()).await;
     let mut released = started_send(&mut started).await;
     let handle = server
@@ -179,6 +190,7 @@ async fn segmented_worker_blocked_send_does_not_block_inline_ack_or_abort() {
         0,
         "segmented child must not retain or reacquire the top-level slot"
     );
+    assert_eq!(server.request_tasks.peer_entries(), [0; 3]);
     // Fill the confirmed class with held real handlers before routing controls.
     for id in 20..84 {
         let Apdu::ConfirmedRequest(mut request) = confirmed(false) else {

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1729,10 +1729,14 @@ class RequestAdmissionCounters(TypedDict):
     confirmed_active: int
     confirmed_admitted_total: int
     confirmed_overloaded_total: int
+    confirmed_global_overloaded_total: int
+    confirmed_peer_overloaded_total: int
     confirmed_shutdown_rejected_total: int
     unconfirmed_active: int
     unconfirmed_admitted_total: int
     unconfirmed_overloaded_total: int
+    unconfirmed_global_overloaded_total: int
+    unconfirmed_peer_overloaded_total: int
     unconfirmed_shutdown_rejected_total: int
     abort_active: int
     abort_admitted_total: int
@@ -1775,6 +1779,8 @@ class BACnetServer:
         mstp_max_info_frames: int = 1,
         max_confirmed_in_flight: int = 64,
         max_unconfirmed_in_flight: int = 32,
+        max_confirmed_in_flight_per_peer: int = 16,
+        max_unconfirmed_in_flight_per_peer: int = 8,
     ) -> None: ...
 
     # --- Analog objects ---

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -27,7 +27,9 @@ impl BACnetServer {
         mstp_max_master=127,
         mstp_max_info_frames=1,
         max_confirmed_in_flight=64,
-        max_unconfirmed_in_flight=32
+        max_unconfirmed_in_flight=32,
+        max_confirmed_in_flight_per_peer=16,
+        max_unconfirmed_in_flight_per_peer=8
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -54,10 +56,14 @@ impl BACnetServer {
         mstp_max_info_frames: u8,
         max_confirmed_in_flight: usize,
         max_unconfirmed_in_flight: usize,
+        max_confirmed_in_flight_per_peer: usize,
+        max_unconfirmed_in_flight_per_peer: usize,
     ) -> PyResult<Self> {
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
             max_unconfirmed_in_flight,
+            max_confirmed_in_flight_per_peer,
+            max_unconfirmed_in_flight_per_peer,
         };
         request_admission_policy
             .validate()

--- a/crates/rusty-bacnet/src/server/server_methods/request_admission.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/request_admission.rs
@@ -16,6 +16,22 @@ impl BACnetServer {
             };
             // Owned Rust data only; no Python borrow or server guard escapes.
             Ok(std::collections::HashMap::from([
+                (
+                    "confirmed_global_overloaded_total",
+                    counters.confirmed_global_overloaded_total,
+                ),
+                (
+                    "confirmed_peer_overloaded_total",
+                    counters.confirmed_peer_overloaded_total,
+                ),
+                (
+                    "unconfirmed_global_overloaded_total",
+                    counters.unconfirmed_global_overloaded_total,
+                ),
+                (
+                    "unconfirmed_peer_overloaded_total",
+                    counters.unconfirmed_peer_overloaded_total,
+                ),
                 ("confirmed_active", counters.confirmed_active as u64),
                 (
                     "confirmed_admitted_total",

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -62,7 +62,8 @@ MSTP_KEYWORD_ONLY = [
     "mstp_max_info_frames",
 ]
 SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
-    "max_confirmed_in_flight", "max_unconfirmed_in_flight"
+    "max_confirmed_in_flight", "max_unconfirmed_in_flight",
+    "max_confirmed_in_flight_per_peer", "max_unconfirmed_in_flight_per_peer"
 ]
 SUPPORTED_BAUD_RATES = (9_600, 19_200, 38_400, 57_600, 76_800, 115_200)
 SUPPORTED_BAUD_ERROR = (

--- a/crates/rusty-bacnet/tests/test_peer_admission.py
+++ b/crates/rusty-bacnet/tests/test_peer_admission.py
@@ -1,0 +1,74 @@
+"""Installed-wheel peer quota propagation; deterministic saturation lives in Rust."""
+import asyncio
+import socket
+import unittest
+
+from rusty_bacnet import BACnetServer
+
+
+class PeerAdmissionRuntimeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_two_udp_sources_peer_rejection_and_recovery(self):
+        server = BACnetServer(123, interface="127.0.0.1", port=0,
+                              broadcast_address="127.0.0.1",
+                              max_confirmed_in_flight_per_peer=1,
+                              max_unconfirmed_in_flight_per_peer=1)
+        sockets = [socket.socket(socket.AF_INET, socket.SOCK_DGRAM) for _ in range(2)]
+        for sock in sockets:
+            sock.bind(("127.0.0.1", 0))
+            sock.setblocking(False)
+        self.assertNotEqual(sockets[0].getsockname(), sockets[1].getsockname())
+        loop = asyncio.get_running_loop()
+        try:
+            await server.start()
+            ip, port = (await server.local_address()).rsplit(":", 1)
+            address = (ip, int(port))
+
+            async def send(sock, apdu):
+                npdu = b"\x01\x00" + apdu
+                wire = b"\x81\x0a" + (4 + len(npdu)).to_bytes(2, "big") + npdu
+                await loop.sock_sendto(sock, wire, address)
+
+            async def quiescent():
+                async with asyncio.timeout(3):
+                    while True:
+                        counters = await server.request_admission_counters()
+                        if counters["confirmed_active"] == counters["abort_active"] == 0:
+                            return counters
+                        await asyncio.sleep(0)
+
+            # Same logical peer, distinct requests. Do not assert exact UDP counts.
+            counters = await server.request_admission_counters()
+            for batch in range(8):
+                body = b"\x0c\x02\x00\x00\x7b\x1e" + b"\x09\x4d" * (256 + batch) + b"\x1f"
+                for invoke in range(128):
+                    await send(sockets[0], bytes([0, 5, invoke, 14]) + body)
+                counters = await server.request_admission_counters()
+                self.assertLessEqual(counters["confirmed_active"], 1)
+                if counters["confirmed_peer_overloaded_total"]:
+                    break
+            self.assertGreater(counters["confirmed_peer_overloaded_total"], 0)
+            counters = await quiescent()
+            self.assertEqual(counters["confirmed_global_overloaded_total"], 0)
+            self.assertEqual(counters["confirmed_overloaded_total"], counters["confirmed_peer_overloaded_total"])
+            self.assertEqual(counters["confirmed_overloaded_total"],
+                             counters["abort_admitted_total"] + counters["confirmed_fallback_dropped_total"])
+            # Both immediate UDP sources can execute normal requests afterward.
+            # Simultaneous second-peer availability is covered by Rust barriers.
+            for sock in sockets:
+                while True:
+                    try:
+                        sock.recvfrom(65536)
+                    except BlockingIOError:
+                        break
+                await send(sock, b"\x00\x05\xfa\x0c")
+                async with asyncio.timeout(3):
+                    while True:
+                        wire, _ = await loop.sock_recvfrom(sock, 65536)
+                        if len(wire) >= 8 and wire[7] == 250:
+                            self.assertEqual(wire[6] >> 4, 5)  # handler Error, not overload Abort
+                            break
+                await quiescent()
+        finally:
+            await server.stop()
+            for sock in sockets:
+                sock.close()

--- a/crates/rusty-bacnet/tests/test_request_admission.py
+++ b/crates/rusty-bacnet/tests/test_request_admission.py
@@ -14,6 +14,8 @@ from rusty_bacnet import BACnetServer
 
 
 FIELDS = {
+    "confirmed_global_overloaded_total", "confirmed_peer_overloaded_total",
+    "unconfirmed_global_overloaded_total", "unconfirmed_peer_overloaded_total",
     "confirmed_active", "confirmed_admitted_total", "confirmed_overloaded_total",
     "confirmed_shutdown_rejected_total", "unconfirmed_active",
     "unconfirmed_admitted_total", "unconfirmed_overloaded_total",
@@ -31,7 +33,8 @@ class AdmissionSignatureTests(unittest.TestCase):
         constructor = next(n for n in server.body if isinstance(n, ast.FunctionDef) and n.name == "__init__")
         defaults = dict(zip((a.arg for a in constructor.args.kwonlyargs), constructor.args.kw_defaults))
         signature = inspect.signature(BACnetServer)
-        for name, value in [("max_confirmed_in_flight", 64), ("max_unconfirmed_in_flight", 32)]:
+        for name, value in [("max_confirmed_in_flight", 64), ("max_unconfirmed_in_flight", 32),
+                            ("max_confirmed_in_flight_per_peer", 16), ("max_unconfirmed_in_flight_per_peer", 8)]:
             self.assertEqual(signature.parameters[name].kind, inspect.Parameter.KEYWORD_ONLY)
             self.assertEqual(signature.parameters[name].default, value)
             default = defaults[name]
@@ -45,7 +48,8 @@ class AdmissionSignatureTests(unittest.TestCase):
 
     def test_invalid_limits_rejected_at_constructor_for_all_transports(self):
         for transport in ["bip", "ipv6", "sc", "mstp"]:
-            for name in ["max_confirmed_in_flight", "max_unconfirmed_in_flight"]:
+            for name in ["max_confirmed_in_flight", "max_unconfirmed_in_flight",
+                         "max_confirmed_in_flight_per_peer", "max_unconfirmed_in_flight_per_peer"]:
                 for value, error in [(0, ValueError), (-1, OverflowError), (1 << 200, OverflowError), ((1 << 64) - 1, ValueError)]:
                     with self.subTest(transport=transport, name=name, value=value):
                         with self.assertRaises(error):

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1704,15 +1704,30 @@ ms and require `sc_heartbeat_timeout_ms` to be greater than the interval.
 ## Request admission limits
 
 `BACnetServer(...)` accepts keyword-only `max_confirmed_in_flight=64` and
-`max_unconfirmed_in_flight=32`. Both must be positive; zero is rejected during
+`max_unconfirmed_in_flight=32`, followed by keyword-only
+`max_confirmed_in_flight_per_peer=16` and `max_unconfirmed_in_flight_per_peer=8`.
+Existing positional arguments and global defaults are unchanged.
+All must be positive and within the native semaphore range; zero is rejected during
 construction, before any transport opens. These provisional defaults bound
 top-level handler concurrency, not all server work or per-peer fairness.
+Each effective peer cap is the smaller of its configured cap and global cap;
+global=1 with peer defaults is valid. A valid routed network (1..65534) and
+nonempty source MAC identify the logical peer, otherwise the immediate MAC does.
+On SC, the supplied VMAC/logical source is not an authenticated principal.
+Identity multiplication/spoofing can exhaust global capacity; quotas do not
+guarantee availability once that capacity is full. Critical-service reservations
+and work/response budgets remain deferred.
 
 `await server.request_admission_counters()` returns a stable typed dictionary
 of independent active/admitted/overload/shutdown counters, including the
 separate eight-worker Abort pool and its counted confirmed-drop fallback.
 Like `comm_state()`, this accessor raises `RuntimeError` before start and after
 stop. Admission totals do not imply successful response sends.
+The additive `confirmed_global_overloaded_total`, `confirmed_peer_overloaded_total`,
+`unconfirmed_global_overloaded_total`, and `unconfirmed_peer_overloaded_total`
+fields classify rejections global-first. Each aggregate overload total equals
+its two reason totals at quiescence; independently sampled snapshots are not
+atomic. No peer identity history is exposed.
 
 See [server request admission](request-admission.md) for exact fields, accepted
 ranges, overload behavior, and the known extreme-overload/conformance limitation.

--- a/docs/request-admission.md
+++ b/docs/request-admission.md
@@ -1,20 +1,32 @@
 # Server request admission
 
 Each running server has independent, global limits for **top-level inbound
-handlers**: 64 confirmed and 32 unconfirmed by default. These finite defaults
+handlers**: 64 confirmed and 32 unconfirmed by default, plus independent
+per-logical-peer limits of **16 confirmed and 8 unconfirmed**. These finite defaults
 are provisional owner policy, not benchmark results or normative BACnet limits.
 
 Rust exposes `server::RequestAdmissionPolicy` through
 `ServerConfig::request_admission_policy` and the generic, BIP, and SC builders'
-`request_admission_policy(policy)` method. Both fields,
-`max_confirmed_in_flight` and `max_unconfirmed_in_flight`, must be positive and
+`request_admission_policy(policy)` method. All four fields,
+`max_confirmed_in_flight`, `max_unconfirmed_in_flight`,
+`max_confirmed_in_flight_per_peer`, and `max_unconfirmed_in_flight_per_peer`, must be positive and
 no greater than `tokio::sync::Semaphore::MAX_PERMITS`. Invalid values return an
 error before server transport startup (and before SC TLS dialing). Validation
 does not undo work already performed by a caller constructing its own transport.
 Existing route, APDU, and SC reconnect validation precedence is retained.
+The effective peer limit is `min(configured peer limit, global limit)` for each
+class. A global limit of 1 with the default peer limits is valid; there is no
+peer-less-than-or-equal-to-global validation requirement.
+
+Adding the two Rust policy fields and four counter fields is a **source-breaking
+struct expansion** for exhaustive downstream literals/patterns. Policy literals
+can use `..RequestAdmissionPolicy::default()` to inherit peer defaults, or set
+explicit positive peer limits. Global defaults and the private Abort cap are unchanged.
 
 Python appends keyword-only `max_confirmed_in_flight=64` and
-`max_unconfirmed_in_flight=32` to `BACnetServer(...)`. Zero or a representable
+`max_unconfirmed_in_flight=32`, followed by
+`max_confirmed_in_flight_per_peer=16` and `max_unconfirmed_in_flight_per_peer=8`,
+to `BACnetServer(...)`, preserving old positional arguments. Zero or a representable
 value above the semaphore bound raises `ValueError`; negative or integer values
 outside the native unsigned range raise `OverflowError`. Validation occurs in
 the constructor, before any transport startup, including synchronous MS/TP
@@ -22,10 +34,25 @@ serial opening. There is no zero-as-disable or unlimited mode.
 
 ## Admission and overload
 
+The shared private inbound duplicate/admission identity uses a routed source's
+network and MAC when the network is 1 through 65534 and the MAC is nonempty.
+Otherwise it uses the immediate source MAC. Thus one routed origin through two
+routers shares a quota, while distinct origins have separate quotas. On SC this
+is the supplied VMAC/logical source, **not an authenticated principal**. Spoofed
+or multiplied identities can bypass a single identity's quota and exhaust the
+global pool. COV, reassembly, and endpoint-core identity contracts are not changed.
+
 - Capacity is acquired synchronously before a handler is spawned. No queue of
   rejected work or capacity-waiting tasks is created. A slot lasts through the
   actual handler future, including awaited post-response work; completion,
   panic, and cancellation release it, even if its completed task is not reaped.
+  The sealed-owner check precedes global acquisition, which precedes peer
+  registration. If both capacities are exhausted, the rejection is global.
+  Peer rejection releases the temporary global permit without counting admission.
+  Separate class maps contain only active peer counts, bounded by their global
+  quotas. Last-guard drop removes the peer entry before releasing its global
+  permit, including never-polled cancellation. There are no historical peer
+  entries, timestamps, eviction rules, or exposed identity maps.
 - Detectable exact pending/completed confirmed duplicates are discarded before
   capacity admission. They do not count as admitted or overloaded. The existing
   bounded duplicate retention, source canonicalization, and oversized untracked
@@ -33,7 +60,8 @@ serial opening. There is no zero-as-disable or unlimited mode.
 - Confirmed overload schedules a server Abort with the original Invoke ID and
   `OUT_OF_RESOURCES`, retaining direct, routed, and MS/TP reply-channel paths.
   A separate private pool permits at most **eight owned Abort send workers**.
-  It does not consume either handler class's slots and never waits for capacity.
+  It does not consume either handler class's global or peer slots and never waits
+  for capacity. Global and peer rejection use this same eight-worker pool.
   If that pool is also full, the confirmed request is silently dropped and the
   fallback counter increments. Admission does not mean the send succeeded.
 - Unconfirmed overload is silently dropped and counted. DCC and discovery
@@ -41,9 +69,9 @@ serial opening. There is no zero-as-disable or unlimited mode.
   acquire a slot or provoke an inappropriate overload response.
 - Inline SimpleAck, Error, Reject, Abort, and SegmentAck handling does not acquire
   these slots. Incoming reassembly retains its existing session/peer/byte bounds
-  and acquires one handler slot only on completed dispatch. Segmented ComplexAck
+  and acquires one global and logical-peer handler slot only on completed dispatch. Segmented ComplexAck
   descendants remain owned and governed by their separate existing sender cap;
-  they are not charged another confirmed slot.
+  they are not charged another confirmed global or peer slot.
 - Explicit stop seals registration and cancels/joins owned handlers and overload
   workers using the existing request-task owner. Shutdown rejection is distinct
   from capacity exhaustion. This does not promise async Drop joining, arbitrary
@@ -67,6 +95,8 @@ stable fields, described by the shipped `RequestAdmissionCounters` TypedDict:
 | `confirmed_active`, `unconfirmed_active` | Registered handler futures not yet finished/dropped |
 | `confirmed_admitted_total`, `unconfirmed_admitted_total` | Cumulative handler registrations |
 | `confirmed_overloaded_total`, `unconfirmed_overloaded_total` | Capacity-rejected requests; unconfirmed requests are dropped |
+| `confirmed_global_overloaded_total`, `unconfirmed_global_overloaded_total` | Global capacity rejections, tested first |
+| `confirmed_peer_overloaded_total`, `unconfirmed_peer_overloaded_total` | Peer capacity rejections while global capacity was available |
 | `confirmed_shutdown_rejected_total`, `unconfirmed_shutdown_rejected_total` | Registrations denied by the sealed task owner |
 | `abort_active` | Live overload Abort workers, at most eight |
 | `abort_admitted_total` | Cumulative Abort registrations, **not send completions** |
@@ -75,7 +105,9 @@ stable fields, described by the shipped `RequestAdmissionCounters` TypedDict:
 
 Fields are sampled independently from bounded atomic counters; the aggregate is
 not a transactionally consistent snapshot. Totals cover one server lifetime,
-without request history storage. Rust counters remain readable after successful
+and at quiescence each class's overload total equals its global plus peer reason
+totals (not necessarily while concurrently sampling them).
+No request history is stored by these counters. Rust counters remain readable after successful
 stop, with active counts zero. Python follows its existing `comm_state()` and
 `local_address()` accessors: before start and after stop it raises
 `RuntimeError("server not started")`. Immediately after a traffic-free start,
@@ -83,7 +115,9 @@ all counters are zero. No new restart semantics are promised.
 
 ## Remaining limits
 
-There is no per-peer fairness or reserved critical-service capacity. A busy
+Peer quotas partition identities, but do not provide scheduling fairness,
+critical-service reservations, or guaranteed availability once the global pool
+is full. A busy
 confirmed class can reject DeviceCommunicationControl or ReinitializeDevice;
 neither has a reserved slot. This bounds top-level handler concurrency, not
 every allocation, incoming byte, service effect, notification, transport task,


### PR DESCRIPTION
## Approved policy
- Default to 16 confirmed / 8 unconfirmed top-level handlers per logical peer. Preserve global64/32 limits and the existing private8-worker Abort path with counted fallback.
- Use valid routed source (network1..65534 and nonempty MAC), otherwise immediate source MAC. This matches existing duplicate identity; SC uses supplied VMAC/logical source, not authenticated principal identity.
- Effective peer limits are min(configured peer, global); positive-only validation remains and tiny global configurations stay valid.
- Global-first admission preserves aggregate overload counters and adds four global/peer reason counters. Peer records exist only while work is active, with RAII removal before global permit release.
- Add matching Rust policy/counter fields and Python keyword-only settings/TypedDict fields. Exhaustive downstream Rust struct literals/patterns require migration; this source expansion was explicitly approved.

Refs #521 (partial; do not close). #522 unchanged.

## Validation
- Default-cap regression failed on baseline (17 active vs16 expected) then passed after implementation.
- Seven peer tests cover identity/fallback matrix, class/origin independence, global-first classification, duplicate/retry behavior, shared Abort fallback/wire paths, and cleanup across2048 sequential identities per class.
- Admission28, duplicate8, request-task45, DCC28, segmentation69, server928+3, integration38, and SC pre-dial2 passed.
- cargo test --workspace --exclude rusty-bacnet --locked: 4,251 passed, 0 failed, 3 ignored. Fmt/Clippy (warnings)/file-size/no-secret/whitespace gates passed; root reran staged gates including new files.
- Binding cargo check/clippy passed with Python3.12. Fresh locked macOS arm64 wheel built after final production/binding changes; installed stub matches. Full Python suite34 tests/221subtests passed, no skips; root independently repeated it. Peer module passed10 repeated runs.
- Wheel SHA256 ec0e35b98911f4083ce013c5305a8a716b7872da93becc482cb4c9068a1e86f4.
- Exact-head five lean CI checks and independent reviews pending; heavy/release, other OS/interpreters, and hardware qualification excluded.

## Limits
Quotas partition reported identities; they do not authenticate them or guarantee fairness/availability once global capacity fills. Identity multiplication/spoofing, critical-service reservations, and work/response budgets remain deferred. Existing extreme-overload confirmed-drop limitation remains. No changes to COV/reassembly/endpoint correlation identity, transport, protocol response, CI, or dependencies. See docs/request-admission.md.

Native exact source governed while optional Codebase Memory coverage was unavailable. No licensed specification excerpts or new conformance claims.