### PR TITLE
ci: validate docs and gate manual Pages publication

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,122 @@
+name: Docs
+
+on:
+  pull_request:
+    branches: [dev, main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs-pages.yml'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the reviewed site from dev
+        type: boolean
+        default: false
+        required: true
+      expected_sha:
+        description: Full reviewed dev commit SHA (required when publish is true)
+        type: string
+        default: ''
+        required: false
+
+# PR checks cannot cancel a publication. Manual publications share one lane;
+# GitHub concurrency is not a FIFO queue, so dispatch one publication at a time.
+concurrency:
+  group: docs-pages-${{ github.event_name == 'workflow_dispatch' && inputs.publish == true && 'publish' || format('{0}-{1}', github.event_name, github.ref) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    name: Docs validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: website
+        shell: bash
+    env:
+      DOCS_TEST_PORT: '46329'
+    steps:
+      - name: Check out the event commit
+        id: checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Check publication request
+        id: publication-request
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true }}
+        env:
+          EXPECTED_SHA: ${{ inputs.expected_sha }}
+        run: |
+          test "$GITHUB_REPOSITORY" = 'jscott3201/rusty-bacnet'
+          test "$GITHUB_REF" = 'refs/heads/dev'
+          [[ "$EXPECTED_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$EXPECTED_SHA" = "$GITHUB_SHA"
+      - name: Set up Node 24
+        id: node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - name: Install locked website dependencies
+        id: dependencies
+        run: npm ci
+      - name: Install Chromium and Linux dependencies
+        id: browser
+        run: npx playwright install --with-deps chromium
+      - name: Check, test and build the production site
+        id: verify
+        run: npm run verify
+      - name: Retain browser failure evidence
+        id: reports
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs-browser-failure-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            website/playwright-report
+            website/test-results
+          retention-days: 7
+          if-no-files-found: ignore
+          include-hidden-files: false
+      - name: Package only the validated static site
+        id: pages
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish == true && github.ref == 'refs/heads/dev' && github.repository == 'jscott3201/rusty-bacnet' }}
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        with:
+          name: github-pages
+          path: website/dist
+          retention-days: 1
+          include-hidden-files: false
+      - name: Record validated source and artifact
+        id: provenance
+        env:
+          PAGES_ARTIFACT_ID: ${{ steps.pages.outputs.artifact_id }}
+        run: |
+          printf 'Validated commit: %s\n\nPages artifact ID (empty for validation-only): %s\n' \
+            "$GITHUB_SHA" "$PAGES_ARTIFACT_ID" >> "$GITHUB_STEP_SUMMARY"
+
+  deploy:
+    name: Publish documentation
+    if: ${{ needs.validate.result == 'success' && github.event_name == 'workflow_dispatch' && inputs.publish == true && github.ref == 'refs/heads/dev' && github.repository == 'jscott3201/rusty-bacnet' }}
+    needs: validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      # No checkout or rebuild: deploy-pages finds this run's named artifact,
+      # and fails if it is missing or ambiguous.
+      - name: Deploy the validated artifact
+        id: deployment
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5
+        with:
+          artifact_name: github-pages

--- a/website/README.md
+++ b/website/README.md
@@ -17,8 +17,9 @@ npm run verify
 
 `verify` runs Astro checking, Node unit tests, the production build, and local
 Playwright/axe tests at 320, 390, 768, and 1440 CSS pixels. It does not run Python
-tests or publish anything. These Node checks are local evidence, not an existing
-repository CI job.
+tests or publish anything. The `Docs validation` CI job runs the same command on
+native Ubuntu with Node 24 and Chromium. Local results do not prove that a GitHub
+Actions run or Pages deployment succeeded.
 
 The build regenerates 19 plain Markdown exports, `llms.txt`, and the example
 download, then forces a content-layer sync. This prevents cached Markdown HTML
@@ -85,6 +86,92 @@ The release `bacnet-macos-arm64` executable also read value 72.5 and units 64
 from a 30-second loopback server that then stopped. This is bounded tutorial
 evidence, not PyPI, general wheel/platform, or physical-network qualification.
 
+## Docs CI and manual publication
+
+`.github/workflows/docs-pages.yml` validates pull requests targeting `dev` or
+`main` when `website/**` (including the workflow guard tests) or the workflow
+itself changes. It also accepts manual dispatches. There is no push, schedule,
+merge-triggered publication, or privileged pull-request workflow. The existing
+Rust CI gates remain separate and unchanged; this job runs no BACnet, Python or
+equipment tests. WebKit remains an optional local second-engine check.
+
+The validation job has only `contents: read`, checks out the fixed event SHA
+without persisting credentials, runs `npm ci`, installs Chromium with Linux
+dependencies, and runs the entire `npm run verify`. `npm test` includes maintained
+YAML contract guards and Bash expected-SHA cases; these and local `actionlint`
+are static/local evidence, not a substitute for an actual Linux Actions run.
+When editing the workflow, also run from the repository root:
+
+```sh
+actionlint .github/workflows/docs-pages.yml
+```
+
+Only a successful **manual** dispatch with `publish=true`, on `refs/heads/dev`,
+in `jscott3201/rusty-bacnet` can publish. Its `expected_sha` must be the full
+40-character lowercase reviewed `dev` SHA and must match the dispatch event SHA.
+It is a freeze check, not a checkout ref: a branch move before dispatch fails
+closed. A later branch move does not change the commit already being validated.
+Review and delivery gates remain a maintainer responsibility; this input does
+not prove approvals. PR validation uses GitHub's event (merge) SHA, not an
+arbitrarily supplied branch/head.
+
+The publish attempt packages **only `website/dist`**, after verification, as the
+`github-pages` artifact with one-day retention. Validation-only runs do not
+upload a Pages artifact. The separate deployment job requires successful
+validation, alone receives `pages: write` and `id-token: write`, and deploys that
+same run's named artifact with no checkout or rebuild. The pinned Pages actions
+fail for missing artifacts; deployment also rejects ambiguous artifact names.
+No source tree, dependencies, browser reports or private environments are sent
+as the public artifact. Browser failure reports and screenshots are separate
+Actions artifacts retained for seven days, with hidden files excluded.
+
+### Maintainer sequence (not evidence of publication)
+
+1. Review and merge this workflow only after the actual Linux `Docs validation`
+   job and existing five lean CI gates pass. Do not infer live CI from local tests.
+2. Once the workflow is on the default branch, dispatch **validation only** from
+   `dev`. `publish` defaults to false; `expected_sha` can be omitted:
+
+   ```sh
+   gh workflow run docs-pages.yml --repo jscott3201/rusty-bacnet --ref dev -f publish=false
+   ```
+
+   Identify the new run in Actions, confirm its `headSha`/source summary, successful
+   validation, skipped deployment and absence of a `github-pages` artifact.
+3. Before the first publication, the repository owner must set Pages **Source**
+   to **GitHub Actions** (`build_type=workflow`) and configure the `github-pages`
+   environment for **Selected branches: `dev` only**, not tags or all protected
+   branches. Leave the existing `release` environment unchanged. This workflow
+   does not change settings, add reviewers/wait timers, or run `configure-pages`;
+   Astro already has an explicit static `site` and project `base`.
+4. After review and validation gates, record the full approved `dev` commit and
+   dispatch with publication explicitly enabled (replace the placeholder):
+
+   ```sh
+   gh workflow run docs-pages.yml --repo jscott3201/rusty-bacnet --ref dev -f publish=true -f expected_sha=FULL_REVIEWED_DEV_SHA
+   ```
+
+   Verify the new run's `headSha` and summary equal the reviewed SHA. Record the
+   run ID, `github-pages` artifact ID from the validation summary, artifact digest
+   from the upload log, and deployment outcome/environment URL. Inspect the
+   artifact to confirm it contains the built static site, not repository files.
+   Confirm both jobs succeed; a green validation alone is not a publication.
+5. Verify the **returned deployment URL** in a browser: homepage, direct nested
+   route/reload, native search, theme/tabs, assets, raw Markdown, example download,
+   original SVGs, sitemap/canonical URLs and 404 recovery under `/rusty-bacnet/`.
+   Only after deployment and live checks may a **separate** follow-up add public
+   repository README/package links or replace the unpublished status above.
+
+Future deployments remain manual with the same sequence and reviewed SHA.
+PR runs may cancel older checks for that PR, never a publication. Manual publish
+runs share a non-cancelling concurrency group; validation-only dispatches have a
+separate lane. GitHub concurrency is not FIFO and may replace pending runs: send
+one publication at a time, inspect its outcome, and do not assume dispatch order
+is deployment order. If validation fails, fix/review rather than bypass checks.
+If the artifact expires or publication fails, inspect the failure and use a new
+reviewed dispatch to rebuild and revalidate; do not substitute another run's
+artifact or fetch a mutable branch in the deployment job.
+
 ## Maintenance boundaries
 
 - Preserve native Starlight navigation, Pagefind, tabs, theme selection and code
@@ -98,6 +185,7 @@ evidence, not PyPI, general wheel/platform, or physical-network qualification.
   diagram on a page.
 - Keep `public/raw/`, `public/examples/`, `public/llms.txt`, `dist/`, `.astro/`,
   dependency trees, screenshots and browser reports untracked.
-- No deployment workflow, Pages setting, repository README/package links, or
-  support-status database is introduced here. Publication and CI integration
-  require owner review and approval as a separate slice.
+- The docs workflow is approved for CI and manual publication only. Pages
+  settings and actual publication remain owner-operated; the workflow's presence
+  does not mean this site is live. Repository README/package public links remain
+  deferred until verified deployment. Do not introduce a support-status database.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -17,7 +17,8 @@
         "@axe-core/playwright": "^4.11.0",
         "@playwright/test": "1.61.1",
         "playwright-core": "1.61.1",
-        "typescript": "6.0.3"
+        "typescript": "6.0.3",
+        "yaml": "2.9.0"
       },
       "engines": {
         "node": ">=22.12.0"

--- a/website/package.json
+++ b/website/package.json
@@ -26,6 +26,7 @@
     "typescript": "6.0.3",
     "@playwright/test": "1.61.1",
     "playwright-core": "1.61.1",
-    "@axe-core/playwright": "^4.11.0"
+    "@axe-core/playwright": "^4.11.0",
+    "yaml": "2.9.0"
   }
 }

