### PR TITLE
feat(server): expose completed DCC outcome telemetry

### DIFF
--- a/crates/bacnet-server/src/handlers/device_mgmt.rs
+++ b/crates/bacnet-server/src/handlers/device_mgmt.rs
@@ -57,36 +57,77 @@ pub(crate) fn handle_device_communication_control_with_policy(
     dcc_password: &Option<String>,
     policy: crate::server::DccPolicy,
 ) -> Result<(EnableDisable, Option<u16>), Error> {
-    let request = DeviceCommunicationControlRequest::decode(service_data)?;
-    validate_password(dcc_password, &request.password)?;
+    let validated = validate_dcc(service_data, dcc_password, policy).map_err(|f| f.error)?;
+    let (mode, duration, new_state) = validated;
+    comm_state.store(new_state, Ordering::Release);
+    tracing::debug!(
+        "DeviceCommunicationControl: state set to {:?} ({}), duration={:?} min",
+        mode,
+        new_state,
+        duration
+    );
+    Ok((mode, duration))
+}
+
+pub(crate) struct DccFailure {
+    pub error: Error,
+    pub outcome: crate::server::dcc_outcomes::DccOutcome,
+    pub metadata: crate::server::dcc_outcomes::DccMetadata,
+}
+
+pub(crate) fn validate_dcc(
+    service_data: &[u8],
+    dcc_password: &Option<String>,
+    policy: crate::server::DccPolicy,
+) -> Result<(EnableDisable, Option<u16>, u8), DccFailure> {
+    use crate::server::dcc_outcomes::{DccMetadata, DccOutcome};
+    let request =
+        DeviceCommunicationControlRequest::decode(service_data).map_err(|error| DccFailure {
+            error,
+            outcome: DccOutcome::Malformed,
+            metadata: DccMetadata::default(),
+        })?;
+    let metadata = DccMetadata {
+        mode: Some(request.enable_disable.to_raw()),
+        duration: request.time_duration,
+    };
+    let failure = |error, outcome| DccFailure {
+        error,
+        outcome,
+        metadata,
+    };
+    validate_password(dcc_password, &request.password)
+        .map_err(|e| failure(e, DccOutcome::PasswordFailure))?;
     let new_state = if request.enable_disable == EnableDisable::ENABLE {
         0u8
     } else if request.enable_disable == EnableDisable::DISABLE {
         // ASHRAE 135-2020 Clause 16.1: reject deprecated DISABLE after
         // password validation, without changing state or the caller's timer.
-        return Err(Error::Protocol {
-            class: ErrorClass::SERVICES.to_raw() as u32,
-            code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
-        });
+        return Err(failure(
+            Error::Protocol {
+                class: ErrorClass::SERVICES.to_raw() as u32,
+                code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+            },
+            DccOutcome::DeprecatedDenied,
+        ));
     } else if request.enable_disable == EnableDisable::DISABLE_INITIATION {
         2u8
     } else {
-        return Err(Error::Encoding("unknown EnableDisable value".into()));
+        return Err(failure(
+            Error::Encoding("unknown EnableDisable value".into()),
+            DccOutcome::Malformed,
+        ));
     };
     if policy == crate::server::DccPolicy::DenyAll {
-        return Err(Error::Protocol {
-            class: ErrorClass::SERVICES.to_raw() as u32,
-            code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
-        });
+        return Err(failure(
+            Error::Protocol {
+                class: ErrorClass::SERVICES.to_raw() as u32,
+                code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+            },
+            DccOutcome::PolicyDenied,
+        ));
     }
-    comm_state.store(new_state, Ordering::Release);
-    tracing::debug!(
-        "DeviceCommunicationControl: state set to {:?} ({}), duration={:?} min",
-        request.enable_disable,
-        new_state,
-        request.time_duration
-    );
-    Ok((request.enable_disable, request.time_duration))
+    Ok((request.enable_disable, request.time_duration, new_state))
 }
 
 /// Handle a ReinitializeDevice request.

--- a/crates/bacnet-server/src/handlers/mod.rs
+++ b/crates/bacnet-server/src/handlers/mod.rs
@@ -40,7 +40,7 @@ mod alarm_event;
 mod audit_log_query;
 mod audit_notification;
 mod cov;
-mod device_mgmt;
+pub(crate) mod device_mgmt;
 mod file;
 mod list;
 mod object_mgmt;

