### PR TITLE
fix(server): bound RPM work and service ACK bytes

### DIFF
--- a/crates/bacnet-integration-tests/tests/server/basic.rs
+++ b/crates/bacnet-integration-tests/tests/server/basic.rs
@@ -1,6 +1,37 @@
 use super::*;
 
 #[tokio::test]
+async fn rpm_default_work_budget_aborts_whole_service() {
+    use bacnet_services::common::PropertyReference;
+    use bacnet_services::rpm::ReadAccessSpecification;
+    use bacnet_types::{enums::AbortReason, error::Error};
+
+    let mut server = make_server().await;
+    let mut client = make_client().await;
+    let result = client
+        .read_property_multiple(
+            server.local_mac(),
+            vec![ReadAccessSpecification {
+                object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+                list_of_property_references: vec![
+                    PropertyReference {
+                        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+                        property_array_index: None,
+                    };
+                    257
+                ],
+            }],
+        )
+        .await;
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+    assert!(
+        matches!(result, Err(Error::Abort { reason }) if reason == AbortReason::OUT_OF_RESOURCES.to_raw()),
+        "{result:?}"
+    );
+}
+
+#[tokio::test]
 async fn read_property_from_server() {
     let mut server = make_server().await;
     let mut client = make_client().await;

--- a/crates/bacnet-server/src/handlers/mod.rs
+++ b/crates/bacnet-server/src/handlers/mod.rs
@@ -46,6 +46,8 @@ mod list;
 mod object_mgmt;
 mod read_property;
 mod read_range;
+mod rpm_budget;
+pub(crate) use rpm_budget::{handle_rpm_budgeted, RpmFailure};
 mod write_property;
 
 pub use alarm_event::*;

--- a/crates/bacnet-server/src/handlers/read_property.rs
+++ b/crates/bacnet-server/src/handlers/read_property.rs
@@ -49,7 +49,10 @@ pub fn handle_read_property(
 }
 
 /// Resolve Device wildcard instance 4194303 to the actual Device object.
-fn resolve_device_wildcard(db: &ObjectDatabase, oid: &ObjectIdentifier) -> ObjectIdentifier {
+pub(super) fn resolve_device_wildcard(
+    db: &ObjectDatabase,
+    oid: &ObjectIdentifier,
+) -> ObjectIdentifier {
     if oid.object_type() == ObjectType::DEVICE && oid.instance_number() == 4194303 {
         for candidate in db.list_objects() {
             if candidate.object_type() == ObjectType::DEVICE {
@@ -115,6 +118,8 @@ fn expand_property_reference(
 /// Handle a ReadPropertyMultiple request.
 ///
 /// Per-property errors are returned inline rather than failing the entire request.
+/// This legacy low-level helper has no configured service budget. Configured
+/// `BACnetServer` dispatch uses a separate bounded implementation.
 pub fn handle_read_property_multiple(
     db: &ObjectDatabase,
     service_data: &[u8],

--- a/crates/bacnet-server/src/handlers/rpm_budget.rs
+++ b/crates/bacnet-server/src/handlers/rpm_budget.rs
@@ -1,0 +1,205 @@
+//! Bounded server-owned RPM planning and service-ACK accumulation.
+use super::*;
+use crate::server::ReadPropertyMultipleBudget;
+use bacnet_objects::{property_metadata::PropertyConformance, traits::BACnetObject};
+use bacnet_services::common::PropertyReference;
+
+#[derive(Debug)]
+pub(crate) enum RpmFailure {
+    Service(Error),
+    Work,
+    Bytes,
+}
+
+struct PlannedObject {
+    response_oid: ObjectIdentifier,
+    lookup_oid: ObjectIdentifier,
+    properties: Vec<PropertyReference>,
+}
+
+// Visit expansion rows without collecting a second, unbounded expansion vector.
+// Opaque metadata/property-list allocation is outside this service budget.
+fn expand(
+    object: &dyn BACnetObject,
+    reference: &PropertyReference,
+    mut visit: impl FnMut(PropertyIdentifier) -> Result<(), RpmFailure>,
+) -> Result<(), RpmFailure> {
+    let id = reference.property_identifier;
+    if !matches!(
+        id,
+        PropertyIdentifier::ALL | PropertyIdentifier::REQUIRED | PropertyIdentifier::OPTIONAL
+    ) {
+        return visit(id);
+    }
+    let metadata = object.property_metadata();
+    if !metadata.is_empty() {
+        for row in metadata.iter() {
+            let selected = match id {
+                PropertyIdentifier::ALL => {
+                    row.property_identifier != PropertyIdentifier::PROPERTY_LIST
+                }
+                PropertyIdentifier::REQUIRED => {
+                    row.property_identifier != PropertyIdentifier::PROPERTY_LIST
+                        && row.conformance.is_required()
+                }
+                _ => row.conformance == PropertyConformance::Optional,
+            };
+            if selected {
+                visit(row.property_identifier)?;
+            }
+        }
+    } else {
+        match id {
+            PropertyIdentifier::ALL => {
+                for &property in object.property_list().iter() {
+                    visit(property)?;
+                }
+            }
+            PropertyIdentifier::REQUIRED => {
+                for &property in object.required_properties().iter() {
+                    visit(property)?;
+                }
+            }
+            _ => {
+                let required = object.required_properties();
+                for &property in object.property_list().iter() {
+                    if !required.contains(&property) {
+                        visit(property)?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn plan(
+    db: &ObjectDatabase,
+    request: &ReadPropertyMultipleRequest,
+    limit: usize,
+) -> Result<Vec<PlannedObject>, RpmFailure> {
+    let mut plan = Vec::new();
+    let mut count = 0usize;
+    for spec in &request.list_of_read_access_specs {
+        let lookup_oid = read_property::resolve_device_wildcard(db, &spec.object_identifier);
+        let mut properties = Vec::new();
+        for reference in &spec.list_of_property_references {
+            let mut push = |id| {
+                count = count
+                    .checked_add(1)
+                    .filter(|&n| n <= limit)
+                    .ok_or(RpmFailure::Work)?;
+                properties.push(PropertyReference {
+                    property_identifier: id,
+                    property_array_index: if id == reference.property_identifier {
+                        reference.property_array_index
+                    } else {
+                        None
+                    },
+                });
+                Ok(())
+            };
+            match db.get(&lookup_oid) {
+                Some(object) => expand(object, reference, push)?,
+                None => push(reference.property_identifier)?,
+            }
+        }
+        // Empty object wrappers are retained; their count is bounded by the
+        // existing decoded request, not by the expanded-result policy.
+        plan.push(PlannedObject {
+            response_oid: spec.object_identifier,
+            lookup_oid,
+            properties,
+        });
+    }
+    Ok(plan)
+}
+
+fn element(object: Option<&dyn BACnetObject>, reference: &PropertyReference) -> ReadResultElement {
+    let id = reference.property_identifier;
+    let index = reference.property_array_index;
+    let result = match object {
+        None => Err((ErrorClass::OBJECT, ErrorCode::UNKNOWN_OBJECT)),
+        Some(object) if index.is_some() && !object.is_array_property(id) => {
+            Err((ErrorClass::PROPERTY, ErrorCode::PROPERTY_IS_NOT_AN_ARRAY))
+        }
+        Some(object) => match object.read_property(id, index) {
+            Ok(value) => {
+                // One property may return/encode an arbitrarily large owned
+                // value. Only accumulated service bytes are bounded here.
+                let mut encoded = BytesMut::new();
+                encode_property_value(&mut encoded, &value)
+                    .map(|()| encoded.to_vec())
+                    .map_err(|_| (ErrorClass::PROPERTY, ErrorCode::OTHER))
+            }
+            Err(Error::Protocol { class, code }) => Err((
+                ErrorClass::from_raw(class as u16),
+                ErrorCode::from_raw(code as u16),
+            )),
+            Err(_) => Err((ErrorClass::PROPERTY, ErrorCode::UNKNOWN_PROPERTY)),
+        },
+    };
+    let (property_value, error) = match result {
+        Ok(value) => (Some(value), None),
+        Err(error) => (None, Some(error)),
+    };
+    ReadResultElement {
+        property_identifier: id,
+        property_array_index: index,
+        property_value,
+        error,
+    }
+}
+
+struct Scratch {
+    bytes: BytesMut,
+    limit: usize,
+}
+
+impl Scratch {
+    fn append(&mut self, bytes: &[u8], reserved: usize) -> Result<(), RpmFailure> {
+        self.bytes
+            .len()
+            .checked_add(bytes.len())
+            .and_then(|n| n.checked_add(reserved))
+            .filter(|&n| n <= self.limit)
+            .ok_or(RpmFailure::Bytes)?;
+        self.bytes.extend_from_slice(bytes);
+        Ok(())
+    }
+}
+
+/// Atomic with respect to the caller's buffer, not object read side effects.
+pub(crate) fn handle_rpm_budgeted(
+    db: &ObjectDatabase,
+    data: &[u8],
+    buf: &mut BytesMut,
+    budget: ReadPropertyMultipleBudget,
+) -> Result<(), RpmFailure> {
+    let request = ReadPropertyMultipleRequest::decode(data).map_err(RpmFailure::Service)?;
+    let plan = plan(db, &request, budget.max_result_elements)?;
+    let mut scratch = Scratch {
+        bytes: BytesMut::new(),
+        limit: budget.max_service_ack_bytes,
+    };
+    let mut footer = BytesMut::new();
+    ReadAccessResult::encode_footer(&mut footer);
+    for spec in plan {
+        let mut header = BytesMut::new();
+        ReadAccessResult::encode_header(&mut header, &spec.response_oid);
+        scratch.append(&header, footer.len())?;
+        for reference in spec.properties {
+            let result = element(db.get(&spec.lookup_oid), &reference);
+            let mut encoded = BytesMut::new();
+            result.encode(&mut encoded);
+            scratch.append(&encoded, footer.len())?;
+        }
+        scratch.append(&footer, 0)?;
+    }
+    buf.extend_from_slice(&scratch.bytes);
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "tests/rpm_budget.rs"]
+mod tests;

--- a/crates/bacnet-server/src/handlers/rpm_budget.rs
+++ b/crates/bacnet-server/src/handlers/rpm_budget.rs
@@ -61,7 +61,10 @@ fn expand(
                 }
             }
             _ => {
-                let required = object.required_properties();
+                // Preserve legacy expected-linear selection even when every
+                // row is required and the result budget never cuts the scan.
+                let required: HashSet<PropertyIdentifier> =
+                    object.required_properties().iter().copied().collect();
                 for &property in object.property_list().iter() {
                     if !required.contains(&property) {
                         visit(property)?;

--- a/crates/bacnet-server/src/handlers/tests/rpm_budget.rs
+++ b/crates/bacnet-server/src/handlers/tests/rpm_budget.rs
@@ -1,0 +1,357 @@
+use super::*;
+use bacnet_services::rpm::ReadAccessSpecification;
+use std::borrow::Cow;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+struct Counting {
+    reads: Arc<AtomicUsize>,
+    array: bool,
+    empty: bool,
+}
+
+impl BACnetObject for Counting {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        oid(1)
+    }
+    fn object_name(&self) -> &str {
+        "counting"
+    }
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        if self.empty {
+            Cow::Borrowed(&[])
+        } else {
+            Cow::Borrowed(&[
+                PropertyIdentifier::PRESENT_VALUE,
+                PropertyIdentifier::OBJECT_NAME,
+                PropertyIdentifier::DESCRIPTION,
+            ])
+        }
+    }
+    fn required_properties(&self) -> Cow<'static, [PropertyIdentifier]> {
+        if self.empty {
+            Cow::Borrowed(&[])
+        } else {
+            Cow::Borrowed(&[
+                PropertyIdentifier::PRESENT_VALUE,
+                PropertyIdentifier::OBJECT_NAME,
+            ])
+        }
+    }
+    fn is_array_property(&self, _: PropertyIdentifier) -> bool {
+        self.array
+    }
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        if self.array {
+            return Ok(PropertyValue::List(vec![PropertyValue::Unsigned(1); 1000]));
+        }
+        if property == PropertyIdentifier::DESCRIPTION {
+            return Err(Error::Protocol { class: 2, code: 32 });
+        }
+        Ok(PropertyValue::Unsigned(1))
+    }
+    fn write_property(
+        &mut self,
+        _: PropertyIdentifier,
+        _: Option<u32>,
+        _: PropertyValue,
+        _: Option<u8>,
+    ) -> Result<(), Error> {
+        unreachable!()
+    }
+}
+
+fn oid(instance: u32) -> ObjectIdentifier {
+    ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap()
+}
+fn fixture(array: bool, empty: bool) -> (ObjectDatabase, Arc<AtomicUsize>) {
+    let reads = Arc::new(AtomicUsize::new(0));
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(Counting {
+        reads: reads.clone(),
+        array,
+        empty,
+    }))
+    .unwrap();
+    (db, reads)
+}
+fn reference(id: PropertyIdentifier) -> PropertyReference {
+    PropertyReference {
+        property_identifier: id,
+        property_array_index: None,
+    }
+}
+fn spec(instance: u32, properties: Vec<PropertyReference>) -> ReadAccessSpecification {
+    ReadAccessSpecification {
+        object_identifier: oid(instance),
+        list_of_property_references: properties,
+    }
+}
+fn request(specs: Vec<ReadAccessSpecification>) -> BytesMut {
+    let mut bytes = BytesMut::new();
+    ReadPropertyMultipleRequest {
+        list_of_read_access_specs: specs,
+    }
+    .encode(&mut bytes);
+    bytes
+}
+fn budget(work: usize, bytes: usize) -> ReadPropertyMultipleBudget {
+    ReadPropertyMultipleBudget {
+        max_result_elements: work,
+        max_service_ack_bytes: bytes,
+    }
+}
+
+#[test]
+fn rpm_work_aggregate_boundaries_preflight_no_reads() {
+    for count in [3, 4, 5] {
+        let (db, reads) = fixture(false, false);
+        let data = request(vec![
+            spec(1, vec![reference(PropertyIdentifier::PRESENT_VALUE); 2]),
+            spec(
+                1,
+                vec![reference(PropertyIdentifier::PRESENT_VALUE); count - 2],
+            ),
+        ]);
+        let mut out = BytesMut::from(&b"prefix"[..]);
+        let result = handle_rpm_budgeted(&db, &data, &mut out, budget(4, 1024));
+        if count > 4 {
+            assert!(matches!(result, Err(RpmFailure::Work)));
+            assert_eq!(reads.load(Ordering::SeqCst), 0);
+            assert_eq!(&out[..], b"prefix");
+        } else {
+            result.unwrap();
+            assert_eq!(reads.load(Ordering::SeqCst), count);
+        }
+    }
+}
+
+#[test]
+fn rpm_wildcards_duplicates_unknown_and_index_count_results() {
+    let (db, reads) = fixture(false, false);
+    for (property, count) in [
+        (PropertyIdentifier::ALL, 3),
+        (PropertyIdentifier::REQUIRED, 2),
+        (PropertyIdentifier::OPTIONAL, 1),
+    ] {
+        let data = request(vec![
+            spec(1, vec![reference(property); 2]),
+            spec(99, vec![reference(PropertyIdentifier::ALL)]),
+        ]);
+        let decoded = ReadPropertyMultipleRequest::decode(&data).unwrap();
+        assert!(matches!(
+            plan(&db, &decoded, count * 2),
+            Err(RpmFailure::Work)
+        ));
+        assert!(matches!(
+            handle_rpm_budgeted(&db, &data, &mut BytesMut::new(), budget(count * 2, 1024)),
+            Err(RpmFailure::Work)
+        ));
+        assert_eq!(reads.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            plan(&db, &decoded, count * 2 + 1)
+                .unwrap()
+                .iter()
+                .map(|p| p.properties.len())
+                .sum::<usize>(),
+            count * 2 + 1
+        );
+    }
+    let data = request(vec![spec(
+        1,
+        vec![
+            PropertyReference {
+                property_identifier: PropertyIdentifier::PRESENT_VALUE,
+                property_array_index: Some(1)
+            };
+            2
+        ],
+    )]);
+    assert!(matches!(
+        handle_rpm_budgeted(&db, &data, &mut BytesMut::new(), budget(1, 1024)),
+        Err(RpmFailure::Work)
+    ));
+    handle_rpm_budgeted(&db, &data, &mut BytesMut::new(), budget(2, 1024)).unwrap();
+    assert_eq!(reads.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn rpm_bytes_exact_wrappers_errors_index_atomic_and_legacy_parity() {
+    let (db, _) = fixture(false, false);
+    let data = request(vec![
+        spec(
+            1,
+            vec![
+                reference(PropertyIdentifier::ALL),
+                PropertyReference {
+                    property_identifier: PropertyIdentifier::PRESENT_VALUE,
+                    property_array_index: Some(0),
+                },
+            ],
+        ),
+        spec(99, vec![reference(PropertyIdentifier::ALL)]),
+    ]);
+    let mut legacy = BytesMut::new();
+    handle_read_property_multiple(&db, &data, &mut legacy).unwrap();
+    for cap in [legacy.len() - 1, legacy.len(), legacy.len() + 1] {
+        let mut out = BytesMut::from(&b"prefix"[..]);
+        let result = handle_rpm_budgeted(&db, &data, &mut out, budget(5, cap));
+        if cap < legacy.len() {
+            assert!(matches!(result, Err(RpmFailure::Bytes)));
+            assert_eq!(&out[..], b"prefix");
+        } else {
+            result.unwrap();
+            assert_eq!(&out[6..], &legacy[..]);
+        }
+    }
+}
+
+#[test]
+fn rpm_byte_overflow_stops_reads_and_whole_array_is_not_preempted() {
+    for array in [false, true] {
+        let (db, reads) = fixture(array, false);
+        let data = request(vec![spec(
+            1,
+            vec![reference(PropertyIdentifier::PRESENT_VALUE); 3],
+        )]);
+        // Header + footer fit (7 bytes), but the first value does not.
+        assert!(matches!(
+            handle_rpm_budgeted(&db, &data, &mut BytesMut::new(), budget(3, 7)),
+            Err(RpmFailure::Bytes)
+        ));
+        assert_eq!(reads.load(Ordering::SeqCst), 1);
+        reads.store(0, Ordering::SeqCst);
+        // A scalar result fits, then the next one fails: earlier reads persist
+        // but the third property is never read. A whole array still fails first.
+        assert!(matches!(
+            handle_rpm_budgeted(&db, &data, &mut BytesMut::new(), budget(3, 13)),
+            Err(RpmFailure::Bytes)
+        ));
+        assert_eq!(reads.load(Ordering::SeqCst), if array { 1 } else { 2 });
+    }
+}
+
+#[test]
+fn rpm_empty_expansions_still_charge_object_wrappers() {
+    let (db, reads) = fixture(false, true);
+    let data = request(vec![spec(1, vec![reference(PropertyIdentifier::ALL)])]);
+    for cap in [6, 7, 8] {
+        let mut out = BytesMut::new();
+        let result = handle_rpm_budgeted(&db, &data, &mut out, budget(1, cap));
+        if cap == 6 {
+            assert!(matches!(result, Err(RpmFailure::Bytes)));
+        } else {
+            result.unwrap();
+            // Independently worked context-0 AI:1, open-1, close-1.
+            assert_eq!(&out[..], &[0x0c, 0, 0, 0, 1, 0x1e, 0x1f]);
+        }
+    }
+    assert_eq!(reads.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn rpm_scratch_growth_never_exceeds_cap_even_on_overflow() {
+    let mut scratch = Scratch {
+        bytes: BytesMut::new(),
+        limit: 4,
+    };
+    scratch.append(&[1, 2], 2).unwrap();
+    assert_eq!(scratch.bytes.len(), 2);
+    assert!(matches!(
+        scratch.append(&[3, 4, 5], 0),
+        Err(RpmFailure::Bytes)
+    ));
+    assert_eq!(scratch.bytes.len(), 2);
+    assert!(matches!(
+        scratch.append(&[], usize::MAX),
+        Err(RpmFailure::Bytes)
+    ));
+    scratch.append(&[3, 4], 0).unwrap();
+    assert_eq!(scratch.bytes.len(), 4);
+}
+
+#[test]
+fn rpm_decode_failure_keeps_priority_and_caller_prefix() {
+    let (db, reads) = fixture(false, false);
+    let mut out = BytesMut::from(&b"prefix"[..]);
+    assert!(matches!(
+        handle_rpm_budgeted(&db, &[0xff], &mut out, budget(1, 1)),
+        Err(RpmFailure::Service(_))
+    ));
+    assert_eq!(&out[..], b"prefix");
+    assert_eq!(reads.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn rpm_success_independent_scalar_golden() {
+    let (db, _) = fixture(false, false);
+    let data = request(vec![spec(
+        1,
+        vec![reference(PropertyIdentifier::PRESENT_VALUE)],
+    )]);
+    let mut out = BytesMut::new();
+    handle_rpm_budgeted(&db, &data, &mut out, budget(1, 13)).unwrap();
+    // context object AI:1, open results, property 85, open value,
+    // application unsigned 1, close value/results (independent vector).
+    assert_eq!(
+        &out[..],
+        &[0x0c, 0, 0, 0, 1, 0x1e, 0x29, 0x55, 0x4e, 0x21, 1, 0x4f, 0x1f]
+    );
+}
+
+#[test]
+fn rpm_migrated_metadata_device_wildcard_and_index_legacy_parity() {
+    use bacnet_objects::device::{DeviceConfig, DeviceObject};
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(
+        DeviceObject::new(DeviceConfig {
+            instance: 123,
+            ..Default::default()
+        })
+        .unwrap(),
+    ))
+    .unwrap();
+    let wildcard = ObjectIdentifier::new(ObjectType::DEVICE, 4194303).unwrap();
+    for property in [
+        PropertyIdentifier::ALL,
+        PropertyIdentifier::REQUIRED,
+        PropertyIdentifier::OPTIONAL,
+    ] {
+        let data = request(vec![ReadAccessSpecification {
+            object_identifier: wildcard,
+            list_of_property_references: vec![
+                reference(property),
+                reference(property),
+                PropertyReference {
+                    property_identifier: PropertyIdentifier::OBJECT_LIST,
+                    property_array_index: Some(0),
+                },
+            ],
+        }]);
+        let mut legacy = BytesMut::new();
+        handle_read_property_multiple(&db, &data, &mut legacy).unwrap();
+        let ack = ReadPropertyMultipleACK::decode(&legacy).unwrap();
+        let count = ack.list_of_read_access_results[0].list_of_results.len();
+        assert_eq!(
+            ack.list_of_read_access_results[0].object_identifier,
+            wildcard
+        );
+        for work in [count - 1, count, count + 1] {
+            let mut out = BytesMut::new();
+            let result = handle_rpm_budgeted(&db, &data, &mut out, budget(work, legacy.len()));
+            if work < count {
+                assert!(matches!(result, Err(RpmFailure::Work)));
+            } else {
+                result.unwrap();
+                assert_eq!(out, legacy);
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/handlers/tests/rpm_budget.rs
+++ b/crates/bacnet-server/src/handlers/tests/rpm_budget.rs
@@ -1,4 +1,7 @@
 use super::*;
+
+#[path = "rpm_optional_fallback.rs"]
+mod optional_fallback;
 use bacnet_services::rpm::ReadAccessSpecification;
 use std::borrow::Cow;
 use std::sync::{

--- a/crates/bacnet-server/src/handlers/tests/rpm_optional_fallback.rs
+++ b/crates/bacnet-server/src/handlers/tests/rpm_optional_fallback.rs
@@ -1,0 +1,154 @@
+//! ROOT-1 semantic characterization; no wall-clock performance assertions.
+use super::*;
+
+const REQUIRED_COUNT: usize = 4096;
+const OPTIONAL_IDS: [PropertyIdentifier; 4] = [
+    PropertyIdentifier::from_raw(6001),
+    PropertyIdentifier::from_raw(6000),
+    PropertyIdentifier::from_raw(6001),
+    PropertyIdentifier::from_raw(6002),
+];
+
+const fn properties() -> [PropertyIdentifier; REQUIRED_COUNT + 4] {
+    let mut result = [PropertyIdentifier::PRESENT_VALUE; REQUIRED_COUNT + 4];
+    let mut i = 0;
+    while i < REQUIRED_COUNT {
+        result[i] = PropertyIdentifier::from_raw(512 + i as u32);
+        i += 1;
+    }
+    let mut j = 0;
+    while j < OPTIONAL_IDS.len() {
+        result[i + j] = OPTIONAL_IDS[j];
+        j += 1;
+    }
+    result
+}
+
+static PROPERTIES: [PropertyIdentifier; REQUIRED_COUNT + 4] = properties();
+
+struct BorrowedLegacy {
+    all_required: bool,
+    reads: Arc<AtomicUsize>,
+}
+
+impl BACnetObject for BorrowedLegacy {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        oid(1)
+    }
+    fn object_name(&self) -> &str {
+        "large borrowed legacy metadata"
+    }
+    // Deliberately inherit the empty property_metadata default.
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(if self.all_required {
+            &PROPERTIES[..REQUIRED_COUNT]
+        } else {
+            &PROPERTIES
+        })
+    }
+    fn required_properties(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&PROPERTIES[..REQUIRED_COUNT])
+    }
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        _: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        Ok(PropertyValue::Unsigned(u64::from(property.to_raw())))
+    }
+    fn write_property(
+        &mut self,
+        _: PropertyIdentifier,
+        _: Option<u32>,
+        _: PropertyValue,
+        _: Option<u8>,
+    ) -> Result<(), Error> {
+        unreachable!()
+    }
+}
+
+fn legacy_fixture(all_required: bool) -> (ObjectDatabase, Arc<AtomicUsize>) {
+    let reads = Arc::new(AtomicUsize::new(0));
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(BorrowedLegacy {
+        all_required,
+        reads: reads.clone(),
+    }))
+    .unwrap();
+    (db, reads)
+}
+
+#[test]
+fn rpm_optional_large_borrowed_all_required_preserves_empty_wrappers() {
+    let (db, reads) = legacy_fixture(true);
+    let data = request(vec![
+        spec(1, vec![reference(PropertyIdentifier::OPTIONAL)]),
+        spec(1, vec![reference(PropertyIdentifier::OPTIONAL)]),
+    ]);
+    for bytes in [13, 14, 15] {
+        let mut out = BytesMut::from(&b"prefix"[..]);
+        let result = handle_rpm_budgeted(&db, &data, &mut out, budget(1, bytes));
+        if bytes == 13 {
+            assert!(matches!(result, Err(RpmFailure::Bytes)));
+            assert_eq!(&out[..], b"prefix");
+        } else {
+            result.unwrap();
+            let empty = [0x0c, 0, 0, 0, 1, 0x1e, 0x1f];
+            assert_eq!(&out[6..], empty.repeat(2));
+        }
+    }
+    assert_eq!(reads.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn rpm_optional_large_borrowed_mostly_required_order_duplicates_and_late_cap() {
+    let (db, reads) = legacy_fixture(false);
+    let object = db.get(&oid(1)).unwrap();
+    assert!(object.property_metadata().is_empty());
+    assert!(matches!(object.property_list(), Cow::Borrowed(_)));
+    assert!(matches!(object.required_properties(), Cow::Borrowed(_)));
+
+    // The visitor's failure must stop before the final optional occurrence;
+    // required rows themselves never spend expanded-result capacity.
+    let mut visits = Vec::new();
+    let result = expand(object, &reference(PropertyIdentifier::OPTIONAL), |id| {
+        visits.push(id);
+        if visits.len() == 3 {
+            Err(RpmFailure::Work)
+        } else {
+            Ok(())
+        }
+    });
+    assert!(matches!(result, Err(RpmFailure::Work)));
+    assert_eq!(visits, OPTIONAL_IDS[..3]);
+
+    let data = request(vec![
+        spec(1, vec![reference(PROPERTIES[0])]),
+        spec(1, vec![reference(PropertyIdentifier::OPTIONAL)]),
+    ]);
+    let mut out = BytesMut::from(&b"prefix"[..]);
+    assert!(matches!(
+        handle_rpm_budgeted(&db, &data, &mut out, budget(4, 1024)),
+        Err(RpmFailure::Work)
+    ));
+    assert_eq!(reads.load(Ordering::SeqCst), 0);
+    assert_eq!(&out[..], b"prefix");
+
+    for limit in [5, 6] {
+        let mut out = BytesMut::new();
+        handle_rpm_budgeted(&db, &data, &mut out, budget(limit, 1024)).unwrap();
+        let ack = ReadPropertyMultipleACK::decode(&out).unwrap();
+        let results = &ack.list_of_read_access_results[1].list_of_results;
+        assert_eq!(
+            results
+                .iter()
+                .map(|r| r.property_identifier)
+                .collect::<Vec<_>>(),
+            OPTIONAL_IDS
+        );
+        let mut legacy = BytesMut::new();
+        handle_read_property_multiple(&db, &data, &mut legacy).unwrap();
+        assert_eq!(out, legacy);
+    }
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -272,6 +272,8 @@ pub struct TimeSyncData {
 /// Server configuration.
 #[derive(Clone)]
 pub struct ServerConfig {
+    /// Per-service RPM work and encoded response limits (finite by default).
+    pub read_property_multiple_budget: ReadPropertyMultipleBudget,
     /// Local interface to bind.
     pub interface: Ipv4Addr,
     /// UDP port (default 0xBAC0 = 47808).
@@ -374,6 +376,10 @@ pub struct ServerConfig {
 impl std::fmt::Debug for ServerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ServerConfig")
+            .field(
+                "read_property_multiple_budget",
+                &self.read_property_multiple_budget,
+            )
             .field("interface", &self.interface)
             .field("port", &self.port)
             .field("broadcast_address", &self.broadcast_address)
@@ -429,6 +435,7 @@ impl Default for ServerConfig {
     fn default() -> Self {
         Self {
             interface: Ipv4Addr::UNSPECIFIED,
+            read_property_multiple_budget: ReadPropertyMultipleBudget::default(),
             port: 0xBAC0,
             broadcast_address: Ipv4Addr::BROADCAST,
             max_apdu_length: 1476,
@@ -878,6 +885,8 @@ mod segmented_receive;
 mod segmented_send;
 pub(crate) use segmented_send::*;
 mod request_admission;
+mod rpm_budget;
+pub use rpm_budget::ReadPropertyMultipleBudget;
 mod request_peer;
 mod request_tasks;
 pub use request_admission::{RequestAdmissionCounters, RequestAdmissionPolicy};

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -40,7 +40,11 @@ impl RequestTasks {
     pub(super) fn for_server(
         config: &super::ServerConfig,
     ) -> Result<Arc<Self>, bacnet_types::error::Error> {
-        Self::new(config.request_admission_policy).map(Arc::new)
+        let tasks = Self::new(config.request_admission_policy)?;
+        // Retain admission validation precedence; both policies must be valid
+        // before the lifecycle starts a transport or exposes a request owner.
+        config.read_property_multiple_budget.validate()?;
+        Ok(Arc::new(tasks))
     }
 
     pub(super) fn new(policy: RequestAdmissionPolicy) -> Result<Self, bacnet_types::error::Error> {

--- a/crates/bacnet-server/src/server/request_tasks_tests.rs
+++ b/crates/bacnet-server/src/server/request_tasks_tests.rs
@@ -17,6 +17,9 @@ mod notification_worker_tests;
 #[path = "request_admission_tests.rs"]
 mod request_admission_tests;
 
+#[path = "rpm_wire_tests.rs"]
+mod rpm_wire_tests;
+
 struct SendGuard(Option<oneshot::Sender<()>>);
 
 impl Drop for SendGuard {

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -129,13 +129,25 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             }
             s if s == ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE => {
                 let db = db.read().await;
-                match handlers::handle_read_property_multiple(
+                match handlers::handle_rpm_budgeted(
                     &db,
                     &req.service_request,
                     &mut ack_buf,
+                    config.read_property_multiple_budget,
                 ) {
                     Ok(()) => complex_ack(ack_buf),
-                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
+                    Err(handlers::RpmFailure::Service(e)) => {
+                        Self::error_apdu_from_error(invoke_id, service_choice, &e)
+                    }
+                    Err(failure) => Apdu::Abort(AbortPdu {
+                        sent_by_server: true,
+                        invoke_id,
+                        abort_reason: match failure {
+                            handlers::RpmFailure::Work => AbortReason::OUT_OF_RESOURCES,
+                            handlers::RpmFailure::Bytes => AbortReason::BUFFER_OVERFLOW,
+                            handlers::RpmFailure::Service(_) => unreachable!(),
+                        },
+                    }),
                 }
             }
             s if s == ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE => {

--- a/crates/bacnet-server/src/server/rpm_budget.rs
+++ b/crates/bacnet-server/src/server/rpm_budget.rs
@@ -1,0 +1,156 @@
+//! Per-service RPM limits, independent of concurrent handler admission.
+use super::*;
+
+/// Local ReadPropertyMultiple planning and encoded service-ACK limits.
+///
+/// These do not bound request decoding, object metadata, an individual property
+/// read/value encoding, allocator capacity, or process memory. Byte refusal does
+/// not roll back reads already performed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadPropertyMultipleBudget {
+    /// Maximum aggregate expanded result occurrences (default 256).
+    pub max_result_elements: usize,
+    /// Maximum encoded service parameters, excluding APDU/NPDU (default 16384).
+    pub max_service_ack_bytes: usize,
+}
+
+impl Default for ReadPropertyMultipleBudget {
+    fn default() -> Self {
+        Self {
+            max_result_elements: 256,
+            max_service_ack_bytes: 16384,
+        }
+    }
+}
+
+impl ReadPropertyMultipleBudget {
+    /// Reject zero; no semaphore-derived or allocation-capacity upper limit.
+    pub fn validate(&self) -> Result<(), Error> {
+        for (name, value) in [
+            ("rpm_max_result_elements", self.max_result_elements),
+            ("rpm_max_service_ack_bytes", self.max_service_ack_bytes),
+        ] {
+            if value == 0 {
+                return Err(Error::Encoding(format!("{name} must be positive")));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Set positive per-service RPM limits, validated before transport startup.
+    pub fn read_property_multiple_budget(mut self, budget: ReadPropertyMultipleBudget) -> Self {
+        self.config.read_property_multiple_budget = budget;
+        self
+    }
+}
+
+impl BipServerBuilder {
+    /// Set positive per-service RPM limits, validated before transport startup.
+    pub fn read_property_multiple_budget(mut self, budget: ReadPropertyMultipleBudget) -> Self {
+        self.config.read_property_multiple_budget = budget;
+        self
+    }
+}
+
+#[cfg(feature = "sc-tls")]
+impl ScServerBuilder {
+    /// Set positive per-service RPM limits, validated before SC dialing.
+    pub fn read_property_multiple_budget(mut self, budget: ReadPropertyMultipleBudget) -> Self {
+        self.config.read_property_multiple_budget = budget;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct NeverStart;
+    impl TransportPort for NeverStart {
+        async fn start(
+            &mut self,
+        ) -> Result<tokio::sync::mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error>
+        {
+            panic!("invalid RPM budget reached transport startup")
+        }
+        async fn stop(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+            Ok(())
+        }
+        fn local_mac(&self) -> &[u8] {
+            &[1]
+        }
+    }
+
+    #[tokio::test]
+    async fn rpm_defaults_builders_and_validation_before_start() {
+        let defaults = ReadPropertyMultipleBudget::default();
+        assert_eq!(
+            (defaults.max_result_elements, defaults.max_service_ack_bytes),
+            (256, 16384)
+        );
+        assert_eq!(
+            ServerConfig::default().read_property_multiple_budget,
+            defaults
+        );
+        assert!(format!("{:?}", ServerConfig::default()).contains("read_property_multiple_budget"));
+        ReadPropertyMultipleBudget {
+            max_result_elements: usize::MAX,
+            max_service_ack_bytes: usize::MAX,
+        }
+        .validate()
+        .unwrap();
+        for budget in [
+            ReadPropertyMultipleBudget {
+                max_result_elements: 0,
+                ..defaults
+            },
+            ReadPropertyMultipleBudget {
+                max_service_ack_bytes: 0,
+                ..defaults
+            },
+        ] {
+            let direct = BACnetServer::start(
+                ServerConfig {
+                    read_property_multiple_budget: budget,
+                    ..Default::default()
+                },
+                ObjectDatabase::new(),
+                NeverStart,
+            )
+            .await;
+            let generic = BACnetServer::generic_builder()
+                .transport(NeverStart)
+                .read_property_multiple_budget(budget)
+                .build()
+                .await;
+            let bip = BACnetServer::bip_builder()
+                .port(0)
+                .read_property_multiple_budget(budget)
+                .build()
+                .await;
+            for error in [direct.err(), generic.err(), bip.err()] {
+                assert!(matches!(error, Some(Error::Encoding(m)) if m.contains("rpm_max_")));
+            }
+            let config = ServerConfig {
+                max_apdu_length: 3,
+                read_property_multiple_budget: budget,
+                ..Default::default()
+            };
+            let error = BACnetServer::start(config, ObjectDatabase::new(), NeverStart)
+                .await
+                .err()
+                .unwrap();
+            assert!(
+                !error.to_string().contains("rpm_max_"),
+                "preserve existing APDU validation priority"
+            );
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/rpm_wire_tests.rs
+++ b/crates/bacnet-server/src/server/rpm_wire_tests.rs
@@ -1,0 +1,115 @@
+use super::*;
+use bacnet_services::{
+    common::PropertyReference,
+    rpm::{ReadAccessSpecification, ReadPropertyMultipleRequest},
+};
+
+#[tokio::test]
+async fn rpm_whole_abort_direct_routed_reply_and_segmentation_matrix() {
+    for work in [false, true] {
+        for segmented_response_accepted in [false, true] {
+            for routed in [false, true] {
+                for reply in [false, true] {
+                    let budget = ReadPropertyMultipleBudget {
+                        max_result_elements: if work { 1 } else { 2 },
+                        max_service_ack_bytes: if work { 16384 } else { 7 },
+                    };
+                    let (mut server, tx, mut started) = fixture_with_config(
+                        "rpm",
+                        ServerConfig {
+                            read_property_multiple_budget: budget,
+                            segmentation_supported: Segmentation::BOTH,
+                            ..Default::default()
+                        },
+                    )
+                    .await;
+                    let source = routed.then(|| NpduAddress {
+                        network: 7,
+                        mac_address: MacAddr::from_slice(&[9]),
+                    });
+                    let mut service = BytesMut::new();
+                    ReadPropertyMultipleRequest {
+                        list_of_read_access_specs: vec![ReadAccessSpecification {
+                            object_identifier: ObjectIdentifier::new(ObjectType::DEVICE, 4194303)
+                                .unwrap(),
+                            list_of_property_references: vec![
+                                PropertyReference {
+                                    property_identifier: PropertyIdentifier::OBJECT_NAME,
+                                    property_array_index: None,
+                                };
+                                2
+                            ],
+                        }],
+                    }
+                    .encode(&mut service);
+                    let mut payload = BytesMut::new();
+                    encode_apdu(
+                        &mut payload,
+                        &Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+                            segmented: false,
+                            more_follows: false,
+                            segmented_response_accepted,
+                            max_segments: None,
+                            max_apdu_length: 50,
+                            invoke_id: 42,
+                            sequence_number: None,
+                            proposed_window_size: None,
+                            service_choice: ConfirmedServiceChoice::READ_PROPERTY_MULTIPLE,
+                            service_request: service.freeze(),
+                        }),
+                    )
+                    .unwrap();
+                    let mut npdu = BytesMut::new();
+                    encode_npdu(
+                        &mut npdu,
+                        &Npdu {
+                            source: source.clone(),
+                            payload: payload.freeze(),
+                            ..Default::default()
+                        },
+                    )
+                    .unwrap();
+                    let (reply_tx, reply_rx) = oneshot::channel();
+                    tx.send(ReceivedNpdu {
+                        npdu: npdu.freeze(),
+                        source_mac: MacAddr::from_slice(&[1]),
+                        link_layer_group: false,
+                        data_attributes: Vec::new(),
+                        reply_tx: reply.then_some(reply_tx),
+                    })
+                    .await
+                    .unwrap();
+                    let response = if reply {
+                        let bytes = tokio::time::timeout(Duration::from_secs(2), reply_rx)
+                            .await
+                            .unwrap()
+                            .unwrap();
+                        let decoded = decode_npdu(bytes).unwrap();
+                        assert_eq!(decoded.destination, source);
+                        assert!(server.network.transport().frames.lock().unwrap().is_empty());
+                        apdu::decode_apdu(decoded.payload).unwrap()
+                    } else {
+                        let _completion =
+                            tokio::time::timeout(Duration::from_secs(2), started.recv())
+                                .await
+                                .unwrap()
+                                .unwrap();
+                        let transport = server.network.transport();
+                        assert_eq!(
+                            transport.routes.lock().unwrap().as_slice(),
+                            &[(source, MacAddr::from_slice(&[1]))]
+                        );
+                        let frames = transport.frames.lock().unwrap();
+                        assert_eq!(frames.len(), 1, "no partial ComplexACK before Abort");
+                        frames[0].clone()
+                    };
+                    assert!(
+                        matches!(response, Apdu::Abort(AbortPdu { sent_by_server: true, invoke_id: 42, abort_reason }) if abort_reason == if work { AbortReason::OUT_OF_RESOURCES } else { AbortReason::BUFFER_OVERFLOW }),
+                        "{response:?}"
+                    );
+                    server.stop().await.unwrap();
+                }
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -186,6 +186,7 @@ impl ScServerBuilder {
             .ok_or_else(|| Error::Encoding("SC server builder: tls_config is required".into()))?;
 
         self.config.request_admission_policy.validate()?;
+        self.config.read_property_multiple_budget.validate()?;
 
         let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
             .await?;
@@ -226,6 +227,38 @@ impl ScServerBuilder {
 mod tests {
     use super::*;
     use bacnet_transport::sc::ScReconnectConfig;
+
+    #[tokio::test]
+    async fn rpm_sc_budget_validation_before_dial() {
+        for budget in [
+            ReadPropertyMultipleBudget {
+                max_result_elements: 0,
+                ..Default::default()
+            },
+            ReadPropertyMultipleBudget {
+                max_service_ack_bytes: 0,
+                ..Default::default()
+            },
+        ] {
+            let tls = tokio_rustls::rustls::ClientConfig::builder()
+                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+                .with_no_client_auth();
+            let builder = BACnetServer::sc_builder()
+                .hub_url("not-a-websocket-url")
+                .tls_config(Arc::new(tls))
+                .read_property_multiple_budget(budget);
+            assert_eq!(builder.config.read_property_multiple_budget, budget);
+            let error = builder.build().await.err().unwrap();
+            assert!(matches!(error, Error::Encoding(m) if m.contains("rpm_max_")));
+            let error = BACnetServer::sc_builder()
+                .read_property_multiple_budget(budget)
+                .build()
+                .await
+                .err()
+                .unwrap();
+            assert!(matches!(error, Error::Encoding(m) if m.contains("tls_config")));
+        }
+    }
 
     #[tokio::test]
     async fn sc_server_builder_rejects_invalid_reconnect_before_tls_and_bindings() {

--- a/crates/bacnet-services/src/rpm.rs
+++ b/crates/bacnet-services/src/rpm.rs
@@ -139,34 +139,47 @@ pub struct ReadPropertyMultipleACK {
     pub list_of_read_access_results: Vec<ReadAccessResult>,
 }
 
+impl ReadAccessResult {
+    /// Encode an object's identifier and opening list-of-results tag.
+    pub fn encode_header(buf: &mut BytesMut, object_identifier: &ObjectIdentifier) {
+        primitives::encode_ctx_object_id(buf, 0, object_identifier);
+        tags::encode_opening_tag(buf, 1);
+    }
+
+    /// Encode the closing list-of-results tag.
+    pub fn encode_footer(buf: &mut BytesMut) {
+        tags::encode_closing_tag(buf, 1);
+    }
+}
+
+impl ReadResultElement {
+    /// Encode one result, preserving value-over-error precedence.
+    pub fn encode(&self, buf: &mut BytesMut) {
+        primitives::encode_ctx_unsigned(buf, 2, self.property_identifier.to_raw() as u64);
+        if let Some(idx) = self.property_array_index {
+            primitives::encode_ctx_unsigned(buf, 3, idx as u64);
+        }
+        if let Some(ref value) = self.property_value {
+            tags::encode_opening_tag(buf, 4);
+            buf.extend_from_slice(value);
+            tags::encode_closing_tag(buf, 4);
+        } else if let Some((class, code)) = self.error {
+            tags::encode_opening_tag(buf, 5);
+            primitives::encode_app_enumerated(buf, class.to_raw() as u32);
+            primitives::encode_app_enumerated(buf, code.to_raw() as u32);
+            tags::encode_closing_tag(buf, 5);
+        }
+    }
+}
+
 impl ReadPropertyMultipleACK {
     pub fn encode(&self, buf: &mut BytesMut) {
         for result in &self.list_of_read_access_results {
-            // [0] object-identifier
-            primitives::encode_ctx_object_id(buf, 0, &result.object_identifier);
-            // [1] list-of-results (opening/closing)
-            tags::encode_opening_tag(buf, 1);
+            ReadAccessResult::encode_header(buf, &result.object_identifier);
             for elem in &result.list_of_results {
-                // [2] property-identifier
-                primitives::encode_ctx_unsigned(buf, 2, elem.property_identifier.to_raw() as u64);
-                // [3] property-array-index (optional)
-                if let Some(idx) = elem.property_array_index {
-                    primitives::encode_ctx_unsigned(buf, 3, idx as u64);
-                }
-                if let Some(ref value) = elem.property_value {
-                    // [4] property-value (opening/closing)
-                    tags::encode_opening_tag(buf, 4);
-                    buf.extend_from_slice(value);
-                    tags::encode_closing_tag(buf, 4);
-                } else if let Some((class, code)) = elem.error {
-                    // [5] property-access-error (opening/closing)
-                    tags::encode_opening_tag(buf, 5);
-                    primitives::encode_app_enumerated(buf, class.to_raw() as u32);
-                    primitives::encode_app_enumerated(buf, code.to_raw() as u32);
-                    tags::encode_closing_tag(buf, 5);
-                }
+                elem.encode(buf);
             }
-            tags::encode_closing_tag(buf, 1);
+            ReadAccessResult::encode_footer(buf);
         }
     }
 

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1786,6 +1786,8 @@ class BACnetServer:
         max_unconfirmed_in_flight_per_peer: int = 8,
         confirmed_recovery_reserve: int = 4,
         max_recovery_in_flight_per_peer: int = 1,
+        rpm_max_result_elements: int = 256,
+        rpm_max_service_ack_bytes: int = 16384,
     ) -> None: ...
 
     # --- Analog objects ---

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -102,6 +102,7 @@ pub struct BACnetServer {
     dcc_password: Option<String>,
     reinit_password: Option<String>,
     request_admission_policy: server::RequestAdmissionPolicy,
+    read_property_multiple_budget: server::ReadPropertyMultipleBudget,
     /// Whether the server has been started.
     started: Arc<AtomicBool>,
     /// Objects to add before starting. Cleared after start.

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -203,6 +203,7 @@ mod tests {
             dcc_password: None,
             reinit_password: None,
             request_admission_policy: server::RequestAdmissionPolicy::default(),
+            read_property_multiple_budget: server::ReadPropertyMultipleBudget::default(),
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         }

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -38,6 +38,7 @@ impl BACnetServer {
         let dcc_password = self.dcc_password.clone();
         let reinit_password = self.reinit_password.clone();
         let request_admission_policy = self.request_admission_policy;
+        let read_property_multiple_budget = self.read_property_multiple_budget;
 
         let objects: Vec<Box<dyn BACnetObject + Send>> = {
             let mut guard = self.lock_pending()?;
@@ -142,6 +143,7 @@ impl BACnetServer {
             let mut builder = server::BACnetServer::generic_builder()
                 .database(db)
                 .request_admission_policy(request_admission_policy)
+                .read_property_multiple_budget(read_property_multiple_budget)
                 .transport(transport);
             if let Some(pw) = dcc_password {
                 builder = builder.dcc_password(pw);

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -31,7 +31,9 @@ impl BACnetServer {
         max_confirmed_in_flight_per_peer=16,
         max_unconfirmed_in_flight_per_peer=8,
         confirmed_recovery_reserve=4,
-        max_recovery_in_flight_per_peer=1
+        max_recovery_in_flight_per_peer=1,
+        rpm_max_result_elements=256,
+        rpm_max_service_ack_bytes=16384
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -62,6 +64,8 @@ impl BACnetServer {
         max_unconfirmed_in_flight_per_peer: usize,
         confirmed_recovery_reserve: usize,
         max_recovery_in_flight_per_peer: usize,
+        rpm_max_result_elements: usize,
+        rpm_max_service_ack_bytes: usize,
     ) -> PyResult<Self> {
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
@@ -72,6 +76,13 @@ impl BACnetServer {
             max_recovery_in_flight_per_peer,
         };
         request_admission_policy
+            .validate()
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let read_property_multiple_budget = server::ReadPropertyMultipleBudget {
+            max_result_elements: rpm_max_result_elements,
+            max_service_ack_bytes: rpm_max_service_ack_bytes,
+        };
+        read_property_multiple_budget
             .validate()
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         Ok(Self {
@@ -98,6 +109,7 @@ impl BACnetServer {
             dcc_password,
             reinit_password,
             request_admission_policy,
+            read_property_multiple_budget,
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         })

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -64,7 +64,8 @@ MSTP_KEYWORD_ONLY = [
 SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
     "max_confirmed_in_flight", "max_unconfirmed_in_flight",
     "max_confirmed_in_flight_per_peer", "max_unconfirmed_in_flight_per_peer",
-    "confirmed_recovery_reserve", "max_recovery_in_flight_per_peer"
+    "confirmed_recovery_reserve", "max_recovery_in_flight_per_peer",
+    "rpm_max_result_elements", "rpm_max_service_ack_bytes",
 ]
 SUPPORTED_BAUD_RATES = (9_600, 19_200, 38_400, 57_600, 76_800, 115_200)
 SUPPORTED_BAUD_ERROR = (

--- a/crates/rusty-bacnet/tests/test_rpm_budget.py
+++ b/crates/rusty-bacnet/tests/test_rpm_budget.py
@@ -1,0 +1,75 @@
+"""Installed-extension RPM budgets, with independently encoded UDP requests."""
+import asyncio
+import inspect
+import socket
+import struct
+import unittest
+from pathlib import Path
+from typing import Any
+
+import rusty_bacnet
+from rusty_bacnet import BACnetServer
+
+
+class RpmConstructorTests(unittest.TestCase):
+    def test_defaults_keyword_only_stub_and_ranges(self):
+        signature = inspect.signature(BACnetServer)
+        for name, default in [("rpm_max_result_elements", 256), ("rpm_max_service_ack_bytes", 16384)]:
+            parameter = signature.parameters[name]
+            self.assertEqual(parameter.default, default)
+            self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+            stub = Path(rusty_bacnet.__file__).with_suffix(".pyi")
+            self.assertIn(f"{name}: int = {default}", stub.read_text())
+            for transport in ["bip", "ipv6", "sc", "mstp"]:
+                for value, error in [(0, ValueError), (-1, OverflowError), (1 << 200, OverflowError), (1.5, TypeError)]:
+                    with self.subTest(name=name, transport=transport, value=value):
+                        with self.assertRaises(error):
+                            invalid: dict[str, Any] = {name: value}
+                            BACnetServer(123, transport=transport, **invalid)
+                # Configuration is not used as an allocation capacity or a semaphore limit.
+                positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
+                BACnetServer(123, transport=transport, **positive)
+
+
+class RpmNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_work_bytes_and_success_with_both_client_segment_capabilities(self):
+        for policy, expected in [
+            ({"rpm_max_result_elements": 1}, 9),  # OUT_OF_RESOURCES
+            ({"rpm_max_service_ack_bytes": 7}, 1),  # BUFFER_OVERFLOW
+            ({"rpm_max_result_elements": 2, "rpm_max_service_ack_bytes": 25}, None),
+        ]:
+            server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                  broadcast_address="127.0.0.1", **policy)
+            server.add_analog_input(1, "AI", present_value=72.5)
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.bind(("127.0.0.1", 0))
+            sock.setblocking(False)
+            loop = asyncio.get_running_loop()
+            try:
+                await server.start()
+                ip, port = (await server.local_address()).rsplit(":", 1)
+                for segmented in [False, True]:
+                    invoke = 2 if segmented else 1
+                    # RPM request AI:1, two occurrences of Present_Value.
+                    service = b"\x0c\x00\x00\x00\x01\x1e\x09\x55\x09\x55\x1f"
+                    npdu = b"\x01\x00" + bytes([2 if segmented else 0, 5, invoke, 14]) + service
+                    wire = b"\x81\x0a" + (len(npdu) + 4).to_bytes(2, "big") + npdu
+                    await loop.sock_sendto(sock, wire, (ip, int(port)))
+                    reply, _ = await asyncio.wait_for(loop.sock_recvfrom(sock, 4096), 2)
+                    self.assertEqual(reply[:2], b"\x81\x0a")
+                    self.assertEqual(int.from_bytes(reply[2:4], "big"), len(reply))
+                    if expected is not None:
+                        self.assertEqual(reply[6:], bytes([0x71, invoke, expected]))
+                    else:
+                        element = b"\x29\x55\x4e\x44" + struct.pack(">f", 72.5) + b"\x4f"
+                        ack = b"\x0c\x00\x00\x00\x01\x1e" + element * 2 + b"\x1f"
+                        self.assertEqual(reply[6:], bytes([0x30, invoke, 14]) + ack)
+                    # Native completion, not a timing delay, separates invocations.
+                    async with asyncio.timeout(2):
+                        while (await server.request_admission_counters())["confirmed_active"]:
+                            await asyncio.sleep(0)
+                    with self.assertRaises(BlockingIOError):
+                        sock.recvfrom(4096)
+            finally:
+                await server.stop()
+                sock.close()

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1703,6 +1703,17 @@ ms and require `sc_heartbeat_timeout_ms` to be greater than the interval.
 
 ## Request admission limits
 
+RPM additionally has independent, positive keyword-only constructor limits:
+`rpm_max_result_elements=256` and `rpm_max_service_ack_bytes=16384`.
+Whole-request expanded-result overflow returns server Abort OUT_OF_RESOURCES
+before handler property reads. Accumulated encoded service-ACK overflow returns
+server Abort BUFFER_OVERFLOW, without a partial ACK; previous read side effects
+are not rolled back. Zero raises `ValueError`, negative/native-overflow values
+raise `OverflowError`, before any transport startup. These limits do not bound
+decoder/metadata allocations, individual property reads or value encodings,
+allocator capacity, or whole-process memory. See [RPM budgets](rpm-budget.md)
+for counting rules, Rust configuration, compatibility, and protocol rationale.
+
 `BACnetServer(...)` accepts keyword-only `max_confirmed_in_flight=64` and
 `max_unconfirmed_in_flight=32`, followed by keyword-only
 `max_confirmed_in_flight_per_peer=16`, `max_unconfirmed_in_flight_per_peer=8`,

--- a/docs/rpm-budget.md
+++ b/docs/rpm-budget.md
@@ -1,0 +1,106 @@
+# ReadPropertyMultiple service budgets
+
+Configured Rust and Python servers default to **256 expanded result elements**
+and **16,384 encoded service-ACK bytes** per ReadPropertyMultiple (RPM) request.
+These positive limits are local owner policy, not Standard-mandated values or
+benchmark-derived guarantees.
+
+## Configuration and compatibility
+
+Rust exposes `bacnet_server::server::ReadPropertyMultipleBudget` with public
+`max_result_elements` and `max_service_ack_bytes` fields. Set it through
+`ServerConfig::read_property_multiple_budget` or the
+`read_property_multiple_budget(...)` method on generic, BACnet/IP, and SC
+builders. `validate()` rejects zero; values through `usize::MAX` are accepted
+without reserving that much storage. Validation precedes transport startup and
+SC dialing, while retaining preceding route, APDU, admission, and SC-specific
+validation priorities.
+
+The added public `ServerConfig` field is a Rust source expansion: exhaustive
+struct literals need the new field; literals using `..Default::default()` do
+not. Existing large RPM consumers may need explicitly larger budgets. Success
+within the limits retains ordinary ComplexACK encoding and segmentation.
+
+Python adds keyword-only constructor arguments:
+
+```python
+server = BACnetServer(
+    123,
+    rpm_max_result_elements=256,
+    rpm_max_service_ack_bytes=16384,
+)
+```
+
+Zero raises `ValueError`; negative or native-integer-overflow values raise
+`OverflowError`. Validation occurs in the constructor, before any transport,
+including synchronous MS/TP serial open. All transport startup paths propagate
+the same policy through the common Rust builder.
+
+The existing public low-level
+`handlers::handle_read_property_multiple(db, data, buf)` remains unconfigured
+and retains its legacy behavior. It is not the configured server dispatch path.
+Manual callers of that helper do not receive these server limits.
+
+## Work admission
+
+The handler decodes the request, then plans the whole request before invoking
+property reads. Each explicit reference counts once. For known objects,
+ALL/REQUIRED/OPTIONAL count their actual expanded results, preserving order and
+duplicate occurrences. Unknown objects count each original reference once,
+including wildcard references that produce genuine UNKNOWN_OBJECT results.
+Invalid array-index results count even though no property read is called.
+Empty expansions count zero and retain their object wrappers.
+
+Checked aggregate accounting refuses before appending a result beyond the
+limit. A late overflowing specification therefore causes **no handler property
+reads**, not successful results for an earlier prefix. Empty object-plan
+wrappers remain bounded by the existing decoded request's specification count.
+The whole service returns a server Abort with **OUT_OF_RESOURCES** and the
+original invoke ID.
+
+## Encoded response accumulation
+
+Results are read and encoded one at a time, not collected into a complete
+value-bearing ACK vector. Checked pre-append accounting keeps the scratch
+service buffer's logical length within `max_service_ack_bytes`, reserving the
+current object's closing tag. All object/property tags, array indexes, encoded
+values and genuine property errors count; APDU and NPDU bytes do not.
+
+If an append cannot fit, the scratch response is discarded, no further
+properties are read, and the whole service returns a server Abort with
+**BUFFER_OVERFLOW**. No partial successful RPM ACK or fabricated per-property
+resource error is sent. Budget refusal precedes generic response segmentation
+and is independent of whether the client accepts segmented responses. The
+internal bounded helper leaves the caller's buffer prefix unchanged on failure.
+
+## Explicit exclusions
+
+This slice does **not** bound allocations/work inside the existing request
+decoder, opaque object metadata, one `read_property` call (including a returned
+whole array/list), or one value/result encoding. Scratch allocator capacity
+may exceed logical length. It is not a peak-RSS, whole-request allocation,
+CPU-time, or arbitrary-object preemption guarantee. A byte overflow can occur
+after earlier property reads; their side effects are **not rolled back**.
+
+Genuine per-property access and encoding error projection, Device-wildcard
+lookup and response identifiers, array-index semantics, request decoding,
+admission quotas, DCC checks, recovery partitions, and duplicate handling are
+unchanged. This is partial resource hardening for #521, not full issue closure;
+#522, fairness/authentication, and other service work budgets are unchanged.
+
+## Protocol rationale (ASHRAE 135-2020, paraphrased)
+
+RPM requires complete results, not a success prefix (§15.7, printed 742–743 /
+PDF 744–745). Per-property errors describe actual access failures (§15.7.3.2,
+printed 744 / PDF 746). The ACK production provides no continuation/truncation
+flag (§21, printed 864 / PDF 866; ReadAccessResult, printed 950–951 /
+PDF 952–953).
+
+Local work-admission refusal uses OUT_OF_RESOURCES; actual configured encoded
+ACK exhaustion uses BUFFER_OVERFLOW (§18.10, printed 800–801 / PDF 802–803).
+Planning itself may already constitute processing; this is a defensible local
+policy, not a claim that the Standard mandates this planning model. The local
+whole-transaction Abort and server flag/invoke/reason follow §5.4.5.3 (printed
+49 / PDF 51) and §20.1.9 (printed 838–839 / PDF 840–841). RESOURCES/OUT_OF_MEMORY
+is not substituted for a configured cap: §18.11 (printed 801 / PDF 803)
+concerns actual allocation failure.


### PR DESCRIPTION
## Owner-approved RPM-only policy
- Configured servers default to256 expanded result elements and16,384 encoded RPM service-ACK bytes per request. Positive limits are configurable through Rust ServerConfig/generic/BIP/SC builders and additive Python keyword-only settings.
- Plan all result occurrences before property reads: explicit, wildcard-expanded, duplicate and unknown-object results count. Work refusal returns whole-service server Abort OUT_OF_RESOURCES without handler property reads.
- Accumulate encoded ACK bytes incrementally, counting object/property/error/value wrappers and closing tags but excluding APDU/NPDU. Overflow discards scratch and returns whole-service BUFFER_OVERFLOW; no partial successful ACK or fabricated per-property errors.
- Preserve genuine property errors, Device wildcard/index behavior, within-budget encoding/segmentation, and the legacy unconfigured low-level handler. Typed internal failures keep budget errors distinct.

Refs #521 (partial; do not close). #522 unchanged.

## Validation
- Default257-result integration regression failed on baseline with successful ACK, then passed after the fix.
- Services RPM17; server RPM33; admission42; DCC28; segmentation70; server953+3; integration39; SC pre-dial1 passed.
- cargo test --workspace --exclude rusty-bacnet --locked: 4,279 passed, 0 failed, 3 ignored. Fmt/Clippy (warnings)/file-size/no-secret/whitespace passed; root reran staged checks including new files.
- Fresh locked Python3.12.13 macOS-arm64 wheel built after final production Rust/binding/codec changes; binding check/clippy and installed stub parity passed. Full Python38 tests/293subtests passed, no skips; root independently reran. RPM module10repeats passed.
- Wheel SHA256 f50214f4b1930b8ca53c16401f2c060f48a5dbe3156079a431ef6f0c15111892.
- Exact-head five lean CI checks and independent reviews pending. Other platform/interpreter/hardware/heavy-release qualification excluded.

## Explicit limits and compatibility
This bounds expanded-result planning and accumulated scratch logical bytes only. Existing request decoder, opaque metadata, one property read/whole-array result, and one value/result encoding can allocate outside the cap; allocator capacity/RSS/CPU time are not bounded. Byte refusal does not roll back earlier read effects. New ServerConfig field requires downstream exhaustive literals to migrate; legacy low-level handler remains unconfigured.

RPM requires complete results and has no continuation/truncation marker. Abort choices are a defensible owner-approved local resource policy, not Standard-mandated thresholds or full-conformance evidence. Source rationale in docs/rpm-budget.md uses original paraphrases/citations only. No licensed excerpts, dependency/CI changes, or unrelated service-budget changes. Native exact source governed while optional Codebase Memory was unavailable.