### PR TITLE
feat(server): bound ReadRange response pages

### DIFF
--- a/crates/bacnet-server/src/handlers/read_range.rs
+++ b/crates/bacnet-server/src/handlers/read_range.rs
@@ -5,6 +5,10 @@ use bacnet_objects::log_buffer::LogRecordIdentity;
 use bacnet_services::read_range::{RangeSpec, ReadRangeAck, ReadRangeRequest};
 use bacnet_types::primitives::{Date, Time};
 
+#[path = "read_range_page.rs"]
+mod page;
+pub(crate) use page::ReadRangeFailure;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct SignedRangeSelection {
     pub(super) range: Range<usize>,
@@ -175,6 +179,39 @@ pub fn handle_read_range(
     service_data: &[u8],
     response: &mut BytesMut,
 ) -> Result<(), Error> {
+    let selected = prepare_read_range(db, service_data)?;
+    append_read_range_ack_with(
+        &selected.request,
+        &selected.items,
+        &selected.selection,
+        selected.first_sequence_number,
+        response,
+        encode_property_value,
+    )
+}
+
+pub(crate) fn handle_read_range_budgeted(
+    db: &ObjectDatabase,
+    service_data: &[u8],
+    response: &mut BytesMut,
+    budget: crate::server::ReadRangeBudget,
+) -> Result<(), ReadRangeFailure> {
+    let selected = prepare_read_range(db, service_data).map_err(ReadRangeFailure::Service)?;
+    page::append_page_with(&selected, response, budget, encode_property_value)
+}
+
+struct PreparedReadRange {
+    request: ReadRangeRequest,
+    items: Vec<PropertyValue>,
+    selection: SignedRangeSelection,
+    first_sequence_number: Option<u32>,
+    identities: Option<Vec<LogRecordIdentity>>,
+}
+
+fn prepare_read_range(
+    db: &ObjectDatabase,
+    service_data: &[u8],
+) -> Result<PreparedReadRange, Error> {
     let request = ReadRangeRequest::decode(service_data)?;
     let object = db.get(&request.object_identifier).ok_or(Error::Protocol {
         class: ErrorClass::OBJECT.to_raw() as u32,
@@ -199,6 +236,7 @@ pub fn handle_read_range(
         }
     };
 
+    let mut resident_identities = None;
     let (selection, first_sequence_number) = match &request.range {
         None => (
             SignedRangeSelection::from_range(items.len(), 0..items.len()),
@@ -232,6 +270,7 @@ pub fn handle_read_range(
             let selection = select_signed_range(items.len(), reference, *count);
             let first_sequence_number = (!selection.range.is_empty())
                 .then(|| identities[selection.range.start].sequence_number());
+            resident_identities = Some(identities);
             (selection, first_sequence_number)
         }
         Some(RangeSpec::ByTime {
@@ -241,17 +280,21 @@ pub fn handle_read_range(
             if request.property_identifier != PropertyIdentifier::LOG_BUFFER {
                 return Err(list_item_not_timestamped());
             }
-            let identities = object.log_record_identities_internal();
-            select_time_range(items.len(), identities.as_deref(), *reference_time, *count)?
+            resident_identities = object.log_record_identities_internal();
+            select_time_range(
+                items.len(),
+                resident_identities.as_deref(),
+                *reference_time,
+                *count,
+            )?
         }
     };
 
-    append_read_range_ack_with(
-        &request,
-        &items,
-        &selection,
+    Ok(PreparedReadRange {
+        request,
+        items,
+        selection,
         first_sequence_number,
-        response,
-        encode_property_value,
-    )
+        identities: resident_identities,
+    })
 }

--- a/crates/bacnet-server/src/handlers/read_range_page.rs
+++ b/crates/bacnet-server/src/handlers/read_range_page.rs
@@ -1,0 +1,125 @@
+//! Directional, contiguous ReadRange pages after all selection validation.
+use super::*;
+use crate::server::ReadRangeBudget;
+
+#[cfg(test)]
+#[path = "tests/read_range_page_encoding.rs"]
+mod tests;
+
+#[derive(Debug)]
+pub(crate) enum ReadRangeFailure {
+    Service(Error),
+    Bytes,
+}
+
+fn negative(range: &Option<RangeSpec>) -> bool {
+    matches!(range,
+        Some(RangeSpec::ByPosition { count, .. }
+        | RangeSpec::BySequenceNumber { count, .. }
+        | RangeSpec::ByTime { count, .. }) if *count < 0)
+}
+
+fn envelope(
+    selected: &PreparedReadRange,
+    range: Range<usize>,
+) -> Result<ReadRangeAck, ReadRangeFailure> {
+    let count = u32::try_from(range.len()).map_err(|_| ReadRangeFailure::Bytes)?;
+    Ok(ReadRangeAck {
+        object_identifier: selected.request.object_identifier,
+        property_identifier: selected.request.property_identifier,
+        property_array_index: selected.request.property_array_index,
+        result_flags: if range.is_empty() {
+            (false, false, false)
+        } else {
+            (
+                range.start == 0,
+                range.end == selected.items.len(),
+                range != selected.selection.range,
+            )
+        },
+        item_count: count,
+        item_data: Vec::new(),
+        first_sequence_number: selected
+            .identities
+            .as_ref()
+            .filter(|_| count != 0)
+            .map(|ids| ids[range.start].sequence_number()),
+    })
+}
+
+pub(super) fn append_page_with<F>(
+    selected: &PreparedReadRange,
+    response: &mut BytesMut,
+    budget: ReadRangeBudget,
+    mut encode_item: F,
+) -> Result<(), ReadRangeFailure>
+where
+    F: FnMut(&mut BytesMut, &PropertyValue) -> Result<(), Error>,
+{
+    let backwards = negative(&selected.request.range);
+    let matching = selected.selection.range.clone();
+    let mut range = if backwards {
+        matching.end..matching.end
+    } else {
+        matching.start..matching.start
+    };
+    let mut ack = envelope(selected, range.clone())?;
+    let mut header = BytesMut::new();
+    ack.encode(&mut header);
+    if header.len() > budget.max_service_ack_bytes {
+        return Err(ReadRangeFailure::Bytes);
+    }
+
+    // Store each accepted encoding once. Backward traversal reverses chunks, not
+    // bytes, at final assembly; prepending/re-encoding the growing page is quadratic.
+    let mut chunks = Vec::new();
+    let mut accepted_bytes = 0usize;
+    for offset in 0..matching.len() {
+        if chunks.len() >= budget.max_returned_items || chunks.len() >= u32::MAX as usize {
+            break;
+        }
+        let index = if backwards {
+            matching.end - 1 - offset
+        } else {
+            matching.start + offset
+        };
+        let candidate = if backwards {
+            index..matching.end
+        } else {
+            matching.start..index + 1
+        };
+        let next_ack = envelope(selected, candidate.clone())?;
+        header.clear();
+        next_ack.encode(&mut header);
+        if header.len() > budget.max_service_ack_bytes {
+            break;
+        }
+        let mut item = BytesMut::new();
+        encode_item(&mut item, &selected.items[index]).map_err(ReadRangeFailure::Service)?;
+        let Some(bytes) = accepted_bytes.checked_add(item.len()) else {
+            break;
+        };
+        if bytes > budget.max_service_ack_bytes - header.len() {
+            break;
+        }
+        chunks.push(item);
+        accepted_bytes = bytes;
+        range = candidate;
+        ack = next_ack;
+    }
+    if !matching.is_empty() && range.is_empty() {
+        return Err(ReadRangeFailure::Bytes);
+    }
+    if backwards {
+        chunks.reverse();
+    }
+    ack.item_data = Vec::with_capacity(accepted_bytes);
+    for chunk in chunks {
+        ack.item_data.extend_from_slice(&chunk);
+    }
+    let mut encoded = BytesMut::new();
+    ack.encode(&mut encoded);
+    debug_assert!(encoded.len() <= budget.max_service_ack_bytes);
+    response.extend_from_slice(&encoded);
+    Ok(())
+}

--- a/crates/bacnet-server/src/handlers/tests/read_range.rs
+++ b/crates/bacnet-server/src/handlers/tests/read_range.rs
@@ -10,6 +10,11 @@ use bacnet_services::read_range::{RangeSpec, ReadRangeAck, ReadRangeRequest};
 use bacnet_types::constructed::{BACnetLogRecord, LogDatum};
 use bacnet_types::primitives::{Date, Time};
 
+#[path = "read_range_pages.rs"]
+mod pages;
+#[path = "read_range_wire.rs"]
+mod wire;
+
 pub(super) const DATE: Date = Date {
     year: 126,
     month: 8,
@@ -199,6 +204,41 @@ fn by_position_is_one_based_signed_and_reports_exact_endpoints() {
         .unwrap();
         assert_ack(&ack, &[], (false, false, false), None);
     }
+}
+
+#[tokio::test]
+async fn read_range_default_257_returns_256_item_page() {
+    use crate::server::BACnetServer;
+    use bacnet_client::client::BACnetClient;
+    use std::net::Ipv4Addr;
+
+    let items = unsigned_items(&(0..257).collect::<Vec<_>>());
+    let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, items.clone(), None);
+    let mut server = BACnetServer::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .database(db)
+        .build()
+        .await
+        .unwrap();
+    let mut client = BACnetClient::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .build()
+        .await
+        .unwrap();
+    let result = client
+        .read_range(
+            server.local_mac(),
+            oid,
+            PropertyIdentifier::LOG_BUFFER,
+            None,
+            None,
+        )
+        .await;
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+    assert_ack(&result.unwrap(), &items[..256], (true, false, true), None);
 }
 
 #[test]

--- a/crates/bacnet-server/src/handlers/tests/read_range_page_encoding.rs
+++ b/crates/bacnet-server/src/handlers/tests/read_range_page_encoding.rs
@@ -1,0 +1,198 @@
+use super::*;
+
+fn selected(
+    backwards: bool,
+    property: u32,
+    index: Option<u32>,
+    sequences: Option<&[u32]>,
+) -> PreparedReadRange {
+    PreparedReadRange {
+        request: ReadRangeRequest {
+            object_identifier: ObjectIdentifier::new(ObjectType::TREND_LOG, 1).unwrap(),
+            property_identifier: PropertyIdentifier::from_raw(property),
+            property_array_index: index,
+            range: Some(RangeSpec::ByPosition {
+                reference_index: if backwards { 3 } else { 1 },
+                count: if backwards { -3 } else { 3 },
+            }),
+        },
+        items: vec![
+            PropertyValue::Unsigned(1),
+            PropertyValue::Unsigned(2),
+            PropertyValue::Unsigned(3),
+        ],
+        selection: SignedRangeSelection::from_range(3, 0..3),
+        first_sequence_number: sequences.map(|s| s[0]),
+        identities: sequences.map(|s| {
+            s.iter()
+                .map(|seq| {
+                    LogRecordIdentity::new(
+                        *seq,
+                        Date {
+                            year: 126,
+                            month: 9,
+                            day: 1,
+                            day_of_week: 2,
+                        },
+                        Time {
+                            hour: 1,
+                            minute: 0,
+                            second: 0,
+                            hundredths: 0,
+                        },
+                    )
+                    .unwrap()
+                })
+                .collect()
+        }),
+    }
+}
+
+#[test]
+fn bounded_encode_calls_defer_failures_and_preserve_output_on_current_error() {
+    for backwards in [false, true] {
+        let selected = selected(backwards, 131, None, None);
+        for (cap, byte_cap, failure_at, expected_calls, success) in [
+            (1, 100, 2, 1, true),  // next item deferred, never encoded
+            (3, 16, 3, 2, true),   // one fitting item, one oversized trial, third untouched
+            (3, 100, 2, 2, false), // error after accepted scratch, not a successful page
+            (3, 13, 1, 0, false),  // even empty header cannot fit
+            (3, 15, 3, 1, false),  // first item cannot fit; no empty MORE_ITEMS loop
+        ] {
+            let mut output = BytesMut::from(&b"old"[..]);
+            let mut calls = 0;
+            let mut order = Vec::new();
+            let result = append_page_with(
+                &selected,
+                &mut output,
+                ReadRangeBudget {
+                    max_returned_items: cap,
+                    max_service_ack_bytes: byte_cap,
+                },
+                |buf, item| {
+                    calls += 1;
+                    order.push(item.clone());
+                    if calls == failure_at {
+                        return Err(Error::Encoding("current item".into()));
+                    }
+                    encode_property_value(buf, item)
+                },
+            );
+            assert_eq!(calls, expected_calls);
+            assert_eq!(result.is_ok(), success);
+            if success {
+                let ack = ReadRangeAck::decode(&output[3..]).unwrap();
+                assert_eq!(ack.item_count, 1);
+                assert_eq!(ack.result_flags, (!backwards, backwards, true));
+            } else {
+                assert_eq!(&output[..], b"old");
+                if calls == failure_at {
+                    assert!(matches!(
+                        result,
+                        Err(ReadRangeFailure::Service(Error::Encoding(_)))
+                    ));
+                } else {
+                    assert!(matches!(result, Err(ReadRangeFailure::Bytes)));
+                }
+            }
+            if calls > 0 {
+                assert_eq!(order[0], selected.items[if backwards { 2 } else { 0 }]);
+            }
+        }
+    }
+}
+
+#[test]
+fn exact_envelopes_include_property_index_and_changing_first_sequence_widths() {
+    for property in [255, 256, 65535, 65536, u32::MAX] {
+        for index in [
+            None,
+            Some(255),
+            Some(256),
+            Some(65535),
+            Some(65536),
+            Some(u32::MAX),
+        ] {
+            for sequences in [[u32::MAX, 255, 256], [1, 65536, 65535], [256, 1, u32::MAX]] {
+                for backwards in [false, true] {
+                    let selected = selected(backwards, property, index, Some(&sequences));
+                    // Independent field-width arithmetic: OID=5, flags=3, count=2,
+                    // opening/closing tags=2; unsigned/enumerated fields add tag+width.
+                    let width = |x: u32| {
+                        if x <= 255 {
+                            1
+                        } else if x <= 65535 {
+                            2
+                        } else if x <= 16777215 {
+                            3
+                        } else {
+                            4
+                        }
+                    };
+                    let fixed = 12 + 1 + width(property) + index.map_or(0, |i| 1 + width(i));
+                    for n in [1, 2, 3] {
+                        let first = if backwards { 3 - n } else { 0 };
+                        let bytes = fixed + n * 2 + 1 + width(sequences[first]);
+                        let mut output = BytesMut::new();
+                        let result = append_page_with(
+                            &selected,
+                            &mut output,
+                            ReadRangeBudget {
+                                max_returned_items: n,
+                                max_service_ack_bytes: bytes,
+                            },
+                            encode_property_value,
+                        );
+                        // A later narrower identity must not rescue a page whose
+                        // directional first item (or earlier candidate) did not fit.
+                        let first_over = (1..=n).find(|m| {
+                            let start = if backwards { 3 - m } else { 0 };
+                            fixed + m * 2 + 1 + width(sequences[start]) > bytes
+                        });
+                        if let Some(m) = first_over {
+                            if m == 1 {
+                                assert!(matches!(result, Err(ReadRangeFailure::Bytes)));
+                                assert!(output.is_empty());
+                            } else {
+                                result.unwrap();
+                                assert_eq!(
+                                    ReadRangeAck::decode(&output).unwrap().item_count,
+                                    (m - 1) as u32
+                                );
+                            }
+                            continue;
+                        }
+                        result.unwrap();
+                        assert_eq!(output.len(), bytes);
+                        let ack = ReadRangeAck::decode(&output).unwrap();
+                        assert_eq!(ack.first_sequence_number, Some(sequences[first]));
+                        assert_eq!(ack.item_count, n as u32);
+                        let mut expected = BytesMut::new();
+                        for item in &selected.items[if backwards { 3 - n..3 } else { 0..n }] {
+                            encode_property_value(&mut expected, item).unwrap();
+                        }
+                        assert_eq!(ack.item_data, expected);
+                        let mut under = BytesMut::from(&b"old"[..]);
+                        let result = append_page_with(
+                            &selected,
+                            &mut under,
+                            ReadRangeBudget {
+                                max_returned_items: n,
+                                max_service_ack_bytes: bytes - 1,
+                            },
+                            encode_property_value,
+                        );
+                        if n == 1 {
+                            assert!(matches!(result, Err(ReadRangeFailure::Bytes)));
+                            assert_eq!(&under[..], b"old");
+                        } else if result.is_ok() {
+                            assert!(
+                                ReadRangeAck::decode(&under[3..]).unwrap().item_count < n as u32
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/handlers/tests/read_range_pages.rs
+++ b/crates/bacnet-server/src/handlers/tests/read_range_pages.rs
@@ -1,0 +1,358 @@
+use super::*;
+use crate::server::ReadRangeBudget;
+
+fn page(
+    db: &ObjectDatabase,
+    oid: ObjectIdentifier,
+    range: Option<RangeSpec>,
+    cap: usize,
+    bytes: usize,
+) -> Result<ReadRangeAck, ReadRangeFailure> {
+    let request = ReadRangeRequest {
+        object_identifier: oid,
+        property_identifier: PropertyIdentifier::LOG_BUFFER,
+        property_array_index: None,
+        range,
+    };
+    let mut input = BytesMut::new();
+    request.encode(&mut input);
+    let mut output = BytesMut::from(&b"sentinel"[..]);
+    let result = handle_read_range_budgeted(
+        db,
+        &input,
+        &mut output,
+        ReadRangeBudget {
+            max_returned_items: cap,
+            max_service_ack_bytes: bytes,
+        },
+    );
+    if result.is_err() {
+        assert_eq!(&output[..], b"sentinel");
+    }
+    result?;
+    assert!(output.len() - 8 <= bytes);
+    Ok(ReadRangeAck::decode(&output[8..]).unwrap())
+}
+
+#[test]
+fn directional_pages_preserve_sparse_wrapped_resident_identity() {
+    let items = unsigned_items(&[10, 20, 30, 40, 50]);
+    let ids = vec![
+        identity(u32::MAX, 1),
+        identity(1, 2),
+        identity(255, 3),
+        identity(65536, 4),
+        identity(9, 5),
+    ];
+    let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, items.clone(), Some(ids));
+    for cap in [1, 2, 5, 256] {
+        for kind in 0..3 {
+            for backwards in [false, true] {
+                let count = if backwards { -4 } else { 4 };
+                let range = match kind {
+                    0 => RangeSpec::ByPosition {
+                        reference_index: if backwards { 4 } else { 2 },
+                        count,
+                    },
+                    1 => RangeSpec::BySequenceNumber {
+                        reference_seq: if backwards { 65536 } else { 1 },
+                        count,
+                    },
+                    _ => RangeSpec::ByTime {
+                        reference_time: (DATE, time(if backwards { 5 } else { 1 })),
+                        count,
+                    },
+                };
+                let n = cap.min(4);
+                let expected = if backwards { 4 - n..4 } else { 1..1 + n };
+                let first = (kind != 0).then(|| [u32::MAX, 1, 255, 65536, 9][expected.start]);
+                let ack = page(&db, oid, Some(range), cap, 16384).unwrap();
+                assert_ack(
+                    &ack,
+                    &items[expected.clone()],
+                    (expected.start == 0, expected.end == 5, n < 4),
+                    first,
+                );
+            }
+        }
+        let n = cap.min(5);
+        assert_ack(
+            &page(&db, oid, None, cap, 16384).unwrap(),
+            &items[..n],
+            (true, n == 5, n < 5),
+            None,
+        );
+    }
+}
+
+#[test]
+fn count_width_255_256_and_default_exact_limit() {
+    for total in [256, 257] {
+        let items = vec![PropertyValue::Unsigned(1); total];
+        let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, items.clone(), None);
+        let unlimited = call(&db, oid, PropertyIdentifier::LOG_BUFFER, None).unwrap();
+        for n in [1, 255, 256] {
+            let ack = page(&db, oid, None, n, 16384).unwrap();
+            let mut encoded = BytesMut::new();
+            ack.encode(&mut encoded);
+            assert_eq!(encoded.len(), 12 + if n == 256 { 3 } else { 2 } + n * 2);
+            assert_ack(
+                &page(&db, oid, None, usize::MAX, encoded.len()).unwrap(),
+                &items[..n],
+                (true, n == total, n < total),
+                None,
+            );
+            if n > 1 {
+                assert_eq!(
+                    page(&db, oid, None, usize::MAX, encoded.len() - 1)
+                        .unwrap()
+                        .item_count,
+                    (n - 1) as u32
+                );
+            }
+        }
+        let parity = page(&db, oid, None, usize::MAX, usize::MAX).unwrap();
+        let mut actual = BytesMut::new();
+        let mut expected = BytesMut::new();
+        parity.encode(&mut actual);
+        unlimited.encode(&mut expected);
+        assert_eq!(actual, expected);
+    }
+}
+
+#[test]
+fn missing_references_empty_lists_and_validation_precede_tiny_budget() {
+    let (db, oid) = list_db(
+        PropertyIdentifier::LOG_BUFFER,
+        unsigned_items(&[1]),
+        Some(vec![identity(1, 1)]),
+    );
+    for range in [
+        RangeSpec::ByPosition {
+            reference_index: 2,
+            count: -1,
+        },
+        RangeSpec::BySequenceNumber {
+            reference_seq: 2,
+            count: 1,
+        },
+        RangeSpec::ByTime {
+            reference_time: (DATE, time(0)),
+            count: -1,
+        },
+    ] {
+        assert_ack(
+            &page(&db, oid, Some(range.clone()), 1, 14).unwrap(),
+            &[],
+            (false, false, false),
+            None,
+        );
+        assert!(matches!(
+            page(&db, oid, Some(range), 1, 13),
+            Err(ReadRangeFailure::Bytes)
+        ));
+    }
+    let (empty, empty_oid) = list_db(PropertyIdentifier::LOG_BUFFER, vec![], None);
+    assert_ack(
+        &page(&empty, empty_oid, None, 1, 14).unwrap(),
+        &[],
+        (false, false, false),
+        None,
+    );
+    for ids in [None, Some(vec![])] {
+        let (bad, bad_oid) = list_db(PropertyIdentifier::LOG_BUFFER, unsigned_items(&[1]), ids);
+        for range in [
+            RangeSpec::BySequenceNumber {
+                reference_seq: 1,
+                count: 1,
+            },
+            RangeSpec::ByTime {
+                reference_time: (DATE, time(0)),
+                count: 1,
+            },
+        ] {
+            assert!(matches!(
+                page(&bad, bad_oid, Some(range), 1, 1),
+                Err(ReadRangeFailure::Service(Error::Protocol { .. }))
+            ));
+        }
+    }
+    for count in [0, 32768, -32769] {
+        assert!(matches!(
+            page(
+                &db,
+                oid,
+                Some(RangeSpec::ByPosition {
+                    reference_index: 1,
+                    count
+                }),
+                1,
+                1
+            ),
+            Err(ReadRangeFailure::Service(Error::Decoding { .. }))
+        ));
+    }
+    assert!(matches!(
+        page(&empty, oid, None, 1, 1),
+        Err(ReadRangeFailure::Bytes)
+    ));
+    let missing_oid = ObjectIdentifier::new(ObjectType::TREND_LOG, 92).unwrap();
+    assert!(
+        matches!(page(&db, missing_oid, None, 1, 1), Err(ReadRangeFailure::Service(Error::Protocol { code, .. }))
+        if code == ErrorCode::UNKNOWN_OBJECT.to_raw() as u32)
+    );
+}
+
+#[test]
+fn read_range_error_precedence_matches_legacy_before_pagination() {
+    let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, unsigned_items(&[1]), None);
+    for (property, index, range) in [
+        (PropertyIdentifier::LOG_BUFFER, Some(0), None),
+        (PropertyIdentifier::LOG_BUFFER, Some(1), None),
+        (PropertyIdentifier::ALL, None, None),
+        (PropertyIdentifier::REQUIRED, None, None),
+        (PropertyIdentifier::OPTIONAL, None, None),
+        (PropertyIdentifier::PRESENT_VALUE, None, None),
+        (
+            PropertyIdentifier::LOG_BUFFER,
+            None,
+            Some(RangeSpec::ByTime {
+                reference_time: (DATE, time(24)),
+                count: 1,
+            }),
+        ),
+    ] {
+        let mut request = BytesMut::new();
+        ReadRangeRequest {
+            object_identifier: oid,
+            property_identifier: property,
+            property_array_index: index,
+            range,
+        }
+        .encode(&mut request);
+        let legacy = handle_read_range(&db, &request, &mut BytesMut::new()).unwrap_err();
+        let mut output = BytesMut::from(&b"old"[..]);
+        let ReadRangeFailure::Service(error) = handle_read_range_budgeted(
+            &db,
+            &request,
+            &mut output,
+            ReadRangeBudget {
+                max_returned_items: 1,
+                max_service_ack_bytes: 1,
+            },
+        )
+        .unwrap_err() else {
+            panic!("budget hid existing error")
+        };
+        assert_eq!(error.to_string(), legacy.to_string());
+        assert_eq!(&output[..], b"old");
+    }
+    let mut scalar_db = ObjectDatabase::new();
+    let scalar = bacnet_objects::analog::AnalogValueObject::new(1, "scalar", 62).unwrap();
+    let scalar_oid = scalar.object_identifier();
+    scalar_db.add(Box::new(scalar)).unwrap();
+    let mut request = BytesMut::new();
+    ReadRangeRequest {
+        object_identifier: scalar_oid,
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+        range: None,
+    }
+    .encode(&mut request);
+    assert!(
+        matches!(handle_read_range_budgeted(&scalar_db, &request, &mut BytesMut::new(),
+        ReadRangeBudget { max_returned_items:1, max_service_ack_bytes:1 }),
+        Err(ReadRangeFailure::Service(Error::Protocol { code, .. })) if code == ErrorCode::PROPERTY_IS_NOT_A_LIST.to_raw() as u32)
+    );
+}
+
+#[test]
+fn byte_overflow_never_skips_or_loses_direction_anchor() {
+    let items = vec![
+        PropertyValue::Unsigned(1),
+        PropertyValue::OctetString(vec![0; 100]),
+        PropertyValue::Unsigned(3),
+    ];
+    let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, items.clone(), None);
+    for backwards in [false, true] {
+        let range = Some(RangeSpec::ByPosition {
+            reference_index: if backwards { 3 } else { 1 },
+            count: if backwards { -3 } else { 3 },
+        });
+        let ack = page(&db, oid, range, 10, 20).unwrap();
+        assert_ack(
+            &ack,
+            &items[if backwards { 2..3 } else { 0..1 }],
+            (!backwards, backwards, true),
+            None,
+        );
+        let oversized = Some(RangeSpec::ByPosition {
+            reference_index: 2,
+            count: if backwards { -2 } else { 2 },
+        });
+        assert!(matches!(
+            page(&db, oid, oversized, 10, 20),
+            Err(ReadRangeFailure::Bytes)
+        ));
+    }
+}
+
+#[tokio::test]
+async fn read_range_client_pages_all_matches_forward_and_backward() {
+    use crate::server::BACnetServer;
+    use bacnet_client::client::BACnetClient;
+    use std::net::Ipv4Addr;
+    let items = unsigned_items(&[10, 20, 30, 40, 50]);
+    let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, items.clone(), None);
+    let mut server = BACnetServer::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .database(db)
+        .read_range_budget(ReadRangeBudget {
+            max_returned_items: 2,
+            ..Default::default()
+        })
+        .build()
+        .await
+        .unwrap();
+    let mut client = BACnetClient::bip_builder()
+        .interface(Ipv4Addr::LOCALHOST)
+        .port(0)
+        .build()
+        .await
+        .unwrap();
+    for backwards in [false, true] {
+        let mut remaining = 5;
+        let mut pieces = Vec::new();
+        while remaining > 0 {
+            let reference_index = if backwards { remaining } else { 6 - remaining };
+            let ack = client
+                .read_range(
+                    server.local_mac(),
+                    oid,
+                    PropertyIdentifier::LOG_BUFFER,
+                    None,
+                    Some(RangeSpec::ByPosition {
+                        reference_index,
+                        count: if backwards {
+                            -(remaining as i32)
+                        } else {
+                            remaining as i32
+                        },
+                    }),
+                )
+                .await
+                .unwrap();
+            assert!(ack.item_count > 0 && ack.item_count <= 2);
+            remaining -= ack.item_count;
+            assert_eq!(ack.result_flags.2, remaining > 0);
+            pieces.push(ack.item_data);
+        }
+        if backwards {
+            pieces.reverse();
+        }
+        assert_eq!(pieces.concat(), encoded_items(&items));
+    }
+    client.stop().await.unwrap();
+    server.stop().await.unwrap();
+}

--- a/crates/bacnet-server/src/handlers/tests/read_range_wire.rs
+++ b/crates/bacnet-server/src/handlers/tests/read_range_wire.rs
@@ -1,0 +1,217 @@
+use super::*;
+use crate::server::{BACnetServer, ReadRangeBudget, ServerConfig};
+use bacnet_encoding::apdu::{decode_apdu, encode_apdu, Apdu, ConfirmedRequest};
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu, NpduAddress};
+use bacnet_transport::bip::BipTransport;
+use bacnet_types::enums::{AbortReason, ConfirmedServiceChoice, Segmentation};
+use bytes::Bytes;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+#[tokio::test]
+async fn read_range_unsegmented_direct_and_routed_fit_actual_peer_local_envelope() {
+    for segmentation in [
+        Segmentation::NONE,
+        Segmentation::RECEIVE,
+        Segmentation::TRANSMIT,
+        Segmentation::BOTH,
+    ] {
+        for accepts in [false, true] {
+            if accepts && matches!(segmentation, Segmentation::TRANSMIT | Segmentation::BOTH) {
+                continue;
+            }
+            for (peer, local) in [(50, 1476), (480, 50)] {
+                for (cap, expected_count) in
+                    [(16384, Some(16)), (18, Some(2)), (15, None), (1, None)]
+                {
+                    let items = unsigned_items(&(1..=30).collect::<Vec<_>>());
+                    let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, items.clone(), None);
+                    let mut server = BACnetServer::start(
+                        ServerConfig {
+                            segmentation_supported: segmentation,
+                            max_apdu_length: local,
+                            read_range_budget: ReadRangeBudget {
+                                max_service_ack_bytes: cap,
+                                ..Default::default()
+                            },
+                            ..Default::default()
+                        },
+                        db,
+                        BipTransport::new(Ipv4Addr::LOCALHOST, 0, Ipv4Addr::LOCALHOST),
+                    )
+                    .await
+                    .unwrap();
+                    let mac = server.local_mac();
+                    let dest = (
+                        Ipv4Addr::new(mac[0], mac[1], mac[2], mac[3]),
+                        u16::from_be_bytes([mac[4], mac[5]]),
+                    );
+                    let socket = tokio::net::UdpSocket::bind((Ipv4Addr::LOCALHOST, 0))
+                        .await
+                        .unwrap();
+                    for routed in [false, true] {
+                        let route = routed.then(|| NpduAddress {
+                            network: 7,
+                            mac_address: bacnet_types::MacAddr::from_slice(&[9]),
+                        });
+                        let mut service = BytesMut::new();
+                        ReadRangeRequest {
+                            object_identifier: oid,
+                            property_identifier: PropertyIdentifier::LOG_BUFFER,
+                            property_array_index: None,
+                            range: None,
+                        }
+                        .encode(&mut service);
+                        let request = Apdu::ConfirmedRequest(ConfirmedRequest {
+                            segmented: false,
+                            more_follows: false,
+                            segmented_response_accepted: accepts,
+                            max_segments: None,
+                            max_apdu_length: peer,
+                            invoke_id: 17,
+                            sequence_number: None,
+                            proposed_window_size: None,
+                            service_choice: ConfirmedServiceChoice::READ_RANGE,
+                            service_request: service.freeze(),
+                        });
+                        let mut apdu = BytesMut::new();
+                        encode_apdu(&mut apdu, &request).unwrap();
+                        let mut npdu = BytesMut::new();
+                        encode_npdu(
+                            &mut npdu,
+                            &Npdu {
+                                source: route.clone(),
+                                payload: apdu.freeze(),
+                                ..Default::default()
+                            },
+                        )
+                        .unwrap();
+                        let mut wire = vec![0x81, 0x0a];
+                        wire.extend_from_slice(&((npdu.len() + 4) as u16).to_be_bytes());
+                        wire.extend_from_slice(&npdu);
+                        socket.send_to(&wire, dest).await.unwrap();
+                        let mut reply = vec![0; 4096];
+                        let n =
+                            tokio::time::timeout(Duration::from_secs(2), socket.recv(&mut reply))
+                                .await
+                                .unwrap()
+                                .unwrap();
+                        assert_eq!(u16::from_be_bytes([reply[2], reply[3]]) as usize, n);
+                        let npdu = decode_npdu(Bytes::copy_from_slice(&reply[4..n])).unwrap();
+                        assert_eq!(npdu.destination, route);
+                        assert!(npdu.payload.len() <= 50);
+                        match (decode_apdu(npdu.payload).unwrap(), expected_count) {
+                            (Apdu::ComplexAck(a), Some(count)) => {
+                                assert!(!a.segmented);
+                                assert!(a.service_ack.len() <= cap);
+                                assert_ack(
+                                    &ReadRangeAck::decode(&a.service_ack).unwrap(),
+                                    &items[..count],
+                                    (true, false, true),
+                                    None,
+                                );
+                            }
+                            (Apdu::Abort(a), None) => {
+                                assert!(a.sent_by_server);
+                                assert_eq!(a.abort_reason, AbortReason::BUFFER_OVERFLOW);
+                            }
+                            other => panic!("unexpected response: {other:?}"),
+                        }
+                    }
+                    server.stop().await.unwrap();
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn read_range_segmented_complete_page_keeps_config_cap_and_actual_identity() {
+    use bacnet_client::client::BACnetClient;
+    for segmentation in [Segmentation::TRANSMIT, Segmentation::BOTH] {
+        let items = unsigned_items(&(1..=100).collect::<Vec<_>>());
+        let ids = (0..100).map(|i| identity(1000 + i * 2, 1)).collect();
+        let (db, oid) = list_db(PropertyIdentifier::LOG_BUFFER, items.clone(), Some(ids));
+        let mut server = BACnetServer::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .database(db)
+            .segmentation_supported(segmentation)
+            .read_range_budget(ReadRangeBudget {
+                max_returned_items: 60,
+                ..Default::default()
+            })
+            .build()
+            .await
+            .unwrap();
+        let mut client = BACnetClient::bip_builder()
+            .interface(Ipv4Addr::LOCALHOST)
+            .port(0)
+            .max_apdu_length(50)
+            .build()
+            .await
+            .unwrap();
+        let ack = client
+            .read_range(
+                server.local_mac(),
+                oid,
+                PropertyIdentifier::LOG_BUFFER,
+                None,
+                Some(RangeSpec::BySequenceNumber {
+                    reference_seq: 1198,
+                    count: -100,
+                }),
+            )
+            .await
+            .unwrap();
+        assert_ack(&ack, &items[40..], (false, true, true), Some(1080));
+        let mut encoded = BytesMut::new();
+        ack.encode(&mut encoded);
+        assert!(encoded.len() > 50);
+        for backwards in [false, true] {
+            let first = client
+                .read_range(
+                    server.local_mac(),
+                    oid,
+                    PropertyIdentifier::LOG_BUFFER,
+                    None,
+                    Some(RangeSpec::ByTime {
+                        reference_time: (DATE, time(if backwards { 2 } else { 0 })),
+                        count: if backwards { -100 } else { 100 },
+                    }),
+                )
+                .await
+                .unwrap();
+            assert_eq!(first.item_count, 60);
+            assert_eq!(
+                first.first_sequence_number,
+                Some(if backwards { 1080 } else { 1000 })
+            );
+            // These next resident identities are known from this stable fixture,
+            // not guessed by adding an ordinal to First_Sequence_Number.
+            let next = client
+                .read_range(
+                    server.local_mac(),
+                    oid,
+                    PropertyIdentifier::LOG_BUFFER,
+                    None,
+                    Some(RangeSpec::BySequenceNumber {
+                        reference_seq: if backwards { 1078 } else { 1120 },
+                        count: if backwards { -40 } else { 40 },
+                    }),
+                )
+                .await
+                .unwrap();
+            assert_eq!(next.item_count, 40);
+            assert!(!next.result_flags.2);
+            let combined = if backwards {
+                [next.item_data, first.item_data].concat()
+            } else {
+                [first.item_data, next.item_data].concat()
+            };
+            assert_eq!(combined, encoded_items(&items));
+        }
+        client.stop().await.unwrap();
+        server.stop().await.unwrap();
+    }
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -278,6 +278,8 @@ pub struct ServerConfig {
     pub get_enrollment_summary_budget: GetEnrollmentSummaryBudget,
     /// Local AtomicReadFile raw-count and complete service-ACK limits.
     pub atomic_read_file_budget: AtomicReadFileBudget,
+    /// ReadRange directional page item and logical service-byte limits.
+    pub read_range_budget: ReadRangeBudget,
     /// Per-service RPM work and encoded response limits (finite by default).
     pub read_property_multiple_budget: ReadPropertyMultipleBudget,
     /// Local interface to bind.
@@ -388,6 +390,7 @@ impl std::fmt::Debug for ServerConfig {
                 &self.get_enrollment_summary_budget,
             )
             .field("atomic_read_file_budget", &self.atomic_read_file_budget)
+            .field("read_range_budget", &self.read_range_budget)
             .field(
                 "read_property_multiple_budget",
                 &self.read_property_multiple_budget,
@@ -451,6 +454,7 @@ impl Default for ServerConfig {
             get_alarm_summary_budget: GetAlarmSummaryBudget::default(),
             get_enrollment_summary_budget: GetEnrollmentSummaryBudget::default(),
             atomic_read_file_budget: AtomicReadFileBudget::default(),
+            read_range_budget: ReadRangeBudget::default(),
             port: 0xBAC0,
             broadcast_address: Ipv4Addr::BROADCAST,
             max_apdu_length: 1476,
@@ -905,6 +909,8 @@ pub use rpm_budget::ReadPropertyMultipleBudget;
 mod alarm_summary_budget;
 pub use alarm_summary_budget::GetAlarmSummaryBudget;
 mod atomic_read_file_budget;
+mod read_range_budget;
+pub use read_range_budget::ReadRangeBudget;
 mod enrollment_summary_budget;
 pub use atomic_read_file_budget::AtomicReadFileBudget;
 pub use enrollment_summary_budget::GetEnrollmentSummaryBudget;

--- a/crates/bacnet-server/src/server/read_range_budget.rs
+++ b/crates/bacnet-server/src/server/read_range_budget.rs
@@ -1,0 +1,155 @@
+//! ReadRange response-page limits, not total list-read work limits.
+use super::*;
+
+/// Positive limits on returned items and the complete logical service ACK.
+/// APDU/NPDU envelopes are excluded. Unsegmented peers may further reduce bytes.
+/// Full property reads, identity retrieval/selection, and one trial item encoding
+/// remain outside these limits.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReadRangeBudget {
+    /// Maximum items per directional page (default 256).
+    pub max_returned_items: usize,
+    /// Maximum complete service-ACK bytes (default 16384).
+    pub max_service_ack_bytes: usize,
+}
+
+impl Default for ReadRangeBudget {
+    fn default() -> Self {
+        Self {
+            max_returned_items: 256,
+            max_service_ack_bytes: 16384,
+        }
+    }
+}
+
+impl ReadRangeBudget {
+    /// Reject zero configuration before startup or SC dialing.
+    pub fn validate(&self) -> Result<(), Error> {
+        for (name, value) in [
+            ("read_range_max_returned_items", self.max_returned_items),
+            (
+                "read_range_max_service_ack_bytes",
+                self.max_service_ack_bytes,
+            ),
+        ] {
+            if value == 0 {
+                return Err(Error::Encoding(format!("{name} must be positive")));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Set ReadRange page limits, validated before startup.
+    pub fn read_range_budget(mut self, budget: ReadRangeBudget) -> Self {
+        self.config.read_range_budget = budget;
+        self
+    }
+}
+impl BipServerBuilder {
+    /// Set ReadRange page limits, validated before startup.
+    pub fn read_range_budget(mut self, budget: ReadRangeBudget) -> Self {
+        self.config.read_range_budget = budget;
+        self
+    }
+}
+#[cfg(feature = "sc-tls")]
+impl ScServerBuilder {
+    /// Set ReadRange page limits, validated before SC dialing.
+    pub fn read_range_budget(mut self, budget: ReadRangeBudget) -> Self {
+        self.config.read_range_budget = budget;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct NeverStart;
+    impl TransportPort for NeverStart {
+        async fn start(
+            &mut self,
+        ) -> Result<mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+            panic!("invalid budget reached startup")
+        }
+        async fn stop(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+            Ok(())
+        }
+        fn local_mac(&self) -> &[u8] {
+            &[1]
+        }
+    }
+    #[tokio::test]
+    async fn read_range_all_builders_validate_before_start_or_dial() {
+        let default = ReadRangeBudget::default();
+        assert_eq!(
+            (default.max_returned_items, default.max_service_ack_bytes),
+            (256, 16384)
+        );
+        assert_eq!(ServerConfig::default().read_range_budget, default);
+        assert!(format!("{:?}", ServerConfig::default()).contains("read_range_budget"));
+        ReadRangeBudget {
+            max_returned_items: usize::MAX,
+            max_service_ack_bytes: usize::MAX,
+        }
+        .validate()
+        .unwrap();
+        for budget in [
+            ReadRangeBudget {
+                max_returned_items: 0,
+                ..default
+            },
+            ReadRangeBudget {
+                max_service_ack_bytes: 0,
+                ..default
+            },
+        ] {
+            let direct = BACnetServer::start(
+                ServerConfig {
+                    read_range_budget: budget,
+                    ..Default::default()
+                },
+                ObjectDatabase::new(),
+                NeverStart,
+            )
+            .await
+            .err();
+            let generic = BACnetServer::generic_builder()
+                .transport(NeverStart)
+                .read_range_budget(budget)
+                .build()
+                .await
+                .err();
+            let bip = BACnetServer::bip_builder()
+                .port(0)
+                .read_range_budget(budget)
+                .build()
+                .await
+                .err();
+            for error in [direct, generic, bip] {
+                assert!(matches!(error, Some(Error::Encoding(m)) if m.contains("read_range_max_")));
+            }
+            #[cfg(feature = "sc-tls")]
+            {
+                let tls = tokio_rustls::rustls::ClientConfig::builder()
+                    .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+                    .with_no_client_auth();
+                let error = BACnetServer::sc_builder()
+                    .hub_url("not-a-websocket-url")
+                    .tls_config(Arc::new(tls))
+                    .read_range_budget(budget)
+                    .build()
+                    .await
+                    .err();
+                assert!(matches!(error, Some(Error::Encoding(m)) if m.contains("read_range_max_")));
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -47,6 +47,7 @@ impl RequestTasks {
         config.get_alarm_summary_budget.validate()?;
         config.get_enrollment_summary_budget.validate()?;
         config.atomic_read_file_budget.validate()?;
+        config.read_range_budget.validate()?;
         Ok(Arc::new(tasks))
     }
 

--- a/crates/bacnet-server/src/server/requests/event_information.rs
+++ b/crates/bacnet-server/src/server/requests/event_information.rs
@@ -46,7 +46,7 @@ pub(super) async fn response(
     }
 }
 
-fn unsegmented_complex_ack_service_budget(
+pub(super) fn unsegmented_complex_ack_service_budget(
     invoke_id: u8,
     service_choice: ConfirmedServiceChoice,
     max_apdu: u16,

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -14,6 +14,7 @@ mod enrollment_summary;
 mod event_information;
 #[cfg(test)]
 mod executed;
+mod read_range;
 mod unconfirmed;
 #[cfg(test)]
 mod unconfirmed_tests;
@@ -320,11 +321,14 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 acknowledge_alarm::response(db, &req, &mut accepted_acknowledgment).await
             }
             s if s == ConfirmedServiceChoice::READ_RANGE => {
-                let db = db.read().await;
-                match handlers::handle_read_range(&db, &req.service_request, &mut ack_buf) {
-                    Ok(()) => complex_ack(ack_buf),
-                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
-                }
+                read_range::response(
+                    db,
+                    &req,
+                    config.read_range_budget,
+                    effective_max_apdu,
+                    segmented_response_available,
+                )
+                .await
             }
             s if s == ConfirmedServiceChoice::ATOMIC_READ_FILE => {
                 let db = db.read().await;

--- a/crates/bacnet-server/src/server/requests/read_range.rs
+++ b/crates/bacnet-server/src/server/requests/read_range.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+pub(super) async fn response(
+    db: &RwLock<ObjectDatabase>,
+    request: &ConfirmedRequestPdu,
+    mut budget: ReadRangeBudget,
+    effective_max_apdu: u16,
+    segmented_response_available: bool,
+) -> Apdu {
+    if !segmented_response_available {
+        budget.max_service_ack_bytes = budget.max_service_ack_bytes.min(
+            event_information::unsegmented_complex_ack_service_budget(
+                request.invoke_id,
+                request.service_choice,
+                effective_max_apdu,
+            ),
+        );
+    }
+    let mut service_ack = BytesMut::new();
+    let db = db.read().await;
+    match handlers::handle_read_range_budgeted(
+        &db,
+        &request.service_request,
+        &mut service_ack,
+        budget,
+    ) {
+        Ok(()) => Apdu::ComplexAck(ComplexAck {
+            segmented: false,
+            more_follows: false,
+            invoke_id: request.invoke_id,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: request.service_choice,
+            service_ack: service_ack.freeze(),
+        }),
+        Err(handlers::ReadRangeFailure::Service(error)) => {
+            confirmed_response::error_apdu_from_error(
+                request.invoke_id,
+                request.service_choice,
+                &error,
+            )
+        }
+        Err(handlers::ReadRangeFailure::Bytes) => Apdu::Abort(AbortPdu {
+            sent_by_server: true,
+            invoke_id: request.invoke_id,
+            abort_reason: AbortReason::BUFFER_OVERFLOW,
+        }),
+    }
+}

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -190,6 +190,7 @@ impl ScServerBuilder {
         self.config.get_alarm_summary_budget.validate()?;
         self.config.get_enrollment_summary_budget.validate()?;
         self.config.atomic_read_file_budget.validate()?;
+        self.config.read_range_budget.validate()?;
 
         let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
             .await?;

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1795,6 +1795,8 @@ class BACnetServer:
         atomic_read_file_max_requested_stream_octets: int = 16384,
         atomic_read_file_max_requested_records: int = 256,
         atomic_read_file_max_service_ack_bytes: int = 16384,
+        read_range_max_returned_items: int = 256,
+        read_range_max_service_ack_bytes: int = 16384,
     ) -> None: ...
 
     # --- Analog objects ---

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -106,6 +106,7 @@ pub struct BACnetServer {
     get_alarm_summary_budget: server::GetAlarmSummaryBudget,
     get_enrollment_summary_budget: server::GetEnrollmentSummaryBudget,
     atomic_read_file_budget: server::AtomicReadFileBudget,
+    read_range_budget: server::ReadRangeBudget,
     /// Whether the server has been started.
     started: Arc<AtomicBool>,
     /// Objects to add before starting. Cleared after start.

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -207,6 +207,7 @@ mod tests {
             get_alarm_summary_budget: server::GetAlarmSummaryBudget::default(),
             get_enrollment_summary_budget: server::GetEnrollmentSummaryBudget::default(),
             atomic_read_file_budget: server::AtomicReadFileBudget::default(),
+            read_range_budget: server::ReadRangeBudget::default(),
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         }

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -42,6 +42,7 @@ impl BACnetServer {
         let get_alarm_summary_budget = self.get_alarm_summary_budget;
         let get_enrollment_summary_budget = self.get_enrollment_summary_budget;
         let atomic_read_file_budget = self.atomic_read_file_budget;
+        let read_range_budget = self.read_range_budget;
 
         let objects: Vec<Box<dyn BACnetObject + Send>> = {
             let mut guard = self.lock_pending()?;
@@ -150,6 +151,7 @@ impl BACnetServer {
                 .get_alarm_summary_budget(get_alarm_summary_budget)
                 .get_enrollment_summary_budget(get_enrollment_summary_budget)
                 .atomic_read_file_budget(atomic_read_file_budget)
+                .read_range_budget(read_range_budget)
                 .transport(transport);
             if let Some(pw) = dcc_password {
                 builder = builder.dcc_password(pw);

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -40,7 +40,9 @@ impl BACnetServer {
         enrollment_summary_max_service_ack_bytes=16384,
         atomic_read_file_max_requested_stream_octets=16384,
         atomic_read_file_max_requested_records=256,
-        atomic_read_file_max_service_ack_bytes=16384
+        atomic_read_file_max_service_ack_bytes=16384,
+        read_range_max_returned_items=256,
+        read_range_max_service_ack_bytes=16384
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -80,6 +82,8 @@ impl BACnetServer {
         atomic_read_file_max_requested_stream_octets: usize,
         atomic_read_file_max_requested_records: usize,
         atomic_read_file_max_service_ack_bytes: usize,
+        read_range_max_returned_items: usize,
+        read_range_max_service_ack_bytes: usize,
     ) -> PyResult<Self> {
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
@@ -121,6 +125,13 @@ impl BACnetServer {
         atomic_read_file_budget
             .validate()
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let read_range_budget = server::ReadRangeBudget {
+            max_returned_items: read_range_max_returned_items,
+            max_service_ack_bytes: read_range_max_service_ack_bytes,
+        };
+        read_range_budget
+            .validate()
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(None)),
             device_instance,
@@ -149,6 +160,7 @@ impl BACnetServer {
             get_alarm_summary_budget,
             get_enrollment_summary_budget,
             atomic_read_file_budget,
+            read_range_budget,
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         })

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -70,6 +70,7 @@ SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
     "enrollment_summary_max_objects", "enrollment_summary_max_service_ack_bytes",
     "atomic_read_file_max_requested_stream_octets", "atomic_read_file_max_requested_records",
     "atomic_read_file_max_service_ack_bytes",
+    "read_range_max_returned_items", "read_range_max_service_ack_bytes",
 ]
 SUPPORTED_BAUD_RATES = (9_600, 19_200, 38_400, 57_600, 76_800, 115_200)
 SUPPORTED_BAUD_ERROR = (

--- a/crates/rusty-bacnet/tests/test_read_range_budget.py
+++ b/crates/rusty-bacnet/tests/test_read_range_budget.py
@@ -1,0 +1,131 @@
+"""Installed native ReadRange pages using independent direct/routed UDP vectors."""
+import asyncio
+import inspect
+import socket
+import struct
+import unittest
+from pathlib import Path
+from typing import Any
+
+import rusty_bacnet
+from rusty_bacnet import BACnetServer
+
+
+class ReadRangeConstructorTests(unittest.TestCase):
+    def test_defaults_keyword_only_stub_and_positive_validation(self):
+        signature = inspect.signature(BACnetServer)
+        for name, default in [("read_range_max_returned_items", 256),
+                              ("read_range_max_service_ack_bytes", 16384)]:
+            parameter = signature.parameters[name]
+            self.assertEqual(parameter.default, default)
+            self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+            self.assertIn(f"{name}: int = {default}",
+                          Path(rusty_bacnet.__file__).with_suffix(".pyi").read_text())
+            for transport in ["bip", "ipv6", "sc", "mstp"]:
+                for value, error in [(0, ValueError), (-1, OverflowError),
+                                     (1 << 200, OverflowError), (1.5, TypeError)]:
+                    with self.subTest(name=name, transport=transport, value=value):
+                        with self.assertRaises(error):
+                            BACnetServer(123, transport=transport, **{name: value})
+                positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
+                BACnetServer(123, transport=transport, **positive)
+
+
+class ReadRangeNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def exchange(self, server, sock, service, routed, segmented, peer, invoke):
+        ip, port = (await server.local_address()).rsplit(":", 1)
+        header = b"\x01\x08\x00\x07\x01\x09" if routed else b"\x01\x00"
+        npdu = header + bytes([2 if segmented else 0, peer, invoke, 26]) + service
+        wire = b"\x81\x0a" + (len(npdu) + 4).to_bytes(2, "big") + npdu
+        loop = asyncio.get_running_loop()
+        await loop.sock_sendto(sock, wire, (ip, int(port)))
+        reply, _ = await asyncio.wait_for(loop.sock_recvfrom(sock, 4096), 2)
+        self.assertEqual(reply[:2], b"\x81\x0a")
+        self.assertEqual(int.from_bytes(reply[2:4], "big"), len(reply))
+        if routed:
+            self.assertEqual(reply[4:11], b"\x01\x20\x00\x07\x01\x09\xff")
+        apdu = reply[11:] if routed else reply[6:]
+        self.assertLessEqual(len(apdu), {0: 50, 3: 480, 5: 1476}[peer])
+        async with asyncio.timeout(2):
+            while (await server.request_admission_counters())["confirmed_active"]:
+                await asyncio.sleep(0)
+        return apdu
+
+    async def test_directional_pages_bytes_peer_limits_and_abort_wire(self):
+        # Device:123 Object_List contains device then six registered AI objects.
+        request = b"\x0c\x02\x00\x00\x7b\x19\x4c"
+        objects = [b"\xc4\x02\x00\x00\x7b"] + [b"\xc4" + i.to_bytes(4, "big") for i in range(1, 7)]
+        for policy, capacity in [({}, 7), ({"read_range_max_returned_items": 1}, 1),
+                                 ({"read_range_max_returned_items": 2}, 2),
+                                 ({"read_range_max_service_ack_bytes": 24}, 2),
+                                 ({"read_range_max_service_ack_bytes": 23}, 1),
+                                 ({"read_range_max_service_ack_bytes": 18}, 0),
+                                 ({"read_range_max_service_ack_bytes": 13}, 0)]:
+            server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                  broadcast_address="127.0.0.1", **policy)
+            for i in range(1, 7):
+                server.add_analog_input(i, f"AI-{i}")
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.bind(("127.0.0.1", 0))
+            sock.setblocking(False)
+            try:
+                await server.start()
+                for routed in [False, True]:
+                    for segmented in [False, True]:
+                        for peer in [0, 3]:
+                            for direction in [0, 1, -1]:
+                                with self.subTest(policy=policy, routed=routed, segmented=segmented,
+                                                  peer=peer, direction=direction):
+                                    invoke = 11 + direction
+                                    range_wire = b"" if direction == 0 else bytes([
+                                        0x3e, 0x21, 7 if direction < 0 else 1, 0x31,
+                                        249 if direction < 0 else 7, 0x3f])
+                                    apdu = await self.exchange(server, sock, request + range_wire,
+                                                               routed, segmented, peer, invoke)
+                                    n = min(capacity, 6 if peer == 0 else 7)
+                                    if n == 0:
+                                        self.assertEqual(apdu, bytes([0x71, invoke, 1]))
+                                    else:
+                                        chosen = objects[-n:] if direction < 0 else objects[:n]
+                                        flags = (0x40 if direction < 0 else 0x80) | 0x20 if n < 7 else 0xc0
+                                        ack = request + bytes([0x3a, 5, flags, 0x49, n, 0x5e]) + b"".join(chosen) + b"\x5f"
+                                        self.assertEqual(apdu, bytes([0x30, invoke, 26]) + ack)
+                # Missing reference is a genuine empty match, never MORE_ITEMS.
+                empty = await self.exchange(server, sock, request + b"\x3e\x21\x08\x31\x01\x3f", False, False, 3, 42)
+                if policy.get("read_range_max_service_ack_bytes", 16384) < 14:
+                    self.assertEqual(empty, b"\x71\x2a\x01")
+                else:
+                    self.assertEqual(empty, b"\x30\x2a\x1a" + request + b"\x3a\x05\x00\x49\x00\x5e\x5f")
+            finally:
+                await server.stop()
+                sock.close()
+
+    async def test_default_257_and_forward_backward_continuation(self):
+        server = BACnetServer(123, interface="127.0.0.1", port=0, broadcast_address="127.0.0.1")
+        for i in range(1, 257):
+            server.add_analog_input(i, f"AI-{i}")
+        objects = [b"\xc4\x02\x00\x00\x7b"] + [b"\xc4" + i.to_bytes(4, "big") for i in range(1, 257)]
+        request = b"\x0c\x02\x00\x00\x7b\x19\x4c"
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.setblocking(False)
+        try:
+            await server.start()
+            for backwards in [False, True]:
+                reference = 257 if backwards else 1
+                count = -257 if backwards else 257
+                service = request + b"\x3e\x22" + reference.to_bytes(2, "big") + b"\x32" + count.to_bytes(2, "big", signed=True) + b"\x3f"
+                apdu = await self.exchange(server, sock, service, True, True, 5, 77)
+                flags = 0x60 if backwards else 0xa0
+                chosen = objects[1:] if backwards else objects[:256]
+                self.assertEqual(apdu, b"\x30\x4d\x1a" + request + bytes([0x3a, 5, flags, 0x4a, 1, 0, 0x5e]) + b"".join(chosen) + b"\x5f")
+                reference = 1 if backwards else 257
+                service = request + b"\x3e\x22" + reference.to_bytes(2, "big") + bytes([0x31, 255 if backwards else 1, 0x3f])
+                final = await self.exchange(server, sock, service, True, True, 5, 78)
+                flags = 0x80 if backwards else 0x40
+                last = objects[0] if backwards else objects[-1]
+                self.assertEqual(final, b"\x30\x4e\x1a" + request + bytes([0x3a, 5, flags, 0x49, 1, 0x5e]) + last + b"\x5f")
+                self.assertEqual((last + b"".join(chosen)) if backwards else (b"".join(chosen) + last), b"".join(objects))
+        finally:
+            await server.stop()
+            sock.close()

--- a/docs/read-range-budget.md
+++ b/docs/read-range-budget.md
@@ -1,0 +1,73 @@
+# ReadRange response pages
+
+The server defaults to `ReadRangeBudget { max_returned_items: 256,
+max_service_ack_bytes: 16384 }`. Both settings must be positive; these are local
+policy defaults, not protocol-mandated thresholds or measured performance claims.
+The byte limit includes the complete logical ReadRange service ACK, including
+count, flags, optional array index and first sequence number, but excludes APDU
+and NPDU envelopes.
+
+Configure `ServerConfig::read_range_budget` or `.read_range_budget(budget)` on the
+generic, B/IP or SC server builder. Validation occurs before transport startup or
+SC dialing. Existing exhaustive Rust `ServerConfig` literals must add the field
+(typically `ReadRangeBudget::default()`), or use `..Default::default()` where
+appropriate. Positive `usize` values are accepted; returned counts remain checked
+against the wire representation.
+
+Python `BACnetServer` adds keyword-only `read_range_max_returned_items=256` and
+`read_range_max_service_ack_bytes=16384`. Zero raises `ValueError`; negative or
+out-of-`usize` integers raise `OverflowError`. Installed native signatures and
+stubs use the same defaults. Existing positional arguments are unchanged.
+
+## Paging and continuation
+
+Existing selection semantics are unchanged. An absent Range or positive Count
+returns a contiguous prefix of the selected matches. Negative Count returns a
+contiguous suffix nearest the requested reference, in normal forward wire order.
+FIRST_ITEM and LAST_ITEM describe actual list endpoints included in the page;
+MORE_ITEMS means page capacity omitted selected matches, not that unrelated list
+items exist. Item_Count is the actual returned count. Nonempty sequence/time pages
+take First_Sequence_Number from the actual first returned resident identity,
+including sparse or wrapped identities. Missing references and genuinely empty
+matches still return zero count without a first sequence number if the envelope
+fits.
+
+Continue in the requested direction without treating a negative page as a prefix.
+For stable positional lists, advance a forward reference by the returned count;
+move a backward reference earlier by the returned count and prepend each received
+page. Sequence identities are not resident ordinals: do not calculate a page's
+first identity by adding an ordinal to a sequence number. For time-based reads,
+use returned record identities and the sequence continuation contract rather than
+inventing timestamp increments (timestamps may repeat). List mutation between
+requests still requires the application's existing missing-reference handling;
+paging is not a cross-request snapshot guarantee.
+
+If segmentation is unavailable because the server cannot transmit segments or
+the peer declines them, the service byte cap is also limited by the smaller
+peer/local APDU size minus the actually encoded unsegmented ComplexACK envelope.
+When segmentation is available, the configured service cap remains in force and
+the existing generic segmentation and accepted segment-count constraints apply.
+
+If the header or first directional item cannot fit, the server returns whole
+Abort BUFFER_OVERFLOW rather than an empty MORE_ITEMS page. A later oversized item
+ends the page; it is not skipped. Current-page item encoding errors remain service
+errors, discarding scratch without changing caller output. Deferred items are not
+encoded, including after the item cap is reached. The public unconfigured Rust
+`handle_read_range` retains its prior unlimited behavior for direct callers.
+
+## Scope of the bounds
+
+Only response item count and accumulated accepted logical service bytes are
+bounded. Complete-list property production/allocations, identity vector retrieval,
+existing selection scans and time validation, one trial item's recursive encoding
+and allocations, callbacks, allocator capacity/OOM/RSS/CPU/deadlines and rollback
+are excluded. One trial encoding can exceed the cap and is discarded. No total
+read-work, whole-memory, authorization, fairness or full-conformance claim follows.
+Object models, log storage, identity assignment, status projection and other
+services are unchanged.
+
+Protocol rationale is paraphrased from the local licensed ASHRAE 135-2020
+§15.8 (selection, directional partial results and continuation), §21 ReadRange
+request/ACK and ResultFlags productions, §18.10 (buffer Abort), and §5.4.5.3
+(ordinary segmentation). The local limits and first-item refusal policy are owner
+policy; this document does not redistribute licensed source text.


### PR DESCRIPTION
## Summary
Refs #521. ReadRange-only positive Rust/Python defaults256 returned items and16384 logical service-ACK bytes. Return contiguous directional pages: absent/positive prefix, negative suffix nearest reference in normal wire order. Correct count/endpoint/MORE_ITEMS flags and actual resident FirstSequenceNumber; no ordinal-based identity guesses.

For unsegmented responses, also fit min(peer/local APDU) minus actual encoded ComplexACK envelope. Header/first directional item unable to fit yields server Abort BUFFER_OVERFLOW instead of empty MORE_ITEMS. Later byte overflow ends the page; current-page encoding errors remain errors, deferred items not encoded. Legacy helper, selection algorithms, object/identity/storage semantics and normal segmentation unchanged.

## Validation
- Genuine baseline257 returned items RED-to-GREEN at default256.
- ReadRange server29/services25/client5, integration segmentation5, summary54/file65/admission42/DCC28/segmentation70/SC1 pass.
- Server996unit+3integration; integration39; workspace4326passed/3existing ignored.
- Fmt/clippy(warnings)/size/secrets/diff/newfiles/bindingcheck+clippy pass.
- Fresh locked CPython3.12.13 macOSarm64 wheel after final production; native/stub/direct_url verified. FullPython47tests623subtests pass incl root independent rerun; focused3/200repeat.
- WheelSHA a157bea038f98733a53693b5cdddf94f8a5c6a73432c27967d4b4dfebda82809.
- Forward/backward continuation, sparse/wrapped identities, variable headers, direct/routed peer/local limits and real segmented page reassembly tested.

## Boundaries
Only returned item count and accumulated accepted service bytes bounded. Whole-list property production, identity retrieval/selection, one trial item encode, callbacks/allocator/OOM/RSS/CPU/deadline/rollback excluded. No cross-request snapshot guarantee. Rust exhaustive config migration and Python keyword-only settings documented. Object storage/status/index/identity algorithms and other services unchanged. #521 remains partial; #522 and deferred Audit/EventLog/additional#181 fault-family/GATE0007/SC work untouched. No new CI/support/conformance claims.

Two independent exact-head reviews and CI pending.