### PR TITLE
Require strict local TLS policy for built-in SC nodes

### DIFF
--- a/Benchmarks.md
+++ b/Benchmarks.md
@@ -83,7 +83,11 @@ are neither currently reproducible comparison-mode results nor mTLS conformance 
 ### 1.5 BACnet/SC — Mutual TLS (mTLS)
 
 The original `sc_mtls_latency` and `sc_mtls_throughput` targets remain unchanged.
-Strict-hub migration checks compile them, not measure them. The known all-zero
+Strict hub/node migration checks compile them, not measure them. Node helpers now
+use `ScNodeTlsConfig` with explicit trust and matching operational credentials;
+normal TLS resumption is preserved. This local policy does not prove an arbitrary
+remote hub requests/verifies a certificate (no-request handshakes can complete,
+and resumed connections may not retransmit certificates). The known all-zero
 node UUID collision in other default-based setups remains unfixed; this is not
 full benchmark runtime or performance qualification. The numeric results below
 are historical, including SC comparisons and takeaways elsewhere in this report.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking Rust node TLS API:** `TlsWebSocket::connect`,
+  `ScClientBuilder::tls_config`, and `ScServerBuilder::tls_config` require opaque
+  `ScNodeTlsConfig` rather than `Arc<rustls::ClientConfig>`. Construct from owned
+  CA/chain/key DER: explicit nonempty trust, all-entry syntax checks, matching
+  operational key, fixed aws-lc, normal server CA/name verification and TLS 1.3-only
+  local policy, before I/O. No raw/mutable escape. Clones and reconnects share the
+  same configuration and normal resumption cache; tickets/early-data policy remain.
+  This local contract supplies identity when requested and compatible, not proof
+  of presentation on every connection or remote hub verification. Trusted servers
+  without CertificateRequest can complete; resumption may not retransmit certs.
+  Generic custom WebSocket transports remain outside the built-in driver guarantee.
+  Python/CLI interfaces, file/error phases, Docker provisioning and hub policy stay
+  compatible. No local date/issuer/EKU/authorization preflight or full-profile claim;
+  #513 stays open pending final acceptance assessment. See the
+  [migration and limits](docs/rust-api.md#strict-local-node-tls-configuration).
+
 - **Breaking Rust hub TLS API:** `ScHub::start`, `start_with_uuid`, and
   `start_with_uuid_and_timeouts` now require `ScHubTlsConfig` as their second
   argument, not `TlsAcceptor`. All public hub startup enforces explicit CA trust,
@@ -22,7 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the old raw-policy characterization with strict-family runtime and compile-fail
   coverage; WebSocket tests now authenticate before testing WebSocket semantics.
   Python and Docker already use the alias and retain behavior/signatures. Node
-  `ClientConfig`/`TlsWebSocket` remains caller-managed. No full-profile, UUID fix,
+  `ClientConfig`/`TlsWebSocket` was left caller-managed by that hub change;
+  its subsequent migration is above. No full-profile, UUID fix,
   or performance claim; #513 remains partial, not for public raw hub startup.
   See [Rust migration and limits](docs/rust-api.md#bacnetsc-hub).
 
@@ -54,8 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validated handshake timeouts while reusing the existing lifecycle. Python hub
   startup delegates to this factory; its constructor, errors and file-loading
   boundary stay compatible. The initial additive change left raw `TlsAcceptor`
-  startup APIs unchanged; their retirement is described above. Node TLS APIs are
-  not migrated. Docker's separate
+  startup APIs unchanged; their retirement is described above. That initial change
+  did not migrate node TLS APIs; the subsequent source break is above. Docker's separate
   standalone migration is described above. Native
   preflight, compile-fail, real TLS/SC relay/deadline and installed Python tests
   cover this partial migration, not full-profile conformance or #513 closure.
@@ -67,8 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Native/system roots are no longer loaded; there is no environment-trust or
   insecure fallback. Local file/configuration failures, including mismatched
   cert/key, fail before dial. Help/version, non-SC transports and capture paths
-  without a client stay independent of SC files. TLS 1.3-only remains; public Rust
-  node TLS configuration APIs remain compatible (hub retirement is described
+  without a client stay independent of SC files. TLS 1.3-only remains; that CLI change
+  left Rust node TLS APIs compatible (subsequent node/hub retirement is described
   above), and #513 remains partial. See the
   [CLI migration and test scope](docs/CLI.md#transport-variants).
 

--- a/benchmarks/src/bin/sc/device.rs
+++ b/benchmarks/src/bin/sc/device.rs
@@ -1,14 +1,14 @@
-//! Private standalone-device policy; public raw Rust TLS APIs remain unchanged.
+//! Standalone-device input validation and shared strict local node TLS policy.
 
 use super::credentials::{required, Credentials};
 use super::Args;
-use std::sync::Arc;
+use bacnet_transport::sc_tls::ScNodeTlsConfig;
 
 pub(super) struct ScConfig<'a> {
     pub url: &'a str,
     pub vmac: [u8; 6],
     pub uuid: [u8; 16],
-    pub tls: Arc<rustls::ClientConfig>,
+    pub tls: ScNodeTlsConfig,
 }
 
 impl<'a> ScConfig<'a> {
@@ -30,30 +30,13 @@ impl<'a> ScConfig<'a> {
             return Err("--sc-device-uuid must be nonzero and unique on this SC network".into());
         }
         let material = Credentials::load(ca, cert, key, ["--sc-ca", "--sc-cert", "--sc-key"])?;
-        let mut roots = rustls::RootCertStore::empty();
-        for cert in material.ca {
-            roots
-                .add(cert)
-                .map_err(|e| format!("--sc-ca: invalid CA certificate: {e}"))?;
-        }
-        for cert in &material.chain {
-            rustls::server::ParsedCertificate::try_from(cert)
-                .map_err(|e| format!("--sc-cert: invalid certificate DER: {e}"))?;
-        }
-        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
-        // with_client_auth_cert validates the built-in provider's signing key
-        // against the leaf before TlsWebSocket can perform DNS or TCP I/O.
-        let tls = rustls::ClientConfig::builder_with_provider(provider)
-            .with_protocol_versions(&[&rustls::version::TLS13])
-            .map_err(|e| format!("SC TLS configuration: {e}"))?
-            .with_root_certificates(roots)
-            .with_client_auth_cert(material.chain, material.key)
-            .map_err(|e| format!("--sc-cert/--sc-key: invalid or mismatched credentials: {e}"))?;
+        let tls = ScNodeTlsConfig::from_der(material.ca, material.chain, material.key)
+            .map_err(|e| format!("--sc-ca/--sc-cert/--sc-key: SC TLS configuration: {e}"))?;
         Ok(Self {
             url,
             vmac,
             uuid,
-            tls: Arc::new(tls),
+            tls,
         })
     }
 }

--- a/benchmarks/src/sc_helpers.rs
+++ b/benchmarks/src/sc_helpers.rs
@@ -10,7 +10,7 @@ use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use bacnet_transport::sc::ScTransport;
 use bacnet_transport::sc_frame::Vmac;
 use bacnet_transport::sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig};
-use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_transport::sc_tls::{ScNodeTlsConfig, TlsWebSocket};
 use bacnet_types::error::Error;
 
 /// Generated certificate material for testing.
@@ -246,7 +246,20 @@ pub fn try_make_hub_tls_config(certs: &CertMaterial) -> Result<ScHubTlsConfig, E
     ScHubTlsConfig::from_der(ca_certs, cert_chain, key)
 }
 
-/// Build a rustls ClientConfig that presents a client certificate (mTLS).
+/// Build the strict local node policy from in-memory PEM, without file/network I/O.
+pub fn try_make_node_tls_config(certs: &CertMaterial) -> Result<ScNodeTlsConfig, Error> {
+    let chain = CertificateDer::pem_slice_iter(certs.client_cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| Error::Encoding(format!("failed to parse client certificates: {e}")))?;
+    let key = PrivateKeyDer::from_pem_slice(certs.client_key_pem.as_bytes())
+        .map_err(|e| Error::Encoding(format!("failed to parse client key: {e}")))?;
+    let ca = CertificateDer::pem_slice_iter(certs.ca_cert_pem.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| Error::Encoding(format!("failed to parse CA certificates: {e}")))?;
+    ScNodeTlsConfig::from_der(ca, chain, key)
+}
+
+/// Build a raw rustls ClientConfig with client credentials for independent peers.
 ///
 /// The client authenticates to the hub by including its certificate chain
 /// and private key, satisfying the hub's client-auth requirement.
@@ -327,7 +340,7 @@ pub async fn make_sc_transport_mtls(
     certs: &CertMaterial,
     vmac: Vmac,
 ) -> ScTransport<TlsWebSocket> {
-    let tls_config = make_client_tls_config_mtls(certs);
+    let tls_config = try_make_node_tls_config(certs).unwrap();
     let ws = TlsWebSocket::connect(hub_url, tls_config).await.unwrap();
     ScTransport::new(ws, vmac)
 }

--- a/benchmarks/tests/sc_binary/handshake.rs
+++ b/benchmarks/tests/sc_binary/handshake.rs
@@ -2,7 +2,7 @@ use super::peer::Peer;
 use super::preflight::replace;
 use super::support::*;
 use bacnet_benchmarks::sc_helpers::*;
-use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_transport::sc_tls::ScNodeTlsConfig;
 use rcgen::{CertificateParams, Issuer, KeyPair};
 use rustls::pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer};
 use std::sync::Arc;
@@ -33,7 +33,7 @@ async fn good_pair(files: &Files, certs: &CertMaterial) {
     let url = hub.hub_url().await;
     let mut device = Process::start(&mut files.device(&url), files);
     device.ready("SC device connected").await;
-    let peer = Peer::connect(&url, make_client_tls_config_mtls(certs), 42).await;
+    let peer = Peer::connect(&url, try_make_node_tls_config(certs).unwrap(), 42).await;
     peer.read().await;
     assert!(device.child.try_wait().unwrap().is_none());
 }
@@ -98,7 +98,13 @@ async fn actual_binaries_mutual_tls_reads_and_denials_recover() {
         Some(rustls::ProtocolVersion::TLSv1_3)
     );
     drop(tls);
-    let peer = Peer::connect(&url, peer_tls, 42).await;
+    let node = ScNodeTlsConfig::from_der(
+        vec![CertificateDer::from_pem_slice(certs.ca_cert_pem.as_bytes()).unwrap()],
+        vec![CertificateDer::from_pem_slice(cert.as_bytes()).unwrap()],
+        PrivateKeyDer::from_pem_slice(key.as_bytes()).unwrap(),
+    )
+    .unwrap();
+    let peer = Peer::connect(&url, node, 42).await;
     peer.read().await;
     let wrong = generate_test_certs();
     let (expired, expired_key) = leaf("expired", ClientAuth, Some((2000, 2001)));
