### PR TITLE
feat(server): default DCC to deny-all with explicit policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Default configured-server DCC authorization to deny all, even with a correct
+  configured password. Add explicit Rust `DccPolicy` and Python keyword-only
+  `dcc_policy` modes; deprecated DISABLE remains denied in every mode.
+
 - Bound server request admission with configurable global/logical-peer quotas,
   inclusive counters and deterministic overload handling, including the known
   counted-drop fallback when all eight owned Abort workers are busy. Explicit stop
@@ -24,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for defaults, precise exclusions and per-service compatibility migrations.
 
 ### Migration notes
+
+- DCC password configuration alone no longer enables the service. Explicitly
+  select `RequirePassword` / `"require_password"` with a nonempty password, or
+  the **INSECURE** `LegacyPermissive` / `"legacy_permissive"` compatibility mode.
+  Exhaustive Rust `ServerConfig` literals need the new `dcc_policy` field.
+  See [DCC policy](docs/dcc-policy.md) for precedence and unchanged timer limits.
 
 - Review [request admission configuration and migrations](docs/request-admission.md):
   Rust public struct expansions affect exhaustive literals/patterns, small custom

--- a/crates/bacnet-integration-tests/tests/server.rs
+++ b/crates/bacnet-integration-tests/tests/server.rs
@@ -23,6 +23,12 @@ use tokio::time::Duration;
 
 /// Build a server with a Device, an AnalogInput, and a BinaryValue.
 async fn make_server() -> BACnetServer<BipTransport> {
+    make_server_with_dcc_policy(bacnet_server::server::DccPolicy::default()).await
+}
+
+async fn make_server_with_dcc_policy(
+    policy: bacnet_server::server::DccPolicy,
+) -> BACnetServer<BipTransport> {
     let mut db = ObjectDatabase::new();
 
     // Device object (instance 1234)
@@ -54,6 +60,7 @@ async fn make_server() -> BACnetServer<BipTransport> {
     db.add(Box::new(bv)).unwrap();
 
     BACnetServer::bip_builder()
+        .dcc_policy(policy)
         .interface(Ipv4Addr::LOCALHOST)
         .port(0) // ephemeral
         .broadcast_address(Ipv4Addr::LOCALHOST)

--- a/crates/bacnet-integration-tests/tests/server/dcc.rs
+++ b/crates/bacnet-integration-tests/tests/server/dcc.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+async fn make_server() -> BACnetServer<BipTransport> {
+    make_server_with_dcc_policy(bacnet_server::server::DccPolicy::LegacyPermissive).await
+}
+
 // ---------------------------------------------------------------------------
 // DeviceCommunicationControl enforcement tests (Clause 16.1)
 // ---------------------------------------------------------------------------
@@ -92,6 +96,7 @@ async fn dcc_disable_initiation_allows_rp_blocks_cov() {
     db.add(Box::new(dev)).unwrap();
 
     let mut server = BACnetServer::bip_builder()
+        .dcc_policy(bacnet_server::server::DccPolicy::LegacyPermissive)
         .interface(Ipv4Addr::LOCALHOST)
         .port(0)
         .database(db)
@@ -205,6 +210,7 @@ async fn dcc_enable_restores_normal_operation() {
     db.add(Box::new(dev)).unwrap();
 
     let mut server = BACnetServer::bip_builder()
+        .dcc_policy(bacnet_server::server::DccPolicy::LegacyPermissive)
         .interface(Ipv4Addr::LOCALHOST)
         .port(0)
         .database(db)

--- a/crates/bacnet-server/src/handlers/device_mgmt.rs
+++ b/crates/bacnet-server/src/handlers/device_mgmt.rs
@@ -36,10 +36,26 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
 ///
 /// Updates the communication state and returns the requested state plus
 /// optional duration (minutes) for auto-revert.
+/// This unconfigured helper retains legacy optional-password authorization;
+/// configured servers apply their separate local DCC policy.
 pub fn handle_device_communication_control(
     service_data: &[u8],
     comm_state: &AtomicU8,
     dcc_password: &Option<String>,
+) -> Result<(EnableDisable, Option<u16>), Error> {
+    handle_device_communication_control_with_policy(
+        service_data,
+        comm_state,
+        dcc_password,
+        crate::server::DccPolicy::LegacyPermissive,
+    )
+}
+
+pub(crate) fn handle_device_communication_control_with_policy(
+    service_data: &[u8],
+    comm_state: &AtomicU8,
+    dcc_password: &Option<String>,
+    policy: crate::server::DccPolicy,
 ) -> Result<(EnableDisable, Option<u16>), Error> {
     let request = DeviceCommunicationControlRequest::decode(service_data)?;
     validate_password(dcc_password, &request.password)?;
@@ -57,6 +73,12 @@ pub fn handle_device_communication_control(
     } else {
         return Err(Error::Encoding("unknown EnableDisable value".into()));
     };
+    if policy == crate::server::DccPolicy::DenyAll {
+        return Err(Error::Protocol {
+            class: ErrorClass::SERVICES.to_raw() as u32,
+            code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+        });
+    }
     comm_state.store(new_state, Ordering::Release);
     tracing::debug!(
         "DeviceCommunicationControl: state set to {:?} ({}), duration={:?} min",

--- a/crates/bacnet-server/src/server/dcc_policy.rs
+++ b/crates/bacnet-server/src/server/dcc_policy.rs
@@ -1,0 +1,43 @@
+use super::{BipServerBuilder, ServerBuilder, TransportPort};
+use bacnet_types::error::Error;
+
+/// Local DeviceCommunicationControl authorization, not source authentication.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum DccPolicy {
+    /// Deny all valid DCC modes, even with a correct configured password.
+    #[default]
+    DenyAll,
+    /// Allow supported modes only with a configured nonempty password.
+    RequirePassword,
+    /// INSECURE compatibility mode: preserve optional-password authorization.
+    /// A configured password is still checked; absence permits any requester.
+    LegacyPermissive,
+}
+
+impl DccPolicy {
+    /// Validate operator configuration before transport startup or dialing.
+    pub fn validate(self, password: &Option<String>) -> Result<(), Error> {
+        if self == Self::RequirePassword && password.as_ref().is_none_or(String::is_empty) {
+            return Err(Error::Encoding(
+                "RequirePassword DCC policy requires a nonempty dcc_password".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Select explicit local DCC authorization (default: deny all).
+    pub fn dcc_policy(mut self, policy: DccPolicy) -> Self {
+        self.config.dcc_policy = policy;
+        self
+    }
+}
+
+impl BipServerBuilder {
+    /// Select explicit local DCC authorization (default: deny all).
+    pub fn dcc_policy(mut self, policy: DccPolicy) -> Self {
+        self.config.dcc_policy = policy;
+        self
+    }
+}

--- a/crates/bacnet-server/src/server/dcc_policy_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_policy_tests.rs
@@ -1,0 +1,149 @@
+use super::*;
+
+#[test]
+fn dcc_configured_validation_retains_decode_password_unknown_mode_precedence() {
+    for policy in [
+        DccPolicy::DenyAll,
+        DccPolicy::RequirePassword,
+        DccPolicy::LegacyPermissive,
+    ] {
+        let state = AtomicU8::new(2);
+        let password = Some("required".to_owned());
+        let invalid = handlers::handle_device_communication_control_with_policy(
+            &[0x19],
+            &state,
+            &password,
+            policy,
+        );
+        assert!(matches!(invalid, Err(Error::Decoding { .. })));
+        let unknown = &[0x19, 3];
+        let error = handlers::handle_device_communication_control_with_policy(
+            unknown, &state, &password, policy,
+        );
+        assert!(matches!(error, Err(Error::Protocol { class, code })
+            if class == ErrorClass::SECURITY.to_raw() as u32 && code == ErrorCode::PASSWORD_FAILURE.to_raw() as u32));
+        let mut data = BytesMut::new();
+        DeviceCommunicationControlRequest {
+            time_duration: None,
+            enable_disable: EnableDisable::from_raw(3),
+            password: password.clone(),
+        }
+        .encode(&mut data)
+        .unwrap();
+        let error = handlers::handle_device_communication_control_with_policy(
+            &data, &state, &password, policy,
+        );
+        assert!(matches!(error, Err(Error::Encoding(m)) if m == "unknown EnableDisable value"));
+        assert_eq!(state.load(Ordering::Acquire), 2);
+    }
+}
+
+pub(super) async fn legacy_fixture() -> (
+    BACnetServer<HeldTransport>,
+    mpsc::Sender<ReceivedNpdu>,
+    mpsc::UnboundedReceiver<oneshot::Receiver<()>>,
+) {
+    fixture_with_config(
+        "recovery",
+        ServerConfig {
+            segmentation_supported: Segmentation::BOTH,
+            dcc_policy: DccPolicy::LegacyPermissive,
+            ..Default::default()
+        },
+    )
+    .await
+}
+
+#[tokio::test]
+async fn dcc_require_password_rejected_before_start() {
+    for password in [None, Some(String::new())] {
+        let started = Arc::new(AtomicBool::new(false));
+        let config = ServerConfig {
+            dcc_policy: DccPolicy::RequirePassword,
+            dcc_password: password.clone(),
+            ..Default::default()
+        };
+        let error = BACnetServer::start(
+            config,
+            ObjectDatabase::new(),
+            NeverStart(Arc::clone(&started)),
+        )
+        .await
+        .err()
+        .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("nonempty dcc_password")));
+        let mut builder = BACnetServer::generic_builder()
+            .transport(NeverStart(Arc::clone(&started)))
+            .dcc_policy(DccPolicy::RequirePassword);
+        if let Some(password) = &password {
+            builder = builder.dcc_password(password);
+        }
+        assert!(builder.build().await.is_err());
+        assert!(!started.load(Ordering::Acquire));
+        let mut builder = BACnetServer::bip_builder().dcc_policy(DccPolicy::RequirePassword);
+        if let Some(password) = &password {
+            builder = builder.dcc_password(password);
+        }
+        assert!(builder.build().await.is_err());
+    }
+    for policy in [DccPolicy::DenyAll, DccPolicy::LegacyPermissive] {
+        for password in [None, Some(String::new()), Some("x".repeat(100))] {
+            assert!(policy.validate(&password).is_ok());
+        }
+    }
+    let config = ServerConfig {
+        dcc_password: Some("secret-sentinel".into()),
+        ..Default::default()
+    };
+    let debug = format!("{config:?}");
+    assert!(!debug.contains("secret-sentinel"));
+    assert!(debug.contains("DenyAll"));
+}
+
+#[cfg(feature = "sc-tls")]
+#[tokio::test]
+async fn dcc_require_password_rejected_before_sc_dial() {
+    for password in [None, Some("")] {
+        let tls = tokio_rustls::rustls::ClientConfig::builder()
+            .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+            .with_no_client_auth();
+        let mut builder = BACnetServer::sc_builder()
+            .hub_url("not-a-websocket-url")
+            .tls_config(Arc::new(tls))
+            .dcc_policy(DccPolicy::RequirePassword);
+        if let Some(password) = password {
+            builder = builder.dcc_password(password);
+        }
+        let error = builder.build().await.err().unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("nonempty dcc_password")));
+    }
+}
+
+#[tokio::test]
+async fn dcc_default_recovery_admission_does_not_authorize_enable() {
+    for password in [None, Some("required")] {
+        let (mut server, _tx, mut started) = fixture_with_config(
+            "default deny",
+            ServerConfig {
+                dcc_password: password.map(str::to_owned),
+                ..Default::default()
+            },
+        )
+        .await;
+        server.comm_state.store(2, Ordering::Release);
+        for id in 1..=2 {
+            dispatch(&server, enable(id, password), source(id), None).await;
+            observed(&mut started).await;
+            assert_eq!(server.comm_state(), 2);
+            assert!(server.dcc_timer.lock().await.is_none());
+            assert!(
+                matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::Error(e))
+                if e.error_class == ErrorClass::SERVICES && e.error_code == ErrorCode::SERVICE_REQUEST_DENIED)
+            );
+        }
+        let counters = server.request_admission_counters();
+        assert_eq!(counters.recovery_admitted_total, 2);
+        assert_eq!(counters.recovery_active, 2);
+        server.stop().await.unwrap();
+    }
+}

--- a/crates/bacnet-server/src/server/dcc_timer.rs
+++ b/crates/bacnet-server/src/server/dcc_timer.rs
@@ -15,13 +15,18 @@ pub(super) async fn replace(
     comm_state: &Arc<AtomicU8>,
     service_data: &[u8],
     password: &Option<String>,
+    policy: DccPolicy,
 ) -> Result<(), Error> {
     // The synchronous handler validates and writes only this temporary state.
     // Preserve its public contract and validation precedence, without changing
     // live state before an await that cancellation could interrupt.
     let proposed = AtomicU8::new(0);
-    let (_, duration) =
-        handlers::handle_device_communication_control(service_data, &proposed, password)?;
+    let (_, duration) = handlers::handle_device_communication_control_with_policy(
+        service_data,
+        &proposed,
+        password,
+        policy,
+    )?;
     let mut slot = timer.lock().await;
     cancel(&mut slot).await;
     // Replacement, expiry, and shutdown share this linearization boundary.

--- a/crates/bacnet-server/src/server/dcc_timer_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_timer_tests.rs
@@ -2,6 +2,21 @@ use super::*;
 use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
 use bacnet_types::enums::EnableDisable;
 
+async fn fixture() -> (
+    BACnetServer<HeldTransport>,
+    mpsc::Sender<ReceivedNpdu>,
+    mpsc::UnboundedReceiver<oneshot::Receiver<()>>,
+) {
+    fixture_with_config(
+        "DCC timer",
+        ServerConfig {
+            dcc_policy: DccPolicy::LegacyPermissive,
+            ..Default::default()
+        },
+    )
+    .await
+}
+
 async fn activate(tx: &mpsc::Sender<ReceivedNpdu>) {
     let mut data = BytesMut::new();
     DeviceCommunicationControlRequest {

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -330,6 +330,8 @@ pub struct ServerConfig {
     pub unconfirmed_audit_notification_authorizer: Option<UnconfirmedAuditNotificationAuthorizer>,
     /// Optional password required for DeviceCommunicationControl.
     pub dcc_password: Option<String>,
+    /// Local DCC authorization. Supplying a password alone does not enable DCC.
+    pub dcc_policy: DccPolicy,
     /// Optional password required for ReinitializeDevice.
     pub reinit_password: Option<String>,
     /// Enable periodic fault detection / reliability evaluation.
@@ -438,6 +440,7 @@ impl std::fmt::Debug for ServerConfig {
                     .map(|_| "<callback>"),
             )
             .field("dcc_password", &self.dcc_password.as_ref().map(|_| "***"))
+            .field("dcc_policy", &self.dcc_policy)
             .field(
                 "reinit_password",
                 &self.reinit_password.as_ref().map(|_| "***"),
@@ -478,6 +481,7 @@ impl Default for ServerConfig {
             audit_notification_authorizer: None,
             unconfirmed_audit_notification_authorizer: None,
             dcc_password: None,
+            dcc_policy: DccPolicy::default(),
             reinit_password: None,
             enable_fault_detection: false,
             enable_event_enrollment: true,
@@ -883,7 +887,9 @@ mod cov_clock;
 mod cov_encoding;
 mod cov_notifications;
 mod cov_snapshot;
+mod dcc_policy;
 mod dcc_timer;
+pub use dcc_policy::DccPolicy;
 mod device_bindings;
 mod discovery;
 pub use discovery::{DiscoveryCounters, DiscoveryPolicy};

--- a/crates/bacnet-server/src/server/recovery_admission_tests.rs
+++ b/crates/bacnet-server/src/server/recovery_admission_tests.rs
@@ -4,6 +4,11 @@ use crate::server::request_tasks::RequestTasks;
 use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
 use bacnet_types::enums::EnableDisable;
 
+#[path = "dcc_policy_tests.rs"]
+mod dcc_policy_tests;
+
+use dcc_policy_tests::legacy_fixture as fixture;
+
 fn peer(id: u8) -> crate::server::request_peer::CanonicalRequester {
     canonical_requester(&[id], None)
 }
@@ -625,6 +630,7 @@ async fn recovery_classification_is_not_password_authorization() {
         "recovery",
         ServerConfig {
             dcc_password: Some("required".into()),
+            dcc_policy: DccPolicy::RequirePassword,
             ..Default::default()
         },
     )

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -44,6 +44,7 @@ impl RequestTasks {
         // Retain admission validation precedence; both policies must be valid
         // before the lifecycle starts a transport or exposes a request owner.
         config.read_property_multiple_budget.validate()?;
+        config.dcc_policy.validate(&config.dcc_password)?;
         config.get_alarm_summary_budget.validate()?;
         config.get_enrollment_summary_budget.validate()?;
         config.atomic_read_file_budget.validate()?;

--- a/crates/bacnet-server/src/server/requests/dcc_tests.rs
+++ b/crates/bacnet-server/src/server/requests/dcc_tests.rs
@@ -16,7 +16,10 @@ async fn dispatch(
         dcc_timer,
         mode,
         duration,
-        &ServerConfig::default(),
+        &ServerConfig {
+            dcc_policy: DccPolicy::LegacyPermissive,
+            ..Default::default()
+        },
     )
     .await
 }
@@ -28,6 +31,18 @@ async fn dispatch_with_config(
     duration: Option<u16>,
     config: &ServerConfig,
 ) -> Apdu {
+    dispatch_wire(comm_state, dcc_timer, mode, duration, config, None, None).await
+}
+
+async fn dispatch_wire(
+    comm_state: &Arc<AtomicU8>,
+    dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
+    mode: EnableDisable,
+    duration: Option<u16>,
+    config: &ServerConfig,
+    password: Option<&str>,
+    source: Option<NpduAddress>,
+) -> Apdu {
     let network = Arc::new(NetworkLayer::new(BipTransport::new(
         Ipv4Addr::LOCALHOST,
         0,
@@ -37,7 +52,7 @@ async fn dispatch_with_config(
     DeviceCommunicationControlRequest {
         time_duration: duration,
         enable_disable: mode,
-        password: None,
+        password: password.map(str::to_owned),
     }
     .encode(&mut data)
     .unwrap();
@@ -70,7 +85,7 @@ async fn dispatch_with_config(
         config,
         &Arc::new(crate::server::request_tasks::RequestTasks::default()).spawner(),
         &[127, 0, 0, 1, 0xba, 0xc0],
-        None,
+        source,
         request,
         Some(tx),
     )
@@ -90,6 +105,135 @@ fn assert_denied(apdu: Apdu) {
     );
     assert_eq!(error.error_class, ErrorClass::SERVICES);
     assert_eq!(error.error_code, ErrorCode::SERVICE_REQUEST_DENIED);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_default_denies_valid_modes_without_live_mutation() {
+    for mode in [EnableDisable::ENABLE, EnableDisable::DISABLE_INITIATION] {
+        for initial in [0, 1, 2] {
+            for duration in [None, Some(0), Some(1)] {
+                let state = Arc::new(AtomicU8::new(initial));
+                let timer = Arc::new(Mutex::new(None));
+                let response =
+                    dispatch_with_config(&state, &timer, mode, duration, &ServerConfig::default())
+                        .await;
+                assert_eq!(state.load(Ordering::Acquire), initial);
+                assert!(timer.lock().await.is_none());
+                assert_denied(response);
+            }
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_policy_wire_password_precedence_direct_and_routed() {
+    for policy in [
+        DccPolicy::DenyAll,
+        DccPolicy::RequirePassword,
+        DccPolicy::LegacyPermissive,
+    ] {
+        for configured in [None, Some("required")] {
+            if policy == DccPolicy::RequirePassword && configured.is_none() {
+                continue;
+            }
+            let config = ServerConfig {
+                dcc_policy: policy,
+                dcc_password: configured.map(str::to_owned),
+                ..Default::default()
+            };
+            for password in [None, Some("wrong"), Some("required")] {
+                for mode in [
+                    EnableDisable::ENABLE,
+                    EnableDisable::DISABLE_INITIATION,
+                    EnableDisable::DISABLE,
+                ] {
+                    for routed in [false, true] {
+                        for duration in [None, Some(0), Some(2)] {
+                            let state = Arc::new(AtomicU8::new(1));
+                            let timer = Arc::new(Mutex::new(None));
+                            let source = routed.then(|| NpduAddress {
+                                network: 7,
+                                mac_address: MacAddr::from_slice(&[42]),
+                            });
+                            let response = dispatch_wire(
+                                &state, &timer, mode, duration, &config, password, source,
+                            )
+                            .await;
+                            let bad_password = configured.is_some() && password != configured;
+                            if bad_password {
+                                assert!(
+                                    matches!(response, Apdu::Error(e) if e.error_class == ErrorClass::SECURITY && e.error_code == ErrorCode::PASSWORD_FAILURE)
+                                );
+                            } else if policy == DccPolicy::DenyAll || mode == EnableDisable::DISABLE
+                            {
+                                assert_denied(response);
+                            } else {
+                                assert!(matches!(response, Apdu::SimpleAck(_)));
+                                assert_eq!(
+                                    state.load(Ordering::Acquire),
+                                    if mode == EnableDisable::ENABLE { 0 } else { 2 }
+                                );
+                                assert_eq!(timer.lock().await.is_some(), duration.is_some());
+                                super::super::super::dcc_timer::cancel(&mut *timer.lock().await)
+                                    .await;
+                                continue;
+                            }
+                            assert_eq!(state.load(Ordering::Acquire), 1);
+                            assert!(timer.lock().await.is_none());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_default_denials_preserve_timer_even_with_expiry_waiting_for_lock() {
+    for pending_expiry in [false, true] {
+        let state = Arc::new(AtomicU8::new(0));
+        let timer = Arc::new(Mutex::new(None));
+        assert!(matches!(
+            dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, Some(1)).await,
+            Apdu::SimpleAck(_)
+        ));
+        tokio::task::yield_now().await;
+        let slot = timer.lock().await;
+        let id = slot.as_ref().unwrap().id();
+        advance(Duration::from_secs(if pending_expiry { 60 } else { 30 })).await;
+        tokio::task::yield_now().await;
+        for mode in [
+            EnableDisable::ENABLE,
+            EnableDisable::DISABLE_INITIATION,
+            EnableDisable::DISABLE,
+        ] {
+            for duration in [None, Some(0), Some(5)] {
+                for password in [None, Some("required")] {
+                    let config = ServerConfig {
+                        dcc_password: password.map(str::to_owned),
+                        ..Default::default()
+                    };
+                    // Holding the live lock proves rejection cannot wait for or mutate it.
+                    assert_denied(
+                        dispatch_wire(&state, &timer, mode, duration, &config, password, None)
+                            .await,
+                    );
+                    assert_eq!(state.load(Ordering::Acquire), 2);
+                    assert_eq!(slot.as_ref().unwrap().id(), id);
+                }
+            }
+        }
+        drop(slot);
+        if !pending_expiry {
+            advance(Duration::from_secs(29)).await;
+            tokio::task::yield_now().await;
+            assert_eq!(state.load(Ordering::Acquire), 2);
+            advance(Duration::from_secs(1)).await;
+        }
+        let task = timer.lock().await.take().unwrap();
+        task.await.unwrap();
+        assert_eq!(state.load(Ordering::Acquire), 0);
+    }
 }
 
 #[tokio::test(start_paused = true)]
@@ -136,6 +280,61 @@ fn held_timer() -> (JoinHandle<()>, oneshot::Receiver<()>) {
         std::future::pending::<()>().await;
     });
     (handle, rx)
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_require_password_preserves_replacement_expiry_and_enable_timer_semantics() {
+    let config = ServerConfig {
+        dcc_policy: DccPolicy::RequirePassword,
+        dcc_password: Some("required".into()),
+        ..Default::default()
+    };
+    let state = Arc::new(AtomicU8::new(0));
+    let timer = Arc::new(Mutex::new(None));
+    for (mode, duration) in [
+        (EnableDisable::DISABLE_INITIATION, Some(1)),
+        (EnableDisable::DISABLE_INITIATION, Some(2)),
+        (EnableDisable::ENABLE, Some(2)),
+        (EnableDisable::DISABLE_INITIATION, None),
+        (EnableDisable::ENABLE, None),
+        (EnableDisable::DISABLE_INITIATION, Some(0)),
+    ] {
+        let previous = timer.lock().await.as_ref().map(JoinHandle::abort_handle);
+        assert!(matches!(
+            dispatch_wire(
+                &state,
+                &timer,
+                mode,
+                duration,
+                &config,
+                Some("required"),
+                None
+            )
+            .await,
+            Apdu::SimpleAck(_)
+        ));
+        if let Some(previous) = previous {
+            assert!(previous.is_finished());
+        }
+        assert_eq!(
+            state.load(Ordering::Acquire),
+            if mode == EnableDisable::ENABLE { 0 } else { 2 }
+        );
+        assert_eq!(timer.lock().await.is_some(), duration.is_some());
+        tokio::task::yield_now().await;
+        if duration == Some(0) {
+            let task = timer.lock().await.take().unwrap();
+            task.await.unwrap();
+            assert_eq!(state.load(Ordering::Acquire), 0);
+        } else {
+            advance(Duration::from_secs(30)).await;
+            tokio::task::yield_now().await;
+            assert_eq!(
+                state.load(Ordering::Acquire),
+                if mode == EnableDisable::ENABLE { 0 } else { 2 }
+            );
+        }
+    }
 }
 
 #[tokio::test(start_paused = true)]

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -293,6 +293,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     comm_state,
                     &req.service_request,
                     &config.dcc_password,
+                    config.dcc_policy,
                 )
                 .await
                 {

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -96,6 +96,12 @@ impl ScServerBuilder {
         self
     }
 
+    /// Select explicit local DCC authorization (default: deny all).
+    pub fn dcc_policy(mut self, policy: DccPolicy) -> Self {
+        self.config.dcc_policy = policy;
+        self
+    }
+
     /// Set the password required for ReinitializeDevice requests.
     pub fn reinit_password(mut self, password: impl Into<String>) -> Self {
         self.config.reinit_password = Some(password.into());
@@ -186,6 +192,7 @@ impl ScServerBuilder {
             .ok_or_else(|| Error::Encoding("SC server builder: tls_config is required".into()))?;
 
         self.config.request_admission_policy.validate()?;
+        self.config.dcc_policy.validate(&self.config.dcc_password)?;
         self.config.read_property_multiple_budget.validate()?;
         self.config.get_alarm_summary_budget.validate()?;
         self.config.get_enrollment_summary_budget.validate()?;

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1775,6 +1775,7 @@ class BACnetServer:
         dcc_password: Optional[str] = None,
         reinit_password: Optional[str] = None,
         *,
+        dcc_policy: str = "deny_all",
         serial_port: Optional[str] = None,
         mstp_baud: int = 38400,
         mstp_mac: int = 1,

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -100,6 +100,7 @@ pub struct BACnetServer {
     mstp_max_info_frames: u8,
     // Passwords
     dcc_password: Option<String>,
+    dcc_policy: server::DccPolicy,
     reinit_password: Option<String>,
     request_admission_policy: server::RequestAdmissionPolicy,
     read_property_multiple_budget: server::ReadPropertyMultipleBudget,

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -201,6 +201,7 @@ mod tests {
             mstp_max_master: 127,
             mstp_max_info_frames: 1,
             dcc_password: None,
+            dcc_policy: server::DccPolicy::default(),
             reinit_password: None,
             request_admission_policy: server::RequestAdmissionPolicy::default(),
             read_property_multiple_budget: server::ReadPropertyMultipleBudget::default(),

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -36,6 +36,7 @@ impl BACnetServer {
         let sc_heartbeat_timeout_ms = self.sc_heartbeat_timeout_ms;
         let ipv6_interface = self.ipv6_interface.clone();
         let dcc_password = self.dcc_password.clone();
+        let dcc_policy = self.dcc_policy;
         let reinit_password = self.reinit_password.clone();
         let request_admission_policy = self.request_admission_policy;
         let read_property_multiple_budget = self.read_property_multiple_budget;
@@ -160,6 +161,7 @@ impl BACnetServer {
             if let Some(pw) = dcc_password {
                 builder = builder.dcc_password(pw);
             }
+            builder = builder.dcc_policy(dcc_policy);
             if let Some(pw) = reinit_password {
                 builder = builder.reinit_password(pw);
             }

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -21,6 +21,7 @@ impl BACnetServer {
         dcc_password=None,
         reinit_password=None,
         *,
+        dcc_policy="deny_all",
         serial_port=None,
         mstp_baud=38400,
         mstp_mac=1,
@@ -68,6 +69,7 @@ impl BACnetServer {
         ipv6_interface: Option<String>,
         dcc_password: Option<String>,
         reinit_password: Option<String>,
+        dcc_policy: &str,
         serial_port: Option<String>,
         mstp_baud: u32,
         mstp_mac: u8,
@@ -97,6 +99,19 @@ impl BACnetServer {
         event_information_max_returned_summaries: usize,
         event_information_max_service_ack_bytes: usize,
     ) -> PyResult<Self> {
+        let dcc_policy = match dcc_policy {
+            "deny_all" => server::DccPolicy::DenyAll,
+            "require_password" => server::DccPolicy::RequirePassword,
+            "legacy_permissive" => server::DccPolicy::LegacyPermissive,
+            _ => {
+                return Err(pyo3::exceptions::PyValueError::new_err(
+                    "dcc_policy must be 'deny_all', 'require_password', or 'legacy_permissive'",
+                ))
+            }
+        };
+        dcc_policy
+            .validate(&dcc_password)
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
             max_unconfirmed_in_flight,
@@ -182,6 +197,7 @@ impl BACnetServer {
             mstp_max_master,
             mstp_max_info_frames,
             dcc_password,
+            dcc_policy,
             reinit_password,
             request_admission_policy,
             read_property_multiple_budget,

--- a/crates/rusty-bacnet/tests/test_dcc_policy.py
+++ b/crates/rusty-bacnet/tests/test_dcc_policy.py
@@ -1,0 +1,118 @@
+"""Installed-native DCC local policy, not source authentication or hardware proof."""
+import asyncio
+import inspect
+import socket
+import unittest
+from typing import Any
+
+from rusty_bacnet import BACnetServer
+
+
+class DccConstructorTests(unittest.TestCase):
+    def test_policy_validation_before_every_transport(self):
+        parameter = inspect.signature(BACnetServer).parameters["dcc_policy"]
+        self.assertEqual(parameter.default, "deny_all")
+        self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+        for transport in ["bip", "ipv6", "sc", "mstp"]:
+            for invalid in ["", "DenyAll", "DENY_ALL", "require-password", "unknown"]:
+                with self.subTest(transport=transport, invalid=invalid):
+                    with self.assertRaisesRegex(ValueError, "dcc_policy"):
+                        BACnetServer(123, transport=transport, dcc_policy=invalid)
+            for invalid in [None, 1, b"deny_all"]:
+                with self.assertRaises(TypeError):
+                    BACnetServer(123, transport=transport, dcc_policy=invalid)
+            for password in [None, ""]:
+                with self.assertRaisesRegex(ValueError, "nonempty dcc_password"):
+                    BACnetServer(123, transport=transport, dcc_policy="require_password",
+                                 dcc_password=password)
+            BACnetServer(123, transport=transport, dcc_policy="require_password", dcc_password="x")
+            for policy in ["deny_all", "legacy_permissive"]:
+                for password in [None, "", "x" * 100]:
+                    BACnetServer(123, transport=transport, dcc_policy=policy, dcc_password=password)
+
+
+class DccNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def exchange(self, server, sock, invoke, mode, password, routed, duration=None):
+        body = b"" if duration is None else bytes([0x09, duration])
+        body += bytes([0x19, mode])
+        if password is not None:
+            content = b"\0" + password.encode()
+            body += bytes([0x2d, len(content)]) + content
+        # Routed source is an address, deliberately not an authenticated principal.
+        header = b"\x01\x08\x00\x07\x01\x2a" if routed else b"\x01\x00"
+        npdu = header + bytes([0, 5, invoke, 17]) + body
+        wire = b"\x81\x0a" + (len(npdu) + 4).to_bytes(2, "big") + npdu
+        ip, port = (await server.local_address()).rsplit(":", 1)
+        loop = asyncio.get_running_loop()
+        await loop.sock_sendto(sock, wire, (ip, int(port)))
+        reply, _ = await asyncio.wait_for(loop.sock_recvfrom(sock, 2048), 2)
+        self.assertEqual(reply[:2], b"\x81\x0a")
+        self.assertEqual(int.from_bytes(reply[2:4], "big"), len(reply))
+        offset = 6
+        if reply[5] & 0x20:
+            offset += 4 + reply[8]  # DNET, DLEN, DADR, hop count
+        apdu = reply[offset:]
+        self.assertEqual(apdu[1:3], bytes([invoke, 17]))
+        async with asyncio.timeout(2):
+            while (await server.request_admission_counters())["confirmed_active"]:
+                await asyncio.sleep(0)
+        return apdu
+
+    async def test_default_and_explicit_modes_wire_precedence(self):
+        for policy in [None, "require_password", "legacy_permissive"]:
+            for configured in [None, "required"]:
+                if policy == "require_password" and configured is None:
+                    continue
+                options: dict[str, Any] = {} if policy is None else {"dcc_policy": policy}
+                server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                      broadcast_address="127.0.0.1", dcc_password=configured, **options)
+                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                sock.bind(("127.0.0.1", 0))
+                sock.setblocking(False)
+                try:
+                    await server.start()
+                    invoke = 0
+                    for routed in [False, True]:
+                        for mode in [2, 0, 1]:
+                            for password in [None, "wrong", "required"]:
+                                invoke += 1
+                                before = await server.comm_state()
+                                reply = await self.exchange(server, sock, invoke, mode, password, routed)
+                                bad_password = configured is not None and password != configured
+                                denied = bad_password or policy is None or mode == 1
+                                with self.subTest(policy=policy, configured=configured, mode=mode,
+                                                  password=password, routed=routed):
+                                    if denied:
+                                        # Independent Error encoding: class SECURITY=4/code PASSWORD_FAILURE=26;
+                                        # class SERVICES=5/code SERVICE_REQUEST_DENIED=29.
+                                        self.assertEqual(reply, bytes([0x50, invoke, 17, 0x91,
+                                                                      4 if bad_password else 5, 0x91,
+                                                                      26 if bad_password else 29]))
+                                        self.assertEqual(await server.comm_state(), before)
+                                    else:
+                                        self.assertEqual(reply, bytes([0x20, invoke, 17]))
+                                        self.assertEqual(await server.comm_state(), mode)
+                    counters = await server.request_admission_counters()
+                    self.assertEqual(counters["recovery_admitted_total"], 6)
+                finally:
+                    await server.stop()
+                    sock.close()
+
+    async def test_native_zero_and_indefinite_legacy_timer_semantics(self):
+        server = BACnetServer(123, interface="127.0.0.1", port=0,
+                              broadcast_address="127.0.0.1", dcc_policy="legacy_permissive")
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.setblocking(False)
+        try:
+            await server.start()
+            self.assertEqual((await self.exchange(server, sock, 1, 2, None, False))[0], 0x20)
+            await asyncio.sleep(0.02)
+            self.assertEqual(await server.comm_state(), 2)
+            self.assertEqual((await self.exchange(server, sock, 2, 2, None, False, 0))[0], 0x20)
+            async with asyncio.timeout(2):
+                while await server.comm_state() != 0:
+                    await asyncio.sleep(0)
+        finally:
+            await server.stop()
+            sock.close()

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -61,7 +61,7 @@ MSTP_KEYWORD_ONLY = [
     "mstp_max_master",
     "mstp_max_info_frames",
 ]
-SERVER_KEYWORD_ONLY = MSTP_KEYWORD_ONLY + [
+SERVER_KEYWORD_ONLY = ["dcc_policy"] + MSTP_KEYWORD_ONLY + [
     "max_confirmed_in_flight", "max_unconfirmed_in_flight",
     "max_confirmed_in_flight_per_peer", "max_unconfirmed_in_flight_per_peer",
     "confirmed_recovery_reserve", "max_recovery_in_flight_per_peer",

--- a/crates/rusty-bacnet/tests/test_recovery_admission.py
+++ b/crates/rusty-bacnet/tests/test_recovery_admission.py
@@ -45,6 +45,7 @@ class RecoveryNativeTests(unittest.IsolatedAsyncioTestCase):
         for reserve in [0, 1]:
             server = BACnetServer(123, interface="127.0.0.1", port=0,
                                   broadcast_address="127.0.0.1", dcc_password="required",
+                                  dcc_policy="require_password",
                                   max_confirmed_in_flight=2, confirmed_recovery_reserve=reserve,
                                   max_recovery_in_flight_per_peer=1)
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/docs/dcc-policy.md
+++ b/docs/dcc-policy.md
@@ -1,0 +1,75 @@
+# DeviceCommunicationControl local authorization
+
+Configured servers now **deny DCC by default**, including valid ENABLE and
+DISABLE_INITIATION requests with the correct configured password. A password
+alone no longer enables the service. This is stricter **local operator policy**,
+not a BACnet-mandated default and not authentication of a source principal.
+
+| Rust `server::DccPolicy` | Python keyword-only `dcc_policy` | Authorization |
+|---|---|---|
+| `DenyAll` (default) | `"deny_all"` (default) | Deny valid supported modes |
+| `RequirePassword` | `"require_password"` | Explicit opt-in; require a configured nonempty `dcc_password` and matching request password |
+| `LegacyPermissive` | `"legacy_permissive"` | **INSECURE compatibility opt-in**: preserve optional-password behavior |
+
+LegacyPermissive does **not** bypass a configured password. Without one, any
+requester whose request reaches the handler can change communications. Do not
+mistake this compatibility option, a shared password, a routed address, or an SC
+VMAC for authenticated source identity. Source authorization, auditing and rate
+policy remain future work under the partial, separate #522 scope.
+
+## Migration
+
+Rust: set `ServerConfig::dcc_policy` or call `.dcc_policy(DccPolicy::RequirePassword)`
+alongside `.dcc_password(...)` on the generic, B/IP or SC builder. Exhaustive
+`ServerConfig` literals must add the new field (or an appropriate default update).
+The default is DenyAll, even for applications already setting `dcc_password`.
+
+Python: pass `dcc_policy="require_password"` alongside `dcc_password=...` to
+`BACnetServer`. The new argument is keyword-only; existing positional password
+and ReinitializeDevice arguments retain their positions. Exact lower-case values
+above are accepted; unknown strings raise `ValueError`, nonstrings `TypeError`.
+RequirePassword with absent or empty configuration fails before startup/dial
+(Python constructor: `ValueError`; Rust startup/build: configuration error).
+DenyAll and LegacyPermissive introduce no password-length restrictions.
+
+The public unconfigured Rust
+`handlers::handle_device_communication_control` keeps its legacy optional-password
+API and behavior. It does not inherit the configured server default.
+ReinitializeDevice's separate password and handler are unchanged.
+
+## Ordering and side effects
+
+Existing admission, duplicate handling and DCC ingress discards are unchanged.
+After admission: decode, existing constant-time password check, deprecated DISABLE
+rejection, then local policy for ENABLE/DISABLE_INITIATION, then live state/timer
+commit. Missing/wrong configured passwords return SECURITY/PASSWORD_FAILURE even
+under DenyAll or for DISABLE. Otherwise denied valid requests return
+SERVICES/SERVICE_REQUEST_DENIED. Unknown-mode decoding/encoding errors retain
+their existing precedence. Deprecated DISABLE remains denied in **every** policy.
+
+Denial happens before the live timer lock, cancellation or state mutation.
+Repeated denied requests cannot create, cancel or extend a timer, including when
+its expiry is waiting for the same lock; denied ENABLE cannot clear state 2.
+Admitted requests preserve existing behavior: absent duration is indefinite,
+zero schedules immediate expiry, positive values use minutes, and subsequent
+admitted requests replace the timer. Existing ENABLE timer handling is retained.
+These are compatibility semantics, **not new timer conformance evidence**:
+ASHRAE 135-2020 §16.1 specifies ignoring duration for ENABLE; this slice does not
+change that existing implementation nuance. Explicit stop still cancels and
+joins the owned timer.
+
+Decode-accepted ENABLE remains eligible for protected recovery capacity regardless
+of policy or password. It can occupy that capacity until the handler denies it;
+there is no pre-admission authorization. Capacity exhaustion may still Abort
+before handler validation. [Request admission](request-admission.md) and the
+completed bounded #521 acceptance remain unchanged, not reopened.
+
+## Source and limits
+
+Local licensed ASHRAE 135-2020 §16.1 (printed 759–760) supplies the existing
+optional-password and deprecated-DISABLE rules; §18.6 (printed 795) describes
+SERVICE_REQUEST_DENIED for lack of authorization. The three configuration modes,
+nonempty startup requirement and deny-all default are operator policy, not new
+normative claims. This does not expand authenticated-SC, physical-transport,
+full-conformance, Audit/#125, EventLog integration, additional #181 fault-family
+or GATE0007 qualification.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1147,7 +1147,8 @@ server = BACnetServer(
     broadcast_address="255.255.255.255",
     transport="bip",             # "bip", "ipv6", or "sc"
     # SC options same as BACnetClient
-    dcc_password=None,           # password for DeviceCommunicationControl
+    dcc_password=None,           # password alone does not enable DCC
+    dcc_policy="deny_all",       # keyword-only; explicit require_password or INSECURE legacy_permissive
     reinit_password=None,        # password for ReinitializeDevice
 )
 ```
@@ -1740,7 +1741,8 @@ On SC, the supplied VMAC/logical source is not an authenticated principal.
 Identity multiplication/spoofing can exhaust global capacity; quotas do not
 guarantee availability once that capacity is full. The default confirmed total64
 is strictly partitioned into ordinary60/protected4 with no lending in either
-direction. Only decoder-accepted DCC ENABLE is protected; existing password checks
+direction. Only decoder-accepted DCC ENABLE is protected; [local DCC policy](dcc-policy.md)
+defaults to denial without changing eligibility. Existing password checks
 still apply in the handler, so wrong/missing required passwords can consume a slot
 before PASSWORD_FAILURE. Ordinary peer16 and protected peer1 are independent:
 the same peer can hold 16+1 handlers in either arrival order. This replaces the

--- a/docs/request-admission.md
+++ b/docs/request-admission.md
@@ -64,7 +64,9 @@ Classification is **not authorization**: existing handler password checks remain
 authoritative. Decode-valid ENABLE with a wrong or missing required password can
 briefly occupy a protected slot and return PASSWORD_FAILURE. Capacity exhaustion
 still produces the existing Abort before handler execution or password validation.
-No authentication or default-deny behavior changes.
+The separate [DCC policy](dcc-policy.md) now defaults to denial after these
+checks. Decode-valid ENABLE remains eligible regardless of policy; admission is
+not authorization and policy denial does not change live communications or timers.
 
 Neither partition lends capacity: ordinary requests cannot use free protected
 slots; protected requests cannot fall back to free ordinary slots when `R > 0`.
@@ -236,8 +238,9 @@ Explicit stop joins the owned task families above, not async Drop or all server
 work regardless of transport and opaque blocking behavior.
 
 [#522](https://github.com/jscott3201/rusty-bacnet/issues/522) remains open and separate:
-authentication/default-deny policy and deprecated DCC DISABLE handling are not
-implemented by this work. Deferred production EventLog integration, Audit/#125,
+deprecated DISABLE rejection and [default-deny local policy](dcc-policy.md) are
+delivered separately; source authorization, audit and rate policy remain future
+work. Deferred production EventLog integration, Audit/#125,
 additional #181 EventEnrollment fault families, and GATE0007/SC restrictions are
 unchanged. Accepted exclusions do not automatically create follow-up tasks or
 reopen the bounded #521 scope.


### PR DESCRIPTION
## Summary
Refs #522 (partial). Configured servers default to DccPolicy::DenyAll, even with a correct configured password. Explicit RequirePassword requires nonempty configured password before startup/dial; explicit LegacyPermissive preserves optional-password behavior and is documented INSECURE. Python keyword-only dcc_policy defaults deny_all; existing positional passwords unchanged. Rust ServerConfig field and behavior migration documented.

Admission then decode/password/deprecated-DISABLE gates retain precedence; local deny follows, before live timer lock/cancel/state mutation. Wrong/missing configured password remains PASSWORD_FAILURE; otherwise policy denial is SERVICES/SERVICE_REQUEST_DENIED. Repeated denied requests cannot create/cancel/extend active timer. DISABLE remains denied in every mode. Shared legacy low-level helper, ReinitializeDevice, password algorithm, recovery classifier/quotas and admitted duration/replacement behavior unchanged.

## Validation
- Genuine baselineRED defaultENABLE produced unexpectedSimpleACK; no separate baseline timer-mutation claim.
- DCC35/password15/device_event10/timer10/recovery25/admission48/shutdown70/SC1 pass.
- Server1026unit+3integration; integration40; workspace4358passed/3existingignored;fmt/clippywarnings/size/secrets/diff/newfiles/bindingcheckclippy pass.
- Freshlocked CPython3.12.13 macOSarm64 DEV wheel after final production, noneditable/nativeorigin/direct_url/stubparity verified. Python55tests913subtests pass incl root independent rerun;focused16/192repeat.
- WheelSHA f7aa6ab93be4e9edc3957c0aa46485ad9cb8092aadb829057005aedd1b5018cd.
- Direct/routed policy/password matrix, timer identity under held expiry lock, and admitted-but-denied ENABLE recovery occupancy covered. Existing success-dependent fixtures explicitly opt in.

## Boundaries
Local operator authorization, not source authentication or Standard-mandated default. No authenticated-SC principal/allowlist, audit or rate-limit implementation; #522 remains open/partial. #521 remains completed; eligible denied ENABLE still occupies recovery capacity until handler completion. Existing zero/ENABLE duration nuance retained, not new conformance evidence. No Reinit/object/CI/dependency/support expansion, hardware/authenticated-SC live session or release-performance claim.

Two independent exact-head reviews and CI pending.