### PR TITLE
feat(server): bound GetEnrollmentSummary scan and response work

### DIFF
--- a/crates/bacnet-server/src/handlers/alarm_event/get_enrollment_summary.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/get_enrollment_summary.rs
@@ -20,8 +20,65 @@ pub fn handle_get_enrollment_summary(
     buf: &mut BytesMut,
 ) -> Result<(), Error> {
     let request = GetEnrollmentSummaryRequest::decode(service_data)?;
-
     let mut entries = Vec::new();
+    visit_entries::<Error>(db, &request, |entry| {
+        entries.push(entry);
+        Ok(())
+    })?;
+    GetEnrollmentSummaryAck { entries }.encode(buf);
+    Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) enum EnrollmentSummaryFailure {
+    Work,
+    Bytes,
+    Service(Error),
+}
+
+impl From<Error> for EnrollmentSummaryFailure {
+    fn from(error: Error) -> Self {
+        Self::Service(error)
+    }
+}
+
+/// Complete logical service ACK, transactional under the caller's database view.
+pub(crate) fn handle_get_enrollment_summary_budgeted(
+    db: &ObjectDatabase,
+    service_data: &[u8],
+    buf: &mut BytesMut,
+    budget: crate::server::GetEnrollmentSummaryBudget,
+) -> Result<(), EnrollmentSummaryFailure> {
+    // Preserve decoder errors even when the database cannot be admitted.
+    let request = GetEnrollmentSummaryRequest::decode(service_data)?;
+    if db.len() > budget.max_objects {
+        return Err(EnrollmentSummaryFailure::Work);
+    }
+    let mut scratch = BytesMut::new();
+    let mut entry_buf = BytesMut::new();
+    visit_entries::<EnrollmentSummaryFailure>(db, &request, |entry| {
+        entry_buf.clear();
+        // The ACK is a bare sequence: concatenated singleton encodings retain
+        // the complete-service wire shape without retaining all entries.
+        GetEnrollmentSummaryAck {
+            entries: vec![entry],
+        }
+        .encode(&mut entry_buf);
+        if entry_buf.len() > budget.max_service_ack_bytes - scratch.len() {
+            return Err(EnrollmentSummaryFailure::Bytes);
+        }
+        scratch.extend_from_slice(&entry_buf);
+        Ok(())
+    })?;
+    buf.extend_from_slice(&scratch);
+    Ok(())
+}
+
+fn visit_entries<E: From<Error>>(
+    db: &ObjectDatabase,
+    request: &GetEnrollmentSummaryRequest,
+    mut emit: impl FnMut(EnrollmentSummaryEntry) -> Result<(), E>,
+) -> Result<(), E> {
     for (_oid, object) in db.iter_objects() {
         let Some(capability) = object.enrollment_summary_capability_internal() else {
             continue;
@@ -41,7 +98,8 @@ pub fn handle_get_enrollment_summary(
                     return Err(operational_problem(
                         object_identifier,
                         "Event_Detection_Enable is not Boolean",
-                    ))
+                    )
+                    .into())
                 }
             }
         }
@@ -88,16 +146,15 @@ pub fn handle_get_enrollment_summary(
             continue;
         }
 
-        entries.push(EnrollmentSummaryEntry {
+        emit(EnrollmentSummaryEntry {
             object_identifier,
             event_type: capability.event_type,
             event_state,
             priority: class_projection.priority,
             notification_class: Some(notification_class),
-        });
+        })?;
     }
 
-    GetEnrollmentSummaryAck { entries }.encode(buf);
     Ok(())
 }
 

