### PR TITLE
feat(server): add optional exact-source DCC restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add optional exact claimed-source DCC restriction only with explicit
+  `RequirePassword` / `require_password`: absent preserves behavior, empty denies
+  all sources, and direct/routed addresses match full bytes. Invalid policy/list
+  combinations fail before startup/dial. Rust exhaustive `ServerConfig` literals
+  need `dcc_source_restriction: None`; Python adds a keyword-only typed list.
+  Addresses (including SC VMAC) remain spoofable, not authenticated principals.
+  Existing counters, timer/error precedence and recovery admission are retained;
+  [DCC policy](docs/dcc-policy.md) documents the API. #522 remains partial.
+
 - Default configured-server DCC authorization to deny all, even with a correct
   configured password. Add explicit Rust `DccPolicy` and Python keyword-only
   `dcc_policy` modes; deprecated DISABLE remains denied in every mode.

--- a/crates/bacnet-server/src/server/dcc_outcome_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_outcome_tests.rs
@@ -30,6 +30,15 @@ fn request(mode: u32, password: Option<&str>, duration: Option<u16>) -> Confirme
 }
 
 async fn handle(server: &BACnetServer<HeldTransport>, req: ConfirmedRequestPdu) {
+    handle_source(server, req, &[1], None).await;
+}
+
+async fn handle_source(
+    server: &BACnetServer<HeldTransport>,
+    req: ConfirmedRequestPdu,
+    mac: &[u8],
+    source: Option<NpduAddress>,
+) {
     BACnetServer::handle_admitted_confirmed_request(
         &server.db,
         &server.network,
@@ -45,12 +54,91 @@ async fn handle(server: &BACnetServer<HeldTransport>, req: ConfirmedRequestPdu) 
         &server.dcc_outcomes,
         &server.config,
         &server.request_tasks.spawner(),
-        &[1],
-        None,
+        mac,
+        source,
         req,
         None,
     )
     .await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_source_outcomes_exactly_once_precedence_and_malformed_routing() {
+    for (mode, password, expected) in [
+        (0, Some("required"), "policy_denied"),
+        (2, Some("required"), "policy_denied"),
+        (1, Some("required"), "deprecated_denied"),
+        (1, None, "password_failure"),
+        (99, Some("required"), "malformed"),
+    ] {
+        for (network, address) in [
+            (7, vec![2]),
+            (0, vec![1]),
+            (65535, vec![1]),
+            (7, vec![]),
+            (7, vec![1; 256]),
+        ] {
+            let (mut server, _, mut started) = fixture_with_config(
+                "source outcomes",
+                ServerConfig {
+                    dcc_policy: DccPolicy::RequirePassword,
+                    dcc_password: Some("required".into()),
+                    dcc_source_restriction: Some(
+                        DccSourceRestriction::new(vec![DccSource::Direct(vec![1])]).unwrap(),
+                    ),
+                    ..Default::default()
+                },
+            )
+            .await;
+            let capture = Capture::default();
+            {
+                let future = handle_source(
+                    &server,
+                    request(mode, password, None),
+                    &[1],
+                    Some(NpduAddress {
+                        network,
+                        mac_address: MacAddr::from_slice(&address),
+                    }),
+                )
+                .with_subscriber(capture.clone());
+                tokio::pin!(future);
+                // Valid response routing blocks on transport; malformed routing can
+                // fail response encoding immediately. Both follow completed denial.
+                poll_fn(|cx| {
+                    let _ = future.as_mut().poll(cx);
+                    Poll::Ready(())
+                })
+                .await;
+                let counts = server.dcc_outcome_counters();
+                assert_eq!(counts.accepted_total, 0);
+                assert_eq!(
+                    counts.policy_denied_total,
+                    u64::from(expected == "policy_denied")
+                );
+                assert_eq!(
+                    counts.password_failure_total,
+                    u64::from(expected == "password_failure")
+                );
+                assert_eq!(
+                    counts.deprecated_denied_total,
+                    u64::from(expected == "deprecated_denied")
+                );
+                assert_eq!(counts.malformed_total, u64::from(expected == "malformed"));
+                assert_eq!(server.comm_state(), 0);
+                assert!(server.dcc_timer.lock().await.is_none());
+                let events = capture.0.lock().unwrap();
+                assert_eq!(events.len(), 1);
+                assert_eq!(events[0]["outcome"], expected);
+                assert_eq!(events[0]["source_kind"], "claimed_routed");
+            }
+            let _ = started.try_recv();
+            let counts = server.dcc_outcome_counters();
+            server.stop().await.unwrap();
+            assert_eq!(server.dcc_outcome_counters(), counts);
+            assert_eq!(capture.0.lock().unwrap().len(), 1);
+        }
+    }
 }
 
 async fn poll_pending(future: std::pin::Pin<&mut impl Future<Output = ()>>) {

--- a/crates/bacnet-server/src/server/dcc_policy.rs
+++ b/crates/bacnet-server/src/server/dcc_policy.rs
@@ -1,5 +1,91 @@
 use super::{BipServerBuilder, ServerBuilder, TransportPort};
+use bacnet_encoding::npdu::NpduAddress;
 use bacnet_types::error::Error;
+
+/// Exact claimed DCC source, not an authenticated principal (including SC VMAC).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DccSource {
+    /// Full link source MAC bytes, used only when no routed source is present.
+    Direct(Vec<u8>),
+    /// Full routed source network and address, independent of the immediate router.
+    Routed {
+        /// Claimed source network (1..=65534).
+        network: u16,
+        /// Complete claimed source address (1..=255 octets).
+        address: Vec<u8>,
+    },
+}
+
+/// Validated static exact-source restriction. An empty list denies every source.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DccSourceRestriction(Vec<DccSource>);
+
+impl DccSourceRestriction {
+    /// Accept at most 256 entries, each with 1..=255 address octets.
+    /// Routed networks must be 1..=65534. These are local configuration limits.
+    pub fn new(sources: Vec<DccSource>) -> Result<Self, Error> {
+        if sources.len() > 256 {
+            return Err(Error::Encoding(
+                "DCC source restriction allows at most 256 entries".into(),
+            ));
+        }
+        for source in &sources {
+            let address = match source {
+                DccSource::Direct(address) => address,
+                DccSource::Routed { network, address } => {
+                    if !(1..=65534).contains(network) {
+                        return Err(Error::Encoding(
+                            "DCC routed source network must be 1..=65534".into(),
+                        ));
+                    }
+                    address
+                }
+            };
+            if !(1..=255).contains(&address.len()) {
+                return Err(Error::Encoding(
+                    "DCC source address must contain 1..=255 octets".into(),
+                ));
+            }
+        }
+        Ok(Self(sources))
+    }
+
+    /// Reject a configured restriction unless password-required policy is explicit.
+    pub fn validate_policy(&self, policy: DccPolicy) -> Result<(), Error> {
+        if policy != DccPolicy::RequirePassword {
+            return Err(Error::Encoding(
+                "DCC source restriction requires RequirePassword policy".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn allows(&self, mac: &[u8], routed: Option<&NpduAddress>) -> bool {
+        // Never use the admission canonicalizer: its malformed routed fallback
+        // is not an authorization identity. Compare all bytes, not telemetry.
+        match routed {
+            Some(source) => {
+                (1..=65534).contains(&source.network)
+                    && (1..=255).contains(&source.mac_address.len())
+                    && self.0.iter().any(|entry| matches!(entry,
+                        DccSource::Routed { network, address }
+                        if *network == source.network && address.as_slice() == source.mac_address.as_slice()))
+            }
+            None => (1..=255).contains(&mac.len()) && self.0.iter().any(|entry|
+                matches!(entry, DccSource::Direct(address) if address.as_slice() == mac)),
+        }
+    }
+}
+
+impl super::ServerConfig {
+    pub(super) fn validate_dcc_config(&self) -> Result<(), Error> {
+        self.dcc_policy.validate(&self.dcc_password)?;
+        if let Some(restriction) = &self.dcc_source_restriction {
+            restriction.validate_policy(self.dcc_policy)?;
+        }
+        Ok(())
+    }
+}
 
 /// Local DeviceCommunicationControl authorization, not source authentication.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -27,6 +113,17 @@ impl DccPolicy {
 }
 
 impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Set the password required for DeviceCommunicationControl requests.
+    pub fn dcc_password(mut self, password: impl Into<String>) -> Self {
+        self.config.dcc_password = Some(password.into());
+        self
+    }
+
+    /// Restrict claimed DCC sources; None preserves unrestricted policy behavior.
+    pub fn dcc_source_restriction(mut self, restriction: Option<DccSourceRestriction>) -> Self {
+        self.config.dcc_source_restriction = restriction;
+        self
+    }
     /// Select explicit local DCC authorization (default: deny all).
     pub fn dcc_policy(mut self, policy: DccPolicy) -> Self {
         self.config.dcc_policy = policy;
@@ -35,6 +132,11 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
 }
 
 impl BipServerBuilder {
+    /// Restrict claimed DCC sources; requires explicit RequirePassword policy.
+    pub fn dcc_source_restriction(mut self, restriction: Option<DccSourceRestriction>) -> Self {
+        self.config.dcc_source_restriction = restriction;
+        self
+    }
     /// Select explicit local DCC authorization (default: deny all).
     pub fn dcc_policy(mut self, policy: DccPolicy) -> Self {
         self.config.dcc_policy = policy;

--- a/crates/bacnet-server/src/server/dcc_policy_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_policy_tests.rs
@@ -1,6 +1,117 @@
 use super::*;
 
 #[test]
+fn dcc_source_restriction_configuration_bounds() {
+    for length in [0, 256, 65536] {
+        assert!(DccSourceRestriction::new(vec![DccSource::Direct(vec![1; length])]).is_err());
+    }
+    for network in [0, 65535] {
+        assert!(DccSourceRestriction::new(vec![DccSource::Routed {
+            network,
+            address: vec![1]
+        }])
+        .is_err());
+    }
+    assert!(DccSourceRestriction::new(vec![DccSource::Direct(vec![1]); 257]).is_err());
+    assert!(DccSourceRestriction::new(vec![DccSource::Direct(vec![1; 255]); 256]).is_ok());
+    for entries in [vec![], vec![DccSource::Direct(vec![1])]] {
+        let restriction = DccSourceRestriction::new(entries).unwrap();
+        assert!(restriction
+            .validate_policy(DccPolicy::RequirePassword)
+            .is_ok());
+        for policy in [DccPolicy::DenyAll, DccPolicy::LegacyPermissive] {
+            assert!(restriction.validate_policy(policy).is_err());
+        }
+    }
+}
+
+#[tokio::test]
+async fn dcc_source_restriction_rejected_before_start() {
+    for policy in [DccPolicy::DenyAll, DccPolicy::LegacyPermissive] {
+        let restriction = Some(DccSourceRestriction::new(vec![]).unwrap());
+        let started = Arc::new(AtomicBool::new(false));
+        let config = ServerConfig {
+            dcc_policy: policy,
+            dcc_source_restriction: restriction.clone(),
+            ..Default::default()
+        };
+        let error = BACnetServer::start(config, ObjectDatabase::new(), NeverStart(started.clone()))
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("source restriction")));
+        assert!(BACnetServer::generic_builder()
+            .transport(NeverStart(started.clone()))
+            .dcc_policy(policy)
+            .dcc_source_restriction(restriction.clone())
+            .build()
+            .await
+            .is_err());
+        assert!(!started.load(Ordering::Acquire));
+        let error = BACnetServer::bip_builder()
+            .dcc_policy(policy)
+            .dcc_source_restriction(restriction)
+            .build()
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("source restriction")));
+    }
+}
+
+#[cfg(feature = "sc-tls")]
+#[tokio::test]
+async fn dcc_source_restriction_rejected_before_sc_dial() {
+    for policy in [DccPolicy::DenyAll, DccPolicy::LegacyPermissive] {
+        let tls = tokio_rustls::rustls::ClientConfig::builder()
+            .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+            .with_no_client_auth();
+        let error = BACnetServer::sc_builder()
+            .hub_url("not-a-websocket-url")
+            .tls_config(Arc::new(tls))
+            .dcc_policy(policy)
+            .dcc_source_restriction(Some(DccSourceRestriction::new(vec![]).unwrap()))
+            .build()
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("source restriction")));
+    }
+}
+
+#[tokio::test]
+async fn dcc_source_denied_enable_still_occupies_recovery() {
+    let (mut server, _, mut started) = fixture_with_config(
+        "source denial",
+        ServerConfig {
+            dcc_policy: DccPolicy::RequirePassword,
+            dcc_password: Some("required".into()),
+            dcc_source_restriction: Some(DccSourceRestriction::new(vec![]).unwrap()),
+            ..Default::default()
+        },
+    )
+    .await;
+    server.comm_state.store(2, Ordering::Release);
+    for id in 1..=2 {
+        dispatch(&server, enable(id, Some("required")), source(id), None).await;
+        observed(&mut started).await;
+        assert_eq!(server.comm_state(), 2);
+        assert!(server.dcc_timer.lock().await.is_none());
+        assert!(
+            matches!(server.network.transport().frames.lock().unwrap().last(), Some(Apdu::Error(e))
+            if e.error_class == ErrorClass::SERVICES && e.error_code == ErrorCode::SERVICE_REQUEST_DENIED)
+        );
+    }
+    assert_eq!(server.request_admission_counters().recovery_active, 2);
+    assert_eq!(
+        server.request_admission_counters().recovery_admitted_total,
+        2
+    );
+    assert_eq!(server.dcc_outcome_counters().policy_denied_total, 2);
+    server.stop().await.unwrap();
+}
+
+#[test]
 fn dcc_configured_validation_retains_decode_password_unknown_mode_precedence() {
     for policy in [
         DccPolicy::DenyAll,

--- a/crates/bacnet-server/src/server/dcc_timer.rs
+++ b/crates/bacnet-server/src/server/dcc_timer.rs
@@ -14,13 +14,34 @@ pub(super) async fn replace(
     timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
     comm_state: &Arc<AtomicU8>,
     service_data: &[u8],
-    password: &Option<String>,
-    policy: DccPolicy,
+    config: &ServerConfig,
+    source_mac: &[u8],
+    source: Option<&bacnet_encoding::npdu::NpduAddress>,
 ) -> Result<dcc_outcomes::DccMetadata, handlers::device_mgmt::DccFailure> {
     // Decode and validate once, retaining only non-secret proposed state and
     // metadata. Never change live state before a cancellable await.
     let (mode, duration, proposed) =
-        handlers::device_mgmt::validate_dcc(service_data, password, policy)?;
+        handlers::device_mgmt::validate_dcc(service_data, &config.dcc_password, config.dcc_policy)?;
+    if config
+        .dcc_source_restriction
+        .as_ref()
+        .is_some_and(|restriction| {
+            config.dcc_policy != DccPolicy::RequirePassword
+                || !restriction.allows(source_mac, source)
+        })
+    {
+        return Err(handlers::device_mgmt::DccFailure {
+            error: Error::Protocol {
+                class: ErrorClass::SERVICES.to_raw() as u32,
+                code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+            },
+            outcome: dcc_outcomes::DccOutcome::PolicyDenied,
+            metadata: dcc_outcomes::DccMetadata {
+                mode: Some(mode.to_raw()),
+                duration,
+            },
+        });
+    }
     let mut slot = timer.lock().await;
     cancel(&mut slot).await;
     // Replacement, expiry, and shutdown share this linearization boundary.

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -332,6 +332,8 @@ pub struct ServerConfig {
     pub dcc_password: Option<String>,
     /// Local DCC authorization. Supplying a password alone does not enable DCC.
     pub dcc_policy: DccPolicy,
+    /// Optional exact claimed-source restriction, valid only with RequirePassword.
+    pub dcc_source_restriction: Option<DccSourceRestriction>,
     /// Optional password required for ReinitializeDevice.
     pub reinit_password: Option<String>,
     /// Enable periodic fault detection / reliability evaluation.
@@ -441,6 +443,7 @@ impl std::fmt::Debug for ServerConfig {
             )
             .field("dcc_password", &self.dcc_password.as_ref().map(|_| "***"))
             .field("dcc_policy", &self.dcc_policy)
+            .field("dcc_source_restriction", &self.dcc_source_restriction)
             .field(
                 "reinit_password",
                 &self.reinit_password.as_ref().map(|_| "***"),
@@ -482,6 +485,7 @@ impl Default for ServerConfig {
             unconfirmed_audit_notification_authorizer: None,
             dcc_password: None,
             dcc_policy: DccPolicy::default(),
+            dcc_source_restriction: None,
             reinit_password: None,
             enable_fault_detection: false,
             enable_event_enrollment: true,
@@ -518,12 +522,6 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
     pub fn device_binding(mut self, binding: DeviceBinding) -> Result<Self, Error> {
         register_configured_binding(&mut self.configured_device_bindings, binding)?;
         Ok(self)
-    }
-
-    /// Set the password required for DeviceCommunicationControl requests.
-    pub fn dcc_password(mut self, password: impl Into<String>) -> Self {
-        self.config.dcc_password = Some(password.into());
-        self
     }
 
     /// Set the password required for ReinitializeDevice requests.
@@ -892,7 +890,7 @@ pub(crate) mod dcc_outcomes;
 mod dcc_policy;
 mod dcc_timer;
 pub use dcc_outcomes::DccOutcomeCounters;
-pub use dcc_policy::DccPolicy;
+pub use dcc_policy::{DccPolicy, DccSource, DccSourceRestriction};
 mod device_bindings;
 mod discovery;
 pub use discovery::{DiscoveryCounters, DiscoveryPolicy};

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -44,7 +44,7 @@ impl RequestTasks {
         // Retain admission validation precedence; both policies must be valid
         // before the lifecycle starts a transport or exposes a request owner.
         config.read_property_multiple_budget.validate()?;
-        config.dcc_policy.validate(&config.dcc_password)?;
+        config.validate_dcc_config()?;
         config.get_alarm_summary_budget.validate()?;
         config.get_enrollment_summary_budget.validate()?;
         config.atomic_read_file_budget.validate()?;

--- a/crates/bacnet-server/src/server/requests/dcc.rs
+++ b/crates/bacnet-server/src/server/requests/dcc.rs
@@ -13,8 +13,9 @@ pub(super) async fn response<T: TransportPort + 'static>(
         timer,
         comm_state,
         &req.service_request,
-        &config.dcc_password,
-        config.dcc_policy,
+        config,
+        source_mac,
+        source,
     )
     .await;
     // No await between validation failure/live commit and completion telemetry.

--- a/crates/bacnet-server/src/server/requests/dcc_tests.rs
+++ b/crates/bacnet-server/src/server/requests/dcc_tests.rs
@@ -5,6 +5,149 @@ use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
 use bacnet_types::enums::EnableDisable;
 use tokio::time::{advance, Duration};
 
+#[tokio::test(start_paused = true)]
+async fn dcc_source_exact_full_bytes_and_fail_closed_wire() {
+    use crate::server::{DccSource, DccSourceRestriction};
+    let direct = vec![127, 0, 0, 1, 0xba, 0xc0];
+    let long = vec![42; 255];
+    let restrictions = [
+        None,
+        Some(DccSourceRestriction::new(vec![]).unwrap()),
+        Some(DccSourceRestriction::new(vec![DccSource::Direct(direct.clone())]).unwrap()),
+        Some(
+            DccSourceRestriction::new(vec![DccSource::Routed {
+                network: 7,
+                address: long.clone(),
+            }])
+            .unwrap(),
+        ),
+    ];
+    for (kind, restriction) in restrictions.into_iter().enumerate() {
+        let config = ServerConfig {
+            dcc_policy: DccPolicy::RequirePassword,
+            dcc_password: Some("required".into()),
+            dcc_source_restriction: restriction,
+            ..Default::default()
+        };
+        let mut different_tail = long.clone();
+        different_tail[254] = 43;
+        for (network, address, exact) in [
+            (7, long.clone(), true),
+            (8, long.clone(), false),
+            (7, different_tail, false),
+            (7, long[..32].to_vec(), false),
+            (7, direct.clone(), false),
+        ] {
+            for routed in [false, true] {
+                let source = routed.then(|| NpduAddress {
+                    network,
+                    mac_address: MacAddr::from_slice(&address),
+                });
+                let state = Arc::new(AtomicU8::new(1));
+                let timer = Arc::new(Mutex::new(None));
+                let response = dispatch_wire(
+                    &state,
+                    &timer,
+                    EnableDisable::ENABLE,
+                    None,
+                    &config,
+                    Some("required"),
+                    source,
+                )
+                .await;
+                let allowed = kind == 0 || (kind == 2 && !routed) || (kind == 3 && routed && exact);
+                if allowed {
+                    assert!(matches!(response, Apdu::SimpleAck(_)));
+                } else {
+                    assert_denied(response);
+                }
+                assert_eq!(state.load(Ordering::Acquire), if allowed { 0 } else { 1 });
+                assert!(timer.lock().await.is_none());
+            }
+        }
+    }
+    // Direct matching also uses full bytes, independently of the wire fixture's MAC.
+    for length in [1, 32, 33, 255] {
+        let address = vec![1; length];
+        let restriction =
+            DccSourceRestriction::new(vec![DccSource::Direct(address.clone())]).unwrap();
+        assert!(restriction.allows(&address, None));
+        let mut other = address.clone();
+        other[length - 1] = 2;
+        assert!(!restriction.allows(&other, None));
+        assert!(!restriction.allows(&address[..length - 1], None));
+        for (network, mac) in [
+            (0, address.clone()),
+            (65535, address.clone()),
+            (7, vec![]),
+            (7, vec![1; 256]),
+        ] {
+            assert!(!restriction.allows(
+                &address,
+                Some(&NpduAddress {
+                    network,
+                    mac_address: MacAddr::from_slice(&mac)
+                })
+            ));
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_source_denial_preserves_timer_and_error_precedence() {
+    use crate::server::DccSourceRestriction;
+    for pending_expiry in [false, true] {
+        let state = Arc::new(AtomicU8::new(0));
+        let timer = Arc::new(Mutex::new(None));
+        assert!(matches!(
+            dispatch(&state, &timer, EnableDisable::DISABLE_INITIATION, Some(1)).await,
+            Apdu::SimpleAck(_)
+        ));
+        tokio::task::yield_now().await;
+        let slot = timer.lock().await;
+        let id = slot.as_ref().unwrap().id();
+        advance(Duration::from_secs(if pending_expiry { 60 } else { 30 })).await;
+        let config = ServerConfig {
+            dcc_policy: DccPolicy::RequirePassword,
+            dcc_password: Some("required".into()),
+            dcc_source_restriction: Some(DccSourceRestriction::new(vec![]).unwrap()),
+            ..Default::default()
+        };
+        for mode in [
+            EnableDisable::ENABLE,
+            EnableDisable::DISABLE_INITIATION,
+            EnableDisable::DISABLE,
+        ] {
+            for duration in [None, Some(0), Some(5)] {
+                for password in [None, Some("wrong"), Some("required")] {
+                    let response =
+                        dispatch_wire(&state, &timer, mode, duration, &config, password, None)
+                            .await;
+                    if password == Some("required") {
+                        assert_denied(response);
+                    } else {
+                        assert!(
+                            matches!(response, Apdu::Error(e) if e.error_class == ErrorClass::SECURITY && e.error_code == ErrorCode::PASSWORD_FAILURE)
+                        );
+                    }
+                    assert_eq!(slot.as_ref().unwrap().id(), id);
+                    assert_eq!(state.load(Ordering::Acquire), 2);
+                }
+            }
+        }
+        drop(slot);
+        if !pending_expiry {
+            advance(Duration::from_secs(29)).await;
+            tokio::task::yield_now().await;
+            assert_eq!(state.load(Ordering::Acquire), 2);
+            advance(Duration::from_secs(1)).await;
+        }
+        let task = timer.lock().await.take().unwrap();
+        task.await.unwrap();
+        assert_eq!(state.load(Ordering::Acquire), 0);
+    }
+}
+
 async fn dispatch(
     comm_state: &Arc<AtomicU8>,
     dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
@@ -287,6 +430,12 @@ async fn dcc_require_password_preserves_replacement_expiry_and_enable_timer_sema
     let config = ServerConfig {
         dcc_policy: DccPolicy::RequirePassword,
         dcc_password: Some("required".into()),
+        dcc_source_restriction: Some(
+            crate::server::DccSourceRestriction::new(vec![crate::server::DccSource::Direct(vec![
+                127, 0, 0, 1, 0xba, 0xc0,
+            ])])
+            .unwrap(),
+        ),
         ..Default::default()
     };
     let state = Arc::new(AtomicU8::new(0));

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -102,6 +102,15 @@ impl ScServerBuilder {
         self
     }
 
+    /// Restrict claimed DCC sources; requires explicit RequirePassword policy.
+    pub fn dcc_source_restriction(
+        mut self,
+        restriction: Option<super::DccSourceRestriction>,
+    ) -> Self {
+        self.config.dcc_source_restriction = restriction;
+        self
+    }
+
     /// Set the password required for ReinitializeDevice requests.
     pub fn reinit_password(mut self, password: impl Into<String>) -> Self {
         self.config.reinit_password = Some(password.into());
@@ -192,7 +201,7 @@ impl ScServerBuilder {
             .ok_or_else(|| Error::Encoding("SC server builder: tls_config is required".into()))?;
 
         self.config.request_admission_policy.validate()?;
-        self.config.dcc_policy.validate(&self.config.dcc_password)?;
+        self.config.validate_dcc_config()?;
         self.config.read_property_multiple_budget.validate()?;
         self.config.get_alarm_summary_budget.validate()?;
         self.config.get_enrollment_summary_budget.validate()?;

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1784,6 +1784,7 @@ class BACnetServer:
         reinit_password: Optional[str] = None,
         *,
         dcc_policy: str = "deny_all",
+        dcc_source_restriction: list[tuple[int | None, bytes]] | None = None,
         serial_port: Optional[str] = None,
         mstp_baud: int = 38400,
         mstp_mac: int = 1,

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -101,6 +101,7 @@ pub struct BACnetServer {
     // Passwords
     dcc_password: Option<String>,
     dcc_policy: server::DccPolicy,
+    dcc_source_restriction: Option<server::DccSourceRestriction>,
     reinit_password: Option<String>,
     request_admission_policy: server::RequestAdmissionPolicy,
     read_property_multiple_budget: server::ReadPropertyMultipleBudget,

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -202,6 +202,7 @@ mod tests {
             mstp_max_info_frames: 1,
             dcc_password: None,
             dcc_policy: server::DccPolicy::default(),
+            dcc_source_restriction: None,
             reinit_password: None,
             request_admission_policy: server::RequestAdmissionPolicy::default(),
             read_property_multiple_budget: server::ReadPropertyMultipleBudget::default(),

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -37,6 +37,7 @@ impl BACnetServer {
         let ipv6_interface = self.ipv6_interface.clone();
         let dcc_password = self.dcc_password.clone();
         let dcc_policy = self.dcc_policy;
+        let dcc_source_restriction = self.dcc_source_restriction.clone();
         let reinit_password = self.reinit_password.clone();
         let request_admission_policy = self.request_admission_policy;
         let read_property_multiple_budget = self.read_property_multiple_budget;
@@ -161,7 +162,9 @@ impl BACnetServer {
             if let Some(pw) = dcc_password {
                 builder = builder.dcc_password(pw);
             }
-            builder = builder.dcc_policy(dcc_policy);
+            builder = builder
+                .dcc_policy(dcc_policy)
+                .dcc_source_restriction(dcc_source_restriction);
             if let Some(pw) = reinit_password {
                 builder = builder.reinit_password(pw);
             }

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -22,6 +22,7 @@ impl BACnetServer {
         reinit_password=None,
         *,
         dcc_policy="deny_all",
+        dcc_source_restriction=None,
         serial_port=None,
         mstp_baud=38400,
         mstp_mac=1,
@@ -70,6 +71,7 @@ impl BACnetServer {
         dcc_password: Option<String>,
         reinit_password: Option<String>,
         dcc_policy: &str,
+        dcc_source_restriction: Option<Vec<(Option<u16>, Vec<u8>)>>,
         serial_port: Option<String>,
         mstp_baud: u32,
         mstp_mac: u8,
@@ -111,6 +113,22 @@ impl BACnetServer {
         };
         dcc_policy
             .validate(&dcc_password)
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let dcc_source_restriction = dcc_source_restriction
+            .map(|entries| {
+                let restriction = server::DccSourceRestriction::new(
+                    entries
+                        .into_iter()
+                        .map(|(network, address)| match network {
+                            None => server::DccSource::Direct(address),
+                            Some(network) => server::DccSource::Routed { network, address },
+                        })
+                        .collect(),
+                )?;
+                restriction.validate_policy(dcc_policy)?;
+                Ok::<_, bacnet_types::error::Error>(restriction)
+            })
+            .transpose()
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
         let request_admission_policy = server::RequestAdmissionPolicy {
             max_confirmed_in_flight,
@@ -198,6 +216,7 @@ impl BACnetServer {
             mstp_max_info_frames,
             dcc_password,
             dcc_policy,
+            dcc_source_restriction,
             reinit_password,
             request_admission_policy,
             read_property_multiple_budget,

--- a/crates/rusty-bacnet/tests/test_dcc_policy.py
+++ b/crates/rusty-bacnet/tests/test_dcc_policy.py
@@ -9,6 +9,29 @@ from rusty_bacnet import BACnetServer
 
 
 class DccConstructorTests(unittest.TestCase):
+    def test_source_restriction_validation_before_every_transport(self):
+        parameter = inspect.signature(BACnetServer).parameters["dcc_source_restriction"]
+        self.assertIsNone(parameter.default)
+        self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+        for transport in ["bip", "ipv6", "sc", "mstp"]:
+            for policy in ["deny_all", "legacy_permissive"]:
+                for restriction in [[], [(None, b"x")]]:
+                    with self.assertRaisesRegex(ValueError, "source restriction"):
+                        BACnetServer(123, transport=transport, dcc_policy=policy,
+                                     dcc_source_restriction=restriction)
+            for restriction in [[(None, b"")], [(None, b"x" * 256)], [(0, b"x")],
+                                [(65535, b"x")], [(7, b"")], [(None, b"x")] * 257]:
+                with self.assertRaises(ValueError):
+                    BACnetServer(123, transport=transport, dcc_policy="require_password",
+                                 dcc_password="required", dcc_source_restriction=restriction)
+            for restriction in [[], [(None, b"x")], [(65534, b"x" * 255)] * 256]:
+                BACnetServer(123, transport=transport, dcc_policy="require_password",
+                             dcc_password="required", dcc_source_restriction=restriction)
+        for invalid in [1, "bad", [(None, "bad")], [(65536, b"x")], [(-1, b"x")]]:
+            with self.assertRaises((TypeError, ValueError, OverflowError)):
+                BACnetServer(123, dcc_policy="require_password", dcc_password="required",
+                             dcc_source_restriction=invalid)
+
     def test_policy_validation_before_every_transport(self):
         parameter = inspect.signature(BACnetServer).parameters["dcc_policy"]
         self.assertEqual(parameter.default, "deny_all")
@@ -32,6 +55,50 @@ class DccConstructorTests(unittest.TestCase):
 
 
 class DccNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_source_restriction_direct_routed_and_outcomes(self):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.setblocking(False)
+        direct = socket.inet_aton("127.0.0.1") + sock.getsockname()[1].to_bytes(2, "big")
+        restrictions: list[list[tuple[int | None, bytes]] | None] = [
+            None, [], [(None, direct)], [(7, b"\x2a")], [(8, b"\x2a")], [(7, b"\x2b")],
+        ]
+        try:
+            for kind, restriction in enumerate(restrictions):
+                server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                      broadcast_address="127.0.0.1", dcc_policy="require_password",
+                                      dcc_password="required", dcc_source_restriction=restriction)
+                try:
+                    await server.start()
+                    invoke = 0
+                    expected = dict(accepted_total=0, policy_denied_total=0, password_failure_total=0,
+                                    deprecated_denied_total=0, malformed_total=0)
+                    for routed in [False, True]:
+                        for mode in [2, 0, 1]:
+                            for password in [None, "wrong", "required"]:
+                                invoke += 1
+                                before = await server.comm_state()
+                                reply = await self.exchange(server, sock, invoke, mode, password, routed)
+                                allowed = kind == 0 or (kind == 2 and not routed) or (kind == 3 and routed)
+                                outcome = ("password_failure" if password != "required" else
+                                           "deprecated_denied" if mode == 1 else
+                                           "policy_denied" if not allowed else "accepted")
+                                expected[outcome + "_total"] += 1
+                                if outcome == "accepted":
+                                    self.assertEqual(reply, bytes([0x20, invoke, 17]))
+                                    self.assertEqual(await server.comm_state(), mode)
+                                else:
+                                    bad = outcome == "password_failure"
+                                    self.assertEqual(reply, bytes([0x50, invoke, 17, 0x91,
+                                                                  4 if bad else 5, 0x91, 26 if bad else 29]))
+                                    self.assertEqual(await server.comm_state(), before)
+                                self.assertEqual(await server.dcc_outcome_counters(), expected)
+                    self.assertEqual((await server.request_admission_counters())["recovery_admitted_total"], 6)
+                finally:
+                    await server.stop()
+        finally:
+            sock.close()
+
     async def exchange(self, server, sock, invoke, mode, password, routed, duration=None):
         body = b"" if duration is None else bytes([0x09, duration])
         body += bytes([0x19, mode])

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -61,7 +61,7 @@ MSTP_KEYWORD_ONLY = [
     "mstp_max_master",
     "mstp_max_info_frames",
 ]
-SERVER_KEYWORD_ONLY = ["dcc_policy"] + MSTP_KEYWORD_ONLY + [
+SERVER_KEYWORD_ONLY = ["dcc_policy", "dcc_source_restriction"] + MSTP_KEYWORD_ONLY + [
     "max_confirmed_in_flight", "max_unconfirmed_in_flight",
     "max_confirmed_in_flight_per_peer", "max_unconfirmed_in_flight_per_peer",
     "confirmed_recovery_reserve", "max_recovery_in_flight_per_peer",

--- a/docs/dcc-policy.md
+++ b/docs/dcc-policy.md
@@ -14,8 +14,9 @@ not a BACnet-mandated default and not authentication of a source principal.
 LegacyPermissive does **not** bypass a configured password. Without one, any
 requester whose request reaches the handler can change communications. Do not
 mistake this compatibility option, a shared password, a routed address, or an SC
-VMAC for authenticated source identity. Source authorization, auditing and rate
-policy remain future work under the partial, separate #522 scope.
+VMAC for authenticated source identity. Exact address restriction below is not
+principal authentication. Full auditing and rate policy remain future work under
+the partial, separate #522 scope.
 
 ## Migration
 
@@ -39,9 +40,41 @@ ReinitializeDevice's separate password and handler are unchanged.
 
 ## Ordering and side effects
 
+### Optional exact-source restriction
+
+`ServerConfig::dcc_source_restriction` defaults to `None`, preserving existing
+policy behavior. Generic, B/IP and SC builders expose `.dcc_source_restriction(...)`.
+Use `Some(DccSourceRestriction::new(entries)?)` with `DccSource::Direct(Vec<u8>)`
+or `DccSource::Routed { network, address: Vec<u8> }`. Exhaustive Rust config
+literals need `dcc_source_restriction: None` (or a suitable default update).
+The validated list permits at most 256 entries and 1–255 octets per address;
+routed networks must be 1–65534. These are static local limits, not transport
+support promises. No CIDR, prefixes, ranges or dynamic callbacks are supported.
+
+Python's keyword-only `dcc_source_restriction` accepts `None` or a list of
+`(network_or_none, address_bytes)` tuples: for example `[(7, b"\x2a")]` permits
+the claimed routed address 42 on network 7; `[(None, b"\x7f\x00\x00\x01\xba\xc0")]`
+permits that exact direct IPv4-plus-UDP-port address. `[]` explicitly denies all
+sources; it is **not** equivalent to `None`. Configuration is copied at construction.
+Invalid limits raise `ValueError`, invalid types `TypeError`, and out-of-u16
+network values may raise `OverflowError`.
+
+A configured list, including empty, requires explicit `RequirePassword` and a
+nonempty password. Other policies reject configuration before transport startup
+or SC dialing (Python constructor, Rust build/start), never silently ignoring it.
+Direct entries only match requests without a routed source. Routed entries match
+the exact network and full source address, not the immediate router's MAC.
+Malformed routed identities fail closed rather than falling back to direct matching.
+All address bytes participate, independently of the 32-byte DEBUG truncation.
+Claimed addresses are spoofable and unauthenticated, **including SC VMACs**.
+An allowed address still needs the correct password; a shared password plus an
+address match does not establish principal identity or authenticated-SC provenance.
+
+### Validation and timer order
+
 Existing admission, duplicate handling and DCC ingress discards are unchanged.
 After admission: decode, existing constant-time password check, deprecated DISABLE
-rejection, then local policy for ENABLE/DISABLE_INITIATION, then live state/timer
+rejection, then local policy and optional source restriction for ENABLE/DISABLE_INITIATION, then live state/timer
 commit. Missing/wrong configured passwords return SECURITY/PASSWORD_FAILURE even
 under DenyAll or for DISABLE. Otherwise denied valid requests return
 SERVICES/SERVICE_REQUEST_DENIED. Unknown-mode decoding/encoding errors retain
@@ -59,7 +92,7 @@ change that existing implementation nuance. Explicit stop still cancels and
 joins the owned timer.
 
 Decode-accepted ENABLE remains eligible for protected recovery capacity regardless
-of policy or password. It can occupy that capacity until the handler denies it;
+of policy, password or source restriction. It can occupy that capacity until the handler denies it;
 there is no pre-admission authorization. Capacity exhaustion may still Abort
 before handler validation. [Request admission](request-admission.md) and the
 completed bounded #521 acceptance remain unchanged, not reopened.
@@ -116,6 +149,6 @@ ordering, rate limiting and flood resistance are not guaranteed. Counters and
 events exclude duplicates, pre-handler admission/shutdown/Abort-fallback
 rejections, handlers cancelled before completion, timer expiry, and response
 delivery failures after commit. Existing admission counters cover their separate
-admission boundary. No authorization, timer or wire-response policy is changed.
-This is partial #522 observability, not full auditing, rate policy or source-aware
-authorization; #521 remains closed.
+admission boundary. Source mismatch reuses `policy_denied_total` and the existing
+`policy_denied` DEBUG event/schema, without new counters. This remains partial
+#522 work, not full auditing, rate policy or principal authentication; #521 remains closed.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1149,6 +1149,7 @@ server = BACnetServer(
     # SC options same as BACnetClient
     dcc_password=None,           # password alone does not enable DCC
     dcc_policy="deny_all",       # keyword-only; explicit require_password or INSECURE legacy_permissive
+    dcc_source_restriction=None, # optional list[(network_or_None, bytes)]; [] denies all; requires require_password
     reinit_password=None,        # password for ReinitializeDevice
 )
 ```


### PR DESCRIPTION
## Summary
- Add optional exact direct/routed claimed-source restrictions to explicit password-required DCC in Rust and Python; absent preserves behavior, empty denies all.
- Fail invalid configuration before startup/dial; source mismatch preserves error precedence and timer state, reusing existing outcome telemetry.
- Document spoofable-address limitations, Rust configuration migration, and unchanged protected recovery admission.

## Scope
Related to #522 (remains partial). No authenticated SC principal, rate limiter, durable audit, timer-semantics correction, or #521 reopening.

## Validation
- Workspace: 4,372 passed, 0 failed, 3 existing ignored; standalone server 1,039 unit + 3 integration; integration package 40 passed.
- Focused DCC 48, SC pre-dial 1, password 17, timer 13, recovery 30, admission 54, shutdown 79 passed.
- Fresh locked native CPython 3.12.13 macOS arm64 DEV wheel: 59 tests / 913 subtests; focused 13 / 214 passed. Installed origin and stub parity verified.
- Formatting, Clippy (existing warnings), size, secrets, diff and explicit-interpreter binding gates passed.
- Three independent exact-head reviews and lean CI pending; no release-performance, hardware or full-conformance claim.