### PR TITLE
Add opt-in validated SC hub TLS configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Opt-in native hub TLS configuration:** `ScHubTlsConfig::from_der` validates
+  explicitly supplied, already loaded CA/chain/key DER without I/O, builds
+  mandatory client verification and TLS 1.3-only local policy, and exposes no raw
+  or mutable policy escape. `ScHub::start_with_tls_config` accepts caller UUID and
+  validated handshake timeouts while reusing the existing lifecycle. Python hub
+  startup delegates to this factory; its constructor, errors and file-loading
+  boundary stay compatible. All raw `TlsAcceptor` startup APIs remain unchanged,
+  without deprecation; Docker, CLI and node TLS APIs are not migrated. Native
+  preflight, compile-fail, real TLS/SC relay/deadline and installed Python tests
+  cover this partial migration, not full-profile conformance or #513 closure.
+  See [native hub configuration and limits](docs/rust-api.md#bacnetsc-hub).
+
 - **CLI SC trust compatibility change:** `bacnet --sc` client invocations now
   require `--sc-ca <FILE>` with explicit usable site CA PEM certificate(s), in
   addition to the existing operational cert/key and SC identity arguments.
@@ -16,7 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   insecure fallback. Local file/configuration failures, including mismatched
   cert/key, fail before dial. Help/version, non-SC transports and capture paths
   without a client stay independent of SC files. TLS 1.3-only remains; public Rust
-  TLS configuration APIs are unchanged and #513 remains partial. See the
+  caller-managed TLS configuration APIs remain compatible (the opt-in hub path
+  above is additive), and #513 remains partial. See the
   [CLI migration and test scope](docs/CLI.md#transport-variants).
 
 - **Python SC node compatibility change:** `BACnetClient` and `BACnetServer`

--- a/crates/bacnet-transport/src/sc_hub.rs
+++ b/crates/bacnet-transport/src/sc_hub.rs
@@ -35,8 +35,10 @@ mod relay_send;
 mod retirement;
 mod tasks;
 mod timeouts;
+mod tls_config;
 
 pub use timeouts::ScHubHandshakeTimeouts;
+pub use tls_config::ScHubTlsConfig;
 
 use client::HubClient;
 use helpers::*;
@@ -108,11 +110,39 @@ pub struct ScHub {
 }
 
 impl ScHub {
+    /// Start with opt-in validated TLS policy, a caller-specified Device UUID,
+    /// and independent validated handshake budgets.
+    ///
+    /// [`ScHubTlsConfig::from_der`] performs credential/configuration validation
+    /// without I/O before this method can bind. This delegates to the same hub
+    /// lifecycle as the caller-managed raw startup methods. Use [`Self::stop`]
+    /// to await worker cleanup. See [`ScHubTlsConfig`] for an executable example.
+    pub async fn start_with_tls_config(
+        bind_addr: &str,
+        tls_config: ScHubTlsConfig,
+        hub_vmac: Vmac,
+        hub_uuid: DeviceUuid,
+        timeouts: ScHubHandshakeTimeouts,
+    ) -> Result<Self, bacnet_types::error::Error> {
+        Self::start_with_uuid_and_timeouts(
+            bind_addr,
+            tls_config.into_acceptor(),
+            hub_vmac,
+            hub_uuid,
+            timeouts,
+        )
+        .await
+    }
+
     /// Start the hub, binding to `bind_addr` (e.g. `"127.0.0.1:0"` for a
     /// random port).
     ///
     /// The hub begins accepting TLS WebSocket connections immediately on a
     /// background task.
+    ///
+    /// TLS policy is entirely caller-managed: this does not validate the raw
+    /// acceptor's trust, client authentication, or protocol versions. Opt into
+    /// [`Self::start_with_tls_config`] for constrained policy.
     pub async fn start(
         bind_addr: &str,
         tls_acceptor: TlsAcceptor,
@@ -122,6 +152,7 @@ impl ScHub {
     }
 
     /// Start the hub with a specific Device UUID.
+    /// TLS policy remains caller-managed, as in [`Self::start`].
     pub async fn start_with_uuid(
         bind_addr: &str,
         tls_acceptor: TlsAcceptor,
@@ -140,6 +171,8 @@ impl ScHub {
 
     /// Start with a Device UUID and validated independent handshake budgets.
     /// Established connections are not governed by these budgets.
+    /// TLS policy remains caller-managed, as in [`Self::start`]; validated
+    /// timeouts do not validate the supplied TLS acceptor.
     ///
     /// ```no_run
     /// # async fn example(acceptor: tokio_rustls::TlsAcceptor) -> Result<(), bacnet_types::error::Error> {

--- a/crates/bacnet-transport/src/sc_hub/tls_config.rs
+++ b/crates/bacnet-transport/src/sc_hub/tls_config.rs
@@ -1,0 +1,148 @@
+//! Opt-in, immutable TLS policy for native hubs.
+
+use std::{fmt, sync::Arc};
+
+use bacnet_types::error::Error;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio_rustls::TlsAcceptor;
+
+/// Validated hub credentials with explicit trust, mandatory client authentication,
+/// and TLS 1.3-only local policy. Available with the `sc-tls` feature.
+///
+/// Construct from already loaded, owned DER; no filesystem or network I/O occurs.
+/// Only the supplied CA certificates become rustls trust anchors. The constructor
+/// checks certificate syntax and the hub's matching certificate/key, not local
+/// certificate dates, issuer relationships, revocation, or BACnet identity policy.
+/// Peers verify operational certificates during TLS. This is not certification
+/// of the complete Annex AB security profile (which requires TLS 1.3 *support*).
+///
+/// Clones share the same constrained configuration. There is no raw configuration
+/// getter, mutable access, or unchecked conversion from caller-managed TLS.
+/// Existing raw [`super::ScHub::start`] APIs remain independent and unchanged.
+///
+/// An executable, in-memory example (applications normally load site credentials):
+///
+/// ```
+/// use bacnet_transport::sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig};
+/// use rcgen::{CertificateParams, Issuer, KeyPair};
+/// use rustls::pki_types::PrivatePkcs8KeyDer;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut ca_params = CertificateParams::new(Vec::<String>::new())?;
+/// ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+/// let ca_key = KeyPair::generate()?;
+/// let ca = ca_params.self_signed(&ca_key)?;
+/// let issuer = Issuer::from_params(&ca_params, &ca_key);
+/// let key = KeyPair::generate()?;
+/// let cert = CertificateParams::new(vec!["localhost".into()])?.signed_by(&key, &issuer)?;
+/// let tls = ScHubTlsConfig::from_der(
+///     vec![ca.der().clone()], vec![cert.der().clone()],
+///     PrivatePkcs8KeyDer::from(key.serialize_der()).into(),
+/// )?;
+/// tokio::runtime::Builder::new_current_thread().enable_all().build()?.block_on(async {
+///     let mut hub = ScHub::start_with_tls_config(
+///         "127.0.0.1:0", tls, [0x12; 6], [0x34; 16], ScHubHandshakeTimeouts::default(),
+///     ).await?;
+///     assert!(hub.local_addr().is_some());
+///     hub.stop().await;
+///     Ok::<_, bacnet_types::error::Error>(())
+/// })?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Raw acceptors cannot be converted into this type:
+///
+/// ```compile_fail,E0277
+/// use bacnet_transport::sc_hub::ScHubTlsConfig;
+/// fn convert(acceptor: tokio_rustls::TlsAcceptor) -> ScHubTlsConfig {
+///     acceptor.into()
+/// }
+/// ```
+///
+/// Neither can an arbitrary rustls configuration:
+///
+/// ```compile_fail,E0277
+/// use bacnet_transport::sc_hub::ScHubTlsConfig;
+/// fn convert(config: rustls::ServerConfig) -> ScHubTlsConfig {
+///     config.into()
+/// }
+/// ```
+///
+/// The inner policy cannot be constructed or extracted by a caller:
+///
+/// ```compile_fail,E0451
+/// use bacnet_transport::sc_hub::ScHubTlsConfig;
+/// fn bypass(inner: std::sync::Arc<rustls::ServerConfig>) -> ScHubTlsConfig {
+///     ScHubTlsConfig { inner }
+/// }
+/// ```
+///
+/// ```compile_fail,E0616
+/// use bacnet_transport::sc_hub::ScHubTlsConfig;
+/// fn extract(config: ScHubTlsConfig) -> std::sync::Arc<rustls::ServerConfig> {
+///     config.inner
+/// }
+/// ```
+#[derive(Clone)]
+pub struct ScHubTlsConfig {
+    inner: Arc<rustls::ServerConfig>,
+}
+
+impl ScHubTlsConfig {
+    /// Build the constrained policy before a hub can bind.
+    ///
+    /// `ca_certs` must be nonempty and every entry must be a usable rustls trust
+    /// anchor. `cert_chain` must be nonempty, leaf first, with well-formed DER and
+    /// a matching usable `key`. Errors retain configuration-stage context in
+    /// [`Error::Encoding`]. No ambient/system trust is loaded.
+    pub fn from_der(
+        ca_certs: Vec<CertificateDer<'static>>,
+        cert_chain: Vec<CertificateDer<'static>>,
+        key: PrivateKeyDer<'static>,
+    ) -> Result<Self, Error> {
+        if cert_chain.is_empty() {
+            return Err(Error::Encoding("no server certificates found".into()));
+        }
+        if ca_certs.is_empty() {
+            return Err(Error::Encoding("no CA certificates found".into()));
+        }
+        let mut roots = rustls::RootCertStore::empty();
+        for cert in ca_certs {
+            roots
+                .add(cert)
+                .map_err(|e| Error::Encoding(format!("failed to add CA cert: {e}")))?;
+        }
+        for cert in &cert_chain {
+            rustls::server::ParsedCertificate::try_from(cert)
+                .map_err(|e| Error::Encoding(format!("TLS server config error: {e}")))?;
+        }
+        // Fix the existing aws-lc provider rather than accepting a process-wide
+        // custom key provider that might not establish certificate/key matching.
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        let verifier = rustls::server::WebPkiClientVerifier::builder_with_provider(
+            Arc::new(roots),
+            provider.clone(),
+        )
+        .build()
+        .map_err(|e| Error::Encoding(format!("failed to build client verifier: {e}")))?;
+        let config = rustls::ServerConfig::builder_with_provider(provider)
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .map_err(|e| Error::Encoding(format!("TLS server config error: {e}")))?
+            .with_client_cert_verifier(verifier)
+            .with_single_cert(cert_chain, key)
+            .map_err(|e| Error::Encoding(format!("TLS server config error: {e}")))?;
+        Ok(Self {
+            inner: Arc::new(config),
+        })
+    }
+
+    pub(super) fn into_acceptor(self) -> TlsAcceptor {
+        TlsAcceptor::from(self.inner)
+    }
+}
+
+impl fmt::Debug for ScHubTlsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScHubTlsConfig").finish_non_exhaustive()
+    }
+}

--- a/crates/bacnet-transport/tests/hub_tls_support/mod.rs
+++ b/crates/bacnet-transport/tests/hub_tls_support/mod.rs
@@ -1,0 +1,150 @@
+use std::{future::Future, net::SocketAddr, sync::Arc, time::Duration};
+
+use bacnet_transport::sc_hub::ScHub;
+use futures_util::{SinkExt, StreamExt};
+use rcgen::{CertificateParams, Issuer, KeyPair};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+use tokio_tungstenite::{tungstenite::Message, WebSocketStream};
+
+pub type Peer = WebSocketStream<tokio_rustls::client::TlsStream<TcpStream>>;
+pub const HUB_VMAC: [u8; 6] = [0x10; 6];
+pub const HUB_UUID: [u8; 16] = [0x10; 16];
+
+pub struct Identity {
+    pub cert: CertificateDer<'static>,
+    pub key: PrivateKeyDer<'static>,
+}
+
+pub struct Fixture {
+    pub ca: CertificateDer<'static>,
+    pub server: Identity,
+    pub good: Identity,
+    pub wrong: Identity,
+    pub expired: Identity,
+    pub future: Identity,
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        let mut params = CertificateParams::new(Vec::<String>::new()).unwrap();
+        params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let key = KeyPair::generate().unwrap();
+        let ca = params.self_signed(&key).unwrap().der().clone();
+        let issuer = Issuer::from_params(&params, &key);
+        let foreign_key = KeyPair::generate().unwrap();
+        let mut foreign_params = params.clone();
+        foreign_params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, "foreign CA");
+        let foreign = Issuer::from_params(&foreign_params, &foreign_key);
+        let leaf = |issuer: &Issuer<'_, &KeyPair>, dates: Option<(i32, i32)>| {
+            let mut params = CertificateParams::new(vec!["localhost".into()]).unwrap();
+            if let Some((start, end)) = dates {
+                params.not_before = rcgen::date_time_ymd(start, 1, 1);
+                params.not_after = rcgen::date_time_ymd(end, 1, 1);
+            }
+            let key = KeyPair::generate().unwrap();
+            Identity {
+                cert: params.signed_by(&key, issuer).unwrap().der().clone(),
+                key: PrivatePkcs8KeyDer::from(key.serialize_der()).into(),
+            }
+        };
+        Self {
+            ca,
+            server: leaf(&issuer, None),
+            good: leaf(&issuer, None),
+            wrong: leaf(&foreign, None),
+            expired: leaf(&issuer, Some((2000, 2001))),
+            future: leaf(&issuer, Some((2099, 2100))),
+        }
+    }
+
+    pub fn client(
+        &self,
+        identity: Option<&Identity>,
+        version: &'static rustls::SupportedProtocolVersion,
+    ) -> Arc<rustls::ClientConfig> {
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(self.ca.clone()).unwrap();
+        let builder = rustls::ClientConfig::builder_with_protocol_versions(&[version])
+            .with_root_certificates(roots);
+        Arc::new(match identity {
+            Some(id) => builder
+                .with_client_auth_cert(vec![id.cert.clone()], id.key.clone_key())
+                .unwrap(),
+            None => builder.with_no_client_auth(),
+        })
+    }
+}
+
+pub async fn bounded<T>(future: impl Future<Output = T>) -> T {
+    tokio::time::timeout(Duration::from_secs(3), future)
+        .await
+        .expect("owned loopback operation exceeded 3 seconds")
+}
+
+pub async fn websocket(address: SocketAddr, config: Arc<rustls::ClientConfig>) -> Peer {
+    let tcp = bounded(TcpStream::connect(address)).await.unwrap();
+    let tls = bounded(
+        TlsConnector::from(config).connect(ServerName::try_from("localhost").unwrap(), tcp),
+    )
+    .await
+    .unwrap();
+    let request = tokio_tungstenite::tungstenite::client::ClientRequestBuilder::new(
+        format!("wss://localhost:{}", address.port())
+            .parse()
+            .unwrap(),
+    )
+    .with_sub_protocol("hub.bsc.bacnet.org");
+    bounded(tokio_tungstenite::client_async(request, tls))
+        .await
+        .unwrap()
+        .0
+}
+
+pub async fn connect(peer: &mut Peer, id: u8, uuid: [u8; 16]) {
+    // Independent AB.2.10/11 wire vector: fixed 26-byte Connect payload.
+    let mut request = vec![6, 0, 0x22, id];
+    request.extend_from_slice(&[id; 6]);
+    request.extend_from_slice(&[id; 16]);
+    request.extend_from_slice(&[0x05, 0xc4, 0x05, 0xc4]);
+    bounded(peer.send(Message::Binary(request.into())))
+        .await
+        .unwrap();
+    let Message::Binary(accepted) = bounded(peer.next()).await.unwrap().unwrap() else {
+        panic!("expected SC Connect-Accept");
+    };
+    assert_eq!(&accepted[..4], &[7, 0, 0x22, id]);
+    assert_eq!(&accepted[4..10], &HUB_VMAC);
+    assert_eq!(&accepted[10..26], &uuid);
+    assert_eq!(accepted.len(), 30);
+}
+
+pub async fn relay(sender: &mut Peer, recipient: &mut Peer, id: u8) {
+    // Unicast NPDU: the hub replaces destination VMAC with originating VMAC.
+    let mut sent = vec![1, 4, 0x33, id];
+    sent.extend_from_slice(&[2; 6]);
+    sent.extend_from_slice(&[1, 0, 0x10, 8]);
+    bounded(sender.send(Message::Binary(sent.into())))
+        .await
+        .unwrap();
+    let received = bounded(recipient.next()).await.unwrap().unwrap();
+    let mut expected = vec![1, 8, 0x33, id];
+    expected.extend_from_slice(&[1; 6]);
+    expected.extend_from_slice(&[1, 0, 0x10, 8]);
+    assert_eq!(received, Message::Binary(expected.into()));
+}
+
+// The body is caught by each caller so explicit stop/join also runs on assertion
+// failure; Drop is only the last-resort fallback for a broken cleanup itself.
+pub async fn finish(mut hub: ScHub, outcome: std::thread::Result<()>) {
+    let address = hub.local_addr().unwrap();
+    bounded(hub.stop()).await;
+    let listener = tokio::net::TcpListener::bind(address).await.unwrap();
+    drop(listener);
+    if let Err(panic) = outcome {
+        std::panic::resume_unwind(panic);
+    }
+}

--- a/crates/bacnet-transport/tests/sc_hub_tls.rs
+++ b/crates/bacnet-transport/tests/sc_hub_tls.rs
@@ -1,0 +1,255 @@
+//! External-consumer acceptance and raw-API compatibility for hub TLS policy.
+#![cfg(feature = "sc-tls")]
+
+mod hub_tls_support;
+
+use std::{panic::AssertUnwindSafe, sync::Arc, time::Duration};
+
+use bacnet_transport::sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig};
+use futures_util::{FutureExt, StreamExt};
+use hub_tls_support::*;
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer, ServerName};
+use tokio::{io::AsyncReadExt, net::TcpStream};
+use tokio_rustls::{TlsAcceptor, TlsConnector};
+use tokio_tungstenite::tungstenite::Message;
+
+#[test]
+fn typed_config_rejects_empty_ca_before_startup() {
+    let fixture = Fixture::new();
+    let error = ScHubTlsConfig::from_der(vec![], vec![fixture.server.cert], fixture.server.key)
+        .unwrap_err();
+    assert!(
+        matches!(error, bacnet_types::error::Error::Encoding(ref message) if message == "no CA certificates found")
+    );
+}
+
+#[test]
+fn typed_config_validates_all_der_and_key_inputs() {
+    let f = Fixture::new();
+    let bad = CertificateDer::from(vec![1, 2, 3]);
+    let cases = [
+        (
+            vec![f.ca.clone()],
+            vec![],
+            f.server.key.clone_key(),
+            "no server certificates found",
+        ),
+        (
+            vec![bad.clone()],
+            vec![f.server.cert.clone()],
+            f.server.key.clone_key(),
+            "failed to add CA cert:",
+        ),
+        (
+            vec![f.ca.clone(), bad.clone()],
+            vec![f.server.cert.clone()],
+            f.server.key.clone_key(),
+            "failed to add CA cert:",
+        ),
+        (
+            vec![bad.clone(), f.ca.clone()],
+            vec![f.server.cert.clone()],
+            f.server.key.clone_key(),
+            "failed to add CA cert:",
+        ),
+        (
+            vec![f.ca.clone()],
+            vec![bad.clone()],
+            f.server.key.clone_key(),
+            "TLS server config error:",
+        ),
+        (
+            vec![f.ca.clone()],
+            vec![f.server.cert.clone(), bad],
+            f.server.key.clone_key(),
+            "TLS server config error:",
+        ),
+        (
+            vec![f.ca.clone()],
+            vec![f.server.cert.clone()],
+            PrivatePkcs8KeyDer::from(vec![1, 2, 3]).into(),
+            "TLS server config error:",
+        ),
+        (
+            vec![f.ca.clone()],
+            vec![f.server.cert.clone()],
+            f.good.key.clone_key(),
+            "TLS server config error:",
+        ),
+    ];
+    for (ca, chain, key, expected) in cases {
+        let error = ScHubTlsConfig::from_der(ca, chain, key).unwrap_err();
+        assert!(
+            matches!(error, bacnet_types::error::Error::Encoding(ref message) if message.starts_with(expected)),
+            "{error}"
+        );
+    }
+    let config = typed_config(&f);
+    assert_eq!(format!("{config:?}"), "ScHubTlsConfig { .. }");
+    assert_eq!(format!("{:?}", config.clone()), "ScHubTlsConfig { .. }");
+    // Preflight is not local issuer/date certification: the remote peer decides.
+    for id in [&f.wrong, &f.expired, &f.future] {
+        ScHubTlsConfig::from_der(
+            vec![f.ca.clone()],
+            vec![id.cert.clone()],
+            id.key.clone_key(),
+        )
+        .unwrap();
+    }
+}
+
+fn typed_config(f: &Fixture) -> ScHubTlsConfig {
+    ScHubTlsConfig::from_der(
+        vec![f.ca.clone()],
+        vec![f.server.cert.clone(), f.ca.clone()],
+        f.server.key.clone_key(),
+    )
+    .unwrap()
+}
+
+async fn typed_hub(f: &Fixture, timeouts: ScHubHandshakeTimeouts) -> ScHub {
+    bounded(ScHub::start_with_tls_config(
+        "127.0.0.1:0",
+        typed_config(f).clone(),
+        HUB_VMAC,
+        HUB_UUID,
+        timeouts,
+    ))
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn typed_hub_mutual_tls13_connect_relay_and_peer_denials() {
+    let f = Fixture::new();
+    let hub = typed_hub(&f, ScHubHandshakeTimeouts::default()).await;
+    let outcome = AssertUnwindSafe(async {
+        let address = hub.local_addr().unwrap();
+        let mut sender = websocket(address, f.client(Some(&f.good), &rustls::version::TLS13)).await;
+        let mut recipient = websocket(address, f.client(Some(&f.good), &rustls::version::TLS13)).await;
+        assert_eq!(sender.get_ref().get_ref().1.protocol_version(), Some(rustls::ProtocolVersion::TLSv1_3));
+        connect(&mut sender, 1, HUB_UUID).await;
+        connect(&mut recipient, 2, HUB_UUID).await;
+        relay(&mut sender, &mut recipient, 0).await;
+        let cases = [
+            (None, &rustls::version::TLS13, rustls::AlertDescription::CertificateRequired),
+            (Some(&f.wrong), &rustls::version::TLS13, rustls::AlertDescription::UnknownCA),
+            (Some(&f.expired), &rustls::version::TLS13, rustls::AlertDescription::CertificateExpired),
+            (Some(&f.future), &rustls::version::TLS13, rustls::AlertDescription::CertificateExpired),
+            (Some(&f.good), &rustls::version::TLS12, rustls::AlertDescription::ProtocolVersion),
+        ];
+        for (i, (id, version, alert)) in cases.into_iter().enumerate() {
+            let tcp = bounded(TcpStream::connect(address)).await.unwrap();
+            let connector = TlsConnector::from(f.client(id, version));
+            let result = bounded(connector.connect(ServerName::try_from("localhost").unwrap(), tcp)).await;
+            // TLS 1.3 client completion may precede the server's client-cert
+            // rejection. Read the actual alert, never accept timeout/EOF as proof.
+            let error = match result {
+                Err(error) => error,
+                Ok(mut tls) => bounded(tls.read(&mut [0; 1])).await.unwrap_err(),
+            };
+            assert!(matches!(error.get_ref().and_then(|e| e.downcast_ref::<rustls::Error>()), Some(rustls::Error::AlertReceived(actual)) if *actual == alert), "expected {alert:?}, got {error:?}");
+            relay(&mut sender, &mut recipient, i as u8 + 1).await;
+        }
+    }).catch_unwind().await;
+    finish(hub, outcome).await;
+}
+
+#[tokio::test]
+async fn typed_hub_honors_each_timeout_and_preserves_established_peers() {
+    let f = Fixture::new();
+    let budgets = ScHubHandshakeTimeouts::new(
+        Duration::from_millis(400),
+        Duration::from_millis(500),
+        Duration::from_secs(5),
+    )
+    .unwrap();
+    let hub = typed_hub(&f, budgets).await;
+    let outcome = AssertUnwindSafe(async {
+        let address = hub.local_addr().unwrap();
+        let mut sender = websocket(address, f.client(Some(&f.good), &rustls::version::TLS13)).await;
+        let mut recipient =
+            websocket(address, f.client(Some(&f.good), &rustls::version::TLS13)).await;
+        connect(&mut sender, 1, HUB_UUID).await;
+        connect(&mut recipient, 2, HUB_UUID).await;
+        let mut silent = bounded(TcpStream::connect(address)).await.unwrap();
+        // These are deadline oracles, not TLS authentication oracles. The 3s
+        // bound distinguishes our short budgets from the 10s defaults.
+        assert!(matches!(
+            bounded(silent.read(&mut [0; 1])).await,
+            Ok(0) | Err(_)
+        ));
+        let tcp = bounded(TcpStream::connect(address)).await.unwrap();
+        let mut tls = bounded(
+            TlsConnector::from(f.client(Some(&f.good), &rustls::version::TLS13))
+                .connect(ServerName::try_from("localhost").unwrap(), tcp),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(
+            bounded(tls.read(&mut [0; 1])).await,
+            Ok(0) | Err(_)
+        ));
+        let mut idle = websocket(address, f.client(Some(&f.good), &rustls::version::TLS13)).await;
+        let closed = tokio::time::timeout(Duration::from_secs(6), idle.next())
+            .await
+            .unwrap();
+        assert!(matches!(closed, Some(Ok(Message::Close(_)))), "{closed:?}");
+        relay(&mut sender, &mut recipient, 1).await;
+    })
+    .catch_unwind()
+    .await;
+    finish(hub, outcome).await;
+}
+
+#[tokio::test]
+async fn raw_hub_start_apis_preserve_caller_managed_tls() {
+    let fixture = Fixture::new();
+    // Deliberately TLS 1.2 and no client auth: raw APIs remain caller-managed.
+    let config = rustls::ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS12])
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![fixture.server.cert.clone()],
+            fixture.server.key.clone_key(),
+        )
+        .unwrap();
+    let acceptor = TlsAcceptor::from(Arc::new(config));
+    for api in 0..3 {
+        let hub = bounded(async {
+            match api {
+                0 => ScHub::start("127.0.0.1:0", acceptor.clone(), HUB_VMAC).await,
+                1 => {
+                    ScHub::start_with_uuid("127.0.0.1:0", acceptor.clone(), HUB_VMAC, HUB_UUID)
+                        .await
+                }
+                _ => {
+                    ScHub::start_with_uuid_and_timeouts(
+                        "127.0.0.1:0",
+                        acceptor.clone(),
+                        HUB_VMAC,
+                        HUB_UUID,
+                        ScHubHandshakeTimeouts::default(),
+                    )
+                    .await
+                }
+            }
+        })
+        .await
+        .unwrap();
+        let outcome = AssertUnwindSafe(async {
+            let mut peer = websocket(
+                hub.local_addr().unwrap(),
+                fixture.client(None, &rustls::version::TLS12),
+            )
+            .await;
+            assert_eq!(
+                peer.get_ref().get_ref().1.protocol_version(),
+                Some(rustls::ProtocolVersion::TLSv1_2)
+            );
+            connect(&mut peer, 1, if api == 0 { [0; 16] } else { HUB_UUID }).await;
+        })
+        .catch_unwind()
+        .await;
+        finish(hub, outcome).await;
+    }
+}