--- a/crates/bacnet-server/src/server/dcc_outcome_admission_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_outcome_admission_tests.rs
@@ -1,0 +1,120 @@
+use super::*;
+use crate::server::dcc_outcomes::trace_tests::Capture;
+
+fn dcc(id: u8) -> Apdu {
+    let Apdu::ConfirmedRequest(mut req) = request(id) else {
+        unreachable!()
+    };
+    req.service_choice = ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL;
+    req.service_request = Bytes::from_static(b"\x19\x00");
+    Apdu::ConfirmedRequest(req)
+}
+
+#[tokio::test]
+async fn dcc_outcomes_exclude_global_peer_and_abort_fallback_rejections() {
+    for (global, peer) in [(1, 16), (4, 1)] {
+        let capture = Capture::default();
+        let _subscriber = tracing::subscriber::set_default(capture.clone());
+        let (mut server, _, mut started) = fixture_with_config(
+            "overload",
+            ServerConfig {
+                request_admission_policy: RequestAdmissionPolicy {
+                    max_confirmed_in_flight: global,
+                    max_confirmed_in_flight_per_peer: peer,
+                    confirmed_recovery_reserve: 0,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        )
+        .await;
+        dispatch(&server, dcc(1), None, None).await;
+        let mut completions = vec![observed(&mut started).await];
+        for id in 2..=9 {
+            dispatch(&server, dcc(id), None, None).await;
+            completions.push(observed(&mut started).await);
+        }
+        dispatch(&server, dcc(10), None, None).await;
+        let counters = server.request_admission_counters();
+        assert_eq!(
+            counters.confirmed_global_overloaded_total,
+            if global == 1 { 9 } else { 0 }
+        );
+        assert_eq!(
+            counters.confirmed_peer_overloaded_total,
+            if peer == 1 { 9 } else { 0 }
+        );
+        assert_eq!(counters.abort_admitted_total, 8);
+        assert_eq!(counters.confirmed_fallback_dropped_total, 1);
+        assert_eq!(server.dcc_outcome_counters().policy_denied_total, 1);
+        assert_eq!(capture.0.lock().unwrap().len(), 1);
+        server.stop().await.unwrap();
+        for completion in completions {
+            completion.await.unwrap();
+        }
+        assert_eq!(capture.0.lock().unwrap().len(), 1);
+    }
+}
+
+#[tokio::test]
+async fn dcc_outcomes_recovery_denied_duplicate_overload_and_shutdown() {
+    // Current-thread runtime: this scoped default also covers spawned handlers.
+    // No global subscriber is installed and no events escape the test.
+    let capture = Capture::default();
+    let _subscriber = tracing::subscriber::set_default(capture.clone());
+    let (mut server, _, mut started) = fixture_with_config(
+        "outcomes admission",
+        ServerConfig {
+            request_admission_policy: RequestAdmissionPolicy {
+                max_confirmed_in_flight: 2,
+                confirmed_recovery_reserve: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .await;
+    dispatch(&server, request(1), None, None).await;
+    let ordinary = observed(&mut started).await;
+    assert!(
+        tracing::dispatcher::get_default(|d| d.is::<Capture>()),
+        "lost scoped subscriber before dispatch"
+    );
+    dispatch(&server, dcc(2), None, None).await;
+    let recovery = observed(&mut started).await;
+    assert_eq!(server.dcc_outcome_counters().policy_denied_total, 1);
+    assert_eq!(
+        server.request_admission_counters().recovery_admitted_total,
+        1
+    );
+    assert_eq!(capture.0.lock().unwrap().len(), 1);
+    assert_eq!(capture.0.lock().unwrap()[0]["outcome"], "policy_denied");
+    dispatch(&server, dcc(2), None, None).await; // in-flight duplicate
+    assert_eq!(
+        server.request_admission_counters().confirmed_admitted_total,
+        2
+    );
+    dispatch(&server, dcc(3), None, None).await; // recovery partition full
+    let abort = observed(&mut started).await;
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .recovery_overloaded_total,
+        1
+    );
+    assert_eq!(server.dcc_outcome_counters().policy_denied_total, 1);
+    assert_eq!(capture.0.lock().unwrap().len(), 1);
+    server.stop().await.unwrap();
+    ordinary.await.unwrap();
+    recovery.await.unwrap();
+    abort.await.unwrap();
+    dispatch(&server, dcc(4), None, None).await;
+    assert_eq!(
+        server
+            .request_admission_counters()
+            .confirmed_shutdown_rejected_total,
+        1
+    );
+    assert_eq!(server.dcc_outcome_counters().policy_denied_total, 1);
+    assert_eq!(capture.0.lock().unwrap().len(), 1);
+}

--- a/crates/bacnet-server/src/server/dcc_outcome_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_outcome_tests.rs
@@ -1,0 +1,242 @@
+use super::*;
+use crate::server::dcc_outcomes::trace_tests::Capture;
+use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
+use bacnet_types::enums::EnableDisable;
+use std::future::{poll_fn, Future};
+use std::task::Poll;
+use tracing::instrument::WithSubscriber;
+
+fn request(mode: u32, password: Option<&str>, duration: Option<u16>) -> ConfirmedRequestPdu {
+    let mut data = BytesMut::new();
+    DeviceCommunicationControlRequest {
+        time_duration: duration,
+        enable_disable: EnableDisable::from_raw(mode),
+        password: password.map(str::to_owned),
+    }
+    .encode(&mut data)
+    .unwrap();
+    ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 480,
+        invoke_id: 42,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+        service_request: data.freeze(),
+    }
+}
+
+async fn handle(server: &BACnetServer<HeldTransport>, req: ConfirmedRequestPdu) {
+    BACnetServer::handle_admitted_confirmed_request(
+        &server.db,
+        &server.network,
+        &server.cov_table,
+        &server.seg_ack_senders,
+        &server.seg_send_permits,
+        &server.cov_in_flight,
+        &server.server_tsm,
+        &server.notification_transactions,
+        &server.device_bindings,
+        &server.comm_state,
+        &server.dcc_timer,
+        &server.dcc_outcomes,
+        &server.config,
+        &server.request_tasks.spawner(),
+        &[1],
+        None,
+        req,
+        None,
+    )
+    .await;
+}
+
+async fn poll_pending(future: std::pin::Pin<&mut impl Future<Output = ()>>) {
+    let mut future = future;
+    poll_fn(|cx| {
+        assert!(future.as_mut().poll(cx).is_pending());
+        Poll::Ready(())
+    })
+    .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_outcomes_exact_precedence_before_response_and_secret_redaction() {
+    // Acceptance tests for the new API, not a claimed baseline behavioral RED.
+    for (policy, mode, password, expected) in [
+        (
+            DccPolicy::LegacyPermissive,
+            2,
+            "sentinel-correct",
+            "accepted",
+        ),
+        (
+            DccPolicy::RequirePassword,
+            0,
+            "sentinel-correct",
+            "accepted",
+        ),
+        (DccPolicy::DenyAll, 0, "sentinel-correct", "policy_denied"),
+        (DccPolicy::DenyAll, 2, "sentinel-correct", "policy_denied"),
+        (
+            DccPolicy::DenyAll,
+            1,
+            "sentinel-correct",
+            "deprecated_denied",
+        ),
+        (DccPolicy::DenyAll, 1, "sentinel-wrong", "password_failure"),
+        (DccPolicy::DenyAll, 99, "sentinel-correct", "malformed"),
+        (DccPolicy::DenyAll, 99, "sentinel-wrong", "password_failure"),
+    ] {
+        let (mut server, _, mut started) = fixture_with_config(
+            "outcomes",
+            ServerConfig {
+                dcc_policy: policy,
+                dcc_password: Some("sentinel-correct".into()),
+                ..Default::default()
+            },
+        )
+        .await;
+        let capture = Capture::default();
+        assert_eq!(server.dcc_outcome_counters(), DccOutcomeCounters::default());
+        {
+            let future = handle(&server, request(mode, Some(password), Some(10)))
+                .with_subscriber(capture.clone());
+            tokio::pin!(future);
+            poll_pending(future.as_mut()).await;
+            let completion = started.try_recv().unwrap();
+            let counts = server.dcc_outcome_counters();
+            assert_eq!(counts.accepted_total, u64::from(expected == "accepted"));
+            assert_eq!(
+                counts.policy_denied_total,
+                u64::from(expected == "policy_denied")
+            );
+            assert_eq!(
+                counts.password_failure_total,
+                u64::from(expected == "password_failure")
+            );
+            assert_eq!(
+                counts.deprecated_denied_total,
+                u64::from(expected == "deprecated_denied")
+            );
+            assert_eq!(counts.malformed_total, u64::from(expected == "malformed"));
+            assert_eq!(
+                server.comm_state(),
+                if expected == "accepted" {
+                    mode as u8
+                } else {
+                    0
+                }
+            );
+            {
+                let events = capture.0.lock().unwrap();
+                assert_eq!(events.len(), 1);
+                assert_eq!(events[0]["outcome"], expected);
+                assert_eq!(events[0]["decoded_mode"], mode.to_string());
+                assert_eq!(events[0]["duration_minutes"], "10");
+                assert_eq!(events[0]["invoke_id"], "42");
+                assert_eq!(events[0]["service"], "17");
+                assert!(!format!("{events:?}").contains("sentinel"));
+                assert!(!events[0].keys().any(|key| key.contains("password")));
+            }
+            // Fail transport after the commit; never revise or double count it.
+            server
+                .network
+                .transport()
+                .fail_next
+                .store(true, Ordering::Release);
+            server.network.transport().release.notify_one();
+            future.await;
+            completion.await.unwrap();
+            assert_eq!(server.dcc_outcome_counters(), counts);
+        }
+        let counts = server.dcc_outcome_counters();
+        server.stop().await.unwrap();
+        assert_eq!(server.dcc_outcome_counters(), counts);
+        assert_eq!(capture.0.lock().unwrap().len(), 1);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_outcomes_cancellation_denial_timer_identity_and_decode_failure() {
+    let (mut server, _, mut started) = fixture_with_config(
+        "cancel",
+        ServerConfig {
+            dcc_policy: DccPolicy::LegacyPermissive,
+            ..Default::default()
+        },
+    )
+    .await;
+    let capture = Capture::default();
+    let _subscriber = tracing::subscriber::set_default(capture.clone());
+    let lock = server.dcc_timer.lock().await;
+    {
+        let future = handle(&server, request(2, None, Some(10))).with_subscriber(capture.clone());
+        tokio::pin!(future);
+        poll_pending(future.as_mut()).await;
+    }
+    assert_eq!(server.dcc_outcome_counters(), DccOutcomeCounters::default());
+    assert_eq!(server.comm_state(), 0);
+    assert!(capture.0.lock().unwrap().is_empty());
+    drop(lock);
+    {
+        let future = handle(&server, request(2, None, Some(10))).with_subscriber(capture.clone());
+        tokio::pin!(future);
+        poll_pending(future.as_mut()).await;
+        started.try_recv().unwrap();
+        // Drop while response is blocked, after the live commit.
+    }
+    assert_eq!(server.dcc_outcome_counters().accepted_total, 1);
+    tokio::task::yield_now().await; // Arm the accepted timer before advancing time.
+    server.config.dcc_policy = DccPolicy::DenyAll;
+    let lock = server.dcc_timer.lock().await;
+    let identity = lock.as_ref().unwrap().id();
+    for _ in 0..2 {
+        let future = handle(&server, request(1, None, None)).with_subscriber(capture.clone());
+        tokio::pin!(future);
+        poll_pending(future.as_mut()).await;
+        started.try_recv().unwrap();
+        assert_eq!(lock.as_ref().unwrap().id(), identity);
+    }
+    for mode in [0, 2] {
+        let future = handle(&server, request(mode, None, None)).with_subscriber(capture.clone());
+        tokio::pin!(future);
+        poll_pending(future.as_mut()).await;
+        started.try_recv().unwrap();
+        assert_eq!(lock.as_ref().unwrap().id(), identity);
+        assert_eq!(server.comm_state(), 2);
+    }
+    // Invalid UTF-8 password: no partially decoded metadata or error text logged.
+    let mut malformed = request(0, None, None);
+    malformed.service_request = Bytes::from_static(b"\x19\x00\x2d\x0b\x00\xffsentinel!");
+    {
+        let future = handle(&server, malformed).with_subscriber(capture.clone());
+        tokio::pin!(future);
+        poll_pending(future.as_mut()).await;
+        started.try_recv().unwrap();
+    }
+    {
+        let records = capture.0.lock().unwrap();
+        assert_eq!(records.len(), 6);
+        assert_eq!(records[5]["outcome"], "malformed");
+        assert!(!records[5].contains_key("decoded_mode"));
+        assert!(!records[5].contains_key("duration_minutes"));
+        assert!(!format!("{records:?}").contains("sentinel"));
+    }
+    drop(lock);
+    let counts = server.dcc_outcome_counters();
+    assert_eq!(counts.deprecated_denied_total, 2);
+    assert_eq!(counts.malformed_total, 1);
+    assert_eq!(counts.policy_denied_total, 2);
+    tokio::time::advance(Duration::from_secs(601)).await;
+    tokio::task::yield_now().await;
+    assert_eq!(server.dcc_outcome_counters(), counts);
+    assert_eq!(server.comm_state(), 0);
+    assert_eq!(capture.0.lock().unwrap().len(), 6);
+    let (mut other, _, _) = fixture().await;
+    assert_eq!(other.dcc_outcome_counters(), DccOutcomeCounters::default());
+    other.stop().await.unwrap();
+    server.stop().await.unwrap();
+}

--- a/crates/bacnet-server/src/server/dcc_outcomes.rs
+++ b/crates/bacnet-server/src/server/dcc_outcomes.rs
@@ -1,0 +1,146 @@
+use super::*;
+use std::fmt;
+use std::sync::atomic::AtomicU64;
+#[cfg(test)]
+#[path = "dcc_trace_tests.rs"]
+pub(crate) mod trace_tests;
+
+/// Lifetime totals for completed, admitted DCC handlers, saturating at `u64::MAX`.
+/// New servers start at zero. Fields are independently sampled, not an atomic
+/// aggregate. These are local operational telemetry, not a durable audit log.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DccOutcomeCounters {
+    /// State/timer replacement committed; does not imply response delivery.
+    pub accepted_total: u64,
+    /// A valid mode was refused by local policy.
+    pub policy_denied_total: u64,
+    /// The configured password check failed.
+    pub password_failure_total: u64,
+    /// Deprecated DISABLE was refused after the password check.
+    pub deprecated_denied_total: u64,
+    /// Decode failed or the decoded mode was unknown after the password check.
+    pub malformed_total: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum DccOutcome {
+    Accepted,
+    PolicyDenied,
+    PasswordFailure,
+    DeprecatedDenied,
+    Malformed,
+}
+
+impl DccOutcome {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Accepted => "accepted",
+            Self::PolicyDenied => "policy_denied",
+            Self::PasswordFailure => "password_failure",
+            Self::DeprecatedDenied => "deprecated_denied",
+            Self::Malformed => "malformed",
+        }
+    }
+}
+
+/// Only decoded, non-secret metadata can cross the validation boundary.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct DccMetadata {
+    pub mode: Option<u32>,
+    pub duration: Option<u16>,
+}
+
+#[derive(Default)]
+pub(super) struct DccOutcomes([AtomicU64; 5]);
+
+impl DccOutcomes {
+    pub(super) fn snapshot(&self) -> DccOutcomeCounters {
+        let [accepted_total, policy_denied_total, password_failure_total, deprecated_denied_total, malformed_total] =
+            self.0.each_ref().map(|v| v.load(Ordering::Relaxed));
+        DccOutcomeCounters {
+            accepted_total,
+            policy_denied_total,
+            password_failure_total,
+            deprecated_denied_total,
+            malformed_total,
+        }
+    }
+
+    pub(super) fn record(
+        &self,
+        outcome: DccOutcome,
+        metadata: DccMetadata,
+        invoke_id: u8,
+        source_mac: &[u8],
+        source: Option<&NpduAddress>,
+    ) {
+        // Counters publish no other data. Saturation and relaxed independent
+        // samples intentionally provide no cross-handler ordering guarantee.
+        let index = match outcome {
+            DccOutcome::Accepted => 0,
+            DccOutcome::PolicyDenied => 1,
+            DccOutcome::PasswordFailure => 2,
+            DccOutcome::DeprecatedDenied => 3,
+            DccOutcome::Malformed => 4,
+        };
+        let _ = self.0[index].fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+            Some(n.saturating_add(1))
+        });
+        // Lazy bounded Display performs no address formatting/allocation when
+        // the event's own callsite is disabled; no second filter callsite needed.
+        let routed = source.map(|s| s.mac_address.as_slice());
+        tracing::debug!(target: "bacnet_server::dcc_outcome",
+            outcome = outcome.label(), invoke_id, service = 17u8,
+            decoded_mode = metadata.mode, duration_minutes = metadata.duration,
+            source_kind = if source.is_some() { "claimed_routed" } else { "claimed_direct" },
+            claimed_source_mac = %BoundedHex(source_mac),
+            source_mac_truncated = source_mac.len() > 32,
+            claimed_snet = source.map(|s| s.network),
+            claimed_sadr = %BoundedHex(routed.unwrap_or_default()),
+            sadr_truncated = routed.is_some_and(|s| s.len() > 32),
+        );
+    }
+}
+
+struct BoundedHex<'a>(&'a [u8]);
+#[test]
+fn dcc_outcomes_saturation_without_subscriber() {
+    let counters = DccOutcomes::default();
+    for counter in &counters.0 {
+        counter.store(u64::MAX - 1, Ordering::Relaxed);
+    }
+    tracing::subscriber::with_default(tracing::subscriber::NoSubscriber::default(), || {
+        for _ in 0..3 {
+            for outcome in [
+                DccOutcome::Accepted,
+                DccOutcome::PolicyDenied,
+                DccOutcome::PasswordFailure,
+                DccOutcome::DeprecatedDenied,
+                DccOutcome::Malformed,
+            ] {
+                counters.record(outcome, DccMetadata::default(), 0, &[], None);
+            }
+        }
+    });
+    assert!(counters
+        .0
+        .iter()
+        .all(|counter| counter.load(Ordering::Relaxed) == u64::MAX));
+}
+impl fmt::Display for BoundedHex<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for byte in self.0.iter().take(32) {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+impl<T: TransportPort + 'static> BACnetServer<T> {
+    /// Sample completed admitted DCC outcomes, including after `stop()`.
+    /// Excludes pre-handler rejections, duplicates, incomplete cancelled handlers,
+    /// timer expiry and response delivery outcomes. No history is retained.
+    pub fn dcc_outcome_counters(&self) -> DccOutcomeCounters {
+        self.dcc_outcomes.snapshot()
+    }
+}