--- a/website/tests/unit/docs-workflow.test.mjs
+++ b/website/tests/unit/docs-workflow.test.mjs
@@ -1,0 +1,172 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { parseDocument } from 'yaml';
+
+const source = readFileSync(new URL('../../../.github/workflows/docs-pages.yml', import.meta.url), 'utf8');
+const document = parseDocument(source, { uniqueKeys: true });
+assert.deepEqual(document.errors, [], 'workflow must be valid YAML without duplicate keys');
+const workflow = document.toJS();
+const { validate, deploy } = workflow.jobs;
+const step = (id) => {
+  const matches = validate.steps.filter((entry) => entry.id === id);
+  assert.equal(matches.length, 1, `exactly one ${id} step`);
+  return matches[0];
+};
+// Compare GitHub expressions as contract text, not a home-grown interpreter.
+const publishCondition = "github.event_name == 'workflow_dispatch' && inputs.publish == true && github.ref == 'refs/heads/dev' && github.repository == 'jscott3201/rusty-bacnet'";
+const expression = (condition) => `\${{ ${condition} }}`;
+
+test('docs run automatically only for relevant pull requests, and publish defaults off', () => {
+  assert.deepEqual(Object.keys(workflow.on).sort(), ['pull_request', 'workflow_dispatch']);
+  assert.deepEqual(workflow.on.pull_request, {
+    branches: ['dev', 'main'],
+    paths: ['website/**', '.github/workflows/docs-pages.yml'],
+  });
+  // The website/** filter covers this guard as well as the lockfile and site.
+  assert.deepEqual(workflow.on.workflow_dispatch.inputs, {
+    publish: {
+      description: 'Publish the reviewed site from dev',
+      type: 'boolean', default: false, required: true,
+    },
+    expected_sha: {
+      description: 'Full reviewed dev commit SHA (required when publish is true)',
+      type: 'string', default: '', required: false,
+    },
+  });
+});
+
+test('only the separate deployment job has Pages and OIDC permissions', () => {
+  assert.equal(workflow.permissions, undefined, 'no global permissions');
+  assert.deepEqual(Object.keys(workflow.jobs), ['validate', 'deploy']);
+  assert.deepEqual(validate.permissions, { contents: 'read' });
+  assert.deepEqual(deploy.permissions, { pages: 'write', 'id-token': 'write' });
+  assert.equal(validate.environment, undefined);
+  assert.deepEqual(deploy.environment, {
+    name: 'github-pages', url: expression('steps.deployment.outputs.page_url'),
+  });
+});
+
+test('validation uses the event SHA without persisted checkout credentials or ref inputs', () => {
+  assert.deepEqual(step('checkout').with, {
+    ref: expression('github.sha'), 'persist-credentials': false,
+  });
+  assert.equal(step('checkout').if, undefined);
+  assert.equal(step('publication-request').if,
+    expression("github.event_name == 'workflow_dispatch' && inputs.publish == true"));
+  assert.deepEqual(step('publication-request').env, { EXPECTED_SHA: expression('inputs.expected_sha') });
+});
+
+test('native Ubuntu validation installs the lockfile, Chromium and runs the complete verify script', () => {
+  assert.equal(validate.name, 'Docs validation');
+  assert.equal(validate['runs-on'], 'ubuntu-latest');
+  assert.equal(validate['timeout-minutes'], 20);
+  assert.deepEqual(validate.defaults, { run: { 'working-directory': 'website', shell: 'bash' } });
+  assert.deepEqual(validate.env, { DOCS_TEST_PORT: '46329' });
+  assert.equal(validate.if, undefined);
+  assert.equal(validate.container, undefined);
+  assert.equal(validate.strategy, undefined);
+  assert.deepEqual(step('node').with, {
+    'node-version': '24', cache: 'npm', 'cache-dependency-path': 'website/package-lock.json',
+  });
+  assert.deepEqual(validate.steps.map((entry) => entry.id), [
+    'checkout', 'publication-request', 'node', 'dependencies', 'browser', 'verify', 'reports', 'pages', 'provenance',
+  ]);
+  for (const [id, command] of [
+    ['dependencies', 'npm ci'],
+    ['browser', 'npx playwright install --with-deps chromium'],
+    ['verify', 'npm run verify'],
+  ]) {
+    assert.equal(step(id).run, command);
+    assert.equal(step(id).if, undefined, `${id} must not skip validation`);
+    assert.equal(step(id).env, undefined, `${id} must not override the test configuration`);
+  }
+  for (const job of Object.values(workflow.jobs)) {
+    assert.equal(job['continue-on-error'], undefined);
+    for (const entry of job.steps) assert.equal(entry['continue-on-error'], undefined);
+  }
+  assert.deepEqual(validate.steps.filter((entry) => entry.run).map((entry) => entry.id),
+    ['publication-request', 'dependencies', 'browser', 'verify', 'provenance']);
+});
+
+test('only a successful manual canonical dev publication uploads dist and deploys the same named artifact', () => {
+  assert.equal(step('pages').if, expression(publishCondition));
+  assert.deepEqual(step('pages').with, {
+    name: 'github-pages', path: 'website/dist', 'retention-days': 1, 'include-hidden-files': false,
+  });
+  assert.equal(deploy.needs, 'validate');
+  assert.equal(deploy.if, expression(`needs.validate.result == 'success' && ${publishCondition}`));
+  assert.equal(deploy['runs-on'], 'ubuntu-latest');
+  assert.equal(deploy['timeout-minutes'], 15);
+  assert.equal(deploy.steps.length, 1, 'no checkout, fetch, rebuild or other artifact source in deploy');
+  assert.equal(deploy.steps[0].id, 'deployment');
+  assert.deepEqual(deploy.steps[0].with, { artifact_name: step('pages').with.name });
+  assert.equal(deploy.steps[0].run, undefined);
+  assert.equal(deploy.steps[0].if, undefined);
+});
+
+test('browser failure artifacts are bounded and separate from the public Pages artifact', () => {
+  assert.equal(step('reports').if, expression('failure()'));
+  assert.deepEqual(step('reports').with, {
+    name: 'docs-browser-failure-${{ github.run_id }}-${{ github.run_attempt }}',
+    path: 'website/playwright-report\nwebsite/test-results\n',
+    'retention-days': 7, 'if-no-files-found': 'ignore', 'include-hidden-files': false,
+  });
+  assert.notEqual(step('reports').with.name, step('pages').with.name);
+  assert.deepEqual(step('provenance').env, { PAGES_ARTIFACT_ID: expression('steps.pages.outputs.artifact_id') });
+  assert.match(step('provenance').run, /"\$GITHUB_SHA" "\$PAGES_ARTIFACT_ID" >> "\$GITHUB_STEP_SUMMARY"/);
+});
+
+test('PR cancellation is isolated from the serialized manual publication lane', () => {
+  assert.deepEqual(workflow.concurrency, {
+    group: "docs-pages-${{ github.event_name == 'workflow_dispatch' && inputs.publish == true && 'publish' || format('{0}-{1}', github.event_name, github.ref) }}",
+    'cancel-in-progress': expression("github.event_name == 'pull_request'"),
+  });
+  assert.equal(validate.concurrency, undefined);
+  assert.equal(deploy.concurrency, undefined);
+});
+
+test('every external action is pinned to the reviewed immutable release', () => {
+  const pins = [
+    ['actions/checkout', '3d3c42e5aac5ba805825da76410c181273ba90b1', 'v7'],
+    ['actions/setup-node', '249970729cb0ef3589644e2896645e5dc5ba9c38', 'v6'],
+    ['actions/upload-artifact', '043fb46d1a93c77aae656e7c1c64a875d1fc6a0a', 'v7.0.1'],
+    ['actions/upload-pages-artifact', 'fc324d3547104276b827a68afc52ff2a11cc49c9', 'v5'],
+    ['actions/deploy-pages', '368f82528645a54fb793d4d04e342629a3f51346', 'v5'],
+  ];
+  const actions = Object.values(workflow.jobs).flatMap((job) => job.steps)
+    .filter((entry) => entry.uses).map((entry) => entry.uses);
+  assert.deepEqual(actions, pins.map(([action, sha]) => `${action}@${sha}`));
+  for (const [action, sha, version] of pins) {
+    assert.match(sha, /^[0-9a-f]{40}$/);
+    assert.ok(source.includes(`uses: ${action}@${sha} # ${version}\n`));
+  }
+});
+
+// Execute the real, side-effect-free Bash guard with environment fixtures.
+// This tests the expected-SHA check, not GitHub's event/expression engine.
+const reviewedSha = 'b455b8677be88966cb5d1452cd4cc587266468bd';
+const publicationEnv = {
+  GITHUB_REPOSITORY: 'jscott3201/rusty-bacnet', GITHUB_REF: 'refs/heads/dev',
+  GITHUB_SHA: reviewedSha, EXPECTED_SHA: reviewedSha,
+};
+for (const [label, overrides, accepted] of [
+  ['exact reviewed dev commit', {}, true],
+  ['missing expected SHA', { EXPECTED_SHA: '' }, false],
+  ['abbreviated SHA', { EXPECTED_SHA: reviewedSha.slice(0, 7) }, false],
+  ['branch moved before dispatch', { GITHUB_SHA: '0'.repeat(40) }, false],
+  ['other branch', { GITHUB_REF: 'refs/heads/main' }, false],
+  ['tag named dev', { GITHUB_REF: 'refs/tags/dev' }, false],
+  ['fork repository', { GITHUB_REPOSITORY: 'fork/rusty-bacnet' }, false],
+  ['shell-shaped input', { EXPECTED_SHA: '$(exit 0)' }, false],
+]) {
+  test(`publication request guard: ${label}`, () => {
+    const result = spawnSync('bash', ['--noprofile', '--norc', '-e', '-o', 'pipefail', '-c', step('publication-request').run], {
+      env: { ...publicationEnv, ...overrides }, encoding: 'utf8', timeout: 5_000,
+    });
+    assert.equal(result.error, undefined);
+    assert.equal(result.signal, null);
+    assert.equal(result.status, accepted ? 0 : 1, result.stderr);
+  });
+}