--- a/crates/rusty-bacnet/src/hub.rs
+++ b/crates/rusty-bacnet/src/hub.rs
@@ -9,9 +9,8 @@ use std::sync::Arc;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use tokio::sync::Mutex;
-use tokio_rustls::TlsAcceptor;
 
-use bacnet_transport::sc_hub::ScHub;
+use bacnet_transport::sc_hub::{ScHub, ScHubHandshakeTimeouts};
 
 use crate::errors::to_py_err;
 
@@ -97,11 +96,15 @@ impl PyScHub {
             let server_tls =
                 crate::tls::build_server_tls_config(&cert, &key, &ca_cert).map_err(to_py_err)?;
 
-            let acceptor = TlsAcceptor::from(server_tls);
-
-            let hub = ScHub::start(&listen, acceptor, vmac)
-                .await
-                .map_err(to_py_err)?;
+            let hub = ScHub::start_with_tls_config(
+                &listen,
+                server_tls,
+                vmac,
+                [0; 16],
+                ScHubHandshakeTimeouts::default(),
+            )
+            .await
+            .map_err(to_py_err)?;
 
             let addr = hub
                 .local_addr()

--- a/crates/rusty-bacnet/src/tls.rs
+++ b/crates/rusty-bacnet/src/tls.rs
@@ -1,18 +1,17 @@
 //! TLS configuration helpers for Python bindings.
 
+use bacnet_transport::sc_hub::ScHubTlsConfig;
 use bacnet_types::error::Error;
 use std::sync::Arc;
 use tokio_rustls::rustls::pki_types::pem::PemObject;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 
-/// Build a TLS 1.3 server config requiring client certificates (for Python ScHub).
+/// Load Python hub credentials, then build the constrained native TLS policy.
 pub fn build_server_tls_config(
     cert_path: &str,
     key_path: &str,
     ca_cert_path: &str,
-) -> Result<Arc<tokio_rustls::rustls::ServerConfig>, Error> {
-    use tokio_rustls::rustls;
-
+) -> Result<ScHubTlsConfig, Error> {
     let cert_data = std::fs::read(cert_path)
         .map_err(|e| Error::Encoding(format!("failed to read server cert: {e}")))?;
     let key_data = std::fs::read(key_path)
@@ -32,27 +31,7 @@ pub fn build_server_tls_config(
     let ca_certs: Vec<CertificateDer<'static>> = CertificateDer::pem_slice_iter(&ca_data)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| Error::Encoding(format!("failed to parse CA cert: {e}")))?;
-    if ca_certs.is_empty() {
-        return Err(Error::Encoding("no CA certificates found".into()));
-    }
-
-    let mut root_store = rustls::RootCertStore::empty();
-    for cert in ca_certs {
-        root_store
-            .add(cert)
-            .map_err(|e| Error::Encoding(format!("failed to add CA cert: {e}")))?;
-    }
-
-    let client_verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(root_store))
-        .build()
-        .map_err(|e| Error::Encoding(format!("failed to build client verifier: {e}")))?;
-
-    let config = rustls::ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-        .with_client_cert_verifier(client_verifier)
-        .with_single_cert(certs, key)
-        .map_err(|e| Error::Encoding(format!("TLS server config error: {e}")))?;
-
-    Ok(Arc::new(config))
+    ScHubTlsConfig::from_der(ca_certs, certs, key)
 }
 
 /// Require explicit SC credential paths without performing file I/O.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1558,8 +1558,16 @@ unreadable, empty, or malformed credentials and mismatched server keys raise
 Missing, untrusted, expired, or not-yet-valid peer certificates are rejected.
 This addresses the Python hub admission boundary of Annex AB.7.4, not full
 security-profile conformance. CA membership does not authorize BACnet operations
-or bind a certificate to a claimed VMAC/Device UUID. Rust `ScHub` still accepts a
-caller-configured `TlsAcceptor`; caller-owned Rust TLS configurations remain
+or bind a certificate to a claimed VMAC/Device UUID. Python startup loads/parses
+files and delegates policy construction to native `ScHubTlsConfig::from_der`, then
+uses `ScHub::start_with_tls_config` with the existing zero UUID and default phase
+timeouts. This is an internal integration, not a new Python signature or another
+certificate-less-access fix; required CA, error categories, file repair/retry and
+async lifecycle remain unchanged. Native construction does not itself load files
+or certify local certificate dates/issuer relationships.
+
+Rust also retains its caller-managed raw `TlsAcceptor` startup APIs alongside the
+[opt-in constrained path](rust-api.md#bacnetsc-hub). Arbitrary raw policy remains
 outside this Python boundary, so #513 remains partial. Python nodes require the
 explicit credentials described [below](#bacnetsc-secure-connect).
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -315,14 +315,52 @@ Production BACnet/SC transports validate heartbeat settings at `start()`: the in
 ### BACnet/SC Hub
 
 ```rust
-use bacnet_transport::sc_hub::ScHub;
+use bacnet_transport::sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig};
 
-let hub = ScHub::new(listen_addr, tls_acceptor, hub_vmac);
-let addr = hub.start().await?;  // Returns SocketAddr
-// hub.stop().await;
+// Owned, already loaded DER: Vec<CertificateDer<'static>> for both lists,
+// and PrivateKeyDer<'static> for hub_key. File loading belongs to the caller.
+let tls = ScHubTlsConfig::from_der(ca_certs, hub_cert_chain, hub_key)?;
+let mut hub = ScHub::start_with_tls_config(
+    listen_addr, tls, hub_vmac, hub_uuid, ScHubHandshakeTimeouts::default(),
+).await?;
+let addr = hub.local_addr().expect("started hub has a bound address");
+// ... use the hub ...
+hub.stop().await;
 ```
 
 The SC hub is a TLS WebSocket relay. Both clients and servers connect to it as spoke nodes. Messages are routed by VMAC address.
+
+With `sc-tls`, `ScHubTlsConfig` is an **opt-in** constrained native configuration:
+explicit nonempty CA trust anchors, mandatory WebPKI client verification, and
+TLS 1.3-only local policy. Its fallible `from_der` constructor performs no file or
+network I/O. Empty CA/chain, malformed DER (including a bad entry in an otherwise
+valid list), unusable keys, and certificate/key mismatch return `Error::Encoding`
+before startup can bind. The hub chain is leaf first. Configuration is private;
+clones share the same policy, with no mutable/raw accessor or unchecked conversion.
+The constructor uses the built-in aws-lc provider, not a caller-installed provider.
+
+`start_with_tls_config` preserves the supplied Device UUID and validated
+`ScHubHandshakeTimeouts`, using the existing hub lifecycle. Existing
+`start`, `start_with_uuid`, and `start_with_uuid_and_timeouts` still accept raw
+`TlsAcceptor` values without additional validation or deprecation. Their policy
+is **caller-managed**: the typed path makes no guarantee about arbitrary raw
+configurations. Existing node `ClientConfig`/`TlsWebSocket`, CLI and Docker modes
+are unchanged. Python hub startup now uses the typed path internally.
+
+Local configuration checks do not certify certificate dates or issuer
+relationships: peers verify certificates at handshake time using rustls trust
+anchors. Base Standard 135-2020 AB.7.4/AB.7.4.1.1 provides the mutual operational
+authentication and installation-credential context; TLS 1.3-*only* is local policy,
+not the Standard's TLS 1.3-*support* requirement. This does not add direct-issuer,
+revocation, SAN or certificate-to-VMAC/UUID policy, or close the full security
+profile gap (#513 remains partial).
+
+Evidence includes executable/compile-fail rustdoc, native preflight rejection,
+TLS 1.3 mutual authentication with Connect-Accept and relay barriers after missing,
+wrong-issuer, expired, not-yet-valid client and TLS 1.2 denials, custom phase
+deadlines, and explicit stop. A raw TLS 1.2/server-auth-only characterization test
+deliberately remains valid. Installed Python tests separately exercise OpenSSL
+peers and ReadProperty; these are not hardware or full-profile certification.
 
 ### MS/TP (Serial RS-485)
 
@@ -1217,21 +1255,29 @@ let client = BACnetClient::generic_builder().transport(transport).build().await?
 ### BACnet/SC with Hub
 
 ```rust
-use bacnet_transport::sc::ScTransport;
-use bacnet_transport::sc_hub::ScHub;
-use bacnet_transport::sc_tls::{TlsWebSocket, build_tls_config};
+use bacnet_client::client::BACnetClient;
+use bacnet_transport::sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig};
 
-// Start hub
-let hub = ScHub::new(listen_addr, tls_acceptor, [0xFF, 0, 0, 0, 0, 1]);
-let hub_addr = hub.start().await?;
+// Start the hub with already loaded site CA, hub chain, and matching key DER.
+let hub_tls = ScHubTlsConfig::from_der(ca_certs, hub_cert_chain, hub_key)?;
+let mut hub = ScHub::start_with_tls_config(
+    listen_addr, hub_tls, [0xFF, 0, 0, 0, 0, 1], hub_uuid,
+    ScHubHandshakeTimeouts::default(),
+).await?;
+let hub_addr = hub.local_addr().expect("started hub has a bound address");
 
-// Connect client to hub
-let client = BACnetClient::sc_builder()
+// The caller-managed client config must trust the hub and supply a client cert/key.
+// Use a persistent nonzero client_uuid, distinct from hub_uuid and every other peer.
+let mut client = BACnetClient::sc_builder()
     .hub_url(&format!("wss://127.0.0.1:{}", hub_addr.port()))
     .tls_config(tls_config)
     .vmac([0, 1, 2, 3, 4, 5])
+    .device_uuid(client_uuid)
     .build()
     .await?;
+// ... use the client ...
+client.stop().await?;
+hub.stop().await;
 ```
 
 ### MS/TP with USB Adapter


### PR DESCRIPTION
## Summary
- Add opaque ScHubTlsConfig::from_der from explicitly supplied, already loaded CA certificates, hub chain and matching key. No file/network I/O; explicit trust, mandatory client verification and TLS 1.3-only policy.
- Add one full-control ScHub::start_with_tls_config entry point retaining UUID and validated handshake timeouts, delegated to the existing lifecycle.
- Integrate Python ScHub internally without changing its signature, error categories or file-loading boundary.
- Preserve all raw TlsAcceptor startup APIs unchanged and without deprecation. This is owner-approved additive/opt-in work, not enforcement over every native hub.

Refs #513 — remains OPEN/Partial.

## Contract and compatibility
The typed policy has private immutable state, no raw/mutable accessor or unchecked conversion, and redacted Debug. It fixes the built-in aws-lc provider so caller-installed custom key providers cannot weaken the matching-key invariant. Raw APIs remain available for caller-managed customization.

Empty or malformed CA/chain DER, unusable keys and mismatches fail before bind. Local preflight is not certificate-date/issuer or full-profile certification; peer authentication remains a real handshake check. TLS 1.3-only is local policy, distinct from base2020 TLS 1.3 support requirements.

Existing Docker, CLI, node TLS APIs and UUID behavior are unchanged. No dependencies, CI, README/PICS/support claims or releases changed. Touched Rust hub examples now use actual startup APIs and required nonzero client UUID.

## Verification
- Five native acceptance/compatibility tests passed ten final-source runs: DER rejection, TLS1.3/SC Connect-Accept and exact relay barriers after certificate/TLS1.2 denials, supplied UUID/deadlines, explicit stop, and deliberately permissive raw-API characterization.
- Four compile-fail consumer examples plus an executable typed startup example passed. Existing raw example and ignored docs retained.
- Transport SC: 569 unit + 7 integration + 6 doctests passed; 2 existing ignored docs. CLI SC: 108 passed.
- Default workspace: 4,405 passed; portable SC/IPv6/serde including explicit CLI SC: 4,427 passed. Each retains 3 existing ignored.
- Fresh installed native CPython3.12.13/macOSarm64 DEV wheel: 73 tests / 1,132 subtests passed; root independently reran the same suite in 2.25s. Ten focused hub/node runs each passed 11 tests / 219 subtests. Exact installed stub, native origin and wheel parity verified.
- Python benchmark TLS preflight only: 1 passed, 10 deselected, 3 existing warnings; no performance/topology/Python>=3.13-floor qualification.
- Fmt, workspace/transport-SC Clippy, explicit-interpreter binding check/Clippy, size/secrets/diff gates pass. Root repeated size/secrets after staging all new files.
- New-API compile failure is not represented as behavioral RED. Prior Python hub was already authenticated; this is policy consolidation, not another Python bypass fix.

Exact-head lean CI and three independent reviews remain required before merge. No hardware/external-device/full-security-profile/release qualification claimed.

## Preserved evidence
Receipt SHA256: dedf0442228570aa707189a79f213a15911de82ae191620d351ddbc629357070.
Source manifest SHA256: 50790f216762b8e56b187800fb219463bae458f92f6130655efe91e6fc1e02d8.
Fresh DEV wheel SHA256: b4c65b533cfead210f04da78550c2769690d1f913d04750af6df4a8877b243cd.
All exact commands, intermediate failures, logs and artifacts are preserved locally.