--- a/crates/bacnet-server/src/server/dcc_timer.rs
+++ b/crates/bacnet-server/src/server/dcc_timer.rs
@@ -16,22 +16,16 @@ pub(super) async fn replace(
     service_data: &[u8],
     password: &Option<String>,
     policy: DccPolicy,
-) -> Result<(), Error> {
-    // The synchronous handler validates and writes only this temporary state.
-    // Preserve its public contract and validation precedence, without changing
-    // live state before an await that cancellation could interrupt.
-    let proposed = AtomicU8::new(0);
-    let (_, duration) = handlers::handle_device_communication_control_with_policy(
-        service_data,
-        &proposed,
-        password,
-        policy,
-    )?;
+) -> Result<dcc_outcomes::DccMetadata, handlers::device_mgmt::DccFailure> {
+    // Decode and validate once, retaining only non-secret proposed state and
+    // metadata. Never change live state before a cancellable await.
+    let (mode, duration, proposed) =
+        handlers::device_mgmt::validate_dcc(service_data, password, policy)?;
     let mut slot = timer.lock().await;
     cancel(&mut slot).await;
     // Replacement, expiry, and shutdown share this linearization boundary.
     // No suspension between the live commit and installing the new owner.
-    comm_state.store(proposed.load(Ordering::Acquire), Ordering::Release);
+    comm_state.store(proposed, Ordering::Release);
     if let Some(minutes) = duration {
         let owner = Arc::downgrade(timer);
         let comm = Arc::clone(comm_state);
@@ -49,5 +43,8 @@ pub(super) async fn replace(
             }
         }));
     }