--- a/crates/bacnet-server/src/handlers/tests/enrollment_summary_budget.rs
+++ b/crates/bacnet-server/src/handlers/tests/enrollment_summary_budget.rs
@@ -1,0 +1,267 @@
+use super::enrollment_summary_support::*;
+use super::*;
+use crate::server::GetEnrollmentSummaryBudget;
+use bacnet_objects::event::EnrollmentSummaryCapability;
+use bacnet_objects::traits::BACnetObject;
+use bacnet_types::enums::EventType;
+use std::borrow::Cow;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+struct Counted(SummaryFixture, Arc<AtomicUsize>);
+impl BACnetObject for Counted {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.1.fetch_add(1, Ordering::SeqCst);
+        self.0.object_identifier()
+    }
+    fn object_name(&self) -> &str {
+        self.1.fetch_add(1, Ordering::SeqCst);
+        self.0.object_name()
+    }
+    fn read_property(&self, p: PropertyIdentifier, i: Option<u32>) -> Result<PropertyValue, Error> {
+        self.1.fetch_add(1, Ordering::SeqCst);
+        self.0.read_property(p, i)
+    }
+    fn write_property(
+        &mut self,
+        p: PropertyIdentifier,
+        i: Option<u32>,
+        v: PropertyValue,
+        priority: Option<u8>,
+    ) -> Result<(), Error> {
+        self.1.fetch_add(1, Ordering::SeqCst);
+        self.0.write_property(p, i, v, priority)
+    }
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        self.1.fetch_add(1, Ordering::SeqCst);
+        self.0.property_list()
+    }
+    fn enrollment_summary_capability_internal(&self) -> Option<EnrollmentSummaryCapability> {
+        self.1.fetch_add(1, Ordering::SeqCst);
+        self.0.enrollment_summary_capability_internal()
+    }
+}
+fn candidate(instance: u32) -> SummaryFixture {
+    SummaryFixture::candidate(
+        instance,
+        EventType::OUT_OF_RANGE,
+        EventState::NORMAL,
+        7,
+        7,
+        None,
+    )
+}
+fn budget(objects: usize, bytes: usize) -> GetEnrollmentSummaryBudget {
+    GetEnrollmentSummaryBudget {
+        max_objects: objects,
+        max_service_ack_bytes: bytes,
+    }
+}
+
+#[test]
+fn enrollment_summary_object_preflight_and_decode_precedence_zero_callbacks() {
+    for capable in [false, true] {
+        let count = Arc::new(AtomicUsize::new(0));
+        let mut db = ObjectDatabase::new();
+        for instance in 1..=4097 {
+            let object = candidate(instance);
+            let object = if capable {
+                object
+            } else {
+                object.without_capability()
+            };
+            db.add(Box::new(Counted(object, count.clone()))).unwrap();
+        }
+        count.store(0, Ordering::SeqCst);
+        let mut out = BytesMut::from(&b"caller"[..]);
+        assert!(matches!(
+            handle_get_enrollment_summary_budgeted(
+                &db,
+                &[9, 0],
+                &mut out,
+                GetEnrollmentSummaryBudget::default()
+            ),
+            Err(EnrollmentSummaryFailure::Work)
+        ));
+        // Bad tag, undefined acknowledgment, reversed priority interval, wide priority.
+        for request in [
+            &[0x19, 0][..],
+            &[9, 3],
+            &[9, 0, 0x4e, 9, 2, 0x19, 1, 0x4f],
+            &[9, 0, 0x4e, 0x0a, 1, 0, 0x19, 1, 0x4f],
+        ] {
+            let legacy = handle_get_enrollment_summary(&db, request, &mut out).unwrap_err();
+            let Err(EnrollmentSummaryFailure::Service(actual)) =
+                handle_get_enrollment_summary_budgeted(
+                    &db,
+                    request,
+                    &mut out,
+                    GetEnrollmentSummaryBudget::default(),
+                )
+            else {
+                panic!("decode must precede work refusal")
+            };
+            assert_eq!(format!("{actual:?}"), format!("{legacy:?}"));
+        }
+        assert_eq!(count.load(Ordering::SeqCst), 0);
+        assert_eq!(&out[..], b"caller");
+    }
+}
+
+#[test]
+fn enrollment_summary_exact_bytes_independent_vector_and_all_object_count() {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(candidate(1))).unwrap();
+    db.add(Box::new(candidate(2).without_capability())).unwrap();
+    db.add(Box::new(class(7, 7, [11, 22, 33], vec![]))).unwrap();
+    // Clause 21 bare sequence: AI:1, out-of-range(5), normal(0), priority33, class7.
+    let expected = [0xc4, 0, 0, 0, 1, 0x91, 5, 0x91, 0, 0x21, 33, 0x21, 7];
+    for cap in [1, 12, 13, 14] {
+        let mut out = BytesMut::from(&b"prefix"[..]);
+        let result = handle_get_enrollment_summary_budgeted(&db, &[9, 0], &mut out, budget(3, cap));
+        if cap < 13 {
+            assert!(matches!(result, Err(EnrollmentSummaryFailure::Bytes)));
+            assert_eq!(&out[..], b"prefix");
+        } else {
+            result.unwrap();
+            assert_eq!(&out[6..], &expected);
+        }
+    }
+    assert!(matches!(
+        handle_get_enrollment_summary_budgeted(&db, &[9, 0], &mut BytesMut::new(), budget(2, 100)),
+        Err(EnrollmentSummaryFailure::Work)
+    ));
+    let mut out = BytesMut::from(&b"prefix"[..]);
+    handle_get_enrollment_summary_budgeted(&ObjectDatabase::new(), &[9, 0], &mut out, budget(1, 1))
+        .unwrap();
+    assert_eq!(&out[..], b"prefix");
+}
+
+#[test]
+fn enrollment_summary_byte_refusal_stops_later_candidate_and_class_reads() {
+    let first = Arc::new(AtomicUsize::new(0));
+    let second = Arc::new(AtomicUsize::new(0));
+    let class_reads = Arc::new(AtomicUsize::new(0));
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(Counted(candidate(1), first.clone())))
+        .unwrap();
+    db.add(Box::new(Counted(candidate(2), second.clone())))
+        .unwrap();
+    db.add(Box::new(Counted(
+        SummaryFixture::notification_class(
+            7,
+            None,
+            Some(PropertyValue::List(vec![
+                PropertyValue::Unsigned(11),
+                PropertyValue::Unsigned(22),
+                PropertyValue::Unsigned(33),
+            ])),
+            None,
+        ),
+        class_reads.clone(),
+    )))
+    .unwrap();
+    let order: Vec<_> = db
+        .iter_objects()
+        .filter_map(|(_, object)| {
+            let oid = object.object_identifier();
+            (oid.object_type() == ObjectType::ANALOG_INPUT).then_some(oid)
+        })
+        .collect();
+    let later = if order[1] == ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap() {
+        &first
+    } else {
+        &second
+    };
+    first.store(0, Ordering::SeqCst);
+    second.store(0, Ordering::SeqCst);
+    let class_visited_first = db
+        .iter_objects()
+        .next()
+        .unwrap()
+        .1
+        .object_identifier()
+        .object_type()
+        == ObjectType::NOTIFICATION_CLASS;
+    class_reads.store(0, Ordering::SeqCst);
+    let mut out = BytesMut::from(&b"unchanged"[..]);
+    assert!(matches!(
+        handle_get_enrollment_summary_budgeted(&db, &[9, 0], &mut out, budget(3, 12)),
+        Err(EnrollmentSummaryFailure::Bytes)
+    ));
+    assert_eq!(later.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        class_reads.load(Ordering::SeqCst),
+        1 + usize::from(class_visited_first)
+    );
+    assert_eq!(&out[..], b"unchanged");
+}
+
+#[test]
+fn enrollment_summary_variable_enum_and_class_widths() {
+    for (value, enum_bytes) in [
+        (255, vec![0x91, 255]),
+        (256, vec![0x92, 1, 0]),
+        (65536, vec![0x93, 1, 0, 0]),
+        (u32::MAX, vec![0x94, 255, 255, 255, 255]),
+    ] {
+        for (class_id, class_bytes) in [
+            (255, vec![0x21, 255]),
+            (256, vec![0x22, 1, 0]),
+            (65536, vec![0x23, 1, 0, 0]),
+        ] {
+            let mut db = ObjectDatabase::new();
+            db.add(Box::new(SummaryFixture::candidate(
+                1,
+                EventType::from_raw(value),
+                EventState::from_raw(value),
+                7,
+                class_id,
+                Some(bacnet_objects::event::EventTransition::ToNormal),
+            )))
+            .unwrap();
+            db.add(Box::new(class(class_id, class_id, [1, 2, 3], vec![])))
+                .unwrap();
+            let mut expected = vec![0xc4, 0, 0, 0, 1];
+            expected.extend_from_slice(&enum_bytes);
+            expected.extend_from_slice(&enum_bytes);
+            expected.extend_from_slice(&[0x21, 3]);
+            expected.extend_from_slice(&class_bytes);
+            for cap in [expected.len() - 1, expected.len()] {
+                let mut out = BytesMut::from(&b"prefix"[..]);
+                let result =
+                    handle_get_enrollment_summary_budgeted(&db, &[9, 0], &mut out, budget(2, cap));
+                if cap < expected.len() {
+                    assert!(matches!(result, Err(EnrollmentSummaryFailure::Bytes)));
+                    assert_eq!(&out[..], b"prefix");
+                } else {
+                    result.unwrap();
+                    assert_eq!(&out[6..], expected);
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn enrollment_summary_discards_accumulated_scratch_on_late_overflow() {
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(candidate(1))).unwrap();
+    db.add(Box::new(candidate(2))).unwrap();
+    db.add(Box::new(class(7, 7, [11, 22, 33], vec![]))).unwrap();
+    for cap in [13, 25, 26] {
+        let mut out = BytesMut::from(&b"prefix"[..]);
+        let result = handle_get_enrollment_summary_budgeted(&db, &[9, 0], &mut out, budget(3, cap));
+        if cap < 26 {
+            assert!(matches!(result, Err(EnrollmentSummaryFailure::Bytes)));
+            assert_eq!(&out[..], b"prefix");
+        } else {
+            result.unwrap();
+            let mut legacy = BytesMut::from(&b"prefix"[..]);
+            handle_get_enrollment_summary(&db, &[9, 0], &mut legacy).unwrap();
+            assert_eq!(out, legacy);
+        }
+    }
+}

--- a/crates/bacnet-server/src/handlers/tests/enrollment_summary_support.rs
+++ b/crates/bacnet-server/src/handlers/tests/enrollment_summary_support.rs
@@ -207,7 +207,22 @@ pub(super) fn response(
     let mut encoded_request = BytesMut::new();
     request.encode(&mut encoded_request);
     let mut encoded_ack = BytesMut::new();
-    handle_get_enrollment_summary(db, &encoded_request, &mut encoded_ack)?;
+    let legacy = handle_get_enrollment_summary(db, &encoded_request, &mut encoded_ack);
+    let mut bounded_ack = BytesMut::new();
+    let bounded = handle_get_enrollment_summary_budgeted(
+        db,
+        &encoded_request,
+        &mut bounded_ack,
+        crate::server::GetEnrollmentSummaryBudget::default(),
+    );
+    match (&legacy, bounded) {
+        (Ok(()), Ok(())) => assert_eq!(bounded_ack, encoded_ack),
+        (Err(expected), Err(EnrollmentSummaryFailure::Service(actual))) => {
+            assert_eq!(format!("{actual:?}"), format!("{expected:?}"))
+        }
+        (expected, actual) => panic!("legacy/budget parity: {expected:?} vs {actual:?}"),
+    }
+    legacy?;
     GetEnrollmentSummaryAck::decode(&encoded_ack)
 }
 

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -46,6 +46,7 @@ mod binary_lighting_relinquish_default;
 mod cov_multiple_parameters;
 mod detection_enable_summary;
 mod device_event;
+mod enrollment_summary_budget;
 mod enrollment_summary_filters;
 mod enrollment_summary_recipients;
 mod enrollment_summary_strict;

--- a/crates/bacnet-server/src/server/alarm_summary_tests.rs
+++ b/crates/bacnet-server/src/server/alarm_summary_tests.rs
@@ -128,6 +128,28 @@ async fn alarm_summary_response(
     max_apdu_length: u16,
     segmented_response_accepted: bool,
 ) -> Apdu {
+    summary_response(
+        count,
+        malformed,
+        config,
+        max_apdu_length,
+        segmented_response_accepted,
+        ConfirmedServiceChoice::GET_ALARM_SUMMARY,
+        Bytes::new(),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn summary_response(
+    count: u32,
+    malformed: bool,
+    config: ServerConfig,
+    max_apdu_length: u16,
+    segmented_response_accepted: bool,
+    service_choice: ConfirmedServiceChoice,
+    service_request: Bytes,
+) -> Apdu {
     let mut database = ObjectDatabase::new();
     for instance in 1..=count {
         database
@@ -163,8 +185,8 @@ async fn alarm_summary_response(
         invoke_id: 0x50,
         sequence_number: None,
         proposed_window_size: None,
-        service_choice: ConfirmedServiceChoice::GET_ALARM_SUMMARY,
-        service_request: Bytes::new(),
+        service_choice,
+        service_request,
     };
     let (tx, rx) = oneshot::channel();
     let route = Some(NpduAddress {
@@ -197,6 +219,51 @@ async fn alarm_summary_response(
     let npdu = decode_npdu(rx.await.unwrap()).unwrap();
     assert_eq!(npdu.destination, route);
     decode_apdu(npdu.payload).unwrap()
+}
+
+#[tokio::test]
+async fn enrollment_summary_routed_work_abort_and_decode_error_precedence() {
+    for peer in [50, 480] {
+        for segmented in [false, true] {
+            let response = summary_response(
+                4097,
+                false,
+                ServerConfig::default(),
+                peer,
+                segmented,
+                ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY,
+                Bytes::from_static(&[9, 0]),
+            )
+            .await;
+            assert!(
+                matches!(response, Apdu::Abort(a) if a.sent_by_server && a.invoke_id == 0x50 && a.abort_reason == AbortReason::OUT_OF_RESOURCES)
+            );
+            for request in [&[0x19, 0][..], &[9, 3], &[9, 0, 0x4e, 9, 2, 0x19, 1, 0x4f]] {
+                let baseline = summary_response(
+                    0,
+                    false,
+                    ServerConfig::default(),
+                    peer,
+                    segmented,
+                    ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY,
+                    Bytes::copy_from_slice(request),
+                )
+                .await;
+                let over = summary_response(
+                    4097,
+                    false,
+                    ServerConfig::default(),
+                    peer,
+                    segmented,
+                    ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY,
+                    Bytes::copy_from_slice(request),
+                )
+                .await;
+                assert_eq!(format!("{baseline:?}"), format!("{over:?}"));
+                assert!(!matches!(over, Apdu::ComplexAck(_) | Apdu::Abort(_)));
+            }
+        }
+    }
 }
 
 #[tokio::test]

--- a/crates/bacnet-server/src/server/enrollment_summary_budget.rs
+++ b/crates/bacnet-server/src/server/enrollment_summary_budget.rs
@@ -1,0 +1,66 @@
+//! Local limits for the deprecated GetEnrollmentSummary interoperability service.
+use super::*;
+
+/// Positive limits on total database objects and complete logical ACK bytes.
+///
+/// Counts all objects before any callbacks, after request decoding. Bytes exclude
+/// APDU/NPDU and are independent of peer APDU size and segmentation. Does not bound
+/// request decoding, individual callbacks/reads, recipient-list processing,
+/// allocation capacity/OOM, RSS, CPU or deadlines. Reads are not rolled back.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GetEnrollmentSummaryBudget {
+    /// Maximum total database objects, including noncandidates and classes (4096).
+    pub max_objects: usize,
+    /// Maximum encoded service ACK logical bytes (16384).
+    pub max_service_ack_bytes: usize,
+}
+
+impl Default for GetEnrollmentSummaryBudget {
+    fn default() -> Self {
+        Self {
+            max_objects: 4096,
+            max_service_ack_bytes: 16384,
+        }
+    }
+}
+
+impl GetEnrollmentSummaryBudget {
+    /// Reject zero; positive limits are local operator policy, not BACnet limits.
+    pub fn validate(&self) -> Result<(), Error> {
+        for (name, value) in [
+            ("enrollment_summary_max_objects", self.max_objects),
+            (
+                "enrollment_summary_max_service_ack_bytes",
+                self.max_service_ack_bytes,
+            ),
+        ] {
+            if value == 0 {
+                return Err(Error::Encoding(format!("{name} must be positive")));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Set GetEnrollmentSummary limits validated before transport startup.
+    pub fn get_enrollment_summary_budget(mut self, budget: GetEnrollmentSummaryBudget) -> Self {
+        self.config.get_enrollment_summary_budget = budget;
+        self
+    }
+}
+impl BipServerBuilder {
+    /// Set GetEnrollmentSummary limits validated before transport startup.
+    pub fn get_enrollment_summary_budget(mut self, budget: GetEnrollmentSummaryBudget) -> Self {
+        self.config.get_enrollment_summary_budget = budget;
+        self
+    }
+}
+#[cfg(feature = "sc-tls")]
+impl ScServerBuilder {
+    /// Set GetEnrollmentSummary limits validated before SC dialing.
+    pub fn get_enrollment_summary_budget(mut self, budget: GetEnrollmentSummaryBudget) -> Self {
+        self.config.get_enrollment_summary_budget = budget;
+        self
+    }
+}

--- a/crates/bacnet-server/src/server/enrollment_summary_tests.rs
+++ b/crates/bacnet-server/src/server/enrollment_summary_tests.rs
@@ -1,0 +1,227 @@
+use super::*;
+
+struct NeverStart;
+impl TransportPort for NeverStart {
+    async fn start(
+        &mut self,
+    ) -> Result<tokio::sync::mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+        panic!("invalid enrollment budget reached startup")
+    }
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+    fn local_mac(&self) -> &[u8] {
+        &[1]
+    }
+}
+
+#[tokio::test]
+async fn enrollment_summary_defaults_and_all_builders_validate_before_start() {
+    let default = GetEnrollmentSummaryBudget::default();
+    assert_eq!(
+        (default.max_objects, default.max_service_ack_bytes),
+        (4096, 16384)
+    );
+    assert_eq!(
+        ServerConfig::default().get_enrollment_summary_budget,
+        default
+    );
+    assert!(format!("{:?}", ServerConfig::default()).contains("get_enrollment_summary_budget"));
+    GetEnrollmentSummaryBudget {
+        max_objects: usize::MAX,
+        max_service_ack_bytes: usize::MAX,
+    }
+    .validate()
+    .unwrap();
+    for budget in [
+        GetEnrollmentSummaryBudget {
+            max_objects: 0,
+            ..default
+        },
+        GetEnrollmentSummaryBudget {
+            max_service_ack_bytes: 0,
+            ..default
+        },
+    ] {
+        let direct = BACnetServer::start(
+            ServerConfig {
+                get_enrollment_summary_budget: budget,
+                ..Default::default()
+            },
+            ObjectDatabase::new(),
+            NeverStart,
+        )
+        .await
+        .err();
+        let generic = BACnetServer::generic_builder()
+            .transport(NeverStart)
+            .get_enrollment_summary_budget(budget)
+            .build()
+            .await
+            .err();
+        let bip = BACnetServer::bip_builder()
+            .port(0)
+            .get_enrollment_summary_budget(budget)
+            .build()
+            .await
+            .err();
+        for error in [direct, generic, bip] {
+            assert!(
+                matches!(error, Some(Error::Encoding(m)) if m.contains("enrollment_summary_max_"))
+            );
+        }
+        #[cfg(feature = "sc-tls")]
+        {
+            let tls = tokio_rustls::rustls::ClientConfig::builder()
+                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+                .with_no_client_auth();
+            let result = BACnetServer::sc_builder()
+                .hub_url("not-a-websocket-url")
+                .tls_config(Arc::new(tls))
+                .get_enrollment_summary_budget(budget)
+                .build()
+                .await
+                .err();
+            assert!(
+                matches!(result, Some(Error::Encoding(m)) if m.contains("enrollment_summary_max_"))
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn enrollment_summary_segmented_complete_ack_or_whole_abort() {
+    use bacnet_client::client::BACnetClient;
+    use bacnet_objects::{analog::AnalogValueObject, notification_class::NotificationClass};
+    for (objects, bytes, expected) in [
+        (21, 260, None),
+        (21, 259, Some(AbortReason::BUFFER_OVERFLOW)),
+        (20, 260, Some(AbortReason::OUT_OF_RESOURCES)),
+    ] {
+        let mut database = ObjectDatabase::new();
+        for instance in 1..=20 {
+            database
+                .add(Box::new(
+                    AnalogValueObject::new(instance, format!("summary-{instance}"), 62).unwrap(),
+                ))
+                .unwrap();
+        }
+        database
+            .add(Box::new(NotificationClass::new(0, "NC").unwrap()))
+            .unwrap();
+        let mut server = BACnetServer::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .database(database)
+            .segmentation_supported(Segmentation::BOTH)
+            .get_enrollment_summary_budget(GetEnrollmentSummaryBudget {
+                max_objects: objects,
+                max_service_ack_bytes: bytes,
+            })
+            .build()
+            .await
+            .unwrap();
+        let mut client = BACnetClient::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .max_apdu_length(50)
+            .build()
+            .await
+            .unwrap();
+        let result = client
+            .confirmed_request(
+                server.local_mac(),
+                ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY,
+                &[9, 0],
+            )
+            .await;
+        client.stop().await.unwrap();
+        server.stop().await.unwrap();
+        match expected {
+            Some(expected) => assert!(
+                matches!(result, Err(Error::Abort { reason }) if reason == expected.to_raw()),
+                "{result:?}"
+            ),
+            None => {
+                let ack = result.unwrap();
+                assert_eq!(ack.len(), 260);
+                assert_eq!(
+                    bacnet_services::enrollment_summary::GetEnrollmentSummaryAck::decode(&ack)
+                        .unwrap()
+                        .entries
+                        .len(),
+                    20
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn enrollment_summary_default_object_budget_wire() {
+    default_object_budget_wire(true).await;
+}
+
+#[tokio::test]
+async fn enrollment_summary_default_noncandidate_budget_wire() {
+    default_object_budget_wire(false).await;
+}
+
+async fn default_object_budget_wire(candidate: bool) {
+    use bacnet_client::client::BACnetClient;
+    use bacnet_objects::analog::AnalogValueObject;
+
+    let mut database = ObjectDatabase::new();
+    for instance in 1..=4097 {
+        if candidate {
+            database
+                .add(Box::new(
+                    AnalogValueObject::new(instance, format!("summary-{instance}"), 62).unwrap(),
+                ))
+                .unwrap();
+        } else {
+            database
+                .add(Box::new(
+                    bacnet_objects::notification_class::NotificationClass::new(
+                        instance,
+                        format!("class-{instance}"),
+                    )
+                    .unwrap(),
+                ))
+                .unwrap();
+        }
+    }
+    let mut server = BACnetServer::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .database(database)
+        .build()
+        .await
+        .unwrap();
+    let mut client = BACnetClient::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .build()
+        .await
+        .unwrap();
+    let result = client
+        .confirmed_request(
+            server.local_mac(),
+            ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY,
+            &[0x09, 0],
+        )
+        .await;
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+    assert!(
+        matches!(result, Err(Error::Abort { reason })
+        if reason == AbortReason::OUT_OF_RESOURCES.to_raw()),
+        "{result:?}"
+    );
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -274,6 +274,8 @@ pub struct TimeSyncData {
 pub struct ServerConfig {
     /// Per-service GetAlarmSummary database scan and encoded response limits.
     pub get_alarm_summary_budget: GetAlarmSummaryBudget,
+    /// Local complete-response limits for GetEnrollmentSummary.
+    pub get_enrollment_summary_budget: GetEnrollmentSummaryBudget,
     /// Per-service RPM work and encoded response limits (finite by default).
     pub read_property_multiple_budget: ReadPropertyMultipleBudget,
     /// Local interface to bind.
@@ -380,6 +382,10 @@ impl std::fmt::Debug for ServerConfig {
         f.debug_struct("ServerConfig")
             .field("get_alarm_summary_budget", &self.get_alarm_summary_budget)
             .field(
+                "get_enrollment_summary_budget",
+                &self.get_enrollment_summary_budget,
+            )
+            .field(
                 "read_property_multiple_budget",
                 &self.read_property_multiple_budget,
             )
@@ -440,6 +446,7 @@ impl Default for ServerConfig {
             interface: Ipv4Addr::UNSPECIFIED,
             read_property_multiple_budget: ReadPropertyMultipleBudget::default(),
             get_alarm_summary_budget: GetAlarmSummaryBudget::default(),
+            get_enrollment_summary_budget: GetEnrollmentSummaryBudget::default(),
             port: 0xBAC0,
             broadcast_address: Ipv4Addr::BROADCAST,
             max_apdu_length: 1476,
@@ -893,6 +900,10 @@ mod rpm_budget;
 pub use rpm_budget::ReadPropertyMultipleBudget;
 mod alarm_summary_budget;
 pub use alarm_summary_budget::GetAlarmSummaryBudget;
+mod enrollment_summary_budget;
+pub use enrollment_summary_budget::GetEnrollmentSummaryBudget;
+#[cfg(test)]
+mod enrollment_summary_tests;
 mod request_peer;
 mod request_tasks;
 pub use request_admission::{RequestAdmissionCounters, RequestAdmissionPolicy};

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -45,6 +45,7 @@ impl RequestTasks {
         // before the lifecycle starts a transport or exposes a request owner.
         config.read_property_multiple_budget.validate()?;
         config.get_alarm_summary_budget.validate()?;
+        config.get_enrollment_summary_budget.validate()?;
         Ok(Arc::new(tasks))
     }
 

--- a/crates/bacnet-server/src/server/requests/enrollment_summary.rs
+++ b/crates/bacnet-server/src/server/requests/enrollment_summary.rs
@@ -1,0 +1,36 @@
+use super::*;
+
+impl<T: TransportPort + 'static> BACnetServer<T> {
+    pub(super) fn enrollment_summary_response(
+        db: &ObjectDatabase,
+        invoke_id: u8,
+        request: &[u8],
+        budget: GetEnrollmentSummaryBudget,
+    ) -> Apdu {
+        let service_choice = ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY;
+        let mut buf = BytesMut::new();
+        match handlers::handle_get_enrollment_summary_budgeted(db, request, &mut buf, budget) {
+            Ok(()) => Apdu::ComplexAck(ComplexAck {
+                segmented: false,
+                more_follows: false,
+                invoke_id,
+                sequence_number: None,
+                proposed_window_size: None,
+                service_choice,
+                service_ack: buf.freeze(),
+            }),
+            Err(handlers::EnrollmentSummaryFailure::Service(e)) => {
+                Self::error_apdu_from_error(invoke_id, service_choice, &e)
+            }
+            Err(failure) => Apdu::Abort(AbortPdu {
+                sent_by_server: true,
+                invoke_id,
+                abort_reason: match failure {
+                    handlers::EnrollmentSummaryFailure::Work => AbortReason::OUT_OF_RESOURCES,
+                    handlers::EnrollmentSummaryFailure::Bytes => AbortReason::BUFFER_OVERFLOW,
+                    handlers::EnrollmentSummaryFailure::Service(_) => unreachable!(),
+                },
+            }),
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -9,6 +9,7 @@ mod endpoint_responder;
 #[cfg(test)]
 #[path = "endpoint_shared_runtime_tests.rs"]
 mod endpoint_shared_runtime_tests;
+mod enrollment_summary;
 mod event_information;
 #[cfg(test)]
 mod executed;
@@ -360,12 +361,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 Self::alarm_summary_response(&db, invoke_id, config.get_alarm_summary_budget)
             }
             s if s == ConfirmedServiceChoice::GET_ENROLLMENT_SUMMARY => {
-                let mut buf = BytesMut::new();
                 let db = db.read().await;
-                match handlers::handle_get_enrollment_summary(&db, &req.service_request, &mut buf) {
-                    Ok(()) => complex_ack(buf),
-                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
-                }
+                Self::enrollment_summary_response(
+                    &db,
+                    invoke_id,
+                    &req.service_request,
+                    config.get_enrollment_summary_budget,
+                )
             }
             s if s == ConfirmedServiceChoice::AUDIT_LOG_QUERY => {
                 // Query under the read guard, then release it before ACK

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -188,6 +188,7 @@ impl ScServerBuilder {
         self.config.request_admission_policy.validate()?;
         self.config.read_property_multiple_budget.validate()?;
         self.config.get_alarm_summary_budget.validate()?;
+        self.config.get_enrollment_summary_budget.validate()?;
 
         let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
             .await?;

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1790,6 +1790,8 @@ class BACnetServer:
         rpm_max_service_ack_bytes: int = 16384,
         alarm_summary_max_objects: int = 4096,
         alarm_summary_max_service_ack_bytes: int = 16384,
+        enrollment_summary_max_objects: int = 4096,
+        enrollment_summary_max_service_ack_bytes: int = 16384,
     ) -> None: ...
 
     # --- Analog objects ---

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -104,6 +104,7 @@ pub struct BACnetServer {
     request_admission_policy: server::RequestAdmissionPolicy,
     read_property_multiple_budget: server::ReadPropertyMultipleBudget,
     get_alarm_summary_budget: server::GetAlarmSummaryBudget,
+    get_enrollment_summary_budget: server::GetEnrollmentSummaryBudget,
     /// Whether the server has been started.
     started: Arc<AtomicBool>,
     /// Objects to add before starting. Cleared after start.

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -205,6 +205,7 @@ mod tests {
             request_admission_policy: server::RequestAdmissionPolicy::default(),
             read_property_multiple_budget: server::ReadPropertyMultipleBudget::default(),
             get_alarm_summary_budget: server::GetAlarmSummaryBudget::default(),
+            get_enrollment_summary_budget: server::GetEnrollmentSummaryBudget::default(),
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         }

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -40,6 +40,7 @@ impl BACnetServer {
         let request_admission_policy = self.request_admission_policy;
         let read_property_multiple_budget = self.read_property_multiple_budget;
         let get_alarm_summary_budget = self.get_alarm_summary_budget;
+        let get_enrollment_summary_budget = self.get_enrollment_summary_budget;
 
         let objects: Vec<Box<dyn BACnetObject + Send>> = {
             let mut guard = self.lock_pending()?;
@@ -146,6 +147,7 @@ impl BACnetServer {
                 .request_admission_policy(request_admission_policy)
                 .read_property_multiple_budget(read_property_multiple_budget)
                 .get_alarm_summary_budget(get_alarm_summary_budget)
+                .get_enrollment_summary_budget(get_enrollment_summary_budget)
                 .transport(transport);
             if let Some(pw) = dcc_password {
                 builder = builder.dcc_password(pw);

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -35,7 +35,9 @@ impl BACnetServer {
         rpm_max_result_elements=256,
         rpm_max_service_ack_bytes=16384,
         alarm_summary_max_objects=4096,
-        alarm_summary_max_service_ack_bytes=16384
+        alarm_summary_max_service_ack_bytes=16384,
+        enrollment_summary_max_objects=4096,
+        enrollment_summary_max_service_ack_bytes=16384
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -70,6 +72,8 @@ impl BACnetServer {
         rpm_max_service_ack_bytes: usize,
         alarm_summary_max_objects: usize,
         alarm_summary_max_service_ack_bytes: usize,
+        enrollment_summary_max_objects: usize,
+        enrollment_summary_max_service_ack_bytes: usize,
     ) -> PyResult<Self> {
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
@@ -94,6 +98,13 @@ impl BACnetServer {
             max_service_ack_bytes: alarm_summary_max_service_ack_bytes,
         };
         get_alarm_summary_budget
+            .validate()
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let get_enrollment_summary_budget = server::GetEnrollmentSummaryBudget {
+            max_objects: enrollment_summary_max_objects,
+            max_service_ack_bytes: enrollment_summary_max_service_ack_bytes,
+        };
+        get_enrollment_summary_budget
             .validate()
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         Ok(Self {
@@ -122,6 +133,7 @@ impl BACnetServer {
             request_admission_policy,
             read_property_multiple_budget,
             get_alarm_summary_budget,
+            get_enrollment_summary_budget,
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         })

--- a/crates/rusty-bacnet/tests/test_enrollment_summary_budget.py
+++ b/crates/rusty-bacnet/tests/test_enrollment_summary_budget.py
@@ -1,0 +1,84 @@
+"""Installed native GetEnrollmentSummary limits and independent UDP vectors."""
+import asyncio
+import inspect
+import socket
+import struct
+import unittest
+from pathlib import Path
+from typing import Any
+
+import rusty_bacnet
+from rusty_bacnet import BACnetServer
+
+
+class EnrollmentSummaryConstructorTests(unittest.TestCase):
+    def test_defaults_keyword_only_stub_and_positive_validation(self):
+        signature = inspect.signature(BACnetServer)
+        for name, default in [("enrollment_summary_max_objects", 4096),
+                              ("enrollment_summary_max_service_ack_bytes", 16384)]:
+            parameter = signature.parameters[name]
+            self.assertEqual(parameter.default, default)
+            self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+            self.assertIn(f"{name}: int = {default}",
+                          Path(rusty_bacnet.__file__).with_suffix(".pyi").read_text())
+            for transport in ["bip", "ipv6", "sc", "mstp"]:
+                for value, error in [(0, ValueError), (-1, OverflowError),
+                                     (1 << 200, OverflowError), (1.5, TypeError)]:
+                    with self.subTest(name=name, transport=transport, value=value):
+                        with self.assertRaises(error):
+                            BACnetServer(123, transport=transport, **{name: value})
+                positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
+                BACnetServer(123, transport=transport, **positive)
+
+
+class EnrollmentSummaryNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_complete_ack_or_abort_direct_and_routed(self):
+        for candidate, policy, expected in [
+            (False, {"enrollment_summary_max_objects": 1}, 9),
+            (False, {"enrollment_summary_max_objects": 2,
+                     "enrollment_summary_max_service_ack_bytes": 1}, None),
+            (True, {"enrollment_summary_max_service_ack_bytes": 12}, 1),
+            (True, {"enrollment_summary_max_service_ack_bytes": 13}, None),
+            (True, {}, None),
+        ]:
+            server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                  broadcast_address="127.0.0.1", **policy)
+            server.add_notification_class(0, "NC")
+            if candidate:
+                server.add_analog_input(1, "AI")
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.bind(("127.0.0.1", 0))
+            sock.setblocking(False)
+            loop = asyncio.get_running_loop()
+            try:
+                await server.start()
+                ip, port = (await server.local_address()).rsplit(":", 1)
+                for routed in [False, True]:
+                    for segmented in [False, True]:
+                        invoke = 2 if segmented else 1
+                        header = b"\x01\x08\x00\x07\x01\x09" if routed else b"\x01\x00"
+                        # Service4, acknowledgmentFilter context0 all(0).
+                        npdu = header + bytes([2 if segmented else 0, 0, invoke, 4, 9, 0])
+                        wire = b"\x81\x0a" + (len(npdu) + 4).to_bytes(2, "big") + npdu
+                        await loop.sock_sendto(sock, wire, (ip, int(port)))
+                        reply, _ = await asyncio.wait_for(loop.sock_recvfrom(sock, 4096), 2)
+                        self.assertEqual(reply[:2], b"\x81\x0a")
+                        self.assertEqual(int.from_bytes(reply[2:4], "big"), len(reply))
+                        if routed:
+                            self.assertEqual(reply[4:11], b"\x01\x20\x00\x07\x01\x09\xff")
+                            apdu = reply[11:]
+                        else:
+                            apdu = reply[6:]
+                        if expected is not None:
+                            self.assertEqual(apdu, bytes([0x71, invoke, expected]))
+                        else:
+                            self.assertEqual(apdu[:3], bytes([0x30, invoke, 4]))
+                            self.assertEqual(len(apdu[3:]), 13 if candidate else 0)
+                        async with asyncio.timeout(2):
+                            while (await server.request_admission_counters())["confirmed_active"]:
+                                await asyncio.sleep(0)
+                        with self.assertRaises(BlockingIOError):
+                            sock.recvfrom(4096)
+            finally:
+                await server.stop()
+                sock.close()

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -67,6 +67,7 @@ SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
     "confirmed_recovery_reserve", "max_recovery_in_flight_per_peer",
     "rpm_max_result_elements", "rpm_max_service_ack_bytes",
     "alarm_summary_max_objects", "alarm_summary_max_service_ack_bytes",
+    "enrollment_summary_max_objects", "enrollment_summary_max_service_ack_bytes",
 ]
 SUPPORTED_BAUD_RATES = (9_600, 19_200, 38_400, 57_600, 76_800, 115_200)
 SUPPORTED_BAUD_ERROR = (

--- a/docs/enrollment-summary-budget.md
+++ b/docs/enrollment-summary-budget.md
@@ -1,0 +1,65 @@
+# GetEnrollmentSummary local response policy
+
+The deprecated GetEnrollmentSummary interoperability service now defaults to
+4096 **total database objects** and 16384 **encoded service-ACK logical bytes**.
+These are owner-selected local policy values, not BACnet normative thresholds.
+
+The request is decoded first, preserving existing malformed-request Error/Reject
+behavior. Under the same database read view, a total object count above the cap
+causes a whole-service server Abort `OUT_OF_RESOURCES`, before any capability,
+identifier, metadata, property or Notification Class callback. Noncandidates and
+Notification Class objects count too.
+
+Matching entries are encoded incrementally into scratch storage using the service
+codec. If the next entry would exceed the byte limit, the service returns server
+Abort `BUFFER_OVERFLOW`, discards scratch and stops later callbacks. Caller output
+is unchanged on failure; there is no partial successful list, cursor or continuation.
+The cap excludes APDU/NPDU overhead and is independent of peer maximum APDU size
+and segmentation. A complete within-budget ACK still uses normal segmentation.
+
+## Configuration and migration
+
+Rust `server::GetEnrollmentSummaryBudget` exposes positive `max_objects` and
+`max_service_ack_bytes` fields. Set it through
+`ServerConfig::get_enrollment_summary_budget` or the generic, B/IP and SC builders'
+`get_enrollment_summary_budget(...)` method. Validation rejects zero before
+transport startup or SC dialing. Positive values through `usize::MAX` are accepted.
+Exhaustive external `ServerConfig` literals must add the new field, normally
+`get_enrollment_summary_budget: Default::default()`, or use a default struct update.
+The public unconfigured `handle_get_enrollment_summary` helper retains its legacy
+unlimited behavior and error contract.
+
+Python `BACnetServer` adds keyword-only `enrollment_summary_max_objects=4096` and
+`enrollment_summary_max_service_ack_bytes=16384`. Zero raises `ValueError`;
+negative or platform-`usize` overflow raises `OverflowError`. The installed stub
+and native constructor expose the same defaults. Earlier positional arguments
+remain unchanged.
+
+## Scope and evidence
+
+Within-budget projection, all conjunctive filters, disabled detection omission,
+latest-transition priority selection, recipient membership, strict Notification
+Class failures, iteration order and response routing retain their existing semantics.
+The shared Notification Class resolver is unchanged.
+
+This is **not** full work preemption or a conformance guarantee. Exclusions include
+request decoding, individual callbacks/reads, recipient-list size, decoding and
+scanning (which may repeat for class lookups), allocator capacity or actual OOM,
+RSS, CPU, deadlines and rollback of reads. No other service policy changes.
+Audit #125, EventLog #181, GATE0007 and existing SC security hard stops remain open.
+
+Source rationale (original paraphrases of the licensed local base ASHRAE135-2020):
+
+| Source | Relevant distinction |
+| --- | --- |
+| §13.11, printed696–698 / PDF698–700 | Historical/deprecated service; server execution is discouraged. Its filters combine conjunctively and positive execution returns the complete matching list, including an empty list. |
+| §21, printed861 / PDF863 | ACK is a bare sequence of object ID, event type, state, priority and optional class entries; no continuation mechanism. |
+| §18.10, printed800–801 / PDF802–803 | Cannot-start resource refusal is distinct from response buffer overflow. |
+| §18.11, printed801 / PDF803 | Actual dynamic allocation failure is distinct from these configured limits. |
+| §5.4.5.3, printed48–49 / PDF50–51 | Local SendAbort and normal responding transaction/segmentation behavior remain applicable. |
+
+Focused Rust tests cover decoder precedence, zero callbacks at preflight, complete
+wire vectors and variable widths, exact/over limits, stopping later callbacks,
+legacy strict/filter parity, configuration and localhost segmented responses.
+Installed native Python tests cover constructor/stub parity and direct/routed
+complete ACK or Abort behavior. No external device/platform qualification implied.


### PR DESCRIPTION
## Summary
Refs #521. GetEnrollmentSummary only: owner-approved positive defaults4096 TOTAL database objects and16384 logical service-ACK bytes, configurable in Rust/Python. Request decoding retains precedence. The same-view object preflight precedes all callbacks and returns whole-service server Abort OUT_OF_RESOURCES on exhaustion. Incremental byte overflow discards scratch, stops later callbacks and returns BUFFER_OVERFLOW, never a truncated successful list.

Legacy helper and configured path share projection/filter semantics; Notification Class resolver unchanged. Within-budget errors, routing and segmentation preserved. Rust ServerConfig expansion and Python keyword-only settings documented.

## Validation
- Candidate4097 true baseline RED-to-GREEN; noncandidate baseline-dispatch replay RED-to-GREEN (not full baseline checkout).
- Enrollment36, alarm16 (includes adjacent enrollment test), segmentation70, admission42, DCC28, SC1 pass.
- Server973unit+3integration; integration39; workspace4300passed/3existing ignored.
- Fmt, Clippy (warnings), size, secrets, diff and binding check/Clippy pass.
- Fresh locked CPython3.12.13 macOS-arm64 wheel built after final production/binding source; origin/provenance/stub parity verified. Python42tests/357subtests pass including root independent rerun; focused repeat2/32 pass.
- Wheel SHA256 dbc24501f422f1710596cc8fcbe1d423af9c347531596de0f641b83ccecd46f4.

## Boundaries
Limits are unbenchmarked local policy, not Standard thresholds or full work-preemption guarantees. Request decoding, individual callbacks/reads, recipient-list size/decoding/scanning (including repeated lookups), allocator/OOM/RSS/CPU/deadlines/rollback excluded. Other services, auth/fairness, Audit#125/EventLog#181/GATE0007/SC boundaries unchanged. #521 stays partial; #522 unchanged. Existing deprecated service hardening, no new support/conformance or CI claims.

Two independent exact-head reviews and CI pending.