### PR TITLE
fix(server): separate ordinary and recovery peer quotas

### DIFF
--- a/crates/bacnet-server/src/server/peer_admission_tests.rs
+++ b/crates/bacnet-server/src/server/peer_admission_tests.rs
@@ -182,7 +182,12 @@ async fn peer_admission_independent_classes_origins_and_global_first() {
 
 #[tokio::test]
 async fn peer_admission_guard_cleanup_normal_panic_never_polled_and_unique_stream() {
-    for class in [Class::Confirmed, Class::Unconfirmed, Class::Abort] {
+    for class in [
+        Class::Confirmed,
+        Class::Unconfirmed,
+        Class::Abort,
+        Class::Recovery,
+    ] {
         let owner = RequestTasks::default();
         let peer = canonical_requester(b"peer", None);
         owner

--- a/crates/bacnet-server/src/server/recovery_admission_tests.rs
+++ b/crates/bacnet-server/src/server/recovery_admission_tests.rs
@@ -8,6 +8,162 @@ fn peer(id: u8) -> crate::server::request_peer::CanonicalRequester {
     canonical_requester(&[id], None)
 }
 
+#[test]
+fn recovery_small_quota_table_release_refill_and_global_first() {
+    use crate::server::request_admission::Admission;
+
+    for global in 1..=6 {
+        for reserve in 0..global {
+            for normal_peer in 1..=7 {
+                for recovery_peer in 1..=7 {
+                    for recovery_first in [false, true] {
+                        let admission = Admission::new(RequestAdmissionPolicy {
+                            max_confirmed_in_flight: global,
+                            confirmed_recovery_reserve: reserve,
+                            max_confirmed_in_flight_per_peer: normal_peer,
+                            max_recovery_in_flight_per_peer: recovery_peer,
+                            ..Default::default()
+                        })
+                        .unwrap();
+                        let ordinary = normal_peer.min(global - reserve);
+                        let protected = recovery_peer.min(reserve);
+                        let order = if recovery_first {
+                            [(Class::Recovery, protected), (Class::Confirmed, ordinary)]
+                        } else {
+                            [(Class::Confirmed, ordinary), (Class::Recovery, protected)]
+                        };
+                        let mut held = Vec::new();
+                        let mut admitted = 0;
+                        let mut recovery_admitted = 0;
+                        for (class, count) in order {
+                            for _ in 0..count {
+                                held.push((
+                                    class,
+                                    Some(admission.try_enter(class, peer(1), false).unwrap()),
+                                ));
+                                admitted += 1;
+                                recovery_admitted += usize::from(matches!(class, Class::Recovery));
+                            }
+                        }
+                        let c = admission.snapshot();
+                        assert_eq!(
+                            (c.confirmed_active, c.recovery_active),
+                            (ordinary + protected, protected)
+                        );
+                        // Both partitions stay full at this peer while each slot is
+                        // independently released/refilled, including the opposite order.
+                        for (class, guard) in &mut held {
+                            let replacement = admission.try_enter(*class, peer(1), false);
+                            assert!(matches!(replacement, Err(Rejection::Overloaded)));
+                            // Drop exactly one guard without releasing the other class.
+                            drop(guard.take());
+                            *guard = Some(admission.try_enter(*class, peer(1), false).unwrap());
+                            admitted += 1;
+                            recovery_admitted += usize::from(matches!(class, Class::Recovery));
+                        }
+                        let before = admission.snapshot();
+                        for class in [Class::Confirmed, Class::Recovery] {
+                            assert!(matches!(
+                                admission.try_enter(class, peer(1), false),
+                                Err(Rejection::Overloaded)
+                            ));
+                        }
+                        let after = admission.snapshot();
+                        let global_denials = usize::from(ordinary == global - reserve)
+                            + usize::from(if reserve == 0 {
+                                ordinary == global
+                            } else {
+                                protected == reserve
+                            });
+                        assert_eq!(
+                            after.confirmed_global_overloaded_total
+                                - before.confirmed_global_overloaded_total,
+                            global_denials as u64
+                        );
+                        assert_eq!(
+                            after.confirmed_peer_overloaded_total
+                                - before.confirmed_peer_overloaded_total,
+                            (2 - global_denials) as u64
+                        );
+                        assert_eq!(after.confirmed_admitted_total, admitted);
+                        assert_eq!(after.recovery_admitted_total, recovery_admitted as u64);
+                        assert_eq!(
+                            after.confirmed_overloaded_total,
+                            after.confirmed_global_overloaded_total
+                                + after.confirmed_peer_overloaded_total
+                        );
+                        // Peer-denied temporary permits must be available to other peers.
+                        for (class, count) in [
+                            (Class::Confirmed, global - reserve - ordinary),
+                            (Class::Recovery, reserve - protected),
+                        ] {
+                            for id in 0..count {
+                                held.push((
+                                    class,
+                                    Some(
+                                        admission
+                                            .try_enter(class, peer(2 + id as u8), false)
+                                            .unwrap(),
+                                    ),
+                                ));
+                            }
+                        }
+                        assert_eq!(admission.snapshot().confirmed_active, global);
+                        for class in [Class::Confirmed, Class::Recovery] {
+                            assert!(matches!(
+                                admission.try_enter(class, peer(99), false),
+                                Err(Rejection::Overloaded)
+                            ));
+                        }
+                        drop(held);
+                        assert_eq!(admission.peer_entries(), [0; 3]);
+                        assert_eq!(admission.snapshot().confirmed_active, 0);
+                        assert_eq!(admission.snapshot().recovery_active, 0);
+                        // R=0 routes Recovery through the ordinary peer/global caps.
+                        let guard = admission
+                            .try_enter(Class::Recovery, peer(1), false)
+                            .unwrap();
+                        assert_eq!(
+                            admission.snapshot().recovery_active,
+                            usize::from(reserve != 0)
+                        );
+                        drop(guard);
+                        assert_eq!(admission.peer_entries(), [0; 3]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn recovery_wire_same_peer_enable_with_sixteen_ordinary_held() {
+    let (mut server, tx, mut started) = fixture().await;
+    for id in 0..16 {
+        inject(&tx, request(id)).await;
+        observed(&mut started).await; // Transport barrier: ordinary handler stays live.
+    }
+    assert_eq!(server.request_admission_counters().confirmed_active, 16);
+    server.comm_state.store(1, Ordering::Release);
+    inject(&tx, enable(16, None)).await;
+    observed(&mut started).await;
+    assert!(
+        matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::SimpleAck(a)) if a.invoke_id == 16)
+    );
+    assert_eq!(server.comm_state.load(Ordering::Acquire), 0);
+    let c = server.request_admission_counters();
+    assert_eq!((c.confirmed_active, c.recovery_active), (17, 1));
+    assert_eq!(
+        (c.confirmed_admitted_total, c.recovery_admitted_total),
+        (17, 1)
+    );
+    assert_eq!(c.confirmed_overloaded_total, 0);
+    server.network.transport().release.notify_waiters();
+    wait_reaped(&server).await;
+    assert_eq!(server.request_tasks.peer_entries(), [0; 3]);
+    server.stop().await.unwrap();
+}
+
 #[tokio::test]
 async fn recovery_segmented_enable_charged_once_after_reassembly() {
     let (mut server, tx, mut started) = fixture().await;
@@ -93,6 +249,42 @@ async fn drain(owner: &RequestTasks) {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recovery_spawn_close_race_reclaims_both_peer_maps() {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        for _ in 0..32 {
+            let owner = Arc::new(RequestTasks::default());
+            let barrier = Arc::new(tokio::sync::Barrier::new(3));
+            let mut writers = Vec::new();
+            for class in [Class::Confirmed, Class::Recovery] {
+                let owner = Arc::clone(&owner);
+                let barrier = Arc::clone(&barrier);
+                writers.push(tokio::spawn(async move {
+                    barrier.wait().await;
+                    owner.try_spawn(class, peer(1), std::future::pending)
+                }));
+            }
+            barrier.wait().await;
+            owner.close();
+            for writer in writers {
+                assert!(matches!(
+                    writer.await.unwrap(),
+                    Ok(()) | Err(Rejection::Closed)
+                ));
+            }
+            drain(&owner).await;
+            let c = owner.counters();
+            assert_eq!(
+                c.confirmed_admitted_total + c.confirmed_shutdown_rejected_total,
+                2
+            );
+            assert_eq!(c.confirmed_overloaded_total, 0);
+        }
+    })
+    .await
+    .unwrap();
+}
+
 #[tokio::test]
 async fn recovery_default_ordinary_partition_is_sixty_not_sixty_four() {
     let owner = RequestTasks::default();
@@ -163,19 +355,53 @@ async fn recovery_strict_partitions_no_lending_and_aggregate_counters() {
 }
 
 #[tokio::test]
-async fn recovery_peer_total_is_inclusive_and_protected_peer_is_additional() {
+async fn recovery_peer_quotas_are_independent_in_both_arrival_orders() {
+    fn hold(owner: &RequestTasks, class: Class, wait: oneshot::Receiver<()>) {
+        owner
+            .try_spawn(class, peer(1), || async move {
+                wait.await.unwrap();
+            })
+            .unwrap();
+    }
     for recovery_first in [false, true] {
         let owner = RequestTasks::default();
+        let (recovery_release, recovery_wait) = oneshot::channel::<()>();
+        let mut recovery_wait = Some(recovery_wait);
         if recovery_first {
-            owner
-                .try_spawn(Class::Recovery, peer(1), std::future::pending)
-                .unwrap();
+            hold(&owner, Class::Recovery, recovery_wait.take().unwrap());
         }
-        for _ in 0..if recovery_first { 15 } else { 16 } {
+        let (ordinary_release, ordinary_wait) = oneshot::channel::<()>();
+        hold(&owner, Class::Confirmed, ordinary_wait);
+        for _ in 0..15 {
             owner
                 .try_spawn(Class::Confirmed, peer(1), std::future::pending)
                 .unwrap();
         }
+        if !recovery_first {
+            hold(&owner, Class::Recovery, recovery_wait.take().unwrap());
+        }
+        ordinary_release.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), owner.join_next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let c = owner.counters();
+        assert_eq!((c.confirmed_active, c.recovery_active), (16, 1));
+        owner
+            .try_spawn(Class::Confirmed, peer(1), std::future::pending)
+            .unwrap();
+        recovery_release.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), owner.join_next())
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        let c = owner.counters();
+        assert_eq!((c.confirmed_active, c.recovery_active), (16, 0));
+        owner
+            .try_spawn(Class::Recovery, peer(1), std::future::pending)
+            .unwrap();
         for class in [Class::Recovery, Class::Confirmed] {
             assert_eq!(
                 owner.try_spawn(class, peer(1), std::future::pending),
@@ -199,7 +425,7 @@ async fn recovery_peer_total_is_inclusive_and_protected_peer_is_additional() {
                 c.confirmed_peer_overloaded_total,
                 c.confirmed_global_overloaded_total
             ),
-            (18, 3, 0)
+            (19, 3, 0)
         );
         assert_eq!(c.recovery_overloaded_total, 2);
         drain(&owner).await;

--- a/crates/bacnet-server/src/server/request_admission.rs
+++ b/crates/bacnet-server/src/server/request_admission.rs
@@ -20,8 +20,8 @@ pub struct RequestAdmissionPolicy {
     pub max_confirmed_in_flight: usize,
     /// Maximum concurrent unconfirmed handlers (default 32).
     pub max_unconfirmed_in_flight: usize,
-    /// Maximum concurrent confirmed handlers per logical peer (default 16).
-    /// The effective limit is the smaller of this and the global limit.
+    /// Maximum concurrent ordinary confirmed handlers per logical peer (default 16).
+    /// Clamped to global capacity minus the reserve; independent of recovery.
     pub max_confirmed_in_flight_per_peer: usize,
     /// Maximum concurrent unconfirmed handlers per logical peer (default 8).
     /// This partitions capacity by identity; it does not guarantee fairness.
@@ -29,8 +29,8 @@ pub struct RequestAdmissionPolicy {
     /// Strict DCC ENABLE partition inside the confirmed global limit (default 4).
     /// Zero disables protection; otherwise must be smaller than the global limit.
     pub confirmed_recovery_reserve: usize,
-    /// Additional protected per-peer limit (default 1), always positive.
-    /// The existing confirmed per-peer limit remains inclusive of both partitions.
+    /// Independent protected per-peer limit (default 1), always positive.
+    /// Clamped only to the reserve; zero reserve uses ordinary accounting instead.
     pub max_recovery_in_flight_per_peer: usize,
 }
 
@@ -101,7 +101,7 @@ pub struct RequestAdmissionCounters {
     pub confirmed_overloaded_total: u64,
     /// Confirmed capacity rejections classified partition-first (ordinary or protected).
     pub confirmed_global_overloaded_total: u64,
-    /// Confirmed rejections with a partition permit but no total/protected peer slot.
+    /// Confirmed rejections with a partition permit but no slot in that peer partition.
     pub confirmed_peer_overloaded_total: u64,
     /// Confirmed registrations rejected after shutdown sealed the owner.
     pub confirmed_shutdown_rejected_total: u64,
@@ -177,6 +177,7 @@ impl Pool {
 
 pub(super) struct Guard {
     pool: Arc<Pool>,
+    // Counters only: recovery never registers in the ordinary peer map.
     aggregate: Option<Arc<Pool>>,
     peer: Option<CanonicalRequester>,
     _permit: OwnedSemaphorePermit,
@@ -186,15 +187,15 @@ impl Drop for Guard {
     fn drop(&mut self) {
         // Remove registration before Rust drops _permit and releases global
         // capacity. This lock never acquires the task owner's lock.
-        for pool in std::iter::once(&self.pool).chain(self.aggregate.iter()) {
-            if let Some(peer) = &self.peer {
-                let mut peers = pool.peers.lock().unwrap_or_else(|e| e.into_inner());
-                let count = peers.get_mut(peer).expect("live peer registration");
-                *count -= 1;
-                if *count == 0 {
-                    peers.remove(peer);
-                }
+        if let Some(peer) = &self.peer {
+            let mut peers = self.pool.peers.lock().unwrap_or_else(|e| e.into_inner());
+            let count = peers.get_mut(peer).expect("live peer registration");
+            *count -= 1;
+            if *count == 0 {
+                peers.remove(peer);
             }
+        }
+        for pool in std::iter::once(&self.pool).chain(self.aggregate.iter()) {
             pool.active.fetch_sub(1, Ordering::Relaxed);
         }
     }
@@ -203,7 +204,10 @@ impl Drop for Guard {
 impl Admission {
     #[cfg(test)]
     pub(super) fn peer_entries(&self) -> [usize; 3] {
-        std::array::from_fn(|i| self.pools[i].peers.lock().unwrap().len())
+        let mut entries = std::array::from_fn(|i| self.pools[i].peers.lock().unwrap().len());
+        // Count entries in both confirmed maps, not distinct confirmed identities.
+        entries[0] += self.recovery.peers.lock().unwrap().len();
+        entries
     }
 
     pub(super) fn new(policy: RequestAdmissionPolicy) -> Result<Self, Error> {
@@ -214,7 +218,7 @@ impl Admission {
                     policy.max_confirmed_in_flight - policy.confirmed_recovery_reserve,
                     policy
                         .max_confirmed_in_flight_per_peer
-                        .min(policy.max_confirmed_in_flight),
+                        .min(policy.max_confirmed_in_flight - policy.confirmed_recovery_reserve),
                 ),
                 Pool::new(
                     policy.max_unconfirmed_in_flight,
@@ -228,8 +232,7 @@ impl Admission {
                 policy.confirmed_recovery_reserve,
                 policy
                     .max_recovery_in_flight_per_peer
-                    .min(policy.confirmed_recovery_reserve)
-                    .min(policy.max_confirmed_in_flight_per_peer),
+                    .min(policy.confirmed_recovery_reserve),
             ),
             recovery_enabled: policy.confirmed_recovery_reserve != 0,
         })
@@ -267,20 +270,9 @@ impl Admission {
             }
             Rejection::Overloaded
         })?;
-        // Spawn serialization belongs to RequestTasks. Hold the shared total map
-        // through both checks so no partial registration needs rollback. Drops
-        // never hold both maps simultaneously and never acquire the owner lock.
-        let mut total_peers =
-            aggregate.map(|total| total.peers.lock().unwrap_or_else(|e| e.into_inner()));
-        if let (Some(total), Some(peers)) = (aggregate, total_peers.as_ref()) {
-            if peers.get(&peer).copied().unwrap_or(0) >= total.peer_limit {
-                pool.overloaded.fetch_add(1, Ordering::Relaxed);
-                pool.peer_overloaded.fetch_add(1, Ordering::Relaxed);
-                total.overloaded.fetch_add(1, Ordering::Relaxed);
-                total.peer_overloaded.fetch_add(1, Ordering::Relaxed);
-                return Err(Rejection::Overloaded);
-            }
-        }
+        // Spawn serialization belongs to RequestTasks. Peer registrations are
+        // partition-local, while confirmed counters remain inclusive. Only one
+        // map is locked, so no cross-partition registration or rollback is needed.
         // Abort workers are global-only, with no peer registration or charge.
         let peer = if matches!(class, Class::Abort) {
             None
@@ -296,9 +288,6 @@ impl Admission {
                 return Err(Rejection::Overloaded);
             }
             *peers.entry(peer.clone()).or_default() += 1;
-            if let Some(peers) = total_peers.as_mut() {
-                *peers.entry(peer.clone()).or_default() += 1;
-            }
             Some(peer)
         };
         pool.active.fetch_add(1, Ordering::Relaxed);

--- a/crates/rusty-bacnet/tests/test_recovery_admission.py
+++ b/crates/rusty-bacnet/tests/test_recovery_admission.py
@@ -30,12 +30,18 @@ class RecoveryConstructorTests(unittest.TestCase):
                     BACnetServer(123, transport=transport, **invalid)
             BACnetServer(123, transport=transport, max_confirmed_in_flight=1, confirmed_recovery_reserve=0)
             BACnetServer(123, transport=transport, max_confirmed_in_flight=2, confirmed_recovery_reserve=1)
+            # Independent quotas accept recovery peer > ordinary peer; Rust
+            # barrier tests prove simultaneous 1+3 holding, not this constructor.
+            BACnetServer(123, transport=transport, max_confirmed_in_flight=8,
+                         confirmed_recovery_reserve=3, max_confirmed_in_flight_per_peer=1,
+                         max_recovery_in_flight_per_peer=3)
 
 
 class RecoveryNativeTests(unittest.IsolatedAsyncioTestCase):
     async def test_wire_classification_password_and_zero_reserve_policy(self):
         # Sequential wire checks establish installed native policy propagation.
-        # Rust held-transport barriers provide deterministic 60/4 saturation.
+        # Rust held-transport barriers prove 60/4 and same-peer 16+1 saturation;
+        # sequential UDP replies cannot prove simultaneous independent quotas.
         for reserve in [0, 1]:
             server = BACnetServer(123, interface="127.0.0.1", port=0,
                                   broadcast_address="127.0.0.1", dcc_password="required",

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1742,8 +1742,13 @@ guarantee availability once that capacity is full. The default confirmed total64
 is strictly partitioned into ordinary60/protected4 with no lending in either
 direction. Only decoder-accepted DCC ENABLE is protected; existing password checks
 still apply in the handler, so wrong/missing required passwords can consume a slot
-before PASSWORD_FAILURE. Total confirmed peer16 includes both partitions, with
-an additional protected peer1 cap. A peer already at total16 can be denied ENABLE.
+before PASSWORD_FAILURE. Ordinary peer16 and protected peer1 are independent:
+the same peer can hold 16+1 handlers in either arrival order. This replaces the
+former inclusive peer16 policy without changing constructor fields or defaults.
+Ordinary peer capacity is clamped to global minus reserve; recovery peer capacity
+is clamped only to reserve, no longer to the ordinary peer setting. For example,
+ordinary peer1/recovery peer3/reserve3 permit 1+3 if global room exists. Reserve0
+retains shared ordinary accounting with the ordinary peer cap clamped to global.
 Other critical-service reservations and work/response budgets remain deferred.
 
 `await server.request_admission_counters()` returns a stable typed dictionary

--- a/docs/request-admission.md
+++ b/docs/request-admission.md
@@ -2,9 +2,10 @@
 
 Each running server has independent, global limits for **top-level inbound
 handlers**: 64 confirmed and 32 unconfirmed by default, plus independent
-per-logical-peer limits of **16 confirmed and 8 unconfirmed**. Inside the confirmed
+per-logical-peer limits of **16 ordinary confirmed and 8 unconfirmed**. Inside the confirmed
 64, a strict **4-slot DCC ENABLE recovery reserve** leaves **60 ordinary slots**.
-The additional protected per-peer cap is **1**, not an addition to the total 16.
+The independent protected per-peer cap is **1**: one peer can hold **16 ordinary
+plus 1 recovery = 17 confirmed handlers**, regardless of arrival order.
 These finite defaults
 are provisional owner policy, not benchmark results or normative BACnet limits.
 
@@ -18,14 +19,25 @@ no greater than `tokio::sync::Semaphore::MAX_PERMITS`. Invalid values return an
 error before server transport startup (and before SC TLS dialing). Validation
 does not undo work already performed by a caller constructing its own transport.
 Existing route, APDU, and SC reconnect validation precedence is retained.
-The effective peer limit is `min(configured peer limit, global limit)` for each
-class. `confirmed_recovery_reserve` (default 4) must satisfy `0 <= R < G`, where
+The effective unconfirmed peer limit is `min(configured peer limit, global limit)`.
+`confirmed_recovery_reserve` (default 4) must satisfy `0 <= R < G`, where
 `G = max_confirmed_in_flight`. Zero disables protection: eligible ENABLE requests
 use ordinary capacity as before. A custom global limit of 4 or less must now
 explicitly configure reserve 0 or a smaller valid reserve. In particular, global
 1 requires reserve 0; default peer limits remain valid. There is no
-peer-less-than-or-equal-to-global validation requirement. The effective protected
-peer cap is `min(max_recovery_in_flight_per_peer, R, max_confirmed_in_flight_per_peer)`.
+peer-less-than-or-equal-to-global validation requirement. With protection enabled,
+the effective ordinary peer cap is `min(max_confirmed_in_flight_per_peer, G-R)`;
+the effective protected peer cap is `min(max_recovery_in_flight_per_peer, R)`.
+With `R=0`, both request classes use the ordinary peer cap
+`min(max_confirmed_in_flight_per_peer, G)`; the recovery peer setting must still be positive.
+
+**Semantic migration:** the former inclusive confirmed peer policy is replaced
+by independent ordinary and recovery quotas. Default numbers, constructors, and
+counter fields have not changed. Recovery is no longer clamped by the ordinary
+peer setting: for example ordinary peer=1, recovery peer=3 and R=3 now allow the
+same peer to hold 1 ordinary plus 3 recovery handlers if global room exists.
+Deployments relying on the former combined peer ceiling must account for the sum
+of the two effective caps; this is not an opt-in exemption or a fairness guarantee.
 
 Adding these two Rust policy fields and three recovery counter fields is a **source-breaking
 struct expansion** for exhaustive downstream literals/patterns. Policy literals
@@ -56,10 +68,11 @@ No authentication or default-deny behavior changes.
 
 Neither partition lends capacity: ordinary requests cannot use free protected
 slots; protected requests cannot fall back to free ordinary slots when `R > 0`.
-Total confirmed active handlers never exceed G. Both partitions share the existing
-total confirmed peer cap, so a peer with 16 ordinary handlers can still be denied
-ENABLE despite free protected capacity. Recovery availability is not promised for
-a peer already at its own total cap.
+Total confirmed active handlers never exceed G. Each partition checks only its
+own peer count: ordinary saturation at a peer does not deny eligible ENABLE when
+that peer's recovery quota and the global recovery partition have room, and held
+recovery handlers do not reduce its ordinary quota. Either exhausted recovery
+limit can still deny ENABLE; availability is not guaranteed.
 
 The server-private classifier first traverses borrowed tag contents and bounds
 optional password content before invoking the existing decoder. A decoded password
@@ -84,11 +97,11 @@ global pool. COV, reassembly, and endpoint-core identity contracts are not chang
   rejected work or capacity-waiting tasks is created. A slot lasts through the
   actual handler future, including awaited post-response work; completion,
   panic, and cancellation release it, even if its completed task is not reaped.
-  The sealed-owner check precedes partition acquisition, then the inclusive total
-  peer check, then the additional protected peer check. If partition and peer
+   The sealed-owner check precedes partition acquisition, then that partition's
+   peer check. If partition and peer
   capacities are both exhausted, the rejection is classified global/partition.
   Peer rejection releases the temporary global permit without counting admission.
-  Shared confirmed (ordinary plus protected), additional protected, and separate
+   Independent ordinary confirmed, protected, and
   unconfirmed maps contain only active peer counts, bounded by their quotas.
   Last-guard drop removes all its peer registrations before releasing its partition
   permit, including never-polled cancellation. There are no historical peer
@@ -136,7 +149,7 @@ stable fields, described by the shipped `RequestAdmissionCounters` TypedDict:
 | `confirmed_admitted_total`, `unconfirmed_admitted_total` | Cumulative handler registrations |
 | `confirmed_overloaded_total`, `unconfirmed_overloaded_total` | Capacity-rejected requests; unconfirmed requests are dropped |
 | `confirmed_global_overloaded_total`, `unconfirmed_global_overloaded_total` | Confirmed partition capacity or unconfirmed global capacity rejections, tested first |
-| `confirmed_peer_overloaded_total`, `unconfirmed_peer_overloaded_total` | Total/protected peer capacity rejections while partition/global capacity was available |
+| `confirmed_peer_overloaded_total`, `unconfirmed_peer_overloaded_total` | Relevant partition's peer capacity rejections while partition/global capacity was available |
 | `recovery_active`, `recovery_admitted_total`, `recovery_overloaded_total` | Protected subset of the corresponding confirmed aggregates; all zero when reserve is zero |
 | `confirmed_shutdown_rejected_total`, `unconfirmed_shutdown_rejected_total` | Registrations denied by the sealed task owner |
 | `abort_active` | Live overload Abort workers, at most eight |


### PR DESCRIPTION
## Summary
Refs #521. Owner-approved semantic replacement of inclusive confirmed-peer quotas: with recovery enabled, ordinary/recovery peer maps are independent. Default same peer may hold16 ordinary+1 DCC ENABLE in either arrival order. Global60+4=64, no lending, unchanged classifier/password/overload/drop/shutdown rules.

Ordinary effective peer=min(configured,G-R); recovery=min(configured,R), no old ordinary-peer clamp. R0 retains ordinary fallback. Inclusive confirmed counters with recovery subset retained; no constructor/default/metric ABI fields added. Migration/tradeoff documented, including custom1ordinary+3recovery.

## Validation
- Genuine baselineRED: recovery denied after16ordinary; finalGREEN both orders/release/refill.
- 2058 small quota table cases, same-peer held-transport ENABLE wire success/restored comms,32spawn-close races, Recovery panic/never-polled/2048uniquepeer cleanup.
- Recovery23/admission46/request_tasks60/peer35/shutdown68/DCC28/classifier3/seg71/File74/summary54/ReadRange29 pass.
- Server1019unit+3integration; integration40; workspace4350passed/3existing ignored; fmt/clippywarnings/size/secrets/diff/binding gates pass.
- Fresh locked CPython3.12.13 macOSarm64 DEV wheel after final source, nativeorigin/direct_url/stub verified. Python52tests803subtests incl root independent rerun; focused7/104repeat. Python sequential wire tests do NOT prove simultaneous same-peer saturation; deterministic Rust barrier tests do.
- WheelSHA3aa6dd24b90b3b5241c698d32317e7fcbf25bba36afbf6966d44bb98945d248f.

## Boundaries
Intentional reversal of earlier inclusive16 policy, not an opt-in flag. Recovery quota/global partition may still fill; wrong-password ENABLE still consumes capacity until handler failure. No new services/auth/queues/full-global fairness/identity assurance/resource preemption promises. #521 remains partial;#522 and deferred EventLog/Audit125/additional181/GATE0007SC unchanged. No CI/dependency/support expansion.

Both independent exact-head reviews and CI pending.