### PR TITLE
test(server): validate DCC policy over mutual-TLS SC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,8 @@ dependencies = [
  "bacnet-transport",
  "bacnet-types",
  "bytes",
+ "futures-util",
+ "rcgen",
  "tokio",
  "tokio-rustls",
  "tracing",

--- a/crates/bacnet-server/Cargo.toml
+++ b/crates/bacnet-server/Cargo.toml
@@ -26,6 +26,8 @@ tokio-rustls = { workspace = true, optional = true }
 sc-tls = ["bacnet-transport/sc-tls", "tokio-rustls"]
 
 [dev-dependencies]
+rcgen.workspace = true
+futures-util.workspace = true
 bacnet-client.workspace = true
 bacnet-transport.workspace = true
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "sync", "macros", "time", "test-util"] }

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+#[cfg(test)]
+#[path = "sc_dcc_mtls_tests.rs"]
+mod dcc_mtls_tests;
+
 impl BACnetServer<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>> {
     /// Create an SC-specific builder that connects to a BACnet/SC hub.
     pub fn sc_builder() -> ScServerBuilder {

--- a/crates/bacnet-server/src/server/sc_dcc_mtls_support.rs
+++ b/crates/bacnet-server/src/server/sc_dcc_mtls_support.rs
@@ -1,0 +1,406 @@
+use crate::server::*;
+use bacnet_encoding::apdu::decode_apdu;
+use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu};
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
+use bacnet_services::read_property::{ReadPropertyACK, ReadPropertyRequest};
+use bacnet_transport::port::ReceivedNpdu;
+use bacnet_transport::sc::ScTransport;
+use bacnet_transport::sc_hub::ScHub;
+use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_types::enums::EnableDisable;
+use futures_util::FutureExt;
+use rcgen::{CertificateParams, ExtendedKeyUsagePurpose, Issuer, KeyPair};
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use tokio_rustls::rustls::{self, pki_types::PrivatePkcs8KeyDer};
+use tokio_rustls::TlsAcceptor;
+
+pub(super) const SERVER: [u8; 6] = [2, 0, 0, 0, 0, 1];
+pub(super) const PEERS: [[u8; 6]; 2] = [[2, 0, 0, 0, 0, 2], [2, 0, 0, 0, 0, 3]];
+pub(super) const PASSWORD: &str = "test-only-dcc";
+type Transport = ScTransport<TlsWebSocket>;
+type Server = BACnetServer<Transport>;
+
+pub(super) async fn bounded<T>(future: impl Future<Output = T>) -> T {
+    tokio::time::timeout(Duration::from_secs(5), future)
+        .await
+        .expect("loopback operation exceeded its deadline")
+}
+
+// All keys stay in memory. Each endpoint has its own key/certificate, including
+// the BACnet server (a TLS client of the hub). No permissive verifier is used.
+pub(super) struct Certificates {
+    pub hub: Arc<rustls::ServerConfig>,
+    pub clients: Vec<Arc<rustls::ClientConfig>>,
+    pub missing: Arc<rustls::ClientConfig>,
+    pub untrusted: Arc<rustls::ClientConfig>,
+    pub wrong_server_trust: Arc<rustls::ClientConfig>,
+}
+
+impl Certificates {
+    pub fn new() -> Self {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_key = KeyPair::generate().unwrap();
+        let ca = params.self_signed(&ca_key).unwrap();
+        let issuer = Issuer::from_params(&params, &ca_key);
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(ca.der().clone()).unwrap();
+        let leaf = |name: &str, usage| {
+            let mut params = CertificateParams::new(vec![name.into()]).unwrap();
+            params.extended_key_usages = vec![usage];
+            let key = KeyPair::generate().unwrap();
+            let cert = params.signed_by(&key, &issuer).unwrap();
+            (
+                cert.der().clone(),
+                PrivatePkcs8KeyDer::from(key.serialize_der()),
+            )
+        };
+        let (hub_cert, hub_key) = leaf("127.0.0.1", ExtendedKeyUsagePurpose::ServerAuth);
+        let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(roots.clone()))
+            .build()
+            .unwrap();
+        let hub = rustls::ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(vec![hub_cert.clone()], hub_key.into())
+            .unwrap();
+        let mut certs = vec![hub_cert];
+        let clients = (0..3)
+            .map(|index| {
+                let (cert, key) = leaf(
+                    &format!("peer-{index}"),
+                    ExtendedKeyUsagePurpose::ClientAuth,
+                );
+                assert!(!certs.contains(&cert), "endpoint certificates must differ");
+                certs.push(cert.clone());
+                Arc::new(
+                    rustls::ClientConfig::builder_with_protocol_versions(&[
+                        &rustls::version::TLS13,
+                    ])
+                    .with_root_certificates(roots.clone())
+                    .with_client_auth_cert(vec![cert], key.into())
+                    .unwrap(),
+                )
+            })
+            .collect();
+        let missing =
+            rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+                .with_root_certificates(roots.clone())
+                .with_no_client_auth();
+        let rogue_key = KeyPair::generate().unwrap();
+        let mut rogue_params = CertificateParams::new(vec!["untrusted-peer".into()]).unwrap();
+        rogue_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
+        let rogue = rogue_params.self_signed(&rogue_key).unwrap();
+        let untrusted =
+            rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+                .with_root_certificates(roots)
+                .with_client_auth_cert(
+                    vec![rogue.der().clone()],
+                    PrivatePkcs8KeyDer::from(rogue_key.serialize_der()).into(),
+                )
+                .unwrap();
+        let (cert, key) = leaf("wrong-server-trust", ExtendedKeyUsagePurpose::ClientAuth);
+        let wrong_server_trust =
+            rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+                .with_root_certificates(rustls::RootCertStore::empty())
+                .with_client_auth_cert(vec![cert], key.into())
+                .unwrap();
+        Self {
+            hub: Arc::new(hub),
+            clients,
+            missing: Arc::new(missing),
+            untrusted: Arc::new(untrusted),
+            wrong_server_trust: Arc::new(wrong_server_trust),
+        }
+    }
+}
+
+pub(super) struct Peer {
+    transport: Transport,
+    receiver: Option<mpsc::Receiver<ReceivedNpdu>>,
+    next_invoke: u8,
+}
+
+#[derive(Default)]
+pub(super) struct Fixture {
+    hub: Option<ScHub>,
+    pub server: Option<Server>,
+    peers: Vec<Peer>,
+    pub url: String,
+}
+
+impl Fixture {
+    pub fn server(&self) -> &Server {
+        self.server.as_ref().unwrap()
+    }
+
+    pub async fn hub(&mut self, certs: &Certificates) {
+        let hub = bounded(ScHub::start(
+            "127.0.0.1:0",
+            TlsAcceptor::from(certs.hub.clone()),
+            [2, 0, 0, 0, 0, 9],
+        ))
+        .await
+        .unwrap();
+        self.url = format!("wss://127.0.0.1:{}", hub.local_addr().unwrap().port());
+        self.hub = Some(hub);
+    }
+
+    pub async fn start(&mut self, certs: &Certificates, builder: sc_builder::ScServerBuilder) {
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(
+            DeviceObject::new(DeviceConfig {
+                instance: 123,
+                ..Default::default()
+            })
+            .unwrap(),
+        ))
+        .unwrap();
+        self.server = Some(
+            bounded(
+                builder
+                    .hub_url(&self.url)
+                    .tls_config(certs.clients[0].clone())
+                    .vmac(SERVER)
+                    .database(db)
+                    .build(),
+            )
+            .await
+            .unwrap(),
+        );
+        for (index, vmac) in PEERS.into_iter().enumerate() {
+            let ws = bounded(TlsWebSocket::connect(
+                &self.url,
+                certs.clients[index + 1].clone(),
+            ))
+            .await
+            .unwrap();
+            // Register ownership before the cancellable SC handshake.
+            self.peers.push(Peer {
+                transport: ScTransport::new(ws, vmac).with_device_uuid([index as u8 + 1; 16]),
+                receiver: None,
+                next_invoke: 1,
+            });
+            let peer = self.peers.last_mut().unwrap();
+            peer.receiver = Some(bounded(peer.transport.start()).await.unwrap());
+            // start() awaits ConnectAccept; ReadProperty proves end-to-end service
+            // dispatch, not merely TLS admission or a timeout interpreted as denial.
+            self.read_property(index).await;
+        }
+    }
+
+    pub async fn exchange(
+        &mut self,
+        peer: usize,
+        service: ConfirmedServiceChoice,
+        data: Bytes,
+        source: Option<NpduAddress>,
+    ) -> (u8, Apdu) {
+        let peer = &mut self.peers[peer];
+        let invoke = peer.next_invoke;
+        peer.next_invoke = invoke.checked_add(1).unwrap();
+        let mut payload = BytesMut::new();
+        encode_apdu(
+            &mut payload,
+            &Apdu::ConfirmedRequest(ConfirmedRequestPdu {
+                segmented: false,
+                more_follows: false,
+                segmented_response_accepted: false,
+                max_segments: None,
+                max_apdu_length: 480,
+                invoke_id: invoke,
+                sequence_number: None,
+                proposed_window_size: None,
+                service_choice: service,
+                service_request: data,
+            }),
+        )
+        .unwrap();
+        let mut wire = BytesMut::new();
+        encode_npdu(
+            &mut wire,
+            &Npdu {
+                expecting_reply: true,
+                source: source.clone(),
+                payload: payload.freeze(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        bounded(peer.transport.send_unicast(&wire, &SERVER))
+            .await
+            .unwrap();
+        let response = bounded(async {
+            loop {
+                let incoming = peer
+                    .receiver
+                    .as_mut()
+                    .unwrap()
+                    .recv()
+                    .await
+                    .expect("SC receive closed");
+                let npdu = decode_npdu(incoming.npdu).unwrap();
+                let apdu = decode_apdu(npdu.payload).unwrap();
+                if matches!(apdu, Apdu::UnconfirmedRequest(_)) {
+                    continue;
+                }
+                assert_eq!(incoming.source_mac.as_slice(), SERVER);
+                assert!(!incoming.link_layer_group);
+                assert_eq!(
+                    npdu.destination, source,
+                    "routed reply must retain final destination"
+                );
+                return apdu;
+            }
+        })
+        .await;
+        (invoke, response)
+    }
+
+    pub async fn read_property(&mut self, peer: usize) {
+        let object_identifier = ObjectIdentifier::new(ObjectType::DEVICE, 123).unwrap();
+        let mut data = BytesMut::new();
+        ReadPropertyRequest {
+            object_identifier,
+            property_identifier: PropertyIdentifier::OBJECT_IDENTIFIER,
+            property_array_index: None,
+        }
+        .encode(&mut data);
+        let (id, response) = self
+            .exchange(
+                peer,
+                ConfirmedServiceChoice::READ_PROPERTY,
+                data.freeze(),
+                None,
+            )
+            .await;
+        let Apdu::ComplexAck(ack) = response else {
+            panic!("expected ReadProperty ACK, got {response:?}")
+        };
+        assert_eq!(ack.invoke_id, id);
+        assert_eq!(ack.service_choice, ConfirmedServiceChoice::READ_PROPERTY);
+        let value = ReadPropertyACK::decode(&ack.service_ack).unwrap();
+        assert_eq!(value.object_identifier, object_identifier);
+        assert_eq!(
+            value.property_identifier,
+            PropertyIdentifier::OBJECT_IDENTIFIER
+        );
+        assert_eq!(value.property_array_index, None);
+        // Independent application ObjectIdentifier tag + device(8), instance123.
+        assert_eq!(value.property_value, [0xc4, 0x02, 0x00, 0x00, 0x7b]);
+    }
+
+    pub async fn dcc(
+        &mut self,
+        peer: usize,
+        mode: EnableDisable,
+        duration: Option<u16>,
+        password: Option<&str>,
+        source: Option<NpduAddress>,
+        expected: Outcome,
+    ) {
+        let mut data = BytesMut::new();
+        DeviceCommunicationControlRequest {
+            time_duration: duration,
+            enable_disable: mode,
+            password: password.map(str::to_owned),
+        }
+        .encode(&mut data)
+        .unwrap();
+        let before = self.server().dcc_outcome_counters();
+        let (id, response) = self
+            .exchange(
+                peer,
+                ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+                data.freeze(),
+                source,
+            )
+            .await;
+        let mut after = before;
+        let error = match expected {
+            Outcome::Accepted => {
+                after.accepted_total += 1;
+                None
+            }
+            Outcome::Policy => {
+                after.policy_denied_total += 1;
+                Some((ErrorClass::SERVICES, ErrorCode::SERVICE_REQUEST_DENIED))
+            }
+            Outcome::Password => {
+                after.password_failure_total += 1;
+                Some((ErrorClass::SECURITY, ErrorCode::PASSWORD_FAILURE))
+            }
+            Outcome::Deprecated => {
+                after.deprecated_denied_total += 1;
+                Some((ErrorClass::SERVICES, ErrorCode::SERVICE_REQUEST_DENIED))
+            }
+        };
+        if let Some((class, code)) = error {
+            let Apdu::Error(pdu) = response else {
+                panic!("expected DCC Error, got {response:?}")
+            };
+            assert_eq!(pdu.invoke_id, id);
+            assert_eq!(
+                pdu.service_choice,
+                ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL
+            );
+            assert_eq!((pdu.error_class, pdu.error_code), (class, code));
+        } else {
+            let Apdu::SimpleAck(pdu) = response else {
+                panic!("expected DCC SimpleACK, got {response:?}")
+            };
+            assert_eq!(pdu.invoke_id, id);
+            assert_eq!(
+                pdu.service_choice,
+                ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL
+            );
+        }
+        assert_eq!(self.server().dcc_outcome_counters(), after);
+    }
+
+    async fn stop(&mut self) -> bool {
+        // Attempt every owner's joined stop even when another cleanup fails.
+        let mut clean = true;
+        for peer in &mut self.peers {
+            clean &= matches!(
+                tokio::time::timeout(Duration::from_secs(5), peer.transport.stop()).await,
+                Ok(Ok(()))
+            );
+        }
+        if let Some(server) = &mut self.server {
+            clean &= matches!(
+                tokio::time::timeout(Duration::from_secs(5), server.stop()).await,
+                Ok(Ok(()))
+            );
+        }
+        if let Some(hub) = &mut self.hub {
+            clean &= tokio::time::timeout(Duration::from_secs(5), hub.stop())
+                .await
+                .is_ok();
+            // Successful stop releases the listener before returning.
+            clean &= tokio::net::TcpListener::bind(hub.local_addr().unwrap())
+                .await
+                .is_ok();
+        }
+        clean
+    }
+}
+
+pub(super) enum Outcome {
+    Accepted,
+    Policy,
+    Password,
+    Deprecated,
+}
+
+pub(super) async fn run(test: impl AsyncFnOnce(&mut Fixture)) {
+    let mut fixture = Fixture::default();
+    let result = AssertUnwindSafe(test(&mut fixture)).catch_unwind().await;
+    let clean = fixture.stop().await;
+    assert!(clean, "SC fixture failed joined cleanup");
+    if let Err(panic) = result {
+        std::panic::resume_unwind(panic);
+    }
+}

--- a/crates/bacnet-server/src/server/sc_dcc_mtls_tests.rs
+++ b/crates/bacnet-server/src/server/sc_dcc_mtls_tests.rs
@@ -1,0 +1,493 @@
+//! Standalone SC service-path evidence, not certificate-bound DCC principals.
+use crate::server::*;
+use bacnet_transport::sc::{ScConnectError, ScWebSocketErrorKind};
+use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_types::enums::EnableDisable;
+const DISABLE: EnableDisable = EnableDisable::DISABLE;
+const DISABLE_INITIATION: EnableDisable = EnableDisable::DISABLE_INITIATION;
+const ENABLE: EnableDisable = EnableDisable::ENABLE;
+
+#[path = "sc_dcc_mtls_support.rs"]
+mod support;
+use support::{bounded, run, Certificates, Outcome, PASSWORD, PEERS};
+
+#[tokio::test]
+async fn sc_dcc_mtls_requires_client_and_server_trust() {
+    run(async |f| {
+        let certs = Certificates::new();
+        f.hub(&certs).await;
+        for tls in [&certs.missing, &certs.untrusted, &certs.wrong_server_trust] {
+            let result = bounded(TlsWebSocket::connect(&f.url, tls.clone())).await;
+            // TLS1.3 client authentication rejection may surface during the
+            // WebSocket upgrade. A completed error, never a deadline, is required.
+            let error = result
+                .err()
+                .expect("unauthenticated TLS endpoint was admitted");
+            assert!(
+                matches!(
+                    ScConnectError::from_error(&error),
+                    Some(ScConnectError::WebSocket {
+                        kind: ScWebSocketErrorKind::TlsHandshake
+                            | ScWebSocketErrorKind::WebSocketHandshake,
+                        ..
+                    })
+                ),
+                "expected TLS/upgrade rejection, not a dial/timeout error: {error:?}"
+            );
+        }
+        f.start(&certs, BACnetServer::sc_builder()).await;
+        assert_eq!(
+            f.server().dcc_outcome_counters(),
+            DccOutcomeCounters::default()
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn sc_dcc_mtls_default_denies_even_correct_password() {
+    for configured in [false, true] {
+        run(async |f| {
+            let certs = Certificates::new();
+            f.hub(&certs).await;
+            let mut builder = BACnetServer::sc_builder(); // Intentionally no policy opt-in.
+            if configured {
+                builder = builder.dcc_password(PASSWORD);
+            }
+            f.start(&certs, builder).await;
+            for mode in [ENABLE, DISABLE_INITIATION, DISABLE] {
+                for password in [None, Some("wrong"), Some(PASSWORD)] {
+                    let expected = if configured && password != Some(PASSWORD) {
+                        Outcome::Password
+                    } else if mode == DISABLE {
+                        Outcome::Deprecated
+                    } else {
+                        Outcome::Policy
+                    };
+                    f.dcc(0, mode, Some(1), password, None, expected).await;
+                    assert_eq!(f.server().comm_state(), 0);
+                    assert!(f.server().dcc_timer.lock().await.is_none());
+                }
+            }
+            // A second independently certified hub peer is equally unauthorized.
+            f.dcc(
+                1,
+                DISABLE_INITIATION,
+                None,
+                Some(PASSWORD),
+                None,
+                Outcome::Policy,
+            )
+            .await;
+            f.read_property(0).await;
+            f.read_property(1).await;
+        })
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn sc_dcc_mtls_exact_vmac_restriction_and_live_timer() {
+    run(async |f| {
+        let certs = Certificates::new();
+        f.hub(&certs).await;
+        let restriction =
+            DccSourceRestriction::new(vec![DccSource::Direct(PEERS[0].to_vec())]).unwrap();
+        f.start(
+            &certs,
+            BACnetServer::sc_builder()
+                .dcc_policy(DccPolicy::RequirePassword)
+                .dcc_password(PASSWORD)
+                .dcc_source_restriction(Some(restriction)),
+        )
+        .await;
+        f.dcc(
+            0,
+            DISABLE_INITIATION,
+            Some(1),
+            Some(PASSWORD),
+            None,
+            Outcome::Accepted,
+        )
+        .await;
+        assert_eq!(f.server().comm_state(), 2);
+        let timer = f.server().dcc_timer.clone();
+        let slot = bounded(timer.lock()).await;
+        let task = slot.as_ref().unwrap();
+        let id = task.id();
+        // Hold the real live timer lock through the exchanges. Denials must
+        // neither wait for it nor replace/cancel it, even for ENABLE/zero/longer.
+        for duration in [None, Some(0), Some(1), Some(5)] {
+            for mode in [ENABLE, DISABLE_INITIATION] {
+                f.dcc(1, mode, duration, Some(PASSWORD), None, Outcome::Policy)
+                    .await;
+                assert_eq!(f.server().comm_state(), 2);
+                assert_eq!(slot.as_ref().unwrap().id(), id);
+                assert!(!task.is_finished());
+            }
+        }
+        f.dcc(1, ENABLE, None, Some("wrong"), None, Outcome::Password)
+            .await;
+        f.dcc(1, DISABLE, None, Some(PASSWORD), None, Outcome::Deprecated)
+            .await;
+        // Routed origin must not be silently treated as this allowed direct VMAC.
+        let routed = NpduAddress {
+            network: 7,
+            mac_address: MacAddr::from_slice(&[44]),
+        };
+        f.dcc(
+            0,
+            ENABLE,
+            None,
+            Some(PASSWORD),
+            Some(routed),
+            Outcome::Policy,
+        )
+        .await;
+        assert_eq!(f.server().comm_state(), 2);
+        assert!(!task.is_finished());
+        let old = task.abort_handle();
+        drop(slot);
+        f.read_property(1).await; // DISABLE_INITIATION still executes normal requests.
+        f.dcc(0, ENABLE, None, Some(PASSWORD), None, Outcome::Accepted)
+            .await;
+        assert_eq!(f.server().comm_state(), 0);
+        assert!(old.is_finished());
+        assert!(timer.lock().await.is_none());
+        f.dcc(
+            1,
+            DISABLE_INITIATION,
+            Some(5),
+            Some(PASSWORD),
+            None,
+            Outcome::Policy,
+        )
+        .await;
+        assert_eq!(f.server().comm_state(), 0);
+        assert!(timer.lock().await.is_none());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn sc_dcc_mtls_empty_restriction_denies_trusted_peers() {
+    run(async |f| {
+        let certs = Certificates::new();
+        f.hub(&certs).await;
+        f.start(
+            &certs,
+            BACnetServer::sc_builder()
+                .dcc_policy(DccPolicy::RequirePassword)
+                .dcc_password(PASSWORD)
+                .dcc_source_restriction(Some(DccSourceRestriction::new(vec![]).unwrap())),
+        )
+        .await;
+        for peer in 0..2 {
+            for mode in [ENABLE, DISABLE_INITIATION] {
+                f.dcc(peer, mode, Some(1), Some(PASSWORD), None, Outcome::Policy)
+                    .await;
+                assert_eq!(f.server().comm_state(), 0);
+                assert!(f.server().dcc_timer.lock().await.is_none());
+            }
+            f.read_property(peer).await;
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn sc_dcc_mtls_global_burst_enable_exemption_and_uncharged_failures() {
+    run(async |f| {
+        let certs = Certificates::new();
+        f.hub(&certs).await;
+        f.start(
+            &certs,
+            BACnetServer::sc_builder()
+                .dcc_policy(DccPolicy::RequirePassword)
+                .dcc_password(PASSWORD)
+                .dcc_disable_rate_limit(Some(DccDisableRateLimit::default()))
+                .dcc_source_restriction(Some(
+                    DccSourceRestriction::new(vec![
+                        DccSource::Direct(PEERS[0].to_vec()),
+                        DccSource::Direct(PEERS[1].to_vec()),
+                        DccSource::Routed {
+                            network: 8,
+                            address: vec![45],
+                        },
+                    ])
+                    .unwrap(),
+                )),
+        )
+        .await;
+        // Keep the actual 3/20s defaults. A short whole-case deadline prevents
+        // scheduler delays/refills from turning this into ambiguous rate evidence.
+        bounded(async {
+            let before = f.server().dcc_outcome_counters();
+            let (id, response) = f
+                .exchange(
+                    0,
+                    ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+                    Bytes::new(),
+                    None,
+                )
+                .await;
+            let Apdu::Error(error) = response else {
+                panic!("expected malformed DCC Error")
+            };
+            assert_eq!(error.invoke_id, id);
+            assert_eq!(
+                error.service_choice,
+                ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL
+            );
+            assert_eq!(
+                (error.error_class, error.error_code),
+                (ErrorClass::SERVICES, ErrorCode::OTHER)
+            );
+            assert_eq!(
+                f.server().dcc_outcome_counters(),
+                DccOutcomeCounters {
+                    malformed_total: before.malformed_total + 1,
+                    ..before
+                }
+            );
+            f.dcc(
+                0,
+                DISABLE_INITIATION,
+                Some(1),
+                Some(PASSWORD),
+                Some(NpduAddress {
+                    network: 9,
+                    mac_address: MacAddr::from_slice(&[45]),
+                }),
+                Outcome::Policy,
+            )
+            .await;
+            for peer in 0..2 {
+                f.dcc(
+                    peer,
+                    DISABLE_INITIATION,
+                    None,
+                    None,
+                    None,
+                    Outcome::Password,
+                )
+                .await;
+                f.dcc(
+                    peer,
+                    DISABLE_INITIATION,
+                    None,
+                    Some("wrong"),
+                    None,
+                    Outcome::Password,
+                )
+                .await;
+                f.dcc(
+                    peer,
+                    DISABLE,
+                    None,
+                    Some(PASSWORD),
+                    None,
+                    Outcome::Deprecated,
+                )
+                .await;
+            }
+            f.dcc(
+                0,
+                DISABLE_INITIATION,
+                Some(1),
+                Some(PASSWORD),
+                None,
+                Outcome::Accepted,
+            )
+            .await;
+            f.dcc(1, ENABLE, None, Some(PASSWORD), None, Outcome::Accepted)
+                .await;
+            assert_eq!(f.server().comm_state(), 0);
+            f.dcc(
+                1,
+                DISABLE_INITIATION,
+                Some(1),
+                Some(PASSWORD),
+                None,
+                Outcome::Accepted,
+            )
+            .await;
+            f.dcc(
+                0,
+                DISABLE_INITIATION,
+                Some(1),
+                Some(PASSWORD),
+                None,
+                Outcome::Accepted,
+            )
+            .await;
+            let timer = f.server().dcc_timer.clone();
+            let slot = timer.lock().await;
+            let id = slot.as_ref().unwrap().id();
+            let old = slot.as_ref().unwrap().abort_handle();
+            for peer in 0..2 {
+                for duration in [None, Some(0), Some(5)] {
+                    f.dcc(
+                        peer,
+                        DISABLE_INITIATION,
+                        duration,
+                        Some(PASSWORD),
+                        None,
+                        Outcome::Policy,
+                    )
+                    .await;
+                    assert_eq!(f.server().comm_state(), 2);
+                    assert_eq!(slot.as_ref().unwrap().id(), id);
+                    assert!(!old.is_finished());
+                }
+            }
+            // A routed claimed identity consumes the same depleted server budget.
+            f.dcc(
+                1,
+                DISABLE_INITIATION,
+                Some(5),
+                Some(PASSWORD),
+                Some(NpduAddress {
+                    network: 8,
+                    mac_address: MacAddr::from_slice(&[45]),
+                }),
+                Outcome::Policy,
+            )
+            .await;
+            drop(slot);
+            for peer in 0..2 {
+                f.dcc(peer, ENABLE, None, Some(PASSWORD), None, Outcome::Accepted)
+                    .await;
+                assert_eq!(f.server().comm_state(), 0);
+                assert!(old.is_finished());
+                assert!(timer.lock().await.is_none());
+                f.dcc(
+                    peer,
+                    DISABLE_INITIATION,
+                    Some(1),
+                    Some(PASSWORD),
+                    None,
+                    Outcome::Policy,
+                )
+                .await;
+                assert_eq!(f.server().comm_state(), 0);
+                assert!(timer.lock().await.is_none());
+                f.read_property(peer).await;
+            }
+        })
+        .await;
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn sc_dcc_mtls_failure_path_joins_fixture() {
+    use futures_util::FutureExt;
+    use std::panic::AssertUnwindSafe;
+    let result = AssertUnwindSafe(run(async |f| {
+        let certs = Certificates::new();
+        f.hub(&certs).await;
+        f.start(&certs, BACnetServer::sc_builder()).await;
+        panic!("intentional fixture failure");
+    }))
+    .catch_unwind()
+    .await;
+    let panic = result.expect_err("injected failure must propagate after cleanup");
+    assert_eq!(
+        panic.downcast_ref::<&str>(),
+        Some(&"intentional fixture failure")
+    );
+}
+
+#[tokio::test]
+async fn sc_dcc_mtls_routed_source_and_existing_duration_semantics() {
+    run(async |f| {
+        let certs = Certificates::new();
+        f.hub(&certs).await;
+        let routed = NpduAddress {
+            network: 7,
+            mac_address: MacAddr::from_slice(&[44]),
+        };
+        let restriction = DccSourceRestriction::new(vec![DccSource::Routed {
+            network: 7,
+            address: vec![44],
+        }])
+        .unwrap();
+        f.start(
+            &certs,
+            BACnetServer::sc_builder()
+                .dcc_policy(DccPolicy::RequirePassword)
+                .dcc_password(PASSWORD)
+                .dcc_source_restriction(Some(restriction)),
+        )
+        .await;
+        for source in [
+            None,
+            Some(NpduAddress {
+                network: 8,
+                ..routed.clone()
+            }),
+            Some(NpduAddress {
+                mac_address: MacAddr::from_slice(&[45]),
+                ..routed.clone()
+            }),
+        ] {
+            f.dcc(
+                0,
+                DISABLE_INITIATION,
+                None,
+                Some(PASSWORD),
+                source,
+                Outcome::Policy,
+            )
+            .await;
+        }
+        f.dcc(
+            0,
+            DISABLE_INITIATION,
+            None,
+            Some(PASSWORD),
+            Some(routed.clone()),
+            Outcome::Accepted,
+        )
+        .await;
+        assert_eq!(f.server().comm_state(), 2);
+        assert!(f.server().dcc_timer.lock().await.is_none());
+        // Matching routed claims through different TLS peers are not principals.
+        f.dcc(
+            1,
+            ENABLE,
+            Some(1),
+            Some(PASSWORD),
+            Some(routed.clone()),
+            Outcome::Accepted,
+        )
+        .await;
+        assert_eq!(f.server().comm_state(), 0);
+        assert!(f.server().dcc_timer.lock().await.is_some());
+        f.dcc(
+            0,
+            DISABLE_INITIATION,
+            Some(0),
+            Some(PASSWORD),
+            Some(routed),
+            Outcome::Accepted,
+        )
+        .await;
+        // Existing zero duration installs a zero-delay timer, rather than making
+        // disable indefinite. Join it through the existing private ownership slot.
+        let timer = f.server().dcc_timer.clone();
+        let mut task = timer.lock().await.take().unwrap();
+        let completed = tokio::time::timeout(Duration::from_secs(5), &mut task).await;
+        if completed.is_err() {
+            task.abort();
+            let _ = task.await;
+        }
+        completed
+            .expect("zero-duration timer did not finish")
+            .unwrap();
+        assert_eq!(f.server().comm_state(), 0);
+        f.read_property(0).await;
+    })
+    .await;
+}

--- a/docs/dcc-policy.md
+++ b/docs/dcc-policy.md
@@ -146,6 +146,33 @@ completed bounded #521 acceptance remain unchanged, not reopened.
 
 ## Source and limits
 
+### Standalone SC loopback evidence
+
+`cargo test -p bacnet-server --locked --features sc-tls sc_dcc_mtls` exercises
+the real standalone `BACnetServer::sc_builder`, TLS WebSocket transport and SC
+hub on `127.0.0.1:0`. Test-only certificates and distinct endpoint keys are
+generated in memory. The hub requires client certificates; clients verify the
+hub certificate. Missing/untrusted client credentials and missing server trust
+are rejected, while trusted peers complete SC connection establishment and
+successful ReadProperty exchanges before DCC assertions.
+
+The tests check exact DCC response identity, error class/code and five-counter
+deltas: default denial (including a correct configured password), password
+precedence, deprecated DISABLE, explicit RequirePassword with exact direct VMAC
+or routed-source restrictions, an empty restriction, and the shared three-token
+disable budget. They cover earlier malformed/password/deprecated/source failures
+not consuming that budget, authorized ENABLE exemption without a reset, and
+repeated denials leaving state and the same live timer intact even with its lock
+held. Existing absent/zero/ENABLE-duration behavior is characterized, not corrected.
+Fixture shutdown is joined on success and on an injected assertion failure.
+
+Mutual TLS authenticates each TLS endpoint to the hub, **not a DCC principal to
+the BACnet server**. The server receives claimed VMAC/NPDU source addresses;
+these tests do not bind them to certificates. Matching routed claims through
+different certified peers demonstrate address-policy behavior, not principal
+authentication. This evidence does not qualify reconnect/failover, external
+interoperability, a combined endpoint, full auditing or completion of #522.
+
 Local licensed ASHRAE 135-2020 §16.1 (printed 759–760) supplies the existing
 optional-password and deprecated-DISABLE rules; §18.6 (printed 795) describes
 SERVICE_REQUEST_DENIED for lack of authorization. The three configuration modes,


### PR DESCRIPTION
## Summary
- Seven end-to-end standalone SC DCC tests through a real loopback hub with required mutual TLS and ephemeral in-memory certificates.
- Prove TLS trust rejection and successful ReadProperty before exact DCC denial/allow assertions, claimed direct/routed restrictions, global disable limit, ENABLE exemption, and timer preservation.
- Bounded joined fixture teardown on success and injected failure; no production API/behavior or binding changes.

## Scope
Refs #522 (remains partial). TLS endpoint authentication to hub is not certificate-bound DCC principal authorization. No public endpoint, external interoperability, reconnect/failover, full auditing or #521 changes. Only test modules, test registration, already-locked dev dependency edges and narrow documentation.

## Validation
- Seven focused tests pass in ten consecutive runs; SC transport287, SC server1069+3, integration40 pass.
- Default workspace4390pass/3existingignored; portable SC/IPv6/serde workspace4403pass/3existingignored.
- DCC68 with SC; existing password/timer/recovery/admission/shutdown and static gates pass; Clippy existing warnings unchanged.
- Existing CI selects the new tests. Prior native wheel evidence reused only as prior evidence; no new binding qualification.
- Three independent reviews and exact-head Linux lean CI pending.