### PR TITLE
feat(server): bound GetAlarmSummary scan and response work

### DIFF
--- a/crates/bacnet-server/src/handlers/alarm_event/get_alarm_summary.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/get_alarm_summary.rs
@@ -102,6 +102,54 @@ pub fn handle_get_alarm_summary(db: &ObjectDatabase, buf: &mut BytesMut) -> Resu
     Ok(())
 }
 
+#[derive(Debug)]
+pub(crate) enum AlarmSummaryFailure {
+    Work,
+    Bytes,
+    Service(Error),
+}
+
+/// Transactional service encoding under the caller's database read guard.
+pub(crate) fn handle_get_alarm_summary_budgeted(
+    db: &ObjectDatabase,
+    buf: &mut BytesMut,
+    budget: crate::server::GetAlarmSummaryBudget,
+) -> Result<(), AlarmSummaryFailure> {
+    use bacnet_services::alarm_summary::{AlarmSummaryEntry, GetAlarmSummaryAck};
+
+    // This is deliberately all objects, before ANY object callback or projection.
+    if db.len() > budget.max_objects {
+        return Err(AlarmSummaryFailure::Work);
+    }
+    let mut scratch = BytesMut::new();
+    let mut entry_buf = BytesMut::new();
+    for (_, object) in db.iter_objects() {
+        let projection =
+            match AlarmSummaryProjection::read(object).map_err(AlarmSummaryFailure::Service)? {
+                AlarmSummaryProjectionResult::NotEventInitiating
+                | AlarmSummaryProjectionResult::Excluded => continue,
+                AlarmSummaryProjectionResult::Projected(projection) => projection,
+            };
+        // Strict projection bounds this triple: object ID, u32 enum, three bits.
+        // Reuse the service codec, retaining only one entry rather than the set.
+        entry_buf.clear();
+        GetAlarmSummaryAck {
+            entries: vec![AlarmSummaryEntry {
+                object_identifier: projection.object_identifier,
+                alarm_state: EventState::from_raw(projection.event_state),
+                acknowledged_transitions: projection.acknowledged_transitions,
+            }],
+        }
+        .encode(&mut entry_buf);
+        if entry_buf.len() > budget.max_service_ack_bytes - scratch.len() {
+            return Err(AlarmSummaryFailure::Bytes);
+        }
+        scratch.extend_from_slice(&entry_buf);
+    }
+    buf.extend_from_slice(&scratch);
+    Ok(())
+}
+
 fn read_required(
     object: &dyn BACnetObject,
     object_identifier: ObjectIdentifier,

--- a/crates/bacnet-server/src/handlers/tests/alarm_summary_budget.rs
+++ b/crates/bacnet-server/src/handlers/tests/alarm_summary_budget.rs
@@ -1,0 +1,181 @@
+use super::*;
+use crate::server::GetAlarmSummaryBudget;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+struct Counted {
+    object: AlarmSummaryFixture,
+    callbacks: Arc<AtomicUsize>,
+}
+
+impl BACnetObject for Counted {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.callbacks.fetch_add(1, Ordering::SeqCst);
+        self.object.object_identifier()
+    }
+    fn object_name(&self) -> &str {
+        self.callbacks.fetch_add(1, Ordering::SeqCst);
+        self.object.object_name()
+    }
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        self.callbacks.fetch_add(1, Ordering::SeqCst);
+        self.object.property_list()
+    }
+    fn read_property(&self, p: PropertyIdentifier, i: Option<u32>) -> Result<PropertyValue, Error> {
+        self.callbacks.fetch_add(1, Ordering::SeqCst);
+        self.object.read_property(p, i)
+    }
+    fn write_property(
+        &mut self,
+        p: PropertyIdentifier,
+        i: Option<u32>,
+        v: PropertyValue,
+        priority: Option<u8>,
+    ) -> Result<(), Error> {
+        self.object.write_property(p, i, v, priority)
+    }
+}
+
+fn counted(db: &mut ObjectDatabase, object: AlarmSummaryFixture) -> Arc<AtomicUsize> {
+    let callbacks = Arc::new(AtomicUsize::new(0));
+    db.add(Box::new(Counted {
+        object,
+        callbacks: callbacks.clone(),
+    }))
+    .unwrap();
+    callbacks.store(0, Ordering::SeqCst);
+    callbacks
+}
+
+fn limits(objects: usize, bytes: usize) -> GetAlarmSummaryBudget {
+    GetAlarmSummaryBudget {
+        max_objects: objects,
+        max_service_ack_bytes: bytes,
+    }
+}
+
+#[test]
+fn all_object_preflight_exact_over_and_no_callbacks() {
+    let mut db = ObjectDatabase::new();
+    let alarm = counted(&mut db, AlarmSummaryFixture::alarm(1));
+    let mut non_alarm = AlarmSummaryFixture::alarm(2);
+    non_alarm.advertised.clear();
+    let other = counted(&mut db, non_alarm);
+    // Reset after all database registration callbacks, outside the service.
+    alarm.store(0, Ordering::SeqCst);
+    let mut out = BytesMut::from(&b"prefix"[..]);
+    assert!(matches!(
+        handle_get_alarm_summary_budgeted(&db, &mut out, limits(1, 100)),
+        Err(AlarmSummaryFailure::Work)
+    ));
+    assert_eq!(&out[..], b"prefix");
+    assert_eq!(alarm.load(Ordering::SeqCst), 0);
+    assert_eq!(other.load(Ordering::SeqCst), 0);
+    handle_get_alarm_summary_budgeted(&db, &mut out, limits(2, 100)).unwrap();
+    assert_eq!(
+        GetAlarmSummaryAck::decode(&out[6..]).unwrap().entries.len(),
+        1
+    );
+}
+
+#[test]
+fn byte_exact_over_tiny_empty_and_legacy_compatibility() {
+    let mut db = ObjectDatabase::new();
+    add(&mut db, AlarmSummaryFixture::alarm(1));
+    add(&mut db, AlarmSummaryFixture::alarm(2));
+    // Independently specified triples: application object-id(5), enum(2), bits(3).
+    let expected: Vec<u8> = db
+        .iter_objects()
+        .flat_map(|(oid, _)| {
+            [
+                0xc4,
+                0,
+                0,
+                0,
+                oid.instance_number() as u8,
+                0x91,
+                2,
+                0x82,
+                5,
+                0xe0,
+            ]
+        })
+        .collect();
+    for cap in [1, 9, 10, 19, 20, 21] {
+        let mut out = BytesMut::from(&b"prefix"[..]);
+        let result = handle_get_alarm_summary_budgeted(&db, &mut out, limits(2, cap));
+        if cap < 20 {
+            assert!(matches!(result, Err(AlarmSummaryFailure::Bytes)));
+            assert_eq!(&out[..], b"prefix");
+        } else {
+            result.unwrap();
+            assert_eq!(&out[6..], &expected);
+        }
+    }
+    let mut legacy = BytesMut::new();
+    handle_get_alarm_summary(&db, &mut legacy).unwrap();
+    assert_eq!(&legacy[..], &expected);
+    let mut empty = BytesMut::from(&b"prefix"[..]);
+    handle_get_alarm_summary_budgeted(&ObjectDatabase::new(), &mut empty, limits(1, 1)).unwrap();
+    assert_eq!(&empty[..], b"prefix");
+}
+
+#[test]
+fn byte_failure_stops_later_callbacks_and_service_errors_do_not_commit() {
+    let mut db = ObjectDatabase::new();
+    let first = counted(&mut db, AlarmSummaryFixture::alarm(1));
+    let second = counted(&mut db, AlarmSummaryFixture::alarm(2));
+    first.store(0, Ordering::SeqCst);
+    let later = if db.iter_objects().nth(1).unwrap().0.instance_number() == 1 {
+        first
+    } else {
+        second
+    };
+    let mut out = BytesMut::from(&b"prefix"[..]);
+    assert!(matches!(
+        handle_get_alarm_summary_budgeted(&db, &mut out, limits(2, 9)),
+        Err(AlarmSummaryFailure::Bytes)
+    ));
+    assert_eq!(later.load(Ordering::SeqCst), 0);
+    assert_eq!(&out[..], b"prefix");
+    let mut db = ObjectDatabase::new();
+    let mut malformed = AlarmSummaryFixture::alarm(2);
+    malformed.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Boolean(true),
+    );
+    add(&mut db, malformed);
+    let Err(AlarmSummaryFailure::Service(error)) =
+        handle_get_alarm_summary_budgeted(&db, &mut out, limits(2, 20))
+    else {
+        panic!("genuine projection error must survive");
+    };
+    assert_operational_problem(error);
+    assert_eq!(&out[..], b"prefix");
+}
+
+#[test]
+fn raised_limits_and_variable_enum_width() {
+    let mut db = ObjectDatabase::new();
+    let mut object = AlarmSummaryFixture::alarm(1);
+    object.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Enumerated(u32::MAX),
+    );
+    add(&mut db, object);
+    let mut out = BytesMut::new();
+    assert!(matches!(
+        handle_get_alarm_summary_budgeted(&db, &mut out, limits(1, 12)),
+        Err(AlarmSummaryFailure::Bytes)
+    ));
+    handle_get_alarm_summary_budgeted(&db, &mut out, limits(usize::MAX, 13)).unwrap();
+    assert_eq!(out.len(), 13);
+    assert_eq!(
+        GetAlarmSummaryAck::decode(&out).unwrap().entries[0]
+            .alarm_state
+            .to_raw(),
+        u32::MAX
+    );
+}

