### PR TITLE
docs(sc): close scoped device identity acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Scoped SC Device UUID acceptance closeout (#517):** document the owner-approved
+  [six-criterion resolution and evidence](docs/conformance/standard-135-2020-ledger.md#device-identity-acceptance-closeout)
+  for startup/default/nil identity and peer admission. Runtime is unchanged;
+  existing proof is reused. Caller provisioning/durable lifetime storage remain
+  required; nonzero bits remain opaque, with raw/manual and post-start mutable
+  paths excluded. No RFC bit-profile, enforced lifetime or full Annex AB claim.
+  Issue closure belongs to this proposed closeout; earlier entries retain their
+  slice-time behavior and exclusions.
+
 - **Receiving hub peer identity compatibility break (Refs #517):** all-zero
   Device UUIDs in received Connect-Request now fail after TLS/WebSocket setup,
   before activity refresh, registration, capacity decisions or replacement.
@@ -20,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Generic codecs/manual raw sending still allow nil syntax. The Connect-Accept
   extension below supersedes this slice's original response-policy exclusion.
   No pre-dial peer check, certificate binding, persistence or full Annex AB claim;
-  #517 remains open. Earlier startup-only entries describe those slices' scope.
+  #517 remained open at slice time. Earlier startup-only entries describe those slices' scope.
 
 - **Receiving Connect-Accept identity compatibility break (Refs #517):** after
   TLS/WebSocket setup, initiating nodes silently discard an all-zero peer UUID.
@@ -31,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy reaches native Python SC client/server startup without API changes.
   Nonzero bits stay opaque; generic nil codec syntax and existing malformed
   Accept silence remain. No persistence, certificate binding, full Annex AB or
-  direct-connection claim; #517 remains open.
+  direct-connection claim; #517 remained open at slice time.
 
 - **Raw SC transport startup compatibility break (Refs #517):** the two-argument
   `ScTransport::new(ws, vmac)` retains its unstarted zero UUID placeholder, but
@@ -47,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mutation through public `connection()`. Pure codec/manual WebSocket use, later
   handshake validation, peer admission and internal reconnect/reseed behavior are
   unchanged. Raw runtime fixtures and mTLS benchmarks supply explicit test identities,
-  distinct for coexisting devices. #517 remains open; no full-profile promotion.
+  distinct for coexisting devices. #517 remained open at slice time; no full-profile promotion.
 
 - **Hub-local identity compatibility break (#517):** all four Rust `ScHub`
   startup APIs require a nonzero 16-byte hosting device UUID and reject reserved
@@ -62,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   predeployment generation and durable lifetime storage; exact Connect-Accept
   identities survive tested restarts/recreation. No auto-generation, storage,
   UUID-bit policy, certificate binding, remote-peer admission or node/raw transport
-  policy changes. #517 remains open; no conformance/status promotion.
+  policy changes. #517 remained open at slice time; no conformance/status promotion.
 
 - **SC node UUID runtime compatibility break:** `ScServerBuilder` now requires
   `.device_uuid([u8; 16])`; Python `BACnetClient`/`BACnetServer` require the new
@@ -75,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it per start. There is no generation/storage backend, version/variant enforcement,
   or detection of changed persisted identity. Rust client identity policy, hubs,
   raw transport defaults, wire admission and VMAC policy are unchanged. Same-UUID
-  hub replacement is intentional. #517 remains open for residual identity work;
+  hub replacement is intentional. #517 remained open at slice time for residual identity work;
   no lifetime-storage or full-profile guarantee. See the
   [Python](docs/python-api.md#sc-device-uuid-migration) and
   [Rust](docs/rust-api.md#sc-device-uuid-migration) migration contracts.

--- a/README.md
+++ b/README.md
@@ -157,8 +157,10 @@ environment variables; it does not generate or persist them. See the
 > Hub/node configuration validation rejects missing/all-zero
 > UUIDs, not UUID version/variant bits; no certificate-to-UUID binding or durable
 > change detection is provided. Later application mutation through Rust's public
-> `connection()` is outside the startup guard. [#517](https://github.com/jscott3201/rusty-bacnet/issues/517)
-> remains open. Generated-certificate installed-native tests cover the two-node
+> `connection()` is outside the startup guard. The owner-approved
+> [#517 acceptance closeout](docs/conformance/standard-135-2020-ledger.md#device-identity-acceptance-closeout)
+> resolves the scoped default/nil identity problem with these limits, not an RFC
+> bit-profile or enforced lifetime guarantee. Generated-certificate installed-native tests cover the two-node
 > ReadProperty and same-identity replacement paths, not full Annex AB conformance
 > or your deployment's credentials and lifetime storage.
 

--- a/crates/bacnet-integration-tests/tests/conformance_ledger.rs
+++ b/crates/bacnet-integration-tests/tests/conformance_ledger.rs
@@ -353,8 +353,9 @@ fn sc_identity_evidence_keeps_caller_storage_and_raw_transport_limits_explicit()
     ] {
         assert!(row["positive_tests"].as_array().unwrap().iter().any(|test| test == anchor));
     }
+    // The machine-readable tranche notes retain their slice-time issue status.
+    assert!(row["notes"].as_str().unwrap().contains("#517 remains open"));
     for body in [row["notes"].as_str().unwrap(), STANDARD_LEDGER] {
-        assert!(body.contains("#517 remains open"));
         assert!(body.contains("changed UUIDs cannot be detected without application history"));
         assert!(body.contains("before transport-owned I/O or startup state changes"));
         assert!(body.contains("same owned WebSocket"));
@@ -477,7 +478,7 @@ fn sc_peer_uuid_evidence_retains_silent_accept_policy_without_status_promotion()
     for phrase in [
         "Local security policy",
         "Nonzero bits remain opaque",
-        "#517 remains open",
+        "Owner-approved scoped resolution",
         "Connect-Accept with a zero UUID is silently discarded",
         "prohibits replies to response messages",
         "local diagnostic, not a wire NAK",
@@ -519,6 +520,97 @@ fn public_claim_guard_rejects_unknown_status_for_public_claim() {
     assert!(errors
         .iter()
         .any(|e| e.contains("unknown-pending-source-review")));
+}
+
+fn sc_identity_closeout() -> &'static str {
+    let heading = "### Device identity acceptance closeout\n";
+    let section = STANDARD_LEDGER.split_once(heading).unwrap();
+    section.1.split("\n## ").next().unwrap()
+}
+
+#[test]
+fn sc_identity_closeout_maps_six_criteria_without_promoting_excluded_guarantees() {
+    let body = sc_identity_closeout();
+    let criteria: Vec<_> = body.split("\n| A").skip(1).collect();
+    assert_eq!(criteria.len(), 6);
+    for (index, evidence) in [
+        "test_distinct_nodes_and_same_uuid_replacement_leave_other_node_usable",
+        "test_sc_uuid_validation_precedes_file_and_socket_io",
+        "test_uuid_owned_wire_bytes_across_stop_start_and_recreation",
+        "documented provisioning boundary",
+        "strict_hub_start_family_requires_mutual_tls13_and_preserves_uuid",
+        "sc_client_builder_sends_configured_vmac_and_device_uuid",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let row = criteria[index].lines().next().unwrap();
+        assert!(row.starts_with(&format!("{} |", index + 1)));
+        assert!(row.contains(evidence) && row.contains("]("), "{evidence}");
+    }
+    let normalized = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    for boundary in [
+        "proposed closeout",
+        "caller-owned provisioning/storage",
+        "non-colliding VMACs",
+        "all nonzero 128-bit values",
+        "deferred/excluded",
+        "not fully implemented",
+        "not literal all-public-API coverage",
+        "post-start mutation",
+        "cannot undo caller-owned WebSocket",
+        "VMAC validation may follow dialing",
+        "not application disk-storage qualification",
+        "Runtime evidence is reused",
+        "no fresh native/platform qualification",
+        "full Annex AB/PICS/BTL",
+        "bde599405c38e2ceb62e23ee628a0f15d1ac9fe2",
+    ] {
+        let present = normalized.contains(boundary);
+        assert!(present, "missing boundary: {boundary}");
+    }
+    for section in ["4.1.1", "4.1.3", "4.1.7"] {
+        let rfc = "https://www.rfc-editor.org/rfc/rfc4122.html";
+        assert!(body.contains(&format!("{rfc}#section-{section}")));
+    }
+    assert!(!body.contains("#517 remains open"));
+}
+
+#[test]
+fn sc_identity_closeout_links_and_symbol_anchors_resolve_offline() {
+    let target = "conformance/standard-135-2020-ledger.md#device-identity-acceptance-closeout";
+    for (doc, prefix) in [
+        ("README.md", "docs/"),
+        ("CHANGELOG.md", "docs/"),
+        ("docs/rust-api.md", ""),
+        ("docs/python-api.md", ""),
+    ] {
+        let link = format!("]({prefix}{target})");
+        assert!(read_repo_file(doc).contains(&link), "{doc}");
+    }
+    let links = sc_identity_closeout()
+        .split('[')
+        .filter_map(|s| s.split_once("]("));
+    for (label, link) in links {
+        let target = link.split(')').next().unwrap();
+        if target.starts_with("https://") {
+            continue;
+        }
+        let (path, anchor) = target.split_once('#').unwrap_or((target, ""));
+        let source = read_repo_file(&format!("docs/conformance/{path}"));
+        if !anchor.is_empty() {
+            // Both provisioning links target level-four, plain-word headings.
+            let heading = format!("#### {}", anchor.replace('-', " "));
+            let lower = source.to_lowercase();
+            assert!(lower.lines().any(|s| s == heading), "{target}");
+        }
+        if label.starts_with('`') {
+            let symbol = label.trim_matches('`');
+            let rust = source.contains(&format!("fn {symbol}("));
+            let python = source.contains(&format!("def {symbol}("));
+            assert!(rust || python, "missing {symbol} in {path}");
+        }
+    }
 }
 
 #[test]

--- a/docs/conformance/standard-135-2020-ledger.md
+++ b/docs/conformance/standard-135-2020-ledger.md
@@ -25,7 +25,9 @@ remain unchanged. All 68 rows, 19 supported rows and existing statuses are retai
   registry/capacity decisions, commit or replacement. This is a compatibility break
   for legacy nil-request senders, not a pre-dial check or a claim that RFC 4122
   leaves nil UUID syntax undefined. Nonzero bits remain opaque; no version/variant,
-  generation, lifetime storage or certificate binding is added. #517 remains open.
+  generation, lifetime storage or certificate binding is added. The
+  [identity acceptance closeout](#device-identity-acceptance-closeout) below records
+  the owner-approved resolution without broadening this policy.
 - **Source:** licensed base Standard 135-2020 AB.1.5.2–3 (printed 1382/PDF 1384),
   AB.2.10–11 (printed 1389–1390/PDF 1391–1392), and AB.3.1.2/.4/.5 (printed
   1393–1394/PDF 1395–1396). The existing parameter-range classification returns
@@ -63,6 +65,75 @@ remain unchanged. All 68 rows, 19 supported rows and existing statuses are retai
   later-valid recovery and timeout. This is not a new connection-lifecycle or
   caller-owned storage guarantee; raw primary socket retention remains unchanged.
   No full Annex AB/PICS/BTL, new addenda or performance claim is made.
+
+### Device identity acceptance closeout
+
+**Owner-approved scoped resolution of [#517](https://github.com/jscott3201/rusty-bacnet/issues/517):**
+this proposed closeout accepts the delivered startup and received-peer guards,
+with caller-owned provisioning/storage and the exclusions below. Closing the
+scoped issue resolves accidental default/nil identity at those entry points and
+peer admission; it is not literal all-public-API coverage or a new runtime change.
+Issue closure is part of this proposed closeout, not a claim that GitHub is already
+closed before merge.
+
+**Runtime source baseline:**
+[`bde599405c38e2ceb62e23ee628a0f15d1ac9fe2`](https://github.com/jscott3201/rusty-bacnet/tree/bde599405c38e2ceb62e23ee628a0f15d1ac9fe2),
+unchanged by this docs/test closeout. Evidence below refers to that immutable
+runtime and the merged node [#594](https://github.com/jscott3201/rusty-bacnet/pull/594),
+hub [#595](https://github.com/jscott3201/rusty-bacnet/pull/595), raw-start
+[#596](https://github.com/jscott3201/rusty-bacnet/pull/596), Request
+[#597](https://github.com/jscott3201/rusty-bacnet/pull/597) and Accept
+[#600](https://github.com/jscott3201/rusty-bacnet/pull/600) slices. Python lifecycle
+methods below are in `NodeIdentityMtlsTests`.
+
+| ID | Acceptance criterion and disposition | Code/document contract | Existing test evidence |
+|---|---|---|---|
+| A1 | **Met within scope:** distinct nodes coexist with distinct UUIDs and non-colliding VMACs. | [Hub registration](../../crates/bacnet-transport/src/sc_hub/helpers.rs), `hub_client_registration_decision`, distinguishes UUID replacement from VMAC collision. | [`test_distinct_nodes_and_same_uuid_replacement_leave_other_node_usable`](../../crates/rusty-bacnet/tests/test_sc_hub_mtls.py) checks real ReadProperty `72.5` before/after replacement in both client/server roles. |
+| A2 | **Met at approved startup boundaries:** omitted/default/all-zero UUIDs are refused; not every low-level public path. | Rust fixed `[u8; 16]` types enforce length; [raw start](../../crates/bacnet-transport/src/sc/mod.rs) and the startup map below enforce nonzero identity before their owned I/O. Python [owned conversion](../../crates/rusty-bacnet/src/sc_identity.rs) also checks length. | [`test_sc_uuid_validation_precedes_file_and_socket_io`](../../crates/rusty-bacnet/tests/test_sc_node_identity.py), [`test_uuid_required_length_zero_and_vmac_errors_precede_io`](../../crates/rusty-bacnet/tests/test_sc_hub_identity.py) and [`local_hub_identity_rejected_before_bind_on_every_start_api`](../../crates/bacnet-transport/tests/sc_hub_tls.rs) cover missing/wrong-length/zero and no-dial/no-bind boundaries. |
+| A3 | **Met for supplied bytes:** reuse across supported lifecycle/reconnect and intended same-UUID replacement. This is not application disk-storage qualification. | [`reset_for_connect_retry`](../../crates/bacnet-transport/src/sc/reconnect.rs) preserves the local UUID; [hub registration](../../crates/bacnet-transport/src/sc_hub/helpers.rs) replaces the same UUID even with a different VMAC. | [`test_uuid_owned_wire_bytes_across_stop_start_and_recreation`](../../crates/rusty-bacnet/tests/test_sc_hub_mtls.py) mutates the input bytearray after copying and verifies three lifecycles; [`test_hub_owned_identity_survives_stop_start_and_fresh_object`](../../crates/rusty-bacnet/tests/test_sc_hub_mtls.py) checks exact Accept identity. A1 observes incumbent Close and a surviving other node. [Reconnect tests](../../crates/bacnet-transport/src/sc/reconnect_validation_tests.rs) retain UUID/limits through nil-Accept failover, failed primary probes and timeout/redial. |
+| A4 | **Met by the documented provisioning boundary alternative**, not changed-UUID detection after restart. | [Rust provisioning](../rust-api.md#sc-device-uuid-migration) and [Python provisioning](../python-api.md#sc-device-uuid-migration) require predeployment generation, durable storage and the same bytes for the device lifetime. No library backend/history or enforced lifetime immutability. | A3 proves in-memory reuse, not persistence. The [closeout documentation guard](../../crates/bacnet-integration-tests/tests/conformance_ledger.rs) checks this explicit alternative and the linked contracts; detection without application history is not claimed. |
+| A5 | **Met:** hub Connect-Accept carries the configured nonzero hosting device UUID. | All four [Rust hub starts](../../crates/bacnet-transport/src/sc_hub.rs) share pre-bind UUID/VMAC validation; [Accept emission](../../crates/bacnet-transport/src/sc_hub/handler.rs) uses that configured identity. | [`strict_hub_start_family_requires_mutual_tls13_and_preserves_uuid`](../../crates/bacnet-transport/tests/sc_hub_tls.rs), the A2 pre-bind test, and the A3 Python hub test check rejection and exact Accept UUID/VMAC. Request nil rejection and silent Accept discard are additional guards, not bit-profile proof. |
+| A6 | **Preserved:** existing Rust client #92 validation and type propagation. | [`validate_identity`](../../crates/bacnet-client/src/client/mod.rs) checks reserved VMACs then zero UUID before TLS lookup/dial; reconnect validation remains first. | [`sc_client_builder_sends_configured_vmac_and_device_uuid`](../../crates/bacnet-client/src/client/sc_builder_tests.rs), [`sc_client_builder_rejects_reserved_vmac_before_connect`](../../crates/bacnet-client/src/client/sc_builder_tests.rs) and [`sc_client_builder_rejects_broadcast_vmac_and_zero_device_uuid`](../../crates/bacnet-client/src/client/sc_builder_tests.rs). |
+
+**Startup map and exclusions:** [Rust client](../../crates/bacnet-client/src/client/mod.rs)
+validates VMAC/UUID before TLS dial; [Rust server](../../crates/bacnet-server/src/server/sc_builder.rs)
+validates UUID before binding-table lookup/TLS dial, but its VMAC validation may
+follow dialing. All four Rust hub starts validate UUID/VMAC before bind. Python
+node credential-presence checks and [hub CA-first checks](../../crates/rusty-bacnet/src/hub.rs)
+retain precedence before identity preflight/file I/O. The
+[`parse_sc_device_uuid_arg`](../../crates/bacnet-cli/src/transport.rs) CLI parser
+requires fixed-width hex and nonzero bytes; the standalone
+[hub](../../benchmarks/src/bin/bacnet_sc_hub.rs) and
+[device](../../benchmarks/src/bin/sc/device.rs) check identity before credential I/O.
+Raw `ScTransport::start` checks reconnect, heartbeat, then identity before owned
+I/O/socket-take, but cannot undo caller-owned WebSocket creation/dialing.
+`ScConnection::new`, `build_connect_request`, generic codec/manual raw sending and
+post-start mutation through `ScTransport::connection()`'s `Arc<Mutex<ScConnection>>`
+remain outside the guarantee. There is no new rollback or lifetime enforcement.
+
+**Source contract and deferred policy:** the unchanged licensed base 135-2020
+source review covers AB.1.5.3 (printed 1382/PDF 1384), AB.2's prohibition on replies
+to responses (printed 1383/PDF 1385), and AB.6.2 wait/replacement behavior (printed
+1401–1403/PDF 1403–1405). RFC 4122 defines structured
+[variant](https://www.rfc-editor.org/rfc/rfc4122.html#section-4.1.1) and
+[version](https://www.rfc-editor.org/rfc/rfc4122.html#section-4.1.3) fields and the
+[all-zero nil form](https://www.rfc-editor.org/rfc/rfc4122.html#section-4.1.7).
+The structural recommendation is **not fully implemented** as a bit filter:
+all nonzero 128-bit values remain opaque, including reserved variants. Nonzero is
+not an RFC 4122 bit-profile guarantee. Stronger structural enforcement is explicitly
+**deferred/excluded** by the owner, not marked as passed. Applications must provision
+an appropriate RFC 4122 identity before deployment, durably store it and reuse it
+for the device lifetime. No certificate binding, changed-identity history,
+full Annex AB/PICS/BTL, new addenda or RFC 9562 qualification is claimed.
+
+**Evidence reuse:** Runtime evidence is reused because runtime code is unchanged:
+PR #600's recorded checks include 4,479/4,492 Rust workspace passes and 85 installed
+Python tests with 1,163 subtests. This closeout adds documentation/anchor guards,
+with no fresh native/platform qualification, deployment-storage validation or
+conformance certification. The 68 rows, 19 supported rows, all statuses, source
+JSON and generated PICS/BIBBs/support summary, global August 13 review SHA and historical tranche
+evidence remain unchanged; slice-time open/exclusion notes below are historical,
+not the current issue disposition.
 
 ## Status Taxonomy
 

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1789,7 +1789,9 @@ it cannot undo a caller's prior WebSocket dial. Python signatures and earlier
 constructor preflights are unchanged. The raw guard is startup-only, not protection
 against later application mutation through Rust's public `connection()`; see the
 [Rust startup/retry limits](rust-api.md#bacnetsc-client-transport).
-#517 remains open; these local API checks are not certificate-to-UUID
+The owner-approved [#517 acceptance closeout](conformance/standard-135-2020-ledger.md#device-identity-acceptance-closeout)
+resolves the scoped default/nil identity problem with caller-owned provisioning
+and storage. These local API checks are not certificate-to-UUID
 binding, full identity-profile validation, or full Annex AB conformance.
 
 **Receiving hub compatibility break:** legacy raw peers sending an all-zero UUID

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -1373,7 +1373,9 @@ its hosting device's lifetime UUID: see [hub identity migration](#bacnetsc-hub).
 Raw `ScTransport` now has the [startup guard](#bacnetsc-client-transport) above;
 remote-peer VMAC rules remain unchanged. This does not move
 higher-level builder checks or promise that every local VMAC is rejected before
-dialing. #517 remains open for residual identity work; no PICS/profile promotion.
+dialing. The owner-approved [#517 acceptance closeout](conformance/standard-135-2020-ledger.md#device-identity-acceptance-closeout)
+resolves the scoped default/nil identity problem under these boundaries, not all
+low-level public paths or RFC bit-profile/lifetime enforcement; no PICS/profile promotion.
 
 **Receiving hub compatibility break:** a received Connect-Request with an all-zero
 Device UUID now fails after TLS/WebSocket establishment and before admission,


### PR DESCRIPTION
Closes #517

## Owner-approved disposition
This closes the scoped accidental default/nil Device UUID issue after PRs #594, #595, #596, #597 and #600. The owner explicitly approved a documentation/evidence closeout and gated merge, accepting caller-owned provisioning/storage, opaque nonzero bits, and exclusion of raw/manual/post-start mutable paths. It does not claim literal all-public-API protection, RFC bit-profile enforcement, or full Annex AB compliance.

## Acceptance matrix at immutable runtime bde599405c38e2ceb62e23ee628a0f15d1ac9fe2
- A1: distinct UUID/non-colliding VMAC nodes coexist; intended replacement leaves the other node usable.
- A2: omitted/default/zero UUIDs fail at approved startup boundaries, before their owned I/O; Rust type and Python conversion enforce length. Preconnected raw WebSockets cannot be un-dialed, and post-start public mutation is excluded.
- A3: caller-supplied bytes survive supported lifecycles/reconnect; same-UUID replacement is intentional. This is not disk-storage qualification.
- A4: the issue’s documented-provisioning-boundary alternative is satisfied; no library persistence/history or changed-UUID detection is claimed.
- A5: all four hub starts validate identity and emit configured nonzero UUID/VMAC in Accept.
- A6: existing Rust client #92 identity checks and wire propagation are preserved.

The recommended structural filtering is explicitly NOT fully implemented as an RFC version/variant filter. The owner deferred/excluded that stronger policy; accepting nonzero bytes is not a profile-conformance guarantee. AB.2 response prohibition and silent nil-Accept behavior remain unchanged.

## Six-file scope
Add a source-linked A1–A6 matrix in the existing engineering ledger, update current README/API status links, retain earlier changelog slices as history, and add two offline coverage/link/symbol guards. No runtime, API, dependency, website, CI, Pages or package-publication changes.

## Validation
- Genuine doc-guard RED: 15 pass /3 fail before documentation; final18/18 PASS, no ignores.
- Scoped Clippy, fmt, generator --check, strict700LOC, secret/diff checks PASS; guard695LOC.
- Root independently reran all18 guards (0.06s test time), inspected complete six-file diff, and verified958 unchanged runtime/input hashes plus unchanged JSON/PICS/BIBBs/support summary and six changed-source hashes.
- All68 rows/19 supported/statuses/global provenance/historical tranche notes preserved. Runtime and full native evidence from PR600 is reused, not newly executed or broadened.

Three independent immutable-target reviews and all five existing lean CI checks are required before merge. GitHub issue closure will be verified after merge; no early closure or new policy implied.