-    Ok(())
+    Ok(dcc_outcomes::DccMetadata {
+        mode: Some(mode.to_raw()),
+        duration,
+    })
 }

--- a/crates/bacnet-server/src/server/dcc_trace_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_trace_tests.rs
@@ -1,0 +1,145 @@
+use super::*;
+use std::collections::BTreeMap;
+use tracing::{span, Event, Metadata, Subscriber};
+
+#[derive(Clone)]
+pub(in crate::server) struct Capture(pub Arc<std::sync::Mutex<Vec<BTreeMap<String, String>>>>);
+
+impl Default for Capture {
+    fn default() -> Self {
+        // tracing-core 0.1.36's single-dispatch callsite registration consults
+        // the current thread. Other parallel tests have no local subscriber and
+        // can otherwise cache "never" for our shared cold event callsite. Keep a
+        // second, disabled dispatcher registered (NOT installed as a default)
+        // so registration consults all live dispatchers. It retains no events.
+        static REGISTRATION_PEER: std::sync::OnceLock<tracing::Dispatch> =
+            std::sync::OnceLock::new();
+        REGISTRATION_PEER
+            .get_or_init(|| tracing::Dispatch::new(tracing::subscriber::NoSubscriber::default()));
+        Self(Arc::default())
+    }
+}
+
+impl Subscriber for Capture {
+    fn register_callsite(&self, _: &'static Metadata<'static>) -> tracing::subscriber::Interest {
+        // Tests install many different scoped dispatches concurrently. Always
+        // consult this dispatch's filter rather than caching its answer globally.
+        tracing::subscriber::Interest::sometimes()
+    }
+    fn max_level_hint(&self) -> Option<tracing::metadata::LevelFilter> {
+        Some(tracing::metadata::LevelFilter::DEBUG)
+    }
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        metadata.target() == "bacnet_server::dcc_outcome"
+    }
+    fn new_span(&self, _: &span::Attributes<'_>) -> span::Id {
+        span::Id::from_u64(1)
+    }
+    fn record(&self, _: &span::Id, _: &span::Record<'_>) {}
+    fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+    fn event(&self, event: &Event<'_>) {
+        if !self.enabled(event.metadata()) {
+            return;
+        }
+        assert_eq!(*event.metadata().level(), tracing::Level::DEBUG);
+        struct Visitor(BTreeMap<String, String>);
+        impl tracing::field::Visit for Visitor {
+            fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                self.0.insert(field.name().into(), format!("{value:?}"));
+            }
+            fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                self.0.insert(field.name().into(), value.into());
+            }
+        }
+        let mut visitor = Visitor(BTreeMap::new());
+        event.record(&mut visitor);
+        self.0.lock().unwrap().push(visitor.0);
+    }
+    fn enter(&self, _: &span::Id) {}
+    fn exit(&self, _: &span::Id) {}
+}
+
+#[test]
+fn dcc_outcomes_bound_claimed_addresses() {
+    use dcc_outcomes::{DccMetadata, DccOutcome, DccOutcomes};
+    let counters = DccOutcomes::default();
+    let capture = Capture::default();
+    for length in [0, 32, 33, 255, 65536] {
+        let mac = vec![0xab; length];
+        let route = NpduAddress {
+            network: 7,
+            mac_address: MacAddr::from_slice(&mac),
+        };
+        for source in [None, Some(&route)] {
+            tracing::subscriber::with_default(capture.clone(), || {
+                counters.record(
+                    DccOutcome::Accepted,
+                    DccMetadata::default(),
+                    42,
+                    &mac,
+                    source,
+                );
+            });
+            let records = capture.0.lock().unwrap();
+            let event = records.last().unwrap();
+            assert_eq!(event["claimed_source_mac"], "ab".repeat(length.min(32)));
+            assert_eq!(event["source_mac_truncated"], (length > 32).to_string());
+            assert_eq!(
+                event["claimed_sadr"],
+                if source.is_some() {
+                    "ab".repeat(length.min(32))
+                } else {
+                    String::new()
+                }
+            );
+            assert_eq!(
+                event["sadr_truncated"],
+                (source.is_some() && length > 32).to_string()
+            );
+            assert_eq!(
+                event["source_kind"],
+                if source.is_some() {
+                    "claimed_routed"
+                } else {
+                    "claimed_direct"
+                }
+            );
+            assert_eq!(
+                event.get("claimed_snet"),
+                source.map(|_| "7".to_owned()).as_ref()
+            );
+        }
+    }
+    assert_eq!(counters.snapshot().accepted_total, 10);
+    assert_eq!(capture.0.lock().unwrap().len(), 10);
+}
+
+#[test]
+fn dcc_outcomes_concurrent_quiescent_totals_and_events() {
+    let counters = dcc_outcomes::DccOutcomes::default();
+    let capture = Capture::default();
+    let barrier = std::sync::Barrier::new(5);
+    std::thread::scope(|scope| {
+        for _ in 0..5 {
+            let counters = &counters;
+            let barrier = &barrier;
+            let capture = capture.clone();
+            scope.spawn(move || {
+                tracing::subscriber::with_default(capture, || {
+                    barrier.wait();
+                    for _ in 0..100 {
+                        counters.record(
+                            dcc_outcomes::DccOutcome::Accepted,
+                            dcc_outcomes::DccMetadata::default(),
+                            1,
+                            &[],
+                            None,
+                        );
+                    }
+                });
+            });
+        }
+    });
+    assert_eq!(counters.snapshot().accepted_total, 500);
+    assert_eq!(capture.0.lock().unwrap().len(), 500);
+}

