### PR TITLE
Adopt validated TLS in existing mTLS hub callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Route the already-mTLS benchmark hub launcher and CLI/server SC test fixtures
+  through `ScHubTlsConfig`, preserving identity, timeout and lifecycle behavior.
+  Add focused benchmark PEM-loader validation tests; independent raw TLS peer
+  helpers and production CLI/node/Docker modes remain unchanged. This is further
+  opt-in adoption, not raw-API retirement, performance qualification or #513 closure.
+
 - **Opt-in native hub TLS configuration:** `ScHubTlsConfig::from_der` validates
   explicitly supplied, already loaded CA/chain/key DER without I/O, builds
   mandatory client verification and TLS 1.3-only local policy, and exposes no raw

--- a/benchmarks/src/sc_helpers.rs
+++ b/benchmarks/src/sc_helpers.rs
@@ -10,8 +10,9 @@ use tokio_rustls::TlsAcceptor;
 
 use bacnet_transport::sc::ScTransport;
 use bacnet_transport::sc_frame::Vmac;
-use bacnet_transport::sc_hub::ScHub;
+use bacnet_transport::sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig};
 use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_types::error::Error;
 
 /// Generated certificate material for testing.
 pub struct CertMaterial {
@@ -209,15 +210,15 @@ pub fn make_client_tls12_config(certs: &CertMaterial) -> Arc<rustls::ClientConfi
     Arc::new(config)
 }
 
-/// Build a rustls ServerConfig that requires client certificates (mTLS).
+/// Build a raw rustls ServerConfig that requires client certificates (mTLS).
 ///
-/// Per ASHRAE 135-2020 Annex AB.3, the hub verifies client certificates
-/// against the trusted CA to enforce mutual TLS authentication.
+/// Retained for independent TLS peers and compatibility. Already-mTLS hubs use
+/// [`try_make_hub_tls_config`] instead; this raw helper's contract is unchanged.
 pub fn make_server_tls_config_mtls(certs: &CertMaterial) -> Arc<rustls::ServerConfig> {
     try_make_server_tls_config_mtls(certs).unwrap()
 }
 
