### PR TITLE
feat(server): reserve confirmed capacity for DCC ENABLE recovery

### DIFF
--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -143,7 +143,11 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let descendants = request_tasks.spawner();
                 let peer =
                     super::request_peer::canonical_requester(&source_mac, source_network.as_ref());
-                let result = request_tasks.try_spawn(Class::Confirmed, peer.clone(), || {
+                let class = super::request_admission::confirmed_class(
+                    req.service_choice,
+                    &req.service_request,
+                );
+                let result = request_tasks.try_spawn(class, peer.clone(), || {
                     let reply_tx = reply_tx.take();
                     async move {
                         Self::handle_admitted_confirmed_request(

--- a/crates/bacnet-server/src/server/peer_admission_tests.rs
+++ b/crates/bacnet-server/src/server/peer_admission_tests.rs
@@ -116,6 +116,8 @@ async fn peer_admission_logical_identity_and_duplicate_fallback_matrix() {
 async fn peer_admission_independent_classes_origins_and_global_first() {
     let owner = RequestTasks::new(RequestAdmissionPolicy {
         max_confirmed_in_flight: 2,
+        confirmed_recovery_reserve: 0,
+        max_recovery_in_flight_per_peer: 1,
         max_unconfirmed_in_flight: 2,
         max_confirmed_in_flight_per_peer: 1,
         max_unconfirmed_in_flight_per_peer: 1,
@@ -383,6 +385,7 @@ async fn peer_admission_positive_validation_generic_bip_and_tiny_global() {
     }
     let owner = RequestTasks::new(RequestAdmissionPolicy {
         max_confirmed_in_flight: 1,
+        confirmed_recovery_reserve: 0,
         max_unconfirmed_in_flight: 1,
         ..Default::default()
     })

--- a/crates/bacnet-server/src/server/recovery_admission_tests.rs
+++ b/crates/bacnet-server/src/server/recovery_admission_tests.rs
@@ -1,0 +1,493 @@
+use super::*;
+use crate::server::request_peer::canonical_requester;
+use crate::server::request_tasks::RequestTasks;
+use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
+use bacnet_types::enums::EnableDisable;
+
+fn peer(id: u8) -> crate::server::request_peer::CanonicalRequester {
+    canonical_requester(&[id], None)
+}
+
+#[tokio::test]
+async fn recovery_segmented_enable_charged_once_after_reassembly() {
+    let (mut server, tx, mut started) = fixture().await;
+    server.comm_state.store(1, Ordering::Release);
+    let Apdu::ConfirmedRequest(mut first) = enable(42, None) else {
+        unreachable!()
+    };
+    let mut last = first.clone();
+    first.segmented = true;
+    first.more_follows = true;
+    first.sequence_number = Some(0);
+    first.proposed_window_size = Some(1);
+    first.service_request = first.service_request.slice(..1);
+    last.segmented = true;
+    last.sequence_number = Some(1);
+    last.proposed_window_size = Some(1);
+    last.service_request = last.service_request.slice(1..);
+    inject(&tx, Apdu::ConfirmedRequest(first)).await;
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while server.network.transport().frames.lock().unwrap().is_empty() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    assert_eq!(
+        server.request_admission_counters().confirmed_admitted_total,
+        0
+    );
+    assert_eq!(server.comm_state.load(Ordering::Acquire), 1);
+    inject(&tx, Apdu::ConfirmedRequest(last)).await;
+    observed(&mut started).await;
+    let c = server.request_admission_counters();
+    assert_eq!(
+        (
+            c.confirmed_active,
+            c.recovery_active,
+            c.confirmed_admitted_total,
+            c.recovery_admitted_total
+        ),
+        (1, 1, 1, 1)
+    );
+    assert_eq!(server.comm_state.load(Ordering::Acquire), 0);
+    server.stop().await.unwrap();
+}
+
+fn source(id: u8) -> Option<NpduAddress> {
+    Some(NpduAddress {
+        network: 7,
+        mac_address: MacAddr::from_slice(&[id]),
+    })
+}
+
+fn enable(id: u8, password: Option<&str>) -> Apdu {
+    let Apdu::ConfirmedRequest(mut req) = request(id) else {
+        unreachable!()
+    };
+    req.service_choice = ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL;
+    let mut data = BytesMut::new();
+    DeviceCommunicationControlRequest {
+        time_duration: None,
+        enable_disable: EnableDisable::ENABLE,
+        password: password.map(str::to_owned),
+    }
+    .encode(&mut data)
+    .unwrap();
+    req.service_request = data.freeze();
+    Apdu::ConfirmedRequest(req)
+}
+
+async fn drain(owner: &RequestTasks) {
+    owner.close();
+    while !owner.is_empty() {
+        owner.join_next().await;
+    }
+    assert_eq!(owner.peer_entries(), [0; 3]);
+    assert_eq!(
+        (
+            owner.counters().confirmed_active,
+            owner.counters().recovery_active
+        ),
+        (0, 0)
+    );
+}
+
+#[tokio::test]
+async fn recovery_default_ordinary_partition_is_sixty_not_sixty_four() {
+    let owner = RequestTasks::default();
+    for id in 0u8..60 {
+        owner
+            .try_spawn(
+                Class::Confirmed,
+                canonical_requester(&[id], None),
+                std::future::pending,
+            )
+            .unwrap();
+    }
+    assert_eq!(
+        owner.try_spawn(
+            Class::Confirmed,
+            canonical_requester(&[60], None),
+            std::future::pending
+        ),
+        Err(Rejection::Overloaded)
+    );
+    assert_eq!(owner.counters().confirmed_active, 60);
+    owner.close();
+    while !owner.is_empty() {
+        owner.join_next().await;
+    }
+    assert_eq!(owner.peer_entries(), [0; 3]);
+}
+
+#[tokio::test]
+async fn recovery_strict_partitions_no_lending_and_aggregate_counters() {
+    let owner = RequestTasks::default();
+    for id in 0..4 {
+        owner
+            .try_spawn(Class::Recovery, peer(id), std::future::pending)
+            .unwrap();
+    }
+    assert_eq!(
+        owner.try_spawn(Class::Recovery, peer(4), std::future::pending),
+        Err(Rejection::Overloaded)
+    );
+    for id in 0..60 {
+        owner
+            .try_spawn(Class::Confirmed, peer(id), std::future::pending)
+            .unwrap();
+    }
+    assert_eq!(
+        owner.try_spawn(Class::Confirmed, peer(60), std::future::pending),
+        Err(Rejection::Overloaded)
+    );
+    let c = owner.counters();
+    assert_eq!((c.confirmed_active, c.recovery_active), (64, 4));
+    assert_eq!(
+        (c.confirmed_admitted_total, c.recovery_admitted_total),
+        (64, 4)
+    );
+    assert_eq!(
+        (c.confirmed_overloaded_total, c.recovery_overloaded_total),
+        (2, 1)
+    );
+    assert_eq!(
+        (
+            c.confirmed_global_overloaded_total,
+            c.confirmed_peer_overloaded_total
+        ),
+        (2, 0)
+    );
+    drain(&owner).await;
+}
+
+#[tokio::test]
+async fn recovery_peer_total_is_inclusive_and_protected_peer_is_additional() {
+    for recovery_first in [false, true] {
+        let owner = RequestTasks::default();
+        if recovery_first {
+            owner
+                .try_spawn(Class::Recovery, peer(1), std::future::pending)
+                .unwrap();
+        }
+        for _ in 0..if recovery_first { 15 } else { 16 } {
+            owner
+                .try_spawn(Class::Confirmed, peer(1), std::future::pending)
+                .unwrap();
+        }
+        for class in [Class::Recovery, Class::Confirmed] {
+            assert_eq!(
+                owner.try_spawn(class, peer(1), std::future::pending),
+                Err(Rejection::Overloaded)
+            );
+        }
+        owner
+            .try_spawn(Class::Recovery, peer(2), std::future::pending)
+            .unwrap();
+        assert_eq!(
+            owner.try_spawn(Class::Recovery, peer(2), std::future::pending),
+            Err(Rejection::Overloaded)
+        );
+        owner
+            .try_spawn(Class::Recovery, peer(3), std::future::pending)
+            .unwrap();
+        let c = owner.counters();
+        assert_eq!(
+            (
+                c.confirmed_active,
+                c.confirmed_peer_overloaded_total,
+                c.confirmed_global_overloaded_total
+            ),
+            (18, 3, 0)
+        );
+        assert_eq!(c.recovery_overloaded_total, 2);
+        drain(&owner).await;
+    }
+}
+
+#[tokio::test]
+async fn recovery_zero_reserve_uses_ordinary_and_preserves_tiny_global() {
+    let owner = RequestTasks::new(RequestAdmissionPolicy {
+        max_confirmed_in_flight: 1,
+        confirmed_recovery_reserve: 0,
+        ..Default::default()
+    })
+    .unwrap();
+    owner
+        .try_spawn(Class::Recovery, peer(1), std::future::pending)
+        .unwrap();
+    assert_eq!(
+        owner.try_spawn(Class::Confirmed, peer(2), std::future::pending),
+        Err(Rejection::Overloaded)
+    );
+    assert_eq!(
+        (
+            owner.counters().confirmed_active,
+            owner.counters().recovery_active
+        ),
+        (1, 0)
+    );
+    drain(&owner).await;
+}
+
+#[tokio::test]
+async fn recovery_guards_cleanup_panic_cancel_never_polled_and_closed() {
+    let owner = RequestTasks::default();
+    owner
+        .try_spawn(Class::Recovery, peer(1), || async { panic!("injected") })
+        .unwrap();
+    assert!(owner.join_next().await.unwrap().unwrap_err().is_panic());
+    assert_eq!(owner.peer_entries(), [0; 3]);
+    for _ in 0..32 {
+        owner
+            .try_spawn(Class::Recovery, peer(1), || async {})
+            .unwrap();
+        owner.join_next().await.unwrap().unwrap();
+    }
+    owner
+        .try_spawn(Class::Recovery, peer(1), std::future::pending)
+        .unwrap();
+    drain(&owner).await;
+    assert_eq!(
+        owner.try_spawn(Class::Recovery, peer(1), || async { panic!("closed") }),
+        Err(Rejection::Closed)
+    );
+    assert_eq!(owner.counters().confirmed_shutdown_rejected_total, 1);
+    assert_eq!(owner.counters().confirmed_overloaded_total, 0);
+}
+
+#[tokio::test]
+async fn recovery_invalid_reserve_before_direct_generic_and_bip_start() {
+    for (global, reserve) in [(64, 64), (64, 65), (1, 4), (4, 4)] {
+        let policy = RequestAdmissionPolicy {
+            max_confirmed_in_flight: global,
+            confirmed_recovery_reserve: reserve,
+            ..Default::default()
+        };
+        let started = Arc::new(AtomicBool::new(false));
+        let error = BACnetServer::start(
+            ServerConfig {
+                request_admission_policy: policy,
+                ..Default::default()
+            },
+            ObjectDatabase::new(),
+            NeverStart(Arc::clone(&started)),
+        )
+        .await
+        .err()
+        .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("confirmed_recovery_reserve")));
+        let error = BACnetServer::generic_builder()
+            .transport(NeverStart(Arc::clone(&started)))
+            .request_admission_policy(policy)
+            .build()
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("confirmed_recovery_reserve")));
+        assert!(!started.load(Ordering::Acquire));
+        assert!(BACnetServer::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .request_admission_policy(policy)
+            .build()
+            .await
+            .is_err());
+    }
+    for reserve in [0, 4] {
+        for bad in [0, usize::MAX] {
+            assert!(RequestAdmissionPolicy {
+                confirmed_recovery_reserve: reserve,
+                max_recovery_in_flight_per_peer: bad,
+                ..Default::default()
+            }
+            .validate()
+            .is_err());
+        }
+    }
+}
+
+#[tokio::test]
+async fn recovery_wire_enable_restores_communications_at_ordinary_saturation() {
+    let (mut server, tx, mut started) = fixture().await;
+    for id in 0..60 {
+        dispatch(&server, request(id), source(id / 15), None).await;
+        observed(&mut started).await;
+    }
+    dispatch(&server, request(60), source(4), None).await;
+    observed(&mut started).await;
+    assert!(
+        matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::Abort(a)) if a.invoke_id == 60 && a.abort_reason == AbortReason::OUT_OF_RESOURCES)
+    );
+    server.comm_state.store(1, Ordering::Release);
+    inject(&tx, enable(61, None)).await; // Full NPDU/APDU ingress, different logical peer.
+    observed(&mut started).await;
+    assert_eq!(server.comm_state.load(Ordering::Acquire), 0);
+    assert!(
+        matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::SimpleAck(a)) if a.invoke_id == 61)
+    );
+    assert_eq!(
+        (
+            server.request_admission_counters().confirmed_active,
+            server.request_admission_counters().recovery_active
+        ),
+        (61, 1)
+    );
+    server.stop().await.unwrap();
+    assert_eq!(server.request_tasks.peer_entries(), [0; 3]);
+}
+
+#[tokio::test]
+async fn recovery_protected_wire_exhaustion_duplicate_retry_and_abort_fallback() {
+    let (mut server, _tx, mut started) = fixture().await;
+    for id in 0..4 {
+        dispatch(&server, enable(id, None), source(id), None).await;
+        observed(&mut started).await;
+    }
+    // Exact duplicates are quiet even when their partition and peer are full.
+    for id in 0..4 {
+        dispatch(&server, enable(id, None), source(id), None).await;
+    }
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .confirmed_overloaded_total,
+        0
+    );
+    for id in 4..13 {
+        dispatch(&server, enable(id, None), source(id), None).await;
+        if id < 12 {
+            observed(&mut started).await;
+        }
+    }
+    let c = server.request_admission_counters();
+    assert_eq!(
+        (c.confirmed_active, c.recovery_active, c.abort_active),
+        (4, 4, 8)
+    );
+    assert_eq!(
+        (
+            c.recovery_overloaded_total,
+            c.confirmed_fallback_dropped_total
+        ),
+        (9, 1)
+    );
+    assert!(server.network.transport().frames.lock().unwrap()[4..].iter().all(|p| matches!(p, Apdu::Abort(a) if a.abort_reason == AbortReason::OUT_OF_RESOURCES && a.sent_by_server)));
+    server.network.transport().release.notify_waiters();
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while server.request_admission_counters().confirmed_active
+            + server.request_admission_counters().abort_active
+            != 0
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    dispatch(&server, enable(12, None), source(12), None).await;
+    observed(&mut started).await;
+    assert!(
+        matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::SimpleAck(a)) if a.invoke_id == 12)
+    );
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn recovery_classification_is_not_password_authorization() {
+    let (mut server, _tx, mut started) = fixture_with_config(
+        "recovery",
+        ServerConfig {
+            dcc_password: Some("required".into()),
+            ..Default::default()
+        },
+    )
+    .await;
+    server.comm_state.store(1, Ordering::Release);
+    for (id, password) in [(1, None), (2, Some("wrong"))] {
+        dispatch(&server, enable(id, password), source(id), None).await;
+        observed(&mut started).await;
+        assert_eq!(server.comm_state.load(Ordering::Acquire), 1);
+        assert!(
+            matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::Error(e)) if e.error_code == ErrorCode::PASSWORD_FAILURE)
+        );
+    }
+    assert_eq!(server.request_admission_counters().recovery_active, 2);
+    dispatch(&server, enable(3, Some("required")), source(3), None).await;
+    observed(&mut started).await;
+    assert_eq!(server.comm_state.load(Ordering::Acquire), 0);
+    server.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn recovery_noneligible_requests_cannot_borrow_and_password_capacity_precedes_handler() {
+    let (mut server, _tx, mut started) = fixture_with_config(
+        "recovery",
+        ServerConfig {
+            request_admission_policy: RequestAdmissionPolicy {
+                max_confirmed_in_flight: 2,
+                confirmed_recovery_reserve: 1,
+                ..Default::default()
+            },
+            dcc_password: Some("required".into()),
+            ..Default::default()
+        },
+    )
+    .await;
+    dispatch(&server, request(0), source(0), None).await;
+    observed(&mut started).await;
+    for (id, service, data) in [
+        (
+            1,
+            ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+            &[0x19, 1][..],
+        ),
+        (
+            2,
+            ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+            &[0x19, 2][..],
+        ),
+        (
+            3,
+            ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+            &[0x19][..],
+        ),
+        (
+            4,
+            ConfirmedServiceChoice::REINITIALIZE_DEVICE,
+            &[0x09, 0][..],
+        ),
+    ] {
+        let Apdu::ConfirmedRequest(mut req) = request(id) else {
+            unreachable!()
+        };
+        req.service_choice = service;
+        req.service_request = Bytes::copy_from_slice(data);
+        dispatch(&server, Apdu::ConfirmedRequest(req), source(id), None).await;
+        observed(&mut started).await;
+        assert!(
+            matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::Abort(a)) if a.invoke_id == id)
+        );
+    }
+    assert_eq!(
+        server.request_admission_counters().recovery_admitted_total,
+        0
+    );
+    dispatch(&server, enable(5, None), source(5), None).await;
+    observed(&mut started).await;
+    assert!(
+        matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::Error(e)) if e.error_code == ErrorCode::PASSWORD_FAILURE)
+    );
+    dispatch(&server, enable(6, Some("wrong")), source(6), None).await;
+    observed(&mut started).await;
+    assert!(
+        matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::Abort(a)) if a.invoke_id == 6)
+    );
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .recovery_overloaded_total,
+        1
+    );
+    server.stop().await.unwrap();
+}

