### PR TITLE
feat(server): bound GetEventInformation admission and response pages

### DIFF
--- a/crates/bacnet-server/src/handlers/alarm_event/event_information_page.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/event_information_page.rs
@@ -1,0 +1,244 @@
+//! Bounded retained encoding with full strict projection validation.
+use super::*;
+use crate::server::GetEventInformationBudget;
+use bacnet_encoding::{primitives, tags};
+
+#[derive(Debug)]
+pub(crate) enum EventInformationFailure {
+    Service(Error),
+    Objects,
+    Bytes,
+}
+
+impl From<Error> for EventInformationFailure {
+    fn from(error: Error) -> Self {
+        Self::Service(error)
+    }
+}
+
+pub(crate) fn handle_get_event_information_configured(
+    db: &ObjectDatabase,
+    service_data: &[u8],
+    buf: &mut BytesMut,
+    budget: GetEventInformationBudget,
+) -> Result<(), EventInformationFailure> {
+    let request = GetEventInformationRequest::decode(service_data)?;
+    // Admission uses the same database view as the scan, before any callbacks.
+    if db.len() > budget.max_objects {
+        return Err(EventInformationFailure::Objects);
+    }
+    let cursor = request
+        .last_received_object_identifier
+        .map(|oid| oid.encode());
+    let mut identifiers = db.list_objects();
+    identifiers.sort_unstable_by_key(ObjectIdentifier::encode);
+    let mut page = Page::new(budget);
+    for oid in identifiers {
+        if cursor.is_some_and(|cursor| oid.encode() <= cursor) {
+            continue;
+        }
+        let Some(object) = db.get(&oid) else {
+            continue;
+        };
+        // Do not stop validating when the page is full, even for NORMAL objects.
+        if let EventSummaryProjectionResult::Projected(projection) =
+            EventSummaryProjection::read(object, db)?
+        {
+            if projection.is_selected() {
+                page.push(projection.into())?;
+            }
+        }
+    }
+    page.finish(buf)
+}
+
+struct Page {
+    budget: GetEventInformationBudget,
+    encoded: BytesMut,
+    prefix_len: usize,
+    suffix_len: usize,
+    count: usize,
+    more: bool,
+    closed: bool,
+    #[cfg(test)]
+    encodings: usize,
+}
+
+impl Page {
+    fn new(budget: GetEventInformationBudget) -> Self {
+        let mut encoded = BytesMut::new();
+        tags::encode_opening_tag(&mut encoded, 0);
+        let prefix_len = encoded.len();
+        let suffix_len = Self::suffix(false).len();
+        let closed = prefix_len + suffix_len > budget.max_service_ack_bytes;
+        Self {
+            budget,
+            encoded,
+            prefix_len,
+            suffix_len,
+            count: 0,
+            more: false,
+            closed,
+            #[cfg(test)]
+            encodings: 0,
+        }
+    }
+
+    fn suffix(more: bool) -> BytesMut {
+        let mut suffix = BytesMut::new();
+        tags::encode_closing_tag(&mut suffix, 0);
+        primitives::encode_ctx_boolean(&mut suffix, 1, more);
+        suffix
+    }
+
+    fn push(&mut self, summary: EventSummary) -> Result<(), Error> {
+        if self.closed || self.count == self.budget.max_returned_summaries {
+            self.more = true;
+            self.closed = true;
+            return Ok(());
+        }
+        // Reuse the authoritative codec for one candidate, never a full-page
+        // clone or prefix re-encoding. Only its small ACK wrappers are discarded.
+        let mut candidate = BytesMut::new();
+        #[cfg(test)]
+        {
+            self.encodings += 1;
+        }
+        GetEventInformationAck {
+            list_of_event_summaries: vec![summary],
+            more_events: false,
+        }
+        .encode(&mut candidate)?;
+        let item = &candidate[self.prefix_len..candidate.len() - self.suffix_len];
+        let remaining = self
+            .budget
+            .max_service_ack_bytes
+            .saturating_sub(self.encoded.len() + self.suffix_len);
+        if item.len() > remaining {
+            self.more = true;
+            self.closed = true;
+        } else {
+            self.encoded.extend_from_slice(item);
+            self.count += 1;
+            self.closed = self.encoded.len() + self.suffix_len == self.budget.max_service_ack_bytes;
+        }
+        Ok(())
+    }
+
+    fn finish(mut self, buf: &mut BytesMut) -> Result<(), EventInformationFailure> {
+        if self.encoded.len() + self.suffix_len > self.budget.max_service_ack_bytes
+            || (self.count == 0 && self.more)
+        {
+            return Err(EventInformationFailure::Bytes);
+        }
+        self.encoded.extend_from_slice(&Self::suffix(self.more));
+        buf.extend_from_slice(&self.encoded);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(timestamp: BACnetTimeStamp, state: u32) -> EventSummary {
+        EventSummary {
+            object_identifier: ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap(),
+            event_state: state,
+            acknowledged_transitions: 7,
+            event_timestamps: std::array::from_fn(|_| timestamp.clone()),
+            notify_type: state,
+            event_enable: 7,
+            event_priorities: [0, 100, 255],
+            notification_class: 42,
+        }
+    }
+
+    #[test]
+    fn get_event_information_incremental_codec_matches_wrappers_and_widths() {
+        use bacnet_types::primitives::{Date, Time};
+        let time = Time {
+            hour: 1,
+            minute: 2,
+            second: 3,
+            hundredths: 4,
+        };
+        for timestamp in [
+            BACnetTimeStamp::SequenceNumber(0),
+            BACnetTimeStamp::SequenceNumber(65535),
+            BACnetTimeStamp::Time(time),
+            BACnetTimeStamp::DateTime {
+                date: Date {
+                    year: 126,
+                    month: 9,
+                    day: 8,
+                    day_of_week: 2,
+                },
+                time,
+            },
+        ] {
+            for state in [0, 255, 256, 65536, u32::MAX] {
+                for more in [false, true] {
+                    let item = summary(timestamp.clone(), state);
+                    let mut expected = BytesMut::new();
+                    GetEventInformationAck {
+                        list_of_event_summaries: vec![item.clone()],
+                        more_events: more,
+                    }
+                    .encode(&mut expected)
+                    .unwrap();
+                    let mut page = Page::new(GetEventInformationBudget {
+                        max_service_ack_bytes: expected.len(),
+                        ..Default::default()
+                    });
+                    page.push(item.clone()).unwrap();
+                    if more {
+                        page.push(item.clone()).unwrap();
+                    }
+                    assert_eq!(page.encodings, 1);
+                    let mut actual = BytesMut::new();
+                    page.finish(&mut actual).unwrap();
+                    assert_eq!(actual, expected);
+                    let mut under = Page::new(GetEventInformationBudget {
+                        max_service_ack_bytes: expected.len() - 1,
+                        ..Default::default()
+                    });
+                    under.push(item.clone()).unwrap();
+                    for _ in 0..100 {
+                        under.push(item.clone()).unwrap();
+                    }
+                    assert_eq!(under.encodings, 1);
+                    assert!(matches!(
+                        under.finish(&mut BytesMut::new()),
+                        Err(EventInformationFailure::Bytes)
+                    ));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn get_event_information_overflow_closes_prefix_no_smaller_rescue() {
+        let small = summary(BACnetTimeStamp::SequenceNumber(0), 0);
+        let large = summary(BACnetTimeStamp::SequenceNumber(65535), u32::MAX);
+        let mut one = BytesMut::new();
+        GetEventInformationAck {
+            list_of_event_summaries: vec![small.clone()],
+            more_events: false,
+        }
+        .encode(&mut one)
+        .unwrap();
+        let mut page = Page::new(GetEventInformationBudget {
+            max_service_ack_bytes: 2 * one.len() - 4,
+            ..Default::default()
+        });
+        page.push(small.clone()).unwrap();
+        page.push(large).unwrap();
+        page.push(small).unwrap();
+        assert_eq!((page.count, page.encodings, page.more), (1, 2, true));
+        let mut out = BytesMut::new();
+        page.finish(&mut out).unwrap();
+        assert_eq!(out.len(), one.len());
+        assert!(GetEventInformationAck::decode(&out).unwrap().more_events);
+    }
+}

--- a/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
+++ b/crates/bacnet-server/src/handlers/alarm_event/get_event_information.rs
@@ -4,6 +4,10 @@ use super::super::*;
 use bacnet_encoding::primitives::decode_timestamp_choice;
 use bacnet_objects::traits::BACnetObject;
 
+#[path = "event_information_page.rs"]
+mod page;
+pub(crate) use page::{handle_get_event_information_configured, EventInformationFailure};
+
 const EVENT_SUMMARY_SIGNATURE: [PropertyIdentifier; 6] = [
     PropertyIdentifier::EVENT_STATE,
     PropertyIdentifier::ACKED_TRANSITIONS,
@@ -116,8 +120,8 @@ impl From<EventSummaryProjection> for EventSummary {
 
 /// Handle a GetEventInformation request without service-level byte pagination.
 ///
-/// Server dispatch uses the budget-aware variant when segmented transmission is
-/// unavailable. This wrapper remains unbounded for existing direct callers.
+/// Server dispatch uses a separate configured admission and strict page policy.
+/// This wrapper remains unbounded for existing direct callers.
 pub fn handle_get_event_information(
     db: &ObjectDatabase,
     service_data: &[u8],

--- a/crates/bacnet-server/src/handlers/tests/event_information_budget_tests.rs
+++ b/crates/bacnet-server/src/handlers/tests/event_information_budget_tests.rs
@@ -1,0 +1,351 @@
+use super::*;
+use crate::server::GetEventInformationBudget;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+struct Counted {
+    inner: ProjectionFixture,
+    calls: Arc<AtomicUsize>,
+    projections: Arc<AtomicUsize>,
+}
+impl BACnetObject for Counted {
+    fn object_identifier(&self) -> ObjectIdentifier {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.object_identifier()
+    }
+    fn object_name(&self) -> &str {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.object_name()
+    }
+    fn property_list(&self) -> Cow<'static, [PropertyIdentifier]> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.projections.fetch_add(1, Ordering::SeqCst);
+        self.inner.property_list()
+    }
+    fn read_property(
+        &self,
+        property: PropertyIdentifier,
+        index: Option<u32>,
+    ) -> Result<PropertyValue, Error> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.read_property(property, index)
+    }
+    fn write_property(
+        &mut self,
+        property: PropertyIdentifier,
+        index: Option<u32>,
+        value: PropertyValue,
+        priority: Option<u8>,
+    ) -> Result<(), Error> {
+        self.inner.write_property(property, index, value, priority)
+    }
+}
+
+#[test]
+fn get_event_information_preflight_no_callbacks_and_full_scan_after_capacity() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let projections = Arc::new(AtomicUsize::new(0));
+    let mut db = ObjectDatabase::new();
+    for inner in [
+        ProjectionFixture::summary(1),
+        ProjectionFixture::summary(2),
+        ProjectionFixture::notification_class(
+            99,
+            Some(PropertyValue::Unsigned(42)),
+            Some(PropertyValue::List(vec![PropertyValue::Unsigned(1); 3])),
+        ),
+    ] {
+        db.add(Box::new(Counted {
+            inner,
+            calls: calls.clone(),
+            projections: projections.clone(),
+        }))
+        .unwrap();
+    }
+    calls.store(0, Ordering::SeqCst);
+    let budget = GetEventInformationBudget {
+        max_objects: 2,
+        ..Default::default()
+    };
+    for cursor in [
+        None,
+        Some(ObjectIdentifier::new(ObjectType::NOTIFICATION_CLASS, 999).unwrap()),
+    ] {
+        assert!(matches!(
+            configured(&db, cursor, budget),
+            Err(EventInformationFailure::Objects)
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+    for bytes in [1, 16384] {
+        projections.store(0, Ordering::SeqCst);
+        let result = configured(
+            &db,
+            None,
+            GetEventInformationBudget {
+                max_objects: 3,
+                max_returned_summaries: 1,
+                max_service_ack_bytes: bytes,
+            },
+        );
+        assert_eq!(projections.load(Ordering::SeqCst), 3);
+        if bytes == 1 {
+            assert!(matches!(result, Err(EventInformationFailure::Bytes)));
+        } else {
+            assert!(
+                GetEventInformationAck::decode(&result.unwrap())
+                    .unwrap()
+                    .more_events
+            );
+        }
+    }
+}
+
+fn configured(
+    db: &ObjectDatabase,
+    cursor: Option<ObjectIdentifier>,
+    budget: GetEventInformationBudget,
+) -> Result<BytesMut, EventInformationFailure> {
+    let mut encoded = BytesMut::new();
+    handle_get_event_information_configured(db, &request(cursor), &mut encoded, budget)?;
+    Ok(encoded)
+}
+
+fn database(count: u32) -> ObjectDatabase {
+    let mut db = ObjectDatabase::new();
+    add_class(&mut db, 99, [1, 100, 255]);
+    for instance in (1..=count).rev() {
+        db.add(Box::new(ProjectionFixture::summary(instance)))
+            .unwrap();
+    }
+    db
+}
+
+#[test]
+fn get_event_information_configured_256_257_exact_cursor_pages() {
+    for count in [0, 1, 256, 257] {
+        let db = database(count);
+        let encoded = configured(&db, None, GetEventInformationBudget::default()).unwrap();
+        let ack = GetEventInformationAck::decode(&encoded).unwrap();
+        assert_eq!(ack.list_of_event_summaries.len(), count.min(256) as usize);
+        assert_eq!(ack.more_events, count > 256);
+        for (i, summary) in ack.list_of_event_summaries.iter().enumerate() {
+            assert_eq!(summary.object_identifier.instance_number(), i as u32 + 1);
+        }
+        if count == 257 {
+            let cursor = ack
+                .list_of_event_summaries
+                .last()
+                .unwrap()
+                .object_identifier;
+            let final_page =
+                configured(&db, Some(cursor), GetEventInformationBudget::default()).unwrap();
+            let last = GetEventInformationAck::decode(&final_page).unwrap();
+            assert!(!last.more_events);
+            assert_eq!(last.list_of_event_summaries.len(), 1);
+            assert_eq!(
+                last.list_of_event_summaries[0]
+                    .object_identifier
+                    .instance_number(),
+                257
+            );
+        } else {
+            let mut legacy = BytesMut::new();
+            handle_get_event_information(&db, &[], &mut legacy).unwrap();
+            assert_eq!(encoded, legacy);
+        }
+    }
+}
+
+#[test]
+fn get_event_information_configured_exact_bytes_tiny_empty_and_prefix() {
+    let one = configured(&database(1), None, GetEventInformationBudget::default()).unwrap();
+    let two = configured(&database(2), None, GetEventInformationBudget::default()).unwrap();
+    for (bytes, expected, more) in [
+        (one.len(), 1, true),
+        (two.len() - 1, 1, true),
+        (two.len(), 2, false),
+    ] {
+        let encoded = configured(
+            &database(2),
+            None,
+            GetEventInformationBudget {
+                max_service_ack_bytes: bytes,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(encoded.len() <= bytes);
+        let ack = GetEventInformationAck::decode(&encoded).unwrap();
+        assert_eq!(ack.list_of_event_summaries.len(), expected);
+        assert_eq!(ack.more_events, more);
+    }
+    for bytes in [0, 1, 3, one.len() - 1] {
+        assert!(matches!(
+            configured(
+                &database(1),
+                None,
+                GetEventInformationBudget {
+                    max_service_ack_bytes: bytes,
+                    ..Default::default()
+                }
+            ),
+            Err(EventInformationFailure::Bytes)
+        ));
+    }
+    let empty = configured(
+        &database(0),
+        None,
+        GetEventInformationBudget {
+            max_service_ack_bytes: 4,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(&empty[..], &[0x0e, 0x0f, 0x19, 0]);
+    assert!(matches!(
+        configured(
+            &database(0),
+            None,
+            GetEventInformationBudget {
+                max_service_ack_bytes: 3,
+                ..Default::default()
+            }
+        ),
+        Err(EventInformationFailure::Bytes)
+    ));
+}
+
+#[test]
+fn get_event_information_configured_late_errors_win_and_normals_do_not_imply_more() {
+    for bytes in [1, 16384] {
+        for normal in [false, true] {
+            let mut db = database(1);
+            let mut late = ProjectionFixture::summary(2);
+            if normal {
+                late.set(
+                    PropertyIdentifier::EVENT_STATE,
+                    PropertyValue::Enumerated(0),
+                );
+            }
+            late.remove(PropertyIdentifier::NOTIFY_TYPE);
+            db.add(Box::new(late)).unwrap();
+            let budget = GetEventInformationBudget {
+                max_returned_summaries: 1,
+                max_service_ack_bytes: bytes,
+                ..Default::default()
+            };
+            assert!(
+                matches!(configured(&db, None, budget), Err(EventInformationFailure::Service(Error::Protocol { class, code }))
+                if class == ErrorClass::DEVICE.to_raw() as u32 && code == ErrorCode::OPERATIONAL_PROBLEM.to_raw() as u32)
+            );
+            assert!(handle_get_event_information(&db, &[], &mut BytesMut::new()).is_err());
+        }
+    }
+    let mut db = database(1);
+    let mut normal = ProjectionFixture::summary(2);
+    normal.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Enumerated(0),
+    );
+    db.add(Box::new(normal)).unwrap();
+    let mut disabled = ProjectionFixture::summary(3);
+    disabled.advertise(PropertyIdentifier::EVENT_DETECTION_ENABLE);
+    disabled.set(
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+        PropertyValue::Boolean(false),
+    );
+    disabled.remove(PropertyIdentifier::NOTIFY_TYPE);
+    db.add(Box::new(disabled)).unwrap();
+    let ack = configured(
+        &db,
+        None,
+        GetEventInformationBudget {
+            max_returned_summaries: 1,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(!GetEventInformationAck::decode(&ack).unwrap().more_events);
+    db.add(Box::new(ProjectionFixture::summary(4))).unwrap();
+    let ack = configured(
+        &db,
+        None,
+        GetEventInformationBudget {
+            max_returned_summaries: 1,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(GetEventInformationAck::decode(&ack).unwrap().more_events);
+}
+
+#[test]
+fn get_event_information_configured_cardinality_decode_and_cursor_precedence() {
+    let mut db = database(1);
+    // Malformed projection must never be touched on rejected cardinality.
+    let mut malformed = ProjectionFixture::summary(2);
+    malformed.remove(PropertyIdentifier::NOTIFY_TYPE);
+    db.add(Box::new(malformed)).unwrap();
+    let budget = GetEventInformationBudget {
+        max_objects: 2,
+        ..Default::default()
+    };
+    for cursor in [
+        None,
+        Some(ObjectIdentifier::new(ObjectType::NOTIFICATION_CLASS, 999).unwrap()),
+    ] {
+        assert!(matches!(
+            configured(&db, cursor, budget),
+            Err(EventInformationFailure::Objects)
+        ));
+    }
+    let mut out = BytesMut::from(&b"sentinel"[..]);
+    assert!(matches!(
+        handle_get_event_information_configured(&db, &[0xff], &mut out, budget),
+        Err(EventInformationFailure::Service(_))
+    ));
+    assert_eq!(&out[..], b"sentinel");
+}
+
+#[test]
+fn get_event_information_configured_mixed_types_missing_cursor_and_class_errors() {
+    let mut db = database(1);
+    let mut unacked = ProjectionFixture::summary(3);
+    unacked.oid = ObjectIdentifier::new(ObjectType::BINARY_INPUT, 3).unwrap();
+    unacked.set(
+        PropertyIdentifier::EVENT_STATE,
+        PropertyValue::Enumerated(0),
+    );
+    unacked.set(
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        transition_bits(0b110),
+    );
+    db.add(Box::new(unacked)).unwrap();
+    for cursor in [
+        None,
+        Some(ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 2).unwrap()),
+        Some(ObjectIdentifier::new(ObjectType::BINARY_INPUT, 3).unwrap()),
+    ] {
+        let expected = response(&db, cursor, None).unwrap();
+        let encoded = configured(&db, cursor, GetEventInformationBudget::default()).unwrap();
+        let ack = GetEventInformationAck::decode(&encoded).unwrap();
+        assert_eq!(encoded.len(), expected.1);
+        assert_eq!(format!("{ack:?}"), format!("{:?}", expected.0));
+    }
+    add_class(&mut db, 98, [2, 3, 4]);
+    assert!(matches!(
+        configured(&db, None, GetEventInformationBudget::default()),
+        Err(EventInformationFailure::Service(_))
+    ));
+    let mut missing = ObjectDatabase::new();
+    missing
+        .add(Box::new(ProjectionFixture::summary(1)))
+        .unwrap();
+    assert!(matches!(
+        configured(&missing, None, GetEventInformationBudget::default()),
+        Err(EventInformationFailure::Service(_))
+    ));
+}

--- a/crates/bacnet-server/src/handlers/tests/get_event_information_projection.rs
+++ b/crates/bacnet-server/src/handlers/tests/get_event_information_projection.rs
@@ -7,6 +7,9 @@ use bacnet_types::primitives::{Date, Time};
 
 use super::*;
 
+#[path = "event_information_budget_tests.rs"]
+mod configured;
+
 struct ProjectionFixture {
     oid: ObjectIdentifier,
     name: String,
@@ -174,7 +177,29 @@ fn response(
     budget: Option<usize>,
 ) -> Result<(GetEventInformationAck, usize), Error> {
     let mut encoded = BytesMut::new();
-    handle_get_event_information_with_budget(db, &request(cursor), &mut encoded, budget)?;
+    let result =
+        handle_get_event_information_with_budget(db, &request(cursor), &mut encoded, budget);
+    if budget.is_none() {
+        let mut configured = BytesMut::new();
+        let configured_result = handle_get_event_information_configured(
+            db,
+            &request(cursor),
+            &mut configured,
+            crate::server::GetEventInformationBudget {
+                max_objects: usize::MAX,
+                max_returned_summaries: usize::MAX,
+                max_service_ack_bytes: usize::MAX,
+            },
+        );
+        match (&result, configured_result) {
+            (Ok(()), Ok(())) => assert_eq!(encoded, configured),
+            (Err(expected), Err(EventInformationFailure::Service(actual))) => {
+                assert_eq!(expected.to_string(), actual.to_string())
+            }
+            (expected, actual) => panic!("legacy/configured mismatch: {expected:?} / {actual:?}"),
+        }
+    }
+    result?;
     Ok((GetEventInformationAck::decode(&encoded)?, encoded.len()))
 }
 

--- a/crates/bacnet-server/src/server/event_information_budget.rs
+++ b/crates/bacnet-server/src/server/event_information_budget.rs
@@ -1,0 +1,177 @@
+//! GetEventInformation admission and response-page limits.
+use super::*;
+
+/// Positive local limits; callback allocations, CPU and RSS are not bounded.
+/// Every remaining object's strict projection is validated on admitted requests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GetEventInformationBudget {
+    /// Total database objects, including classes and objects before the cursor.
+    pub max_objects: usize,
+    /// Maximum summaries retained in a response page.
+    pub max_returned_summaries: usize,
+    /// Complete encoded service ACK, excluding APDU/NPDU envelopes.
+    pub max_service_ack_bytes: usize,
+}
+
+impl Default for GetEventInformationBudget {
+    fn default() -> Self {
+        Self {
+            max_objects: 4096,
+            max_returned_summaries: 256,
+            max_service_ack_bytes: 16384,
+        }
+    }
+}
+
+impl GetEventInformationBudget {
+    /// Reject zero configuration before startup or SC dialing.
+    pub fn validate(&self) -> Result<(), Error> {
+        for (name, value) in [
+            ("event_information_max_objects", self.max_objects),
+            (
+                "event_information_max_returned_summaries",
+                self.max_returned_summaries,
+            ),
+            (
+                "event_information_max_service_ack_bytes",
+                self.max_service_ack_bytes,
+            ),
+        ] {
+            if value == 0 {
+                return Err(Error::Encoding(format!("{name} must be positive")));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Set GetEventInformation limits, validated before startup.
+    pub fn get_event_information_budget(mut self, budget: GetEventInformationBudget) -> Self {
+        self.config.get_event_information_budget = budget;
+        self
+    }
+}
+impl BipServerBuilder {
+    /// Set GetEventInformation limits, validated before startup.
+    pub fn get_event_information_budget(mut self, budget: GetEventInformationBudget) -> Self {
+        self.config.get_event_information_budget = budget;
+        self
+    }
+}
+#[cfg(feature = "sc-tls")]
+impl ScServerBuilder {
+    /// Set GetEventInformation limits, validated before SC dialing.
+    pub fn get_event_information_budget(mut self, budget: GetEventInformationBudget) -> Self {
+        self.config.get_event_information_budget = budget;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    struct NeverStart;
+    impl TransportPort for NeverStart {
+        async fn start(
+            &mut self,
+        ) -> Result<mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+            panic!("invalid budget reached startup")
+        }
+        async fn stop(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+            Ok(())
+        }
+        fn local_mac(&self) -> &[u8] {
+            &[1]
+        }
+    }
+
+    #[tokio::test]
+    async fn get_event_information_all_builders_validate_before_start_or_dial() {
+        let default = GetEventInformationBudget::default();
+        assert_eq!(
+            (
+                default.max_objects,
+                default.max_returned_summaries,
+                default.max_service_ack_bytes
+            ),
+            (4096, 256, 16384)
+        );
+        assert_eq!(
+            ServerConfig::default().get_event_information_budget,
+            default
+        );
+        assert!(format!("{:?}", ServerConfig::default()).contains("get_event_information_budget"));
+        GetEventInformationBudget {
+            max_objects: usize::MAX,
+            max_returned_summaries: usize::MAX,
+            max_service_ack_bytes: usize::MAX,
+        }
+        .validate()
+        .unwrap();
+        for budget in [
+            GetEventInformationBudget {
+                max_objects: 0,
+                ..default
+            },
+            GetEventInformationBudget {
+                max_returned_summaries: 0,
+                ..default
+            },
+            GetEventInformationBudget {
+                max_service_ack_bytes: 0,
+                ..default
+            },
+        ] {
+            let direct = BACnetServer::start(
+                ServerConfig {
+                    get_event_information_budget: budget,
+                    ..Default::default()
+                },
+                ObjectDatabase::new(),
+                NeverStart,
+            )
+            .await
+            .err();
+            let generic = BACnetServer::generic_builder()
+                .transport(NeverStart)
+                .get_event_information_budget(budget)
+                .build()
+                .await
+                .err();
+            let bip = BACnetServer::bip_builder()
+                .port(0)
+                .get_event_information_budget(budget)
+                .build()
+                .await
+                .err();
+            for error in [direct, generic, bip] {
+                assert!(
+                    matches!(error, Some(Error::Encoding(m)) if m.contains("event_information_max_"))
+                );
+            }
+            #[cfg(feature = "sc-tls")]
+            {
+                let tls = tokio_rustls::rustls::ClientConfig::builder()
+                    .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+                    .with_no_client_auth();
+                let error = BACnetServer::sc_builder()
+                    .hub_url("not-a-websocket-url")
+                    .tls_config(Arc::new(tls))
+                    .get_event_information_budget(budget)
+                    .build()
+                    .await
+                    .err();
+                assert!(
+                    matches!(error, Some(Error::Encoding(m)) if m.contains("event_information_max_"))
+                );
+            }
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -280,6 +280,8 @@ pub struct ServerConfig {
     pub atomic_read_file_budget: AtomicReadFileBudget,
     /// ReadRange directional page item and logical service-byte limits.
     pub read_range_budget: ReadRangeBudget,
+    /// GetEventInformation database admission and strict response-page limits.
+    pub get_event_information_budget: GetEventInformationBudget,
     /// Per-service RPM work and encoded response limits (finite by default).
     pub read_property_multiple_budget: ReadPropertyMultipleBudget,
     /// Local interface to bind.
@@ -392,6 +394,10 @@ impl std::fmt::Debug for ServerConfig {
             .field("atomic_read_file_budget", &self.atomic_read_file_budget)
             .field("read_range_budget", &self.read_range_budget)
             .field(
+                "get_event_information_budget",
+                &self.get_event_information_budget,
+            )
+            .field(
                 "read_property_multiple_budget",
                 &self.read_property_multiple_budget,
             )
@@ -455,6 +461,7 @@ impl Default for ServerConfig {
             get_enrollment_summary_budget: GetEnrollmentSummaryBudget::default(),
             atomic_read_file_budget: AtomicReadFileBudget::default(),
             read_range_budget: ReadRangeBudget::default(),
+            get_event_information_budget: GetEventInformationBudget::default(),
             port: 0xBAC0,
             broadcast_address: Ipv4Addr::BROADCAST,
             max_apdu_length: 1476,
@@ -911,6 +918,8 @@ pub use alarm_summary_budget::GetAlarmSummaryBudget;
 mod atomic_read_file_budget;
 mod read_range_budget;
 pub use read_range_budget::ReadRangeBudget;
+mod event_information_budget;
+pub use event_information_budget::GetEventInformationBudget;
 mod enrollment_summary_budget;
 pub use atomic_read_file_budget::AtomicReadFileBudget;
 pub use enrollment_summary_budget::GetEnrollmentSummaryBudget;

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -48,6 +48,7 @@ impl RequestTasks {
         config.get_enrollment_summary_budget.validate()?;
         config.atomic_read_file_budget.validate()?;
         config.read_range_budget.validate()?;
+        config.get_event_information_budget.validate()?;
         Ok(Arc::new(tasks))
     }
 

--- a/crates/bacnet-server/src/server/requests/event_information.rs
+++ b/crates/bacnet-server/src/server/requests/event_information.rs
@@ -11,23 +11,27 @@ pub(super) fn limit(peer: u16, local: u32) -> u16 {
 pub(super) async fn response(
     db: &RwLock<ObjectDatabase>,
     request: &ConfirmedRequestPdu,
+    mut budget: GetEventInformationBudget,
     effective_max_apdu: u16,
     segmented_response_available: bool,
 ) -> Apdu {
-    let service_ack_budget = (!segmented_response_available).then(|| {
-        unsegmented_complex_ack_service_budget(
-            request.invoke_id,
-            request.service_choice,
-            effective_max_apdu,
-        )
-    });
+    if !segmented_response_available {
+        budget.max_service_ack_bytes =
+            budget
+                .max_service_ack_bytes
+                .min(unsegmented_complex_ack_service_budget(
+                    request.invoke_id,
+                    request.service_choice,
+                    effective_max_apdu,
+                ));
+    }
     let mut service_ack = BytesMut::new();
     let db = db.read().await;
-    match handlers::handle_get_event_information_with_budget(
+    match handlers::handle_get_event_information_configured(
         &db,
         &request.service_request,
         &mut service_ack,
-        service_ack_budget,
+        budget,
     ) {
         Ok(()) => Apdu::ComplexAck(ComplexAck {
             segmented: false,
@@ -38,11 +42,21 @@ pub(super) async fn response(
             service_choice: request.service_choice,
             service_ack: service_ack.freeze(),
         }),
-        Err(error) => confirmed_response::error_apdu_from_error(
-            request.invoke_id,
-            request.service_choice,
-            &error,
-        ),
+        Err(handlers::EventInformationFailure::Service(error)) => {
+            confirmed_response::error_apdu_from_error(
+                request.invoke_id,
+                request.service_choice,
+                &error,
+            )
+        }
+        Err(failure) => Apdu::Abort(AbortPdu {
+            sent_by_server: true,
+            invoke_id: request.invoke_id,
+            abort_reason: match failure {
+                handlers::EventInformationFailure::Objects => AbortReason::OUT_OF_RESOURCES,
+                _ => AbortReason::BUFFER_OVERFLOW,
+            },
+        }),
     }
 }
 
@@ -63,4 +77,55 @@ pub(super) fn unsegmented_complex_ack_service_budget(
     let mut encoded = BytesMut::new();
     encode_apdu(&mut encoded, &envelope).expect("valid empty ComplexACK encoding");
     usize::from(max_apdu).saturating_sub(encoded.len())
+}
+
+#[cfg(test)]
+mod budget_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn get_event_information_default_rejects_4097_total_objects() {
+        for count in [4096, 4097] {
+            let mut database = ObjectDatabase::new();
+            for instance in 0..count {
+                database
+                    .add(Box::new(
+                        bacnet_objects::notification_class::NotificationClass::new(
+                            instance,
+                            format!("NC-{instance}"),
+                        )
+                        .unwrap(),
+                    ))
+                    .unwrap();
+            }
+            let request = ConfirmedRequestPdu {
+                segmented: false,
+                more_follows: false,
+                segmented_response_accepted: true,
+                max_segments: None,
+                max_apdu_length: 1476,
+                invoke_id: 77,
+                sequence_number: None,
+                proposed_window_size: None,
+                service_choice: ConfirmedServiceChoice::GET_EVENT_INFORMATION,
+                service_request: Bytes::new(),
+            };
+            let response = response(
+                &RwLock::new(database),
+                &request,
+                GetEventInformationBudget::default(),
+                1476,
+                true,
+            )
+            .await;
+            if count == 4096 {
+                assert!(
+                    matches!(response, Apdu::ComplexAck(ack) if ack.service_ack.as_ref() == [0x0e, 0x0f, 0x19, 0])
+                );
+            } else {
+                assert!(matches!(response, Apdu::Abort(abort)
+            if abort.sent_by_server && abort.abort_reason == AbortReason::OUT_OF_RESOURCES));
+            }
+        }
+    }
 }

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -312,6 +312,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 event_information::response(
                     db,
                     &req,
+                    config.get_event_information_budget,
                     effective_max_apdu,
                     segmented_response_available,
                 )

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -191,6 +191,7 @@ impl ScServerBuilder {
         self.config.get_enrollment_summary_budget.validate()?;
         self.config.atomic_read_file_budget.validate()?;
         self.config.read_range_budget.validate()?;
+        self.config.get_event_information_budget.validate()?;
 
         let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&self.hub_url, tls_config.clone())
             .await?;

--- a/crates/bacnet-server/src/server/segmentation_tests/get_event_information.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/get_event_information.rs
@@ -163,6 +163,28 @@ async fn dispatch(
     MacAddr,
     Arc<crate::server::request_tasks::RequestTasks>,
 ) {
+    dispatch_with_budget(
+        segmentation,
+        client_accepts_segmented,
+        client_max_apdu,
+        local_max_apdu,
+        GetEventInformationBudget::default(),
+    )
+    .await
+}
+
+async fn dispatch_with_budget(
+    segmentation: Segmentation,
+    client_accepts_segmented: bool,
+    client_max_apdu: u16,
+    local_max_apdu: u32,
+    budget: GetEventInformationBudget,
+) -> (
+    SentFrames,
+    Arc<segmented_send::SegmentedSendRegistry>,
+    MacAddr,
+    Arc<crate::server::request_tasks::RequestTasks>,
+) {
     let sent = SentFrames::default();
     let network = Arc::new(NetworkLayer::new(RecordingTransport::new(Arc::clone(
         &sent,
@@ -179,6 +201,7 @@ async fn dispatch(
     let comm_state = Arc::new(AtomicU8::new(0));
     let dcc_timer = Arc::new(Mutex::new(None::<JoinHandle<()>>));
     let config = ServerConfig {
+        get_event_information_budget: budget,
         max_apdu_length: local_max_apdu,
         segmentation_supported: segmentation,
         ..ServerConfig::default()
@@ -223,17 +246,43 @@ async fn dispatch(
 }
 
 #[tokio::test]
-async fn first_summary_over_unsegmented_budget_uses_existing_segmentation_abort() {
+async fn first_summary_over_unsegmented_budget_uses_buffer_overflow_abort() {
     assert!(unsegmented_apdu_len(full_service_ack()) > 50);
     for (client_max_apdu, local_max_apdu) in [(50, 1476), (480, 50)] {
         let (sent, _, _, _owner) =
             dispatch(Segmentation::NONE, false, client_max_apdu, local_max_apdu).await;
         wait_for_sent_len(&sent, 1).await;
         assert_eq!(sent_count(&sent), 1);
-        assert_eq!(
-            abort_reason(&sent, 0),
-            AbortReason::SEGMENTATION_NOT_SUPPORTED
-        );
+        assert_eq!(abort_reason(&sent, 0), AbortReason::BUFFER_OVERFLOW);
+    }
+}
+
+#[tokio::test]
+async fn get_event_information_configured_abort_independent_of_segmentation() {
+    for segmentation in [Segmentation::NONE, Segmentation::BOTH] {
+        for (budget, expected) in [
+            (
+                GetEventInformationBudget {
+                    max_objects: 1,
+                    ..Default::default()
+                },
+                AbortReason::OUT_OF_RESOURCES,
+            ),
+            (
+                GetEventInformationBudget {
+                    max_service_ack_bytes: 4,
+                    ..Default::default()
+                },
+                AbortReason::BUFFER_OVERFLOW,
+            ),
+        ] {
+            let (sent, _, _, owner) =
+                dispatch_with_budget(segmentation, true, 50, 1476, budget).await;
+            wait_for_sent_len(&sent, 1).await;
+            assert_eq!(abort_reason(&sent, 0), expected);
+            owner.close();
+            while owner.join_next().await.is_some() {}
+        }
     }
 }
 

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1797,6 +1797,9 @@ class BACnetServer:
         atomic_read_file_max_service_ack_bytes: int = 16384,
         read_range_max_returned_items: int = 256,
         read_range_max_service_ack_bytes: int = 16384,
+        event_information_max_objects: int = 4096,
+        event_information_max_returned_summaries: int = 256,
+        event_information_max_service_ack_bytes: int = 16384,
     ) -> None: ...
 
     # --- Analog objects ---

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -107,6 +107,7 @@ pub struct BACnetServer {
     get_enrollment_summary_budget: server::GetEnrollmentSummaryBudget,
     atomic_read_file_budget: server::AtomicReadFileBudget,
     read_range_budget: server::ReadRangeBudget,
+    get_event_information_budget: server::GetEventInformationBudget,
     /// Whether the server has been started.
     started: Arc<AtomicBool>,
     /// Objects to add before starting. Cleared after start.

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -208,6 +208,7 @@ mod tests {
             get_enrollment_summary_budget: server::GetEnrollmentSummaryBudget::default(),
             atomic_read_file_budget: server::AtomicReadFileBudget::default(),
             read_range_budget: server::ReadRangeBudget::default(),
+            get_event_information_budget: server::GetEventInformationBudget::default(),
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         }

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -43,6 +43,7 @@ impl BACnetServer {
         let get_enrollment_summary_budget = self.get_enrollment_summary_budget;
         let atomic_read_file_budget = self.atomic_read_file_budget;
         let read_range_budget = self.read_range_budget;
+        let get_event_information_budget = self.get_event_information_budget;
 
         let objects: Vec<Box<dyn BACnetObject + Send>> = {
             let mut guard = self.lock_pending()?;
@@ -152,6 +153,7 @@ impl BACnetServer {
                 .get_enrollment_summary_budget(get_enrollment_summary_budget)
                 .atomic_read_file_budget(atomic_read_file_budget)
                 .read_range_budget(read_range_budget)
+                .get_event_information_budget(get_event_information_budget)
                 .transport(transport);
             if let Some(pw) = dcc_password {
                 builder = builder.dcc_password(pw);

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -42,7 +42,10 @@ impl BACnetServer {
         atomic_read_file_max_requested_records=256,
         atomic_read_file_max_service_ack_bytes=16384,
         read_range_max_returned_items=256,
-        read_range_max_service_ack_bytes=16384
+        read_range_max_service_ack_bytes=16384,
+        event_information_max_objects=4096,
+        event_information_max_returned_summaries=256,
+        event_information_max_service_ack_bytes=16384
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -84,6 +87,9 @@ impl BACnetServer {
         atomic_read_file_max_service_ack_bytes: usize,
         read_range_max_returned_items: usize,
         read_range_max_service_ack_bytes: usize,
+        event_information_max_objects: usize,
+        event_information_max_returned_summaries: usize,
+        event_information_max_service_ack_bytes: usize,
     ) -> PyResult<Self> {
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
@@ -132,6 +138,14 @@ impl BACnetServer {
         read_range_budget
             .validate()
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let get_event_information_budget = server::GetEventInformationBudget {
+            max_objects: event_information_max_objects,
+            max_returned_summaries: event_information_max_returned_summaries,
+            max_service_ack_bytes: event_information_max_service_ack_bytes,
+        };
+        get_event_information_budget
+            .validate()
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         Ok(Self {
             inner: Arc::new(Mutex::new(None)),
             device_instance,
@@ -161,6 +175,7 @@ impl BACnetServer {
             get_enrollment_summary_budget,
             atomic_read_file_budget,
             read_range_budget,
+            get_event_information_budget,
             started: Arc::new(AtomicBool::new(false)),
             pending_objects: std::sync::Mutex::new(Vec::new()),
         })

--- a/crates/rusty-bacnet/tests/test_event_information_budget.py
+++ b/crates/rusty-bacnet/tests/test_event_information_budget.py
@@ -1,0 +1,142 @@
+"""Installed native GetEventInformation limits with independent UDP framing."""
+import asyncio
+import inspect
+import socket
+import struct
+import unittest
+from pathlib import Path
+from typing import Any
+
+import rusty_bacnet
+from rusty_bacnet import BACnetServer, ObjectIdentifier, ObjectType, PropertyIdentifier, PropertyValue
+
+
+class EventInformationConstructorTests(unittest.TestCase):
+    def test_positive_keyword_only_defaults_and_installed_stub(self):
+        signature = inspect.signature(BACnetServer)
+        for name, default in [("event_information_max_objects", 4096),
+                              ("event_information_max_returned_summaries", 256),
+                              ("event_information_max_service_ack_bytes", 16384)]:
+            parameter = signature.parameters[name]
+            self.assertEqual(parameter.default, default)
+            self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+            self.assertIn(f"{name}: int = {default}",
+                          Path(rusty_bacnet.__file__).with_suffix(".pyi").read_text())
+            for transport in ["bip", "ipv6", "sc", "mstp"]:
+                for value, error in [(0, ValueError), (-1, OverflowError),
+                                     (1 << 200, OverflowError), (1.5, TypeError)]:
+                    with self.subTest(name=name, transport=transport, value=value):
+                        with self.assertRaises(error):
+                            BACnetServer(123, transport=transport, **{name: value})
+                positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
+                BACnetServer(123, transport=transport, **positive)
+
+
+def summary_oids(ack):
+    """Read seven tagged summary fields, including constructed timestamp choices."""
+    assert ack[0] == 0x0e and ack[-3:-1] == b"\x0f\x19"
+    offset = 1
+    result = []
+    while ack[offset] != 0x0f:
+        assert ack[offset] == 0x0c
+        result.append(int.from_bytes(ack[offset + 1:offset + 5], "big"))
+        for field in range(7):
+            tag = ack[offset]
+            assert tag >> 4 == field and tag & 8
+            offset += 1
+            if tag & 7 == 6:
+                depth = 1
+                while depth:
+                    tag = ack[offset]
+                    offset += 1
+                    if tag & 8 and tag & 7 == 6:
+                        depth += 1
+                    elif tag & 8 and tag & 7 == 7:
+                        depth -= 1
+                    else:
+                        assert tag & 7 <= 4
+                        offset += tag & 7
+            else:
+                assert tag & 7 <= 4
+                offset += tag & 7
+    assert offset == len(ack) - 3 and ack[-1] in (0, 1)
+    return result, bool(ack[-1])
+
+
+class EventInformationNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def exchange(self, server, sock, service=b"", routed=False, segmented=False, invoke=77):
+        ip, port = (await server.local_address()).rsplit(":", 1)
+        header = b"\x01\x08\x00\x07\x01\x09" if routed else b"\x01\x00"
+        npdu = header + bytes([2 if segmented else 0, 5, invoke, 29]) + service
+        wire = b"\x81\x0a" + (len(npdu) + 4).to_bytes(2, "big") + npdu
+        loop = asyncio.get_running_loop()
+        await loop.sock_sendto(sock, wire, (ip, int(port)))
+        reply, _ = await asyncio.wait_for(loop.sock_recvfrom(sock, 4096), 2)
+        self.assertEqual(reply[:2], b"\x81\x0a")
+        self.assertEqual(int.from_bytes(reply[2:4], "big"), len(reply))
+        if routed:
+            self.assertEqual(reply[4:11], b"\x01\x20\x00\x07\x01\x09\xff")
+        async with asyncio.timeout(2):
+            while (await server.request_admission_counters())["confirmed_active"]:
+                await asyncio.sleep(0)
+        return reply[11:] if routed else reply[6:]
+
+    async def test_total_object_abort_tiny_empty_bytes_and_decode_precedence(self):
+        for policy, expected in [({"event_information_max_objects": 1}, 9),
+                                 ({"event_information_max_service_ack_bytes": 3}, 1),
+                                 ({"event_information_max_service_ack_bytes": 4}, None),
+                                 ({}, None)]:
+            server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                  broadcast_address="127.0.0.1", **policy)
+            server.add_notification_class(0, "NC")
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.bind(("127.0.0.1", 0))
+            sock.setblocking(False)
+            try:
+                await server.start()
+                for routed in [False, True]:
+                    for segmented in [False, True]:
+                        for service in [b"", b"\x0c\xff\xff\xff\xff"]:
+                            apdu = await self.exchange(server, sock, service, routed, segmented)
+                            self.assertEqual(apdu, bytes([0x71, 77, expected]) if expected else
+                                             b"\x30\x4d\x1d\x0e\x0f\x19\x00")
+                        invalid = await self.exchange(server, sock, b"\xff", routed, segmented, 78)
+                        self.assertNotEqual(invalid[0], 0x71)
+                        self.assertIn(invalid[0] >> 4, [5, 6])
+            finally:
+                await server.stop()
+                sock.close()
+
+    async def test_native_active_event_pages_without_gaps(self):
+        server = BACnetServer(123, interface="127.0.0.1", port=0,
+                              broadcast_address="127.0.0.1",
+                              event_information_max_returned_summaries=2)
+        server.add_notification_class(0, "NC")
+        for instance in range(1, 6):
+            server.add_analog_input(instance, f"AI-{instance}")
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.setblocking(False)
+        try:
+            await server.start()
+            for instance in range(1, 6):
+                oid = ObjectIdentifier(ObjectType.ANALOG_INPUT, instance)
+                await server.write_property_local(oid, PropertyIdentifier.HIGH_LIMIT, PropertyValue.real(1))
+                await server.write_property_local(oid, PropertyIdentifier.LIMIT_ENABLE, PropertyValue.bit_string(6, b"\x40"))
+                await server.set_present_value_local(oid, PropertyValue.real(2))
+            for routed in [False, True]:
+                for segmented in [False, True]:
+                    cursor = b""
+                    seen = []
+                    for page in range(3):
+                        apdu = await self.exchange(server, sock, cursor, routed, segmented, 80 + page)
+                        self.assertEqual(apdu[:3], bytes([0x30, 80 + page, 29]))
+                        oids, more = summary_oids(apdu[3:])
+                        self.assertEqual(len(oids), 2 if page < 2 else 1)
+                        self.assertEqual(more, page < 2)
+                        seen.extend(oids)
+                        cursor = b"\x0c" + oids[-1].to_bytes(4, "big")
+                    self.assertEqual(seen, [1, 2, 3, 4, 5])
+        finally:
+            await server.stop()
+            sock.close()

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -71,6 +71,8 @@ SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
     "atomic_read_file_max_requested_stream_octets", "atomic_read_file_max_requested_records",
     "atomic_read_file_max_service_ack_bytes",
     "read_range_max_returned_items", "read_range_max_service_ack_bytes",
+    "event_information_max_objects", "event_information_max_returned_summaries",
+    "event_information_max_service_ack_bytes",
 ]
 SUPPORTED_BAUD_RATES = (9_600, 19_200, 38_400, 57_600, 76_800, 115_200)
 SUPPORTED_BAUD_ERROR = (

--- a/docs/event-information-budget.md
+++ b/docs/event-information-budget.md
@@ -1,0 +1,65 @@
+# GetEventInformation local budgets
+
+Server dispatch uses `ServerConfig::get_event_information_budget`, a
+`GetEventInformationBudget` with positive defaults:
+
+| Rust field | Python keyword-only constructor argument | Default |
+| --- | --- | --- |
+| `max_objects` | `event_information_max_objects` | 4096 |
+| `max_returned_summaries` | `event_information_max_returned_summaries` | 256 |
+| `max_service_ack_bytes` | `event_information_max_service_ack_bytes` | 16384 |
+
+Generic, B/IP and SC Rust builders accept `.get_event_information_budget(...)`.
+Zero is rejected before startup or SC dialing. Python rejects zero with
+`ValueError`; negative or nonrepresentable integers raise `OverflowError`.
+
+Adding `ServerConfig::get_event_information_budget` is a Rust source-compatibility
+change. Existing exhaustive `ServerConfig` literals must add
+`get_event_information_budget: Default::default()`, or use `..Default::default()`
+where defaulting the remaining fields is appropriate.
+
+After request decoding, dispatch checks total database cardinality using the
+same held read view as the scan, before object callbacks, identifier collection
+or sorting. All objects count, including objects before the cursor, non-event
+objects and Notification Classes. Exceeding the limit produces a whole server
+Abort `OUT_OF_RESOURCES`, even when no objects remain after the cursor.
+
+Admitted requests preserve strict projection validation of every remaining
+object in encoded ObjectIdentifier order. Filling a page stops retained item
+encodings, **not validation**. A later projection error, including one on a
+NORMAL object, takes precedence over a byte refusal. Notification Class lookup
+still matches the class-number property, not its object instance; missing and
+duplicate matches retain their existing errors.
+
+Only the fitting prefix is encoded and retained. Once a qualifying item is
+omitted, later smaller items cannot fill the gap. `More_Events` is true exactly
+when a qualifying summary was omitted; trailing normal, disabled or non-event
+objects alone do not set it. Resume with the last returned identifier. An absent
+or deleted cursor retains numeric encoded-identifier successor behavior.
+
+The byte limit includes the list wrappers and `More_Events`, but excludes APDU
+and NPDU envelopes. Without response segmentation, bytes are further limited by
+the effective peer/local APDU limit minus the actual encoded ComplexACK envelope.
+With segmentation available the configured logical byte limit still applies;
+generic segmentation constraints remain unchanged. An empty ACK requires four
+service bytes. If its wrappers or the first summary cannot fit, dispatch returns
+server Abort `BUFFER_OVERFLOW` only after the strict scan finds no service error.
+There is no oversized-first-item fallback in configured dispatch.
+
+The public `handle_get_event_information` remains an unconfigured, full-result
+handler. The old crate-internal optional-byte helper retains its historical
+first-item fallback for compatibility tests; configured dispatch does not use it.
+
+These are local retained-encoding and database-cardinality policies, not BACnet
+mandated numeric limits or an RSS/CPU guarantee. At default limits at most 256
+retained summaries plus one byte-overflow candidate are encoded. Request decoding,
+individual property/metadata callbacks and their allocations, opaque property
+results, allocator failure, RSS, deadlines and rollback are outside these bounds.
+Repeated Notification Class scans remain O(N*C); there is no lookup cache or
+constant-work-per-projection claim.
+
+Protocol basis: local licensed ASHRAE 135-2020 §13.12 (printed 699–700, PDF
+701–702) supplies selection, cursor continuation and exact qualifying-omission
+semantics. The finite limits and first-item refusal are owner-selected local
+resource policies. This change does not expand object, service or conformance
+support claims.


### PR DESCRIPTION
## Summary
Refs #521. GetEventInformation-only positive Rust/Python defaults4096 total database objects,256returned summaries,16384complete service-ACK bytes. Decode-first same-view cardinality admission precedes callbacks/listing/sorting; excess returns server OUT_OF_RESOURCES even when cursor leaves no remaining objects.

Admitted requests retain full strict remaining-object validation after page capacity closes; late projection errors retain precedence over byte refusal. Incremental fitting-prefix encoding, exact qualifying-omission More_Events, no smaller-item gap rescue. Header/first-summary refusal returns BUFFER_OVERFLOW after strict validation, replacing configured-dispatch oversized-first-summary fallback. Unsegmented peer/local envelope accounted for; generic segmentation, legacy public helper and Notification Class property-number matching unchanged. Rust literal migration/Python keywords documented.

## Validation
- Genuine baseline4097-real-class-objects RED-to-GREEN (initial test typo not counted as RED).
- EventInformation27/projection29/pagination1/summary54/ReadRange29/File65/admission42/DCC28/segmentation71/services19/SC27 pass.
- Server1007unit+3integration; integration39; workspace4337passed/3existing ignored.
- Fmt/clippy(warnings)/size/secrets/diff/newfile/bindingcheck+clippy pass.
- Freshlocked CPython3.12.13 macOSarm64 final2wheel after last production change, explicit native origin/direct_url/stub verified. Python50tests671subtests pass incl root independent rerun; focused3/48repeat.
- WheelSHA98ee56419ec974287d2bfeff5abcdb14f709ca030d676144a313d829b7c6ffa2.
- WiFi interruption resumed same original writer, preserving partial files/artifacts; final evidence verified.

## Boundaries
Database cardinality and retained response encoding limits, not callback allocation/RSS/OOM/CPU/deadline guarantees. Full strict scan remains, including repeated O(N*C) Notification Class lookup. No cache, object model, other service, auth/fairness, CI or support expansion. #521 remains partial; #522 and deferred Audit/EventLog/additional#181/GATE0007/SC work unchanged. Local policy thresholds, not normative BACnet constants.

Two independent exact-head reviews and CI pending.