### PR TITLE
Require explicit credentials for Python SC nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Python SC node compatibility change:** `BACnetClient` and `BACnetServer`
+  with `transport="sc"` now require nonempty `sc_ca_cert`, `sc_client_cert`, and
+  `sc_client_key` paths at construction (`ValueError` otherwise). Positional
+  layout, `None` defaults for non-SC use, and other transports are unchanged.
+  Startup loads explicit site trust and matching operational credentials before
+  dialing, with existing `RuntimeError` TLS-config errors and no system-root or
+  unauthenticated-client fallback. Server local TLS preflight failures preserve
+  registrations for file repair/retry; later failures are not general rollback.
+  TLS 1.3-only remains. Caller-owned Rust TLS configurations are unchanged;
+  #513 remains partial. See [SC configuration](docs/python-api.md#bacnetsc-secure-connect).
+
 - **Python ScHub compatibility change:** `ca_cert` must explicitly name a usable
   trusted issuer CA PEM file. Omission, `None`, and empty paths now raise
   `ValueError` at construction; invalid files or mismatched server cert/key fail
   in `start()` before bind. The fifth positional parameter is unchanged, but its
   default no longer enables one-way TLS. Client verification and TLS 1.3 are
   mandatory, with no insecure escape hatch. The Python SC benchmark now supplies