--- a/crates/bacnet-server/src/server/recovery_classifier.rs
+++ b/crates/bacnet-server/src/server/recovery_classifier.rs
@@ -1,0 +1,188 @@
+//! Local admission classification only; never authorizes or mutates DCC state.
+use super::Class;
+use bacnet_encoding::tags;
+use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
+use bacnet_types::enums::{ConfirmedServiceChoice, EnableDisable};
+
+pub(in crate::server) fn confirmed_class(service: ConfirmedServiceChoice, data: &[u8]) -> Class {
+    if service == ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL
+        && bounded_password(data)
+        && DeviceCommunicationControlRequest::decode(data)
+            .is_ok_and(|request| request.enable_disable == EnableDisable::ENABLE)
+    {
+        Class::Recovery
+    } else {
+        Class::Confirmed
+    }
+}
+
+// Mirror only the decoder's borrowed field traversal, not its accepted language.
+// Its final decode remains authoritative, including optional duration, charset
+// validity and trailing-data tolerance. Every accepted password has <=20 UTF-8
+// bytes: UTF-8/Latin-1 need <=20 wire payload bytes, UCS-2 <=40 (each code point
+// produces at least one UTF-8 byte). Thus rejecting larger content loses no
+// accepted encoding, and the authoritative decode can allocate only bounded
+// password storage. There is deliberately no total-request-length cutoff.
+fn bounded_password(data: &[u8]) -> bool {
+    let Ok((_, offset)) = tags::decode_optional_context(data, 0, 0) else {
+        return false;
+    };
+    let Ok((tag, pos)) = tags::decode_tag(data, offset) else {
+        return false;
+    };
+    if !tag.is_context(1) {
+        return false;
+    }
+    let Some(end) = pos
+        .checked_add(tag.length as usize)
+        .filter(|end| *end <= data.len())
+    else {
+        return false;
+    };
+    if end == data.len() {
+        return true;
+    }
+    let Ok((password, _)) = tags::decode_optional_context(data, end, 2) else {
+        return false;
+    };
+    match password {
+        None => true,
+        Some(content) => match content.first() {
+            Some(0 | 5) => content.len() <= 21,
+            Some(4) => content.len() <= 41,
+            _ => false,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bacnet_encoding::{primitives, tags::TagClass};
+    use bytes::BytesMut;
+
+    #[test]
+    fn recovery_guard_removes_both_peer_maps_before_reuse() {
+        use super::super::{Admission, RequestAdmissionPolicy};
+        use crate::server::request_peer::canonical_requester;
+        let admission = Admission::new(RequestAdmissionPolicy::default()).unwrap();
+        for id in 0u32..2048 {
+            let guard = admission
+                .try_enter(
+                    Class::Recovery,
+                    canonical_requester(&id.to_be_bytes(), None),
+                    false,
+                )
+                .unwrap();
+            assert_eq!(admission.peer_entries(), [1, 0, 0]);
+            assert_eq!(admission.recovery.peers.lock().unwrap().len(), 1);
+            drop(guard);
+            assert_eq!(admission.peer_entries(), [0; 3]);
+            assert!(admission.recovery.peers.lock().unwrap().is_empty());
+            assert_eq!(admission.recovery.permits.available_permits(), 4);
+        }
+    }
+
+    fn assert_matches_decoder(data: &[u8]) {
+        let expected = DeviceCommunicationControlRequest::decode(data)
+            .is_ok_and(|r| r.enable_disable == EnableDisable::ENABLE);
+        assert_eq!(
+            matches!(
+                confirmed_class(ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL, data),
+                Class::Recovery
+            ),
+            expected
+        );
+    }
+
+    #[test]
+    fn recovery_classifier_preserves_decoder_language_and_charset_byte_limits() {
+        for duration in [None, Some(0), Some(u16::MAX)] {
+            for mode in [
+                EnableDisable::ENABLE,
+                EnableDisable::DISABLE,
+                EnableDisable::DISABLE_INITIATION,
+                EnableDisable::from_raw(255),
+            ] {
+                for password in [
+                    None,
+                    Some(""),
+                    Some("abcdefghijklmnopqrst"),
+                    Some("éééééééééé"),
+                    Some("abcdefghijklmnopqrstu"),
+                ] {
+                    let mut data = BytesMut::new();
+                    DeviceCommunicationControlRequest {
+                        time_duration: duration,
+                        enable_disable: mode,
+                        password: password.map(str::to_owned),
+                    }
+                    .encode(&mut data)
+                    .unwrap();
+                    assert_matches_decoder(&data);
+                    data.extend_from_slice(&[0x39, 7, 0xff]); // Existing unrelated trailing tag tolerance.
+                    assert_matches_decoder(&data);
+                }
+            }
+        }
+        for charset in 0..=6 {
+            for len in 0..=44 {
+                for byte in [0, b'a', 0x80, 0xd8, 0xff] {
+                    let mut data = BytesMut::from(&[0x19, 0][..]);
+                    tags::encode_tag(&mut data, 2, TagClass::Context, len + 1);
+                    data.extend_from_slice(&[charset]);
+                    data.extend_from_slice(&vec![byte; len as usize]);
+                    assert_matches_decoder(&data);
+                    // All truncated prefixes must also agree.
+                    for end in 0..data.len() {
+                        assert_matches_decoder(&data[..end]);
+                    }
+                }
+            }
+        }
+        for duration in [65536, u64::MAX] {
+            let mut data = BytesMut::new();
+            primitives::encode_ctx_unsigned(&mut data, 0, duration);
+            data.extend_from_slice(&[0x19, 0]);
+            assert_matches_decoder(&data);
+        }
+        for data in [
+            &[0x19, 0][..],
+            &[0x1d, 2, 0, 0],
+            &[0x19, 0, 0xff],
+            &[0x19, 0, 0x2e],
+        ] {
+            assert_matches_decoder(data);
+            assert!(matches!(
+                confirmed_class(ConfirmedServiceChoice::REINITIALIZE_DEVICE, data),
+                Class::Confirmed
+            ));
+        }
+    }
+
+    #[test]
+    fn recovery_classifier_preflight_rejects_large_password_not_large_trailing_data() {
+        for charset in [0, 4, 5] {
+            let mut data = BytesMut::from(&[0x19, 0][..]);
+            tags::encode_tag(&mut data, 2, TagClass::Context, 1_000_001);
+            data.extend_from_slice(&[charset]);
+            data.resize(data.len() + 1_000_000, b'a');
+            assert!(!bounded_password(&data)); // No allocating character decoder reached.
+            assert!(matches!(
+                confirmed_class(ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL, &data),
+                Class::Confirmed
+            ));
+        }
+        let mut trailing = vec![0x19, 0, 0x39, 1];
+        trailing.resize(1_000_000, 0xff);
+        assert!(bounded_password(&trailing));
+        assert_matches_decoder(&trailing);
+        assert!(matches!(
+            confirmed_class(
+                ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+                &trailing
+            ),
+            Class::Recovery
+        ));
+    }
+}

--- a/crates/bacnet-server/src/server/request_admission.rs
+++ b/crates/bacnet-server/src/server/request_admission.rs
@@ -8,7 +8,11 @@ use super::request_peer::CanonicalRequester;
 use bacnet_types::error::Error;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-/// Independent global and logical-peer top-level handler limits. Zero is invalid.
+#[path = "recovery_classifier.rs"]
+mod recovery_classifier;
+pub(super) use recovery_classifier::confirmed_class;
+
+/// Global and logical-peer top-level handler limits with a strict recovery reserve.
 /// Defaults are provisional owner policy, not benchmark-derived values.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct RequestAdmissionPolicy {
@@ -22,6 +26,12 @@ pub struct RequestAdmissionPolicy {
     /// Maximum concurrent unconfirmed handlers per logical peer (default 8).
     /// This partitions capacity by identity; it does not guarantee fairness.
     pub max_unconfirmed_in_flight_per_peer: usize,
+    /// Strict DCC ENABLE partition inside the confirmed global limit (default 4).
+    /// Zero disables protection; otherwise must be smaller than the global limit.
+    pub confirmed_recovery_reserve: usize,
+    /// Additional protected per-peer limit (default 1), always positive.
+    /// The existing confirmed per-peer limit remains inclusive of both partitions.
+    pub max_recovery_in_flight_per_peer: usize,
 }
 
 impl Default for RequestAdmissionPolicy {
@@ -31,6 +41,8 @@ impl Default for RequestAdmissionPolicy {
             max_unconfirmed_in_flight: 32,
             max_confirmed_in_flight_per_peer: 16,
             max_unconfirmed_in_flight_per_peer: 8,
+            confirmed_recovery_reserve: 4,
+            max_recovery_in_flight_per_peer: 1,
         }
     }
 }
@@ -41,6 +53,10 @@ impl RequestAdmissionPolicy {
         for (name, value) in [
             ("max_confirmed_in_flight", self.max_confirmed_in_flight),
             ("max_unconfirmed_in_flight", self.max_unconfirmed_in_flight),
+            (
+                "max_recovery_in_flight_per_peer",
+                self.max_recovery_in_flight_per_peer,
+            ),
             (
                 "max_confirmed_in_flight_per_peer",
                 self.max_confirmed_in_flight_per_peer,
@@ -57,6 +73,11 @@ impl RequestAdmissionPolicy {
                 )));
             }
         }