-/// Try to build a rustls ServerConfig that requires client certificates (mTLS).
+/// Try to build a raw mTLS ServerConfig for independent TLS peers and compatibility.
 pub fn try_make_server_tls_config_mtls(
     certs: &CertMaterial,
 ) -> Result<Arc<rustls::ServerConfig>, String> {
@@ -255,6 +256,22 @@ pub fn try_make_server_tls_config_mtls(
         .map_err(|e| e.to_string())?;
 
     Ok(Arc::new(config))
+}
+
+/// Parse in-memory PEM into owned DER and build validated SC hub TLS policy.
+///
+/// Returns configuration errors without binding or performing file/network I/O.
+/// Unlike the raw peer helper, validates every certificate in the hub chain.
+pub fn try_make_hub_tls_config(certs: &CertMaterial) -> Result<ScHubTlsConfig, Error> {
+    let cert_chain = CertificateDer::pem_slice_iter(certs.server_cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| Error::Encoding(format!("failed to parse server certificates: {e}")))?;
+    let key = PrivateKeyDer::from_pem_slice(certs.server_key_pem.as_bytes())
+        .map_err(|e| Error::Encoding(format!("failed to parse server key: {e}")))?;
+    let ca_certs = CertificateDer::pem_slice_iter(certs.ca_cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| Error::Encoding(format!("failed to parse CA certificates: {e}")))?;
+    ScHubTlsConfig::from_der(ca_certs, cert_chain, key)
 }
 
 /// Build a rustls ClientConfig that presents a client certificate (mTLS).
@@ -340,11 +357,16 @@ pub async fn make_sc_transport(
 
 /// Start an SC hub with mTLS (client certificate required).
 pub async fn start_sc_hub_mtls(certs: &CertMaterial, hub_vmac: Vmac) -> (ScHub, String) {
-    let tls_config = make_server_tls_config_mtls(certs);
-    let acceptor = TlsAcceptor::from(tls_config);
-    let hub = ScHub::start("127.0.0.1:0", acceptor, hub_vmac)
-        .await
-        .unwrap();
+    let tls_config = try_make_hub_tls_config(certs).unwrap();
+    let hub = ScHub::start_with_tls_config(
+        "127.0.0.1:0",
+        tls_config,
+        hub_vmac,
+        [0; 16],
+        ScHubHandshakeTimeouts::default(),
+    )
+    .await
+    .unwrap();
     let addr = hub.local_addr().unwrap();
     let url = format!("wss://localhost:{}", addr.port());
     (hub, url)

--- a/benchmarks/tests/sc_mtls.rs
+++ b/benchmarks/tests/sc_mtls.rs
@@ -6,7 +6,9 @@ use std::time::Duration;
 use bacnet_benchmarks::sc_helpers::*;
 use bacnet_transport::port::TransportPort;
 use bacnet_transport::sc::{ScConnectionState, ScTransport};
+use bacnet_transport::sc_hub::ScHubTlsConfig;
 use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_types::error::Error;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::rustls;
 use tokio_rustls::rustls::pki_types::ServerName;
@@ -283,4 +285,120 @@ fn sc_tls_config_rejects_mismatched_cert_key_pairs() {
     let other = generate_test_certs();
     certs.client_key_pem = other.client_key_pem;
     assert!(try_make_client_tls_config_mtls(&certs).is_err());
+}
+
+// These are synchronous PEM/configuration tests: no runtime, socket or hub bind.
+// AQID is the deliberately invalid DER byte sequence [1, 2, 3], not a credential.
+const INVALID_CERT_DER_PEM: &str = "-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n";
+const MALFORMED_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----\n!\n-----END CERTIFICATE-----\n";
+
+fn assert_hub_config_error(certs: &CertMaterial, expected: &str) {
+    let error = try_make_hub_tls_config(certs).unwrap_err();
+    assert!(
+        matches!(&error, Error::Encoding(message) if message.starts_with(expected)),
+        "expected {expected:?}, got {error}"
+    );
+}
+
+#[test]
+fn sc_hub_pem_config_owns_credentials_and_preserves_raw_helper_types() {
+    let mut certs = generate_test_certs();
+    // Valid multi-certificate material must not be mistaken for malformed tails.
+    certs.server_cert_pem.push_str(&certs.ca_cert_pem);
+    certs
+        .ca_cert_pem
+        .push_str(&generate_test_certs().ca_cert_pem);
+    let config: Result<ScHubTlsConfig, Error> = try_make_hub_tls_config(&certs);
+    let config = config.unwrap();
+    // Independent TLS acceptors keep their existing, non-sealed return types.
+    let _: Arc<rustls::ServerConfig> = make_server_tls_config_mtls(&certs);
+    let raw: Result<Arc<rustls::ServerConfig>, String> = try_make_server_tls_config_mtls(&certs);
+    raw.unwrap();
+    drop(certs);
+    assert_eq!(format!("{config:?}"), "ScHubTlsConfig { .. }");
+}
+
+#[test]
+fn sc_hub_pem_config_rejects_empty_or_malformed_ca() {
+    let mut certs = generate_test_certs();
+    let valid = certs.ca_cert_pem.clone();
+    for invalid in ["", "not a CA certificate"] {
+        certs.ca_cert_pem = invalid.into();
+        assert_hub_config_error(&certs, "no CA certificates found");
+    }
+    for invalid in [
+        MALFORMED_CERT_PEM.to_owned(),
+        format!("{valid}{MALFORMED_CERT_PEM}"),
+        format!("{MALFORMED_CERT_PEM}{valid}"),
+    ] {
+        certs.ca_cert_pem = invalid;
+        assert_hub_config_error(&certs, "failed to parse CA certificates:");
+    }
+}
+
+#[test]
+fn sc_hub_pem_config_rejects_empty_or_malformed_server_chain() {
+    let mut certs = generate_test_certs();
+    let valid = certs.server_cert_pem.clone();
+    for invalid in ["", "not a server certificate"] {
+        certs.server_cert_pem = invalid.into();
+        assert_hub_config_error(&certs, "no server certificates found");
+    }
+    for invalid in [
+        MALFORMED_CERT_PEM.to_owned(),
+        format!("{valid}{MALFORMED_CERT_PEM}"),
+        format!("{MALFORMED_CERT_PEM}{valid}"),
+    ] {
+        certs.server_cert_pem = invalid;
+        assert_hub_config_error(&certs, "failed to parse server certificates:");
+    }
+}
+
+#[test]
+fn sc_hub_pem_config_rejects_empty_or_malformed_key() {
+    let mut certs = generate_test_certs();
+    for invalid in [
+        "",
+        "not a private key",
+        "-----BEGIN PRIVATE KEY-----\n!\n-----END PRIVATE KEY-----\n",
+    ] {
+        certs.server_key_pem = invalid.into();
+        assert_hub_config_error(&certs, "failed to parse server key:");
+    }
+}
+
+#[test]
+fn sc_hub_pem_config_rejects_invalid_der_in_any_certificate_position() {
+    let mut certs = generate_test_certs();
+    let valid_ca = certs.ca_cert_pem.clone();
+    for invalid in [
+        INVALID_CERT_DER_PEM.to_owned(),
+        format!("{valid_ca}{INVALID_CERT_DER_PEM}"),
+        format!("{INVALID_CERT_DER_PEM}{valid_ca}"),
+    ] {
+        certs.ca_cert_pem = invalid;
+        assert_hub_config_error(&certs, "failed to add CA cert:");
+    }
+    certs.ca_cert_pem = valid_ca;
+    let valid_chain = certs.server_cert_pem.clone();
+    for invalid in [
+        INVALID_CERT_DER_PEM.to_owned(),
+        format!("{valid_chain}{INVALID_CERT_DER_PEM}"),
+        format!("{INVALID_CERT_DER_PEM}{valid_chain}"),
+    ] {
+        certs.server_cert_pem = invalid;
+        assert_hub_config_error(&certs, "TLS server config error:");
+    }
+}
+
+#[test]
+fn sc_hub_pem_config_rejects_unusable_or_mismatched_key() {
+    let mut certs = generate_test_certs();
+    certs.server_key_pem = "-----BEGIN PRIVATE KEY-----\nAQID\n-----END PRIVATE KEY-----\n".into();
+    assert_hub_config_error(&certs, "TLS server config error:");
+    certs.server_key_pem = generate_test_certs().server_key_pem;
+    assert_hub_config_error(
+        &certs,
+        "TLS server config error: keys may not be consistent: KeyMismatch",
+    );
 }

--- a/crates/bacnet-cli/tests/support/sc.rs
+++ b/crates/bacnet-cli/tests/support/sc.rs
@@ -2,7 +2,11 @@ use super::{bounded, command, Files};
 use bacnet_objects::database::ObjectDatabase;
 use bacnet_objects::device::{DeviceConfig, DeviceObject};
 use bacnet_server::server::BACnetServer;
-use bacnet_transport::{sc::ScTransport, sc_hub::ScHub, sc_tls::TlsWebSocket};
+use bacnet_transport::{
+    sc::ScTransport,
+    sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig},
+    sc_tls::TlsWebSocket,
+};
 use futures_util::FutureExt;
 use rcgen::{Certificate, CertificateParams, ExtendedKeyUsagePurpose, Issuer, KeyPair};
 use rustls::pki_types::PrivatePkcs8KeyDer;
@@ -79,6 +83,17 @@ impl Site {
         )
     }
 
+    pub fn hub_tls_config(&self) -> ScHubTlsConfig {
+        let hub = self.leaf("127.0.0.1", ExtendedKeyUsagePurpose::ServerAuth, None);
+        ScHubTlsConfig::from_der(
+            vec![self.ca.der().clone()],
+            vec![hub.cert.der().clone()],
+            PrivatePkcs8KeyDer::from(hub.key.serialize_der()).into(),
+        )
+        .unwrap()
+    }
+
+    // Independent raw TLS peer, including the TLS 1.2 negative oracle.
     pub fn acceptor(&self, version: &'static rustls::SupportedProtocolVersion) -> TlsAcceptor {
         let hub = self.leaf("127.0.0.1", ExtendedKeyUsagePurpose::ServerAuth, None);
         let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(self.roots()))
@@ -134,11 +149,12 @@ pub struct Fixture {
 impl Fixture {
     pub async fn start(&mut self, site: &Site) {
         self.hub = Some(
-            bounded(ScHub::start_with_uuid(
+            bounded(ScHub::start_with_tls_config(
                 "127.0.0.1:0",
-                site.acceptor(&rustls::version::TLS13),
+                site.hub_tls_config(),
                 [2, 0, 0, 0, 0, 9],
                 [9; 16],
+                ScHubHandshakeTimeouts::default(),
             ))
             .await
             .unwrap(),

--- a/crates/bacnet-server/src/server/sc_dcc_mtls_support.rs
+++ b/crates/bacnet-server/src/server/sc_dcc_mtls_support.rs
@@ -6,7 +6,7 @@ use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
 use bacnet_services::read_property::{ReadPropertyACK, ReadPropertyRequest};
 use bacnet_transport::port::ReceivedNpdu;
 use bacnet_transport::sc::ScTransport;
-use bacnet_transport::sc_hub::ScHub;
+use bacnet_transport::sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig};
 use bacnet_transport::sc_tls::TlsWebSocket;
 use bacnet_types::enums::EnableDisable;
 use futures_util::FutureExt;
@@ -14,7 +14,6 @@ use rcgen::{CertificateParams, ExtendedKeyUsagePurpose, Issuer, KeyPair};
 use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use tokio_rustls::rustls::{self, pki_types::PrivatePkcs8KeyDer};
-use tokio_rustls::TlsAcceptor;
 
 pub(super) const SERVER: [u8; 6] = [2, 0, 0, 0, 0, 1];
 pub(super) const PEERS: [[u8; 6]; 2] = [[2, 0, 0, 0, 0, 2], [2, 0, 0, 0, 0, 3]];
@@ -31,7 +30,7 @@ pub(super) async fn bounded<T>(future: impl Future<Output = T>) -> T {
 // All keys stay in memory. Each endpoint has its own key/certificate, including
 // the BACnet server (a TLS client of the hub). No permissive verifier is used.
 pub(super) struct Certificates {
-    pub hub: Arc<rustls::ServerConfig>,
+    pub hub: ScHubTlsConfig,
     pub clients: Vec<Arc<rustls::ClientConfig>>,
     pub missing: Arc<rustls::ClientConfig>,
     pub untrusted: Arc<rustls::ClientConfig>,
@@ -59,13 +58,12 @@ impl Certificates {
             )
         };
         let (hub_cert, hub_key) = leaf("127.0.0.1", ExtendedKeyUsagePurpose::ServerAuth);
-        let verifier = rustls::server::WebPkiClientVerifier::builder(Arc::new(roots.clone()))
-            .build()
-            .unwrap();
-        let hub = rustls::ServerConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-            .with_client_cert_verifier(verifier)
-            .with_single_cert(vec![hub_cert.clone()], hub_key.into())
-            .unwrap();
+        let hub = ScHubTlsConfig::from_der(
+            vec![ca.der().clone()],
+            vec![hub_cert.clone()],
+            hub_key.into(),
+        )
+        .unwrap();
         let mut certs = vec![hub_cert];
         let clients = (0..3)
             .map(|index| {
@@ -108,7 +106,7 @@ impl Certificates {
                 .with_client_auth_cert(vec![cert], key.into())
                 .unwrap();
         Self {
-            hub: Arc::new(hub),
+            hub,
             clients,
             missing: Arc::new(missing),
             untrusted: Arc::new(untrusted),
@@ -137,10 +135,12 @@ impl Fixture {
     }
 
     pub async fn hub(&mut self, certs: &Certificates) {
-        let hub = bounded(ScHub::start(
+        let hub = bounded(ScHub::start_with_tls_config(
             "127.0.0.1:0",
-            TlsAcceptor::from(certs.hub.clone()),
+            certs.hub.clone(),
             [2, 0, 0, 0, 0, 9],
+            [0; 16],
+            ScHubHandshakeTimeouts::default(),
         ))
         .await
         .unwrap();

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -362,6 +362,15 @@ deadlines, and explicit stop. A raw TLS 1.2/server-auth-only characterization te
 deliberately remains valid. Installed Python tests separately exercise OpenSSL
 peers and ReadProperty; these are not hardware or full-profile certification.
 
+The already-mTLS benchmark hub launcher and the CLI ReadProperty and server SC-DCC
+test fixtures also use the validated hub path, retaining their UUIDs, timeouts,
+authentication modes and cleanup. The benchmark PEM loader has focused empty,
+malformed, mixed-valid/invalid DER and mismatched-key tests. Independent raw TLS
+peer helpers (including TLS-version negative controls) retain their existing
+signatures; this adoption does not retire raw configuration or change production
+CLI, node or Docker behavior. Benchmark targets are compile-checked, not new
+performance qualification.
+
 ### MS/TP (Serial RS-485)
 
 MS/TP is a token-passing protocol over RS-485 serial, commonly used for field-level BACnet devices. The serial I/O is abstracted behind the `SerialPort` trait, with three RS-485 direction control modes.


### PR DESCRIPTION
## Summary
- Migrate three already-mTLS ScHub callers to ScHubTlsConfig/from_der and typed startup: benchmark hub launcher, CLI ReadProperty fixtures, and server SC-DCC fixtures.
- Add a fallible in-memory PEM-to-typed-config loader for benchmark hub startup, with six focused ownership/malformed-input/key-mismatch tests.
- Preserve VMACs, UUIDs, default timeouts, lifecycle, helper return types and authentication modes.
- Retain independent raw TLS peer helpers and all no-auth/legacy modes. No raw/mutable escape added to the sealed type.

Refs #513 — remains OPEN/Partial.

## Validation
- Baseline characterization: existing benchmark mTLS/WebSocket 13+11, CLI SC108 and server SC-DCC7 passed before migration. This is adoption evidence, not a security bypass RED.
- Final: benchmark mTLS/WebSocket19+11, CLI SC108, server SC-DCC7, native typed/raw hub5 all passed. All four suites repeated ten times: 1,500 passes, zero failures.
- Root independently reran all30 benchmark mTLS/WebSocket tests after inspecting the full six-file diff and verifying every source hash.
- Default workspace4411 and portable workspace explicitly including CLI SC4433 passed; each retains3 existing ignored.
- cargo check -p bacnet-benchmarks --benches --locked passed (compilation only, not measurements).
- Formatting, workspace and explicit CLI/server SC Clippy, strict file-size/secrets/diff checks passed; existing warnings retained. No tests/assertions removed, no new ignored tests or CI changes.
- Exact-head five lean CI gates and three independent reviews required before merge. Hosted feature selection does not enable CLI SC; explicit local tests/Clippy provide that evidence.

## Boundaries
Existing raw make_server_tls_config_mtls/try_make_server_tls_config_mtls signatures and bodies remain intact for independent TLS peers, including the release RSS fixture. CLI Site::acceptor(version) remains for version-selectable negative peers. New typed helper retains owned DER after source material is dropped and rejects every malformed certificate position.

No production transport/Python/CLI/node API, Docker provisioning, UUID/parser/DCC-policy, dependency, lockfile or configuration change. Public raw hub APIs and standalone insecure benchmark modes remain caller-managed and unchanged. No Python wheel requalification, performance measurement, full-profile or external-device claim; existing artifacts preserved.

## Evidence
Receipt SHA256: 374af4d702c39b9b6ce886386868a9f5c951623610999a99994969a6afda311d.
Source manifest SHA256: 89e48941b3d5e45ccd9715eab7934c9fca7f22a441a1205867c315b70c352fd3.
Exact commands, intermediate formatting/test-authoring corrections, raw compatibility inventory and logs are preserved locally.