### PR TITLE
feat(server): add optional global DCC disable rate policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add a default-OFF optional global DCC DISABLE_INITIATION token bucket per native
+  server. Enabled defaults are burst 3 and one token per 20 seconds; authorized
+  ENABLE is exempt and earlier validation/authorization failures do not charge.
+  Admission charges survive cancellation before commit; denial leaves the timer
+  untouched and reuses existing policy-denied telemetry. Rust exposes
+  `DccDisableRateLimit` / `dcc_disable_rate_limit` on config and generic/BIP/SC
+  builders (exhaustive literals need `None`); Python adds keyword-only
+  `dcc_disable_rate_limit=(capacity, refill_interval_ms)` or `None`.
+  Python stop/start creates a fresh native bucket, so operator restarts reset it.
+  This is not ingress/flood/password-guessing protection or full #522 completion;
+  see [DCC policy](docs/dcc-policy.md).
+
 - Add optional exact claimed-source DCC restriction only with explicit
   `RequirePassword` / `require_password`: absent preserves behavior, empty denies
   all sources, and direct/routed addresses match full bytes. Invalid policy/list

--- a/crates/bacnet-server/src/server/dcc_disable_rate.rs
+++ b/crates/bacnet-server/src/server/dcc_disable_rate.rs
@@ -1,0 +1,171 @@
+use super::{BipServerBuilder, ServerBuilder, TransportPort};
+use bacnet_types::error::Error;
+use std::sync::Mutex;
+use tokio::time::Instant;
+
+/// Optional global authorization budget for DISABLE_INITIATION, not ingress protection.
+/// Use `Some(Default::default())` to enable; server configuration defaults to None.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DccDisableRateLimit {
+    /// Initial and maximum whole tokens (1..=65535).
+    pub capacity: u32,
+    /// Time to earn one token, in milliseconds (1..=86400000).
+    pub refill_interval_ms: u64,
+}
+
+impl Default for DccDisableRateLimit {
+    fn default() -> Self {
+        Self {
+            capacity: 3,
+            refill_interval_ms: 20_000,
+        }
+    }
+}
+
+impl DccDisableRateLimit {
+    /// Validate local operator limits before startup/dialing, without time arithmetic.
+    pub fn validate(self) -> Result<(), Error> {
+        if !(1..=65535).contains(&self.capacity)
+            || !(1..=86_400_000).contains(&self.refill_interval_ms)
+        {
+            return Err(Error::Encoding(
+                "DCC disable rate requires capacity 1..=65535 and refill_interval_ms 1..=86400000"
+                    .into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub(super) struct Bucket {
+    interval_ns: u128,
+    maximum: u128,
+    state: Mutex<State>,
+}
+
+struct State {
+    // Credit is measured in nanoseconds: one token costs interval_ns. This
+    // retains fractional progress even across denied checks, without floats.
+    credit: u128,
+    last: Instant,
+}
+
+impl Bucket {
+    pub(super) fn new(config: DccDisableRateLimit) -> Result<Self, Error> {
+        config.validate()?;
+        let interval_ns = u128::from(config.refill_interval_ms) * 1_000_000;
+        let maximum = interval_ns * u128::from(config.capacity);
+        Ok(Self {
+            interval_ns,
+            maximum,
+            state: Mutex::new(State {
+                credit: maximum,
+                last: Instant::now(),
+            }),
+        })
+    }
+
+    pub(super) fn admit(&self) -> bool {
+        let mut state = self.state.lock().unwrap();
+        // Read time under the lock: concurrent callers cannot move last backwards.
+        let now = Instant::now();
+        state.credit = state
+            .credit
+            .saturating_add(now.duration_since(state.last).as_nanos())
+            .min(self.maximum);
+        state.last = now;
+        if state.credit < self.interval_ns {
+            return false;
+        }
+        state.credit -= self.interval_ns;
+        // Admission is charged now, with no rollback on later cancellation.
+        true
+    }
+}
+
+impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Limit authorized DISABLE_INITIATION globally; None (default) disables it.
+    /// ENABLE is exempt. Each new native server starts with a full bucket.
+    pub fn dcc_disable_rate_limit(mut self, limit: Option<DccDisableRateLimit>) -> Self {
+        self.config.dcc_disable_rate_limit = limit;
+        self
+    }
+}
+
+impl BipServerBuilder {
+    /// Limit authorized DISABLE_INITIATION globally; None (default) disables it.
+    pub fn dcc_disable_rate_limit(mut self, limit: Option<DccDisableRateLimit>) -> Self {
+        self.config.dcc_disable_rate_limit = limit;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Barrier};
+    use tokio::time::{advance, Duration};
+
+    #[tokio::test(start_paused = true)]
+    async fn dcc_disable_rate_fractional_boundaries_and_idle_cap() {
+        let bucket = Bucket::new(DccDisableRateLimit::default()).unwrap();
+        for _ in 0..3 {
+            assert!(bucket.admit());
+        }
+        assert!(!bucket.admit());
+        // Repeated denials must preserve all accumulated fractional credit.
+        for _ in 0..19 {
+            advance(Duration::from_secs(1)).await;
+            assert!(!bucket.admit());
+        }
+        advance(Duration::from_millis(999)).await;
+        assert!(!bucket.admit());
+        advance(Duration::from_micros(999)).await;
+        assert!(!bucket.admit());
+        advance(Duration::from_micros(1)).await;
+        assert!(bucket.admit());
+        assert!(!bucket.admit());
+        advance(Duration::from_millis(45_500)).await;
+        assert!(bucket.admit());
+        assert!(bucket.admit());
+        assert!(!bucket.admit());
+        advance(Duration::from_millis(14_500)).await;
+        assert!(bucket.admit());
+        assert!(!bucket.admit());
+        advance(Duration::from_secs(86400 * 365)).await;
+        for _ in 0..3 {
+            assert!(bucket.admit());
+        }
+        assert!(!bucket.admit());
+    }
+
+    #[test]
+    fn dcc_disable_rate_concurrent_global_burst() {
+        let bucket = Arc::new(
+            Bucket::new(DccDisableRateLimit {
+                capacity: 3,
+                refill_interval_ms: 86_400_000,
+            })
+            .unwrap(),
+        );
+        let barrier = Arc::new(Barrier::new(32));
+        let threads: Vec<_> = (0..32)
+            .map(|_| {
+                let bucket = bucket.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    bucket.admit()
+                })
+            })
+            .collect();
+        assert_eq!(
+            threads
+                .into_iter()
+                .map(|t| usize::from(t.join().unwrap()))
+                .sum::<usize>(),
+            3
+        );
+        assert!(!bucket.admit());
+    }
+}

--- a/crates/bacnet-server/src/server/dcc_policy.rs
+++ b/crates/bacnet-server/src/server/dcc_policy.rs
@@ -83,6 +83,9 @@ impl super::ServerConfig {
         if let Some(restriction) = &self.dcc_source_restriction {
             restriction.validate_policy(self.dcc_policy)?;
         }
+        if let Some(limit) = self.dcc_disable_rate_limit {
+            limit.validate()?;
+        }
         Ok(())
     }
 }
@@ -132,6 +135,12 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
 }
 
 impl BipServerBuilder {
+    /// Set the password required for DeviceCommunicationControl requests.
+    pub fn dcc_password(mut self, password: impl Into<String>) -> Self {
+        self.config.dcc_password = Some(password.into());
+        self
+    }
+
     /// Restrict claimed DCC sources; requires explicit RequirePassword policy.
     pub fn dcc_source_restriction(mut self, restriction: Option<DccSourceRestriction>) -> Self {
         self.config.dcc_source_restriction = restriction;

--- a/crates/bacnet-server/src/server/dcc_policy_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_policy_tests.rs
@@ -1,5 +1,102 @@
 use super::*;
 
+#[tokio::test]
+async fn dcc_disable_rate_validation_before_start() {
+    assert!(ServerConfig::default().dcc_disable_rate_limit.is_none());
+    for limit in [
+        DccDisableRateLimit {
+            capacity: 0,
+            ..Default::default()
+        },
+        DccDisableRateLimit {
+            capacity: 65536,
+            ..Default::default()
+        },
+        DccDisableRateLimit {
+            capacity: u32::MAX,
+            ..Default::default()
+        },
+        DccDisableRateLimit {
+            refill_interval_ms: 0,
+            ..Default::default()
+        },
+        DccDisableRateLimit {
+            refill_interval_ms: 86_400_001,
+            ..Default::default()
+        },
+        DccDisableRateLimit {
+            refill_interval_ms: u64::MAX,
+            ..Default::default()
+        },
+    ] {
+        assert!(limit.validate().is_err());
+        let started = Arc::new(AtomicBool::new(false));
+        let config = ServerConfig {
+            dcc_disable_rate_limit: Some(limit),
+            ..Default::default()
+        };
+        let error = BACnetServer::start(config, ObjectDatabase::new(), NeverStart(started.clone()))
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("DCC disable rate")));
+        assert!(BACnetServer::generic_builder()
+            .transport(NeverStart(started.clone()))
+            .dcc_disable_rate_limit(Some(limit))
+            .build()
+            .await
+            .is_err());
+        assert!(!started.load(Ordering::Acquire));
+        let error = BACnetServer::bip_builder()
+            .dcc_disable_rate_limit(Some(limit))
+            .build()
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("DCC disable rate")));
+    }
+    for limit in [
+        DccDisableRateLimit {
+            capacity: 1,
+            refill_interval_ms: 1,
+        },
+        DccDisableRateLimit {
+            capacity: 65535,
+            refill_interval_ms: 86_400_000,
+        },
+    ] {
+        assert!(limit.validate().is_ok());
+    }
+}
+
+#[cfg(feature = "sc-tls")]
+#[tokio::test]
+async fn dcc_disable_rate_validation_before_sc_dial() {
+    for limit in [
+        DccDisableRateLimit {
+            capacity: 0,
+            ..Default::default()
+        },
+        DccDisableRateLimit {
+            refill_interval_ms: u64::MAX,
+            ..Default::default()
+        },
+    ] {
+        let tls = tokio_rustls::rustls::ClientConfig::builder()
+            .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
+            .with_no_client_auth();
+        let error = BACnetServer::sc_builder()
+            .hub_url("not-a-websocket-url")
+            .tls_config(Arc::new(tls))
+            .dcc_disable_rate_limit(Some(limit))
+            .build()
+            .await
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::Encoding(m) if m.contains("DCC disable rate")));
+    }
+}
+
 #[test]
 fn dcc_source_restriction_configuration_bounds() {
     for length in [0, 256, 65536] {

--- a/crates/bacnet-server/src/server/dcc_timer.rs
+++ b/crates/bacnet-server/src/server/dcc_timer.rs
@@ -17,11 +17,14 @@ pub(super) async fn replace(
     config: &ServerConfig,
     source_mac: &[u8],
     source: Option<&bacnet_encoding::npdu::NpduAddress>,
+    request_tasks: &super::request_tasks::RequestTaskSpawner,
 ) -> Result<dcc_outcomes::DccMetadata, handlers::device_mgmt::DccFailure> {
     // Decode and validate once, retaining only non-secret proposed state and
     // metadata. Never change live state before a cancellable await.
     let (mode, duration, proposed) =
         handlers::device_mgmt::validate_dcc(service_data, &config.dcc_password, config.dcc_policy)?;
+    // Short-circuit source refusal before touching the shared budget. ENABLE
+    // never checks it. A successful charge precedes every cancellable await.
     if config
         .dcc_source_restriction
         .as_ref()
@@ -29,6 +32,8 @@ pub(super) async fn replace(
             config.dcc_policy != DccPolicy::RequirePassword
                 || !restriction.allows(source_mac, source)
         })
+        || (mode == bacnet_types::enums::EnableDisable::DISABLE_INITIATION
+            && !request_tasks.admit_dcc_disable())
     {
         return Err(handlers::device_mgmt::DccFailure {
             error: Error::Protocol {

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -334,6 +334,8 @@ pub struct ServerConfig {
     pub dcc_policy: DccPolicy,
     /// Optional exact claimed-source restriction, valid only with RequirePassword.
     pub dcc_source_restriction: Option<DccSourceRestriction>,
+    /// Optional global DISABLE_INITIATION budget; does not enable DCC authorization.
+    pub dcc_disable_rate_limit: Option<DccDisableRateLimit>,
     /// Optional password required for ReinitializeDevice.
     pub reinit_password: Option<String>,
     /// Enable periodic fault detection / reliability evaluation.
@@ -444,6 +446,7 @@ impl std::fmt::Debug for ServerConfig {
             .field("dcc_password", &self.dcc_password.as_ref().map(|_| "***"))
             .field("dcc_policy", &self.dcc_policy)
             .field("dcc_source_restriction", &self.dcc_source_restriction)
+            .field("dcc_disable_rate_limit", &self.dcc_disable_rate_limit)
             .field(
                 "reinit_password",
                 &self.reinit_password.as_ref().map(|_| "***"),
@@ -486,6 +489,7 @@ impl Default for ServerConfig {
             dcc_password: None,
             dcc_policy: DccPolicy::default(),
             dcc_source_restriction: None,
+            dcc_disable_rate_limit: None,
             reinit_password: None,
             enable_fault_detection: false,
             enable_event_enrollment: true,
@@ -669,12 +673,6 @@ impl BipServerBuilder {
     pub fn device_binding(mut self, binding: DeviceBinding) -> Result<Self, Error> {
         register_configured_binding(&mut self.configured_device_bindings, binding)?;
         Ok(self)
-    }
-
-    /// Set the password required for DeviceCommunicationControl requests.
-    pub fn dcc_password(mut self, password: impl Into<String>) -> Self {
-        self.config.dcc_password = Some(password.into());
-        self
     }
 
     /// Set the password required for ReinitializeDevice requests.
@@ -886,8 +884,10 @@ mod cov_clock;
 mod cov_encoding;
 mod cov_notifications;
 mod cov_snapshot;
+mod dcc_disable_rate;
 pub(crate) mod dcc_outcomes;
 mod dcc_policy;
+pub use dcc_disable_rate::DccDisableRateLimit;
 mod dcc_timer;
 pub use dcc_outcomes::DccOutcomeCounters;
 pub use dcc_policy::{DccPolicy, DccSource, DccSourceRestriction};

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -5,8 +5,13 @@ use std::sync::{Arc, Mutex, Weak};
 use tokio::task::{JoinError, JoinSet};
 
 /// Owns inbound request handlers and their independent segmented responses,
-/// not timers or notification workers started by services.
-pub(super) struct RequestTasks(Mutex<State>, Admission);
+/// not timers or notification workers started by services. The optional DCC
+/// bucket shares this native-server lifetime, independent of task registrations.
+pub(super) struct RequestTasks(
+    Mutex<State>,
+    Admission,
+    Option<super::dcc_disable_rate::Bucket>,
+);
 
 impl Default for RequestTasks {
     fn default() -> Self {
@@ -24,6 +29,15 @@ struct State {
 pub(super) struct RequestTaskSpawner(Weak<RequestTasks>);
 
 impl RequestTaskSpawner {
+    pub(super) fn admit_dcc_disable(&self) -> bool {
+        self.0.upgrade().is_some_and(|owner| {
+            owner
+                .2
+                .as_ref()
+                .is_none_or(super::dcc_disable_rate::Bucket::admit)
+        })
+    }
+
     pub(super) fn spawn(&self, task: impl Future<Output = ()> + Send + 'static) {
         if let Some(owner) = self.0.upgrade() {
             owner.spawn(task);
@@ -40,7 +54,7 @@ impl RequestTasks {
     pub(super) fn for_server(
         config: &super::ServerConfig,
     ) -> Result<Arc<Self>, bacnet_types::error::Error> {
-        let tasks = Self::new(config.request_admission_policy)?;
+        let mut tasks = Self::new(config.request_admission_policy)?;
         // Retain admission validation precedence; both policies must be valid
         // before the lifecycle starts a transport or exposes a request owner.
         config.read_property_multiple_budget.validate()?;
@@ -51,11 +65,19 @@ impl RequestTasks {
         config.atomic_write_file_budget.validate()?;
         config.read_range_budget.validate()?;
         config.get_event_information_budget.validate()?;
+        tasks.2 = config
+            .dcc_disable_rate_limit
+            .map(super::dcc_disable_rate::Bucket::new)
+            .transpose()?;
         Ok(Arc::new(tasks))
     }
 
     pub(super) fn new(policy: RequestAdmissionPolicy) -> Result<Self, bacnet_types::error::Error> {
-        Ok(Self(Mutex::new(State::default()), Admission::new(policy)?))
+        Ok(Self(
+            Mutex::new(State::default()),
+            Admission::new(policy)?,
+            None,
+        ))
     }
 
     pub(super) fn counters(&self) -> RequestAdmissionCounters {

--- a/crates/bacnet-server/src/server/requests/dcc.rs
+++ b/crates/bacnet-server/src/server/requests/dcc.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+#[cfg(test)]
+#[path = "dcc_disable_rate_tests.rs"]
+mod rate_tests;
+
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn response<T: TransportPort + 'static>(
     timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
     comm_state: &Arc<AtomicU8>,
@@ -8,6 +13,7 @@ pub(super) async fn response<T: TransportPort + 'static>(
     req: &ConfirmedRequestPdu,
     source_mac: &[u8],
     source: Option<&NpduAddress>,
+    request_tasks: &super::super::request_tasks::RequestTaskSpawner,
 ) -> Apdu {
     let result = super::super::dcc_timer::replace(
         timer,
@@ -16,6 +22,7 @@ pub(super) async fn response<T: TransportPort + 'static>(
         config,
         source_mac,
         source,
+        request_tasks,
     )
     .await;
     // No await between validation failure/live commit and completion telemetry.

--- a/crates/bacnet-server/src/server/requests/dcc_disable_rate_tests.rs
+++ b/crates/bacnet-server/src/server/requests/dcc_disable_rate_tests.rs
@@ -1,0 +1,381 @@
+use super::*;
+use crate::server::{
+    request_tasks::RequestTasks, DccDisableRateLimit, DccSource, DccSourceRestriction,
+};
+use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
+use bacnet_types::enums::EnableDisable;
+use std::future::Future;
+use tokio::time::{advance, Duration};
+
+struct Fixture {
+    config: ServerConfig,
+    tasks: Arc<RequestTasks>,
+    timer: Arc<Mutex<Option<JoinHandle<()>>>>,
+    state: Arc<AtomicU8>,
+    outcomes: dcc_outcomes::DccOutcomes,
+}
+
+impl Fixture {
+    fn new(limit: Option<DccDisableRateLimit>) -> Self {
+        let config = ServerConfig {
+            dcc_policy: DccPolicy::LegacyPermissive,
+            dcc_disable_rate_limit: limit,
+            ..Default::default()
+        };
+        Self {
+            tasks: RequestTasks::for_server(&config).unwrap(),
+            config,
+            timer: Arc::new(Mutex::new(None)),
+            state: Arc::new(AtomicU8::new(0)),
+            outcomes: Default::default(),
+        }
+    }
+
+    async fn send(
+        &self,
+        mode: EnableDisable,
+        duration: Option<u16>,
+        password: Option<&str>,
+        peer: u8,
+        routed: bool,
+    ) -> Apdu {
+        let mut data = BytesMut::new();
+        DeviceCommunicationControlRequest {
+            enable_disable: mode,
+            time_duration: duration,
+            password: password.map(str::to_owned),
+        }
+        .encode(&mut data)
+        .unwrap();
+        self.raw(data.freeze(), peer, routed).await
+    }
+
+    async fn raw(&self, data: Bytes, peer: u8, routed: bool) -> Apdu {
+        let req = ConfirmedRequestPdu {
+            segmented: false,
+            more_follows: false,
+            segmented_response_accepted: false,
+            max_segments: None,
+            max_apdu_length: 480,
+            invoke_id: peer,
+            sequence_number: None,
+            proposed_window_size: None,
+            service_choice: ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+            service_request: data,
+        };
+        let source = routed.then(|| NpduAddress {
+            network: u16::from(peer) + 1,
+            mac_address: MacAddr::from_slice(&[peer]),
+        });
+        response::<BipTransport>(
+            &self.timer,
+            &self.state,
+            &self.outcomes,
+            &self.config,
+            &req,
+            &[peer],
+            source.as_ref(),
+            &self.tasks.spawner(),
+        )
+        .await
+    }
+
+    async fn disable(&self, peer: u8) -> Apdu {
+        self.send(
+            EnableDisable::DISABLE_INITIATION,
+            None,
+            None,
+            peer,
+            peer.is_multiple_of(2),
+        )
+        .await
+    }
+
+    async fn cleanup(&self) {
+        crate::server::dcc_timer::cancel(&mut *self.timer.lock().await).await;
+    }
+}
+
+fn denied(response: Apdu) {
+    assert!(
+        matches!(response, Apdu::Error(e) if e.error_class == ErrorClass::SERVICES && e.error_code == ErrorCode::SERVICE_REQUEST_DENIED && e.service_choice == ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL)
+    );
+}
+
+fn accepted(response: Apdu) {
+    assert!(matches!(response, Apdu::SimpleAck(_)));
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_disable_rate_denial_has_one_existing_debug_event_and_counter() {
+    use tracing::instrument::WithSubscriber;
+    let fixture = Fixture::new(Some(DccDisableRateLimit {
+        capacity: 1,
+        ..Default::default()
+    }));
+    accepted(fixture.disable(1).await);
+    let capture = dcc_outcomes::trace_tests::Capture::default();
+    denied(
+        fixture
+            .send(EnableDisable::DISABLE_INITIATION, Some(5), None, 42, true)
+            .with_subscriber(capture.clone())
+            .await,
+    );
+    assert_eq!(fixture.outcomes.snapshot().policy_denied_total, 1);
+    let records = capture.0.lock().unwrap();
+    assert_eq!(records.len(), 1);
+    let record = &records[0];
+    assert_eq!(record["outcome"], "policy_denied");
+    assert_eq!(record["invoke_id"], "42");
+    assert_eq!(record["service"], "17");
+    assert_eq!(record["decoded_mode"], "2");
+    assert_eq!(record["duration_minutes"], "5");
+    assert_eq!(record.len(), 11);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_disable_rate_global_identity_enable_exemption_and_native_reset() {
+    let fixture = Fixture::new(Some(Default::default()));
+    for peer in 1..=3 {
+        accepted(fixture.disable(peer).await);
+    }
+    denied(fixture.disable(4).await);
+    advance(Duration::from_secs(10)).await;
+    for peer in 5..=25 {
+        accepted(
+            fixture
+                .send(EnableDisable::ENABLE, None, None, peer, true)
+                .await,
+        );
+        denied(fixture.disable(peer).await);
+    }
+    advance(Duration::from_secs(10)).await;
+    accepted(fixture.disable(26).await);
+    denied(fixture.disable(27).await);
+    assert_eq!(fixture.outcomes.snapshot().accepted_total, 25);
+    assert_eq!(fixture.outcomes.snapshot().policy_denied_total, 23);
+    // Closing the same owner never resets the bucket; new native owner does.
+    fixture.tasks.close();
+    assert!(!fixture.tasks.spawner().admit_dcc_disable());
+    let fresh = Fixture::new(Some(Default::default()));
+    for peer in 1..=3 {
+        accepted(fresh.disable(peer).await);
+    }
+    denied(fresh.disable(4).await);
+    let unlimited = Fixture::new(None);
+    for peer in 0..100 {
+        accepted(unlimited.disable(peer).await);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_disable_rate_earlier_failures_do_not_charge() {
+    let mut fixture = Fixture::new(Some(Default::default()));
+    fixture.config.dcc_password = Some("required".into());
+    fixture.config.dcc_policy = DccPolicy::RequirePassword;
+    for _ in 0..10 {
+        assert!(matches!(
+            fixture.raw(Bytes::from_static(&[0x19]), 1, false).await,
+            Apdu::Error(_)
+        ));
+        assert!(
+            matches!(fixture.send(EnableDisable::DISABLE_INITIATION, None, Some("wrong"), 1, false).await,
+            Apdu::Error(e) if e.error_class == ErrorClass::SECURITY && e.error_code == ErrorCode::PASSWORD_FAILURE)
+        );
+        denied(
+            fixture
+                .send(EnableDisable::DISABLE, None, Some("required"), 1, false)
+                .await,
+        );
+        assert!(matches!(
+            fixture
+                .send(EnableDisable::from_raw(3), None, Some("required"), 1, false)
+                .await,
+            Apdu::Error(_)
+        ));
+        fixture.config.dcc_policy = DccPolicy::DenyAll;
+        denied(
+            fixture
+                .send(
+                    EnableDisable::DISABLE_INITIATION,
+                    None,
+                    Some("required"),
+                    1,
+                    false,
+                )
+                .await,
+        );
+        fixture.config.dcc_policy = DccPolicy::RequirePassword;
+        fixture.config.dcc_source_restriction =
+            Some(DccSourceRestriction::new(vec![DccSource::Direct(vec![2])]).unwrap());
+        denied(
+            fixture
+                .send(
+                    EnableDisable::DISABLE_INITIATION,
+                    None,
+                    Some("required"),
+                    1,
+                    false,
+                )
+                .await,
+        );
+        fixture.config.dcc_source_restriction = None;
+    }
+    for _ in 0..3 {
+        accepted(
+            fixture
+                .send(
+                    EnableDisable::DISABLE_INITIATION,
+                    None,
+                    Some("required"),
+                    1,
+                    false,
+                )
+                .await,
+        );
+    }
+    denied(
+        fixture
+            .send(
+                EnableDisable::DISABLE_INITIATION,
+                None,
+                Some("required"),
+                1,
+                false,
+            )
+            .await,
+    );
+    let counters = fixture.outcomes.snapshot();
+    assert_eq!(
+        (
+            counters.accepted_total,
+            counters.policy_denied_total,
+            counters.password_failure_total,
+            counters.deprecated_denied_total,
+            counters.malformed_total
+        ),
+        (3, 21, 10, 10, 20)
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_disable_rate_admitted_cancellation_consumes_before_timer_lock() {
+    let fixture = Fixture::new(Some(DccDisableRateLimit {
+        capacity: 1,
+        ..Default::default()
+    }));
+    let slot = fixture.timer.lock().await;
+    let mut request = Box::pin(fixture.disable(1));
+    assert!(matches!(
+        std::future::poll_fn(|cx| std::task::Poll::Ready(request.as_mut().poll(cx))).await,
+        std::task::Poll::Pending
+    ));
+    drop(request);
+    assert_eq!(fixture.state.load(Ordering::Acquire), 0);
+    assert_eq!(fixture.outcomes.snapshot().accepted_total, 0);
+    // A timeout cannot auto-advance this paused clock: poll once, requiring Ready.
+    let mut denied_request = Box::pin(fixture.disable(2));
+    let result =
+        std::future::poll_fn(|cx| std::task::Poll::Ready(denied_request.as_mut().poll(cx))).await;
+    let std::task::Poll::Ready(result) = result else {
+        panic!("rate denial waited for timer lock")
+    };
+    denied(result);
+    assert!(slot.is_none());
+    assert_eq!(fixture.outcomes.snapshot().policy_denied_total, 1);
+    drop(slot);
+    advance(Duration::from_secs(20)).await;
+    accepted(fixture.disable(3).await);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_disable_rate_concurrent_handlers_admit_only_burst_before_commit() {
+    let fixture = Fixture::new(Some(Default::default()));
+    let slot = fixture.timer.lock().await;
+    let mut pending = Vec::new();
+    for peer in 1..=32 {
+        let mut request = Box::pin(fixture.disable(peer));
+        match std::future::poll_fn(|cx| std::task::Poll::Ready(request.as_mut().poll(cx))).await {
+            std::task::Poll::Pending => pending.push(request),
+            std::task::Poll::Ready(result) => denied(result),
+        }
+    }
+    assert_eq!(pending.len(), 3);
+    assert_eq!(fixture.outcomes.snapshot().accepted_total, 0);
+    assert_eq!(fixture.outcomes.snapshot().policy_denied_total, 29);
+    drop(slot);
+    for request in pending {
+        accepted(request.await);
+    }
+    assert_eq!(fixture.outcomes.snapshot().accepted_total, 3);
+    denied(fixture.disable(33).await);
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_disable_rate_denial_preserves_live_timer_racing_expiry() {
+    for pending_expiry in [false, true] {
+        let fixture = Fixture::new(Some(DccDisableRateLimit {
+            capacity: 1,
+            refill_interval_ms: 120_000,
+        }));
+        accepted(
+            fixture
+                .send(EnableDisable::DISABLE_INITIATION, Some(1), None, 1, false)
+                .await,
+        );
+        tokio::task::yield_now().await;
+        let slot = fixture.timer.lock().await;
+        let id = slot.as_ref().unwrap().id();
+        advance(Duration::from_secs(if pending_expiry { 60 } else { 30 })).await;
+        for duration in [None, Some(0), Some(1), Some(5)] {
+            let mut request =
+                Box::pin(fixture.send(EnableDisable::DISABLE_INITIATION, duration, None, 2, true));
+            let result =
+                std::future::poll_fn(|cx| std::task::Poll::Ready(request.as_mut().poll(cx))).await;
+            let std::task::Poll::Ready(result) = result else {
+                panic!("rate denial waited for timer lock")
+            };
+            denied(result);
+            assert_eq!(slot.as_ref().unwrap().id(), id);
+            assert_eq!(fixture.state.load(Ordering::Acquire), 2);
+        }
+        drop(slot);
+        if !pending_expiry {
+            advance(Duration::from_secs(30)).await;
+        }
+        let task = fixture.timer.lock().await.take().unwrap();
+        task.await.unwrap();
+        assert_eq!(fixture.state.load(Ordering::Acquire), 0);
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn dcc_disable_rate_authorized_timer_parity_and_repeated_charge() {
+    for duration in [None, Some(0), Some(1)] {
+        let fixture = Fixture::new(Some(Default::default()));
+        for _ in 0..3 {
+            accepted(
+                fixture
+                    .send(EnableDisable::DISABLE_INITIATION, duration, None, 1, false)
+                    .await,
+            );
+            assert_eq!(fixture.state.load(Ordering::Acquire), 2);
+            assert_eq!(fixture.timer.lock().await.is_some(), duration.is_some());
+        }
+        denied(
+            fixture
+                .send(EnableDisable::DISABLE_INITIATION, duration, None, 1, false)
+                .await,
+        );
+        accepted(
+            fixture
+                .send(EnableDisable::ENABLE, duration, None, 1, false)
+                .await,
+        );
+        assert_eq!(fixture.state.load(Ordering::Acquire), 0);
+        // Preserve the existing ENABLE-duration behavior, not a protocol correction.
+        assert_eq!(fixture.timer.lock().await.is_some(), duration.is_some());
+        denied(fixture.disable(2).await);
+        fixture.cleanup().await;
+    }
+}

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -298,6 +298,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                     &req,
                     source_mac,
                     source_network.as_ref(),
+                    request_tasks,
                 )
                 .await
             }

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -111,6 +111,12 @@ impl ScServerBuilder {
         self
     }
 
+    /// Limit authorized DISABLE_INITIATION globally; None (default) disables it.
+    pub fn dcc_disable_rate_limit(mut self, limit: Option<super::DccDisableRateLimit>) -> Self {
+        self.config.dcc_disable_rate_limit = limit;
+        self
+    }
+
     /// Set the password required for ReinitializeDevice requests.
     pub fn reinit_password(mut self, password: impl Into<String>) -> Self {
         self.config.reinit_password = Some(password.into());

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1785,6 +1785,7 @@ class BACnetServer:
         *,
         dcc_policy: str = "deny_all",
         dcc_source_restriction: list[tuple[int | None, bytes]] | None = None,
+        dcc_disable_rate_limit: tuple[int, int] | None = None,
         serial_port: Optional[str] = None,
         mstp_baud: int = 38400,
         mstp_mac: int = 1,

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -102,6 +102,7 @@ pub struct BACnetServer {
     dcc_password: Option<String>,
     dcc_policy: server::DccPolicy,
     dcc_source_restriction: Option<server::DccSourceRestriction>,
+    dcc_disable_rate_limit: Option<server::DccDisableRateLimit>,
     reinit_password: Option<String>,
     request_admission_policy: server::RequestAdmissionPolicy,
     read_property_multiple_budget: server::ReadPropertyMultipleBudget,

--- a/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/file_configuration.rs
@@ -203,6 +203,7 @@ mod tests {
             dcc_password: None,
             dcc_policy: server::DccPolicy::default(),
             dcc_source_restriction: None,
+            dcc_disable_rate_limit: None,
             reinit_password: None,
             request_admission_policy: server::RequestAdmissionPolicy::default(),
             read_property_multiple_budget: server::ReadPropertyMultipleBudget::default(),

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -38,6 +38,7 @@ impl BACnetServer {
         let dcc_password = self.dcc_password.clone();
         let dcc_policy = self.dcc_policy;
         let dcc_source_restriction = self.dcc_source_restriction.clone();
+        let dcc_disable_rate_limit = self.dcc_disable_rate_limit;
         let reinit_password = self.reinit_password.clone();
         let request_admission_policy = self.request_admission_policy;
         let read_property_multiple_budget = self.read_property_multiple_budget;
@@ -164,7 +165,8 @@ impl BACnetServer {
             }
             builder = builder
                 .dcc_policy(dcc_policy)
-                .dcc_source_restriction(dcc_source_restriction);
+                .dcc_source_restriction(dcc_source_restriction)
+                .dcc_disable_rate_limit(dcc_disable_rate_limit);
             if let Some(pw) = reinit_password {
                 builder = builder.reinit_password(pw);
             }

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -23,6 +23,7 @@ impl BACnetServer {
         *,
         dcc_policy="deny_all",
         dcc_source_restriction=None,
+        dcc_disable_rate_limit=None,
         serial_port=None,
         mstp_baud=38400,
         mstp_mac=1,
@@ -72,6 +73,7 @@ impl BACnetServer {
         reinit_password: Option<String>,
         dcc_policy: &str,
         dcc_source_restriction: Option<Vec<(Option<u16>, Vec<u8>)>>,
+        dcc_disable_rate_limit: Option<(u32, u64)>,
         serial_port: Option<String>,
         mstp_baud: u32,
         mstp_mac: u8,
@@ -127,6 +129,17 @@ impl BACnetServer {
                 )?;
                 restriction.validate_policy(dcc_policy)?;
                 Ok::<_, bacnet_types::error::Error>(restriction)
+            })
+            .transpose()
+            .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        let dcc_disable_rate_limit = dcc_disable_rate_limit
+            .map(|(capacity, refill_interval_ms)| {
+                let limit = server::DccDisableRateLimit {
+                    capacity,
+                    refill_interval_ms,
+                };
+                limit.validate()?;
+                Ok::<_, bacnet_types::error::Error>(limit)
             })
             .transpose()
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
@@ -217,6 +230,7 @@ impl BACnetServer {
             dcc_password,
             dcc_policy,
             dcc_source_restriction,
+            dcc_disable_rate_limit,
             reinit_password,
             request_admission_policy,
             read_property_multiple_budget,

--- a/crates/rusty-bacnet/tests/test_dcc_policy.py
+++ b/crates/rusty-bacnet/tests/test_dcc_policy.py
@@ -9,6 +9,24 @@ from rusty_bacnet import BACnetServer
 
 
 class DccConstructorTests(unittest.TestCase):
+    def test_disable_rate_constructor_bounds_and_default(self):
+        parameter = inspect.signature(BACnetServer).parameters["dcc_disable_rate_limit"]
+        self.assertIsNone(parameter.default)
+        self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+        for transport in ["bip", "ipv6", "sc", "mstp"]:
+            for invalid in [(0, 20000), (65536, 20000), (3, 0), (3, 86400001),
+                            (2**32 - 1, 20000), (3, 2**64 - 1)]:
+                with self.assertRaisesRegex(ValueError, "DCC disable rate"):
+                    BACnetServer(123, transport=transport, dcc_disable_rate_limit=invalid)
+            for valid in [None, (3, 20000), (1, 1), (65535, 86400000)]:
+                for policy in ["deny_all", "legacy_permissive", "require_password"]:
+                    BACnetServer(123, transport=transport, dcc_policy=policy,
+                                 dcc_password="required", dcc_disable_rate_limit=valid)
+        for invalid in [True, "bad", (), (3,), (3, 20, 1), (-1, 20000), (3, -1),
+                        (2**32, 20000), (3, 2**64), (3.5, 20000), (3, None)]:
+            with self.assertRaises((TypeError, ValueError, OverflowError)):
+                BACnetServer(123, dcc_disable_rate_limit=invalid)
+
     def test_source_restriction_validation_before_every_transport(self):
         parameter = inspect.signature(BACnetServer).parameters["dcc_source_restriction"]
         self.assertIsNone(parameter.default)
@@ -55,6 +73,61 @@ class DccConstructorTests(unittest.TestCase):
 
 
 class DccNativeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_disable_rate_global_native_lifetime_and_enable_exemption(self):
+        for policy in ["legacy_permissive", "require_password"]:
+            server = BACnetServer(123, interface="127.0.0.1", port=0,
+                                  broadcast_address="127.0.0.1", dcc_policy=policy,
+                                  dcc_password="required", dcc_disable_rate_limit=(3, 20000))
+            sockets = [socket.socket(socket.AF_INET, socket.SOCK_DGRAM) for _ in range(2)]
+            for sock in sockets:
+                sock.bind(("127.0.0.1", 0))
+                sock.setblocking(False)
+            try:
+                # Same Python wrapper, distinct native servers: restart resets budget.
+                for _ in range(2):
+                    await server.start()
+                    for invoke in range(1, 7):
+                        reply = await self.exchange(server, sockets[invoke % 2], invoke, 2,
+                                                    "required", invoke % 2 == 0)
+                        self.assertEqual(reply, bytes([0x20, invoke, 17]) if invoke <= 3 else
+                                         bytes([0x50, invoke, 17, 0x91, 5, 0x91, 29]))
+                    for invoke in range(7, 10):
+                        reply = await self.exchange(server, sockets[0], invoke, 0, "required", False)
+                        self.assertEqual(reply, bytes([0x20, invoke, 17]))
+                    self.assertEqual(await server.comm_state(), 0)
+                    reply = await self.exchange(server, sockets[1], 10, 2, "required", True)
+                    self.assertEqual(reply, bytes([0x50, 10, 17, 0x91, 5, 0x91, 29]))
+                    self.assertEqual(await server.comm_state(), 0)
+                    self.assertEqual(await server.dcc_outcome_counters(), dict(
+                        accepted_total=6, policy_denied_total=4, password_failure_total=0,
+                        deprecated_denied_total=0, malformed_total=0))
+                    self.assertEqual((await server.request_admission_counters())["recovery_admitted_total"], 3)
+                    await server.stop()
+            finally:
+                await server.stop()
+                for sock in sockets:
+                    sock.close()
+
+    async def test_disable_rate_password_deprecated_and_configurable_refill(self):
+        server = BACnetServer(123, interface="127.0.0.1", port=0,
+                              broadcast_address="127.0.0.1", dcc_policy="require_password",
+                              dcc_password="required", dcc_disable_rate_limit=(1, 200))
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.setblocking(False)
+        try:
+            await server.start()
+            reply = await self.exchange(server, sock, 1, 2, "wrong", False)
+            self.assertEqual(reply, bytes([0x50, 1, 17, 0x91, 4, 0x91, 26]))
+            reply = await self.exchange(server, sock, 2, 1, "required", False)
+            self.assertEqual(reply, bytes([0x50, 2, 17, 0x91, 5, 0x91, 29]))
+            self.assertEqual((await self.exchange(server, sock, 3, 2, "required", False))[0], 0x20)
+            await asyncio.sleep(0.25)
+            self.assertEqual((await self.exchange(server, sock, 4, 2, "required", True))[0], 0x20)
+        finally:
+            await server.stop()
+            sock.close()
+
     async def test_source_restriction_direct_routed_and_outcomes(self):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.bind(("127.0.0.1", 0))

--- a/crates/rusty-bacnet/tests/test_mstp_compat.py
+++ b/crates/rusty-bacnet/tests/test_mstp_compat.py
@@ -61,7 +61,7 @@ MSTP_KEYWORD_ONLY = [
     "mstp_max_master",
     "mstp_max_info_frames",
 ]
-SERVER_KEYWORD_ONLY = ["dcc_policy", "dcc_source_restriction"] + MSTP_KEYWORD_ONLY + [
+SERVER_KEYWORD_ONLY = ["dcc_policy", "dcc_source_restriction", "dcc_disable_rate_limit"] + MSTP_KEYWORD_ONLY + [
     "max_confirmed_in_flight", "max_unconfirmed_in_flight",
     "max_confirmed_in_flight_per_peer", "max_unconfirmed_in_flight_per_peer",
     "confirmed_recovery_reserve", "max_recovery_in_flight_per_peer",

--- a/docs/dcc-policy.md
+++ b/docs/dcc-policy.md
@@ -15,7 +15,7 @@ LegacyPermissive does **not** bypass a configured password. Without one, any
 requester whose request reaches the handler can change communications. Do not
 mistake this compatibility option, a shared password, a routed address, or an SC
 VMAC for authenticated source identity. Exact address restriction below is not
-principal authentication. Full auditing and rate policy remain future work under
+principal authentication. Full auditing and broader abuse protection remain future work under
 the partial, separate #522 scope.
 
 ## Migration
@@ -70,15 +70,62 @@ Claimed addresses are spoofable and unauthenticated, **including SC VMACs**.
 An allowed address still needs the correct password; a shared password plus an
 address match does not establish principal identity or authenticated-SC provenance.
 
+### Optional global DISABLE_INITIATION rate policy
+
+`ServerConfig::dcc_disable_rate_limit: Option<DccDisableRateLimit>` defaults to
+`None` (**OFF**), preserving all existing authorization, including explicit
+LegacyPermissive. Generic, B/IP and SC builders expose `.dcc_disable_rate_limit(...)`.
+Use `Some(DccDisableRateLimit::default())` for an initial/maximum burst of **3**
+tokens and **one token per 20 seconds**. Public fields `capacity: u32` (1–65535)
+and `refill_interval_ms: u64` (1–86400000) are configurable local operator limits.
+Invalid values fail validation before transport startup/SC dialing. Exhaustive
+Rust config literals need `dcc_disable_rate_limit: None` or a default update.
+
+Python's keyword-only `dcc_disable_rate_limit: tuple[int, int] | None = None`
+accepts `(capacity, refill_interval_ms)`; pass `(3, 20000)` for the enabled defaults.
+The constructor validates and copies configuration before any transport work.
+Invalid bounds raise `ValueError`; wrong types raise `TypeError`, and integers
+outside the native unsigned representation may raise `OverflowError`.
+
+This is **one shared bucket per native server**, never a per-source table.
+All locally authorized DISABLE_INITIATION requests, including repeated requests
+with the same mode/duration and explicit LegacyPermissive requests, spend one token.
+Changing claimed direct/routed identities or immediate peers does not obtain a new
+budget. Enabling the limiter never enables DCC: DenyAll remains the default policy.
+Authorized **ENABLE is exempt**: it neither checks nor charges the bucket, nor
+resets its balance/refill progress. Existing #521 request-admission limits still apply.
+
+Refill uses Tokio monotonic elapsed time, with fractional nanosecond accounting,
+saturating at capacity and discarding surplus while full. Denied checks preserve
+elapsed progress. There is no refill task, wall-clock dependency or persistence.
+Admission and charge are serialized in one short blocking critical section with
+no await. **A charge is not refunded if the admitted handler is cancelled before
+the timer/state commit.** Such incomplete handlers still produce no completed-handler
+counter/event. Rate denial produces the existing SERVICES/SERVICE_REQUEST_DENIED,
+`policy_denied_total` and `policy_denied` DEBUG event without new telemetry fields.
+
+Each new native server starts full. Stop does not replenish that instance's bucket.
+Python stop drops the native server; each successful subsequent start on the same
+Python wrapper creates a **new native lifetime and fresh full bucket**. No bucket
+state is kept in the wrapper. An operator able to restart a server can reset the
+budget; this policy does not constrain that authority.
+
+This is not all-attempt, ingress, CPU, flood or password-guessing protection:
+decoding/password checks and earlier authorization denials remain unthrottled by
+this policy. It does not authenticate sources, provide fair allocation, or complete #522.
+
 ### Validation and timer order
 
 Existing admission, duplicate handling and DCC ingress discards are unchanged.
 After admission: decode, existing constant-time password check, deprecated DISABLE
-rejection, then local policy and optional source restriction for ENABLE/DISABLE_INITIATION, then live state/timer
+rejection, then local policy and optional source restriction for ENABLE/DISABLE_INITIATION,
+then optional rate admission for DISABLE_INITIATION, then live state/timer
 commit. Missing/wrong configured passwords return SECURITY/PASSWORD_FAILURE even
 under DenyAll or for DISABLE. Otherwise denied valid requests return
 SERVICES/SERVICE_REQUEST_DENIED. Unknown-mode decoding/encoding errors retain
 their existing precedence. Deprecated DISABLE remains denied in **every** policy.
+Malformed, wrong-password, deprecated-mode, DenyAll and source-denied requests
+never check or charge the rate bucket.
 
 Denial happens before the live timer lock, cancellation or state mutation.
 Repeated denied requests cannot create, cancel or extend a timer, including when
@@ -102,7 +149,7 @@ completed bounded #521 acceptance remain unchanged, not reopened.
 Local licensed ASHRAE 135-2020 §16.1 (printed 759–760) supplies the existing
 optional-password and deprecated-DISABLE rules; §18.6 (printed 795) describes
 SERVICE_REQUEST_DENIED for lack of authorization. The three configuration modes,
-nonempty startup requirement and deny-all default are operator policy, not new
+nonempty startup requirement, deny-all default and optional rate limits are operator policy, not new
 normative claims. This does not expand authenticated-SC, physical-transport,
 full-conformance, Audit/#125, EventLog integration, additional #181 fault-family
 or GATE0007 qualification.
@@ -145,10 +192,10 @@ BACnet Audit service. There is no internal history, queue, task, destination or
 new callback API; the Python accessor installs no logger/subscriber or trace
 bridge. Standard tracing subscribers are caller-owned and may filter, discard,
 backpressure, or perform arbitrary work. Event delivery, global concurrent
-ordering, rate limiting and flood resistance are not guaranteed. Counters and
+ordering, event-rate limiting and flood resistance are not guaranteed. Counters and
 events exclude duplicates, pre-handler admission/shutdown/Abort-fallback
 rejections, handlers cancelled before completion, timer expiry, and response
 delivery failures after commit. Existing admission counters cover their separate
 admission boundary. Source mismatch reuses `policy_denied_total` and the existing
 `policy_denied` DEBUG event/schema, without new counters. This remains partial
-#522 work, not full auditing, rate policy or principal authentication; #521 remains closed.
+#522 work, not full auditing, general abuse protection or principal authentication; #521 remains closed.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1150,9 +1150,21 @@ server = BACnetServer(
     dcc_password=None,           # password alone does not enable DCC
     dcc_policy="deny_all",       # keyword-only; explicit require_password or INSECURE legacy_permissive
     dcc_source_restriction=None, # optional list[(network_or_None, bytes)]; [] denies all; requires require_password
+    dcc_disable_rate_limit=None, # optional (capacity, refill_interval_ms); (3, 20000) enables default rate
     reinit_password=None,        # password for ReinitializeDevice
 )
 ```
+
+`dcc_disable_rate_limit` is keyword-only and defaults OFF. When configured, one
+global native-server bucket charges only authorized DISABLE_INITIATION requests;
+authorized ENABLE never checks, charges or resets it. Capacity must be 1–65535
+and refill interval 1–86400000 milliseconds (constructor validation). This does
+not enable DCC or limit password guessing/ingress traffic. Admission charges survive
+cancellation before commit; denial uses the existing policy-denied error/counter.
+Each successful `start()` creates a new native server and full bucket, including
+after `stop()` on the same Python object. An operator able to restart can reset
+the budget. See [DCC policy](dcc-policy.md#optional-global-disable_initiation-rate-policy)
+for exact timing, validation and exclusions.
 
 ### Adding Objects (before start)
 


### PR DESCRIPTION
## Summary
- Optional global token bucket for authorized DISABLE_INITIATION only; default off, enabled defaults burst 3/refill one per 20 seconds, configurable bounded values.
- ENABLE exempt; earlier auth/validation failures do not charge. Admission charges survive cancellation; rate denial leaves timers untouched and reuses existing policy-denied telemetry.
- Rust/Python configuration with explicit native-lifetime reset on Python restart.

## Boundaries
Refs #522, remains partial. No ingress/flood/password-guessing protection, fairness, SC-principal or durable-audit expansion. #521 unchanged. Existing timer semantics retained, not newly certified.

## Validation
- Workspace 4383 passed / 0 failed / 3 existing ignored; server 1049 unit + 3 integration; integration 40.
- DCC58, SC-DCC61, password17, timer16, recovery31, admission55, shutdown80 passed.
- Native CPython3.12.13 macOSarm64 locked DEV wheel: Python62 tests/913 subtests; focused16/214. Origin and installed stub parity verified.
- Formatting, Clippy(existing warnings), size, secrets, whitespace and explicit-interpreter binding checks passed.
- Independent reviews and exact-head lean CI pending. No release/hardware/full-conformance qualification.