-  its generated CA. Rust caller-owned `TlsAcceptor` injection and Python node
-  credential defaults are unchanged; #513 remains partial. See
+  its generated CA. Rust caller-owned `TlsAcceptor` injection is unchanged;
+  #513 remains partial. See
   [ScHub](docs/python-api.md#schub).
 
 - Add a default-OFF optional global DCC DISABLE_INITIATION token bucket per native

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,7 +2208,6 @@ dependencies = [
  "bytes",
  "pyo3",
  "pyo3-async-runtimes",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
 ]

--- a/crates/rusty-bacnet/Cargo.toml
+++ b/crates/rusty-bacnet/Cargo.toml
@@ -23,7 +23,6 @@ pyo3-async-runtimes.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
 bytes.workspace = true
 tokio-rustls.workspace = true
-rustls-native-certs.workspace = true
 
 [lints]
 workspace = true

--- a/crates/rusty-bacnet/rusty_bacnet.pyi
+++ b/crates/rusty-bacnet/rusty_bacnet.pyi
@@ -1022,6 +1022,13 @@ class BACnetClient:
     Supports BACnet/IP (``"bip"``), BACnet/IPv6 (``"ipv6"``),
     BACnet/SC (``"sc"``), and BACnet MS/TP (``"mstp"``) transports.
 
+    For SC, sc_ca_cert, sc_client_cert, and sc_client_key must be nonempty
+    paths; omission, None, or empty strings raise ValueError at construction.
+    Their None defaults preserve non-SC use and positional layout only.
+    Async entry loads the explicit site CA and operational cert/key; invalid
+    TLS configuration raises RuntimeError before dialing. No system-root or
+    unauthenticated-client fallback is available.
+
     Usage::
 
         async with BACnetClient() as client:
@@ -1756,6 +1763,14 @@ class RequestAdmissionCounters(TypedDict):
 
 class BACnetServer:
     """BACnet server that hosts objects and responds to client requests.
+
+    For SC, sc_ca_cert, sc_client_cert, and sc_client_key must be nonempty
+    paths; omission, None, or empty strings raise ValueError at construction.
+    Their None defaults preserve non-SC use and positional layout only.
+    start() loads the explicit site CA and operational cert/key before dialing
+    or draining registrations. Local TLS configuration errors raise RuntimeError;
+    repair the files and retry on the same server. Later startup failures do not
+    have a general registration rollback guarantee.
 
     Usage::
 

--- a/crates/rusty-bacnet/src/client/client_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/client/client_methods/lifecycle.rs
@@ -44,8 +44,16 @@ impl BACnetClient {
         mstp_mac: u8,
         mstp_max_master: u8,
         mstp_max_info_frames: u8,
-    ) -> Self {
-        Self {
+    ) -> PyResult<Self> {
+        if transport == "sc" {
+            crate::tls::required_sc_credentials(
+                sc_ca_cert.as_deref(),
+                sc_client_cert.as_deref(),
+                sc_client_key.as_deref(),
+            )
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        }
+        Ok(Self {
             inner: Arc::new(Mutex::new(None)),
             transport_type: transport.to_string(),
             interface: interface.to_string(),
@@ -65,7 +73,7 @@ impl BACnetClient {
             mstp_mac,
             mstp_max_master,
             mstp_max_info_frames,
-        }
+        })
     }
 
     /// Start the client (called by `async with`).

--- a/crates/rusty-bacnet/src/client/mod.rs
+++ b/crates/rusty-bacnet/src/client/mod.rs
@@ -62,8 +62,13 @@ use crate::types::{
 /// Supports multiple transports via the `transport` parameter:
 /// - `"bip"` (default): BACnet/IP over UDP
 /// - `"ipv6"`: BACnet/IPv6 over UDP multicast
-/// - `"sc"`: BACnet/SC over TLS WebSocket (requires `sc_hub`, `sc_vmac`)
+/// - `"sc"`: BACnet/SC over TLS WebSocket (requires `sc_hub`, `sc_vmac`,
+///   `sc_ca_cert`, `sc_client_cert`, and `sc_client_key`)
 /// - `"mstp"`: BACnet MS/TP over RS-485 (requires `serial_port`)
+///
+/// SC credential paths must be nonempty at construction (ValueError otherwise).
+/// Files are loaded on async entry; invalid TLS configuration raises RuntimeError
+/// before dialing. No system trust or unauthenticated-client fallback is used.
 #[pyclass(name = "BACnetClient")]
 pub struct BACnetClient {
     inner: ClientInner,

--- a/crates/rusty-bacnet/src/server/mod.rs
+++ b/crates/rusty-bacnet/src/server/mod.rs
@@ -70,8 +70,14 @@ use crate::types::{PyObjectIdentifier, PyPropertyIdentifier, PyPropertyValue};
 /// Supports multiple transports via the `transport` parameter:
 /// - `"bip"` (default): BACnet/IP over UDP
 /// - `"ipv6"`: BACnet/IPv6 over UDP multicast
-/// - `"sc"`: BACnet/SC over TLS WebSocket (requires `sc_hub`, `sc_vmac`)
+/// - `"sc"`: BACnet/SC over TLS WebSocket (requires `sc_hub`, `sc_vmac`,
+///   `sc_ca_cert`, `sc_client_cert`, and `sc_client_key`)
 /// - `"mstp"`: BACnet MS/TP over RS-485 (requires `serial_port`)
+///
+/// SC credential paths must be nonempty at construction (ValueError otherwise).
+/// start() loads the files before dialing or draining registrations; local TLS
+/// configuration errors raise RuntimeError and permit retry after file repair.
+/// Later startup failures retain existing behavior, not general rollback.
 #[pyclass(name = "BACnetServer")]
 pub struct BACnetServer {
     inner: Arc<Mutex<Option<server::BACnetServer<AnyTransport<crate::mstp_py::PySerial>>>>>,

--- a/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/lifecycle.rs
@@ -4,6 +4,20 @@ use super::super::*;
 impl BACnetServer {
     /// Start the server. It will begin responding to BACnet requests.
     fn start<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        // Local TLS failures must leave pending registrations available for retry.
+        // Load on each start, not in the constructor, so repaired files are used.
+        let sc_tls_config = if self.transport_type == "sc" {
+            Some(
+                crate::tls::build_client_tls_config(
+                    self.sc_ca_cert.as_deref(),
+                    self.sc_client_cert.as_deref(),
+                    self.sc_client_key.as_deref(),
+                )
+                .map_err(|e| PyRuntimeError::new_err(format!("TLS config error: {e}")))?,
+            )
+        } else {
+            None
+        };
         // MS/TP serial open is synchronous and must succeed before pending
         // registrations are moved into the startup future.
         let mut mstp_transport: Option<AnyTransport<crate::mstp_py::PySerial>> =
@@ -29,9 +43,6 @@ impl BACnetServer {
         let broadcast_str = self.broadcast_address.clone();
         let sc_hub = self.sc_hub.clone();
         let sc_vmac = self.sc_vmac.clone();
-        let sc_ca_cert = self.sc_ca_cert.clone();
-        let sc_client_cert = self.sc_client_cert.clone();
-        let sc_client_key = self.sc_client_key.clone();
         let sc_heartbeat_interval_ms = self.sc_heartbeat_interval_ms;
         let sc_heartbeat_timeout_ms = self.sc_heartbeat_timeout_ms;
         let ipv6_interface = self.ipv6_interface.clone();
@@ -119,12 +130,8 @@ impl BACnetServer {
                     let mut vmac = [0u8; 6];
                     vmac.copy_from_slice(&vmac_bytes);
 
-                    let tls_config = crate::tls::build_client_tls_config(
-                        sc_ca_cert.as_deref(),
-                        sc_client_cert.as_deref(),
-                        sc_client_key.as_deref(),
-                    )
-                    .map_err(|e| PyRuntimeError::new_err(format!("TLS config error: {e}")))?;
+                    let tls_config = sc_tls_config
+                        .ok_or_else(|| PyRuntimeError::new_err("SC TLS config was not prepared"))?;
 
                     let ws = bacnet_transport::sc_tls::TlsWebSocket::connect(&hub_url, tls_config)
                         .await

--- a/crates/rusty-bacnet/src/server/server_methods/registration.rs
+++ b/crates/rusty-bacnet/src/server/server_methods/registration.rs
@@ -206,6 +206,14 @@ impl BACnetServer {
         get_event_information_budget
             .validate()
             .map_err(|error| pyo3::exceptions::PyValueError::new_err(error.to_string()))?;
+        if transport == "sc" {
+            crate::tls::required_sc_credentials(
+                sc_ca_cert.as_deref(),
+                sc_client_cert.as_deref(),
+                sc_client_key.as_deref(),
+            )
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        }
         Ok(Self {
             inner: Arc::new(Mutex::new(None)),
             device_instance,

--- a/crates/rusty-bacnet/src/tls.rs
+++ b/crates/rusty-bacnet/src/tls.rs
@@ -55,7 +55,25 @@ pub fn build_server_tls_config(
     Ok(Arc::new(config))
 }
 
-/// Build a rustls ClientConfig from optional PEM file paths.
+/// Require explicit SC credential paths without performing file I/O.
+pub fn required_sc_credentials<'a>(
+    ca_cert_path: Option<&'a str>,
+    client_cert_path: Option<&'a str>,
+    client_key_path: Option<&'a str>,
+) -> Result<[&'a str; 3], Error> {
+    let required = |path: Option<&'a str>, name: &str| {
+        path.filter(|path| !path.is_empty()).ok_or_else(|| {
+            Error::Encoding(format!("{name} must be a nonempty path for SC mutual TLS"))
+        })
+    };
+    Ok([
+        required(ca_cert_path, "sc_ca_cert")?,
+        required(client_cert_path, "sc_client_cert")?,
+        required(client_key_path, "sc_client_key")?,
+    ])
+}
+
+/// Build a TLS 1.3 client config using only explicit site trust and credentials.
 pub fn build_client_tls_config(
     ca_cert_path: Option<&str>,
     client_cert_path: Option<&str>,
@@ -63,74 +81,41 @@ pub fn build_client_tls_config(
 ) -> Result<Arc<tokio_rustls::rustls::ClientConfig>, Error> {
     use tokio_rustls::rustls;
 
+    let [ca_path, cert_path, key_path] =
+        required_sc_credentials(ca_cert_path, client_cert_path, client_key_path)?;
     let mut root_store = rustls::RootCertStore::empty();
-
-    if let Some(ca_path) = ca_cert_path {
-        let ca_data = std::fs::read(ca_path)
-            .map_err(|e| Error::Encoding(format!("failed to read CA cert: {e}")))?;
-        let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&ca_data)
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| Error::Encoding(format!("failed to parse CA cert: {e}")))?;
-        if certs.is_empty() {
-            return Err(Error::Encoding("no CA certificates found".into()));
-        }
-        for cert in certs {
-            root_store
-                .add(cert)
-                .map_err(|e| Error::Encoding(format!("failed to add CA cert: {e}")))?;
-        }
-    } else {
-        // Use system roots as fallback
-        let native_result = rustls_native_certs::load_native_certs();
-        if !native_result.errors.is_empty() {
-            eprintln!(
-                "Warning: some native TLS certificates could not be loaded: {:?}",
-                native_result.errors
-            );
-        }
-        if native_result.certs.is_empty() {
-            return Err(Error::Encoding(
-                "no native CA certificates could be loaded — provide ca_cert_path explicitly"
-                    .into(),
-            ));
-        }
-        for cert in native_result.certs {
-            let _ = root_store.add(cert);
-        }
+    let ca_data = std::fs::read(ca_path)
+        .map_err(|e| Error::Encoding(format!("failed to read CA cert: {e}")))?;
+    let ca_certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&ca_data)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| Error::Encoding(format!("failed to parse CA cert: {e}")))?;
+    if ca_certs.is_empty() {
+        return Err(Error::Encoding("no CA certificates found".into()));
+    }
+    for cert in ca_certs {
+        root_store
+            .add(cert)
+            .map_err(|e| Error::Encoding(format!("failed to add CA cert: {e}")))?;
     }
 
-    // BACnet/SC requires TLS 1.3 per spec AB.7.4
-    let builder = rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-        .with_root_certificates(root_store);
+    let cert_data = std::fs::read(cert_path)
+        .map_err(|e| Error::Encoding(format!("failed to read client cert: {e}")))?;
+    let key_data = std::fs::read(key_path)
+        .map_err(|e| Error::Encoding(format!("failed to read client key: {e}")))?;
+    let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&cert_data)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| Error::Encoding(format!("failed to parse client cert: {e}")))?;
+    if certs.is_empty() {
+        return Err(Error::Encoding("no client certificates found".into()));
+    }
+    let key = PrivateKeyDer::from_pem_slice(&key_data)
+        .map_err(|e| Error::Encoding(format!("failed to parse client key: {e}")))?;
 
-    let config = match (client_cert_path, client_key_path) {
-        (Some(cert_path), Some(key_path)) => {
-            let cert_data = std::fs::read(cert_path)
-                .map_err(|e| Error::Encoding(format!("failed to read client cert: {e}")))?;
-            let key_data = std::fs::read(key_path)
-                .map_err(|e| Error::Encoding(format!("failed to read client key: {e}")))?;
-
-            let certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&cert_data)
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| Error::Encoding(format!("failed to parse client cert: {e}")))?;
-            if certs.is_empty() {
-                return Err(Error::Encoding("no client certificates found".into()));
-            }
-
-            let key = PrivateKeyDer::from_pem_slice(&key_data)
-                .map_err(|e| Error::Encoding(format!("failed to parse client key: {e}")))?;
-
-            builder
-                .with_client_auth_cert(certs, key)
-                .map_err(|e| Error::Encoding(format!("TLS client auth error: {e}")))?
-        }
-        (None, None) => builder.with_no_client_auth(),
-        _ => {
-            return Err(Error::Encoding(
-                "sc_client_cert and sc_client_key must both be provided or both omitted".into(),
-            ));
-        }
-    };
+    // Retain the local TLS-1.3-only policy; AB.7.4 requires TLS 1.3 support.
+    let config = rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+        .with_root_certificates(root_store)
+        .with_client_auth_cert(certs, key)
+        .map_err(|e| Error::Encoding(format!("TLS client auth error: {e}")))?;
 
     Ok(Arc::new(config))
 }

--- a/crates/rusty-bacnet/tests/test_alarm_summary_budget.py
+++ b/crates/rusty-bacnet/tests/test_alarm_summary_budget.py
@@ -29,7 +29,8 @@ class AlarmSummaryConstructorTests(unittest.TestCase):
                         with self.assertRaises(error):
                             BACnetServer(123, transport=transport, **invalid)
                 positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
-                BACnetServer(123, transport=transport, **positive)
+                BACnetServer(123, transport=transport, **positive,
+                             sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 class AlarmSummaryNativeTests(unittest.IsolatedAsyncioTestCase):

--- a/crates/rusty-bacnet/tests/test_atomic_read_file_budget.py
+++ b/crates/rusty-bacnet/tests/test_atomic_read_file_budget.py
@@ -31,7 +31,8 @@ class AtomicReadFileConstructorTests(unittest.TestCase):
                         with self.assertRaises(error):
                             BACnetServer(123, transport=transport, **{name: value})
                 positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
-                BACnetServer(123, transport=transport, **positive)
+                BACnetServer(123, transport=transport, **positive,
+                             sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 class AtomicReadFileNativeTests(unittest.IsolatedAsyncioTestCase):

--- a/crates/rusty-bacnet/tests/test_atomic_write_file_budget.py
+++ b/crates/rusty-bacnet/tests/test_atomic_write_file_budget.py
@@ -31,7 +31,8 @@ class AtomicWriteFileConstructorTests(unittest.TestCase):
                         with self.assertRaises(error):
                             BACnetServer(123, transport=transport, **{name: value})
                 positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
-                BACnetServer(123, transport=transport, **positive)
+                BACnetServer(123, transport=transport, **positive,
+                             sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 def unsigned(value):

--- a/crates/rusty-bacnet/tests/test_dcc_policy.py
+++ b/crates/rusty-bacnet/tests/test_dcc_policy.py
@@ -21,7 +21,8 @@ class DccConstructorTests(unittest.TestCase):
             for valid in [None, (3, 20000), (1, 1), (65535, 86400000)]:
                 for policy in ["deny_all", "legacy_permissive", "require_password"]:
                     BACnetServer(123, transport=transport, dcc_policy=policy,
-                                 dcc_password="required", dcc_disable_rate_limit=valid)
+                                 dcc_password="required", dcc_disable_rate_limit=valid,
+                                 sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
         for invalid in [True, "bad", (), (3,), (3, 20, 1), (-1, 20000), (3, -1),
                         (2**32, 20000), (3, 2**64), (3.5, 20000), (3, None)]:
             with self.assertRaises((TypeError, ValueError, OverflowError)):
@@ -44,7 +45,8 @@ class DccConstructorTests(unittest.TestCase):
                                  dcc_password="required", dcc_source_restriction=restriction)
             for restriction in [[], [(None, b"x")], [(65534, b"x" * 255)] * 256]:
                 BACnetServer(123, transport=transport, dcc_policy="require_password",
-                             dcc_password="required", dcc_source_restriction=restriction)
+                             dcc_password="required", dcc_source_restriction=restriction,
+                             sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
         for invalid in [1, "bad", [(None, "bad")], [(65536, b"x")], [(-1, b"x")]]:
             with self.assertRaises((TypeError, ValueError, OverflowError)):
                 BACnetServer(123, dcc_policy="require_password", dcc_password="required",
@@ -66,10 +68,12 @@ class DccConstructorTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "nonempty dcc_password"):
                     BACnetServer(123, transport=transport, dcc_policy="require_password",
                                  dcc_password=password)
-            BACnetServer(123, transport=transport, dcc_policy="require_password", dcc_password="x")
+            BACnetServer(123, transport=transport, dcc_policy="require_password", dcc_password="x",
+                         sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
             for policy in ["deny_all", "legacy_permissive"]:
                 for password in [None, "", "x" * 100]:
-                    BACnetServer(123, transport=transport, dcc_policy=policy, dcc_password=password)
+                    BACnetServer(123, transport=transport, dcc_policy=policy, dcc_password=password,
+                                 sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 class DccNativeTests(unittest.IsolatedAsyncioTestCase):

--- a/crates/rusty-bacnet/tests/test_enrollment_summary_budget.py
+++ b/crates/rusty-bacnet/tests/test_enrollment_summary_budget.py
@@ -28,7 +28,8 @@ class EnrollmentSummaryConstructorTests(unittest.TestCase):
                         with self.assertRaises(error):
                             BACnetServer(123, transport=transport, **{name: value})
                 positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
-                BACnetServer(123, transport=transport, **positive)
+                BACnetServer(123, transport=transport, **positive,
+                             sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 class EnrollmentSummaryNativeTests(unittest.IsolatedAsyncioTestCase):

--- a/crates/rusty-bacnet/tests/test_event_information_budget.py
+++ b/crates/rusty-bacnet/tests/test_event_information_budget.py
@@ -29,7 +29,8 @@ class EventInformationConstructorTests(unittest.TestCase):
                         with self.assertRaises(error):
                             BACnetServer(123, transport=transport, **{name: value})
                 positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
-                BACnetServer(123, transport=transport, **positive)
+                BACnetServer(123, transport=transport, **positive,
+                             sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 def summary_oids(ack):

--- a/crates/rusty-bacnet/tests/test_read_range_budget.py
+++ b/crates/rusty-bacnet/tests/test_read_range_budget.py
@@ -28,7 +28,8 @@ class ReadRangeConstructorTests(unittest.TestCase):
                         with self.assertRaises(error):
                             BACnetServer(123, transport=transport, **{name: value})
                 positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
-                BACnetServer(123, transport=transport, **positive)
+                BACnetServer(123, transport=transport, **positive,
+                             sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 class ReadRangeNativeTests(unittest.IsolatedAsyncioTestCase):

--- a/crates/rusty-bacnet/tests/test_recovery_admission.py
+++ b/crates/rusty-bacnet/tests/test_recovery_admission.py
@@ -28,13 +28,16 @@ class RecoveryConstructorTests(unittest.TestCase):
                 with self.assertRaises(TypeError):
                     invalid: dict[str, Any] = {name: 1.5}
                     BACnetServer(123, transport=transport, **invalid)
-            BACnetServer(123, transport=transport, max_confirmed_in_flight=1, confirmed_recovery_reserve=0)
-            BACnetServer(123, transport=transport, max_confirmed_in_flight=2, confirmed_recovery_reserve=1)
+            BACnetServer(123, transport=transport, max_confirmed_in_flight=1, confirmed_recovery_reserve=0,
+                         sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
+            BACnetServer(123, transport=transport, max_confirmed_in_flight=2, confirmed_recovery_reserve=1,
+                         sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
             # Independent quotas accept recovery peer > ordinary peer; Rust
             # barrier tests prove simultaneous 1+3 holding, not this constructor.
             BACnetServer(123, transport=transport, max_confirmed_in_flight=8,
                          confirmed_recovery_reserve=3, max_confirmed_in_flight_per_peer=1,
-                         max_recovery_in_flight_per_peer=3)
+                         max_recovery_in_flight_per_peer=3,
+                         sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 class RecoveryNativeTests(unittest.IsolatedAsyncioTestCase):

--- a/crates/rusty-bacnet/tests/test_request_admission.py
+++ b/crates/rusty-bacnet/tests/test_request_admission.py
@@ -63,7 +63,8 @@ class AdmissionSignatureTests(unittest.TestCase):
                 valid: dict[str, Any] = {name: 2}
                 if name == "max_confirmed_in_flight":
                     valid["confirmed_recovery_reserve"] = 0
-                BACnetServer(123, transport=transport, **valid)
+                BACnetServer(123, transport=transport, **valid,
+                             sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 def packet(apdu: bytes) -> bytes:

--- a/crates/rusty-bacnet/tests/test_rpm_budget.py
+++ b/crates/rusty-bacnet/tests/test_rpm_budget.py
@@ -28,7 +28,8 @@ class RpmConstructorTests(unittest.TestCase):
                             BACnetServer(123, transport=transport, **invalid)
                 # Configuration is not used as an allocation capacity or a semaphore limit.
                 positive: dict[str, Any] = {name: (1 << (8 * struct.calcsize("P"))) - 1}
-                BACnetServer(123, transport=transport, **positive)
+                BACnetServer(123, transport=transport, **positive,
+                             sc_ca_cert="ca.pem", sc_client_cert="cert.pem", sc_client_key="key.pem")
 
 
 class RpmNativeTests(unittest.IsolatedAsyncioTestCase):

--- a/crates/rusty-bacnet/tests/test_sc_hub_mtls.py
+++ b/crates/rusty-bacnet/tests/test_sc_hub_mtls.py
@@ -1,22 +1,28 @@
-"""Installed-native Python hub authentication; no system trust or persistent keys.
+"""Installed-native Python hub/node authentication; no system trust or persistent keys.
 
 OpenSSL CLI creates a temporary site CA and distinct operational certificates.
-TLS negatives use the independent stdlib TLS client, not SC reconnect timeouts.
+TLS negatives use independent stdlib TLS peers, not SC reconnect timeouts.
 """
 import asyncio
 import inspect
+import itertools
 import os
 import socket
 import ssl
 import subprocess
 import tempfile
+import threading
 import unittest
 from pathlib import Path
 
-from rusty_bacnet import BACnetServer, BacnetError, ScHub
+from rusty_bacnet import (
+    BACnetClient, BACnetServer, BacnetError, ObjectIdentifier, ObjectType,
+    PropertyIdentifier, ScHub,
+)
 
 
-class HubMtlsTests(unittest.IsolatedAsyncioTestCase):
+class MtlsFixture(unittest.IsolatedAsyncioTestCase):
+    """Shared fixture only: no inherited test methods or duplicate discovery."""
     @classmethod
     def setUpClass(cls):
         cls.temp = tempfile.TemporaryDirectory(prefix="bacnet-hub-mtls-")
@@ -72,7 +78,7 @@ class HubMtlsTests(unittest.IsolatedAsyncioTestCase):
                      ca_cert=overrides.get("ca_cert", self.path("site.pem")))
 
     def websocket(self, address, peer=None, ca="site", version=ssl.TLSVersion.TLSv1_3,
-                  read_property=False):
+                  read_property=False, serve_ready=None, serve_done=None):
         """Bounded independent TLS + WebSocket handshake, including TLS 1.3 alerts.
 
         The post-handshake read matters: TLS 1.3 may report missing-client-cert
@@ -94,11 +100,11 @@ class HubMtlsTests(unittest.IsolatedAsyncioTestCase):
                     b"Sec-WebSocket-Protocol: hub.bsc.bacnet.org\r\n\r\n")
                 response = tls.recv(4096)
                 self.assertTrue(response.startswith(b"HTTP/1.1 101"), response)
-                if read_property:
-                    self.exchange_read_property(tls)
+                if read_property or serve_ready is not None:
+                    self.exchange_read_property(tls, serve_ready, serve_done)
                 return tls.version()
 
-    def exchange_read_property(self, tls):
+    def exchange_read_property(self, tls, serve_ready=None, serve_done=None):
         # Literal SC Connect-Request/Accept, modeled on sc_frame's independent
         # connect_test_support vectors. A nonzero UUID avoids the existing
         # all-zero default shared by Python BACnetClient/BACnetServer nodes.
@@ -133,6 +139,22 @@ class HubMtlsTests(unittest.IsolatedAsyncioTestCase):
         except TimeoutError as error:
             raise AssertionError("timed out waiting for SC ConnectAccept") from error
         self.assertEqual(accepted[:4], b"\x07\x00\x22\x33")
+        if serve_ready is not None:
+            assert serve_done is not None
+            serve_ready.set()
+            # Independently respond to a native client's ReadProperty AI0/PV.
+            for _ in range(8):
+                request = receive()
+                if request.endswith(b"\x0c\x0c\0\0\0\0\x19\x55"):
+                    self.assertEqual(request[:2], b"\x01\x08")
+                    self.assertEqual(request[4:10], b"\x02\0\0\0\0\2")
+                    self.assertEqual(request[10:13], b"\x01\x04\x02")
+                    invoke = request[14:15]
+                    send(b"\x01\x04\x22\x35" + b"\x02\0\0\0\0\2" + b"\x01\x00" +
+                         b"\x30" + invoke + b"\x0c\x0c\0\0\0\0\x19\x55\x3e\x44\x42\x91\0\0\x3f")
+                    self.assertTrue(serve_done.wait(3), "native client did not finish reading")
+                    return
+            self.fail("no ReadProperty request within bounded incoming frames")
         self.invoke = getattr(self, "invoke", 0) + 1
         invoke = bytes([self.invoke])
         # Encapsulated-NPDU to destination; hub supplies the originating VMAC.
@@ -153,6 +175,14 @@ class HubMtlsTests(unittest.IsolatedAsyncioTestCase):
                 return
         self.fail("no ReadProperty ACK within bounded incoming frames")
 
+    async def stop_hub(self, hub):
+        await asyncio.wait_for(hub.stop(), 5)
+
+    async def stop_server(self, server):
+        await asyncio.wait_for(server.stop(), 5)
+
+
+class HubMtlsTests(MtlsFixture):
     async def test_absent_ca_cannot_admit_certificate_less_peer(self):
         # Baseline behavioral RED: the old constructor starts, then permits an
         # unauthenticated TLS/WebSocket upgrade. New early validation is valid.
@@ -250,8 +280,199 @@ class HubMtlsTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await asyncio.to_thread(self.websocket, address, "client"), "TLSv1.3")
         await barrier()
 
-    async def stop_hub(self, hub):
-        await asyncio.wait_for(hub.stop(), 5)
+class NodeCredentialTests(unittest.TestCase):
+    def test_sc_constructor_requires_each_credential(self):
+        # Genuine baseline RED: both existing APIs accepted missing credentials.
+        # This does not claim a bypass of the now-mandatory hub verification.
+        fields = ("sc_ca_cert", "sc_client_cert", "sc_client_key")
+        omitted = object()
+        for api, args in [(BACnetClient, ()), (BACnetServer, (3000,))]:
+            for values in itertools.product((omitted, None, "", "placeholder.pem"), repeat=3):
+                kwargs = {name: value for name, value in zip(fields, values) if value is not omitted}
+                with self.subTest(api=api.__name__, credentials=kwargs):
+                    if all(value == "placeholder.pem" for value in values):
+                        api(*args, transport="sc", **kwargs)
+                    else:
+                        with self.assertRaisesRegex(ValueError, "sc_.*(cert|key)"):
+                            api(*args, transport="sc", **kwargs)
 
-    async def stop_server(self, server):
-        await asyncio.wait_for(server.stop(), 5)
+    def test_non_sc_credentials_remain_optional_and_unread(self):
+        for api, args in [(BACnetClient, ()), (BACnetServer, (3000,))]:
+            for transport in ("bip", "ipv6", "mstp"):
+                for value in (None, "", "not-a-real-file.pem"):
+                    with self.subTest(api=api.__name__, transport=transport, value=value):
+                        api(*args, transport=transport, sc_ca_cert=value,
+                            sc_client_cert=value, sc_client_key=value)
+
+    def test_sc_positional_defaults_and_following_slots(self):
+        for api in (BACnetClient, BACnetServer):
+            params = inspect.signature(api).parameters
+            for name in ("sc_ca_cert", "sc_client_cert", "sc_client_key",
+                         "sc_heartbeat_interval_ms", "sc_heartbeat_timeout_ms", "ipv6_interface"):
+                self.assertIsNone(params[name].default)
+                self.assertEqual(params[name].kind, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        # Nonexistent paths are allowed until startup, including positional SC use.
+        BACnetClient("0.0.0.0", 0, "255.255.255.255", 6000, "sc", "wss://localhost:1",
+                     b"\x02\0\0\0\0\2", "ca.pem", "cert.pem", "key.pem", 30000, 60000, "::1")
+        BACnetServer(3000, "SC", "0.0.0.0", 0, "255.255.255.255", "sc", "wss://localhost:1",
+                     b"\x02\0\0\0\0\2", "ca.pem", "cert.pem", "key.pem", 30000, 60000, "::1",
+                     "dcc-password", "reinit-password")
+
+
+class NodeMtlsTests(MtlsFixture):
+    def node(self, api, url, **overrides):
+        kwargs = dict(transport="sc", sc_hub=url, sc_vmac=b"\x02\0\0\0\0\2",
+                      sc_ca_cert=self.path("site.pem"), sc_client_cert=self.path("server.pem"),
+                      sc_client_key=self.path("server.key"))
+        kwargs.update(overrides)
+        return api(*((3000,) if api is BACnetServer else ()), **kwargs)
+
+    async def start_node(self, node):
+        if isinstance(node, BACnetServer):
+            await asyncio.wait_for(node.start(), 5)
+        else:
+            self.assertIs(await asyncio.wait_for(node.__aenter__(), 5), node)
+
+    async def test_invalid_local_files_do_not_dial_or_drain(self):
+        cases = []
+        for field, label, read_error in [
+            ("sc_ca_cert", "CERTIFICATE", "CA cert"),
+            ("sc_client_cert", "CERTIFICATE", "client cert"),
+            ("sc_client_key", "PRIVATE KEY", "client key"),
+        ]:
+            for kind, contents in [("empty", ""), ("garbage", "not PEM"),
+                                   ("bad-base64", f"-----BEGIN {label}-----\n%%%\n-----END {label}-----\n"),
+                                   ("bad-der", f"-----BEGIN {label}-----\nYQ==\n-----END {label}-----\n")]:
+                name = f"{field}-{kind}.pem"
+                (self.root / name).write_text(contents)
+                cases.append(({field: self.path(name)}, "TLS config error:"))
+            cases.extend([({field: self.path("does-not-exist.pem")}, f"failed to read {read_error}"),
+                          ({field: str(self.root)}, f"failed to read {read_error}")])
+        cases.append(({"sc_client_key": self.path("client.key")}, "TLS client auth error"))
+        for api in (BACnetClient, BACnetServer):
+            for overrides, message in cases:
+                with self.subTest(api=api.__name__, overrides=overrides), socket.socket() as listener:
+                    listener.bind(("127.0.0.1", 0))
+                    listener.listen()
+                    listener.setblocking(False)
+                    address = listener.getsockname()
+                    node = self.node(api, f"wss://127.0.0.1:{address[1]}", **overrides)
+                    if isinstance(node, BACnetServer):
+                        node.add_analog_input(0, "Pending AI", 64, 72.5)
+                    try:
+                        with self.assertRaisesRegex(RuntimeError, message) as rejected:
+                            await self.start_node(node)
+                        self.assertTrue(str(rejected.exception).startswith("TLS config error:"))
+                        # A completed TCP dial would be queued even if immediately
+                        # closed. Check the live accept queue, not a dial timeout.
+                        with self.assertRaises(BlockingIOError):
+                            listener.accept()
+                        if isinstance(node, BACnetServer):
+                            self.assertEqual(getattr(node, "_pending_registration_count")(), 1)
+                    finally:
+                        await self.stop_server(node)
+                    # Qualify that this exact listener observes an actual dial.
+                    listener.settimeout(3)
+                    with socket.create_connection(address, timeout=3):
+                        accepted, _ = listener.accept()
+                        accepted.close()
+
+    async def test_server_repairs_files_and_serves_preserved_registration(self):
+        hub = self.hub()
+        self.addAsyncCleanup(self.stop_hub, hub)
+        await asyncio.wait_for(hub.start(), 3)
+        paths = {name: self.path(f"retry-{name}.pem") for name in
+                 ("sc_ca_cert", "sc_client_cert", "sc_client_key")}
+        node = self.node(BACnetServer, await hub.url(), **paths)
+        self.addAsyncCleanup(self.stop_server, node)
+        pending_count = getattr(node, "_pending_registration_count")
+        node.add_analog_input(0, "Preserved AI", 64, 72.5)
+        # Construction did not read these still-missing files. Repeated failures
+        # cannot consume registrations; each start reloads repaired credentials.
+        for field, source in [("sc_ca_cert", "site.pem"), ("sc_client_cert", "server.pem"),
+                              ("sc_client_key", "client.key")]:
+            with self.assertRaisesRegex(RuntimeError, "TLS config error:"):
+                await self.start_node(node)
+            self.assertEqual(pending_count(), 1)
+            Path(paths[field]).write_bytes((self.root / source).read_bytes())
+        with self.assertRaisesRegex(RuntimeError, "TLS client auth error"):
+            await self.start_node(node)
+        self.assertEqual(pending_count(), 1)
+        node.add_binary_input(1, "Added after failure")
+        Path(paths["sc_client_key"]).write_bytes((self.root / "server.key").read_bytes())
+        await self.start_node(node)
+        self.assertEqual(pending_count(), 0)
+        self.assertEqual(await asyncio.to_thread(self.websocket, await hub.address(), "client",
+                                                read_property=True), "TLSv1.3")
+
+    async def test_client_repairs_files_and_reads_through_trusted_hub(self):
+        hub = self.hub()
+        self.addAsyncCleanup(self.stop_hub, hub)
+        await asyncio.wait_for(hub.start(), 3)
+        key = self.root / "retry-client.key"
+        key.write_text("not a key")
+        node = self.node(BACnetClient, await hub.url(), sc_client_key=str(key))
+        self.addAsyncCleanup(self.stop_server, node)
+        with self.assertRaisesRegex(RuntimeError, "TLS config error:"):
+            await self.start_node(node)
+        key.write_bytes((self.root / "server.key").read_bytes())
+        await self.start_node(node)
+        ready = threading.Event()
+        done = threading.Event()
+        peer = asyncio.create_task(asyncio.to_thread(
+            self.websocket, await hub.address(), "client", serve_ready=ready, serve_done=done))
+        try:
+            self.assertTrue(await asyncio.to_thread(ready.wait, 3), "raw peer did not connect")
+            value = await asyncio.wait_for(node.read_property(
+                "02:00:00:00:00:03", ObjectIdentifier(ObjectType.ANALOG_INPUT, 0),
+                PropertyIdentifier.PRESENT_VALUE), 3)
+            self.assertEqual(value.value, 72.5)
+        finally:
+            # Socket operations have their own bounds; always join the worker.
+            done.set()
+            self.assertEqual(await peer, "TLSv1.3")
+
+    def rejected_tls_peer(self, listener, cert, trust, version):
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.minimum_version = ctx.maximum_version = version
+        ctx.load_cert_chain(self.path(f"{cert}.pem"), self.path(f"{cert}.key"))
+        ctx.load_verify_locations(self.path(f"{trust}.pem"))
+        ctx.verify_mode = ssl.CERT_REQUIRED
+        listener.settimeout(3)
+        tcp, _ = listener.accept()
+        with tcp:
+            tcp.settimeout(3)
+            with self.assertRaises(ssl.SSLError) as rejected:
+                with ctx.wrap_socket(tcp, server_side=True) as tls:
+                    # TLS 1.3 rejection may arrive after handshake completion.
+                    tls.recv(4096)
+            self.assertNotIsInstance(rejected.exception, ssl.SSLEOFError)
+            self.assertRegex(rejected.exception.reason, "ALERT|CERTIFICATE_VERIFY_FAILED|UNSUPPORTED_PROTOCOL")
+
+    async def test_nodes_reject_untrusted_or_inactive_peers_and_tls12(self):
+        # Independent TLS acceptor proves actual alerts, not SC timeout behavior.
+        cases = [(cert, "site", "server", ssl.TLSVersion.TLSv1_3)
+                 for cert in ("wrong", "expired", "future")]
+        cases += [("hub", "site", cert, ssl.TLSVersion.TLSv1_3)
+                  for cert in ("wrong", "expired", "future")]
+        cases += [("hub", "foreign", "server", ssl.TLSVersion.TLSv1_3),
+                  ("hub", "site", "server", ssl.TLSVersion.TLSv1_2)]
+        for api in (BACnetClient, BACnetServer):
+            for cert, trust, local, version in cases:
+                with self.subTest(api=api.__name__, cert=cert, trust=trust, local=local, version=version):
+                    with socket.socket() as listener:
+                        listener.bind(("127.0.0.1", 0))
+                        listener.listen()
+                        node = self.node(api, f"wss://localhost:{listener.getsockname()[1]}",
+                                         sc_client_cert=self.path(f"{local}.pem"),
+                                         sc_client_key=self.path(f"{local}.key"))
+                        peer = asyncio.create_task(asyncio.to_thread(
+                            self.rejected_tls_peer, listener, cert, trust, version))
+                        try:
+                            with self.assertRaises(BacnetError):
+                                await self.start_node(node)
+                        finally:
+                            try:
+                                await peer
+                            finally:
+                                await self.stop_server(node)

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -264,9 +264,9 @@ client = BACnetClient(
     # SC options:
     sc_hub=None,                 # WebSocket hub URL
     sc_vmac=None,                # 6-byte VMAC
-    sc_ca_cert=None,             # CA certificate path
-    sc_client_cert=None,         # Client certificate path
-    sc_client_key=None,          # Client private key path
+    sc_ca_cert=None,             # Site CA PEM path (required for SC)
+    sc_client_cert=None,         # Operational certificate PEM path (required for SC)
+    sc_client_key=None,          # Matching private key PEM path (required for SC)
     sc_heartbeat_interval_ms=None,  # 3000..=300000 ms when configured
     sc_heartbeat_timeout_ms=None,   # must be greater than interval
 )
@@ -1559,8 +1559,9 @@ Missing, untrusted, expired, or not-yet-valid peer certificates are rejected.
 This addresses the Python hub admission boundary of Annex AB.7.4, not full
 security-profile conformance. CA membership does not authorize BACnet operations
 or bind a certificate to a claimed VMAC/Device UUID. Rust `ScHub` still accepts a
-caller-configured `TlsAcceptor`; Python client/server credential defaults remain
-unchanged and their required-credential migration is deferred under #513.
+caller-configured `TlsAcceptor`; caller-owned Rust TLS configurations remain
+outside this Python boundary, so #513 remains partial. Python nodes require the
+explicit credentials described [below](#bacnetsc-secure-connect).
 
 ### Methods
 
@@ -1697,6 +1698,32 @@ server = BACnetServer(
 ```
 
 ### BACnet/SC (Secure Connect)
+
+**Compatibility change:** both `BACnetClient` and `BACnetServer` require all of
+`sc_ca_cert`, `sc_client_cert`, and `sc_client_key` when `transport="sc"`.
+Omission, `None`, or an empty string raises `ValueError` at construction. Supply
+the installation's trusted CA PEM file and this node's operational certificate
+with its matching private key. There is no native/system-root fallback,
+certificate-less mode, or insecure flag. The `None` defaults and positional slots
+(including subsequent heartbeat, IPv6, and server password arguments) remain
+unchanged for non-SC use and argument-layout compatibility only.
+
+File I/O remains at startup: client async entry and server `start()` load and
+validate the files before TCP/DNS connection attempts. Unreadable, empty, malformed
+credentials and cert/key mismatch raise `RuntimeError` with `TLS config error:`.
+Server **local TLS configuration** failures leave pending object registrations
+intact; repair files at the same paths and retry `start()`. The client also reloads
+files on retry. This is not general startup rollback: later failures, including
+TLS peer rejection after dialing, retain existing lifecycle behavior and may
+consume server registrations. Preflight checks rustls configuration validity,
+not the local certificate's date or issuer against the site store; the remote
+peer validates that certificate during the real handshake.
+
+TLS 1.3-only remains the existing local policy. Base Standard 135-2020 Annex
+AB.7.4/AB.7.4.1.1 supplies the mutual-authentication and installation-credential
+context, but this change is not full security-profile conformance, certificate
+to VMAC/UUID authorization, or a change to hostname/revocation/issuer policy.
+Caller-owned Rust TLS configurations remain unchanged (#513 is still partial).
 
 ```python
 # Client connecting to a hub


### PR DESCRIPTION
## Summary
- Require nonempty sc_ca_cert, sc_client_cert, and sc_client_key for Python BACnetClient/BACnetServer with transport="sc". Omitted/None/empty credentials raise ValueError at construction.
- Remove native/system-root and certificate-less client fallbacks; retain TLS 1.3-only operation, positional layout, and non-SC behavior. Document the owner-approved immediate compatibility migration.
- Load and validate credentials before dialing, preserving the existing RuntimeError TLS-config mapping. Server local TLS preflight now precedes registration draining, allowing file repair and retry; later startup failures are not general rollback.
- Remove only the unused direct binding dependency edge and migrate existing constructor fixtures.

Refs #513 (remains OPEN/Partial; do not close).

## Verification
- Genuine baseline RED: previous installed wheel accepted all 126 missing/None/empty credential combinations. This is constructor evidence, not a bypass of the already-hardened hub.
- Fresh installed native CPython 3.12.13/macOS arm64 DEV wheel: 73 Python tests / 1,132 subtests pass. Root independently reran the full suite: same result in 2.33s.
- Focused hub/node suite repeated ten times: 11 tests / 219 subtests pass each run. Includes 38 live no-dial credential-failure cases, server registration preservation and file-repair retry, trusted TLS 1.3 ReadProperty traffic for both APIs, and 16 independent TLS negatives. Existing hub rejection/barrier tests remain.
- Default Rust workspace: 4,390 passed; portable SC/IPv6/serde workspace: 4,403 passed; each has 3 existing ignored. SC transport and seven SC DCC integration regressions also pass.
- Formatting, workspace Clippy, explicit-PYO3 binding check/Clippy, file-size, secrets, diff checks, exact installed stub and native-wheel parity all pass. Existing warnings retained.
- Benchmark TLS/WebSocket preflight only: 1 passed, 10 deselected, 3 existing config warnings. No topology/performance or benchmark Python>=3.13-floor qualification.
- Exact-head lean CI and three independent reviews are required before merge.

## Boundaries
Base Standard 135-2020 AB.7.4/AB.7.4.1.1 supplies mutual-authentication and installation-credential context; TLS 1.3-only is retained local policy. No addenda, full security-profile, hostname/revocation/direct-issuer-policy change, or support expansion.

Caller-owned Rust TLS configurations, the existing node UUID collision, and certificate-to-VMAC/UUID authorization remain unchanged. Tests use one native node and an independent unique-UUID peer, not a production identity workaround. Local preflight does not validate local certificate dates or issuer against site trust; real peers validate certificates during TLS handshake.

## Artifact provenance
Final DEV wheel SHA256: 16b8fddff9eecdfa7736569c0233f4a86acfca51b5bbb2e87bb12ed787e55eb0. Exact source manifest and local receipt preserved; receipt SHA256: 9c550fe3cfdc5df4da75616f3b8ceada7efaeeea79e851cfc6004f1570936b8c.