--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -93,6 +93,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         device_bindings: &Arc<RwLock<DeviceBindingTable>>,
         comm_state: &Arc<AtomicU8>,
         dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
+        dcc_outcomes: &Arc<dcc_outcomes::DccOutcomes>,
         config: &Arc<ServerConfig>,
         clock: &Option<Arc<ServerClock>>,
         discovery_limiter: &Arc<DiscoveryLimiter>,
@@ -137,6 +138,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let device_bindings = Arc::clone(device_bindings);
                 let comm_state = Arc::clone(comm_state);
                 let dcc_timer = Arc::clone(dcc_timer);
+                let dcc_outcomes = Arc::clone(dcc_outcomes);
                 let config = Arc::clone(config);
                 let source_mac = MacAddr::from_slice(source_mac);
                 let source_network = received.source_network.clone();
@@ -162,6 +164,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             &device_bindings,
                             &comm_state,
                             &dcc_timer,
+                            &dcc_outcomes,
                             &config,
                             &descendants,
                             &source_mac,

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -256,6 +256,7 @@ impl Harness {
             &self.device_bindings,
             &self.comm_state,
             &Arc::new(Mutex::new(None::<JoinHandle<()>>)),
+            &Arc::new(dcc_outcomes::DccOutcomes::default()),
             &Arc::new(ServerConfig::default()),
             &None,
             &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -1,24 +1,9 @@
 use super::event_notifications::ResolvedIntrinsicTransition;
 use super::*;
 
-/// Resolve the configured Event Enrollment interval into a tick period.
-///
-/// `tokio::time::interval` panics on a zero period, and that panic would land
-/// inside a spawned task — `start` would still return `Ok` while enrollment
-/// evaluation was silently dead. A configured `0` is clamped to one second
-/// instead, matching how an invalid `vendor_id` is handled: warn loudly and
-/// keep the device running. Use `enable_event_enrollment(false)` to actually
-/// disable evaluation.
-pub(super) fn event_enrollment_period(secs: u64) -> Duration {
-    if secs == 0 {
-        warn!(
-            "event_enrollment_interval_secs is 0; clamping to 1s. \
-             Use enable_event_enrollment(false) to disable Event Enrollment evaluation"
-        );
-        return Duration::from_secs(1);
-    }
-    Duration::from_secs(secs)
-}
+#[path = "lifecycle_period.rs"]
+mod period;
+pub(super) use period::event_enrollment_period;
 
 impl<T: TransportPort + 'static> BACnetServer<T> {
     pub(super) async fn start_with_clock_mode_and_bindings(
@@ -90,6 +75,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let device_bindings = Arc::new(RwLock::new(device_bindings));
         let comm_state = Arc::new(AtomicU8::new(0)); // 0 = Enable (default)
         let dcc_timer: Arc<Mutex<Option<JoinHandle<()>>>> = Arc::new(Mutex::new(None));
+        let dcc_outcomes = Arc::new(dcc_outcomes::DccOutcomes::default());
+        let dcc_outcomes_dispatch = Arc::clone(&dcc_outcomes);
 
         let network_dispatch = Arc::clone(&network);
         let db_dispatch = Arc::clone(&db);
@@ -455,6 +442,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                                     &device_bindings_dispatch,
                                                     &comm_state_dispatch,
                                                     &dcc_timer_dispatch,
+                                                    &dcc_outcomes_dispatch,
                                                     &config_dispatch,
                                                     &clock_dispatch,
                                                     &discovery_limiter_dispatch,
@@ -508,6 +496,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 &device_bindings_dispatch,
                                 &comm_state_dispatch,
                                 &dcc_timer_dispatch,
+                                &dcc_outcomes_dispatch,
                                 &config_dispatch,
                                 &clock_dispatch,
                                 &discovery_limiter_dispatch,
@@ -758,6 +747,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             device_bindings,
             comm_state,
             dcc_timer,
+            dcc_outcomes,
             dispatch_task: Some(dispatch_task),
             request_tasks,
             cov_purge_task: Some(cov_purge_task),

--- a/crates/bacnet-server/src/server/lifecycle_period.rs
+++ b/crates/bacnet-server/src/server/lifecycle_period.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+/// Resolve the configured Event Enrollment interval into a tick period.
+///
+/// `tokio::time::interval` panics on a zero period, and that panic would land
+/// inside a spawned task — `start` would still return `Ok` while enrollment
+/// evaluation was silently dead. A configured `0` is clamped to one second
+/// instead, matching how an invalid `vendor_id` is handled: warn loudly and
+/// keep the device running. Use `enable_event_enrollment(false)` to actually
+/// disable evaluation.
+pub(in crate::server) fn event_enrollment_period(secs: u64) -> Duration {
+    if secs == 0 {
+        warn!(
+            "event_enrollment_interval_secs is 0; clamping to 1s. \
+             Use enable_event_enrollment(false) to disable Event Enrollment evaluation"
+        );
+        return Duration::from_secs(1);
+    }
+    Duration::from_secs(secs)
+}

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -829,6 +829,7 @@ pub struct BACnetServer<T: TransportPort> {
     /// DCC timer owner and replacement/expiry serialization boundary.
     /// Valid replacement and explicit stop abort and join before clearing it.
     dcc_timer: Arc<Mutex<Option<JoinHandle<()>>>>,
+    dcc_outcomes: Arc<dcc_outcomes::DccOutcomes>,
     dispatch_task: Option<JoinHandle<()>>,
     request_tasks: Arc<request_tasks::RequestTasks>,
     cov_purge_task: Option<JoinHandle<()>>,
@@ -887,8 +888,10 @@ mod cov_clock;
 mod cov_encoding;
 mod cov_notifications;
 mod cov_snapshot;
+pub(crate) mod dcc_outcomes;
 mod dcc_policy;
 mod dcc_timer;
+pub use dcc_outcomes::DccOutcomeCounters;
 pub use dcc_policy::DccPolicy;
 mod device_bindings;
 mod discovery;

--- a/crates/bacnet-server/src/server/notification_transactions_tests.rs
+++ b/crates/bacnet-server/src/server/notification_transactions_tests.rs
@@ -402,6 +402,7 @@ async fn dispatch_keeps_segment_and_complex_acks_out_of_notification_completion(
             &device_bindings,
             &comm_state,
             &dcc_timer,
+            &Arc::new(dcc_outcomes::DccOutcomes::default()),
             &config,
             &None,
             &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),

--- a/crates/bacnet-server/src/server/request_admission_tests.rs
+++ b/crates/bacnet-server/src/server/request_admission_tests.rs
@@ -4,6 +4,8 @@ use crate::server::request_admission::{Class, Rejection};
 #[path = "peer_admission_tests.rs"]
 mod peer_admission_tests;
 
+#[path = "dcc_outcome_admission_tests.rs"]
+mod dcc_outcome_admission_tests;
 #[path = "recovery_admission_tests.rs"]
 mod recovery_admission_tests;
 
@@ -48,6 +50,7 @@ async fn dispatch(
         &server.device_bindings,
         &server.comm_state,
         &server.dcc_timer,
+        &server.dcc_outcomes,
         &Arc::new(server.config.clone()),
         &server._clock,
         &server.discovery_limiter,

--- a/crates/bacnet-server/src/server/request_tasks_tests.rs
+++ b/crates/bacnet-server/src/server/request_tasks_tests.rs
@@ -8,6 +8,8 @@ use tokio::sync::{mpsc, oneshot, Notify};
 #[path = "segmented_worker_tests.rs"]
 mod segmented_worker_tests;
 
+#[path = "dcc_outcome_tests.rs"]
+mod dcc_outcome_tests;
 #[path = "dcc_timer_tests.rs"]
 mod dcc_timer_tests;
 

--- a/crates/bacnet-server/src/server/requests/confirmed.rs
+++ b/crates/bacnet-server/src/server/requests/confirmed.rs
@@ -49,6 +49,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             device_bindings,
             comm_state,
             dcc_timer,
+            &Arc::new(dcc_outcomes::DccOutcomes::default()),
             config,
             request_tasks,
             source_mac,

--- a/crates/bacnet-server/src/server/requests/dcc.rs
+++ b/crates/bacnet-server/src/server/requests/dcc.rs
@@ -1,0 +1,51 @@
+use super::*;
+
+pub(super) async fn response<T: TransportPort + 'static>(
+    timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
+    comm_state: &Arc<AtomicU8>,
+    outcomes: &dcc_outcomes::DccOutcomes,
+    config: &ServerConfig,
+    req: &ConfirmedRequestPdu,
+    source_mac: &[u8],
+    source: Option<&NpduAddress>,
+) -> Apdu {
+    let result = super::super::dcc_timer::replace(
+        timer,
+        comm_state,
+        &req.service_request,
+        &config.dcc_password,
+        config.dcc_policy,
+    )
+    .await;
+    // No await between validation failure/live commit and completion telemetry.
+    // The counter and event happen before constructing either response.
+    match result {
+        Ok(metadata) => {
+            outcomes.record(
+                dcc_outcomes::DccOutcome::Accepted,
+                metadata,
+                req.invoke_id,
+                source_mac,
+                source,
+            );
+            Apdu::SimpleAck(SimpleAck {
+                invoke_id: req.invoke_id,
+                service_choice: req.service_choice,
+            })
+        }
+        Err(failure) => {
+            outcomes.record(
+                failure.outcome,
+                failure.metadata,
+                req.invoke_id,
+                source_mac,
+                source,
+            );
+            BACnetServer::<T>::error_apdu_from_error(
+                req.invoke_id,
+                req.service_choice,
+                &failure.error,
+            )
+        }
+    }
+}

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -7,6 +7,7 @@ mod atomic_write_file;
 mod audit_notification;
 mod confirmed;
 pub(super) mod confirmed_response;
+mod dcc;
 mod endpoint_responder;
 #[cfg(test)]
 #[path = "endpoint_shared_runtime_tests.rs"]
@@ -37,6 +38,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         device_bindings: &Arc<RwLock<DeviceBindingTable>>,
         comm_state: &Arc<AtomicU8>,
         dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
+        dcc_outcomes: &Arc<dcc_outcomes::DccOutcomes>,
         config: &ServerConfig,
         request_tasks: &super::request_tasks::RequestTaskSpawner,
         source_mac: &[u8],
@@ -288,18 +290,16 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 }
             }
             s if s == ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL => {
-                match super::dcc_timer::replace(
+                dcc::response::<T>(
                     dcc_timer,
                     comm_state,
-                    &req.service_request,
-                    &config.dcc_password,
-                    config.dcc_policy,
+                    dcc_outcomes,
+                    config,
+                    &req,
+                    source_mac,
+                    source_network.as_ref(),
                 )
                 .await
-                {
-                    Ok(()) => simple_ack(),
-                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
-                }
             }
             s if s == ConfirmedServiceChoice::REINITIALIZE_DEVICE => {
                 match handlers::handle_reinitialize_device(

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -291,6 +291,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
         &device_bindings,
         &comm_state,
         &dcc_timer,
+        &Arc::new(dcc_outcomes::DccOutcomes::default()),
         &config,
         &None,
         &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1724,6 +1724,14 @@ class BACnetClient:
 # Server
 # ---------------------------------------------------------------------------
 
+class DccOutcomeCounters(TypedDict):
+    """Independent u64 lifetime totals, saturating at 2**64-1; not an audit log."""
+    accepted_total: int
+    policy_denied_total: int
+    password_failure_total: int
+    deprecated_denied_total: int
+    malformed_total: int
+
 class RequestAdmissionCounters(TypedDict):
     """Independent counter samples, not a transactionally atomic aggregate."""
     recovery_active: int
@@ -1995,6 +2003,16 @@ class BACnetServer:
 
     async def comm_state(self) -> int:
         """Get the DeviceCommunicationControl state (0=Enable, 1=Disable, 2=DisableInitiation)."""
+        ...
+
+    async def dcc_outcome_counters(self) -> DccOutcomeCounters:
+        """Sample completed admitted DCC handlers; zero on each new server lifetime.
+
+        Accepted means state/timer commit, not response delivery. Independent
+        samples are not an atomic aggregate. Excludes incomplete cancellation,
+        duplicates, pre-handler rejection and timer expiry. No trace bridge or
+        subscriber installation. Raises RuntimeError before start/after stop.
+        """
         ...
 
     async def request_admission_counters(self) -> RequestAdmissionCounters:

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -141,6 +141,7 @@ impl BACnetServer {
 }
 
 mod server_methods {
+    mod dcc_outcomes;
     mod file_configuration;
     mod lifecycle;
     mod registration;

--- a/crates/rusty-bacnet/src/server/server_methods/dcc_outcomes.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/dcc_outcomes.rs
@@ -1,0 +1,27 @@
+use super::super::*;
+
+#[pymethods]
+impl BACnetServer {
+    /// Independently sample five saturating lifetime DCC completion totals.
+    /// Local telemetry, not a trace bridge or durable audit log. Raises
+    /// RuntimeError("server not started") before start and after stop.
+    fn dcc_outcome_counters<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let inner = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let counters = {
+                let guard = inner.lock().await;
+                guard
+                    .as_ref()
+                    .ok_or_else(|| PyRuntimeError::new_err("server not started"))?
+                    .dcc_outcome_counters()
+            };
+            Ok(std::collections::HashMap::from([
+                ("accepted_total", counters.accepted_total),
+                ("policy_denied_total", counters.policy_denied_total),
+                ("password_failure_total", counters.password_failure_total),
+                ("deprecated_denied_total", counters.deprecated_denied_total),
+                ("malformed_total", counters.malformed_total),
+            ]))
+        })
+    }
+}

--- a/crates/rusty-bacnet/tests/test_dcc_outcomes.py
+++ b/crates/rusty-bacnet/tests/test_dcc_outcomes.py
@@ -1,0 +1,76 @@
+"""Installed-wheel acceptance of local DCC telemetry, not an audit service."""
+import ast
+import asyncio
+import importlib.util
+from pathlib import Path
+import socket
+import unittest
+
+from rusty_bacnet import BACnetServer
+
+FIELDS = {f"{name}_total" for name in (
+    "accepted", "policy_denied", "password_failure", "deprecated_denied", "malformed"
+)}
+
+
+class DccOutcomeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_counter_lifetime_shape_and_independence(self):
+        server = BACnetServer(123, interface="127.0.0.1", port=0,
+                              broadcast_address="127.0.0.1", dcc_password="sentinel")
+        other = BACnetServer(124, interface="127.0.0.1", port=0,
+                             broadcast_address="127.0.0.1", dcc_policy="legacy_permissive")
+        with self.assertRaisesRegex(RuntimeError, "^server not started$"):
+            await server.dcc_outcome_counters()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.setblocking(False)
+        try:
+            await server.start()
+            await other.start()
+            self.assertEqual(await server.dcc_outcome_counters(), dict.fromkeys(FIELDS, 0))
+            self.assertEqual(await other.dcc_outcome_counters(), dict.fromkeys(FIELDS, 0))
+            correct = b"\x2d\x09\x00sentinel"
+            cases = [(server, b"\x19\x00" + correct, "policy_denied_total"),
+                     (server, b"\x19\x01" + correct, "deprecated_denied_total"),
+                     (server, b"\x19\x01", "password_failure_total"),
+                     (server, b"\x19\x63" + correct, "malformed_total"),
+                     (server, b"\x19\x00\x2d\x02\x00\xff", "malformed_total"),
+                     (other, b"\x19\x02", "accepted_total")]
+            for invoke, (target, payload, outcome) in enumerate(cases, 1):
+                before = await target.dcc_outcome_counters()
+                ip, port = (await target.local_address()).rsplit(":", 1)
+                npdu = b"\x01\x00" + bytes([0, 5, invoke, 17]) + payload
+                wire = b"\x81\x0a" + (len(npdu) + 4).to_bytes(2, "big") + npdu
+                loop = asyncio.get_running_loop()
+                await loop.sock_sendto(sock, wire, (ip, int(port)))
+                await asyncio.wait_for(loop.sock_recvfrom(sock, 2048), 2)
+                expected = before.copy()
+                expected[outcome] += 1
+                self.assertEqual(await target.dcc_outcome_counters(), expected)
+            self.assertEqual((await server.dcc_outcome_counters())["accepted_total"], 0)
+            self.assertEqual(await other.dcc_outcome_counters(), {
+                **dict.fromkeys(FIELDS, 0), "accepted_total": 1})
+        finally:
+            await server.stop()
+            await other.stop()
+            sock.close()
+        with self.assertRaisesRegex(RuntimeError, "^server not started$"):
+            await server.dcc_outcome_counters()
+
+    def test_installed_stub_shape(self):
+        spec = importlib.util.find_spec("rusty_bacnet")
+        assert spec is not None and spec.origin is not None
+        origin = Path(spec.origin)
+        candidates = [origin.with_suffix(".pyi"), origin.parent / "rusty_bacnet.pyi"]
+        stub = next(path for path in candidates if path.exists())
+        classes = {node.name: node for node in ast.parse(stub.read_text()).body
+                   if isinstance(node, ast.ClassDef)}
+        fields = {node.target.id: ast.unparse(node.annotation)
+                  for node in classes["DccOutcomeCounters"].body
+                  if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)}
+        self.assertEqual(fields, dict.fromkeys(FIELDS, "int"))
+        method = next(node for node in classes["BACnetServer"].body
+                      if isinstance(node, ast.AsyncFunctionDef)
+                      and node.name == "dcc_outcome_counters")
+        assert method.returns is not None
+        self.assertEqual(ast.unparse(method.returns), "DccOutcomeCounters")

--- a/docs/dcc-policy.md
+++ b/docs/dcc-policy.md
@@ -73,3 +73,49 @@ nonempty startup requirement and deny-all default are operator policy, not new
 normative claims. This does not expand authenticated-SC, physical-transport,
 full-conformance, Audit/#125, EventLog integration, additional #181 fault-family
 or GATE0007 qualification.
+
+## Completed-handler observability
+
+Rust `BACnetServer::dcc_outcome_counters()` returns `DccOutcomeCounters`.
+Python `await server.dcc_outcome_counters()` returns the corresponding typed
+dictionary. Its five stable fields are `accepted_total`, `policy_denied_total`,
+`password_failure_total`, `deprecated_denied_total`, and `malformed_total`.
+Each is an independently sampled cumulative `u64` (Python `int`), saturating
+at `2**64 - 1`. New server lifetimes start at zero; snapshots are not an atomic
+whole view. Rust snapshots remain readable after stop; Python raises
+`RuntimeError("server not started")` before start and after stop.
+
+Exactly one counter increments per completed admitted DCC handler, independently
+of tracing filters. The dedicated structured DEBUG target
+`bacnet_server::dcc_outcome` emits one event at that same completion boundary,
+before response construction/send or any further await. `accepted` means live
+state/timer replacement committed, not successful response delivery or the
+current communication state. Other outcomes follow existing validation order:
+decode failure → `malformed`; configured password failure → `password_failure`;
+deprecated DISABLE → `deprecated_denied`; unknown mode → `malformed`; valid mode
+refused by local policy → `policy_denied`.
+
+Event fields are fixed: `outcome`, `invoke_id`, `service` (17), optional
+`decoded_mode` (raw u32) and `duration_minutes` (u16), `source_kind`
+(`claimed_direct` / `claimed_routed`), `claimed_source_mac`,
+`source_mac_truncated`, optional `claimed_snet`, `claimed_sadr`, and
+`sadr_truncated`. Missing routed SADR is an empty string, distinguished by source
+kind and absent SNET. Each address is at most 32 bytes rendered as 64 lowercase
+hex characters, with its own truncation flag. Both immediate and routed claims
+are included when present. These are untrusted address claims, **not** authenticated
+identity or canonical principals. Failed decoding exposes no decoded metadata.
+Passwords, password-presence flags, request/error text and payloads are excluded.
+No address formatting occurs when the DEBUG target is disabled.
+
+This is bounded local operational telemetry, **not** a durable audit log or
+BACnet Audit service. There is no internal history, queue, task, destination or
+new callback API; the Python accessor installs no logger/subscriber or trace
+bridge. Standard tracing subscribers are caller-owned and may filter, discard,
+backpressure, or perform arbitrary work. Event delivery, global concurrent
+ordering, rate limiting and flood resistance are not guaranteed. Counters and
+events exclude duplicates, pre-handler admission/shutdown/Abort-fallback
+rejections, handlers cancelled before completion, timer expiry, and response
+delivery failures after commit. Existing admission counters cover their separate
+admission boundary. No authorization, timer or wire-response policy is changed.
+This is partial #522 observability, not full auditing, rate policy or source-aware
+authorization; #521 remains closed.


### PR DESCRIPTION
## Summary
Refs #522 (partial). Five saturating per-server DccOutcomeCounters exposed in Rust/Python plus one opt-in DEBUG structured bacnet_server::dcc_outcome event per completed admitted handler. Single decode and typed outcomes preserve existing error precedence. Accepted means state/timer commit before response construction, not reply delivery/current state. No passwords, payloads or error strings; claimed direct/routed addresses capped32bytes each with truncationflags. Lazy formatting when filtered.

No new policy/config/dependency/subscriber/queue/task/destination/callback. Cancelled-before-completion, duplicate, pre-handler admission/shutdown rejection, timer expiry and postcommit delivery failures are outside outcome scope. Saturatingu64 independent counters work without tracing; Python stopped-accessRuntimeError and TypedDict parity. Lifecycle-period helper moved unchanged only to satisfy700LOC cap.

## Validation
- New-API acceptance evidence, not claimed baseline RED.
- Outcomes7/DCC42/password17/timer12/recovery27/admission51/shutdown75 pass; finalserver1033+3/integration40/workspace4365pass3existingignored.
- Secret redaction, exact categories/oneevent, malformedUTF8, cappedsource0/32/33/255/65536, saturation/concurrenttotals, heldtimer cancellation and deniedtimer preservation, blocked/failed/cancelled response semantics, duplicate/overload/fallback/shutdown exclusions covered.
- Scoped tracing capture callsite issue diagnosed against installed tracing-core; test-only disabled registration peer, no globaldefault. Ten consecutive recovery runs passed; final verified logs are authoritative.
- Fmt/clippywarnings/size/secrets/diff/newfiles/bindingcheckclippy pass. Freshlocked CPython3.12.13macOSarm64DEVwheel after finalsource, noneditable nativeorigin/direct_url/stub verified. Python57tests913subtests includingrootrerun; focused11/214repeat.
- WheelSHA c23451d46ef57c4fcd668dfc52ac0ad70f4c59f970470aa53a42ce8b1059b0c9.

## Boundaries
Best-effort operational telemetry, not durable/BACnet audit. Caller-owned subscribers mayfilter/discard/backpressure/work; no rate/flood/globalorder/delivery guarantee or authenticatedsource/SCprincipal claim. Authorization/timer/admission/wire semantics unchanged. #522 stayspartial, #521completed; historicalAudit125/EventLogintegration/additional181/GATE0007SC unchanged. No hardware/releaseperformance claims.

Both independent exact-head reviews and CI pending. User milestone: after clean merge/cleanup produce restart-ready handoff and stop, no next slice/config restart byagent.