--- a/crates/bacnet-server/src/handlers/tests/alarm_summary_projection.rs
+++ b/crates/bacnet-server/src/handlers/tests/alarm_summary_projection.rs
@@ -5,6 +5,9 @@ use bacnet_types::enums::NotifyType;
 
 use super::*;
 
+#[path = "alarm_summary_budget.rs"]
+mod budget;
+
 struct AlarmSummaryFixture {
     oid: ObjectIdentifier,
     name: String,
@@ -106,7 +109,21 @@ fn transition_bits(bits: u8) -> PropertyValue {
 
 fn response(db: &ObjectDatabase) -> Result<GetAlarmSummaryAck, Error> {
     let mut encoded = BytesMut::new();
-    handle_get_alarm_summary(db, &mut encoded)?;
+    let legacy = handle_get_alarm_summary(db, &mut encoded);
+    let mut bounded = BytesMut::new();
+    let result = handle_get_alarm_summary_budgeted(
+        db,
+        &mut bounded,
+        crate::server::GetAlarmSummaryBudget::default(),
+    );
+    match (&legacy, &result) {
+        (Ok(()), Ok(())) => assert_eq!(encoded, bounded),
+        (Err(expected), Err(AlarmSummaryFailure::Service(actual))) => {
+            assert_eq!(expected.to_string(), actual.to_string())
+        }
+        other => panic!("bounded/legacy projection drift: {other:?}"),
+    }
+    legacy?;
     GetAlarmSummaryAck::decode(&encoded)
 }
 

--- a/crates/bacnet-server/src/server/alarm_summary_budget.rs
+++ b/crates/bacnet-server/src/server/alarm_summary_budget.rs
@@ -1,0 +1,149 @@
+//! Local GetAlarmSummary scan and response limits.
+use super::*;
+
+/// Positive local limits for a complete GetAlarmSummary response.
+///
+/// Bounds total database objects before callbacks, and logical encoded service
+/// ACK bytes (not APDU/NPDU or peer APDU size). Does not bound one callback,
+/// property read, metadata operation, allocation capacity, CPU time or RSS.
+/// Byte refusal does not roll back reads already performed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GetAlarmSummaryBudget {
+    /// Maximum total database objects, including non-alarming objects (4096).
+    pub max_objects: usize,
+    /// Maximum encoded service ACK logical bytes (16384).
+    pub max_service_ack_bytes: usize,
+}
+
+impl Default for GetAlarmSummaryBudget {
+    fn default() -> Self {
+        Self {
+            max_objects: 4096,
+            max_service_ack_bytes: 16384,
+        }
+    }
+}
+
+impl GetAlarmSummaryBudget {
+    /// Reject zero; larger positive values are an operator policy choice.
+    pub fn validate(&self) -> Result<(), Error> {
+        for (name, value) in [
+            ("alarm_summary_max_objects", self.max_objects),
+            (
+                "alarm_summary_max_service_ack_bytes",
+                self.max_service_ack_bytes,
+            ),
+        ] {
+            if value == 0 {
+                return Err(Error::Encoding(format!("{name} must be positive")));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Set limits validated before transport startup.
+    pub fn get_alarm_summary_budget(mut self, budget: GetAlarmSummaryBudget) -> Self {
+        self.config.get_alarm_summary_budget = budget;
+        self
+    }
+}
+
+impl BipServerBuilder {
+    /// Set limits validated before transport startup.
+    pub fn get_alarm_summary_budget(mut self, budget: GetAlarmSummaryBudget) -> Self {
+        self.config.get_alarm_summary_budget = budget;
+        self
+    }
+}
+
+#[cfg(feature = "sc-tls")]
+impl ScServerBuilder {
+    /// Set limits validated before SC dialing.
+    pub fn get_alarm_summary_budget(mut self, budget: GetAlarmSummaryBudget) -> Self {
+        self.config.get_alarm_summary_budget = budget;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct NeverStart;
+    impl TransportPort for NeverStart {
+        async fn start(
+            &mut self,
+        ) -> Result<tokio::sync::mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error>
+        {
+            panic!("invalid alarm summary budget reached startup")
+        }
+        async fn stop(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+            Ok(())
+        }
+        fn local_mac(&self) -> &[u8] {
+            &[1]
+        }
+    }
+
+    #[tokio::test]
+    async fn alarm_summary_defaults_builders_and_pre_start_validation() {
+        let defaults = GetAlarmSummaryBudget::default();
+        assert_eq!(
+            (defaults.max_objects, defaults.max_service_ack_bytes),
+            (4096, 16384)
+        );
+        assert_eq!(ServerConfig::default().get_alarm_summary_budget, defaults);
+        assert!(format!("{:?}", ServerConfig::default()).contains("get_alarm_summary_budget"));
+        GetAlarmSummaryBudget {
+            max_objects: usize::MAX,
+            max_service_ack_bytes: usize::MAX,
+        }
+        .validate()
+        .unwrap();
+        for budget in [
+            GetAlarmSummaryBudget {
+                max_objects: 0,
+                ..defaults
+            },
+            GetAlarmSummaryBudget {
+                max_service_ack_bytes: 0,
+                ..defaults
+            },
+        ] {
+            let direct = BACnetServer::start(
+                ServerConfig {
+                    get_alarm_summary_budget: budget,
+                    ..Default::default()
+                },
+                ObjectDatabase::new(),
+                NeverStart,
+            )
+            .await
+            .err();
+            let generic = BACnetServer::generic_builder()
+                .transport(NeverStart)
+                .get_alarm_summary_budget(budget)
+                .build()
+                .await
+                .err();
+            let bip = BACnetServer::bip_builder()
+                .port(0)
+                .get_alarm_summary_budget(budget)
+                .build()
+                .await
+                .err();
+            for error in [direct, generic, bip] {
+                assert!(
+                    matches!(error, Some(Error::Encoding(m)) if m.contains("alarm_summary_max_"))
+                );
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/alarm_summary_tests.rs
+++ b/crates/bacnet-server/src/server/alarm_summary_tests.rs
@@ -8,6 +8,8 @@ use super::*;
 
 struct MalformedAlarmObject {
     oid: ObjectIdentifier,
+    name: String,
+    malformed: bool,
 }
 
 impl BACnetObject for MalformedAlarmObject {
@@ -16,7 +18,7 @@ impl BACnetObject for MalformedAlarmObject {
     }
 
     fn object_name(&self) -> &str {
-        "MALFORMED-ALARM"
+        &self.name
     }
 
     fn read_property(
@@ -25,7 +27,11 @@ impl BACnetObject for MalformedAlarmObject {
         _array_index: Option<u32>,
     ) -> Result<PropertyValue, Error> {
         match property {
-            PropertyIdentifier::EVENT_STATE => Ok(PropertyValue::Boolean(true)),
+            PropertyIdentifier::EVENT_STATE => Ok(if self.malformed {
+                PropertyValue::Boolean(true)
+            } else {
+                PropertyValue::Enumerated(2)
+            }),
             PropertyIdentifier::NOTIFY_TYPE => {
                 Ok(PropertyValue::Enumerated(NotifyType::ALARM.to_raw()))
             }
@@ -64,12 +70,74 @@ impl BACnetObject for MalformedAlarmObject {
 
 #[tokio::test]
 async fn projection_operational_problem_dispatches_error_apdu() {
+    let response = alarm_summary_response(1, true, ServerConfig::default(), 480, false).await;
+    let Apdu::Error(error) = response else {
+        panic!("expected GetAlarmSummary Error APDU");
+    };
+    assert_eq!(error.invoke_id, 0x50);
+    assert_eq!(
+        error.service_choice,
+        ConfirmedServiceChoice::GET_ALARM_SUMMARY
+    );
+    assert_eq!(error.error_class, ErrorClass::DEVICE);
+    assert_eq!(error.error_code, ErrorCode::OPERATIONAL_PROBLEM);
+}
+
+#[tokio::test]
+async fn alarm_summary_default_work_budget_precedes_projection() {
+    let response = alarm_summary_response(4097, true, ServerConfig::default(), 480, false).await;
+    let Apdu::Abort(abort) = response else {
+        panic!("expected work-budget Abort before malformed projection, got {response:?}");
+    };
+    assert!(abort.sent_by_server);
+    assert_eq!(abort.invoke_id, 0x50);
+    assert_eq!(abort.abort_reason, AbortReason::OUT_OF_RESOURCES);
+}
+
+#[tokio::test]
+async fn alarm_summary_wire_byte_budget_is_not_peer_apdu_size() {
+    for peer in [50, 480] {
+        for segmented in [false, true] {
+            for (cap, expected) in [(19, Some(AbortReason::BUFFER_OVERFLOW)), (20, None)] {
+                let config = ServerConfig {
+                    get_alarm_summary_budget: GetAlarmSummaryBudget {
+                        max_objects: 2,
+                        max_service_ack_bytes: cap,
+                    },
+                    ..Default::default()
+                };
+                let response = alarm_summary_response(2, false, config, peer, segmented).await;
+                match (response, expected) {
+                    (Apdu::Abort(a), Some(reason)) => {
+                        assert!(a.sent_by_server);
+                        assert_eq!(a.invoke_id, 0x50);
+                        assert_eq!(a.abort_reason, reason);
+                    }
+                    (Apdu::ComplexAck(a), None) => assert_eq!(a.service_ack.len(), 20),
+                    other => panic!("unexpected response: {other:?}"),
+                }
+            }
+        }
+    }
+}
+
+async fn alarm_summary_response(
+    count: u32,
+    malformed: bool,
+    config: ServerConfig,
+    max_apdu_length: u16,
+    segmented_response_accepted: bool,
+) -> Apdu {
     let mut database = ObjectDatabase::new();
-    database
-        .add(Box::new(MalformedAlarmObject {
-            oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
-        }))
-        .unwrap();
+    for instance in 1..=count {
+        database
+            .add(Box::new(MalformedAlarmObject {
+                oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap(),
+                name: format!("MALFORMED-ALARM-{instance}"),
+                malformed,
+            }))
+            .unwrap();
+    }
     let db = Arc::new(RwLock::new(database));
     let network = Arc::new(NetworkLayer::new(BipTransport::new(
         Ipv4Addr::LOCALHOST,
@@ -89,9 +157,9 @@ async fn projection_operational_problem_dispatches_error_apdu() {
     let confirmed = ConfirmedRequestPdu {
         segmented: false,
         more_follows: false,
-        segmented_response_accepted: false,
+        segmented_response_accepted,
         max_segments: None,
-        max_apdu_length: 480,
+        max_apdu_length,
         invoke_id: 0x50,
         sequence_number: None,
         proposed_window_size: None,
@@ -99,6 +167,10 @@ async fn projection_operational_problem_dispatches_error_apdu() {
         service_request: Bytes::new(),
     };
     let (tx, rx) = oneshot::channel();
+    let route = Some(NpduAddress {
+        network: 7,
+        mac_address: MacAddr::from_slice(&[9]),
+    });
 
     BACnetServer::<BipTransport>::handle_confirmed_request(
         &db,
@@ -113,24 +185,81 @@ async fn projection_operational_problem_dispatches_error_apdu() {
         &device_bindings,
         &comm_state,
         &dcc_timer,
-        &ServerConfig::default(),
+        &config,
         &Arc::new(crate::server::request_tasks::RequestTasks::default()).spawner(),
         &MacAddr::from_slice(&[1]),
-        None,
+        route.clone(),
         confirmed,
         Some(tx),
     )
     .await;
 
-    let response = decode_apdu(decode_npdu(rx.await.unwrap()).unwrap().payload).unwrap();
-    let Apdu::Error(error) = response else {
-        panic!("expected GetAlarmSummary Error APDU");
-    };
-    assert_eq!(error.invoke_id, 0x50);
-    assert_eq!(
-        error.service_choice,
-        ConfirmedServiceChoice::GET_ALARM_SUMMARY
-    );
-    assert_eq!(error.error_class, ErrorClass::DEVICE);
-    assert_eq!(error.error_code, ErrorCode::OPERATIONAL_PROBLEM);
+    let npdu = decode_npdu(rx.await.unwrap()).unwrap();
+    assert_eq!(npdu.destination, route);
+    decode_apdu(npdu.payload).unwrap()
+}
+
+#[tokio::test]
+async fn alarm_summary_within_budget_segmented_bip_roundtrip() {
+    use bacnet_client::client::BACnetClient;
+    for (work, bytes, expected) in [
+        (20, 200, None),
+        (20, 199, Some(AbortReason::BUFFER_OVERFLOW)),
+        (19, 200, Some(AbortReason::OUT_OF_RESOURCES)),
+    ] {
+        let mut database = ObjectDatabase::new();
+        for instance in 1..=20 {
+            database
+                .add(Box::new(MalformedAlarmObject {
+                    oid: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, instance).unwrap(),
+                    name: format!("alarm-{instance}"),
+                    malformed: false,
+                }))
+                .unwrap();
+        }
+        let mut server = BACnetServer::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .database(database)
+            .segmentation_supported(Segmentation::BOTH)
+            .get_alarm_summary_budget(GetAlarmSummaryBudget {
+                max_objects: work,
+                max_service_ack_bytes: bytes,
+            })
+            .build()
+            .await
+            .unwrap();
+        let mut client = BACnetClient::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .max_apdu_length(50)
+            .build()
+            .await
+            .unwrap();
+        let result = client
+            .confirmed_request(
+                server.local_mac(),
+                ConfirmedServiceChoice::GET_ALARM_SUMMARY,
+                &[],
+            )
+            .await;
+        client.stop().await.unwrap();
+        server.stop().await.unwrap();
+        match expected {
+            Some(reason) => assert!(
+                matches!(result, Err(Error::Abort { reason: actual }) if actual == reason.to_raw())
+            ),
+            None => {
+                let response = result.unwrap();
+                assert_eq!(
+                    response.len(),
+                    200,
+                    "must exceed the peer's 50-byte APDU and reassemble completely"
+                );
+                let ack =
+                    bacnet_services::alarm_summary::GetAlarmSummaryAck::decode(&response).unwrap();
+                assert_eq!(ack.entries.len(), 20);
+            }
+        }
+    }
 }

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -272,6 +272,8 @@ pub struct TimeSyncData {
 /// Server configuration.
 #[derive(Clone)]
 pub struct ServerConfig {
+    /// Per-service GetAlarmSummary database scan and encoded response limits.
+    pub get_alarm_summary_budget: GetAlarmSummaryBudget,
     /// Per-service RPM work and encoded response limits (finite by default).
     pub read_property_multiple_budget: ReadPropertyMultipleBudget,
     /// Local interface to bind.
@@ -376,6 +378,7 @@ pub struct ServerConfig {
 impl std::fmt::Debug for ServerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ServerConfig")
+            .field("get_alarm_summary_budget", &self.get_alarm_summary_budget)
             .field(
                 "read_property_multiple_budget",
                 &self.read_property_multiple_budget,
@@ -436,6 +439,7 @@ impl Default for ServerConfig {
         Self {
             interface: Ipv4Addr::UNSPECIFIED,
             read_property_multiple_budget: ReadPropertyMultipleBudget::default(),
+            get_alarm_summary_budget: GetAlarmSummaryBudget::default(),
             port: 0xBAC0,
             broadcast_address: Ipv4Addr::BROADCAST,
             max_apdu_length: 1476,
@@ -887,6 +891,8 @@ pub(crate) use segmented_send::*;
 mod request_admission;
 mod rpm_budget;
 pub use rpm_budget::ReadPropertyMultipleBudget;
+mod alarm_summary_budget;
+pub use alarm_summary_budget::GetAlarmSummaryBudget;
 mod request_peer;
 mod request_tasks;
 pub use request_admission::{RequestAdmissionCounters, RequestAdmissionPolicy};

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -44,6 +44,7 @@ impl RequestTasks {
         // Retain admission validation precedence; both policies must be valid
         // before the lifecycle starts a transport or exposes a request owner.
         config.read_property_multiple_budget.validate()?;
+        config.get_alarm_summary_budget.validate()?;
         Ok(Arc::new(tasks))
     }
 

--- a/crates/bacnet-server/src/server/requests/alarm_summary.rs
+++ b/crates/bacnet-server/src/server/requests/alarm_summary.rs
@@ -1,0 +1,35 @@
+use super::*;
+
+impl<T: TransportPort + 'static> BACnetServer<T> {
+    pub(super) fn alarm_summary_response(
+        db: &ObjectDatabase,
+        invoke_id: u8,
+        budget: GetAlarmSummaryBudget,
+    ) -> Apdu {
+        let service_choice = ConfirmedServiceChoice::GET_ALARM_SUMMARY;
+        let mut buf = BytesMut::new();
+        match handlers::handle_get_alarm_summary_budgeted(db, &mut buf, budget) {
+            Ok(()) => Apdu::ComplexAck(ComplexAck {
+                segmented: false,
+                more_follows: false,
+                invoke_id,
+                sequence_number: None,
+                proposed_window_size: None,
+                service_choice,
+                service_ack: buf.freeze(),
+            }),
+            Err(handlers::AlarmSummaryFailure::Service(e)) => {
+                Self::error_apdu_from_error(invoke_id, service_choice, &e)
+            }
+            Err(failure) => Apdu::Abort(AbortPdu {
+                sent_by_server: true,
+                invoke_id,
+                abort_reason: match failure {
+                    handlers::AlarmSummaryFailure::Work => AbortReason::OUT_OF_RESOURCES,
+                    handlers::AlarmSummaryFailure::Bytes => AbortReason::BUFFER_OVERFLOW,
+                    handlers::AlarmSummaryFailure::Service(_) => unreachable!(),
+                },
+            }),
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 mod acknowledge_alarm;
+mod alarm_summary;
 mod audit_notification;
 mod confirmed;
 pub(super) mod confirmed_response;
@@ -355,12 +356,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 }
             }
             s if s == ConfirmedServiceChoice::GET_ALARM_SUMMARY => {
-                let mut buf = BytesMut::new();
                 let db = db.read().await;
-                match handlers::handle_get_alarm_summary(&db, &mut buf) {
-                    Ok(()) => complex_ack(buf),
-                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
-                }
+                Self::alarm_summary_response(&db, invoke_id, config.get_alarm_summary_budget)
             }
             s if s == ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY => {
                 let mut buf = BytesMut::new();

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -187,6 +187,7 @@ impl ScServerBuilder {
 
         self.config.request_admission_policy.validate()?;
         self.config.read_property_multiple_budget.validate()?;
+        self.config.get_alarm_summary_budget.validate()?;
 
         let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
             .await?;
@@ -227,6 +228,32 @@ impl ScServerBuilder {
 mod tests {
     use super::*;
     use bacnet_transport::sc::ScReconnectConfig;
+
+    #[tokio::test]
+    async fn alarm_summary_sc_budget_validation_before_dial() {
+        for budget in [
+            GetAlarmSummaryBudget {
+                max_objects: 0,
+                ..Default::default()
+            },
+            GetAlarmSummaryBudget {
+                max_service_ack_bytes: 0,
+                ..Default::default()
+            },
+        ] {
+            let tls = tokio_rustls::rustls::ClientConfig::builder()
+                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+                .with_no_client_auth();
+            let builder = BACnetServer::sc_builder()
+                .hub_url("not-a-websocket-url")
+                .tls_config(Arc::new(tls))
+                .get_alarm_summary_budget(budget);
+            assert_eq!(builder.config.get_alarm_summary_budget, budget);
+            assert!(
+                matches!(builder.build().await.err(), Some(Error::Encoding(m)) if m.contains("alarm_summary_max_"))
+            );
+        }
+    }
 
     #[tokio::test]
     async fn rpm_sc_budget_validation_before_dial() {

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1788,6 +1788,8 @@ class BACnetServer:
         max_recovery_in_flight_per_peer: int = 1,
         rpm_max_result_elements: int = 256,
         rpm_max_service_ack_bytes: int = 16384,
+        alarm_summary_max_objects: int = 4096,
+        alarm_summary_max_service_ack_bytes: int = 16384,
     ) -> None: ...
 
     # --- Analog objects ---

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -103,6 +103,7 @@ pub struct BACnetServer {
     reinit_password: Option<String>,
     request_admission_policy: server::RequestAdmissionPolicy,
     read_property_multiple_budget: server::ReadPropertyMultipleBudget,
+    get_alarm_summary_budget: server::GetAlarmSummaryBudget,
     /// Whether the server has been started.
     started: Arc<AtomicBool>,
     /// Objects to add before starting. Cleared after start.

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -204,6 +204,7 @@ mod tests {
             reinit_password: None,
             request_admission_policy: server::RequestAdmissionPolicy::default(),
             read_property_multiple_budget: server::ReadPropertyMultipleBudget::default(),
+            get_alarm_summary_budget: server::GetAlarmSummaryBudget::default(),
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         }

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -39,6 +39,7 @@ impl BACnetServer {
         let reinit_password = self.reinit_password.clone();
         let request_admission_policy = self.request_admission_policy;
         let read_property_multiple_budget = self.read_property_multiple_budget;
+        let get_alarm_summary_budget = self.get_alarm_summary_budget;
 
         let objects: Vec<Box<dyn BACnetObject + Send>> = {
             let mut guard = self.lock_pending()?;
@@ -144,6 +145,7 @@ impl BACnetServer {
                 .database(db)
                 .request_admission_policy(request_admission_policy)
                 .read_property_multiple_budget(read_property_multiple_budget)
+                .get_alarm_summary_budget(get_alarm_summary_budget)
                 .transport(transport);
             if let Some(pw) = dcc_password {
                 builder = builder.dcc_password(pw);

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -33,7 +33,9 @@ impl BACnetServer {
         confirmed_recovery_reserve=4,
         max_recovery_in_flight_per_peer=1,
         rpm_max_result_elements=256,
-        rpm_max_service_ack_bytes=16384
+        rpm_max_service_ack_bytes=16384,
+        alarm_summary_max_objects=4096,
+        alarm_summary_max_service_ack_bytes=16384
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -66,6 +68,8 @@ impl BACnetServer {
         max_recovery_in_flight_per_peer: usize,
         rpm_max_result_elements: usize,
         rpm_max_service_ack_bytes: usize,
+        alarm_summary_max_objects: usize,
+        alarm_summary_max_service_ack_bytes: usize,
     ) -> PyResult<Self> {
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
@@ -83,6 +87,13 @@ impl BACnetServer {
             max_service_ack_bytes: rpm_max_service_ack_bytes,
         };
         read_property_multiple_budget
+            .validate()
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let get_alarm_summary_budget = server::GetAlarmSummaryBudget {
+            max_objects: alarm_summary_max_objects,
+            max_service_ack_bytes: alarm_summary_max_service_ack_bytes,
+        };
+        get_alarm_summary_budget
             .validate()
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         Ok(Self {
@@ -110,6 +121,7 @@ impl BACnetServer {
             reinit_password,
             request_admission_policy,
             read_property_multiple_budget,
+            get_alarm_summary_budget,
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         })

--- a/crates/rusty-bacnet/tests/test_alarm_summary_budget.py
+++ b/crates/rusty-bacnet/tests/test_alarm_summary_budget.py
@@ -1,0 +1,71 @@
+"""Installed native GetAlarmSummary policy; independently encoded UDP requests."""
+import asyncio
+import inspect
+import socket
+import struct
+import unittest
+from pathlib import Path
+from typing import Any
+
+import rusty_bacnet
+from rusty_bacnet import BACnetServer
+
+
+class AlarmSummaryConstructorTests(unittest.TestCase):
+    def test_defaults_keyword_only_stub_and_validation(self):
+        signature = inspect.signature(BACnetServer)
+        for name, default in [("alarm_summary_max_objects", 4096),
+                              ("alarm_summary_max_service_ack_bytes", 16384)]:
+            parameter = signature.parameters[name]
+            self.assertEqual(parameter.default, default)
+            self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+            self.assertIn(f"{name}: int = {default}",
+                          Path(rusty_bacnet.__file__).with_suffix(".pyi").read_text())
+            for transport in ["bip", "ipv6", "sc", "mstp"]:
+                for value, error in [(0, ValueError), (-1, OverflowError),
+                                     (1 << 200, OverflowError), (1.5, TypeError)]:
+                    with self.subTest(name=name, transport=transport, value=value):
+                        invalid: dict[str, Any] = {name: value}
+                        with self.assertRaises(error):
+                            BACnetServer(123, transport=transport, **invalid)
+                positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
+                BACnetServer(123, transport=transport, **positive)
+
+
+class AlarmSummaryNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_non_alarm_scan_work_abort_and_empty_ack_with_tiny_byte_budget(self):
+        # The server adds a Device too: two database objects, no active alarms.
+        for policy, expected in [
+            ({"alarm_summary_max_objects": 1}, 9),
+            ({"alarm_summary_max_objects": 2, "alarm_summary_max_service_ack_bytes": 1}, None),
+            ({}, None),
+            ({"alarm_summary_max_objects": 8192, "alarm_summary_max_service_ack_bytes": 32768}, None),
+        ]:
+            server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                  broadcast_address="127.0.0.1", **policy)
+            server.add_analog_input(1, "AI")
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.bind(("127.0.0.1", 0))
+            sock.setblocking(False)
+            loop = asyncio.get_running_loop()
+            try:
+                await server.start()
+                ip, port = (await server.local_address()).rsplit(":", 1)
+                for segmented in [False, True]:
+                    invoke = 2 if segmented else 1
+                    npdu = b"\x01\x00" + bytes([2 if segmented else 0, 5, invoke, 3])
+                    wire = b"\x81\x0a" + (len(npdu) + 4).to_bytes(2, "big") + npdu
+                    await loop.sock_sendto(sock, wire, (ip, int(port)))
+                    reply, _ = await asyncio.wait_for(loop.sock_recvfrom(sock, 4096), 2)
+                    self.assertEqual(reply[:2], b"\x81\x0a")
+                    self.assertEqual(int.from_bytes(reply[2:4], "big"), len(reply))
+                    self.assertEqual(reply[6:], bytes([0x71, invoke, expected])
+                                     if expected is not None else bytes([0x30, invoke, 3]))
+                    async with asyncio.timeout(2):
+                        while (await server.request_admission_counters())["confirmed_active"]:
+                            await asyncio.sleep(0)
+                    with self.assertRaises(BlockingIOError):
+                        sock.recvfrom(4096)
+            finally:
+                await server.stop()
+                sock.close()

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -66,6 +66,7 @@ SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
     "max_confirmed_in_flight_per_peer", "max_unconfirmed_in_flight_per_peer",
     "confirmed_recovery_reserve", "max_recovery_in_flight_per_peer",
     "rpm_max_result_elements", "rpm_max_service_ack_bytes",
+    "alarm_summary_max_objects", "alarm_summary_max_service_ack_bytes",
 ]
 SUPPORTED_BAUD_RATES = (9_600, 19_200, 38_400, 57_600, 76_800, 115_200)
 SUPPORTED_BAUD_ERROR = (

--- a/docs/alarm-summary-budget.md
+++ b/docs/alarm-summary-budget.md
@@ -1,0 +1,85 @@
+# GetAlarmSummary service budgets
+
+Configured Rust and Python servers default to **4096 total database objects**
+and **16384 logical encoded service-ACK bytes** per GetAlarmSummary request.
+These positive, unbenchmarked thresholds are owner-approved local policy, not
+Standard-mandated values or CPU/memory guarantees.
+
+## Configuration and migration
+
+Rust exposes `bacnet_server::server::GetAlarmSummaryBudget` with `max_objects`
+and `max_service_ack_bytes`. Set `ServerConfig::get_alarm_summary_budget` or
+call `get_alarm_summary_budget(...)` on generic, BACnet/IP or SC builders.
+`validate()` rejects zero; all positive `usize` values are accepted without
+preallocating their capacity. Validation precedes startup and SC dialing;
+existing earlier validation priorities remain intact.
+
+The new public `ServerConfig` field expands Rust source requirements:
+exhaustive literals must add `get_alarm_summary_budget: Default::default()`
+or an explicit budget. Literals with `..Default::default()` need no change.
+Large deployments may need to raise one or both limits explicitly.
+
+Python constructor settings are keyword-only on all transports:
+
+```python
+server = BACnetServer(
+    123,
+    alarm_summary_max_objects=4096,
+    alarm_summary_max_service_ack_bytes=16384,
+)
+```
+
+Zero raises `ValueError`; negative/native-integer-overflow values raise
+`OverflowError`, and non-integer values raise `TypeError`. Constructor
+validation happens before transport startup, including SC dial or serial open.
+The legacy public low-level `handlers::handle_get_alarm_summary(db, buf)` stays
+unconfigured and compatible; manual callers do not acquire server limits.
+
+## Complete response or whole-service refusal
+
+Under the same database read view used for projection, `db.len()` is checked
+**before any object metadata, identifier or property callbacks**. Every object
+counts, including Device and non-alarming objects. A database over the work cap
+receives a server Abort **OUT_OF_RESOURCES**, without projection callbacks.
+
+Within the work cap, existing database iteration order, selection, detection
+enable filtering and strict projection errors remain unchanged. Entries are
+encoded incrementally using a bounded logical scratch buffer and one temporary
+entry, not accumulated as a complete vector. A triple that cannot fit triggers
+a server Abort **BUFFER_OVERFLOW**, discards scratch and prevents later object
+reads. No successful truncated ACK is sent; the internal helper leaves existing
+caller output unchanged on failure. Earlier read side effects are not rolled back.
+An empty selected set succeeds even with a one-byte budget (zero service bytes).
+
+The byte budget counts encoded service parameters only, excluding APDU/NPDU.
+It is independent of the peer's APDU size and segmentation capability. Within
+budget, ordinary response sizing, segmentation and transport routing still apply.
+Genuine projection failures retain their existing service Error mapping.
+
+## Exclusions and evidence boundary
+
+This policy does not bound one metadata callback/property read, its internal
+allocations, allocator capacity, actual OOM, RSS, CPU time or arbitrary callback
+preemption. Scratch capacity may exceed logical length. It does not add
+authorization, fairness, pagination, rollback or other-service budgets. #521
+remains partial; #522 and the #125/#181/GATE0007 SC hard stops are unchanged.
+No README/PICS/BIBB or full-conformance support claim is added.
+
+## Protocol rationale and local-policy evidence
+
+Original paraphrase of ASHRAE 135-2020: §13.10 (printed 694–695 / PDF 696–697)
+describes the deprecated, no-parameter service's complete qualifying active
+alarm set, detection-disabled exclusions and empty result. Server execution is
+discouraged. §21 (printed 861 / PDF 863) defines a flat sequence of identifier,
+state and acknowledgment bits without continuation/truncation signaling.
+§5.4.5.3 (printed 48–49 / PDF 50–51) permits local SendAbort, while ordinary
+segmentation remains distinct. §18.10 (printed 800–801 / PDF 802–803) supports
+the cannot-start resource refusal versus encoded-capacity overflow distinction.
+Configured limits are not actual dynamic allocation failures (§18.11, printed
+801 / PDF 803). ComplexACK remains §20.1.5 (printed 833–834 / PDF 835–836).
+
+Focused evidence lives in handler `tests/alarm_summary_budget.rs`, server
+`alarm_summary_budget.rs`, `alarm_summary_tests.rs`, SC pre-dial tests and
+installed-native Python `test_alarm_summary_budget.py`. Independent triple/wire
+vectors supplement codec comparisons; these tests establish the local policy,
+not normative full conformance or hardware interoperability.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1703,6 +1703,15 @@ ms and require `sc_heartbeat_timeout_ms` to be greater than the interval.
 
 ## Request admission limits
 
+GetAlarmSummary has positive keyword-only `alarm_summary_max_objects=4096`
+and `alarm_summary_max_service_ack_bytes=16384`. The work preflight includes
+all database objects, even non-alarming objects, before any projection callback.
+Overflow returns whole-service server Abort OUT_OF_RESOURCES; encoded service
+byte overflow returns BUFFER_OVERFLOW, never a partial successful ACK. Bytes
+exclude APDU/NPDU and are independent of peer APDU size. See
+[GetAlarmSummary budgets](alarm-summary-budget.md) for migration, preserved
+segmentation, error behavior and precise callback/allocation exclusions.
+
 RPM additionally has independent, positive keyword-only constructor limits:
 `rpm_max_result_elements=256` and `rpm_max_service_ack_bytes=16384`.
 Whole-request expanded-result overflow returns server Abort OUT_OF_RESOURCES


### PR DESCRIPTION
## Summary
Refs #521. GetAlarmSummary only: default 4096 total database objects and 16384 encoded service-ACK bytes, configurable with positive Rust/Python limits. Work preflight precedes all object callbacks and returns whole-service server Abort OUT_OF_RESOURCES. Byte overflow discards scratch, stops later reads and returns BUFFER_OVERFLOW; never truncated success.

Preserves legacy unconfigured helper, genuine projection errors, filtering/order, routing and within-budget segmentation. Rust ServerConfig expansion and Python keyword-only migration documented. Defaults are owner-approved unbenchmarked local policy, not Standard-mandated limits. Existing deprecated service is being hardened, not newly advertised.

## Validation
- Valid default4097 baseline RED to GREEN; focused15, segmentation70, admission42, DCC28, SC pre-dial1 pass.
- Server963 unit+3 integration; integration39; workspace4290 pass,3 existing ignored.
- Fmt, Clippy (warnings), file-size, secrets, diff and binding check/Clippy pass.
- Fresh locked CPython3.12.13 macOS-arm64 wheel built after final production/binding edits; native origin/stub parity verified. Full Python40 tests/325 subtests pass, independently rerun by root; focused repeat2/32 pass.
- Wheel SHA256: 2149c8ce9c7d14733121a3d0b19fd8c52021984f12e1fc608cd7340cf338bc0b.

## Scope limits
No arbitrary callback/property-read, allocation capacity/OOM/RSS/CPU deadline or rollback guarantee. Byte cap is independent of peer APDU size. File/ReadRange/other summaries/auth/fairness and historic Audit/EventLog/GATE0007/SC boundaries unchanged. #521 remains partial; #522 unchanged. No new CI or broad conformance/support claim.

Two independent exact-head reviews and CI are pending.