@@ -128,7 +134,14 @@ async fn actual_binaries_mutual_tls_reads_and_denials_recover() {
         ),
     ];
     for (tls, expected) in negatives {
-        let error = match bounded(TlsWebSocket::connect(&url, tls)).await {
+        let error = match bounded(tokio_tungstenite::connect_async_tls_with_config(
+            &url,
+            None,
+            false,
+            Some(tokio_tungstenite::Connector::Rustls(tls)),
+        ))
+        .await
+        {
             Ok(_) => panic!("invalid peer admitted"),
             Err(error) => error.to_string(),
         };

--- a/benchmarks/tests/sc_binary/peer.rs
+++ b/benchmarks/tests/sc_binary/peer.rs
@@ -5,14 +5,13 @@ use bacnet_encoding::npdu::decode_npdu;
 use bacnet_services::read_property::ReadPropertyACK;
 use bacnet_transport::sc::WebSocketPort;
 use bacnet_transport::sc_frame::{decode_sc_message, encode_sc_message, ScFunction, ScMessage};
-use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_transport::sc_tls::{ScNodeTlsConfig, TlsWebSocket};
 use bytes::{Bytes, BytesMut};
-use std::sync::Arc;
 
 pub struct Peer(pub TlsWebSocket, std::cell::Cell<u8>);
 
 impl Peer {
-    pub async fn connect(url: &str, tls: Arc<rustls::ClientConfig>, id: u8) -> Self {
+    pub async fn connect(url: &str, tls: ScNodeTlsConfig, id: u8) -> Self {
         let peer = Self(
             bounded(TlsWebSocket::connect(url, tls)).await.unwrap(),
             std::cell::Cell::new(7),

--- a/benchmarks/tests/sc_docker.rs
+++ b/benchmarks/tests/sc_docker.rs
@@ -9,28 +9,20 @@ mod support;
 #[tokio::test]
 #[ignore = "requires explicit isolated Docker SC pair and caller-provided peer credentials"]
 async fn docker_pair_read_property() {
+    use bacnet_transport::sc_tls::ScNodeTlsConfig;
     use rustls::pki_types::{pem::PemObject, PrivateKeyDer};
-    use std::sync::Arc;
     let required = |name| std::env::var(name).expect("explicit smoke environment required");
     let url = required("SC_SMOKE_URL");
     let ca = required("SC_SMOKE_CA");
     let cert = required("SC_SMOKE_CERT");
     let key = required("SC_SMOKE_KEY");
-    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
-    let mut roots = rustls::RootCertStore::empty();
-    for ca in support::pem(std::path::Path::new(&ca)) {
-        roots.add(ca).unwrap();
-    }
-    let tls = rustls::ClientConfig::builder_with_provider(provider)
-        .with_protocol_versions(&[&rustls::version::TLS13])
-        .unwrap()
-        .with_root_certificates(roots)
-        .with_client_auth_cert(
-            support::pem(std::path::Path::new(&cert)),
-            PrivateKeyDer::from_pem_file(key).unwrap(),
-        )
-        .unwrap();
-    let peer = peer::Peer::connect(&url, Arc::new(tls), 42).await;
+    let tls = ScNodeTlsConfig::from_der(
+        support::pem(std::path::Path::new(&ca)),
+        support::pem(std::path::Path::new(&cert)),
+        PrivateKeyDer::from_pem_file(key).unwrap(),
+    )
+    .unwrap();
+    let peer = peer::Peer::connect(&url, tls, 42).await;
     peer.read().await;
     eprintln!("Verified mutual-TLS 1.3 SC Connect and Device:5000 / AI:1 ReadProperty values");
 }

--- a/benchmarks/tests/sc_mtls.rs
+++ b/benchmarks/tests/sc_mtls.rs
@@ -7,22 +7,53 @@ use bacnet_benchmarks::sc_helpers::*;
 use bacnet_transport::port::TransportPort;
 use bacnet_transport::sc::{ScConnectionState, ScTransport};
 use bacnet_transport::sc_hub::ScHubTlsConfig;
-use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_transport::sc_tls::{ScNodeTlsConfig, TlsWebSocket};
 use bacnet_types::error::Error;
 use tokio::net::{TcpListener, TcpStream};
 use tokio_rustls::rustls;
 use tokio_rustls::rustls::pki_types::ServerName;
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 
+#[path = "sc_mtls/node_reconnect.rs"]
+mod node_reconnect;
+
 async fn assert_connect_fails(url: &str, tls_config: Arc<rustls::ClientConfig>, message: &str) {
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        TlsWebSocket::connect(url, tls_config),
+        tokio_tungstenite::connect_async_tls_with_config(
+            url,
+            None,
+            false,
+            Some(tokio_tungstenite::Connector::Rustls(tls_config)),
+        ),
     )
     .await
     .expect("TLS/WebSocket connect attempt timed out");
 
-    assert!(result.is_err(), "{message}");
+    let error = result.expect_err("invalid TLS peer was accepted");
+    assert!(
+        format!("{error:?}").contains(message),
+        "expected {message}, got {error:?}"
+    );
+}
+
+async fn assert_node_rejects_server(url: &str, tls: ScNodeTlsConfig, expected: &str) {
+    let error = tokio::time::timeout(Duration::from_secs(5), TlsWebSocket::connect(url, tls))
+        .await
+        .expect("node TLS attempt timed out")
+        .err()
+        .expect("invalid server was accepted");
+    assert!(matches!(
+        bacnet_transport::sc::ScConnectError::from_error(&error),
+        Some(bacnet_transport::sc::ScConnectError::WebSocket {
+            kind: bacnet_transport::sc::ScWebSocketErrorKind::TlsHandshake,
+            ..
+        })
+    ));
+    assert!(
+        error.to_string().contains(expected),
+        "expected {expected}, got {error:?}"
+    );
 }
 
 /// mTLS connection succeeds when the client presents a valid certificate
@@ -36,7 +67,7 @@ async fn sc_mtls_connection_succeeds() {
     let (mut hub, url) = start_sc_hub_mtls(&certs, hub_vmac).await;
 
     // Connect with mTLS client config (presents client cert).
-    let tls_config = make_client_tls_config_mtls(&certs);
+    let tls_config = try_make_node_tls_config(&certs).unwrap();
     let ws = TlsWebSocket::connect(&url, tls_config).await.unwrap();
     let mut transport = ScTransport::new(ws, client_vmac);
     let _rx = transport.start().await.unwrap();
@@ -62,13 +93,7 @@ async fn sc_mtls_rejects_unauthenticated_client() {
 
     // Connect WITHOUT a client certificate (standard non-mTLS config).
     let tls_config = make_client_tls_config(&certs);
-    let result = TlsWebSocket::connect(&url, tls_config).await;
-
-    // Should fail because the hub requires a client cert.
-    assert!(
-        result.is_err(),
-        "Expected TLS handshake to fail without client cert"
-    );
+    assert_connect_fails(&url, tls_config, "CertificateRequired").await;
 
     hub.stop().await;
 }
@@ -166,7 +191,10 @@ async fn sc_mtls_rejects_client_cert_from_wrong_ca() {
     assert_connect_fails(
         &url,
         make_client_tls_config_mtls_with_client_identity(&hub_certs, &wrong_client_certs),
-        "Expected mTLS hub to reject client cert signed by an untrusted CA",
+        // Both generated CAs have rcgen's same default subject; verification
+        // finds that subject but the wrong signing key produces BadSignature,
+        // mapped to DecryptError by rustls 0.23.42 (error.rs).
+        "DecryptError",
     )
     .await;
 
@@ -184,7 +212,7 @@ async fn sc_mtls_rejects_expired_client_cert() {
     assert_connect_fails(
         &url,
         make_client_tls_config_mtls(&certs),
-        "Expected mTLS hub to reject an expired client certificate",
+        "CertificateExpired",
     )
     .await;
 
@@ -202,7 +230,7 @@ async fn sc_mtls_rejects_not_yet_valid_client_cert() {
     assert_connect_fails(
         &url,
         make_client_tls_config_mtls(&certs),
-        "Expected mTLS hub to reject a not-yet-valid client certificate",
+        "CertificateExpired",
     )
     .await;
 
@@ -217,10 +245,10 @@ async fn sc_tls_rejects_expired_server_cert() {
 
     let (mut hub, url) = start_sc_hub_mtls(&certs, hub_vmac).await;
 
-    assert_connect_fails(
+    assert_node_rejects_server(
         &url,
-        make_client_tls_config_mtls(&certs),
-        "Expected BACnet/SC client to reject an expired server certificate",
+        try_make_node_tls_config(&certs).unwrap(),
+        "certificate expired",
     )
     .await;
 
@@ -235,10 +263,10 @@ async fn sc_tls_rejects_not_yet_valid_server_cert() {
 
     let (mut hub, url) = start_sc_hub_mtls(&certs, hub_vmac).await;
 
-    assert_connect_fails(
+    assert_node_rejects_server(
         &url,
-        make_client_tls_config_mtls(&certs),
-        "Expected BACnet/SC client to reject a not-yet-valid server certificate",
+        try_make_node_tls_config(&certs).unwrap(),
+        "not valid yet",
     )
     .await;
 
@@ -253,10 +281,10 @@ async fn sc_tls_rejects_wrong_server_name() {
 
     let (mut hub, url) = start_sc_hub_mtls(&certs, hub_vmac).await;
 
-    assert_connect_fails(
+    assert_node_rejects_server(
         &url,
-        make_client_tls_config_mtls(&certs),
-        "Expected BACnet/SC client to reject a server certificate with the wrong SAN",
+        try_make_node_tls_config(&certs).unwrap(),
+        "not valid for name",
     )
     .await;
 
@@ -304,6 +332,48 @@ fn sc_tls_config_rejects_mismatched_cert_key_pairs() {
 // AQID is the deliberately invalid DER byte sequence [1, 2, 3], not a credential.
 const INVALID_CERT_DER_PEM: &str = "-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n";
 const MALFORMED_CERT_PEM: &str = "-----BEGIN CERTIFICATE-----\n!\n-----END CERTIFICATE-----\n";
+
+#[test]
+fn node_tls_pem_loader_owns_material_and_retains_raw_peer_helper_contracts() {
+    let mut certs = generate_test_certs();
+    certs.client_cert_pem.push_str(&certs.ca_cert_pem);
+    let config = try_make_node_tls_config(&certs).unwrap();
+    let _: Arc<rustls::ClientConfig> = make_client_tls_config(&certs);
+    let _: Arc<rustls::ClientConfig> = make_client_tls_config_mtls(&certs);
+    let _: Result<Arc<rustls::ClientConfig>, String> = try_make_client_tls_config_mtls(&certs);
+    drop(certs);
+    assert_eq!(format!("{config:?}"), "ScNodeTlsConfig { .. }");
+}
+
+#[test]
+fn node_tls_pem_loader_rejects_empty_malformed_and_mixed_der_inputs() {
+    for field in ["ca", "chain", "key"] {
+        for invalid in ["", MALFORMED_CERT_PEM, INVALID_CERT_DER_PEM] {
+            let mut certs = generate_test_certs();
+            match field {
+                "ca" => certs.ca_cert_pem = invalid.into(),
+                "chain" => certs.client_cert_pem = invalid.into(),
+                _ => certs.client_key_pem = invalid.into(),
+            }
+            assert!(matches!(
+                try_make_node_tls_config(&certs),
+                Err(Error::Encoding(_))
+            ));
+        }
+    }
+    for ca in [false, true] {
+        let mut certs = generate_test_certs();
+        if ca {
+            certs.ca_cert_pem.push_str(INVALID_CERT_DER_PEM);
+        } else {
+            certs.client_cert_pem.push_str(INVALID_CERT_DER_PEM);
+        }
+        assert!(matches!(
+            try_make_node_tls_config(&certs),
+            Err(Error::Encoding(_))
+        ));
+    }
+}
 
 fn assert_hub_config_error(certs: &CertMaterial, expected: &str) {
     let error = try_make_hub_tls_config(certs).unwrap_err();

--- a/benchmarks/tests/sc_mtls/node_reconnect.rs
+++ b/benchmarks/tests/sc_mtls/node_reconnect.rs
@@ -1,0 +1,389 @@
+//! Real built-in TLS builder/redial boundaries; no test-only production bypass.
+use bacnet_benchmarks::sc_helpers::*;
+use bacnet_client::client::BACnetClient;
+use bacnet_objects::{
+    database::ObjectDatabase,
+    device::{DeviceConfig, DeviceObject},
+};
+use bacnet_server::server::BACnetServer;
+use bacnet_transport::{
+    sc::{ScReconnectConfig, ScTransport},
+    sc_hub::ScHub,
+    sc_tls::TlsWebSocket,
+};
+use bacnet_types::{
+    enums::{ObjectType, PropertyIdentifier},
+    primitives::ObjectIdentifier,
+};
+use futures_util::FutureExt;
+use std::{future::Future, net::SocketAddr, panic::AssertUnwindSafe, time::Duration};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::mpsc,
+    task::JoinHandle,
+};
+
+type Client = BACnetClient<ScTransport<TlsWebSocket>>;
+type Server = BACnetServer<ScTransport<TlsWebSocket>>;
+const SERVER: [u8; 6] = [2, 0, 0, 0, 0, 1];
+
+async fn bounded<T>(f: impl Future<Output = T>) -> T {
+    tokio::time::timeout(Duration::from_secs(5), f)
+        .await
+        .expect("node TLS barrier timed out")
+}
+
+fn reconnect() -> ScReconnectConfig {
+    ScReconnectConfig {
+        initial_delay_ms: 10,
+        max_delay_ms: 10,
+        max_retries: 1,
+    }
+}
+
+// An opaque TCP forwarder cuts only the selected node's socket. It never
+// terminates TLS, chooses policy, rewrites SC, or performs application reads.
+struct Proxy {
+    url: String,
+    cut: mpsc::Sender<()>,
+    accepted: mpsc::Receiver<usize>,
+    task: JoinHandle<()>,
+}
+
+impl Proxy {
+    async fn new(targets: Vec<SocketAddr>) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("wss://localhost:{}", listener.local_addr().unwrap().port());
+        let (cut, mut cuts) = mpsc::channel(1);
+        let (events, accepted) = mpsc::channel(3);
+        let task = tokio::spawn(async move {
+            for (round, target) in targets.into_iter().enumerate() {
+                let (mut node, _) = listener.accept().await.unwrap();
+                let mut hub = TcpStream::connect(target).await.unwrap();
+                events.send(round).await.unwrap();
+                tokio::select! {
+                    _ = tokio::io::copy_bidirectional(&mut node, &mut hub) => {},
+                    _ = cuts.recv() => {},
+                }
+                // Both sockets drop before accepting the fresh connection.
+            }
+        });
+        Self {
+            url,
+            cut,
+            accepted,
+            task,
+        }
+    }
+}
+
+impl Drop for Proxy {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[derive(Default)]
+struct Fixture {
+    hubs: Vec<ScHub>,
+    client: Option<Client>,
+    server: Option<Server>,
+    proxy: Option<Proxy>,
+    bad_server: Option<JoinHandle<std::io::Error>>,
+}
+
+impl Fixture {
+    async fn hub(&mut self, certs: &CertMaterial, id: u8) -> String {
+        let hub = bounded(ScHub::start_with_uuid(
+            "127.0.0.1:0",
+            try_make_hub_tls_config(certs).unwrap(),
+            [id; 6],
+            [id; 16],
+        ))
+        .await
+        .unwrap();
+        let url = format!("wss://localhost:{}", hub.local_addr().unwrap().port());
+        self.hubs.push(hub);
+        url
+    }
+
+    async fn server(&mut self, url: &str, certs: &CertMaterial) {
+        let mut db = ObjectDatabase::new();
+        db.add(Box::new(
+            DeviceObject::new(DeviceConfig {
+                instance: 123,
+                ..Default::default()
+            })
+            .unwrap(),
+        ))
+        .unwrap();
+        self.server = Some(
+            bounded(
+                BACnetServer::sc_builder()
+                    .hub_url(url)
+                    .tls_config(try_make_node_tls_config(certs).unwrap())
+                    .vmac(SERVER)
+                    .database(db)
+                    .reconnect(reconnect())
+                    .build(),
+            )
+            .await
+            .unwrap(),
+        );
+    }
+
+    async fn client(&mut self, url: &str, certs: &CertMaterial) {
+        self.client = Some(
+            bounded(
+                BACnetClient::sc_builder()
+                    .hub_url(url)
+                    .tls_config(try_make_node_tls_config(certs).unwrap())
+                    .vmac([2; 6])
+                    .device_uuid([2; 16])
+                    .apdu_timeout_ms(100)
+                    .apdu_retries(0)
+                    .reconnect(reconnect())
+                    .build(),
+            )
+            .await
+            .unwrap(),
+        );
+    }
+
+    async fn read(&self) -> Result<(), bacnet_types::error::Error> {
+        let oid = ObjectIdentifier::new(ObjectType::DEVICE, 123).unwrap();
+        let ack = self
+            .client
+            .as_ref()
+            .unwrap()
+            .read_property(&SERVER, oid, PropertyIdentifier::OBJECT_IDENTIFIER, None)
+            .await?;
+        assert_eq!(ack.object_identifier, oid);
+        assert_eq!(ack.property_value, vec![0xc4, 0x02, 0, 0, 123]);
+        Ok(())
+    }
+
+    async fn reads_after_reconnect(&self) {
+        bounded(async {
+            loop {
+                if self.read().await.is_ok() {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await;
+    }
+
+    async fn stop(&mut self) {
+        if let Some(client) = &mut self.client {
+            bounded(client.stop()).await.unwrap();
+        }
+        self.client = None;
+        if let Some(server) = &mut self.server {
+            bounded(server.stop()).await.unwrap();
+        }
+        self.server = None;
+        if let Some(mut proxy) = self.proxy.take() {
+            proxy.task.abort();
+            let result = bounded(&mut proxy.task).await;
+            assert!(result.is_ok() || result.unwrap_err().is_cancelled());
+        }
+        if let Some(task) = self.bad_server.take() {
+            task.abort();
+            let result = bounded(task).await;
+            assert!(result.is_ok() || result.unwrap_err().is_cancelled());
+        }
+        for hub in &mut self.hubs {
+            bounded(hub.stop()).await;
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        if let Some(task) = &self.bad_server {
+            task.abort();
+        }
+    }
+}
+
+async fn run(test: impl AsyncFnOnce(&mut Fixture)) {
+    let mut f = Fixture::default();
+    let result = AssertUnwindSafe(test(&mut f)).catch_unwind().await;
+    f.stop().await;
+    if let Err(panic) = result {
+        std::panic::resume_unwind(panic);
+    }
+}
+
+async fn builder_redial(f: &mut Fixture, client_subject: bool) {
+    let certs = generate_test_certs();
+    let url = f.hub(&certs, 9).await;
+    let good = f.hubs[0].local_addr().unwrap();
+    let wrong = generate_test_certs();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let bad = listener.local_addr().unwrap();
+    f.bad_server = Some(tokio::spawn(async move {
+        let (tcp, _) = listener.accept().await.unwrap();
+        tokio_rustls::TlsAcceptor::from(make_server_tls_config_mtls(&wrong))
+            .accept(tcp)
+            .await
+            .expect_err("node must reject the unrelated server CA")
+    }));
+    f.proxy = Some(Proxy::new(vec![good, good, bad]).await);
+    let proxy_url = f.proxy.as_ref().unwrap().url.clone();
+    // Exactly one zero-UUID ScServerBuilder; client and hub have distinct UUIDs.
+    f.server(if client_subject { &url } else { &proxy_url }, &certs)
+        .await;
+    f.client(if client_subject { &proxy_url } else { &url }, &certs)
+        .await;
+    assert_eq!(
+        bounded(f.proxy.as_mut().unwrap().accepted.recv()).await,
+        Some(0)
+    );
+    bounded(f.read()).await.unwrap();
+    f.proxy.as_ref().unwrap().cut.send(()).await.unwrap();
+    assert_eq!(
+        bounded(f.proxy.as_mut().unwrap().accepted.recv()).await,
+        Some(1)
+    );
+    f.reads_after_reconnect().await; // fresh TLS + SC Connect + application read
+    f.proxy.as_ref().unwrap().cut.send(()).await.unwrap();
+    assert_eq!(
+        bounded(f.proxy.as_mut().unwrap().accepted.recv()).await,
+        Some(2)
+    );
+    let error = bounded(f.bad_server.as_mut().unwrap()).await.unwrap();
+    f.bad_server = None;
+    // Generated CAs share a subject, not a signing key: BadSignature/DecryptError.
+    assert!(format!("{error:?}").contains("DecryptError"), "{error:?}");
+    assert!(
+        bounded(f.read()).await.is_err(),
+        "auth-failing redial must not downgrade"
+    );
+}
+
+#[tokio::test]
+async fn node_tls_client_builder_redials_with_same_policy_and_rejects_wrong_hub() {
+    run(async |f| builder_redial(f, true).await).await;
+}
+
+#[tokio::test]
+async fn node_tls_client_builder_preflight_keeps_existing_error_precedence() {
+    let tls = try_make_node_tls_config(&generate_test_certs()).unwrap();
+    for case in 0..3 {
+        let builder = BACnetClient::sc_builder()
+            .hub_url("not-a-websocket-url")
+            .tls_config(tls.clone())
+            .vmac([2; 6])
+            .device_uuid([2; 16]);
+        let (builder, expected) = match case {
+            0 => (builder.vmac([0; 6]), "unknown VMAC"),
+            1 => (builder.max_segments(Some(1)), "max-segments-accepted"),
+            _ => (
+                builder.reconnect(ScReconnectConfig {
+                    initial_delay_ms: 0,
+                    ..reconnect()
+                }),
+                "reconnect",
+            ),
+        };
+        let error = builder
+            .build()
+            .await
+            .err()
+            .expect("invalid local options must fail");
+        assert!(error.to_string().contains(expected), "{error:?}");
+    }
+}
+
+#[tokio::test]
+async fn node_tls_server_builder_redials_with_same_policy_and_rejects_wrong_hub() {
+    run(async |f| builder_redial(f, false).await).await;
+}
+
+#[tokio::test]
+async fn node_tls_reconnect_fixture_joins_endpoints_and_proxy_on_panic() {
+    let result = AssertUnwindSafe(run(async |f| {
+        let certs = generate_test_certs();
+        let url = f.hub(&certs, 9).await;
+        f.proxy = Some(Proxy::new(vec![f.hubs[0].local_addr().unwrap(); 2]).await);
+        let proxy_url = f.proxy.as_ref().unwrap().url.clone();
+        f.server(&url, &certs).await;
+        f.client(&proxy_url, &certs).await;
+        bounded(f.read()).await.unwrap();
+        panic!("injected node fixture failure");
+    }))
+    .catch_unwind()
+    .await;
+    let panic = result.expect_err("panic must propagate only after joined cleanup");
+    assert_eq!(
+        panic.downcast_ref::<&str>(),
+        Some(&"injected node fixture failure")
+    );
+}
+
+#[tokio::test]
+async fn node_tls_generic_failover_connector_cannot_bypass_typed_policy() {
+    for trusted in [true, false] {
+        run(async |f| {
+            let certs = generate_test_certs();
+            let primary = f.hub(&certs, 9).await;
+            let wrong = generate_test_certs();
+            let secondary_certs = if trusted { &certs } else { &wrong };
+            let secondary = f.hub(secondary_certs, 8).await;
+            f.server(&secondary, secondary_certs).await;
+            let node = try_make_node_tls_config(&certs).unwrap();
+            let ws = bounded(TlsWebSocket::connect(&primary, node.clone()))
+                .await
+                .unwrap();
+            let (events, mut outcomes) = mpsc::unbounded_channel();
+            let transport = ScTransport::new(ws, [2; 6])
+                .with_device_uuid([2; 16])
+                .with_reconnect(ScReconnectConfig {
+                    max_retries: 0,
+                    ..reconnect()
+                })
+                .with_failover_connector(move || {
+                    let url = secondary.clone();
+                    let node = node.clone();
+                    let events = events.clone();
+                    async move {
+                        let result = TlsWebSocket::connect(&url, node).await;
+                        events
+                            .send(result.as_ref().err().map(|e| e.to_string()))
+                            .unwrap();
+                        result
+                    }
+                });
+            f.client = Some(
+                bounded(
+                    BACnetClient::generic_builder()
+                        .transport(transport)
+                        .apdu_timeout_ms(100)
+                        .apdu_retries(0)
+                        .build(),
+                )
+                .await
+                .unwrap(),
+            );
+            bounded(f.hubs[0].stop()).await;
+            let result = bounded(outcomes.recv())
+                .await
+                .expect("failover dial must execute");
+            if trusted {
+                assert_eq!(result, None);
+                f.reads_after_reconnect().await;
+            } else {
+                let error = result.expect("untrusted failover must be rejected");
+                assert!(
+                    error.contains("TLS handshake") && error.contains("BadSignature"),
+                    "{error}"
+                );
+                assert!(bounded(f.read()).await.is_err());
+            }
+        })
+        .await;
+    }
+}

--- a/benchmarks/tests/sc_ws_memory/victim.rs
+++ b/benchmarks/tests/sc_ws_memory/victim.rs
@@ -38,7 +38,7 @@ pub fn run(role: &str) {
         if command == "dial" {
             id += 1;
             let url = setup["url"].as_str().unwrap().to_owned();
-            let config = make_client_tls_config_mtls(&certs);
+            let config = bacnet_benchmarks::sc_helpers::try_make_node_tls_config(&certs).unwrap();
             tasks.push(runtime.spawn(async move {
                 let ws = TlsWebSocket::connect(&url, config).await.unwrap();
                 let mut connection = ScConnection::new([0x22, 0, 0, 0, 0, id], [id; 16]);

--- a/crates/bacnet-cli/src/transport.rs
+++ b/crates/bacnet-cli/src/transport.rs
@@ -97,8 +97,7 @@ pub async fn build_sc_client(
     BACnetClient<bacnet_transport::sc::ScTransport<bacnet_transport::sc_tls::TlsWebSocket>>,
     Error,
 > {
-    use std::sync::Arc;
-
+    use bacnet_transport::sc_tls::ScNodeTlsConfig;
     use rustls::RootCertStore;
     use rustls_pki_types::pem::PemObject;
     use rustls_pki_types::{CertificateDer, PrivateKeyDer};
@@ -130,14 +129,18 @@ pub async fn build_sc_client(
         })?;
 
     let mut root_store = RootCertStore::empty();
-    let ca_certs = CertificateDer::pem_file_iter(ca_path)
+    let ca_iter = CertificateDer::pem_file_iter(ca_path)
         .map_err(|e| Error::Encoding(format!("failed to read --sc-ca PEM: {e}")))?;
-    for cert in ca_certs {
+    let mut ca_certs = Vec::new();
+    // Preserve CA error precedence before identity file I/O. The factory below
+    // owns the actual TLS policy; this store only validates the loaded input.
+    for cert in ca_iter {
         let cert =
             cert.map_err(|e| Error::Encoding(format!("failed to parse --sc-ca PEM: {e}")))?;
         root_store
-            .add(cert)
+            .add(cert.clone())
             .map_err(|e| Error::Encoding(format!("unusable certificate in --sc-ca PEM: {e}")))?;
+        ca_certs.push(cert);
     }
     if root_store.is_empty() {
         return Err(Error::Encoding(
@@ -153,15 +156,12 @@ pub async fn build_sc_client(
     let key = PrivateKeyDer::from_pem_file(key_path)
         .map_err(|e| Error::Encoding(format!("failed to read key PEM: {e}")))?;
 
-    let tls_config =
-        rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-            .with_root_certificates(root_store)
-            .with_client_auth_cert(certs, key)
-            .map_err(|e| Error::Encoding(format!("TLS config error: {e}")))?;
+    let tls_config = ScNodeTlsConfig::from_der(ca_certs, certs, key)
+        .map_err(|e| Error::Encoding(format!("TLS config error: {e}")))?;
 
     BACnetClient::sc_builder()
         .hub_url(hub_url)
-        .tls_config(Arc::new(tls_config))
+        .tls_config(tls_config)
         .vmac(sc_vmac)
         .device_uuid(sc_device_uuid)
         .apdu_timeout_ms(args.timeout_ms)

--- a/crates/bacnet-cli/tests/sc_handshake.rs
+++ b/crates/bacnet-cli/tests/sc_handshake.rs
@@ -3,7 +3,6 @@
 #[allow(dead_code)]
 mod support;
 
-use bacnet_transport::sc_tls::TlsWebSocket;
 use futures_util::FutureExt;
 use rcgen::ExtendedKeyUsagePurpose::ClientAuth;
 use std::panic::AssertUnwindSafe;
@@ -76,6 +75,23 @@ async fn explicit_site_ca_read_property_and_untrusted_ca_rejection() {
             format!("{}{}", Site::new().ca.pem(), site.ca.pem()),
         );
         read_value(&files, &fixture.url, &leaf, &bundle, false).await;
+        // Preserve streaming CA error order: do not parse a later PEM block
+        // before validating the earlier DER entry. Neither is a usable CA.
+        let bad_der = "-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n";
+        let bad_pem = "-----BEGIN CERTIFICATE-----\n!\n-----END CERTIFICATE-----\n";
+        for (contents, expected) in [
+            (
+                format!("{bad_der}{bad_pem}"),
+                "unusable certificate in --sc-ca PEM",
+            ),
+            (format!("{bad_pem}{bad_der}"), "failed to parse --sc-ca PEM"),
+        ] {
+            let path = files.write("ordered-invalid-ca.pem", contents);
+            let mut cmd = cli(&files, &fixture.url, &leaf);
+            cmd.arg("--sc-ca").arg(path);
+            failure(&Process::spawn(read(&mut cmd)).output().await, expected);
+        }
+        read_value(&files, &fixture.url, &leaf, &ca, false).await;
     })
     .await;
 }
@@ -159,13 +175,25 @@ async fn hub_tls_verifier_requires_a_client_certificate() {
     // that the test hub's verifier really requires client authentication.
     let site = Site::new();
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let url = format!("wss://{}", listener.local_addr().unwrap());
     let acceptor = site.acceptor(&rustls::version::TLS13);
     let config = rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
         .with_root_certificates(site.roots())
         .with_no_client_auth();
     let (client, peer) = tokio::join!(
-        bounded(TlsWebSocket::connect(&url, Arc::new(config))),
+        bounded(async {
+            use tokio::io::AsyncReadExt;
+            let tcp = tokio::net::TcpStream::connect(listener.local_addr().unwrap())
+                .await
+                .unwrap();
+            let mut tls = tokio_rustls::TlsConnector::from(Arc::new(config))
+                .connect(
+                    rustls::pki_types::ServerName::try_from("127.0.0.1").unwrap(),
+                    tcp,
+                )
+                .await?;
+            // TLS 1.3 may deliver the server's client-auth alert after Finished.
+            tls.read(&mut [0; 1]).await
+        }),
         bounded(async {
             let (tcp, _) = listener.accept().await.unwrap();
             match acceptor.accept(tcp).await {
@@ -174,7 +202,7 @@ async fn hub_tls_verifier_requires_a_client_certificate() {
             }
         })
     );
-    assert!(client.is_err());
+    assert!(format!("{:?}", client.err().unwrap()).contains("CertificateRequired"));
     assert!(format!("{peer:?}").contains("NoCertificatesPresented"));
 }
 

--- a/crates/bacnet-cli/tests/support/sc.rs
+++ b/crates/bacnet-cli/tests/support/sc.rs
@@ -5,7 +5,7 @@ use bacnet_server::server::BACnetServer;
 use bacnet_transport::{
     sc::ScTransport,
     sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig},
-    sc_tls::TlsWebSocket,
+    sc_tls::{ScNodeTlsConfig, TlsWebSocket},
 };
 use futures_util::FutureExt;
 use rcgen::{Certificate, CertificateParams, ExtendedKeyUsagePurpose, Issuer, KeyPair};
@@ -71,16 +71,13 @@ impl Site {
         roots
     }
 
-    pub fn client(&self, leaf: &Leaf) -> Arc<rustls::ClientConfig> {
-        Arc::new(
-            rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-                .with_root_certificates(self.roots())
-                .with_client_auth_cert(
-                    vec![leaf.cert.der().clone()],
-                    PrivatePkcs8KeyDer::from(leaf.key.serialize_der()).into(),
-                )
-                .unwrap(),
+    pub fn client(&self, leaf: &Leaf) -> ScNodeTlsConfig {
+        ScNodeTlsConfig::from_der(
+            vec![self.ca.der().clone()],
+            vec![leaf.cert.der().clone()],
+            PrivatePkcs8KeyDer::from(leaf.key.serialize_der()).into(),
         )
+        .unwrap()
     }
 
     pub fn hub_tls_config(&self) -> ScHubTlsConfig {

--- a/crates/bacnet-client/src/client/mod.rs
+++ b/crates/bacnet-client/src/client/mod.rs
@@ -599,7 +599,7 @@ pub struct ScClientBuilder {
     config: ClientConfig,
     options: ClientOptions,
     hub_url: String,
-    tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ClientConfig>>,
+    tls_config: Option<bacnet_transport::sc_tls::ScNodeTlsConfig>,
     vmac: bacnet_transport::sc_frame::Vmac,
     device_uuid: [u8; 16],
     heartbeat_interval_ms: u64,
@@ -615,11 +615,24 @@ impl ScClientBuilder {
         self
     }
 
-    /// Set the TLS client configuration.
-    pub fn tls_config(
-        mut self,
-        config: std::sync::Arc<tokio_rustls::rustls::ClientConfig>,
-    ) -> Self {
+    /// Set the validated local node TLS policy, shared across initial and
+    /// reconnect attempts (including normal TLS resumption).
+    ///
+    /// ```
+    /// use bacnet_client::client::{BACnetClient, ScClientBuilder};
+    /// use bacnet_transport::sc_tls::ScNodeTlsConfig;
+    /// fn configured(tls: ScNodeTlsConfig) -> ScClientBuilder {
+    ///     BACnetClient::sc_builder().tls_config(tls)
+    /// }
+    /// ```
+    ///
+    /// ```compile_fail,E0308
+    /// use bacnet_client::client::BACnetClient;
+    /// fn raw(config: std::sync::Arc<tokio_rustls::rustls::ClientConfig>) {
+    ///     let _ = BACnetClient::sc_builder().tls_config(config);
+    /// }
+    /// ```
+    pub fn tls_config(mut self, config: bacnet_transport::sc_tls::ScNodeTlsConfig) -> Self {
         self.tls_config = Some(config);
         self
     }

--- a/crates/bacnet-server/src/server/atomic_read_file_tests.rs
+++ b/crates/bacnet-server/src/server/atomic_read_file_tests.rs
@@ -87,12 +87,9 @@ async fn atomic_read_file_all_builders_validate_before_start_or_dial() {
         }
         #[cfg(feature = "sc-tls")]
         {
-            let tls = tokio_rustls::rustls::ClientConfig::builder()
-                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                .with_no_client_auth();
             let result = BACnetServer::sc_builder()
                 .hub_url("not-a-websocket-url")
-                .tls_config(Arc::new(tls))
+                .tls_config(crate::server::sc_builder::test_tls_config())
                 .atomic_read_file_budget(budget)
                 .build()
                 .await

--- a/crates/bacnet-server/src/server/atomic_write_file_tests.rs
+++ b/crates/bacnet-server/src/server/atomic_write_file_tests.rs
@@ -207,12 +207,9 @@ async fn atomic_write_file_all_builders_validate_before_start_or_dial() {
         }
         #[cfg(feature = "sc-tls")]
         {
-            let tls = tokio_rustls::rustls::ClientConfig::builder()
-                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                .with_no_client_auth();
             let result = BACnetServer::sc_builder()
                 .hub_url("not-a-websocket-url")
-                .tls_config(Arc::new(tls))
+                .tls_config(crate::server::sc_builder::test_tls_config())
                 .atomic_write_file_budget(budget)
                 .build()
                 .await

--- a/crates/bacnet-server/src/server/dcc_policy_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_policy_tests.rs
@@ -82,12 +82,9 @@ async fn dcc_disable_rate_validation_before_sc_dial() {
             ..Default::default()
         },
     ] {
-        let tls = tokio_rustls::rustls::ClientConfig::builder()
-            .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-            .with_no_client_auth();
         let error = BACnetServer::sc_builder()
             .hub_url("not-a-websocket-url")
-            .tls_config(Arc::new(tls))
+            .tls_config(crate::server::sc_builder::test_tls_config())
             .dcc_disable_rate_limit(Some(limit))
             .build()
             .await
@@ -160,12 +157,9 @@ async fn dcc_source_restriction_rejected_before_start() {
 #[tokio::test]
 async fn dcc_source_restriction_rejected_before_sc_dial() {
     for policy in [DccPolicy::DenyAll, DccPolicy::LegacyPermissive] {
-        let tls = tokio_rustls::rustls::ClientConfig::builder()
-            .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-            .with_no_client_auth();
         let error = BACnetServer::sc_builder()
             .hub_url("not-a-websocket-url")
-            .tls_config(Arc::new(tls))
+            .tls_config(crate::server::sc_builder::test_tls_config())
             .dcc_policy(policy)
             .dcc_source_restriction(Some(DccSourceRestriction::new(vec![]).unwrap()))
             .build()
@@ -312,12 +306,9 @@ async fn dcc_require_password_rejected_before_start() {
 #[tokio::test]
 async fn dcc_require_password_rejected_before_sc_dial() {
     for password in [None, Some("")] {
-        let tls = tokio_rustls::rustls::ClientConfig::builder()
-            .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-            .with_no_client_auth();
         let mut builder = BACnetServer::sc_builder()
             .hub_url("not-a-websocket-url")
-            .tls_config(Arc::new(tls))
+            .tls_config(crate::server::sc_builder::test_tls_config())
             .dcc_policy(DccPolicy::RequirePassword);
         if let Some(password) = password {
             builder = builder.dcc_password(password);

--- a/crates/bacnet-server/src/server/enrollment_summary_tests.rs
+++ b/crates/bacnet-server/src/server/enrollment_summary_tests.rs
@@ -78,12 +78,9 @@ async fn enrollment_summary_defaults_and_all_builders_validate_before_start() {
         }
         #[cfg(feature = "sc-tls")]
         {
-            let tls = tokio_rustls::rustls::ClientConfig::builder()
-                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                .with_no_client_auth();
             let result = BACnetServer::sc_builder()
                 .hub_url("not-a-websocket-url")
-                .tls_config(Arc::new(tls))
+                .tls_config(crate::server::sc_builder::test_tls_config())
                 .get_enrollment_summary_budget(budget)
                 .build()
                 .await

--- a/crates/bacnet-server/src/server/event_information_budget.rs
+++ b/crates/bacnet-server/src/server/event_information_budget.rs
@@ -158,12 +158,9 @@ mod tests {
             }
             #[cfg(feature = "sc-tls")]
             {
-                let tls = tokio_rustls::rustls::ClientConfig::builder()
-                    .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                    .with_no_client_auth();
                 let error = BACnetServer::sc_builder()
                     .hub_url("not-a-websocket-url")
-                    .tls_config(Arc::new(tls))
+                    .tls_config(crate::server::sc_builder::test_tls_config())
                     .get_event_information_budget(budget)
                     .build()
                     .await

--- a/crates/bacnet-server/src/server/read_range_budget.rs
+++ b/crates/bacnet-server/src/server/read_range_budget.rs
@@ -138,12 +138,9 @@ mod tests {
             }
             #[cfg(feature = "sc-tls")]
             {
-                let tls = tokio_rustls::rustls::ClientConfig::builder()
-                    .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                    .with_no_client_auth();
                 let error = BACnetServer::sc_builder()
                     .hub_url("not-a-websocket-url")
-                    .tls_config(Arc::new(tls))
+                    .tls_config(crate::server::sc_builder::test_tls_config())
                     .read_range_budget(budget)
                     .build()
                     .await

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -29,7 +29,7 @@ pub struct ScServerBuilder {
     db: ObjectDatabase,
     pub(super) configured_device_bindings: Vec<DeviceBinding>,
     hub_url: String,
-    tls_config: Option<std::sync::Arc<tokio_rustls::rustls::ClientConfig>>,
+    tls_config: Option<bacnet_transport::sc_tls::ScNodeTlsConfig>,
     vmac: bacnet_transport::sc_frame::Vmac,
     heartbeat_interval_ms: u64,
     heartbeat_timeout_ms: u64,
@@ -49,11 +49,24 @@ impl ScServerBuilder {
         self
     }
 
-    /// Set the TLS client configuration.
-    pub fn tls_config(
-        mut self,
-        config: std::sync::Arc<tokio_rustls::rustls::ClientConfig>,
-    ) -> Self {
+    /// Set the validated local node TLS policy, shared across initial and
+    /// reconnect attempts (including normal TLS resumption).
+    ///
+    /// ```
+    /// use bacnet_server::server::{BACnetServer, ScServerBuilder};
+    /// use bacnet_transport::sc_tls::ScNodeTlsConfig;
+    /// fn configured(tls: ScNodeTlsConfig) -> ScServerBuilder {
+    ///     BACnetServer::sc_builder().tls_config(tls)
+    /// }
+    /// ```
+    ///
+    /// ```compile_fail,E0308
+    /// use bacnet_server::server::BACnetServer;
+    /// fn raw(config: std::sync::Arc<tokio_rustls::rustls::ClientConfig>) {
+    ///     let _ = BACnetServer::sc_builder().tls_config(config);
+    /// }
+    /// ```
+    pub fn tls_config(mut self, config: bacnet_transport::sc_tls::ScNodeTlsConfig) -> Self {
         self.tls_config = Some(config);
         self
     }
@@ -256,6 +269,19 @@ impl ScServerBuilder {
 }
 
 #[cfg(test)]
+pub(super) fn test_tls_config() -> bacnet_transport::sc_tls::ScNodeTlsConfig {
+    let rcgen::CertifiedKey { cert, signing_key } =
+        rcgen::generate_simple_self_signed(vec!["node".into()]).unwrap();
+    bacnet_transport::sc_tls::ScNodeTlsConfig::from_der(
+        vec![cert.der().clone()],
+        vec![cert.der().clone()],
+        tokio_rustls::rustls::pki_types::PrivatePkcs8KeyDer::from(signing_key.serialize_der())
+            .into(),
+    )
+    .unwrap()
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use bacnet_transport::sc::ScReconnectConfig;
@@ -272,12 +298,9 @@ mod tests {
                 ..Default::default()
             },
         ] {
-            let tls = tokio_rustls::rustls::ClientConfig::builder()
-                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                .with_no_client_auth();
             let builder = BACnetServer::sc_builder()
                 .hub_url("not-a-websocket-url")
-                .tls_config(Arc::new(tls))
+                .tls_config(test_tls_config())
                 .get_alarm_summary_budget(budget);
             assert_eq!(builder.config.get_alarm_summary_budget, budget);
             assert!(
@@ -298,12 +321,9 @@ mod tests {
                 ..Default::default()
             },
         ] {
-            let tls = tokio_rustls::rustls::ClientConfig::builder()
-                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                .with_no_client_auth();
             let builder = BACnetServer::sc_builder()
                 .hub_url("not-a-websocket-url")
-                .tls_config(Arc::new(tls))
+                .tls_config(test_tls_config())
                 .read_property_multiple_budget(budget);
             assert_eq!(builder.config.read_property_multiple_budget, budget);
             let error = builder.build().await.err().unwrap();
@@ -397,12 +417,9 @@ mod tests {
                 max_unconfirmed_in_flight: bad,
                 ..Default::default()
             };
-            let tls = tokio_rustls::rustls::ClientConfig::builder()
-                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                .with_no_client_auth();
             let error = BACnetServer::sc_builder()
                 .hub_url("not-a-websocket-url")
-                .tls_config(Arc::new(tls))
+                .tls_config(test_tls_config())
                 .request_admission_policy(policy)
                 .build()
                 .await
@@ -430,12 +447,9 @@ mod tests {
                 confirmed_recovery_reserve: reserve,
                 ..Default::default()
             };
-            let tls = tokio_rustls::rustls::ClientConfig::builder()
-                .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                .with_no_client_auth();
             let error = BACnetServer::sc_builder()
                 .hub_url("not-a-websocket-url")
-                .tls_config(Arc::new(tls))
+                .tls_config(test_tls_config())
                 .request_admission_policy(policy)
                 .build()
                 .await
@@ -470,12 +484,9 @@ mod tests {
                     policy.max_unconfirmed_in_flight_per_peer = bad;
                     "max_unconfirmed_in_flight_per_peer"
                 };
-                let tls = tokio_rustls::rustls::ClientConfig::builder()
-                    .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-                    .with_no_client_auth();
                 let builder = BACnetServer::sc_builder()
                     .hub_url("not-a-websocket-url")
-                    .tls_config(Arc::new(tls))
+                    .tls_config(test_tls_config())
                     .request_admission_policy(policy);
                 assert_eq!(builder.config.request_admission_policy, policy);
                 let error = builder.build().await.err().unwrap();

--- a/crates/bacnet-server/src/server/sc_dcc_mtls_support.rs
+++ b/crates/bacnet-server/src/server/sc_dcc_mtls_support.rs
@@ -7,7 +7,7 @@ use bacnet_services::read_property::{ReadPropertyACK, ReadPropertyRequest};
 use bacnet_transport::port::ReceivedNpdu;
 use bacnet_transport::sc::ScTransport;
 use bacnet_transport::sc_hub::{ScHub, ScHubHandshakeTimeouts, ScHubTlsConfig};
-use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_transport::sc_tls::{ScNodeTlsConfig, TlsWebSocket};
 use bacnet_types::enums::EnableDisable;
 use futures_util::FutureExt;
 use rcgen::{CertificateParams, ExtendedKeyUsagePurpose, Issuer, KeyPair};
@@ -31,7 +31,7 @@ pub(super) async fn bounded<T>(future: impl Future<Output = T>) -> T {
 // the BACnet server (a TLS client of the hub). No permissive verifier is used.
 pub(super) struct Certificates {
     pub hub: ScHubTlsConfig,
-    pub clients: Vec<Arc<rustls::ClientConfig>>,
+    pub clients: Vec<ScNodeTlsConfig>,
     pub missing: Arc<rustls::ClientConfig>,
     pub untrusted: Arc<rustls::ClientConfig>,
     pub wrong_server_trust: Arc<rustls::ClientConfig>,
@@ -73,14 +73,7 @@ impl Certificates {
                 );
                 assert!(!certs.contains(&cert), "endpoint certificates must differ");
                 certs.push(cert.clone());
-                Arc::new(
-                    rustls::ClientConfig::builder_with_protocol_versions(&[
-                        &rustls::version::TLS13,
-                    ])
-                    .with_root_certificates(roots.clone())
-                    .with_client_auth_cert(vec![cert], key.into())
-                    .unwrap(),
-                )
+                ScNodeTlsConfig::from_der(vec![ca.der().clone()], vec![cert], key.into()).unwrap()
             })
             .collect();
         let missing =

--- a/crates/bacnet-server/src/server/sc_dcc_mtls_tests.rs
+++ b/crates/bacnet-server/src/server/sc_dcc_mtls_tests.rs
@@ -1,7 +1,5 @@
 //! Standalone SC service-path evidence, not certificate-bound DCC principals.
 use crate::server::*;
-use bacnet_transport::sc::{ScConnectError, ScWebSocketErrorKind};
-use bacnet_transport::sc_tls::TlsWebSocket;
 use bacnet_types::enums::EnableDisable;
 const DISABLE: EnableDisable = EnableDisable::DISABLE;
 const DISABLE_INITIATION: EnableDisable = EnableDisable::DISABLE_INITIATION;
@@ -16,23 +14,37 @@ async fn sc_dcc_mtls_requires_client_and_server_trust() {
     run(async |f| {
         let certs = Certificates::new();
         f.hub(&certs).await;
-        for tls in [&certs.missing, &certs.untrusted, &certs.wrong_server_trust] {
-            let result = bounded(TlsWebSocket::connect(&f.url, tls.clone())).await;
+        for (tls, expected) in [
+            (&certs.missing, "CertificateRequired"),
+            // Same default subject but a different signing key: BadSignature.
+            (&certs.untrusted, "DecryptError"),
+            (&certs.wrong_server_trust, "UnknownIssuer"),
+        ] {
+            let tcp = bounded(tokio::net::TcpStream::connect(
+                f.url.trim_start_matches("wss://"),
+            ))
+            .await
+            .unwrap();
+            let result = bounded(async {
+                use tokio::io::AsyncReadExt;
+                let mut tls = tokio_rustls::TlsConnector::from(tls.clone())
+                    .connect(
+                        tokio_rustls::rustls::pki_types::ServerName::try_from("127.0.0.1").unwrap(),
+                        tcp,
+                    )
+                    .await?;
+                // TLS 1.3's client-side Finished can precede the server's alert.
+                tls.read(&mut [0; 1]).await
+            })
+            .await;
             // TLS1.3 client authentication rejection may surface during the
             // WebSocket upgrade. A completed error, never a deadline, is required.
             let error = result
                 .err()
                 .expect("unauthenticated TLS endpoint was admitted");
             assert!(
-                matches!(
-                    ScConnectError::from_error(&error),
-                    Some(ScConnectError::WebSocket {
-                        kind: ScWebSocketErrorKind::TlsHandshake
-                            | ScWebSocketErrorKind::WebSocketHandshake,
-                        ..
-                    })
-                ),
-                "expected TLS/upgrade rejection, not a dial/timeout error: {error:?}"
+                format!("{error:?}").contains(expected),
+                "expected {expected}, got {error:?}"
             );
         }
         f.start(&certs, BACnetServer::sc_builder()).await;

--- a/crates/bacnet-transport/src/sc_hub/deadline_test_support.rs
+++ b/crates/bacnet-transport/src/sc_hub/deadline_test_support.rs
@@ -90,6 +90,7 @@ pub(super) struct TestTls {
     pub acceptor: TlsAcceptor,
     pub hub_config: ScHubTlsConfig,
     pub client: Arc<rustls::ClientConfig>,
+    pub node: crate::sc_tls::ScNodeTlsConfig,
 }
 
 impl TestTls {
@@ -193,6 +194,12 @@ impl TestTls {
             )
             .unwrap(),
             client: Arc::new(client),
+            node: crate::sc_tls::ScNodeTlsConfig::from_der(
+                vec![ca_cert.der().clone()],
+                vec![client_cert.der().clone()],
+                PrivatePkcs8KeyDer::from(client_key.serialize_der()).into(),
+            )
+            .unwrap(),
         }
     }
 }

--- a/crates/bacnet-transport/src/sc_hub/ws_limits_test_support.rs
+++ b/crates/bacnet-transport/src/sc_hub/ws_limits_test_support.rs
@@ -100,7 +100,7 @@ pub(super) async fn initiating_pair() -> (WebSocketStream<TlsStream>, crate::sc_
     let url = format!("wss://localhost:{}", address.port());
     let (server, node) = tokio::join!(
         accept,
-        crate::sc_tls::TlsWebSocket::connect(&url, tls.client.clone())
+        crate::sc_tls::TlsWebSocket::connect(&url, tls.node.clone())
     );
     (server, node.unwrap())
 }

--- a/crates/bacnet-transport/src/sc_hub/ws_limits_tests.rs
+++ b/crates/bacnet-transport/src/sc_hub/ws_limits_tests.rs
@@ -37,7 +37,7 @@ async fn initiating_websocket_rejects_oversize_declared_frame_without_body() {
         ws
     };
     let url = format!("wss://localhost:{}", address.port());
-    let (server, node) = tokio::join!(server, TlsWebSocket::connect(&url, tls.client.clone()));
+    let (server, node) = tokio::join!(server, TlsWebSocket::connect(&url, tls.node.clone()));
     let node = node.unwrap();
     let outcome = tokio::time::timeout(Duration::from_millis(500), node.recv()).await;
     assert!(

--- a/crates/bacnet-transport/src/sc_tls.rs
+++ b/crates/bacnet-transport/src/sc_tls.rs
@@ -4,13 +4,13 @@
 //! with `rustls` TLS.  This is the production WebSocket driver used by
 //! [`crate::sc::ScTransport`] when connecting to a real BACnet/SC hub.
 
-use std::sync::Arc;
+mod tls_config;
+pub use tls_config::ScNodeTlsConfig;
 
 use futures_util::{SinkExt, StreamExt};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio_rustls::rustls::pki_types::ServerName;
-use tokio_rustls::TlsConnector;
 use tokio_tungstenite::tungstenite::Error as TungsteniteError;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
@@ -34,17 +34,25 @@ pub struct TlsWebSocket {
 impl TlsWebSocket {
     /// Connect to a WebSocket endpoint with TLS.
     ///
-    /// `url` should be a `wss://` URL.  The provided `tls_config` is used for
-    /// the underlying `rustls` TLS handshake.
+    /// `url` must be a `wss://` URL. The validated local policy supplies explicit
+    /// trust and operational credentials; see [`ScNodeTlsConfig`] for the
+    /// certificate-request and normal resumption limits.
     ///
-    /// Per spec AB.7.4, the `tls_config` should be configured for TLS 1.3 only:
-    /// ```ignore
-    /// ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
     /// ```
-    pub async fn connect(
-        url: &str,
-        tls_config: Arc<tokio_rustls::rustls::ClientConfig>,
-    ) -> Result<Self, Error> {
+    /// use bacnet_transport::sc_tls::{ScNodeTlsConfig, TlsWebSocket};
+    /// async fn connect(url: &str, tls: ScNodeTlsConfig)
+    ///     -> Result<TlsWebSocket, bacnet_types::error::Error> {
+    ///     TlsWebSocket::connect(url, tls).await
+    /// }
+    /// ```
+    ///
+    /// ```compile_fail,E0308
+    /// use bacnet_transport::sc_tls::TlsWebSocket;
+    /// async fn raw(config: std::sync::Arc<rustls::ClientConfig>) {
+    ///     let _ = TlsWebSocket::connect("wss://localhost", config).await;
+    /// }
+    /// ```
+    pub async fn connect(url: &str, tls_config: ScNodeTlsConfig) -> Result<Self, Error> {
         let uri = parse_wss_uri(url)?;
         let addr = tcp_addr_from_uri(&uri)?;
         let server_name = tls_server_name_from_uri(&uri)?;
@@ -59,7 +67,8 @@ impl TlsWebSocket {
             .into_bacnet_error_with_io_kind(e.kind())
         })?;
 
-        let tls_stream = TlsConnector::from(tls_config)
+        let tls_stream = tls_config
+            .into_connector()
             .connect(server_name, socket)
             .await
             .map_err(|e| {
@@ -291,8 +300,13 @@ impl WebSocketPort for TlsWebSocket {
 }
 
 #[cfg(test)]
+#[path = "sc_tls/node_tls_tests.rs"]
+mod node_tls_tests;
+
+#[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio_rustls::rustls::pki_types::pem::PemObject;
     use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
@@ -425,20 +439,11 @@ mod tests {
         ));
     }
 
-    fn test_tls_config() -> Arc<tokio_rustls::rustls::ClientConfig> {
-        Arc::new(
-            tokio_rustls::rustls::ClientConfig::builder_with_protocol_versions(&[
-                &tokio_rustls::rustls::version::TLS13,
-            ])
-            .with_root_certificates(tokio_rustls::rustls::RootCertStore::empty())
-            .with_no_client_auth(),
-        )
+    fn test_tls_config() -> ScNodeTlsConfig {
+        test_tls_pair().0
     }
 
-    fn test_tls_pair() -> (
-        Arc<tokio_rustls::rustls::ClientConfig>,
-        Arc<tokio_rustls::rustls::ServerConfig>,
-    ) {
+    pub(super) fn test_tls_pair() -> (ScNodeTlsConfig, Arc<tokio_rustls::rustls::ServerConfig>) {
         let _ = tokio_rustls::rustls::crypto::aws_lc_rs::default_provider().install_default();
 
         let mut ca_params =
@@ -466,21 +471,23 @@ mod tests {
         .with_single_cert(server_chain, server_key)
         .unwrap();
 
-        let mut roots = tokio_rustls::rustls::RootCertStore::empty();
         let ca_certs: Vec<CertificateDer<'static>> =
             CertificateDer::pem_slice_iter(ca_cert.pem().as_bytes())
                 .collect::<Result<Vec<_>, _>>()
                 .unwrap();
-        for cert in ca_certs {
-            roots.add(cert).unwrap();
-        }
-        let client_config = tokio_rustls::rustls::ClientConfig::builder_with_protocol_versions(&[
-            &tokio_rustls::rustls::version::TLS13,
-        ])
-        .with_root_certificates(roots)
-        .with_no_client_auth();
+        let client_key = rcgen::KeyPair::generate().unwrap();
+        let client_cert = rcgen::CertificateParams::new(vec!["node".into()])
+            .unwrap()
+            .signed_by(&client_key, &ca_issuer)
+            .unwrap();
+        let client_config = ScNodeTlsConfig::from_der(
+            ca_certs,
+            vec![client_cert.der().clone()],
+            rustls::pki_types::PrivatePkcs8KeyDer::from(client_key.serialize_der()).into(),
+        )
+        .unwrap();
 
-        (Arc::new(client_config), Arc::new(server_config))
+        (client_config, Arc::new(server_config))
     }
 
     #[tokio::test]

--- a/crates/bacnet-transport/src/sc_tls/node_tls_tests.rs
+++ b/crates/bacnet-transport/src/sc_tls/node_tls_tests.rs
@@ -1,0 +1,60 @@
+use super::{tests::test_tls_pair, *};
+use rustls::{HandshakeKind, ProtocolVersion};
+use std::time::Duration;
+use tokio_rustls::TlsAcceptor;
+
+async fn observe_connections(rounds: usize) -> Vec<HandshakeKind> {
+    // An independent trusted server, deliberately NOT ScHub: no client verifier
+    // and no CertificateRequest. This characterizes the local contract's limit.
+    let (node, server) = test_tls_pair();
+    assert!(server.send_tls13_tickets > 0);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("wss://localhost:{}", listener.local_addr().unwrap().port());
+    let acceptor = TlsAcceptor::from(server);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let accept = async {
+            let mut kinds = Vec::new();
+            for _ in 0..rounds {
+                let (tcp, _) = listener.accept().await.unwrap();
+                let tls = acceptor.accept(tcp).await.unwrap();
+                assert_eq!(tls.get_ref().1.protocol_version(), Some(ProtocolVersion::TLSv1_3));
+                assert!(tls.get_ref().1.peer_certificates().is_none());
+                kinds.push(tls.get_ref().1.handshake_kind().unwrap());
+                let mut ws = tokio_tungstenite::accept_hdr_async(tls,
+                    |_: &_, mut response: tokio_tungstenite::tungstenite::handshake::server::Response| {
+                        response.headers_mut().insert("Sec-WebSocket-Protocol", BACNET_SC_HUB_SUBPROTOCOL.parse().unwrap());
+                        Ok(response)
+                    }).await.unwrap();
+                ws.send(Message::Binary(b"ticket barrier".to_vec().into())).await.unwrap();
+                assert_eq!(ws.next().await.unwrap().unwrap().into_data(), b"node reply"[..]);
+                ws.send(Message::Binary(b"done".to_vec().into())).await.unwrap();
+            }
+            kinds
+        };
+        let connect = async {
+            for _ in 0..rounds {
+                // One factory invocation, same cache/resolver/verifier on every
+                // attempt. Receiving WS traffic processes post-handshake tickets.
+                let ws = TlsWebSocket::connect(&url, node.clone()).await.unwrap();
+                assert_eq!(ws.recv().await.unwrap(), b"ticket barrier");
+                ws.send(b"node reply").await.unwrap();
+                assert_eq!(ws.recv().await.unwrap(), b"done");
+            }
+        };
+        let (kinds, ()) = tokio::join!(accept, connect);
+        kinds
+    }).await.expect("TLS/WS observation timed out")
+}
+
+#[tokio::test]
+async fn node_tls_local_contract_allows_trusted_server_without_certificate_request() {
+    assert_eq!(observe_connections(1).await, vec![HandshakeKind::Full]);
+}
+
+#[tokio::test]
+async fn node_tls_clones_preserve_normal_tls13_resumption() {
+    assert_eq!(
+        observe_connections(2).await,
+        vec![HandshakeKind::Full, HandshakeKind::Resumed]
+    );
+}

--- a/crates/bacnet-transport/src/sc_tls/tls_config.rs
+++ b/crates/bacnet-transport/src/sc_tls/tls_config.rs
@@ -1,0 +1,121 @@
+//! Immutable local TLS policy for the built-in SC node driver.
+
+use std::{fmt, sync::Arc};
+
+use bacnet_types::error::Error;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio_rustls::TlsConnector;
+
+/// Validated node credentials, explicit server trust, and TLS 1.3-only policy.
+/// Available with `sc-tls`; required by the built-in [`super::TlsWebSocket`].
+///
+/// Only supplied CA certificates are trusted, with normal WebPKI server
+/// certificate and name verification. The factory checks every certificate's
+/// syntax and the matching operational key before any I/O, not local certificate
+/// dates, issuer relationships, EKU, revocation, or BACnet identity authorization.
+/// Peers perform certificate validation during TLS.
+///
+/// This is a **local configuration contract**, not proof that a remote hub
+/// requests or verifies the node's identity. Credentials are supplied when
+/// requested and compatible; a trusted server without a CertificateRequest can
+/// complete the handshake. Normal TLS resumption is preserved and may not
+/// retransmit certificates. Clones share the same configuration, verifier,
+/// credential resolver, and resumption cache, including across reconnects.
+///
+/// This does not certify the full Annex AB profile. TLS 1.3-only is local policy;
+/// the base Standard requires TLS 1.3 support. Other implementations of
+/// [`crate::sc::WebSocketPort`] remain outside this built-in driver guarantee.
+///
+/// Load owned DER at the application boundary (no file/network I/O here):
+///
+/// ```
+/// use bacnet_transport::sc_tls::ScNodeTlsConfig;
+/// use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+/// fn policy(ca: Vec<CertificateDer<'static>>, chain: Vec<CertificateDer<'static>>,
+///           key: PrivateKeyDer<'static>) -> Result<ScNodeTlsConfig, bacnet_types::error::Error> {
+///     ScNodeTlsConfig::from_der(ca, chain, key)
+/// }
+/// ```
+///
+/// Arbitrary configurations and connectors cannot be converted:
+///
+/// ```compile_fail,E0277
+/// use bacnet_transport::sc_tls::ScNodeTlsConfig;
+/// fn bypass(config: rustls::ClientConfig) -> ScNodeTlsConfig { config.into() }
+/// ```
+/// ```compile_fail,E0277
+/// use bacnet_transport::sc_tls::ScNodeTlsConfig;
+/// fn bypass(config: std::sync::Arc<rustls::ClientConfig>) -> ScNodeTlsConfig { config.into() }
+/// ```
+/// ```compile_fail,E0277
+/// use bacnet_transport::sc_tls::ScNodeTlsConfig;
+/// fn bypass(connector: tokio_rustls::TlsConnector) -> ScNodeTlsConfig { connector.into() }
+/// ```
+/// ```compile_fail,E0451
+/// use bacnet_transport::sc_tls::ScNodeTlsConfig;
+/// fn bypass(inner: std::sync::Arc<rustls::ClientConfig>) -> ScNodeTlsConfig {
+///     ScNodeTlsConfig { inner }
+/// }
+/// ```
+/// ```compile_fail,E0616
+/// use bacnet_transport::sc_tls::ScNodeTlsConfig;
+/// fn extract(config: ScNodeTlsConfig) -> std::sync::Arc<rustls::ClientConfig> { config.inner }
+/// ```
+#[derive(Clone)]
+pub struct ScNodeTlsConfig {
+    inner: Arc<rustls::ClientConfig>,
+}
+
+impl ScNodeTlsConfig {
+    /// Validate owned, nonempty CA and leaf-first certificate chains and a
+    /// usable matching private key. Configuration errors use [`Error::Encoding`].
+    /// No ambient trust, filesystem access, or networking is used.
+    pub fn from_der(
+        ca_certs: Vec<CertificateDer<'static>>,
+        cert_chain: Vec<CertificateDer<'static>>,
+        key: PrivateKeyDer<'static>,
+    ) -> Result<Self, Error> {
+        if cert_chain.is_empty() {
+            return Err(Error::Encoding("no client certificates found".into()));
+        }
+        if ca_certs.is_empty() {
+            return Err(Error::Encoding("no CA certificates found".into()));
+        }
+        let mut roots = rustls::RootCertStore::empty();
+        for cert in ca_certs {
+            roots
+                .add(cert)
+                .map_err(|e| Error::Encoding(format!("failed to add CA cert: {e}")))?;
+        }
+        for cert in &cert_chain {
+            rustls::server::ParsedCertificate::try_from(cert)
+                .map_err(|e| Error::Encoding(format!("TLS client auth error: {e}")))?;
+        }
+        // Match the hub's fixed provider: caller/global key providers cannot
+        // weaken the built-in provider's certificate/key consistency check.
+        let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+        let config = rustls::ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(&[&rustls::version::TLS13])
+            .map_err(|e| Error::Encoding(format!("TLS client auth error: {e}")))?
+            .with_root_certificates(roots)
+            .with_client_auth_cert(cert_chain, key)
+            .map_err(|e| Error::Encoding(format!("TLS client auth error: {e}")))?;
+        Ok(Self {
+            inner: Arc::new(config),
+        })
+    }
+
+    pub(super) fn into_connector(self) -> TlsConnector {
+        TlsConnector::from(self.inner)
+    }
+}
+
+impl fmt::Debug for ScNodeTlsConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScNodeTlsConfig").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+#[path = "tls_config_tests.rs"]
+mod tests;

--- a/crates/bacnet-transport/src/sc_tls/tls_config_tests.rs
+++ b/crates/bacnet-transport/src/sc_tls/tls_config_tests.rs
@@ -1,0 +1,125 @@
+use super::*;
+use rcgen::{CertificateParams, Issuer, KeyPair};
+use rustls::pki_types::{PrivatePkcs1KeyDer, PrivatePkcs8KeyDer, PrivateSec1KeyDer};
+
+struct Material {
+    ca: CertificateDer<'static>,
+    leaf: CertificateDer<'static>,
+    key: PrivateKeyDer<'static>,
+}
+
+impl Material {
+    fn new(years: Option<(i32, i32)>) -> Self {
+        let mut ca = CertificateParams::new(Vec::<String>::new()).unwrap();
+        ca.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+        let ca_key = KeyPair::generate().unwrap();
+        let cert = ca.self_signed(&ca_key).unwrap();
+        let mut params = CertificateParams::new(vec!["node".into()]).unwrap();
+        if let Some((start, end)) = years {
+            params.not_before = rcgen::date_time_ymd(start, 1, 1);
+            params.not_after = rcgen::date_time_ymd(end, 1, 1);
+        }
+        let key = KeyPair::generate().unwrap();
+        let leaf = params
+            .signed_by(&key, &Issuer::from_params(&ca, &ca_key))
+            .unwrap();
+        Self {
+            ca: cert.der().clone(),
+            leaf: leaf.der().clone(),
+            key: PrivatePkcs8KeyDer::from(key.serialize_der()).into(),
+        }
+    }
+
+    fn policy(&self) -> ScNodeTlsConfig {
+        ScNodeTlsConfig::from_der(
+            vec![self.ca.clone()],
+            vec![self.leaf.clone()],
+            self.key.clone_key(),
+        )
+        .unwrap()
+    }
+}
+
+fn encoding(result: Result<ScNodeTlsConfig, Error>, prefix: &str) {
+    let error = result.unwrap_err();
+    assert!(
+        matches!(&error, Error::Encoding(m) if m.starts_with(prefix)),
+        "{error:?}"
+    );
+    assert!(!error.to_string().contains("PRIVATE KEY"));
+}
+
+#[test]
+fn node_tls_factory_requires_nonempty_ca_and_identity() {
+    let m = Material::new(None);
+    encoding(
+        ScNodeTlsConfig::from_der(vec![], vec![m.leaf.clone()], m.key.clone_key()),
+        "no CA certificates",
+    );
+    encoding(
+        ScNodeTlsConfig::from_der(vec![m.ca], vec![], m.key),
+        "no client certificates",
+    );
+}
+
+#[test]
+fn node_tls_factory_rejects_malformed_der_in_every_position() {
+    let m = Material::new(None);
+    for position in 0..3 {
+        let mut ca = vec![m.ca.clone(); 3];
+        ca[position] = CertificateDer::from(vec![1, 2, 3]);
+        encoding(
+            ScNodeTlsConfig::from_der(ca, vec![m.leaf.clone()], m.key.clone_key()),
+            "failed to add CA cert:",
+        );
+        let mut chain = vec![m.leaf.clone(), m.ca.clone(), m.ca.clone()];
+        chain[position] = CertificateDer::from(vec![1, 2, 3]);
+        encoding(
+            ScNodeTlsConfig::from_der(vec![m.ca.clone()], chain, m.key.clone_key()),
+            "TLS client auth error:",
+        );
+    }
+}
+
+#[test]
+fn node_tls_factory_rejects_unusable_and_mismatched_keys() {
+    let m = Material::new(None);
+    for key in [
+        PrivatePkcs8KeyDer::from(vec![1, 2, 3]).into(),
+        PrivatePkcs1KeyDer::from(vec![1, 2, 3]).into(),
+        PrivateSec1KeyDer::from(vec![1, 2, 3]).into(),
+    ] {
+        encoding(
+            ScNodeTlsConfig::from_der(vec![m.ca.clone()], vec![m.leaf.clone()], key),
+            "TLS client auth error:",
+        );
+    }
+    encoding(
+        ScNodeTlsConfig::from_der(vec![m.ca], vec![m.leaf], Material::new(None).key),
+        "TLS client auth error: keys may not be consistent: KeyMismatch",
+    );
+}
+
+#[test]
+fn node_tls_factory_owns_material_and_clones_share_the_entire_policy() {
+    fn traits<T: Clone + Send + Sync>() {}
+    traits::<ScNodeTlsConfig>();
+    let m = Material::new(None);
+    let config = m.policy();
+    drop(m);
+    let clone = config.clone();
+    assert!(Arc::ptr_eq(&config.inner, &clone.inner));
+    drop(config);
+    assert_eq!(format!("{clone:?}"), "ScNodeTlsConfig { .. }");
+    assert!(!clone.inner.enable_early_data);
+}
+
+#[test]
+fn node_tls_factory_does_not_preflight_local_dates_or_issuer_authorization() {
+    for dates in [None, Some((2000, 2001)), Some((4090, 4091))] {
+        let m = Material::new(dates);
+        let _same_issuer = m.policy();
+        // Trust and local identity need not have the same issuer to construct.
+        ScNodeTlsConfig::from_der(vec![Material::new(None).ca], vec![m.leaf], m.key).unwrap();
+    }
+}

--- a/crates/rusty-bacnet/src/tls.rs
+++ b/crates/rusty-bacnet/src/tls.rs
@@ -1,8 +1,8 @@
 //! TLS configuration helpers for Python bindings.
 
 use bacnet_transport::sc_hub::ScHubTlsConfig;
+use bacnet_transport::sc_tls::ScNodeTlsConfig;
 use bacnet_types::error::Error;
-use std::sync::Arc;
 use tokio_rustls::rustls::pki_types::pem::PemObject;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 
@@ -57,7 +57,7 @@ pub fn build_client_tls_config(
     ca_cert_path: Option<&str>,
     client_cert_path: Option<&str>,
     client_key_path: Option<&str>,
-) -> Result<Arc<tokio_rustls::rustls::ClientConfig>, Error> {
+) -> Result<ScNodeTlsConfig, Error> {
     use tokio_rustls::rustls;
 
     let [ca_path, cert_path, key_path] =
@@ -71,9 +71,11 @@ pub fn build_client_tls_config(
     if ca_certs.is_empty() {
         return Err(Error::Encoding("no CA certificates found".into()));
     }
-    for cert in ca_certs {
+    // Retain CA validation before reading identity files, but construct the
+    // actual connection policy only through the shared native factory below.
+    for cert in &ca_certs {
         root_store
-            .add(cert)
+            .add(cert.clone())
             .map_err(|e| Error::Encoding(format!("failed to add CA cert: {e}")))?;
     }
 
@@ -90,11 +92,5 @@ pub fn build_client_tls_config(
     let key = PrivateKeyDer::from_pem_slice(&key_data)
         .map_err(|e| Error::Encoding(format!("failed to parse client key: {e}")))?;
 
-    // Retain the local TLS-1.3-only policy; AB.7.4 requires TLS 1.3 support.
-    let config = rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
-        .with_root_certificates(root_store)
-        .with_client_auth_cert(certs, key)
-        .map_err(|e| Error::Encoding(format!("TLS client auth error: {e}")))?;
-
-    Ok(Arc::new(config))
+    ScNodeTlsConfig::from_der(ca_certs, certs, key)
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -446,8 +446,12 @@ The CLI tests run the built executable against an ephemeral Rust mTLS SC hub and
 BACnet server, parse a known ReadProperty JSON value, and cover explicit/wrong
 site trust, credential failures, TLS 1.2 rejection, and pre-dial listener checks.
 This is bounded native CLI evidence, not full Annex AB security-profile or
-external-device interoperability certification. Caller-owned Rust library TLS
-configuration APIs are unchanged; #513 remains partial.
+external-device interoperability certification. The CLI now delegates local
+policy construction to `ScNodeTlsConfig`; CLI flags and error phases stay compatible
+despite the [Rust source break](rust-api.md#strict-local-node-tls-configuration).
+Credentials are offered when requested and compatible, not proof of remote hub
+verification. A trusted server without CertificateRequest can complete, and normal
+TLS resumption may not retransmit certificates. Issue #513 remains open/partial.
 
 ## Object Type Shorthand
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1569,8 +1569,10 @@ or certify local certificate dates/issuer relationships.
 All public Rust hub startup now requires the [constrained configuration](rust-api.md#bacnetsc-hub);
 raw `TlsAcceptor` hub injection is retired by a Rust source-breaking change.
 Python already uses the compatible alias, so its signatures and behavior are unchanged.
-Rust node `ClientConfig`/`TlsWebSocket` remains caller-managed; #513 remains partial,
-not because of a public raw hub path. Python nodes require the
+Built-in Rust node APIs now require `ScNodeTlsConfig` too. This is an internal
+Python integration, not another certificate-less-access fix or a signature change.
+Issue #513 remains open for final acceptance assessment and remaining profile
+limits. Python nodes require the
 explicit credentials described [below](#bacnetsc-secure-connect).
 
 ### Methods
@@ -1733,7 +1735,12 @@ TLS 1.3-only remains the existing local policy. Base Standard 135-2020 Annex
 AB.7.4/AB.7.4.1.1 supplies the mutual-authentication and installation-credential
 context, but this change is not full security-profile conformance, certificate
 to VMAC/UUID authorization, or a change to hostname/revocation/issuer policy.
-Caller-owned Rust TLS configurations remain unchanged (#513 is still partial).
+The shared native `ScNodeTlsConfig::from_der` now constructs this local policy;
+Python interfaces and error categories remain unchanged. Normal TLS resumption is
+preserved and may not retransmit certificates. Credentials are offered if requested
+and compatible; a trusted server with no CertificateRequest can complete without
+receiving the node certificate. Local configuration does not attest an arbitrary
+remote hub's verification policy (#513 remains open/partial).
 
 ```python
 # Client connecting to a hub

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -301,8 +301,9 @@ let transport = Bip6Transport::new(
 
 ```rust
 use bacnet_transport::sc::ScTransport;
-use bacnet_transport::sc_tls::TlsWebSocket;
+use bacnet_transport::sc_tls::{ScNodeTlsConfig, TlsWebSocket};
 
+let tls_config = ScNodeTlsConfig::from_der(ca_certs, node_cert_chain, node_key)?;
 let ws = TlsWebSocket::connect("wss://hub:1234", tls_config).await?;
 let transport = ScTransport::new(ws, vmac)
     .with_heartbeat_interval_ms(30_000)
@@ -347,8 +348,8 @@ retired with no public unchecked escape. Names, argument order and return types
 are unchanged. `start` retains its all-zero Device UUID; the other methods retain
 the supplied UUID. Default or explicitly validated handshake budgets and lifecycle
 are preserved. `start_with_tls_config` remains a compatible full-control alias for
-`start_with_uuid_and_timeouts`. Node `ClientConfig`/`TlsWebSocket` APIs remain
-**caller-managed** and unchanged; the hub type does not constrain them.
+`start_with_uuid_and_timeouts`. Built-in node APIs separately require
+`ScNodeTlsConfig`, as described below; generic custom transports remain available.
 Python hub startup uses the typed path internally. The standalone benchmark
 hub/device and Docker SC pair now require explicit mTLS PEM files; see
 [Secure Docker migration](../examples/docker/README.md).
@@ -359,8 +360,8 @@ anchors. Base Standard 135-2020 AB.7.4/AB.7.4.1.1 provides the mutual operationa
 authentication and installation-credential context; TLS 1.3-*only* is local policy,
 not the Standard's TLS 1.3-*support* requirement. This does not add direct-issuer,
 revocation, SAN or certificate-to-VMAC/UUID policy, or close the full security
-profile gap (#513 remains partial, including caller-managed node policy, not a
-public raw hub startup path).
+profile gap (#513 remains open for final acceptance assessment and the remaining
+policy limits, not for a public raw hub startup path).
 
 Evidence includes executable/compile-fail rustdoc, native preflight rejection,
 TLS 1.3 mutual authentication with Connect-Accept and relay barriers after missing,
@@ -376,10 +377,48 @@ authentication modes and cleanup. The benchmark PEM loader has focused empty,
 malformed, mixed-valid/invalid DER and mismatched-key tests. Independent raw TLS
 peer helpers (including TLS-version negative controls) retain their existing
 signatures for independent peers, not public hub startup. The separate
-standalone/Docker migration does not change production CLI or node APIs.
+standalone/Docker migration did not change production CLI or node APIs; the
+subsequent built-in node API migration follows.
 Benchmark compilation and functional TLS tests are not new performance qualification.
 The server-auth-only `sc_latency`/`sc_throughput` targets are retired; the original
 mTLS targets remain, with historical results and limits in [Benchmarks](../Benchmarks.md).
+
+#### Strict local node TLS configuration
+
+**Rust source-breaking migration:** `TlsWebSocket::connect(url, config)`,
+`ScClientBuilder::tls_config(config)`, and `ScServerBuilder::tls_config(config)`
+now require `bacnet_transport::sc_tls::ScNodeTlsConfig`, not
+`Arc<rustls::ClientConfig>`. Names, argument order, return types, identity defaults,
+and lifecycle behavior are unchanged. Load owned DER at your application boundary:
+
+```rust
+use bacnet_transport::sc_tls::{ScNodeTlsConfig, TlsWebSocket};
+let tls = ScNodeTlsConfig::from_der(ca_certs, node_cert_chain, node_private_key)?;
+let ws = TlsWebSocket::connect(hub_url, tls.clone()).await?;
+// Or pass tls to BACnetClient::sc_builder().tls_config(tls), or
+// BACnetServer::sc_builder().tls_config(tls), then finish that builder.
+```
+
+The factory accepts nonempty explicit CA and leaf-first operational chains plus a
+matching usable key. It checks every DER entry before any I/O, uses the fixed
+built-in aws-lc provider, normal WebPKI server CA/name verification, and TLS 1.3
+only. It does not preflight local certificate dates, issuer relationships, EKU,
+or authorization. No raw constructor, getter, mutable access, or unchecked
+conversion exposes the underlying configuration. Clones share one configuration,
+including its verifier, identity resolver and normal resumption cache; reconnects
+do not rebuild it or disable tickets. Early-data policy is unchanged.
+
+**Local contract limit:** the node offers credentials when requested and compatible.
+A trusted TLS 1.3 server that sends no CertificateRequest can complete; resumed
+connections may not retransmit certificates. This does not attest that every
+connection presents an identity or that an arbitrary remote hub verifies it.
+The independent server-side no-request and Full→Resumed tests characterize this
+limit; strict hub and reconnect/failover tests cover the configured mTLS paths.
+`WebSocketPort`, `ScTransport`, and generic builders remain public and generic;
+other WebSocket implementations are outside this built-in driver guarantee.
+Python constructors, CLI flags, file-I/O/error phases, and Docker provisioning stay
+compatible; their existing node policy is consolidated internally. The local raw
+configuration gap is closed, not the full Annex AB profile or issue #513.
 
 ### MS/TP (Serial RS-485)
 
@@ -1285,7 +1324,10 @@ let mut hub = ScHub::start_with_tls_config(
 ).await?;
 let hub_addr = hub.local_addr().expect("started hub has a bound address");
 
-// The caller-managed client config must trust the hub and supply a client cert/key.
+// Build the node policy from separately loaded site trust and operational DER.
+let tls_config = bacnet_transport::sc_tls::ScNodeTlsConfig::from_der(
+    node_ca_certs, node_cert_chain, node_key,
+)?;
 // Use a persistent nonzero client_uuid, distinct from hub_uuid and every other peer.
 let mut client = BACnetClient::sc_builder()
     .hub_url(&format!("wss://127.0.0.1:{}", hub_addr.port()))

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -135,7 +135,7 @@ The single server has stable VMAC `020000001388` and Device UUID
 node a unique nonzero UUID and a unique VMAC other than all-zero/all-ff; these
 are not inferred from the certificate or BACnet Device instance. The binary
 accepts 12/32 hex digits without separators. Public `ScServerBuilder` defaults
-and raw Rust TLS APIs are unchanged.
+are unchanged; the built-in Rust TLS driver now requires `ScNodeTlsConfig`.
 
 ## Rotation and teardown
 
@@ -162,7 +162,12 @@ direct-issuer policy, certificate-to-VMAC/UUID authorization, or physical-device
 interoperability (#513 remains partial). All public Rust hub startup now requires
 `ScHubTlsConfig`; this example already uses its compatible alias, without a change
 to provisioning or runtime behavior. Server-auth-only SC benchmark targets are
-retired; historical results remain. Public Rust node TLS policy is still caller-managed.
+retired; historical results remain. The device and smoke peer now use the shared
+strict local `ScNodeTlsConfig` factory without provisioning or CLI changes.
+Normal TLS resumption is preserved and may not retransmit certificates; a trusted
+server without CertificateRequest can complete without receiving node credentials.
+The paired strict hub requests and verifies credentials, but the node factory alone
+does not enforce that remote behavior or establish full-profile conformance.
 
 Sources: [OpenSSL req](https://docs.openssl.org/3.6/man1/openssl-req/),
 [extensions](https://docs.openssl.org/3.6/man5/x509v3_config/),


### PR DESCRIPTION
## Approved breaking Rust contract
- Add opaque ScNodeTlsConfig from owned CA/certificate-chain/key DER: explicit nonempty trust, all-entry syntax checks, matching operational key, fixed aws-lc, normal WebPKI server/name verification and TLS1.3-only local policy before I/O.
- TlsWebSocket::connect and both SC builders now require this type instead of Arc<rustls::ClientConfig>. No raw/mutable/unchecked escape. Clone preserves the same complete private ClientConfig, resolver/verifier and normal resumption cache.
- Migrate Python, CLI, standalone and reconnect callers while preserving their interfaces, credential/file/error phases, identity defaults, and lifecycle. Independent raw TLS peers remain for negative tests; generic custom WebSocketPort implementations stay outside the built-in driver guarantee.

Owner explicitly approved the STRICT LOCAL contract, not per-connection client-certificate-presentation enforcement or remote-verifier attestation. Credentials are offered when requested and compatible. A trusted server without CertificateRequest can complete; resumed sessions may not retransmit certificates. Existing resumption and early-data policy are not changed.

Refs #513 — keep OPEN pending final acceptance assessment; no full-profile/issue-completion claim.

## Verification
- Three raw-Arc public API compile-fails produce E0308; five node privacy/conversion guards and valid typed consumer examples pass.
- Factory tests cover missing/malformed DER in every position, unsupported/mismatched keys, ownership and shared Clone/Send/Sync policy. Local date/issuer/EKU authorization remains outside preflight.
- Direct independent server observations prove no-request success with peer_certificates=None and Full then Resumed on two connections from one cloned policy.
- Both real SC builders recover after socket loss and complete ReadProperty; wrong-hub redials and failover are rejected. Existing HTTP400 subprotocol, auth alerts, file/error ordering, SC/CLI/standalone and cleanup oracles remain.
- Ten final focused rounds:700 passes, zero failures. Transport576 unit+7 integration+17 docs; client238+3+2; server1069+3+2; CLI108; standalone7 pass. Default workspace4447 and portable4469 pass; three ordinary-workspace ignores include the explicitly executed Docker peer.
- Fresh final2 installed CPython3.12.13/macOSarm64 DEV wheel:73 tests/1132 subtests pass; root independently reran all73/1132 in2.40s. Ten focused Python runs each11/219 pass; exact stub/origin/direct_url/native hash verified.
- Fresh final2 Linux/arm64 image and newly compiled peer passed isolated two-service Device5000/AI1=20.1 reads. Final source, nested README, six read-only mounts and running binary hashes verified. Prior images/credentials preserved; unrelated DB disappearance was external, not task cleanup.
- Formatting, workspace+explicit-SC Clippy, PyO3 check/Clippy, bench compilation, staged700LOC/secrets/diff gates pass. No dependency, lock, CI, version or provisioning changes. Late CLI CA error-order correction received new final2 artifact/affected-gate validation; earlier results retained.

Required five exact-head lean checks and three independent reviews must pass before merge. No performance/RSS/full-topology/hardware/release/sdist/cross-architecture qualification claimed. Raw local configuration gap is closed for the built-in driver, not all Annex AB policy requirements.

## Final evidence
Receipt SHA256:7c4e4c01ca950e7fccd0b2b8b4903649760213ce370c1a762ecb0c37084640b8.
Source manifest SHA256:715ed79834144f920f4974a06727dbbed862429ce755e5d307a506333cc511bf.
Final2 wheel SHA256:2cb0ca4ed4da2fc49e50afc15a3240f12d39e711ad19d44cb381b7ae47671065.
Final2 image strict-sc-node-4c631f8-final2:latest — sha256:25f88f04a03349d9e5ba740fbd15a17eb7718a3f89f5a88c229c2bb0b3b32806 (linux/arm64).
All exact commands, source/peer/native hashes, failures and resource inventories are preserved locally.