### PR TITLE
fix(python): require mutual TLS for ScHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Python ScHub compatibility change:** `ca_cert` must explicitly name a usable
+  trusted issuer CA PEM file. Omission, `None`, and empty paths now raise
+  `ValueError` at construction; invalid files or mismatched server cert/key fail
+  in `start()` before bind. The fifth positional parameter is unchanged, but its
+  default no longer enables one-way TLS. Client verification and TLS 1.3 are
+  mandatory, with no insecure escape hatch. The Python SC benchmark now supplies
+  its generated CA. Rust caller-owned `TlsAcceptor` injection and Python node
+  credential defaults are unchanged; #513 remains partial. See
+  [ScHub](docs/python-api.md#schub).
+
 - Add a default-OFF optional global DCC DISABLE_INITIATION token bucket per native
   server. Enabled defaults are burst 3 and one token per 20 seconds; authorized
   ENABLE is exempt and earlier validation/authorization failures do not charge.

--- a/benchmarks/python/bench_sc.py
+++ b/benchmarks/python/bench_sc.py
@@ -7,6 +7,7 @@ Architecture: ScHub (relay) ← BACnetServer (SC node) ← BACnetClient (SC node
 """
 
 import asyncio
+import ssl
 import time
 import psutil
 import pytest
@@ -52,11 +53,41 @@ async def sc_hub(certs):
         listen="127.0.0.1:0",
         cert=certs.server_cert,
         key=certs.server_key,
+        ca_cert=certs.ca_cert,
         vmac=b"\x00\x00\x00\x00\x00\x01",
     )
-    await hub.start()
-    yield hub
-    await hub.stop()
+    try:
+        await asyncio.wait_for(hub.start(), 5)
+        yield hub
+    finally:
+        await asyncio.wait_for(hub.stop(), 5)
+
+
+@pytest.mark.asyncio(loop_scope="module")
+async def test_sc_mtls_preflight(sc_hub, certs):
+    """Qualify generated benchmark credentials, not latency or node UUIDs."""
+    port = int((await sc_hub.address()).rsplit(":", 1)[1])
+    for cert, key in [(certs.server_cert, certs.server_key),
+                      (certs.client_cert, certs.client_key)]:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.minimum_version = context.maximum_version = ssl.TLSVersion.TLSv1_3
+        context.load_verify_locations(certs.ca_cert)
+        context.load_cert_chain(cert, key)
+        reader, writer = await asyncio.wait_for(asyncio.open_connection(
+            "127.0.0.1", port, ssl=context, server_hostname="localhost"), 5)
+        try:
+            writer.write(
+                b"GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\n"
+                b"Connection: Upgrade\r\nSec-WebSocket-Version: 13\r\n"
+                b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                b"Sec-WebSocket-Protocol: hub.bsc.bacnet.org\r\n\r\n")
+            await asyncio.wait_for(writer.drain(), 5)
+            response = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), 5)
+            assert response.startswith(b"HTTP/1.1 101")
+            assert writer.get_extra_info("ssl_object").version() == "TLSv1.3"
+        finally:
+            writer.close()
+            await asyncio.wait_for(writer.wait_closed(), 5)
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -86,8 +117,8 @@ async def sc_client(sc_server, sc_hub, certs):
         sc_hub=hub_url,
         sc_vmac=b"\x00\x01\x02\x03\x04\x06",
         sc_ca_cert=certs.ca_cert,
-        sc_client_cert=certs.server_cert,
-        sc_client_key=certs.server_key,
+        sc_client_cert=certs.client_cert,
+        sc_client_key=certs.client_key,
     )
     await client.__aenter__()
     # Wait for hub handshake to complete

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -2039,8 +2039,11 @@ class ScHub:
         print(await hub.url())
         await hub.stop()
 
-    Omitting ``ca_cert`` leaves the hub in server-auth-only example mode and is
-    not claimed as BACnet/SC mTLS conformance evidence.
+    ``ca_cert`` must name trusted issuer CA PEM certificates for mutual TLS.
+    Omitted, None, or empty values raise ValueError at construction. The None
+    default retains the existing positional layout only; there is no insecure
+    mode. Invalid/unreadable credentials raise BacnetError from start(), before
+    binding. Connections require TLS 1.3 and a valid trusted client certificate.
     """
 
     def __init__(

--- a/crates/rusty-bacnet/src/hub.rs
+++ b/crates/rusty-bacnet/src/hub.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use tokio::sync::Mutex;
 use tokio_rustls::TlsAcceptor;
@@ -23,7 +23,7 @@ use crate::errors::to_py_err;
 ///     listen="127.0.0.1:0",
 ///     cert="server.pem",
 ///     key="server.key",
-///     ca_cert="ca.pem",       # trusted issuer CA, enables mTLS
+///     ca_cert="ca.pem",       # required trusted issuer CA for mTLS
 ///     vmac=b"\x00\x00\x00\x00\x00\x01",
 /// )
 /// await hub.start()
@@ -37,7 +37,7 @@ pub struct PyScHub {
     listen: String,
     cert: String,
     key: String,
-    ca_cert: Option<String>,
+    ca_cert: String,
     vmac: [u8; 6],
     address: Arc<Mutex<Option<String>>>,
 }
@@ -50,8 +50,10 @@ impl PyScHub {
     ///     listen: Bind address, e.g. ``"127.0.0.1:0"`` for a random port.
     ///     cert: Path to server certificate PEM file.
     ///     key: Path to server private key PEM file.
-    ///     ca_cert: Optional path to issuer CA cert for mTLS (client certificate verification).
-    ///         Omitting this leaves the hub in server-auth-only example mode.
+    ///     ca_cert: Required nonempty path to trusted issuer CA PEM certificates.
+    ///         Omitted, None, or empty values raise ValueError. The default only
+    ///         preserves positional argument compatibility; it does not enable
+    ///         server-auth-only TLS. Files are validated by start() before bind.
     ///     vmac: 6-byte VMAC for the hub itself.
     #[new]
     #[pyo3(signature = (listen, cert, key, vmac, ca_cert=None))]
@@ -62,6 +64,9 @@ impl PyScHub {
         vmac: Vec<u8>,
         ca_cert: Option<String>,
     ) -> PyResult<Self> {
+        let ca_cert = ca_cert.filter(|path| !path.is_empty()).ok_or_else(|| {
+            PyValueError::new_err("ca_cert must be a nonempty CA certificate path for mutual TLS")
+        })?;
         if vmac.len() != 6 {
             return Err(PyRuntimeError::new_err("vmac must be exactly 6 bytes"));
         }
@@ -89,8 +94,8 @@ impl PyScHub {
         let address = self.address.clone();
 
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let server_tls = crate::tls::build_server_tls_config(&cert, &key, ca_cert.as_deref())
-                .map_err(to_py_err)?;
+            let server_tls =
+                crate::tls::build_server_tls_config(&cert, &key, &ca_cert).map_err(to_py_err)?;
 
             let acceptor = TlsAcceptor::from(server_tls);
 

--- a/crates/rusty-bacnet/src/tls.rs
+++ b/crates/rusty-bacnet/src/tls.rs
@@ -5,11 +5,11 @@ use std::sync::Arc;
 use tokio_rustls::rustls::pki_types::pem::PemObject;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 
-/// Build a rustls ServerConfig from PEM file paths (for ScHub).
+/// Build a TLS 1.3 server config requiring client certificates (for Python ScHub).
 pub fn build_server_tls_config(
     cert_path: &str,
     key_path: &str,
-    ca_cert_path: Option<&str>,
+    ca_cert_path: &str,
 ) -> Result<Arc<tokio_rustls::rustls::ServerConfig>, Error> {
     use tokio_rustls::rustls;
 
@@ -27,38 +27,30 @@ pub fn build_server_tls_config(
     let key = PrivateKeyDer::from_pem_slice(&key_data)
         .map_err(|e| Error::Encoding(format!("failed to parse server key: {e}")))?;
 
-    let config = if let Some(ca_path) = ca_cert_path {
-        // mTLS: require client certificates
-        let ca_data = std::fs::read(ca_path)
-            .map_err(|e| Error::Encoding(format!("failed to read CA cert: {e}")))?;
-        let ca_certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&ca_data)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| Error::Encoding(format!("failed to parse CA cert: {e}")))?;
-        if ca_certs.is_empty() {
-            return Err(Error::Encoding("no CA certificates found".into()));
-        }
+    let ca_data = std::fs::read(ca_cert_path)
+        .map_err(|e| Error::Encoding(format!("failed to read CA cert: {e}")))?;
+    let ca_certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&ca_data)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| Error::Encoding(format!("failed to parse CA cert: {e}")))?;
+    if ca_certs.is_empty() {
+        return Err(Error::Encoding("no CA certificates found".into()));
+    }
 
-        let mut root_store = rustls::RootCertStore::empty();
-        for cert in ca_certs {
-            root_store
-                .add(cert)
-                .map_err(|e| Error::Encoding(format!("failed to add CA cert: {e}")))?;
-        }
+    let mut root_store = rustls::RootCertStore::empty();
+    for cert in ca_certs {
+        root_store
+            .add(cert)
+            .map_err(|e| Error::Encoding(format!("failed to add CA cert: {e}")))?;
+    }
 
-        let client_verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
-            .build()
-            .map_err(|e| Error::Encoding(format!("failed to build client verifier: {e}")))?;
+    let client_verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
+        .build()
+        .map_err(|e| Error::Encoding(format!("failed to build client verifier: {e}")))?;
 
-        rustls::ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-            .with_client_cert_verifier(client_verifier)
-            .with_single_cert(certs, key)
-            .map_err(|e| Error::Encoding(format!("TLS server config error: {e}")))?
-    } else {
-        rustls::ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-            .with_no_client_auth()
-            .with_single_cert(certs, key)
-            .map_err(|e| Error::Encoding(format!("TLS server config error: {e}")))?
-    };
+    let config = rustls::ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+        .with_client_cert_verifier(client_verifier)
+        .with_single_cert(certs, key)
+        .map_err(|e| Error::Encoding(format!("TLS server config error: {e}")))?;
 
     Ok(Arc::new(config))
 }

--- a/crates/rusty-bacnet/tests/test_sc_hub_mtls.py
+++ b/crates/rusty-bacnet/tests/test_sc_hub_mtls.py
@@ -1,0 +1,257 @@
+"""Installed-native Python hub authentication; no system trust or persistent keys.
+
+OpenSSL CLI creates a temporary site CA and distinct operational certificates.
+TLS negatives use the independent stdlib TLS client, not SC reconnect timeouts.
+"""
+import asyncio
+import inspect
+import os
+import socket
+import ssl
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from rusty_bacnet import BACnetServer, BacnetError, ScHub
+
+
+class HubMtlsTests(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.temp = tempfile.TemporaryDirectory(prefix="bacnet-hub-mtls-")
+        cls.addClassCleanup(cls.temp.cleanup)
+        cls.root = Path(cls.temp.name)
+
+        def run(*args):
+            subprocess.run(["openssl", *args], cwd=cls.root, check=True,
+                           capture_output=True, timeout=10)
+
+        # Explicit CA constraints; leaves are never substituted for trust anchors.
+        for ca in ("site", "foreign"):
+            run("req", "-x509", "-newkey", "ec", "-pkeyopt",
+                "ec_paramgen_curve:prime256v1", "-nodes", "-days", "2",
+                "-subj", f"/CN={ca}", "-keyout", f"{ca}.key", "-out", f"{ca}.pem",
+                "-addext", "basicConstraints=critical,CA:TRUE",
+                "-addext", "keyUsage=critical,keyCertSign,cRLSign")
+        (cls.root / "index").write_text("")
+        (cls.root / "serial").write_text("1000\n")
+        (cls.root / "ca.cnf").write_text(
+            "[ca]\ndefault_ca=issuer\n[issuer]\ndatabase=index\n"
+            "serial=serial\nnew_certs_dir=.\ncertificate=site.pem\n"
+            "private_key=site.key\ndefault_md=sha256\npolicy=policy\n"
+            "unique_subject=no\n[policy]\ncommonName=supplied\n"
+            "[leaf]\nbasicConstraints=critical,CA:FALSE\n"
+            "keyUsage=critical,digitalSignature\n"
+            "extendedKeyUsage=serverAuth,clientAuth\n"
+            "subjectAltName=DNS:localhost,IP:127.0.0.1\n")
+        for name in ("hub", "server", "client", "wrong", "expired", "future"):
+            run("req", "-newkey", "ec", "-pkeyopt", "ec_paramgen_curve:prime256v1",
+                "-nodes", "-subj", f"/CN={name}", "-keyout", f"{name}.key",
+                "-out", f"{name}.csr")
+            if name in ("expired", "future"):
+                start, end = (("20000101000000Z", "20010101000000Z") if name == "expired"
+                              else ("20990101000000Z", "21000101000000Z"))
+                run("ca", "-batch", "-config", "ca.cnf", "-extensions", "leaf",
+                    "-in", f"{name}.csr", "-out", f"{name}.pem", "-notext",
+                    "-startdate", start, "-enddate", end)
+            else:
+                ca = "foreign" if name == "wrong" else "site"
+                run("x509", "-req", "-in", f"{name}.csr", "-CA", f"{ca}.pem",
+                    "-CAkey", f"{ca}.key", "-CAcreateserial", "-days", "1",
+                    "-extfile", "ca.cnf", "-extensions", "leaf", "-out", f"{name}.pem")
+
+    def path(self, name):
+        return str(self.root / name)
+
+    def hub(self, **overrides):
+        return ScHub(listen=overrides.get("listen", "127.0.0.1:0"),
+                     cert=overrides.get("cert", self.path("hub.pem")),
+                     key=overrides.get("key", self.path("hub.key")),
+                     vmac=b"\x02\0\0\0\0\1",
+                     ca_cert=overrides.get("ca_cert", self.path("site.pem")))
+
+    def websocket(self, address, peer=None, ca="site", version=ssl.TLSVersion.TLSv1_3,
+                  read_property=False):
+        """Bounded independent TLS + WebSocket handshake, including TLS 1.3 alerts.
+
+        The post-handshake read matters: TLS 1.3 may report missing-client-cert
+        rejection only after wrap_socket has returned on the initiating side.
+        This synchronous call is always joined, not abandoned on asyncio timeout.
+        """
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.minimum_version = ctx.maximum_version = version
+        ctx.load_verify_locations(self.path(f"{ca}.pem"))
+        if peer:
+            ctx.load_cert_chain(self.path(f"{peer}.pem"), self.path(f"{peer}.key"))
+        port = int(address.rsplit(":", 1)[1])
+        with socket.create_connection(("127.0.0.1", port), timeout=3) as tcp:
+            with ctx.wrap_socket(tcp, server_hostname="localhost") as tls:
+                tls.sendall(
+                    b"GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: websocket\r\n"
+                    b"Connection: Upgrade\r\nSec-WebSocket-Version: 13\r\n"
+                    b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                    b"Sec-WebSocket-Protocol: hub.bsc.bacnet.org\r\n\r\n")
+                response = tls.recv(4096)
+                self.assertTrue(response.startswith(b"HTTP/1.1 101"), response)
+                if read_property:
+                    self.exchange_read_property(tls)
+                return tls.version()
+
+    def exchange_read_property(self, tls):
+        # Literal SC Connect-Request/Accept, modeled on sc_frame's independent
+        # connect_test_support vectors. A nonzero UUID avoids the existing
+        # all-zero default shared by Python BACnetClient/BACnetServer nodes.
+        def send(payload):
+            self.assertLess(len(payload), 126)
+            mask = os.urandom(4)
+            tls.sendall(bytes([0x82, 0x80 | len(payload)]) + mask +
+                        bytes(byte ^ mask[i % 4] for i, byte in enumerate(payload)))
+
+        def exact(size):
+            data = b""
+            while len(data) < size:
+                part = tls.recv(size - len(data))
+                self.assertTrue(part, "peer closed during frame")
+                data += part
+            return data
+
+        def receive():
+            header = exact(2)
+            self.assertEqual(header[0], 0x82)
+            self.assertFalse(header[1] & 0x80)
+            length = header[1] & 0x7f
+            if length == 126:
+                length = int.from_bytes(exact(2), "big")
+            self.assertLess(length, 4096)
+            return exact(length)
+
+        vmac = b"\x02\0\0\0\0\3"
+        send(b"\x06\x00\x22\x33" + vmac + b"\x01" * 16 + b"\x05\xc4\x05\xc4")
+        try:
+            accepted = receive()
+        except TimeoutError as error:
+            raise AssertionError("timed out waiting for SC ConnectAccept") from error
+        self.assertEqual(accepted[:4], b"\x07\x00\x22\x33")
+        self.invoke = getattr(self, "invoke", 0) + 1
+        invoke = bytes([self.invoke])
+        # Encapsulated-NPDU to destination; hub supplies the originating VMAC.
+        send(b"\x01\x04\x22\x34" + b"\x02\0\0\0\0\2" +
+             b"\x01\x04\x00\x03" + invoke + b"\x0c\x0c\0\0\0\0\x19\x55")
+        # Ignore a bounded number of unsolicited I-Am packets; the reply is
+        # independently asserted through exact APDU bytes (REAL 72.5).
+        seen = []
+        for _ in range(8):
+            try:
+                reply = receive()
+            except TimeoutError as error:
+                raise AssertionError(f"timed out waiting for ReadProperty ACK; frames={seen}") from error
+            seen.append(reply.hex())
+            if b"\x30" + invoke + b"\x0c" in reply:
+                self.assertTrue(reply.endswith(
+                    b"\x30" + invoke + b"\x0c\x0c\0\0\0\0\x19\x55\x3e\x44\x42\x91\0\0\x3f"), reply)
+                return
+        self.fail("no ReadProperty ACK within bounded incoming frames")
+
+    async def test_absent_ca_cannot_admit_certificate_less_peer(self):
+        # Baseline behavioral RED: the old constructor starts, then permits an
+        # unauthenticated TLS/WebSocket upgrade. New early validation is valid.
+        try:
+            hub = self.hub(ca_cert=None)
+        except ValueError as error:
+            self.assertIn("ca_cert", str(error))
+            return
+        try:
+            await asyncio.wait_for(hub.start(), 3)
+            with self.assertRaises(ssl.SSLError):
+                await asyncio.to_thread(self.websocket, await hub.address())
+        finally:
+            await asyncio.wait_for(hub.stop(), 3)
+
+    async def test_constructor_signature_and_required_ca(self):
+        parameters = inspect.signature(ScHub).parameters
+        self.assertEqual(list(parameters), ["listen", "cert", "key", "vmac", "ca_cert"])
+        self.assertIsNone(parameters["ca_cert"].default)
+        self.assertEqual(parameters["ca_cert"].kind, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        args = ("127.0.0.1:0", self.path("hub.pem"), self.path("hub.key"), b"\x02\0\0\0\0\1")
+        for extra in [(), (None,), ("",)]:
+            with self.subTest(extra=extra), self.assertRaisesRegex(ValueError, "ca_cert"):
+                ScHub(*args, *extra)
+        hub = ScHub(*args, self.path("site.pem"))
+        self.assertIsNone(await hub.address())
+        try:
+            await asyncio.wait_for(hub.start(), 3)
+            self.assertEqual(await asyncio.to_thread(self.websocket, await hub.address(), "client"),
+                             "TLSv1.3")
+        finally:
+            await asyncio.wait_for(hub.stop(), 3)
+
+    async def test_invalid_files_fail_before_bind(self):
+        for name, content in [("empty.pem", ""), ("garbage.pem", "not a certificate"),
+                              ("invalid.pem", "-----BEGIN CERTIFICATE-----\nYQ==\n-----END CERTIFICATE-----\n")]:
+            (self.root / name).write_text(content)
+        cases = [({"ca_cert": self.path(name)}, message) for name, message in [
+            ("empty.pem", "no CA certificates"), ("garbage.pem", "no CA certificates"),
+            ("invalid.pem", "failed to add CA cert"), ("missing.pem", "failed to read CA cert")]]
+        cases += [({"ca_cert": str(self.root)}, "failed to read CA cert"),
+                  ({"cert": self.path("empty.pem")}, "no server certificates"),
+                  ({"cert": self.path("missing.pem")}, "failed to read server cert"),
+                  ({"key": self.path("garbage.pem")}, "failed to parse server key"),
+                  ({"key": self.path("missing.pem")}, "failed to read server key"),
+                  ({"key": self.path("client.key")}, "TLS server config error")]
+        for overrides, message in cases:
+            with self.subTest(overrides=overrides):
+                # Holding an already-bound port proves TLS validation precedes
+                # bind: otherwise AddressInUse would replace the expected error.
+                with socket.socket() as reservation:
+                    reservation.bind(("127.0.0.1", 0))
+                    reservation.listen()
+                    address = f"127.0.0.1:{reservation.getsockname()[1]}"
+                    hub = self.hub(listen=address, **overrides)
+                    try:
+                        with self.assertRaisesRegex(BacnetError, message):
+                            await asyncio.wait_for(hub.start(), 3)
+                        self.assertIsNone(await hub.address())
+                    finally:
+                        await asyncio.wait_for(hub.stop(), 3)
+                with socket.socket() as probe:
+                    probe.bind(("127.0.0.1", int(address.rsplit(":", 1)[1])))
+
+    async def test_rejected_peers_leave_trusted_read_property_usable(self):
+        hub = self.hub()
+        self.addAsyncCleanup(self.stop_hub, hub)
+        await asyncio.wait_for(hub.start(), 3)
+        url, address = await hub.url(), await hub.address()
+        server = BACnetServer(3000, "MTLS server", transport="sc", sc_hub=url,
+                              sc_vmac=b"\x02\0\0\0\0\2", sc_ca_cert=self.path("site.pem"),
+                              sc_client_cert=self.path("server.pem"), sc_client_key=self.path("server.key"))
+        self.addAsyncCleanup(self.stop_server, server)
+        server.add_analog_input(0, "AI-0", 64, 72.5)
+        await asyncio.wait_for(server.start(), 5)
+        async def barrier():
+            self.assertEqual(await asyncio.to_thread(
+                self.websocket, address, "client", read_property=True), "TLSv1.3")
+
+        await barrier()
+        for peer, ca, version in [(None, "site", ssl.TLSVersion.TLSv1_3),
+                                  ("wrong", "site", ssl.TLSVersion.TLSv1_3),
+                                  ("expired", "site", ssl.TLSVersion.TLSv1_3),
+                                  ("future", "site", ssl.TLSVersion.TLSv1_3),
+                                  ("client", "foreign", ssl.TLSVersion.TLSv1_3),
+                                  ("client", "site", ssl.TLSVersion.TLSv1_2)]:
+            with self.subTest(peer=peer, ca=ca, version=version):
+                # Timeout, refused TCP, EOF, or a WebSocket error is NOT a TLS
+                # rejection oracle. Only a completed SSL protocol error passes.
+                with self.assertRaises(ssl.SSLError) as rejected:
+                    await asyncio.to_thread(self.websocket, address, peer, ca, version)
+                self.assertNotIsInstance(rejected.exception, ssl.SSLEOFError)
+                self.assertRegex(rejected.exception.reason, "ALERT|CERTIFICATE_VERIFY_FAILED")
+                await barrier()
+        self.assertEqual(await asyncio.to_thread(self.websocket, address, "client"), "TLSv1.3")
+        await barrier()
+
+    async def stop_hub(self, hub):
+        await asyncio.wait_for(hub.stop(), 5)
+
+    async def stop_server(self, server):
+        await asyncio.wait_for(server.stop(), 5)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1545,10 +1545,22 @@ hub = ScHub(
 )
 ```
 
-For Annex AB production deployments, pass `ca_cert` and configure each SC node
-with its own certificate/key pair. Omitting `ca_cert` leaves the hub in
-server-auth-only example mode, which is not claimed as BACnet/SC mTLS
-conformance evidence.
+`ca_cert` is required: omission, `None`, or an empty string raises `ValueError`
+at construction, before listening. Its fifth positional slot and `None` default
+remain for argument-layout compatibility only; there is no server-auth-only
+mode or insecure flag. Existing callers must supply the trusted issuer CA PEM
+file, not a peer leaf certificate. Configure each SC node with its own
+operational certificate/key pair and the CA that signs the hub certificate.
+
+`start()` validates the CA store and server certificate/key before binding;
+unreadable, empty, or malformed credentials and mismatched server keys raise
+`BacnetError`. The hub accepts only TLS 1.3 with verified client certificates.
+Missing, untrusted, expired, or not-yet-valid peer certificates are rejected.
+This addresses the Python hub admission boundary of Annex AB.7.4, not full
+security-profile conformance. CA membership does not authorize BACnet operations
+or bind a certificate to a claimed VMAC/Device UUID. Rust `ScHub` still accepts a
+caller-configured `TlsAcceptor`; Python client/server credential defaults remain
+unchanged and their required-credential migration is deferred under #513.
 
 ### Methods
 


### PR DESCRIPTION
## Summary
- Owner-approved compatibility change: Python ScHub requires a nonempty ca_cert; omitted/None/empty raises ValueError. Fifth positional slot retained. No insecure escape hatch.
- Server TLS helper always verifies client certificates and requires TLS1.3; invalid credential files/key mismatch fail before bind.
- Migrate Python benchmark CA configuration and add a bounded TLS preflight; document hub-only scope.

## Validation
- Genuine baseline RED: prior native wheel admitted a certificate-less TLS/WebSocket peer. Final native suite66tests/932subtests PASS; focused4/19 plus10consecutive repeats.
- Missing/untrusted/expired/future client certificates, wrong hub trust and TLS1.2 rejected; trusted ReadProperty barriers before/after negatives.
- Defaultworkspace4390pass/3existingignored; portableSCworkspace4403pass/3existingignored; focusedRust/static/binding gates PASS, existingwarnings.
- Fresh locked CPython3.12.13 macOSarm64 DEV wheel, origin/stub parity verified. BenchmarkTLSpreflight1pass only; not full performance or benchmark Python>=3.13 qualification.

## Boundaries
Refs #513, remains partial. Python node helper defaults and Rust caller-owned TlsAcceptor unchanged. No cert-to-VMAC binding/security-profile completion; #522 unchanged. Existing all-zero node UUID collision prevented two-native-node topology qualification; distinct-UUID rawSCpeer used, no production workaround.
Three independent reviews and exact-head lean CI pending.