+        if self.confirmed_recovery_reserve >= self.max_confirmed_in_flight {
+            return Err(Error::Encoding(
+                "confirmed_recovery_reserve must be smaller than max_confirmed_in_flight".into(),
+            ));
+        }
         Ok(())
     }
 }
@@ -66,15 +87,21 @@ impl RequestAdmissionPolicy {
 /// include registered futures not yet polled and exclude completed unreaped tasks.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct RequestAdmissionCounters {
+    /// Live protected handlers, also included in confirmed_active.
+    pub recovery_active: usize,
+    /// Protected registrations, also included in confirmed_admitted_total.
+    pub recovery_admitted_total: u64,
+    /// Protected capacity rejections, also included in confirmed_overloaded_total.
+    pub recovery_overloaded_total: u64,
     /// Live confirmed handlers.
     pub confirmed_active: usize,
     /// Confirmed handlers registered since startup.
     pub confirmed_admitted_total: u64,
     /// Confirmed requests rejected for exhausted handler capacity.
     pub confirmed_overloaded_total: u64,
-    /// Confirmed capacity rejections classified global-first.
+    /// Confirmed capacity rejections classified partition-first (ordinary or protected).
     pub confirmed_global_overloaded_total: u64,
-    /// Confirmed capacity rejections with a global permit but no peer slot.
+    /// Confirmed rejections with a partition permit but no total/protected peer slot.
     pub confirmed_peer_overloaded_total: u64,
     /// Confirmed registrations rejected after shutdown sealed the owner.
     pub confirmed_shutdown_rejected_total: u64,
@@ -105,6 +132,7 @@ pub(super) enum Class {
     Confirmed = 0,
     Unconfirmed = 1,
     Abort = 2,
+    Recovery = 3,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -115,6 +143,8 @@ pub(super) enum Rejection {
 
 pub(super) struct Admission {
     pools: [Arc<Pool>; 3],
+    recovery: Arc<Pool>,
+    recovery_enabled: bool,
 }
 
 struct Pool {
@@ -133,7 +163,7 @@ impl Pool {
     fn new(limit: usize, peer_limit: usize) -> Arc<Self> {
         Arc::new(Self {
             permits: Arc::new(Semaphore::new(limit)),
-            peer_limit: peer_limit.min(limit),
+            peer_limit,
             peers: Mutex::new(HashMap::new()),
             active: AtomicUsize::new(0),
             admitted: AtomicU64::new(0),
@@ -147,6 +177,7 @@ impl Pool {
 
 pub(super) struct Guard {
     pool: Arc<Pool>,
+    aggregate: Option<Arc<Pool>>,
     peer: Option<CanonicalRequester>,
     _permit: OwnedSemaphorePermit,
 }
@@ -155,15 +186,17 @@ impl Drop for Guard {
     fn drop(&mut self) {
         // Remove registration before Rust drops _permit and releases global
         // capacity. This lock never acquires the task owner's lock.
-        if let Some(peer) = &self.peer {
-            let mut peers = self.pool.peers.lock().unwrap_or_else(|e| e.into_inner());
-            let count = peers.get_mut(peer).expect("live peer registration");
-            *count -= 1;
-            if *count == 0 {
-                peers.remove(peer);
+        for pool in std::iter::once(&self.pool).chain(self.aggregate.iter()) {
+            if let Some(peer) = &self.peer {
+                let mut peers = pool.peers.lock().unwrap_or_else(|e| e.into_inner());
+                let count = peers.get_mut(peer).expect("live peer registration");
+                *count -= 1;
+                if *count == 0 {
+                    peers.remove(peer);
+                }
             }
+            pool.active.fetch_sub(1, Ordering::Relaxed);
         }
-        self.pool.active.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
@@ -178,15 +211,27 @@ impl Admission {
         Ok(Self {
             pools: [
                 Pool::new(
-                    policy.max_confirmed_in_flight,
-                    policy.max_confirmed_in_flight_per_peer,
+                    policy.max_confirmed_in_flight - policy.confirmed_recovery_reserve,
+                    policy
+                        .max_confirmed_in_flight_per_peer
+                        .min(policy.max_confirmed_in_flight),
                 ),
                 Pool::new(
                     policy.max_unconfirmed_in_flight,
-                    policy.max_unconfirmed_in_flight_per_peer,
+                    policy
+                        .max_unconfirmed_in_flight_per_peer
+                        .min(policy.max_unconfirmed_in_flight),
                 ),
                 Pool::new(8, 8),
             ],
+            recovery: Pool::new(
+                policy.confirmed_recovery_reserve,
+                policy
+                    .max_recovery_in_flight_per_peer
+                    .min(policy.confirmed_recovery_reserve)
+                    .min(policy.max_confirmed_in_flight_per_peer),
+            ),
+            recovery_enabled: policy.confirmed_recovery_reserve != 0,
         })
     }
 
@@ -197,16 +242,45 @@ impl Admission {
         peer: CanonicalRequester,
         closed: bool,
     ) -> Result<Guard, Rejection> {
-        let pool = &self.pools[class as usize];
+        let (pool, aggregate) = if matches!(class, Class::Recovery) {
+            if self.recovery_enabled {
+                (&self.recovery, Some(&self.pools[0]))
+            } else {
+                (&self.pools[0], None)
+            }
+        } else {
+            (&self.pools[class as usize], None)
+        };
         if closed {
             pool.closed.fetch_add(1, Ordering::Relaxed);
+            if let Some(total) = aggregate {
+                total.closed.fetch_add(1, Ordering::Relaxed);
+            }
             return Err(Rejection::Closed);
         }
         let permit = Arc::clone(&pool.permits).try_acquire_owned().map_err(|_| {
             pool.overloaded.fetch_add(1, Ordering::Relaxed);
             pool.global_overloaded.fetch_add(1, Ordering::Relaxed);
+            if let Some(total) = aggregate {
+                total.overloaded.fetch_add(1, Ordering::Relaxed);
+                total.global_overloaded.fetch_add(1, Ordering::Relaxed);
+            }
             Rejection::Overloaded
         })?;
+        // Spawn serialization belongs to RequestTasks. Hold the shared total map
+        // through both checks so no partial registration needs rollback. Drops
+        // never hold both maps simultaneously and never acquire the owner lock.
+        let mut total_peers =
+            aggregate.map(|total| total.peers.lock().unwrap_or_else(|e| e.into_inner()));
+        if let (Some(total), Some(peers)) = (aggregate, total_peers.as_ref()) {
+            if peers.get(&peer).copied().unwrap_or(0) >= total.peer_limit {
+                pool.overloaded.fetch_add(1, Ordering::Relaxed);
+                pool.peer_overloaded.fetch_add(1, Ordering::Relaxed);
+                total.overloaded.fetch_add(1, Ordering::Relaxed);
+                total.peer_overloaded.fetch_add(1, Ordering::Relaxed);
+                return Err(Rejection::Overloaded);
+            }
+        }
         // Abort workers are global-only, with no peer registration or charge.
         let peer = if matches!(class, Class::Abort) {
             None
@@ -215,15 +289,27 @@ impl Admission {
             if peers.get(&peer).copied().unwrap_or(0) >= pool.peer_limit {
                 pool.overloaded.fetch_add(1, Ordering::Relaxed);
                 pool.peer_overloaded.fetch_add(1, Ordering::Relaxed);
+                if let Some(total) = aggregate {
+                    total.overloaded.fetch_add(1, Ordering::Relaxed);
+                    total.peer_overloaded.fetch_add(1, Ordering::Relaxed);
+                }
                 return Err(Rejection::Overloaded);
             }
             *peers.entry(peer.clone()).or_default() += 1;
+            if let Some(peers) = total_peers.as_mut() {
+                *peers.entry(peer.clone()).or_default() += 1;
+            }
             Some(peer)
         };
         pool.active.fetch_add(1, Ordering::Relaxed);
         pool.admitted.fetch_add(1, Ordering::Relaxed);
+        if let Some(total) = aggregate {
+            total.active.fetch_add(1, Ordering::Relaxed);
+            total.admitted.fetch_add(1, Ordering::Relaxed);
+        }
         Ok(Guard {
             pool: Arc::clone(pool),
+            aggregate: aggregate.map(Arc::clone),
             peer,
             _permit: permit,
         })
@@ -232,6 +318,9 @@ impl Admission {
     pub(super) fn snapshot(&self) -> RequestAdmissionCounters {
         let [c, u, a] = &self.pools;
         RequestAdmissionCounters {
+            recovery_active: self.recovery.active.load(Ordering::Relaxed),
+            recovery_admitted_total: self.recovery.admitted.load(Ordering::Relaxed),
+            recovery_overloaded_total: self.recovery.overloaded.load(Ordering::Relaxed),
             confirmed_active: c.active.load(Ordering::Relaxed),
             confirmed_admitted_total: c.admitted.load(Ordering::Relaxed),
             confirmed_overloaded_total: c.overloaded.load(Ordering::Relaxed),

--- a/crates/bacnet-server/src/server/request_admission_tests.rs
+++ b/crates/bacnet-server/src/server/request_admission_tests.rs
@@ -4,6 +4,9 @@ use crate::server::request_admission::{Class, Rejection};
 #[path = "peer_admission_tests.rs"]
 mod peer_admission_tests;
 
+#[path = "recovery_admission_tests.rs"]
+mod recovery_admission_tests;
+
 async fn small_fixture() -> (
     BACnetServer<HeldTransport>,
     mpsc::Sender<ReceivedNpdu>,
@@ -14,6 +17,7 @@ async fn small_fixture() -> (
         ServerConfig {
             request_admission_policy: RequestAdmissionPolicy {
                 max_confirmed_in_flight: 1,
+                confirmed_recovery_reserve: 0,
                 max_unconfirmed_in_flight: 1,
                 ..Default::default()
             },
@@ -94,6 +98,7 @@ async fn admission_default_confirmed_limit_rejects_before_handler() {
         ServerConfig {
             request_admission_policy: RequestAdmissionPolicy {
                 max_confirmed_in_flight_per_peer: 64,
+                confirmed_recovery_reserve: 0,
                 ..Default::default()
             },
             ..Default::default()
@@ -334,6 +339,7 @@ async fn admission_panic_releases_real_handler_and_abort_and_allows_retry() {
 async fn admission_guards_not_joinset_length_and_closed_not_overload() {
     let owner = crate::server::request_tasks::RequestTasks::new(RequestAdmissionPolicy {
         max_confirmed_in_flight: 1,
+        confirmed_recovery_reserve: 0,
         max_unconfirmed_in_flight: 1,
         ..Default::default()
     })

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -302,6 +302,7 @@ mod tests {
         for bad in [0, usize::MAX] {
             let policy = RequestAdmissionPolicy {
                 max_confirmed_in_flight: 1,
+                confirmed_recovery_reserve: 0,
                 max_unconfirmed_in_flight: bad,
                 ..Default::default()
             };
@@ -317,6 +318,41 @@ mod tests {
                 .err()
                 .unwrap();
             assert!(matches!(error, Error::Encoding(m) if m.contains("max_unconfirmed_in_flight")));
+            let error = BACnetServer::sc_builder()
+                .request_admission_policy(policy)
+                .reconnect(ScReconnectConfig {
+                    initial_delay_ms: 0,
+                    ..Default::default()
+                })
+                .build()
+                .await
+                .err()
+                .unwrap();
+            assert!(matches!(error, Error::OutOfRange(m) if m.contains("reconnect")));
+        }
+    }
+
+    #[tokio::test]
+    async fn admission_sc_invalid_policy_recovery_precedes_dial() {
+        for reserve in [64, 65] {
+            let policy = RequestAdmissionPolicy {
+                confirmed_recovery_reserve: reserve,
+                ..Default::default()
+            };
+            let tls = tokio_rustls::rustls::ClientConfig::builder()
+                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+                .with_no_client_auth();
+            let error = BACnetServer::sc_builder()
+                .hub_url("not-a-websocket-url")
+                .tls_config(Arc::new(tls))
+                .request_admission_policy(policy)
+                .build()
+                .await
+                .err()
+                .unwrap();
+            assert!(
+                matches!(error, Error::Encoding(m) if m.contains("confirmed_recovery_reserve"))
+            );
             let error = BACnetServer::sc_builder()
                 .request_admission_policy(policy)
                 .reconnect(ScReconnectConfig {

--- a/crates/bacnet-server/src/server/segmented_worker_tests.rs
+++ b/crates/bacnet-server/src/server/segmented_worker_tests.rs
@@ -167,6 +167,7 @@ async fn segmented_worker_blocked_send_does_not_block_inline_ack_or_abort() {
             segmentation_supported: Segmentation::BOTH,
             request_admission_policy: RequestAdmissionPolicy {
                 max_confirmed_in_flight_per_peer: 64,
+                confirmed_recovery_reserve: 0,
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1726,6 +1726,9 @@ class BACnetClient:
 
 class RequestAdmissionCounters(TypedDict):
     """Independent counter samples, not a transactionally atomic aggregate."""
+    recovery_active: int
+    recovery_admitted_total: int
+    recovery_overloaded_total: int
     confirmed_active: int
     confirmed_admitted_total: int
     confirmed_overloaded_total: int
@@ -1781,6 +1784,8 @@ class BACnetServer:
         max_unconfirmed_in_flight: int = 32,
         max_confirmed_in_flight_per_peer: int = 16,
         max_unconfirmed_in_flight_per_peer: int = 8,
+        confirmed_recovery_reserve: int = 4,
+        max_recovery_in_flight_per_peer: int = 1,
     ) -> None: ...
 
     # --- Analog objects ---

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -29,7 +29,9 @@ impl BACnetServer {
         max_confirmed_in_flight=64,
         max_unconfirmed_in_flight=32,
         max_confirmed_in_flight_per_peer=16,
-        max_unconfirmed_in_flight_per_peer=8
+        max_unconfirmed_in_flight_per_peer=8,
+        confirmed_recovery_reserve=4,
+        max_recovery_in_flight_per_peer=1
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -58,12 +60,16 @@ impl BACnetServer {
         max_unconfirmed_in_flight: usize,
         max_confirmed_in_flight_per_peer: usize,
         max_unconfirmed_in_flight_per_peer: usize,
+        confirmed_recovery_reserve: usize,
+        max_recovery_in_flight_per_peer: usize,
     ) -> PyResult<Self> {
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
             max_unconfirmed_in_flight,
             max_confirmed_in_flight_per_peer,
             max_unconfirmed_in_flight_per_peer,
+            confirmed_recovery_reserve,
+            max_recovery_in_flight_per_peer,
         };
         request_admission_policy
             .validate()

--- a/crates/rusty-bacnet/src/server/server_methods/request_admission.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/request_admission.rs
@@ -16,6 +16,12 @@ impl BACnetServer {
             };
             // Owned Rust data only; no Python borrow or server guard escapes.
             Ok(std::collections::HashMap::from([
+                ("recovery_active", counters.recovery_active as u64),
+                ("recovery_admitted_total", counters.recovery_admitted_total),
+                (
+                    "recovery_overloaded_total",
+                    counters.recovery_overloaded_total,
+                ),
                 (
                     "confirmed_global_overloaded_total",
                     counters.confirmed_global_overloaded_total,

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -63,7 +63,8 @@ MSTP_KEYWORD_ONLY = [
 ]
 SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
     "max_confirmed_in_flight", "max_unconfirmed_in_flight",
-    "max_confirmed_in_flight_per_peer", "max_unconfirmed_in_flight_per_peer"
+    "max_confirmed_in_flight_per_peer", "max_unconfirmed_in_flight_per_peer",
+    "confirmed_recovery_reserve", "max_recovery_in_flight_per_peer"
 ]
 SUPPORTED_BAUD_RATES = (9_600, 19_200, 38_400, 57_600, 76_800, 115_200)
 SUPPORTED_BAUD_ERROR = (

--- a/crates/rusty-bacnet/tests/test_recovery_admission.py
+++ b/crates/rusty-bacnet/tests/test_recovery_admission.py
@@ -1,0 +1,90 @@
+"""Recovery settings and native loopback behavior, not hardware availability proof."""
+import asyncio
+import socket
+import unittest
+from typing import Any
+
+from rusty_bacnet import BACnetServer
+
+
+class RecoveryConstructorTests(unittest.TestCase):
+    def test_ranges_and_tiny_global_migration_before_all_transports(self):
+        for transport in ["bip", "ipv6", "sc", "mstp"]:
+            for global_limit, reserve in [(64, 64), (64, 65), (1, 4), (4, 4)]:
+                with self.subTest(transport=transport, global_limit=global_limit, reserve=reserve):
+                    with self.assertRaisesRegex(ValueError, "confirmed_recovery_reserve"):
+                        BACnetServer(123, transport=transport, max_confirmed_in_flight=global_limit,
+                                     confirmed_recovery_reserve=reserve)
+            for reserve in [0, 4]:
+                for value, error in [(0, ValueError), (-1, OverflowError), (1 << 200, OverflowError)]:
+                    with self.subTest(transport=transport, reserve=reserve, value=value):
+                        with self.assertRaises(error):
+                            BACnetServer(123, transport=transport, confirmed_recovery_reserve=reserve,
+                                         max_recovery_in_flight_per_peer=value)
+            for reserve in [-1, 1 << 200]:
+                with self.assertRaises(OverflowError):
+                    BACnetServer(123, transport=transport, confirmed_recovery_reserve=reserve)
+            for name in ["confirmed_recovery_reserve", "max_recovery_in_flight_per_peer"]:
+                with self.assertRaises(TypeError):
+                    invalid: dict[str, Any] = {name: 1.5}
+                    BACnetServer(123, transport=transport, **invalid)
+            BACnetServer(123, transport=transport, max_confirmed_in_flight=1, confirmed_recovery_reserve=0)
+            BACnetServer(123, transport=transport, max_confirmed_in_flight=2, confirmed_recovery_reserve=1)
+
+
+class RecoveryNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_wire_classification_password_and_zero_reserve_policy(self):
+        # Sequential wire checks establish installed native policy propagation.
+        # Rust held-transport barriers provide deterministic 60/4 saturation.
+        for reserve in [0, 1]:
+            server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                  broadcast_address="127.0.0.1", dcc_password="required",
+                                  max_confirmed_in_flight=2, confirmed_recovery_reserve=reserve,
+                                  max_recovery_in_flight_per_peer=1)
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.bind(("127.0.0.1", 0))
+            sock.setblocking(False)
+            loop = asyncio.get_running_loop()
+            try:
+                await server.start()
+                ip, port = (await server.local_address()).rsplit(":", 1)
+
+                async def exchange(invoke, mode, password=None):
+                    body = bytes([0x19, mode])
+                    if password is not None:
+                        content = b"\0" + password.encode()
+                        body += bytes([0x2d, len(content)]) + content
+                    npdu = b"\x01\x00" + bytes([0, 5, invoke, 17]) + body
+                    wire = b"\x81\x0a" + (len(npdu) + 4).to_bytes(2, "big") + npdu
+                    await loop.sock_sendto(sock, wire, (ip, int(port)))
+                    reply, _ = await asyncio.wait_for(loop.sock_recvfrom(sock, 2048), 2)
+                    self.assertEqual(reply[7], invoke)
+                    async with asyncio.timeout(2):
+                        while True:
+                            counters = await server.request_admission_counters()
+                            if counters["confirmed_active"] == counters["abort_active"] == 0:
+                                break
+                            await asyncio.sleep(0)
+                    self.assertEqual(counters["recovery_active"], 0)
+                    return reply[6:], counters
+
+                # Existing DISABLE rejection is unchanged; use supported
+                # DISABLE_INITIATION for the native recovery transition.
+                reply, counters = await exchange(1, 2, "required")
+                self.assertEqual(reply[0] >> 4, 2)
+                self.assertEqual(await server.comm_state(), 2)
+                self.assertEqual(counters["recovery_admitted_total"], 0)
+                for invoke, password in [(2, None), (3, "wrong")]:
+                    reply, counters = await exchange(invoke, 0, password)
+                    self.assertEqual(reply[0] >> 4, 5)  # authoritative handler Error
+                    self.assertEqual(await server.comm_state(), 2)
+                reply, counters = await exchange(4, 0, "required")
+                self.assertEqual(reply[0] >> 4, 2)
+                self.assertEqual(await server.comm_state(), 0)
+                self.assertEqual(counters["confirmed_admitted_total"], 4)
+                self.assertEqual(counters["recovery_admitted_total"], 3 if reserve else 0)
+                self.assertEqual(counters["confirmed_overloaded_total"], 0)
+                self.assertEqual(counters["recovery_overloaded_total"], 0)
+            finally:
+                await server.stop()
+                sock.close()

--- a/crates/rusty-bacnet/tests/test_request_admission.py
+++ b/crates/rusty-bacnet/tests/test_request_admission.py
@@ -14,6 +14,7 @@ from rusty_bacnet import BACnetServer
 
 
 FIELDS = {
+    "recovery_active", "recovery_admitted_total", "recovery_overloaded_total",
     "confirmed_global_overloaded_total", "confirmed_peer_overloaded_total",
     "unconfirmed_global_overloaded_total", "unconfirmed_peer_overloaded_total",
     "confirmed_active", "confirmed_admitted_total", "confirmed_overloaded_total",
@@ -34,7 +35,8 @@ class AdmissionSignatureTests(unittest.TestCase):
         defaults = dict(zip((a.arg for a in constructor.args.kwonlyargs), constructor.args.kw_defaults))
         signature = inspect.signature(BACnetServer)
         for name, value in [("max_confirmed_in_flight", 64), ("max_unconfirmed_in_flight", 32),
-                            ("max_confirmed_in_flight_per_peer", 16), ("max_unconfirmed_in_flight_per_peer", 8)]:
+                            ("max_confirmed_in_flight_per_peer", 16), ("max_unconfirmed_in_flight_per_peer", 8),
+                            ("confirmed_recovery_reserve", 4), ("max_recovery_in_flight_per_peer", 1)]:
             self.assertEqual(signature.parameters[name].kind, inspect.Parameter.KEYWORD_ONLY)
             self.assertEqual(signature.parameters[name].default, value)
             default = defaults[name]
@@ -59,6 +61,8 @@ class AdmissionSignatureTests(unittest.TestCase):
                     invalid = {name: 1.5}
                     BACnetServer(123, transport=transport, **invalid)
                 valid: dict[str, Any] = {name: 2}
+                if name == "max_confirmed_in_flight":
+                    valid["confirmed_recovery_reserve"] = 0
                 BACnetServer(123, transport=transport, **valid)
 
 
@@ -72,7 +76,8 @@ class AdmissionRuntimeTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.server = BACnetServer(123, interface="127.0.0.1", port=0,
                                   broadcast_address="127.0.0.1",
-                                  max_confirmed_in_flight=1, max_unconfirmed_in_flight=2)
+                                  max_confirmed_in_flight=1, max_unconfirmed_in_flight=2,
+                                  confirmed_recovery_reserve=0)
         self.server.add_analog_value(1, "Admission AV")
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.bind(("127.0.0.1", 0))

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1705,18 +1705,26 @@ ms and require `sc_heartbeat_timeout_ms` to be greater than the interval.
 
 `BACnetServer(...)` accepts keyword-only `max_confirmed_in_flight=64` and
 `max_unconfirmed_in_flight=32`, followed by keyword-only
-`max_confirmed_in_flight_per_peer=16` and `max_unconfirmed_in_flight_per_peer=8`.
+`max_confirmed_in_flight_per_peer=16`, `max_unconfirmed_in_flight_per_peer=8`,
+`confirmed_recovery_reserve=4`, and `max_recovery_in_flight_per_peer=1`.
 Existing positional arguments and global defaults are unchanged.
-All must be positive and within the native semaphore range; zero is rejected during
+All except the reserve must be positive and within the native semaphore range; zero is rejected during
 construction, before any transport opens. These provisional defaults bound
 top-level handler concurrency, not all server work or per-peer fairness.
 Each effective peer cap is the smaller of its configured cap and global cap;
-global=1 with peer defaults is valid. A valid routed network (1..65534) and
+the reserve must satisfy `0 <= reserve < max_confirmed_in_flight`. Thus global=1
+requires explicit reserve=0, and custom globals <=4 must specify a smaller reserve.
+Reserve=0 makes ENABLE ordinary, not denied. A valid routed network (1..65534) and
 nonempty source MAC identify the logical peer, otherwise the immediate MAC does.
 On SC, the supplied VMAC/logical source is not an authenticated principal.
 Identity multiplication/spoofing can exhaust global capacity; quotas do not
-guarantee availability once that capacity is full. Critical-service reservations
-and work/response budgets remain deferred.
+guarantee availability once that capacity is full. The default confirmed total64
+is strictly partitioned into ordinary60/protected4 with no lending in either
+direction. Only decoder-accepted DCC ENABLE is protected; existing password checks
+still apply in the handler, so wrong/missing required passwords can consume a slot
+before PASSWORD_FAILURE. Total confirmed peer16 includes both partitions, with
+an additional protected peer1 cap. A peer already at total16 can be denied ENABLE.
+Other critical-service reservations and work/response budgets remain deferred.
 
 `await server.request_admission_counters()` returns a stable typed dictionary
 of independent active/admitted/overload/shutdown counters, including the
@@ -1725,7 +1733,10 @@ Like `comm_state()`, this accessor raises `RuntimeError` before start and after
 stop. Admission totals do not imply successful response sends.
 The additive `confirmed_global_overloaded_total`, `confirmed_peer_overloaded_total`,
 `unconfirmed_global_overloaded_total`, and `unconfirmed_peer_overloaded_total`
-fields classify rejections global-first. Each aggregate overload total equals
+fields classify rejections partition/global-first. New `recovery_active`,
+`recovery_admitted_total`, and `recovery_overloaded_total` are protected subsets;
+existing confirmed aggregates include both partitions. They remain zero when the
+reserve is zero. Each aggregate overload total equals
 its two reason totals at quiescence; independently sampled snapshots are not
 atomic. No peer identity history is exposed.
 

--- a/docs/request-admission.md
+++ b/docs/request-admission.md
@@ -2,35 +2,73 @@
 
 Each running server has independent, global limits for **top-level inbound
 handlers**: 64 confirmed and 32 unconfirmed by default, plus independent
-per-logical-peer limits of **16 confirmed and 8 unconfirmed**. These finite defaults
+per-logical-peer limits of **16 confirmed and 8 unconfirmed**. Inside the confirmed
+64, a strict **4-slot DCC ENABLE recovery reserve** leaves **60 ordinary slots**.
+The additional protected per-peer cap is **1**, not an addition to the total 16.
+These finite defaults
 are provisional owner policy, not benchmark results or normative BACnet limits.
 
 Rust exposes `server::RequestAdmissionPolicy` through
 `ServerConfig::request_admission_policy` and the generic, BIP, and SC builders'
-`request_admission_policy(policy)` method. All four fields,
+`request_admission_policy(policy)` method. The fields
 `max_confirmed_in_flight`, `max_unconfirmed_in_flight`,
-`max_confirmed_in_flight_per_peer`, and `max_unconfirmed_in_flight_per_peer`, must be positive and
+`max_confirmed_in_flight_per_peer`, `max_unconfirmed_in_flight_per_peer`, and
+`max_recovery_in_flight_per_peer` (default 1), must be positive and
 no greater than `tokio::sync::Semaphore::MAX_PERMITS`. Invalid values return an
 error before server transport startup (and before SC TLS dialing). Validation
 does not undo work already performed by a caller constructing its own transport.
 Existing route, APDU, and SC reconnect validation precedence is retained.
 The effective peer limit is `min(configured peer limit, global limit)` for each
-class. A global limit of 1 with the default peer limits is valid; there is no
-peer-less-than-or-equal-to-global validation requirement.
+class. `confirmed_recovery_reserve` (default 4) must satisfy `0 <= R < G`, where
+`G = max_confirmed_in_flight`. Zero disables protection: eligible ENABLE requests
+use ordinary capacity as before. A custom global limit of 4 or less must now
+explicitly configure reserve 0 or a smaller valid reserve. In particular, global
+1 requires reserve 0; default peer limits remain valid. There is no
+peer-less-than-or-equal-to-global validation requirement. The effective protected
+peer cap is `min(max_recovery_in_flight_per_peer, R, max_confirmed_in_flight_per_peer)`.
 
-Adding the two Rust policy fields and four counter fields is a **source-breaking
+Adding these two Rust policy fields and three recovery counter fields is a **source-breaking
 struct expansion** for exhaustive downstream literals/patterns. Policy literals
-can use `..RequestAdmissionPolicy::default()` to inherit peer defaults, or set
-explicit positive peer limits. Global defaults and the private Abort cap are unchanged.
+can use `..RequestAdmissionPolicy::default()` to inherit defaults, subject to the
+tiny-global migration above. Total global defaults and the private Abort cap are unchanged.
 
 Python appends keyword-only `max_confirmed_in_flight=64` and
 `max_unconfirmed_in_flight=32`, followed by
 `max_confirmed_in_flight_per_peer=16` and `max_unconfirmed_in_flight_per_peer=8`,
-to `BACnetServer(...)`, preserving old positional arguments. Zero or a representable
+then `confirmed_recovery_reserve=4` and `max_recovery_in_flight_per_peer=1`,
+to `BACnetServer(...)`, preserving old positional arguments. Invalid reserve/global
+relationships, zero positive-only limits, or a representable
 value above the semaphore bound raises `ValueError`; negative or integer values
 outside the native unsigned range raise `OverflowError`. Validation occurs in
 the constructor, before any transport startup, including synchronous MS/TP
-serial opening. There is no zero-as-disable or unlimited mode.
+serial opening. Only the reserve accepts zero, disabling protection rather than
+disabling admission or granting unlimited capacity.
+
+## Recovery eligibility and strict partitioning
+
+Only requests accepted by the existing DCC decoder with mode ENABLE are eligible.
+Other DCC modes, ReinitializeDevice, and malformed requests remain ordinary.
+Classification is **not authorization**: existing handler password checks remain
+authoritative. Decode-valid ENABLE with a wrong or missing required password can
+briefly occupy a protected slot and return PASSWORD_FAILURE. Capacity exhaustion
+still produces the existing Abort before handler execution or password validation.
+No authentication or default-deny behavior changes.
+
+Neither partition lends capacity: ordinary requests cannot use free protected
+slots; protected requests cannot fall back to free ordinary slots when `R > 0`.
+Total confirmed active handlers never exceed G. Both partitions share the existing
+total confirmed peer cap, so a peer with 16 ordinary handlers can still be denied
+ENABLE despite free protected capacity. Recovery availability is not promised for
+a peer already at its own total cap.
+
+The server-private classifier first traverses borrowed tag contents and bounds
+optional password content before invoking the existing decoder. A decoded password
+has at most 20 UTF-8 bytes; accepted UTF-8/Latin-1 payloads require at most 20 wire
+bytes and UCS-2 at most 40. The preflight therefore introduces no attacker-sized
+password allocation and excludes no accepted password encoding. Duration handling,
+alternate charset validation, and the decoder's existing trailing-data tolerance
+are retained. There is no arbitrary total-request cutoff, password comparison,
+password logging, or mutating handler call in classification.
 
 ## Admission and overload
 
@@ -46,11 +84,13 @@ global pool. COV, reassembly, and endpoint-core identity contracts are not chang
   rejected work or capacity-waiting tasks is created. A slot lasts through the
   actual handler future, including awaited post-response work; completion,
   panic, and cancellation release it, even if its completed task is not reaped.
-  The sealed-owner check precedes global acquisition, which precedes peer
-  registration. If both capacities are exhausted, the rejection is global.
+  The sealed-owner check precedes partition acquisition, then the inclusive total
+  peer check, then the additional protected peer check. If partition and peer
+  capacities are both exhausted, the rejection is classified global/partition.
   Peer rejection releases the temporary global permit without counting admission.
-  Separate class maps contain only active peer counts, bounded by their global
-  quotas. Last-guard drop removes the peer entry before releasing its global
+  Shared confirmed (ordinary plus protected), additional protected, and separate
+  unconfirmed maps contain only active peer counts, bounded by their quotas.
+  Last-guard drop removes all its peer registrations before releasing its partition
   permit, including never-polled cancellation. There are no historical peer
   entries, timestamps, eviction rules, or exposed identity maps.
 - Detectable exact pending/completed confirmed duplicates are discarded before
@@ -95,8 +135,9 @@ stable fields, described by the shipped `RequestAdmissionCounters` TypedDict:
 | `confirmed_active`, `unconfirmed_active` | Registered handler futures not yet finished/dropped |
 | `confirmed_admitted_total`, `unconfirmed_admitted_total` | Cumulative handler registrations |
 | `confirmed_overloaded_total`, `unconfirmed_overloaded_total` | Capacity-rejected requests; unconfirmed requests are dropped |
-| `confirmed_global_overloaded_total`, `unconfirmed_global_overloaded_total` | Global capacity rejections, tested first |
-| `confirmed_peer_overloaded_total`, `unconfirmed_peer_overloaded_total` | Peer capacity rejections while global capacity was available |
+| `confirmed_global_overloaded_total`, `unconfirmed_global_overloaded_total` | Confirmed partition capacity or unconfirmed global capacity rejections, tested first |
+| `confirmed_peer_overloaded_total`, `unconfirmed_peer_overloaded_total` | Total/protected peer capacity rejections while partition/global capacity was available |
+| `recovery_active`, `recovery_admitted_total`, `recovery_overloaded_total` | Protected subset of the corresponding confirmed aggregates; all zero when reserve is zero |
 | `confirmed_shutdown_rejected_total`, `unconfirmed_shutdown_rejected_total` | Registrations denied by the sealed task owner |
 | `abort_active` | Live overload Abort workers, at most eight |
 | `abort_admitted_total` | Cumulative Abort registrations, **not send completions** |
@@ -105,7 +146,8 @@ stable fields, described by the shipped `RequestAdmissionCounters` TypedDict:
 
 Fields are sampled independently from bounded atomic counters; the aggregate is
 not a transactionally consistent snapshot. Totals cover one server lifetime,
-and at quiescence each class's overload total equals its global plus peer reason
+and all existing confirmed aggregates include ordinary and protected handlers.
+At quiescence each class's overload total equals its global plus peer reason
 totals (not necessarily while concurrently sampling them).
 No request history is stored by these counters. Rust counters remain readable after successful
 stop, with active counts zero. Python follows its existing `comm_state()` and
@@ -115,11 +157,10 @@ all counters are zero. No new restart semantics are promised.
 
 ## Remaining limits
 
-Peer quotas partition identities, but do not provide scheduling fairness,
-critical-service reservations, or guaranteed availability once the global pool
-is full. A busy
-confirmed class can reject DeviceCommunicationControl or ReinitializeDevice;
-neither has a reserved slot. This bounds top-level handler concurrency, not
+Peer quotas partition identities, but do not provide scheduling fairness or
+guaranteed availability once the relevant partition or peer cap is full. Only
+DCC ENABLE has a reserve; all other critical-service reservations, including
+ReinitializeDevice and other DCC modes, remain deferred. This bounds top-level handler concurrency, not
 every allocation, incoming byte, service effect, notification, transport task,
 or response budget. Work/response budgets remain deferred. Issue #521 remains
 partial; #522 is unchanged. No throughput, fairness, hardware timing, or full


### PR DESCRIPTION
## Owner-approved contract
- Protect only existing-decoder-accepted DCC ENABLE requests. Classification is not authorization: handler password validation remains authoritative; malformed DCC, other modes and ReinitializeDevice remain ordinary.
- Default confirmed_recovery_reserve=4 strictly partitions existing total64 into ordinary60/protected4, with no lending in either direction. Reserve0 disables protection and makes ENABLE ordinary.
- Additional max_recovery_in_flight_per_peer=1 applies alongside the existing inclusive total confirmed-peer cap16. A peer already at its total cap is not guaranteed recovery capacity.
- Require 0 <= reserve < confirmed global; custom globals <=4 must explicitly choose reserve0 or a smaller valid reserve. Rust struct expansion and additive Python settings/counters are documented.
- Preserve existing duplicates, DCC state/timers/password precedence, inline control handling, unconfirmed limits, and separate8-worker Abort/fallback path.

Refs #521 (partial; do not close). #522 unchanged: no authorization delivery.

## Implementation
Shared confirmed-peer accounting covers ordinary and protected work; guards remove registrations before releasing capacity. Existing confirmed counters remain inclusive, with recovery_active/admitted_total/overloaded_total subset counters. Partition capacity is classified before peer capacity.

A borrowed password-length preflight bounds allocation before calling the existing DCC decoder. Classifier equivalence tests cover duration, charsets, truncation, and existing trailing tolerance without logging/comparing passwords or changing the decoder.

## Validation
- Ordinary request61 baseline RED->GREEN establishes the new strict60-slot ordinary partition.
- Recovery20, admission42, duplicate8, request-task56, DCC28, segmentation69, server942+3, integration38, SC pre-dial3 passed.
- cargo test --workspace --exclude rusty-bacnet --locked: 4,266 passed, 0 failed, 3 ignored. Fmt/Clippy (warnings)/file-size/no-secret/whitespace passed; root reran staged checks including new files.
- Fresh locked Python3.12.13 macOS-arm64 wheel built after final production/binding changes; binding check/clippy passed, installed stubs match. Full Python36 tests/261subtests passed, no skips; root independently repeated it. Recovery module10repeats passed.
- Wheel SHA256 b97bfbe26f9e9708ba04dbfea3787c991f0c5f1da3347fa3ee641371f73c9e39. Only Python fixture edits followed wheel construction.
- Exact-head five lean CI checks and independent reviews pending. Other OS/interpreters/hardware/heavy-release qualification excluded.

## Limitations
Defaults are unbenchmarked policy. Wrong-password ENABLE can consume protected capacity before rejection; logical identities/SC VMACs are not authenticated principals. Recovery is not guaranteed at peer or protected saturation. Other critical services, fairness, authentication, and work/response budgets remain deferred. Existing counted extreme-overload Abort-drop limitation remains; no full-conformance claim. No dependency/CI changes or licensed excerpts. Native exact source used while optional Codebase Memory was unavailable.