### PR TITLE
feat(server): bound AtomicReadFile requests and service acknowledgments

### DIFF
--- a/crates/bacnet-server/src/handlers/file.rs
+++ b/crates/bacnet-server/src/handlers/file.rs
@@ -109,6 +109,42 @@ pub fn handle_atomic_read_file(
     service_data: &[u8],
     buf: &mut BytesMut,
 ) -> Result<(), Error> {
+    read_file(db, service_data, buf, None).map_err(|failure| match failure {
+        AtomicReadFileFailure::Service(error) => error,
+        AtomicReadFileFailure::Budget(_) => unreachable!("unconfigured read has no budget"),
+    })
+}
+
+/// Keep local budget refusals distinct from pre-existing service/storage errors.
+#[derive(Debug)]
+pub(crate) enum AtomicReadFileFailure {
+    Service(Error),
+    Budget(bacnet_types::enums::AbortReason),
+}
+
+impl From<Error> for AtomicReadFileFailure {
+    fn from(error: Error) -> Self {
+        Self::Service(error)
+    }
+}
+
+/// Apply local request-count and complete service-ACK budgets, preserving the
+/// legacy handler's validation and storage-error precedence for admitted reads.
+pub(crate) fn handle_atomic_read_file_budgeted(
+    db: &ObjectDatabase,
+    service_data: &[u8],
+    buf: &mut BytesMut,
+    budget: crate::server::AtomicReadFileBudget,
+) -> Result<(), AtomicReadFileFailure> {
+    read_file(db, service_data, buf, Some(budget))
+}
+
+fn read_file(
+    db: &ObjectDatabase,
+    service_data: &[u8],
+    buf: &mut BytesMut,
+    budget: Option<crate::server::AtomicReadFileBudget>,
+) -> Result<(), AtomicReadFileFailure> {
     use bacnet_services::common::MAX_DECODED_ITEMS;
     use bacnet_services::file::{
         AtomicReadFileAck, AtomicReadFileRequest, FileAccessMethod, FileReadAckMethod,
@@ -117,7 +153,7 @@ pub fn handle_atomic_read_file(
     let request = AtomicReadFileRequest::decode(service_data)?;
 
     if request.file_identifier.object_type() != ObjectType::FILE {
-        return Err(inconsistent_object_type());
+        return Err(inconsistent_object_type().into());
     }
 
     let object = db
@@ -128,7 +164,7 @@ pub fn handle_atomic_read_file(
     // inaccessible for another reason" is refused before its properties are
     // consulted; an object without storage is that case.
     if object.file_storage_internal().is_none() {
-        return Err(file_access_denied());
+        return Err(file_access_denied().into());
     }
 
     // Clause 14.1: refuse a mismatched access method before any file read
@@ -152,6 +188,13 @@ pub fn handle_atomic_read_file(
         } => {
             let start =
                 u64::try_from(file_start_position).map_err(|_| invalid_file_start_position())?;
+            if budget.is_some_and(|b| {
+                u64::from(requested_octet_count) > b.max_requested_stream_octets as u64
+            }) {
+                return Err(AtomicReadFileFailure::Budget(
+                    bacnet_types::enums::AbortReason::OUT_OF_RESOURCES,
+                ));
+            }
             let read = storage.read_stream(start, u64::from(requested_octet_count))?;
             let ack = AtomicReadFileAck {
                 end_of_file: read.end_of_file,
@@ -160,7 +203,7 @@ pub fn handle_atomic_read_file(
                     file_data: read.data,
                 },
             };
-            ack.encode(buf);
+            encode_read_ack(&ack, buf, budget)?;
             Ok(())
         }
         FileAccessMethod::Record {
@@ -169,6 +212,13 @@ pub fn handle_atomic_read_file(
         } => {
             let start =
                 u64::try_from(file_start_record).map_err(|_| invalid_file_start_position())?;
+            if budget
+                .is_some_and(|b| u64::from(requested_record_count) > b.max_requested_records as u64)
+            {
+                return Err(AtomicReadFileFailure::Budget(
+                    bacnet_types::enums::AbortReason::OUT_OF_RESOURCES,
+                ));
+            }
             // The workspace's AtomicReadFile-ACK decoder accepts at most
             // MAX_DECODED_ITEMS records in one SEQUENCE OF, so one ACK never
             // carries more. A client sees 'Returned Record Count' below its
@@ -186,10 +236,26 @@ pub fn handle_atomic_read_file(
                     file_record_data: read.records,
                 },
             };
-            ack.encode(buf);
+            encode_read_ack(&ack, buf, budget)?;
             Ok(())
         }
     }
+}
+
+fn encode_read_ack(
+    ack: &bacnet_services::file::AtomicReadFileAck,
+    buf: &mut BytesMut,
+    budget: Option<crate::server::AtomicReadFileBudget>,
+) -> Result<(), AtomicReadFileFailure> {
+    if budget.is_some_and(|b| ack.encoded_len_bounded(b.max_service_ack_bytes).is_none()) {
+        return Err(AtomicReadFileFailure::Budget(
+            bacnet_types::enums::AbortReason::BUFFER_OVERFLOW,
+        ));
+    }
+    // All budget failures precede encoding: no payload copy or caller mutation
+    // is needed to size the owned storage result.
+    ack.encode(buf);
+    Ok(())
 }
 
 /// Handle an AtomicWriteFile request.

--- a/crates/bacnet-server/src/handlers/tests/atomic_read_file_budget.rs
+++ b/crates/bacnet-server/src/handlers/tests/atomic_read_file_budget.rs
@@ -1,0 +1,449 @@
+use super::*;
+use crate::server::AtomicReadFileBudget;
+use bacnet_objects::file::{
+    FileObject, FileRecordRead, FileStorage, FileStreamRead, FileWriteStart,
+};
+use bacnet_services::file::{
+    AtomicReadFileAck, AtomicReadFileRequest, FileAccessMethod, FileReadAckMethod,
+};
+use bacnet_types::enums::{AbortReason, FileAccessMethod as Method};
+use std::{
+    borrow::Cow,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+struct Probe {
+    file: FileObject,
+    reads: Arc<AtomicUsize>,
+    count: Arc<AtomicUsize>,
+    hook: bool,
+    failure: bool,
+    window: bool,
+    giant: bool,
+}
+impl BACnetObject for Probe {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.file.object_identifier()
+    }
+    fn object_name(&self) -> &str {
+        self.file.object_name()
+    }
+    fn read_property(&self, p: PropertyIdentifier, i: Option<u32>) -> Result<PropertyValue, Error> {
+        assert_eq!(
+            p,
+            PropertyIdentifier::FILE_ACCESS_METHOD,
+            "no new size/metadata reads"
+        );
+        self.file.read_property(p, i)
+    }
+    fn write_property(
+        &mut self,
+        _: PropertyIdentifier,
+        _: Option<u32>,
+        _: PropertyValue,
+        _: Option<u8>,
+    ) -> Result<(), Error> {
+        panic!("read-only test")
+    }
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        Cow::Borrowed(&[])
+    }
+    fn file_storage_internal(&self) -> Option<&dyn FileStorage> {
+        self.hook.then_some(self)
+    }
+}
+impl FileStorage for Probe {
+    fn read_stream(&self, start: u64, count: u64) -> Result<FileStreamRead, Error> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        self.count.store(count as usize, Ordering::SeqCst);
+        if self.failure {
+            return Err(storage_error());
+        }
+        self.file.read_stream(start, count)
+    }
+    fn read_records(&self, start: u64, count: u64) -> Result<FileRecordRead, Error> {
+        self.reads.fetch_add(1, Ordering::SeqCst);
+        self.count.store(count as usize, Ordering::SeqCst);
+        if self.failure {
+            return Err(storage_error());
+        }
+        if self.giant {
+            return Ok(FileRecordRead {
+                records: vec![vec![42; 1_000_000]],
+                end_of_file: false,
+            });
+        }
+        if self.window {
+            return Ok(FileRecordRead {
+                records: vec![vec![]; count as usize],
+                end_of_file: false,
+            });
+        }
+        self.file.read_records(start, count)
+    }
+    fn write_stream(&mut self, _: FileWriteStart, _: &[u8]) -> Result<u64, Error> {
+        panic!("no writes")
+    }
+    fn write_records(&mut self, _: FileWriteStart, _: &[Vec<u8>]) -> Result<u64, Error> {
+        panic!("no writes")
+    }
+}
+fn storage_error() -> Error {
+    Error::Protocol {
+        class: ErrorClass::SERVICES.to_raw() as u32,
+        code: ErrorCode::FILE_ACCESS_DENIED.to_raw() as u32,
+    }
+}
+fn probe(record: bool) -> Probe {
+    let mut file = FileObject::new(1, "file", "binary").unwrap();
+    if record {
+        file.set_file_access_method(Method::RECORD_ACCESS.to_raw());
+        file.set_records(vec![vec![], vec![1, 2, 3, 4, 5]]);
+    } else {
+        file.set_data(vec![1, 2, 3, 4, 5]);
+    }
+    Probe {
+        file,
+        reads: Arc::new(AtomicUsize::new(0)),
+        count: Arc::new(AtomicUsize::new(0)),
+        hook: true,
+        failure: false,
+        window: false,
+        giant: false,
+    }
+}
+fn wire(record: bool, start: i32, count: u32) -> BytesMut {
+    let mut wire = BytesMut::new();
+    AtomicReadFileRequest {
+        file_identifier: ObjectIdentifier::new(ObjectType::FILE, 1).unwrap(),
+        access: if record {
+            FileAccessMethod::Record {
+                file_start_record: start,
+                requested_record_count: count,
+            }
+        } else {
+            FileAccessMethod::Stream {
+                file_start_position: start,
+                requested_octet_count: count,
+            }
+        },
+    }
+    .encode(&mut wire);
+    wire
+}
+fn abort(result: Result<(), Error>, reason: AbortReason) {
+    assert!(matches!(result, Err(Error::Abort { reason: actual }) if actual == reason.to_raw()));
+}
+fn call(
+    db: &ObjectDatabase,
+    request: &[u8],
+    cap: AtomicReadFileBudget,
+) -> (Result<(), Error>, BytesMut) {
+    let mut out = BytesMut::from(&b"sentinel"[..]);
+    let result =
+        handle_atomic_read_file_budgeted(db, request, &mut out, cap).map_err(
+            |failure| match failure {
+                AtomicReadFileFailure::Service(error) => error,
+                AtomicReadFileFailure::Budget(reason) => Error::Abort {
+                    reason: reason.to_raw(),
+                },
+            },
+        );
+    if result.is_err() {
+        assert_eq!(&out[..], b"sentinel");
+        assert_eq!(out.capacity(), 8);
+    }
+    (result, out)
+}
+
+#[test]
+fn atomic_read_file_raw_count_exact_over_and_opaque_failure_precedence() {
+    for record in [false, true] {
+        for failure in [false, true] {
+            let mut p = probe(record);
+            p.failure = failure;
+            let reads = p.reads.clone();
+            let mut db = ObjectDatabase::new();
+            db.add(Box::new(p)).unwrap();
+            let cap = AtomicReadFileBudget {
+                max_requested_stream_octets: 5,
+                max_requested_records: 5,
+                ..Default::default()
+            };
+            for start in [0, 1, 2, 5, 6] {
+                abort(
+                    call(&db, &wire(record, start, 6), cap).0,
+                    AbortReason::OUT_OF_RESOURCES,
+                );
+            }
+            assert_eq!(reads.load(Ordering::SeqCst), 0);
+            let result = call(&db, &wire(record, 0, 5), cap).0;
+            if failure {
+                assert_eq!(
+                    format!("{:?}", result.unwrap_err()),
+                    format!("{:?}", storage_error())
+                );
+            } else {
+                result.unwrap();
+            }
+            assert_eq!(reads.load(Ordering::SeqCst), 1);
+        }
+    }
+}
+
+#[test]
+fn atomic_read_file_validation_precedes_budget_and_preserves_output() {
+    for record in [false, true] {
+        for hook in [false, true] {
+            for declared_record in [false, true] {
+                let mut p = probe(declared_record);
+                p.hook = hook;
+                let reads = p.reads.clone();
+                let mut db = ObjectDatabase::new();
+                db.add(Box::new(p)).unwrap();
+                for request in [
+                    BytesMut::new(),
+                    BytesMut::from(&b"\xc4"[..]),
+                    wire(record, -1, u32::MAX),
+                ] {
+                    let mut legacy = BytesMut::from(&b"sentinel"[..]);
+                    let expected = handle_atomic_read_file(&db, &request, &mut legacy).unwrap_err();
+                    let (actual, _) = call(&db, &request, AtomicReadFileBudget::default());
+                    assert_eq!(
+                        format!("{:?}", actual.unwrap_err()),
+                        format!("{expected:?}")
+                    );
+                }
+                assert_eq!(reads.load(Ordering::SeqCst), 0);
+            }
+        }
+        for object_type in [ObjectType::FILE, ObjectType::ANALOG_INPUT] {
+            let mut request = wire(record, -1, u32::MAX);
+            let oid = ObjectIdentifier::new(object_type, 2).unwrap();
+            let mut decoded = AtomicReadFileRequest::decode(&request).unwrap();
+            decoded.file_identifier = oid;
+            request.clear();
+            decoded.encode(&mut request);
+            for mut db in [ObjectDatabase::new(), make_db_with_ai()] {
+                if object_type == ObjectType::ANALOG_INPUT {
+                    db.add(Box::new(AnalogInputObject::new(2, "AI-2", 62).unwrap()))
+                        .unwrap();
+                }
+                let expected =
+                    handle_atomic_read_file(&db, &request, &mut BytesMut::new()).unwrap_err();
+                let actual = call(&db, &request, AtomicReadFileBudget::default())
+                    .0
+                    .unwrap_err();
+                assert_eq!(format!("{actual:?}"), format!("{expected:?}"));
+            }
+        }
+    }
+}
+
+#[test]
+fn atomic_read_file_admitted_zero_empty_eof_and_errors_match_legacy() {
+    for record in [false, true] {
+        for empty in [false, true] {
+            let mut p = probe(record);
+            if empty {
+                if record {
+                    p.file.set_records(vec![]);
+                } else {
+                    p.file.set_data(vec![]);
+                }
+            }
+            let mut db = ObjectDatabase::new();
+            db.add(Box::new(p)).unwrap();
+            for start in [0, 1, 2, 5, 6] {
+                for count in [0, 1, 5] {
+                    let request = wire(record, start, count);
+                    let mut legacy = BytesMut::from(&b"sentinel"[..]);
+                    let expected = handle_atomic_read_file(&db, &request, &mut legacy);
+                    let (actual, out) = call(&db, &request, AtomicReadFileBudget::default());
+                    assert_eq!(format!("{actual:?}"), format!("{expected:?}"));
+                    assert_eq!(out, legacy);
+                }
+            }
+            if empty {
+                abort(
+                    call(
+                        &db,
+                        &wire(record, 0, u32::MAX),
+                        AtomicReadFileBudget::default(),
+                    )
+                    .0,
+                    AbortReason::OUT_OF_RESOURCES,
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn atomic_read_file_raw_10001_checked_before_legacy_10000_window() {
+    let mut p = probe(true);
+    p.window = true;
+    let reads = p.reads.clone();
+    let count = p.count.clone();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(p)).unwrap();
+    for cap in [256, 10000] {
+        abort(
+            call(
+                &db,
+                &wire(true, 0, 10001),
+                AtomicReadFileBudget {
+                    max_requested_records: cap,
+                    ..Default::default()
+                },
+            )
+            .0,
+            AbortReason::OUT_OF_RESOURCES,
+        );
+    }
+    assert_eq!(reads.load(Ordering::SeqCst), 0);
+    let (result, out) = call(
+        &db,
+        &wire(true, 0, 10001),
+        AtomicReadFileBudget {
+            max_requested_records: 10001,
+            ..Default::default()
+        },
+    );
+    result.unwrap();
+    assert_eq!(reads.load(Ordering::SeqCst), 1);
+    assert_eq!(count.load(Ordering::SeqCst), 10000);
+    let ack = AtomicReadFileAck::decode(&out[8..]).unwrap();
+    assert!(!ack.end_of_file);
+    assert!(matches!(
+        ack.access,
+        FileReadAckMethod::Record {
+            returned_record_count: 10000,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn atomic_read_file_service_bytes_exact_tiny_and_no_payload_copy_on_refusal() {
+    for record in [false, true] {
+        let mut p = probe(record);
+        // Stream: bool/open/signed(2)/octets(2+5)/close = 12.
+        // Record adds returned count(2) and an empty octet string(1) = 15.
+        let expected = if record { 15 } else { 12 };
+        p.failure = false;
+        let reads = p.reads.clone();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(p)).unwrap();
+        for cap in [1, expected - 1, expected] {
+            let (result, out) = call(
+                &db,
+                &wire(record, 0, 5),
+                AtomicReadFileBudget {
+                    max_service_ack_bytes: cap,
+                    ..Default::default()
+                },
+            );
+            if cap < expected {
+                abort(result, AbortReason::BUFFER_OVERFLOW);
+            } else {
+                result.unwrap();
+                assert_eq!(out.len(), expected + 8);
+            }
+        }
+        assert_eq!(reads.load(Ordering::SeqCst), 3);
+    }
+    let mut p = probe(true);
+    p.giant = true;
+    let reads = p.reads.clone();
+    let mut db = ObjectDatabase::new();
+    db.add(Box::new(p)).unwrap();
+    abort(
+        call(&db, &wire(true, 0, 1), AtomicReadFileBudget::default()).0,
+        AbortReason::BUFFER_OVERFLOW,
+    );
+    assert_eq!(reads.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn atomic_read_file_default_payload_requires_ack_overhead_allowance() {
+    for record in [false, true] {
+        let mut p = probe(record);
+        if record {
+            p.file.set_records(vec![vec![42; 16384]]);
+        } else {
+            p.file.set_data(vec![42; 16384]);
+        }
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(p)).unwrap();
+        let request = wire(record, 0, if record { 1 } else { 16384 });
+        abort(
+            call(&db, &request, AtomicReadFileBudget::default()).0,
+            AbortReason::BUFFER_OVERFLOW,
+        );
+        let cap = 16384 + if record { 11 } else { 9 };
+        let (result, out) = call(
+            &db,
+            &request,
+            AtomicReadFileBudget {
+                max_service_ack_bytes: cap,
+                ..Default::default()
+            },
+        );
+        result.unwrap();
+        assert_eq!(out.len(), 8 + cap);
+        assert!(AtomicReadFileAck::decode(&out[8..]).unwrap().end_of_file);
+    }
+}
+
+#[test]
+fn atomic_read_file_default_exact_counts_and_empty_ack_caps() {
+    for record in [false, true] {
+        let mut p = probe(record);
+        if record {
+            p.file.set_records(vec![]);
+        } else {
+            p.file.set_data(vec![]);
+        }
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(p)).unwrap();
+        let default = AtomicReadFileBudget::default();
+        let count = if record { 256 } else { 16384 };
+        let size = if record { 7 } else { 6 };
+        for requested in [0, count] {
+            for cap in [size - 1, size] {
+                let (result, out) = call(
+                    &db,
+                    &wire(record, 0, requested),
+                    AtomicReadFileBudget {
+                        max_service_ack_bytes: cap,
+                        ..default
+                    },
+                );
+                if cap < size {
+                    abort(result, AbortReason::BUFFER_OVERFLOW);
+                } else {
+                    result.unwrap();
+                    assert_eq!(out.len(), 8 + size);
+                }
+            }
+        }
+        abort(
+            call(&db, &wire(record, 0, count + 1), default).0,
+            AbortReason::OUT_OF_RESOURCES,
+        );
+        let mut p = probe(record);
+        p.file.set_file_access_method(99);
+        let reads = p.reads.clone();
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(p)).unwrap();
+        let request = wire(record, 0, u32::MAX);
+        let expected = handle_atomic_read_file(&db, &request, &mut BytesMut::new()).unwrap_err();
+        let actual = call(&db, &request, default).0.unwrap_err();
+        assert_eq!(format!("{actual:?}"), format!("{expected:?}"));
+        assert_eq!(reads.load(Ordering::SeqCst), 0);
+    }
+}

--- a/crates/bacnet-server/src/handlers/tests/mod.rs
+++ b/crates/bacnet-server/src/handlers/tests/mod.rs
@@ -40,6 +40,7 @@ mod alarm_summary_projection;
 mod alert_enrollment;
 mod array_index_gating;
 mod async_dcc;
+mod atomic_read_file_budget;
 mod audit_log_query;
 mod binary_lighting_operations;
 mod binary_lighting_relinquish_default;

--- a/crates/bacnet-server/src/server/atomic_read_file_budget.rs
+++ b/crates/bacnet-server/src/server/atomic_read_file_budget.rs
@@ -1,0 +1,76 @@
+//! Local AtomicReadFile request-count and logical service-ACK limits.
+use super::*;
+
+/// Positive local limits, independent of peer APDU size and segmentation.
+///
+/// Raw request counts are checked after existing handler validation, before the
+/// storage read. ACK bytes include every service field but exclude APDU/NPDU.
+/// This does not bound opaque storage work or its single owned read result;
+/// notably, a record-count limit is not a total storage-byte limit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AtomicReadFileBudget {
+    /// Maximum raw requested stream octets (default 16384).
+    pub max_requested_stream_octets: usize,
+    /// Maximum raw requested records (default 256); the legacy read window remains.
+    pub max_requested_records: usize,
+    /// Maximum complete encoded service ACK bytes (default 16384).
+    pub max_service_ack_bytes: usize,
+}
+
+impl Default for AtomicReadFileBudget {
+    fn default() -> Self {
+        Self {
+            max_requested_stream_octets: 16384,
+            max_requested_records: 256,
+            max_service_ack_bytes: 16384,
+        }
+    }
+}
+
+impl AtomicReadFileBudget {
+    /// Reject zero configuration values before startup. Request counts may be zero.
+    pub fn validate(&self) -> Result<(), Error> {
+        for (name, value) in [
+            (
+                "atomic_read_file_max_requested_stream_octets",
+                self.max_requested_stream_octets,
+            ),
+            (
+                "atomic_read_file_max_requested_records",
+                self.max_requested_records,
+            ),
+            (
+                "atomic_read_file_max_service_ack_bytes",
+                self.max_service_ack_bytes,
+            ),
+        ] {
+            if value == 0 {
+                return Err(Error::Encoding(format!("{name} must be positive")));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Set AtomicReadFile limits validated before transport startup.
+    pub fn atomic_read_file_budget(mut self, budget: AtomicReadFileBudget) -> Self {
+        self.config.atomic_read_file_budget = budget;
+        self
+    }
+}
+impl BipServerBuilder {
+    /// Set AtomicReadFile limits validated before transport startup.
+    pub fn atomic_read_file_budget(mut self, budget: AtomicReadFileBudget) -> Self {
+        self.config.atomic_read_file_budget = budget;
+        self
+    }
+}
+#[cfg(feature = "sc-tls")]
+impl ScServerBuilder {
+    /// Set AtomicReadFile limits validated before SC dialing.
+    pub fn atomic_read_file_budget(mut self, budget: AtomicReadFileBudget) -> Self {
+        self.config.atomic_read_file_budget = budget;
+        self
+    }
+}

--- a/crates/bacnet-server/src/server/atomic_read_file_tests.rs
+++ b/crates/bacnet-server/src/server/atomic_read_file_tests.rs
@@ -1,0 +1,259 @@
+use super::*;
+use bacnet_client::client::BACnetClient;
+use bacnet_objects::file::FileObject;
+use bacnet_services::file::{AtomicReadFileRequest, FileAccessMethod};
+
+struct NeverStart;
+impl TransportPort for NeverStart {
+    async fn start(
+        &mut self,
+    ) -> Result<mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+        panic!("invalid budget reached startup")
+    }
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+    fn local_mac(&self) -> &[u8] {
+        &[1]
+    }
+}
+
+#[tokio::test]
+async fn atomic_read_file_all_builders_validate_before_start_or_dial() {
+    let default = AtomicReadFileBudget::default();
+    assert_eq!(
+        (
+            default.max_requested_stream_octets,
+            default.max_requested_records,
+            default.max_service_ack_bytes
+        ),
+        (16384, 256, 16384)
+    );
+    assert_eq!(ServerConfig::default().atomic_read_file_budget, default);
+    assert!(format!("{:?}", ServerConfig::default()).contains("atomic_read_file_budget"));
+    AtomicReadFileBudget {
+        max_requested_stream_octets: usize::MAX,
+        max_requested_records: usize::MAX,
+        max_service_ack_bytes: usize::MAX,
+    }
+    .validate()
+    .unwrap();
+    for budget in [
+        AtomicReadFileBudget {
+            max_requested_stream_octets: 0,
+            ..default
+        },
+        AtomicReadFileBudget {
+            max_requested_records: 0,
+            ..default
+        },
+        AtomicReadFileBudget {
+            max_service_ack_bytes: 0,
+            ..default
+        },
+    ] {
+        let direct = BACnetServer::start(
+            ServerConfig {
+                atomic_read_file_budget: budget,
+                ..Default::default()
+            },
+            ObjectDatabase::new(),
+            NeverStart,
+        )
+        .await
+        .err();
+        let generic = BACnetServer::generic_builder()
+            .transport(NeverStart)
+            .atomic_read_file_budget(budget)
+            .build()
+            .await
+            .err();
+        let bip = BACnetServer::bip_builder()
+            .port(0)
+            .atomic_read_file_budget(budget)
+            .build()
+            .await
+            .err();
+        for error in [direct, generic, bip] {
+            assert!(
+                matches!(error, Some(Error::Encoding(m)) if m.contains("atomic_read_file_max_"))
+            );
+        }
+        #[cfg(feature = "sc-tls")]
+        {
+            let tls = tokio_rustls::rustls::ClientConfig::builder()
+                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+                .with_no_client_auth();
+            let result = BACnetServer::sc_builder()
+                .hub_url("not-a-websocket-url")
+                .tls_config(Arc::new(tls))
+                .atomic_read_file_budget(budget)
+                .build()
+                .await
+                .err();
+            assert!(
+                matches!(result, Some(Error::Encoding(m)) if m.contains("atomic_read_file_max_"))
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn atomic_read_file_within_budget_segmented_complete_ack() {
+    use bacnet_services::file::{AtomicReadFileAck, FileReadAckMethod};
+    for record in [false, true] {
+        for over in [false, true] {
+            let mut file = FileObject::new(1, "file", "binary").unwrap();
+            if record {
+                file.set_file_access_method(
+                    bacnet_types::enums::FileAccessMethod::RECORD_ACCESS.to_raw(),
+                );
+                file.set_records(vec![vec![], vec![42; 300]]);
+            } else {
+                file.set_data(vec![42; 300]);
+            }
+            let mut database = ObjectDatabase::new();
+            database.add(Box::new(file)).unwrap();
+            let size = if record { 312 } else { 309 };
+            let mut server = BACnetServer::bip_builder()
+                .interface(Ipv4Addr::LOCALHOST)
+                .port(0)
+                .database(database)
+                .segmentation_supported(Segmentation::BOTH)
+                .atomic_read_file_budget(AtomicReadFileBudget {
+                    max_service_ack_bytes: size - usize::from(over),
+                    ..Default::default()
+                })
+                .build()
+                .await
+                .unwrap();
+            let mut client = BACnetClient::bip_builder()
+                .interface(Ipv4Addr::LOCALHOST)
+                .port(0)
+                .max_apdu_length(50)
+                .build()
+                .await
+                .unwrap();
+            let mut request = BytesMut::new();
+            AtomicReadFileRequest {
+                file_identifier: ObjectIdentifier::new(ObjectType::FILE, 1).unwrap(),
+                access: if record {
+                    FileAccessMethod::Record {
+                        file_start_record: 0,
+                        requested_record_count: 2,
+                    }
+                } else {
+                    FileAccessMethod::Stream {
+                        file_start_position: 0,
+                        requested_octet_count: 300,
+                    }
+                },
+            }
+            .encode(&mut request);
+            let result = client
+                .confirmed_request(
+                    server.local_mac(),
+                    ConfirmedServiceChoice::ATOMIC_READ_FILE,
+                    &request,
+                )
+                .await;
+            client.stop().await.unwrap();
+            server.stop().await.unwrap();
+            if over {
+                assert!(
+                    matches!(result, Err(Error::Abort { reason }) if reason == AbortReason::BUFFER_OVERFLOW.to_raw())
+                );
+            } else {
+                let bytes = result.unwrap();
+                assert_eq!(bytes.len(), size);
+                let ack = AtomicReadFileAck::decode(&bytes).unwrap();
+                assert!(ack.end_of_file);
+                match ack.access {
+                    FileReadAckMethod::Stream {
+                        file_start_position,
+                        file_data,
+                    } => {
+                        assert_eq!(file_start_position, 0);
+                        assert_eq!(file_data, vec![42; 300]);
+                    }
+                    FileReadAckMethod::Record {
+                        file_start_record,
+                        returned_record_count,
+                        file_record_data,
+                    } => {
+                        assert_eq!(file_start_record, 0);
+                        assert_eq!(returned_record_count, 2);
+                        assert_eq!(file_record_data, vec![vec![], vec![42; 300]]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn atomic_read_file_default_stream_raw_count_budget_wire() {
+    default_count_wire(false).await;
+}
+
+#[tokio::test]
+async fn atomic_read_file_default_record_raw_count_budget_wire() {
+    default_count_wire(true).await;
+}
+
+async fn default_count_wire(record: bool) {
+    let mut file = FileObject::new(1, "file", "binary").unwrap();
+    if record {
+        file.set_file_access_method(bacnet_types::enums::FileAccessMethod::RECORD_ACCESS.to_raw());
+    }
+    let mut database = ObjectDatabase::new();
+    database.add(Box::new(file)).unwrap();
+    let mut server = BACnetServer::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .database(database)
+        .build()
+        .await
+        .unwrap();
+    let mut client = BACnetClient::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .build()
+        .await
+        .unwrap();
+    let mut wire = BytesMut::new();
+    AtomicReadFileRequest {
+        file_identifier: ObjectIdentifier::new(ObjectType::FILE, 1).unwrap(),
+        access: if record {
+            FileAccessMethod::Record {
+                file_start_record: 0,
+                requested_record_count: 257,
+            }
+        } else {
+            FileAccessMethod::Stream {
+                file_start_position: 0,
+                requested_octet_count: 16385,
+            }
+        },
+    }
+    .encode(&mut wire);
+    let result = client
+        .confirmed_request(
+            server.local_mac(),
+            ConfirmedServiceChoice::ATOMIC_READ_FILE,
+            &wire,
+        )
+        .await;
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+    assert!(
+        matches!(result, Err(Error::Abort { reason }) if reason == AbortReason::OUT_OF_RESOURCES.to_raw()),
+        "{result:?}"
+    );
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -276,6 +276,8 @@ pub struct ServerConfig {
     pub get_alarm_summary_budget: GetAlarmSummaryBudget,
     /// Local complete-response limits for GetEnrollmentSummary.
     pub get_enrollment_summary_budget: GetEnrollmentSummaryBudget,
+    /// Local AtomicReadFile raw-count and complete service-ACK limits.
+    pub atomic_read_file_budget: AtomicReadFileBudget,
     /// Per-service RPM work and encoded response limits (finite by default).
     pub read_property_multiple_budget: ReadPropertyMultipleBudget,
     /// Local interface to bind.
@@ -385,6 +387,7 @@ impl std::fmt::Debug for ServerConfig {
                 "get_enrollment_summary_budget",
                 &self.get_enrollment_summary_budget,
             )
+            .field("atomic_read_file_budget", &self.atomic_read_file_budget)
             .field(
                 "read_property_multiple_budget",
                 &self.read_property_multiple_budget,
@@ -447,6 +450,7 @@ impl Default for ServerConfig {
             read_property_multiple_budget: ReadPropertyMultipleBudget::default(),
             get_alarm_summary_budget: GetAlarmSummaryBudget::default(),
             get_enrollment_summary_budget: GetEnrollmentSummaryBudget::default(),
+            atomic_read_file_budget: AtomicReadFileBudget::default(),
             port: 0xBAC0,
             broadcast_address: Ipv4Addr::BROADCAST,
             max_apdu_length: 1476,
@@ -900,8 +904,12 @@ mod rpm_budget;
 pub use rpm_budget::ReadPropertyMultipleBudget;
 mod alarm_summary_budget;
 pub use alarm_summary_budget::GetAlarmSummaryBudget;
+mod atomic_read_file_budget;
 mod enrollment_summary_budget;
+pub use atomic_read_file_budget::AtomicReadFileBudget;
 pub use enrollment_summary_budget::GetEnrollmentSummaryBudget;
+#[cfg(test)]
+mod atomic_read_file_tests;
 #[cfg(test)]
 mod enrollment_summary_tests;
 mod request_peer;

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -46,6 +46,7 @@ impl RequestTasks {
         config.read_property_multiple_budget.validate()?;
         config.get_alarm_summary_budget.validate()?;
         config.get_enrollment_summary_budget.validate()?;
+        config.atomic_read_file_budget.validate()?;
         Ok(Arc::new(tasks))
     }
 

--- a/crates/bacnet-server/src/server/requests/atomic_read_file.rs
+++ b/crates/bacnet-server/src/server/requests/atomic_read_file.rs
@@ -1,0 +1,32 @@
+use super::*;
+
+impl<T: TransportPort + 'static> BACnetServer<T> {
+    pub(super) fn atomic_read_file_response(
+        db: &ObjectDatabase,
+        invoke_id: u8,
+        request: &[u8],
+        budget: AtomicReadFileBudget,
+    ) -> Apdu {
+        let service_choice = ConfirmedServiceChoice::ATOMIC_READ_FILE;
+        let mut buf = BytesMut::new();
+        match handlers::handle_atomic_read_file_budgeted(db, request, &mut buf, budget) {
+            Ok(()) => Apdu::ComplexAck(ComplexAck {
+                segmented: false,
+                more_follows: false,
+                invoke_id,
+                sequence_number: None,
+                proposed_window_size: None,
+                service_choice,
+                service_ack: buf.freeze(),
+            }),
+            Err(handlers::AtomicReadFileFailure::Service(error)) => {
+                Self::error_apdu_from_error(invoke_id, service_choice, &error)
+            }
+            Err(handlers::AtomicReadFileFailure::Budget(abort_reason)) => Apdu::Abort(AbortPdu {
+                sent_by_server: true,
+                invoke_id,
+                abort_reason,
+            }),
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -2,6 +2,7 @@ use super::*;
 
 mod acknowledge_alarm;
 mod alarm_summary;
+mod atomic_read_file;
 mod audit_notification;
 mod confirmed;
 pub(super) mod confirmed_response;
@@ -327,10 +328,12 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             }
             s if s == ConfirmedServiceChoice::ATOMIC_READ_FILE => {
                 let db = db.read().await;
-                match handlers::handle_atomic_read_file(&db, &req.service_request, &mut ack_buf) {
-                    Ok(()) => complex_ack(ack_buf),
-                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
-                }
+                Self::atomic_read_file_response(
+                    &db,
+                    invoke_id,
+                    &req.service_request,
+                    config.atomic_read_file_budget,
+                )
             }
             s if s == ConfirmedServiceChoice::ATOMIC_WRITE_FILE => {
                 let result = {

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -189,6 +189,7 @@ impl ScServerBuilder {
         self.config.read_property_multiple_budget.validate()?;
         self.config.get_alarm_summary_budget.validate()?;
         self.config.get_enrollment_summary_budget.validate()?;
+        self.config.atomic_read_file_budget.validate()?;
 
         let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
             .await?;

--- a/crates/bacnet-services/src/file.rs
+++ b/crates/bacnet-services/src/file.rs
@@ -740,3 +740,5 @@ mod ack_strict_tests;
 #[cfg(test)]
 #[path = "file_ack_roundtrip_tests.rs"]
 mod ack_roundtrip_tests;
+#[path = "file_ack_size.rs"]
+mod ack_size;

--- a/crates/bacnet-services/src/file_ack_size.rs
+++ b/crates/bacnet-services/src/file_ack_size.rs
@@ -1,0 +1,71 @@
+//! Bounded sizing for AtomicReadFile ACKs only; never copies storage payloads.
+use super::*;
+
+fn read_ack_octet_string_len(len: usize) -> Option<usize> {
+    let wire_len = u32::try_from(len).ok()?;
+    let prefix = match wire_len {
+        0..=4 => 1,
+        5..=253 => 2,
+        254..=65535 => 4,
+        _ => 6,
+    };
+    len.checked_add(prefix)
+}
+
+impl AtomicReadFileAck {
+    /// Exact logical service encoding length if it fits `limit` and wire lengths.
+    ///
+    /// Borrows payloads without encoding or copying them and stops summing as
+    /// soon as the cap is exceeded. APDU/NPDU headers are not included.
+    pub fn encoded_len_bounded(&self, limit: usize) -> Option<usize> {
+        fn add(total: &mut usize, amount: usize, limit: usize) -> Option<()> {
+            *total = total.checked_add(amount)?;
+            (*total <= limit).then_some(())
+        }
+        // Application Boolean plus opening and closing CHOICE tags.
+        let mut total = 0;
+        add(&mut total, 3, limit)?;
+        match &self.access {
+            FileReadAckMethod::Stream {
+                file_start_position,
+                file_data,
+            } => {
+                add(
+                    &mut total,
+                    1 + primitives::signed_len(*file_start_position) as usize,
+                    limit,
+                )?;
+                add(
+                    &mut total,
+                    read_ack_octet_string_len(file_data.len())?,
+                    limit,
+                )?;
+            }
+            FileReadAckMethod::Record {
+                file_start_record,
+                returned_record_count,
+                file_record_data,
+            } => {
+                u32::try_from(file_record_data.len()).ok()?;
+                add(
+                    &mut total,
+                    1 + primitives::signed_len(*file_start_record) as usize,
+                    limit,
+                )?;
+                add(
+                    &mut total,
+                    1 + primitives::unsigned_len(u64::from(*returned_record_count)) as usize,
+                    limit,
+                )?;
+                for record in file_record_data {
+                    add(&mut total, read_ack_octet_string_len(record.len())?, limit)?;
+                }
+            }
+        }
+        Some(total)
+    }
+}
+
+#[cfg(test)]
+#[path = "file_ack_size_tests.rs"]
+mod tests;

--- a/crates/bacnet-services/src/file_ack_size_tests.rs
+++ b/crates/bacnet-services/src/file_ack_size_tests.rs
@@ -1,0 +1,111 @@
+use super::*;
+
+#[test]
+fn atomic_read_file_ack_size_wire_length_ceiling_without_payload_allocation() {
+    assert_eq!(read_ack_octet_string_len(usize::MAX), None);
+    #[cfg(target_pointer_width = "64")]
+    {
+        assert_eq!(
+            read_ack_octet_string_len(u32::MAX as usize),
+            Some(u32::MAX as usize + 6)
+        );
+        assert_eq!(read_ack_octet_string_len(u32::MAX as usize + 1), None);
+    }
+    #[cfg(target_pointer_width = "32")]
+    assert_eq!(read_ack_octet_string_len(u32::MAX as usize), None);
+}
+
+#[test]
+fn atomic_read_file_ack_size_independent_wire_vectors() {
+    for (start, signed) in [
+        (-129, vec![0x32, 0xff, 0x7f]),
+        (-128, vec![0x31, 0x80]),
+        (0, vec![0x31, 0]),
+        (127, vec![0x31, 0x7f]),
+        (128, vec![0x32, 0, 0x80]),
+        (32767, vec![0x32, 0x7f, 0xff]),
+        (32768, vec![0x33, 0, 0x80, 0]),
+        (8388607, vec![0x33, 0x7f, 0xff, 0xff]),
+        (8388608, vec![0x34, 0, 0x80, 0, 0]),
+        (i32::MIN, vec![0x34, 0x80, 0, 0, 0]),
+        (i32::MAX, vec![0x34, 0x7f, 0xff, 0xff, 0xff]),
+    ] {
+        for (len, prefix) in [
+            (0, vec![0x60]),
+            (4, vec![0x64]),
+            (5, vec![0x65, 5]),
+            (253, vec![0x65, 253]),
+            (254, vec![0x65, 254, 0, 254]),
+            (65535, vec![0x65, 254, 255, 255]),
+            (65536, vec![0x65, 255, 0, 1, 0, 0]),
+        ] {
+            for record in [false, true] {
+                let data = vec![42; len];
+                let ack = AtomicReadFileAck {
+                    end_of_file: false,
+                    access: if record {
+                        FileReadAckMethod::Record {
+                            file_start_record: start,
+                            returned_record_count: 2,
+                            file_record_data: vec![vec![], data.clone()],
+                        }
+                    } else {
+                        FileReadAckMethod::Stream {
+                            file_start_position: start,
+                            file_data: data.clone(),
+                        }
+                    },
+                };
+                let mut expected = vec![0x10, if record { 0x1e } else { 0x0e }];
+                expected.extend_from_slice(&signed);
+                if record {
+                    expected.extend_from_slice(&[0x21, 2, 0x60]);
+                }
+                expected.extend_from_slice(&prefix);
+                expected.extend_from_slice(&data);
+                expected.push(if record { 0x1f } else { 0x0f });
+                assert_eq!(ack.encoded_len_bounded(expected.len() - 1), None);
+                assert_eq!(
+                    ack.encoded_len_bounded(expected.len()),
+                    Some(expected.len())
+                );
+                assert_eq!(ack.encoded_len_bounded(usize::MAX), Some(expected.len()));
+                let mut encoded = BytesMut::new();
+                ack.encode(&mut encoded);
+                assert_eq!(&encoded[..], &expected);
+            }
+        }
+    }
+}
+
+#[test]
+fn atomic_read_file_ack_size_record_count_widths_and_empty_results() {
+    for (count, prefix) in [
+        (0, vec![0x21, 0]),
+        (255, vec![0x21, 255]),
+        (256, vec![0x22, 1, 0]),
+        (65535, vec![0x22, 255, 255]),
+        (65536, vec![0x23, 1, 0, 0]),
+    ] {
+        let ack = AtomicReadFileAck {
+            end_of_file: true,
+            access: FileReadAckMethod::Record {
+                file_start_record: 0,
+                returned_record_count: count,
+                file_record_data: vec![vec![]; count as usize],
+            },
+        };
+        let mut expected = vec![0x11, 0x1e, 0x31, 0];
+        expected.extend_from_slice(&prefix);
+        expected.resize(expected.len() + count as usize, 0x60);
+        expected.push(0x1f);
+        assert_eq!(ack.encoded_len_bounded(expected.len() - 1), None);
+        assert_eq!(
+            ack.encoded_len_bounded(expected.len()),
+            Some(expected.len())
+        );
+        let mut encoded = BytesMut::new();
+        ack.encode(&mut encoded);
+        assert_eq!(&encoded[..], &expected);
+    }
+}

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1792,6 +1792,9 @@ class BACnetServer:
         alarm_summary_max_service_ack_bytes: int = 16384,
         enrollment_summary_max_objects: int = 4096,
         enrollment_summary_max_service_ack_bytes: int = 16384,
+        atomic_read_file_max_requested_stream_octets: int = 16384,
+        atomic_read_file_max_requested_records: int = 256,
+        atomic_read_file_max_service_ack_bytes: int = 16384,
     ) -> None: ...
 
     # --- Analog objects ---

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -105,6 +105,7 @@ pub struct BACnetServer {
     read_property_multiple_budget: server::ReadPropertyMultipleBudget,
     get_alarm_summary_budget: server::GetAlarmSummaryBudget,
     get_enrollment_summary_budget: server::GetEnrollmentSummaryBudget,
+    atomic_read_file_budget: server::AtomicReadFileBudget,
     /// Whether the server has been started.
     started: Arc<AtomicBool>,
     /// Objects to add before starting. Cleared after start.

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -206,6 +206,7 @@ mod tests {
             read_property_multiple_budget: server::ReadPropertyMultipleBudget::default(),
             get_alarm_summary_budget: server::GetAlarmSummaryBudget::default(),
             get_enrollment_summary_budget: server::GetEnrollmentSummaryBudget::default(),
+            atomic_read_file_budget: server::AtomicReadFileBudget::default(),
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         }

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -41,6 +41,7 @@ impl BACnetServer {
         let read_property_multiple_budget = self.read_property_multiple_budget;
         let get_alarm_summary_budget = self.get_alarm_summary_budget;
         let get_enrollment_summary_budget = self.get_enrollment_summary_budget;
+        let atomic_read_file_budget = self.atomic_read_file_budget;
 
         let objects: Vec<Box<dyn BACnetObject + Send>> = {
             let mut guard = self.lock_pending()?;
@@ -148,6 +149,7 @@ impl BACnetServer {
                 .read_property_multiple_budget(read_property_multiple_budget)
                 .get_alarm_summary_budget(get_alarm_summary_budget)
                 .get_enrollment_summary_budget(get_enrollment_summary_budget)
+                .atomic_read_file_budget(atomic_read_file_budget)
                 .transport(transport);
             if let Some(pw) = dcc_password {
                 builder = builder.dcc_password(pw);

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -37,7 +37,10 @@ impl BACnetServer {
         alarm_summary_max_objects=4096,
         alarm_summary_max_service_ack_bytes=16384,
         enrollment_summary_max_objects=4096,
-        enrollment_summary_max_service_ack_bytes=16384
+        enrollment_summary_max_service_ack_bytes=16384,
+        atomic_read_file_max_requested_stream_octets=16384,
+        atomic_read_file_max_requested_records=256,
+        atomic_read_file_max_service_ack_bytes=16384
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -74,6 +77,9 @@ impl BACnetServer {
         alarm_summary_max_service_ack_bytes: usize,
         enrollment_summary_max_objects: usize,
         enrollment_summary_max_service_ack_bytes: usize,
+        atomic_read_file_max_requested_stream_octets: usize,
+        atomic_read_file_max_requested_records: usize,
+        atomic_read_file_max_service_ack_bytes: usize,
     ) -> PyResult<Self> {
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
@@ -107,6 +113,14 @@ impl BACnetServer {
         get_enrollment_summary_budget
             .validate()
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let atomic_read_file_budget = server::AtomicReadFileBudget {
+            max_requested_stream_octets: atomic_read_file_max_requested_stream_octets,
+            max_requested_records: atomic_read_file_max_requested_records,
+            max_service_ack_bytes: atomic_read_file_max_service_ack_bytes,
+        };
+        atomic_read_file_budget
+            .validate()
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(None)),
             device_instance,
@@ -134,6 +148,7 @@ impl BACnetServer {
             read_property_multiple_budget,
             get_alarm_summary_budget,
             get_enrollment_summary_budget,
+            atomic_read_file_budget,
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         })

--- a/crates/rusty-bacnet/tests/test_atomic_read_file_budget.py
+++ b/crates/rusty-bacnet/tests/test_atomic_read_file_budget.py
@@ -1,0 +1,105 @@
+"""Installed native AtomicReadFile policy and independent direct/routed UDP vectors."""
+import asyncio
+import inspect
+import socket
+import struct
+import unittest
+from pathlib import Path
+from typing import Any
+
+import rusty_bacnet
+from rusty_bacnet import BACnetServer
+
+
+class AtomicReadFileConstructorTests(unittest.TestCase):
+    def test_defaults_keyword_only_stub_and_positive_validation(self):
+        signature = inspect.signature(BACnetServer)
+        for name, default in [
+            ("atomic_read_file_max_requested_stream_octets", 16384),
+            ("atomic_read_file_max_requested_records", 256),
+            ("atomic_read_file_max_service_ack_bytes", 16384),
+        ]:
+            parameter = signature.parameters[name]
+            self.assertEqual(parameter.default, default)
+            self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+            self.assertIn(f"{name}: int = {default}",
+                          Path(rusty_bacnet.__file__).with_suffix(".pyi").read_text())
+            for transport in ["bip", "ipv6", "sc", "mstp"]:
+                for value, error in [(0, ValueError), (-1, OverflowError),
+                                     (1 << 200, OverflowError), (1.5, TypeError)]:
+                    with self.subTest(name=name, transport=transport, value=value):
+                        with self.assertRaises(error):
+                            BACnetServer(123, transport=transport, **{name: value})
+                positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
+                BACnetServer(123, transport=transport, **positive)
+
+
+class AtomicReadFileNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_complete_ack_or_abort_direct_and_routed(self):
+        for record in [False, True]:
+            work_name = ("atomic_read_file_max_requested_records" if record else
+                         "atomic_read_file_max_requested_stream_octets")
+            # Independent service vectors: File:1, CHOICE, INTEGER start0,
+            # Unsigned count, closure. Empty-record encoding remains present.
+            normal_count = 2 if record else 5
+            expected_ack = (b"\x11\x1e\x31\x00\x21\x02\x60\x65\x05abcde\x1f" if record
+                            else b"\x11\x0e\x31\x00\x65\x05abcde\x0f")
+            for policy, count, empty, abort in [
+                ({}, normal_count, False, None),
+                ({work_name: normal_count}, normal_count, False, None),
+                ({work_name: normal_count - 1}, normal_count, False, 9),
+                ({}, 257 if record else 16385, True, 9),
+                ({"atomic_read_file_max_service_ack_bytes": len(expected_ack) - 1}, normal_count, False, 1),
+                ({"atomic_read_file_max_service_ack_bytes": len(expected_ack)}, normal_count, False, None),
+                ({"atomic_read_file_max_service_ack_bytes": 1}, 0, True, 1),
+                ({}, 0, True, None),
+                ({work_name: 10001 if record else 16385}, 10001 if record else 16385, True, None),
+            ]:
+                with self.subTest(record=record, policy=policy, count=count, empty=empty):
+                    server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                          broadcast_address="127.0.0.1", **policy)
+                    server.add_file(1, "File")
+                    if record:
+                        server.set_file_access_method(1, "record")
+                        server.set_file_records(1, [] if empty else [b"", b"abcde"])
+                    else:
+                        server.set_file_data(1, b"" if empty else b"abcde")
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    sock.bind(("127.0.0.1", 0))
+                    sock.setblocking(False)
+                    loop = asyncio.get_running_loop()
+                    try:
+                        await server.start()
+                        ip, port = (await server.local_address()).rsplit(":", 1)
+                        for routed in [False, True]:
+                            for segmented in [False, True]:
+                                for peer in [0, 3]:  # 50 and 480 byte peer APDUs
+                                    invoke = 1 + peer + 4 * segmented + 8 * routed
+                                    header = b"\x01\x08\x00\x07\x01\x09" if routed else b"\x01\x00"
+                                    choice = 0x1e if record else 0x0e
+                                    count_wire = bytes([0x21, count]) if count < 256 else b"\x22" + count.to_bytes(2, "big")
+                                    request = b"\xc4\x02\x80\x00\x01" + bytes([choice, 0x31, 0]) + count_wire + bytes([choice + 1])
+                                    npdu = header + bytes([2 if segmented else 0, peer, invoke, 6]) + request
+                                    wire = b"\x81\x0a" + (len(npdu) + 4).to_bytes(2, "big") + npdu
+                                    await loop.sock_sendto(sock, wire, (ip, int(port)))
+                                    reply, _ = await asyncio.wait_for(loop.sock_recvfrom(sock, 4096), 2)
+                                    self.assertEqual(reply[:2], b"\x81\x0a")
+                                    self.assertEqual(int.from_bytes(reply[2:4], "big"), len(reply))
+                                    if routed:
+                                        self.assertEqual(reply[4:11], b"\x01\x20\x00\x07\x01\x09\xff")
+                                    apdu = reply[11:] if routed else reply[6:]
+                                    if abort is not None:
+                                        self.assertEqual(apdu, bytes([0x71, invoke, abort]))
+                                    else:
+                                        expected = expected_ack
+                                        if empty:
+                                            expected = b"\x11\x1e\x31\x00\x21\x00\x1f" if record else b"\x11\x0e\x31\x00\x60\x0f"
+                                        self.assertEqual(apdu, bytes([0x30, invoke, 6]) + expected)
+                                    async with asyncio.timeout(2):
+                                        while (await server.request_admission_counters())["confirmed_active"]:
+                                            await asyncio.sleep(0)
+                                    with self.assertRaises(BlockingIOError):
+                                        sock.recvfrom(4096)
+                    finally:
+                        await server.stop()
+                        sock.close()

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -68,6 +68,8 @@ SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
     "rpm_max_result_elements", "rpm_max_service_ack_bytes",
     "alarm_summary_max_objects", "alarm_summary_max_service_ack_bytes",
     "enrollment_summary_max_objects", "enrollment_summary_max_service_ack_bytes",
+    "atomic_read_file_max_requested_stream_octets", "atomic_read_file_max_requested_records",
+    "atomic_read_file_max_service_ack_bytes",
 ]
 SUPPORTED_BAUD_RATES = (9_600, 19_200, 38_400, 57_600, 76_800, 115_200)
 SUPPORTED_BAUD_ERROR = (

--- a/docs/atomic-read-file-budget.md
+++ b/docs/atomic-read-file-budget.md
@@ -1,0 +1,76 @@
+# AtomicReadFile local budgets
+
+The configured server applies positive, operator-configurable local defaults:
+
+| Rust `AtomicReadFileBudget` field | Default |
+| --- | ---: |
+| `max_requested_stream_octets` | 16384 |
+| `max_requested_records` | 256 |
+| `max_service_ack_bytes` | 16384 |
+
+These are owner policy, not BACnet-mandated thresholds or benchmark results.
+The byte limit measures the **complete logical service ACK**, including Boolean,
+CHOICE tags, start integer, returned record count, every octet-string prefix and
+closing tag. APDU/NPDU overhead is excluded. A full 16384-octet payload therefore
+exceeds the default 16384-byte ACK limit; raise that limit if it must be returned.
+
+Validation retains this order: decode, File identifier/type and lookup, storage
+hook availability, File_Access_Method, negative start conversion, then the **raw
+request count** limit. Excess counts return a whole-service server Abort
+`OUT_OF_RESOURCES` before `read_stream`/`read_records`, even near/at EOF or for an
+empty file, and before storage checks for beyond-EOF starts or read failures.
+No extra storage-size property or metadata reads are performed. Admitted storage
+errors retain their prior behavior. Zero request counts remain admitted; zero
+configuration limits are invalid.
+
+For records the raw limit precedes the existing `min(requested, 10000)` storage
+read window. Raising the limit above 10000 does not remove that legacy local
+window; it is not a normative BACnet limit. This change makes no new claim about
+zero-count, empty-file, at-end, or short-read compliance.
+
+After one successful storage read, bounded checked size arithmetic inspects only
+lengths, without payload copies or per-record clones. An oversized ACK returns
+whole-service server Abort `BUFFER_OVERFLOW` before encoding payload into the
+response. Budget and service failures leave caller output unchanged; there is
+no new budget-driven short successful read or fabricated EOF. Within-budget
+encoding, storage EOF, routing, and generic response segmentation are unchanged.
+The policy is independent of peer APDU size and segmentation capability.
+
+## Configuration and migration
+
+Rust exports `bacnet_server::server::AtomicReadFileBudget`. Set
+`ServerConfig::atomic_read_file_budget` or use `atomic_read_file_budget(...)` on
+generic, B/IP, or SC builders. Positive validation precedes transport startup and
+SC dialing. Existing exhaustive `ServerConfig` literals need
+`atomic_read_file_budget: Default::default()` (or a default struct update).
+The public unconfigured `handle_atomic_read_file` helper remains unconfigured
+and compatible; configured server dispatch uses the budgeted path.
+
+Python `BACnetServer` adds keyword-only arguments:
+`atomic_read_file_max_requested_stream_octets=16384`,
+`atomic_read_file_max_requested_records=256`, and
+`atomic_read_file_max_service_ack_bytes=16384`. Stubs match native defaults.
+Zero raises `ValueError`; negative/out-of-platform-range integers raise
+`OverflowError` before transport setup.
+
+## Deliberate limits of this policy
+
+Excluded: existing request decoding and metadata/property/storage hooks, opaque
+storage callback work and allocations, the single owned read result (including
+one giant record), allocator capacity, actual OOM, RSS, CPU, deadlines and rollback.
+**Requested record count is not a total storage-byte bound.** This is not a
+whole-memory guarantee or preemption mechanism. No FileStorage API changes,
+AtomicWriteFile changes, file writes, authorization/fairness policy, other-service
+budgets, or broader support/issue-closure claims are included. Audit/#125,
+EventLog/#181, GATE0007 and SC identity hard stops remain unchanged.
+
+## Source rationale
+
+Local licensed ASHRAE 135-2020: §14.1 (printed 725–727 / PDF 727–729) supplies the
+read procedure and existing validations; §21 (printed 861–863 / PDF 863–865)
+supplies the stream/record service productions. §18.10 (printed 800–801 / PDF
+802–803) distinguishes inability to start due to resources from buffer overflow;
+§18.11 distinguishes actual dynamic allocation failure. §5.4.5.3 (printed 48–49 /
+PDF 50–51) provides the surrounding Abort/segmentation behavior. The thresholds,
+raw-count precedence over opaque storage failures, and resource exclusions here
+are explicitly approved local policy, not new interpretations of normal reads.


### PR DESCRIPTION
## Summary
Refs #521. AtomicReadFile-only owner-approved positive defaults: raw requested stream octets16384, raw requested records256, complete logical service-ACK bytes16384. Rust/Python configuration and migration included.

Existing handler validation retains precedence. Over-budget raw counts return whole-service server Abort OUT_OF_RESOURCES before storage reads, including at/near EOF and before opaque storage read errors. Admitted records retain the existing10000-record window. After a successful read, checked bounded size arithmetic rejects oversized ACKs with BUFFER_OVERFLOW before payload copying/encoding; no new truncated success or fabricated EOF. Within-budget storage semantics, legacy helper, routing and segmentation retained. AtomicWriteFile/storage API unchanged.

## Validation
- Genuine unchanged-production baseline RED2 to GREEN: oversized stream/record requests formerly succeeded with empty ACKs.
- Final File server65/services42/objects59; summary54/enrollment209/alarm60/segmentation70/admission42/DCC28/SC1 pass.
- Server984unit+3integration; integration39; workspace4314passed/3existing ignored. Fmt/clippy(warnings)/size/secrets/diff/new-file/binding gates pass.
- Fresh locked CPython3.12.13 macOSarm64 wheel after final production:44tests/423subtests pass, root independently reran. Focused repeat2/66; native/stub/direct_url verified.
- Wheel SHA256 ef875a3a36d55272228fd2b193eb93e49c78e8dfecca293986e524b26f2e938c.
- Complete309-byte stream/312-byte record ACK reassembly with50-byte peer APDU tested.

## Boundaries
ACK cap includes service overhead, so16384 payload bytes need a raised ACK cap. Raw-count thresholds apply even if fewer data remain. Opaque storage work/allocations and one owned result (including giant record), metadata/decode, allocator/OOM/RSS/CPU/deadline/rollback excluded. Requested record count is not total storage bytes. Existing10000window/zero/EOF behavior preserved, no new conformance claim. #521 stays partial; #522/Audit#125/EventLog#181/GATE0007/SC hard stops unchanged. No writes, storage API, new CI, other service or support expansion.

Two independent exact-head reviews and CI pending.