### PR TITLE
docs: record bounded request admission acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bound server request admission with configurable global/logical-peer quotas,
+  inclusive counters and deterministic overload handling, including the known
+  counted-drop fallback when all eight owned Abort workers are busy. Explicit stop
+  joins owned requests, Abort workers, known descendants and producers. DCC ENABLE
+  has a strict recovery reserve and independent per-peer quota (default 16 ordinary
+  plus 1 recovery in either arrival order). The owner-accepted bounded #521 scope
+  is complete, not a general fairness, availability or full-conformance guarantee;
+  see the [acceptance/evidence matrix](docs/request-admission.md#bounded-acceptance-and-evidence).
+- Add local payload/cardinality/retained-response budgets for RPM,
+  GetAlarmSummary, GetEnrollmentSummary, AtomicReadFile, ReadRange,
+  GetEventInformation and AtomicWriteFile. See the
+  [service budget index](docs/request-admission.md#delivered-service-budgets)
+  for defaults, precise exclusions and per-service compatibility migrations.
+
+### Migration notes
+
+- Review [request admission configuration and migrations](docs/request-admission.md):
+  Rust public struct expansions affect exhaustive literals/patterns, small custom
+  global limits need an explicit smaller or zero reserve, and independent ordinary
+  and recovery peer quotas replace the former inclusive confirmed peer ceiling.
+  Python additions remain keyword-only. Service budget documents linked above
+  describe new `ServerConfig` fields and limits that large requests may need raised.
+
 ## [0.11.0] - 2026-09-06
 
 ### Release highlights

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1749,7 +1749,14 @@ Ordinary peer capacity is clamped to global minus reserve; recovery peer capacit
 is clamped only to reserve, no longer to the ordinary peer setting. For example,
 ordinary peer1/recovery peer3/reserve3 permit 1+3 if global room exists. Reserve0
 retains shared ordinary accounting with the ordinary peer cap clamped to global.
-Other critical-service reservations and work/response budgets remain deferred.
+DCC ENABLE is the sole designated critical service in the owner-accepted bounded
+#521 scope; other services have no recovery reserve. Seven service-specific
+budgets are delivered, not blanket-deferred. See the
+[acceptance/evidence matrix](request-admission.md#bounded-acceptance-and-evidence)
+and [service budget index](request-admission.md#delivered-service-budgets) for
+the completed scope, configuration/migration links and precise exclusions.
+This acceptance is not a general fairness, all-configurations availability,
+total-work or whole-memory guarantee; #522 remains separate and open.
 
 `await server.request_admission_counters()` returns a stable typed dictionary
 of independent active/admitted/overload/shutdown counters, including the

--- a/docs/request-admission.md
+++ b/docs/request-admission.md
@@ -168,13 +168,88 @@ stop, with active counts zero. Python follows its existing `comm_state()` and
 `RuntimeError("server not started")`. Immediately after a traffic-free start,
 all counters are zero. No new restart semantics are promised.
 
-## Remaining limits
+## Bounded acceptance and evidence
 
-Peer quotas partition identities, but do not provide scheduling fairness or
-guaranteed availability once the relevant partition or peer cap is full. Only
-DCC ENABLE has a reserve; all other critical-service reservations, including
-ReinitializeDevice and other DCC modes, remain deferred. This bounds top-level handler concurrency, not
-every allocation, incoming byte, service effect, notification, transport task,
-or response budget. Work/response budgets remain deferred. Issue #521 remains
-partial; #522 is unchanged. No throughput, fairness, hardware timing, or full
-conformance claim follows from these limits.
+The owner accepts the delivered scope of [#521](https://github.com/jscott3201/rusty-bacnet/issues/521)
+as **bounded and complete**, with the qualifications below. This supersedes the
+earlier partial-scope and blanket work/response-budget deferral descriptions;
+it records acceptance, not a claim that the issue has already been closed.
+The literal requests and acceptance criteria are mapped separately so that
+bounded acceptance is not mistaken for an unqualified availability guarantee.
+
+Evidence is reused from merged PRs through [PR578](https://github.com/jscott3201/rusty-bacnet/pull/578),
+baseline `e1f6ab665332af5042346e6b0302fbdbd9bd7661` (the same production tree as
+reviewed head `e431027ad8c992298b15c7c967e239e31c5ca293`), not new runtime execution
+for this documentation update. Source links below identify the delivered
+implementation and tests; they do not imply live-network or performance testing.
+
+| #521 literal request | Accepted delivery and evidence | Qualification |
+| --- | --- | --- |
+| Configurable global and per-peer request admission limits | [PR568](https://github.com/jscott3201/rusty-bacnet/pull/568), [PR569](https://github.com/jscott3201/rusty-bacnet/pull/569), and PR578; [admission source][admission-source], [global tests][admission-tests], [peer tests][peer-tests] | Top-level handler futures; logical identities, not authenticated principals. |
+| Separate confirmed, unconfirmed, and operationally critical budgets | [PR570](https://github.com/jscott3201/rusty-bacnet/pull/570) and PR578; [recovery tests][recovery-tests] | DCC ENABLE is the sole designated critical service. PR578 replaces PR570's inclusive peer ceiling with independent ordinary/recovery quotas. |
+| Deterministic overload: bounded queue, drop, or protocol-appropriate Reject/Abort | PR568/569/570; [admission tests][admission-tests] and [recovery tests][recovery-tests] | No waiting queue. Confirmed overload normally schedules server OUT_OF_RESOURCES via eight owned Abort workers; a full Abort pool causes a counted silent drop, an accepted extreme-overload limitation, **not protocol-conformant reply permission**. Unconfirmed overload is a counted drop. |
+| Track child tasks under cancellation and join during shutdown | [PR563](https://github.com/jscott3201/rusty-bacnet/pull/563)–[PR567](https://github.com/jscott3201/rusty-bacnet/pull/567); [request owner][request-owner], [stop source][stop-source], lifecycle evidence below | Explicit stop covers owned requests, Abort workers, known descendants and producers, not every transport task or arbitrary blocking work. |
+| Bounded overload/active-handler counters | PR568/569/570/578; [counter source][admission-source] and [admission][admission-tests]/[recovery tests][recovery-tests] | Existing confirmed counters include recovery; recovery counters are a subset. Independently sampled, not an atomic snapshot or send-success count. |
+| Per-service work and response-byte budgets for large RPM, File, ReadRange and summaries | [Seven delivered service budgets](#delivered-service-budgets), PR571–577 | Payload/cardinality/retained-response policies with service-specific exclusions, not total-work or whole-memory limits. |
+
+| #521 literal acceptance evidence | Evidence and bounded interpretation |
+| --- | --- |
+| Hold handlers behind a barrier; inject beyond the limit; active handlers never exceed it | [Global tests][admission-tests] (`admission_default_confirmed_limit_rejects_before_handler`, `admission_default_unconfirmed_limit_is_32_without_waiters`) and [recovery tests][recovery-tests] (`recovery_default_ordinary_partition_is_sixty_not_sixty_four`, `recovery_peer_quotas_are_independent_in_both_arrival_orders`). |
+| One noisy peer cannot starve another peer or designated critical services | Accepted as quota isolation and ENABLE recovery, **not fair scheduling or universal availability**. At defaults a single logical peer's 16 ordinary slots leave 44 of 60 for others, and its one recovery slot leaves three of four, when not occupied by others. [Peer tests][peer-tests] exercise distinct origins; [recovery tests][recovery-tests] include `recovery_wire_same_peer_enable_with_sixteen_ordinary_held`, both arrival orders, release/refill and quota tables. Configured peer caps at or above global caps are valid, so this is not an all-configurations guarantee. |
+| Saturation has deterministic, tested wire behavior | [Admission tests][admission-tests] cover independent handlers, eight Abort workers, routed replies and fallback; [recovery tests][recovery-tests] cover protected exhaustion, duplicate retry, password failures and fallback. A scheduled Abort is not a guaranteed successful send. |
+| Shutdown cancels and joins every admitted child task | [Request-task tests][request-tests] (PR563), [segmented-worker tests][segmented-tests] ([PR564](https://github.com/jscott3201/rusty-bacnet/pull/564)), [DCC timer tests][timer-tests] ([PR565](https://github.com/jscott3201/rusty-bacnet/pull/565)), [notification-worker tests][notification-tests] ([PR566](https://github.com/jscott3201/rusty-bacnet/pull/566)), and [producer shutdown tests][producer-tests] (PR567) cover the explicit-stop owned-task boundary and retained joins after interrupted stop. No async Drop joining or opaque blocking-code preemption promise. |
+| No live-network stress target required | Reused in-process Rust barrier, lifecycle and wire tests plus installed-native Python evidence at the stated baseline; Python sequential tests are not simultaneous-quota proof. No live-network stress target was used for this acceptance. |
+
+## Delivered service budgets
+
+These defaults apply to configured server dispatch. Each linked service document
+contains configuration, compatibility migrations, failure/paging behavior and
+precise exclusions; legacy unconfigured helpers do not acquire these limits.
+Here **16 KiB means 16,384 bytes**; service-ACK caps exclude APDU/NPDU envelopes.
+Earlier per-slice issue-status statements describe their delivery stage, not a
+remaining requirement beyond this owner-accepted scope.
+
+| Service and policy details | Default bounded quantity | Merged implementation and tests |
+| --- | --- | --- |
+| [ReadPropertyMultiple](rpm-budget.md) | 256 expanded results; 16 KiB encoded service ACK | [PR571](https://github.com/jscott3201/rusty-bacnet/pull/571), [handler tests](../crates/bacnet-server/src/handlers/tests/rpm_budget.rs) |
+| [GetAlarmSummary](alarm-summary-budget.md) | 4096 total database objects; 16 KiB service ACK, complete response or refusal | [PR572](https://github.com/jscott3201/rusty-bacnet/pull/572), [handler tests](../crates/bacnet-server/src/handlers/tests/alarm_summary_budget.rs) |
+| [GetEnrollmentSummary](enrollment-summary-budget.md) | 4096 total database objects; 16 KiB service ACK, complete response or refusal | [PR573](https://github.com/jscott3201/rusty-bacnet/pull/573), [handler tests](../crates/bacnet-server/src/handlers/tests/enrollment_summary_budget.rs) |
+| [AtomicReadFile](atomic-read-file-budget.md) | 16,384 raw requested stream octets or 256 raw requested records; 16 KiB complete service ACK | [PR574](https://github.com/jscott3201/rusty-bacnet/pull/574), [handler tests](../crates/bacnet-server/src/handlers/tests/atomic_read_file_budget.rs) |
+| [ReadRange](read-range-budget.md) | 256 returned items; 16 KiB service ACK; directional pages, not total read-work bounds | [PR575](https://github.com/jscott3201/rusty-bacnet/pull/575), [page tests](../crates/bacnet-server/src/handlers/tests/read_range_pages.rs) |
+| [GetEventInformation](event-information-budget.md) | 4096 total database objects; 256 returned summaries; 16 KiB service ACK; full strict remaining-object validation even after a page fills | [PR576](https://github.com/jscott3201/rusty-bacnet/pull/576), [handler tests](../crates/bacnet-server/src/handlers/tests/event_information_budget_tests.rs) |
+| [AtomicWriteFile](atomic-write-file-budget.md) | 16,384 stream payload octets; 256 records; 16,384 summed record payload bytes, after decode and before storage write; no ACK-size cap | [PR577](https://github.com/jscott3201/rusty-bacnet/pull/577), [handler tests](../crates/bacnet-server/src/handlers/tests/atomic_write_file_budget.rs) |
+
+## Accepted limits and separate scope
+
+Peer quotas do not provide fair queues, Sybil resistance, authenticated-principal
+isolation or availability when the relevant pool is full. ENABLE classification
+is not authorization: wrong passwords can occupy protected slots, and exhausted
+protected capacity still denies recovery. There is no lending; `R=0` retains
+ordinary fallback. Only DCC ENABLE is designated critical in this accepted scope;
+ReinitializeDevice and other DCC modes have no reserve.
+
+Admission and service budgets do not bound every allocation, incoming byte,
+opaque callback, service effect, notification or transport task. The linked
+per-service exclusions remain authoritative: there is no full-callback, RSS,
+CPU/deadline, rollback, throughput, hardware-timing or full-conformance guarantee.
+Explicit stop joins the owned task families above, not async Drop or all server
+work regardless of transport and opaque blocking behavior.
+
+[#522](https://github.com/jscott3201/rusty-bacnet/issues/522) remains open and separate:
+authentication/default-deny policy and deprecated DCC DISABLE handling are not
+implemented by this work. Deferred production EventLog integration, Audit/#125,
+additional #181 EventEnrollment fault families, and GATE0007/SC restrictions are
+unchanged. Accepted exclusions do not automatically create follow-up tasks or
+reopen the bounded #521 scope.
+
+[admission-source]: ../crates/bacnet-server/src/server/request_admission.rs
+[admission-tests]: ../crates/bacnet-server/src/server/request_admission_tests.rs
+[peer-tests]: ../crates/bacnet-server/src/server/peer_admission_tests.rs
+[recovery-tests]: ../crates/bacnet-server/src/server/recovery_admission_tests.rs
+[request-owner]: ../crates/bacnet-server/src/server/request_tasks.rs
+[stop-source]: ../crates/bacnet-server/src/server/shutdown.rs
+[request-tests]: ../crates/bacnet-server/src/server/request_tasks_tests.rs
+[segmented-tests]: ../crates/bacnet-server/src/server/segmented_worker_tests.rs
+[timer-tests]: ../crates/bacnet-server/src/server/dcc_timer_tests.rs
+[notification-tests]: ../crates/bacnet-server/src/server/notification_worker_tests.rs
+[producer-tests]: ../crates/bacnet-server/src/server/producer_shutdown_tests.rs


### PR DESCRIPTION
## Summary
Docs-only owner-approved acceptance of the bounded #521 scope. Corrects stale blanket deferred-budget statements, maps all requested changes and acceptance criteria to delivered sources/tests/PRs, indexes seven service budget families, and adds Unreleased/migration notes. DCC ENABLE is the sole designated protected service.

No production/test/API changes. Root will close #521 explicitly after this PR passes both reviews, exact-head CI and merges. This PR references, rather than automatically closes, #521.

## Preserved limits
Not universal fairness/availability, Sybil/authenticated-principal protection, fullcallback/RSS/CPU/deadline/rollback, or full conformance. Eight-worker overload-response exhaustion still yields counted silent drop, an accepted limitation not protocol-conformant reply permission. Explicit stop covers owned tasks, not arbitrary blocking work/asyncDrop/everytransport task. #522 and historic deferred object/security scopes unchanged.

## Validation
Diff/secrets/file-size and all added relative links/fragments/test symbols verified. Exactly three Markdown files. No new builds/wheels/runtime tests: production unchanged from reviewed PR578 tree at e1f6ab665332af5042346e6b0302fbdbd9bd7661 (4350Rustpass/3existingignored,Python52/803); reused evidence, not new execution. No Markdown checker configured in inspected repo config. Two independent exact-head docs reviews and current lean CI pending.