### PR DESCRIPTION
## Outcome
Add owner-approved website CI and manual-only GitHub Pages publication. Relevant PRs to dev/main validate the site; merge/push never deploys it. No protocol, existing Rust CI, root public links, website UI/guides, or conformance claims change.

## Safety boundary
- Read-only validation on native Ubuntu/Node 24: fixed event SHA checkout, no persisted credentials, npm ci, Chromium dependencies, full npm run verify.
- Manual publication defaults off and requires canonical repository, refs/heads/dev, and a full expected_sha matching the event SHA.
- Successful validation packages only website/dist; deployment uses that same run artifact without checkout/rebuild. Only deployment has Pages/OIDC write permissions.
- Pinned action SHAs, isolated non-cancelling publication concurrency, bounded separate failure artifacts.
- Owner-approved Pages configuration/first deployment happen only after merge/gates. Existing release environment untouched. Public README/package links remain a separate follow-up after live verification.

## Local evidence
- actionlint 1.7.12 PASS; 16 maintained YAML/Bash workflow guard tests.
- Node 24.20.0, npm ci and npm run verify PASS: Astro 0/0/0, 25 unit tests, 21 pages, 68 Chromium tests across four widths, no skips/retries; 72 screenshots retained.
- Explicit yaml 2.9.0 dev dependency uses the pre-existing locked resolution; no version upgrades. npm audit zero vulnerabilities.
- Root independently reran workflow lint and all 25 unit tests, checked complete diff/five hashes, staged secret/size/whitespace gates.

Actual Linux Docs validation, all five existing lean CI checks, and three independent exact-target reviews are required before merge. Local success is not deployment evidence.

## Operational sequence
After merge, run publish=false and verify no deployment/artifact; configure Pages workflow source and github-pages environment selected dev branch only; then dispatch publish=true with exact reviewed SHA. Verify run, artifact, deployment and public route/search/download behavior before adding public repository links. Future deployments remain manual.