### PR TITLE
fix(sc): guard and relay hub advertisement solicitation (#519)

### DIFF
--- a/crates/bacnet-transport/src/sc/advertisement.rs
+++ b/crates/bacnet-transport/src/sc/advertisement.rs
@@ -1,0 +1,63 @@
+//! Established-node Advertisement/Solicitation admission, not generic codec
+//! validation and not AB.3.2 status tracking or solicited responses.
+
+use bacnet_types::enums::{ErrorClass, ErrorCode};
+use bytes::BytesMut;
+use tracing::warn;
+
+use super::data_attributes::build_bvlc_result_nak;
+use super::rejection::{RejectionBudget, RejectionExpired};
+use super::WebSocketPort;
+use crate::sc_frame::{
+    advertisement_message_error, encode_sc_message,
+    first_must_understand_destination_option_marker, ScFunction, ScMessage, BROADCAST_VMAC,
+};
+
+pub(super) async fn reject<W: WebSocketPort>(
+    msg: &ScMessage,
+    wire: &[u8],
+    ws: &W,
+    budget: RejectionBudget,
+) -> Result<bool, RejectionExpired> {
+    if !matches!(
+        msg.function,
+        ScFunction::Advertisement | ScFunction::AdvertisementSolicitation
+    ) {
+        return Ok(false);
+    }
+    // Hub-connector AB.5.4: explicit destinations are not for the local BVLL.
+    // Reserved origins are also silent; neither decision spends a budget.
+    if msg.destination_vmac.is_some()
+        || matches!(msg.originating_vmac, Some(vmac) if vmac == [0; 6] || vmac == BROADCAST_VMAC)
+    {
+        return Ok(true);
+    }
+    // Valid shapes are consumed silently with accepted activity (no NPDU, no
+    // state change). AB.3.2 status updates and solicited Advertisement
+    // transmissions are deferred transmission behavior, not admission.
+    let Some(code) = advertisement_message_error(msg) else {
+        return Ok(false);
+    };
+    let marker = if code == ErrorCode::HEADER_NOT_UNDERSTOOD {
+        match first_must_understand_destination_option_marker(wire) {
+            Some(marker) => marker,
+            None => return Ok(true),
+        }
+    } else {
+        0
+    };
+    let nak = build_bvlc_result_nak(
+        msg.message_id,
+        msg.function,
+        marker,
+        msg.originating_vmac,
+        ErrorClass::COMMUNICATION,
+        code,
+    );
+    let mut bytes = BytesMut::new();
+    encode_sc_message(&mut bytes, &nak);
+    if let Err(e) = budget.send(ws, &bytes).await? {
+        warn!("BACnet/SC advertisement NAK send error: {}", e);
+    }
+    Ok(true)
+}

--- a/crates/bacnet-transport/src/sc/advertisement_tests.rs
+++ b/crates/bacnet-transport/src/sc/advertisement_tests.rs
@@ -1,0 +1,412 @@
+//! Independent raw-wire node admission vectors for Advertisement (0x04) and
+//! Advertisement-Solicitation (0x05); no hub fallback involved.
+use super::*;
+use tokio::time::timeout;
+
+fn wire(
+    raw: u8,
+    id: u16,
+    source: Option<Vmac>,
+    dest: Option<Vmac>,
+    flags: u8,
+    body: &[u8],
+) -> Vec<u8> {
+    let mut bytes = vec![
+        raw,
+        flags | (u8::from(source.is_some()) * 8) | (u8::from(dest.is_some()) * 4),
+    ];
+    bytes.extend_from_slice(&id.to_be_bytes());
+    if let Some(source) = source {
+        bytes.extend_from_slice(&source);
+    }
+    if let Some(dest) = dest {
+        bytes.extend_from_slice(&dest);
+    }
+    bytes.extend_from_slice(body);
+    bytes
+}
+
+fn nak(raw: u8, id: u16, dest: Option<Vmac>, code: u16, marker: u8) -> Vec<u8> {
+    let [hi, lo] = code.to_be_bytes();
+    wire(0, id, None, dest, 0, &[raw, 1, marker, 0, 7, hi, lo])
+}
+
+fn valid_advertisement() -> Vec<u8> {
+    vec![1, 1, 0x05, 0xC4, 0x05, 0xC4]
+}
+
+async fn recv(hub: &LoopbackWebSocket) -> Vec<u8> {
+    timeout(Duration::from_secs(1), hub.recv())
+        .await
+        .unwrap()
+        .unwrap()
+}
+
+async fn barrier(hub: &LoopbackWebSocket) {
+    // An invalid known control is an ordered, non-activity barrier, not a valid
+    // sentinel that could conceal unintended activity from advertisement traffic.
+    hub.send(&[0x0A, 0, 0x44, 0x55, 0x42]).await.unwrap();
+    assert_eq!(recv(hub).await, [0, 0, 0x44, 0x55, 0x0A, 1, 0, 0, 7, 0, 7]);
+}
+
+#[tokio::test]
+async fn advertisement_valid_shapes_are_consumed_silently_without_npdu() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    for status in [0, 1, 2] {
+        for direct in [0, 1] {
+            let mut payload = vec![status, direct, 0, 0, 0, 0];
+            payload[2..4].copy_from_slice(&0u16.to_be_bytes());
+            payload[4..6].copy_from_slice(&65535u16.to_be_bytes());
+            for source in [None, Some([0x22; 6])] {
+                hub.send(&wire(4, 0x2233, source, None, 0, &payload))
+                    .await
+                    .unwrap();
+                barrier(&hub).await;
+                assert!(rx.try_recv().is_err());
+            }
+        }
+    }
+    for source in [None, Some([0x22; 6])] {
+        hub.send(&wire(5, 0x2234, source, None, 0, &[]))
+            .await
+            .unwrap();
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    // Non-MU destination options on valid shapes stay silent here.
+    let mut optioned = vec![0x1F];
+    optioned.extend_from_slice(&valid_advertisement());
+    hub.send(&wire(4, 0x2235, None, None, 2, &optioned))
+        .await
+        .unwrap();
+    barrier(&hub).await;
+    assert!(rx.try_recv().is_err());
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn advertisement_negative_matrix_nak_vs_silence() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    // (function, body, expected NAK code, MU marker)
+    let mut faults: Vec<(u8, Vec<u8>, u16, u8)> = Vec::new();
+    faults.push((4, vec![], 149, 0));
+    for len in [1, 3, 5] {
+        faults.push((4, vec![1; len], 147, 0));
+    }
+    for len in [7, 8] {
+        faults.push((4, vec![1; len], 7, 0));
+    }
+    let mut bad_status = valid_advertisement();
+    bad_status[0] = 3;
+    faults.push((4, bad_status, 80, 0));
+    let mut bad_direct = valid_advertisement();
+    bad_direct[1] = 2;
+    faults.push((4, bad_direct, 80, 0));
+    faults.push((4, [valid_advertisement(), vec![0xFF]].concat(), 7, 0));
+    faults.push((5, vec![0x00], 7, 0));
+    faults.push((5, valid_advertisement(), 7, 0));
+    for (function, body, code, _marker) in faults {
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(function, 0x2233, source, None, 0, &body);
+            hub.send(&bytes).await.unwrap();
+            assert_eq!(
+                recv(&hub).await,
+                nak(function, 0x2233, source, code, 0),
+                "function {function} source {source:02x?} body {body:02x?}"
+            );
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    // Data Options are out of range even around otherwise valid payloads.
+    for function in [4, 5] {
+        let payload = if function == 4 {
+            valid_advertisement()
+        } else {
+            vec![]
+        };
+        let mut body = vec![0x01];
+        body.extend_from_slice(&payload);
+        for source in [None, Some([0x22; 6])] {
+            hub.send(&wire(function, 0x2233, source, None, 1, &body))
+                .await
+                .unwrap();
+            assert_eq!(
+                recv(&hub).await,
+                nak(function, 0x2233, source, 80, 0),
+                "function {function} data options source {source:02x?}"
+            );
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    // Must-Understand destination option faults carry the wire marker.
+    for function in [4, 5] {
+        let payload = if function == 4 {
+            valid_advertisement()
+        } else {
+            vec![]
+        };
+        let mut body = vec![0x42];
+        body.extend_from_slice(&payload);
+        for source in [None, Some([0x22; 6])] {
+            hub.send(&wire(function, 0x2234, source, None, 2, &body))
+                .await
+                .unwrap();
+            assert_eq!(
+                recv(&hub).await,
+                nak(function, 0x2234, source, 146, 0x42),
+                "function {function} MU source {source:02x?}"
+            );
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    // Addressed, broadcast, and reserved-origin envelopes stay silent for
+    // both valid and forbidden shapes without spending a rejection budget.
+    let silent_bodies: Vec<(u8, Vec<u8>)> = vec![
+        (4, valid_advertisement()),
+        (4, vec![]),
+        (4, vec![9, 9, 0, 1, 0, 1]),
+        (5, vec![]),
+        (5, vec![0x42]),
+    ];
+    for (function, body) in silent_bodies {
+        for (source, dest) in [
+            (None, Some([0x44; 6])),
+            (Some([0x22; 6]), Some([0x44; 6])),
+            (None, Some(BROADCAST_VMAC)),
+            (Some([0; 6]), None),
+            (Some(BROADCAST_VMAC), None),
+            (Some([0; 6]), Some([0x44; 6])),
+        ] {
+            hub.send(&wire(function, 0x2235, source, dest, 0, &body))
+                .await
+                .unwrap();
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn advertisement_silence_and_known_codes_never_consult_expired_budget() {
+    use super::rejection::{reject, RejectionBudget, RejectionExpired};
+    struct NoIo;
+    impl WebSocketPort for NoIo {
+        async fn send(&self, _: &[u8]) -> Result<(), Error> {
+            panic!("unexpected send")
+        }
+        async fn recv(&self) -> Result<Vec<u8>, Error> {
+            panic!("unexpected receive")
+        }
+    }
+    let expired = RejectionBudget::new(Instant::now() - Duration::from_secs(1), 1);
+    // Forbidden local shapes must consult the budget (expiry surfaces).
+    let nak_cases: Vec<(u8, Vec<u8>)> = vec![
+        (4, vec![]),
+        (4, vec![1, 1, 0]),
+        (4, vec![1; 7]),
+        (4, vec![3, 1, 0, 5, 0, 5]),
+        (5, vec![0x00]),
+    ];
+    for (function, body) in nak_cases {
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(function, 0, source, None, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Err(RejectionExpired),
+                "function {function} source {source:02x?}"
+            );
+        }
+    }
+    // MU faults also consult the budget when the marker is recoverable.
+    for function in [4, 5] {
+        let payload = if function == 4 {
+            valid_advertisement()
+        } else {
+            vec![]
+        };
+        let mut body = vec![0x42];
+        body.extend_from_slice(&payload);
+        let bytes = wire(function, 0, None, None, 2, &body);
+        let msg = decode_sc_message(&bytes).unwrap();
+        assert_eq!(
+            reject(&msg, &bytes, &NoIo, expired).await,
+            Err(RejectionExpired),
+            "function {function} MU"
+        );
+    }
+    // Silent envelopes and valid shapes never consult the budget.
+    for (function, body) in [(4, valid_advertisement()), (5, vec![])] {
+        for (source, dest) in [
+            (None, Some([0x44; 6])),
+            (None, Some(BROADCAST_VMAC)),
+            (Some([0; 6]), None),
+            (Some(BROADCAST_VMAC), None),
+        ] {
+            let bytes = wire(function, 0, source, dest, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Ok(true),
+                "silent function {function}"
+            );
+        }
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(function, 0, source, None, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Ok(false),
+                "valid function {function}"
+            );
+        }
+    }
+}
+
+#[test]
+fn advertisement_direct_connection_is_pure_in_all_states_and_codec_is_permissive() {
+    for state in [
+        ScConnectionState::Disconnected,
+        ScConnectionState::Connecting,
+        ScConnectionState::Connected,
+        ScConnectionState::Disconnecting,
+    ] {
+        let mut conn = ScConnection::new([1; 6], [1; 16]);
+        conn.build_connect_request();
+        conn.state = state;
+        conn.hub_vmac = Some([0x10; 6]);
+        conn.hub_device_uuid = Some([0x33; 16]);
+        conn.disconnect_ack_to_send = Some(conn.build_heartbeat_ack(0x4455));
+        let before = conn.clone();
+        for function in [4, 5] {
+            for dest in [None, Some(BROADCAST_VMAC), Some([1; 6])] {
+                for body in [&[][..], &valid_advertisement()[..], &[9, 9, 0, 1, 0, 1][..]] {
+                    let bytes = wire(function, u16::MAX, Some([0x22; 6]), dest, 0, body);
+                    let msg = decode_sc_message(&bytes).unwrap();
+                    let mut encoded = BytesMut::new();
+                    encode_sc_message(&mut encoded, &msg);
+                    assert_eq!(encoded.as_ref(), bytes);
+                    assert!(conn.handle_received(&msg).is_none());
+                    assert_eq!(conn.state, before.state);
+                    assert_eq!(conn.local_vmac, before.local_vmac);
+                    assert_eq!(conn.device_uuid, before.device_uuid);
+                    assert_eq!(conn.hub_vmac, before.hub_vmac);
+                    assert_eq!(conn.hub_device_uuid, before.hub_device_uuid);
+                    assert_eq!(conn.max_bvlc_length, before.max_bvlc_length);
+                    assert_eq!(conn.max_apdu_length, before.max_apdu_length);
+                    assert_eq!(conn.hub_max_bvlc_length, before.hub_max_bvlc_length);
+                    assert_eq!(conn.hub_max_apdu_length, before.hub_max_apdu_length);
+                    assert_eq!(conn.next_message_id, before.next_message_id);
+                    assert_eq!(
+                        conn.pending_connect_message_id,
+                        before.pending_connect_message_id
+                    );
+                    assert_eq!(conn.connect_retry_allowed, before.connect_retry_allowed);
+                    assert_eq!(conn.disconnect_ack_to_send, before.disconnect_ack_to_send);
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn advertisement_malformed_generic_wire_is_still_silent() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    for bytes in [
+        vec![0x04],
+        vec![0x04, 0x80, 0, 1],
+        vec![0x04, 8, 0, 1],
+        vec![0x04, 4, 0, 1],
+        vec![0x04, 2, 0, 1, 0],
+        vec![0x05, 1, 0, 1, 0x7E, 0, 1],
+    ] {
+        assert!(decode_sc_message(&bytes).is_err());
+        hub.send(&bytes).await.unwrap();
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn advertisement_result_for_keeps_existing_parse_and_fatal_policy() {
+    for raw in [4, 5] {
+        for (body, fatal) in [
+            (vec![raw, 0], false),
+            (vec![raw, 1, 0, 0, 7, 0, 150], true),
+            (vec![raw, 1], true),
+        ] {
+            let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+            let bytes = wire(0, 0x2233, None, None, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(msg.function, ScFunction::Result);
+            hub.send(&bytes).await.unwrap();
+            let mut states = transport.connection_state_changes();
+            let finished = if fatal {
+                timeout(Duration::from_secs(1), async {
+                    while *states.borrow_and_update() != ScConnectionState::Disconnected {
+                        states.changed().await.unwrap();
+                    }
+                })
+                .await
+            } else {
+                barrier(&hub).await;
+                assert_eq!(*states.borrow(), ScConnectionState::Connected);
+                Ok(())
+            };
+            let extra = timeout(Duration::from_millis(20), hub.recv()).await;
+            transport.stop().await.unwrap();
+            finished.unwrap();
+            assert!(extra.is_err(), "response on Result");
+            assert!(rx.try_recv().is_err());
+        }
+    }
+}
+
+#[tokio::test]
+async fn advertisement_valid_traffic_keeps_heartbeat_and_npdu_interop() {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, [1; 6])
+        .with_device_uuid([1; 16])
+        .with_test_heartbeat_timing_ms(80, 700);
+    let (rx, ()) = tokio::join!(
+        transport.start(),
+        super::data_attribute_tests::hub_accept(&hub, [0x10; 6])
+    );
+    let mut rx = rx.unwrap();
+    let probe = recv(&hub).await;
+    assert_eq!(probe[0], 0x0A);
+    // Valid advertisements and solicitations are consumed without replies.
+    for _ in 0..4 {
+        hub.send(&wire(4, 0, None, None, 0, &valid_advertisement()))
+            .await
+            .unwrap();
+        hub.send(&wire(5, 1, Some([0x22; 6]), None, 0, &[]))
+            .await
+            .unwrap();
+    }
+    // No rejection reply may precede the next liveness probe; accepted
+    // advertisement traffic keeps the heartbeat budget alive like NPDUs.
+    let next = timeout(Duration::from_secs(1), hub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(next[0], 0x0A);
+    assert_ne!(&next[2..4], &probe[2..4]);
+    assert!(rx.try_recv().is_err());
+    // Positive controls only AFTER the advertisement window.
+    hub.send(&[0x0B, 0, next[2], next[3]]).await.unwrap();
+    hub.send(&wire(1, 0, Some([0x22; 6]), None, 0, &[1, 0, 0x30]))
+        .await
+        .unwrap();
+    let npdu = timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    transport.stop().await.unwrap();
+    assert_eq!(npdu.npdu.as_ref(), &[1, 0, 0x30]);
+}

--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -300,6 +300,12 @@ impl ScConnection {
                 }
                 None
             }
+            ScFunction::Advertisement | ScFunction::AdvertisementSolicitation => {
+                // Validated before activity by the rejection gate. AB.3.2
+                // status tracking and solicited responses are deferred; the
+                // frame is consumed without NPDU delivery or state change.
+                None
+            }
             _ => None,
         }
     }

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -22,6 +22,7 @@ use crate::sc_frame::{decode_sc_message, encode_sc_message, ScFunction, Vmac, BR
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 
+mod advertisement;
 mod connect_result;
 mod connection;
 mod connector;
@@ -771,6 +772,9 @@ mod empty_npdu_tests;
 
 #[cfg(test)]
 mod unknown_function_tests;
+
+#[cfg(test)]
+mod advertisement_tests;
 
 #[cfg(test)]
 mod primary_restore_tests;

--- a/crates/bacnet-transport/src/sc/rejection.rs
+++ b/crates/bacnet-transport/src/sc/rejection.rs
@@ -95,6 +95,9 @@ pub(super) async fn reject<W: WebSocketPort>(
     if super::empty_npdu::reject(msg, ws, budget).await? {
         return Ok(true);
     }
+    if super::advertisement::reject(msg, wire, ws, budget).await? {
+        return Ok(true);
+    }
     // All preceding gates exclude Unknown. Its identity wins over option or
     // payload diagnostics without changing any known-function admission.
     super::unknown_function::reject(msg, ws, budget).await

--- a/crates/bacnet-transport/src/sc/unknown_function_tests.rs
+++ b/crates/bacnet-transport/src/sc/unknown_function_tests.rs
@@ -156,7 +156,14 @@ async fn unknown_function_silence_and_known_codes_never_consult_expired_budget()
             super::unknown_function::reject(&msg, &NoIo, expired).await,
             Ok(false)
         );
-        assert_eq!(reject(&msg, &bytes, &NoIo, expired).await, Ok(false));
+        // Advertisement (0x04) and Solicitation (0x05) own a later gate that
+        // consults the budget for forbidden local shapes; an empty
+        // Advertisement is such a shape while an empty Solicitation is valid.
+        let expected = match raw {
+            4 => Err(RejectionExpired),
+            _ => Ok(false),
+        };
+        assert_eq!(reject(&msg, &bytes, &NoIo, expired).await, expected);
     }
 }
 

--- a/crates/bacnet-transport/src/sc_frame.rs
+++ b/crates/bacnet-transport/src/sc_frame.rs
@@ -12,10 +12,13 @@
 use bacnet_types::error::Error;
 use bytes::{BufMut, Bytes, BytesMut};
 
+mod advertisement;
 mod connect;
 mod control;
 mod npdu;
 mod result;
+
+pub(crate) use advertisement::advertisement_message_error;
 
 pub(crate) use connect::connect_message_error;
 #[cfg(feature = "sc-tls")]

--- a/crates/bacnet-transport/src/sc_frame/advertisement.rs
+++ b/crates/bacnet-transport/src/sc_frame/advertisement.rs
@@ -1,0 +1,260 @@
+//! Receive-only Advertisement / Advertisement-Solicitation admission after
+//! generic syntax decoding.
+//!
+//! The wire shapes paraphrase ASHRAE 135-2020 Annex AB.2.8/AB.2.8.1 (unicast
+//! Advertisement: no Data Options, six payload octets carrying hub-connection
+//! status 0..2, accept-direct 0..1, and two opaque maximum lengths) and
+//! AB.2.9/AB.2.9.1 (unicast Advertisement-Solicitation: no Data Options and
+//! no defined payload). Error selection and multi-fault precedence interpret
+//! AB.3.1.4 (Must Understand) and AB.3.1.5 (common errors); envelope routing
+//! (broadcast/response silence, self-echo, hub-connector drops) stays with
+//! the hub and node receivers, as for Connect and Control envelopes.
+
+use super::{ScFunction, ScMessage};
+use bacnet_types::enums::ErrorCode;
+
+/// Advertisement payload length: hub-status(1) + accept-direct(1) +
+/// maximum-BVLC(2) + maximum-NPDU(2).
+pub(crate) const ADVERTISEMENT_PAYLOAD_LEN: usize = 6;
+
+pub(crate) fn advertisement_message_error(msg: &ScMessage) -> Option<ErrorCode> {
+    if !matches!(
+        msg.function,
+        ScFunction::Advertisement | ScFunction::AdvertisementSolicitation
+    ) {
+        return None;
+    }
+    // AB.2.8.1/AB.2.9.1 convey no Data Options. The envelope-option fault
+    // precedes payload shape, matching the Connect and Control validators.
+    if !msg.data_options.is_empty() {
+        return Some(ErrorCode::PARAMETER_OUT_OF_RANGE);
+    }
+    if msg.function == ScFunction::AdvertisementSolicitation {
+        // AB.2.9.1 defines no payload. Trailing bytes are inconsistent,
+        // matching the Control policy for unexpected payloads.
+        if !msg.payload.is_empty() {
+            return Some(ErrorCode::INCONSISTENT_PARAMETERS);
+        }
+    } else {
+        if msg.payload.is_empty() {
+            return Some(ErrorCode::PAYLOAD_EXPECTED);
+        }
+        if msg.payload.len() < ADVERTISEMENT_PAYLOAD_LEN {
+            return Some(ErrorCode::MESSAGE_INCOMPLETE);
+        }
+        if msg.payload.len() > ADVERTISEMENT_PAYLOAD_LEN {
+            return Some(ErrorCode::INCONSISTENT_PARAMETERS);
+        }
+        // AB.2.8.1 enumerates hub-status 0..2 and accept-direct 0..1.
+        // Maximum lengths stay opaque: no positive floor and no
+        // BVLC/NPDU relationship is imposed here.
+        if msg.payload[0] > 2 || msg.payload[1] > 1 {
+            return Some(ErrorCode::PARAMETER_OUT_OF_RANGE);
+        }
+    }
+    if msg.dest_options.iter().any(|option| option.must_understand) {
+        // Known-option shape/placement validation remains separate work.
+        return Some(ErrorCode::HEADER_NOT_UNDERSTOOD);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sc_frame::{decode_sc_message, encode_sc_message, ScOption};
+    use bytes::{Bytes, BytesMut};
+
+    fn message(function: ScFunction, payload: &[u8]) -> ScMessage {
+        ScMessage {
+            function,
+            message_id: 0x2233,
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::copy_from_slice(payload),
+        }
+    }
+
+    fn valid_advertisement() -> Vec<u8> {
+        vec![1, 1, 0x05, 0xC4, 0x05, 0xC4]
+    }
+
+    #[test]
+    fn ignores_other_functions() {
+        for raw in [
+            0x00, 0x01, 0x02, 0x03, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
+        ] {
+            let msg = message(ScFunction::from_raw(raw), &[0xFF; 9]);
+            assert_eq!(advertisement_message_error(&msg), None);
+        }
+        for raw in [0x0D, 0x42, 0xFF] {
+            let msg = message(ScFunction::from_raw(raw), &[]);
+            assert_eq!(advertisement_message_error(&msg), None);
+        }
+    }
+
+    #[test]
+    fn valid_shapes_pass_without_positive_floors() {
+        for status in [0, 1, 2] {
+            for direct in [0, 1] {
+                for (bvlc, npdu) in [
+                    (0u16, 0u16),
+                    (1, 1),
+                    (300, 1476),
+                    (1476, 480),
+                    (65535, 65535),
+                ] {
+                    let mut payload = vec![status, direct];
+                    payload.extend_from_slice(&bvlc.to_be_bytes());
+                    payload.extend_from_slice(&npdu.to_be_bytes());
+                    assert_eq!(
+                        advertisement_message_error(&message(ScFunction::Advertisement, &payload)),
+                        None
+                    );
+                }
+            }
+        }
+        assert_eq!(
+            advertisement_message_error(&message(ScFunction::AdvertisementSolicitation, &[])),
+            None
+        );
+    }
+
+    #[test]
+    fn generic_syntax_preserves_rejected_shapes() {
+        // The generic codec stays permissive; this validator owns the verdict.
+        let mut msg = message(ScFunction::Advertisement, &[9, 9, 0, 1, 0, 1]);
+        msg.data_options.push(ScOption {
+            option_type: 1,
+            must_understand: false,
+            data: Vec::new(),
+        });
+        let mut encoded = BytesMut::new();
+        encode_sc_message(&mut encoded, &msg);
+        let decoded = decode_sc_message(&encoded).unwrap();
+        assert_eq!(decoded.payload.as_ref(), &[9, 9, 0, 1, 0, 1]);
+        assert_eq!(
+            advertisement_message_error(&decoded),
+            Some(ErrorCode::PARAMETER_OUT_OF_RANGE)
+        );
+    }
+
+    #[test]
+    fn data_options_are_out_of_range_for_both_functions() {
+        for function in [
+            ScFunction::Advertisement,
+            ScFunction::AdvertisementSolicitation,
+        ] {
+            let mut msg = if function == ScFunction::Advertisement {
+                message(function, &valid_advertisement())
+            } else {
+                message(function, &[])
+            };
+            msg.data_options.push(ScOption {
+                option_type: 1,
+                must_understand: false,
+                data: Vec::new(),
+            });
+            assert_eq!(
+                advertisement_message_error(&msg),
+                Some(ErrorCode::PARAMETER_OUT_OF_RANGE),
+                "{function:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn advertisement_payload_length_matrix() {
+        assert_eq!(
+            advertisement_message_error(&message(ScFunction::Advertisement, &[])),
+            Some(ErrorCode::PAYLOAD_EXPECTED)
+        );
+        for len in 1..6 {
+            assert_eq!(
+                advertisement_message_error(&message(ScFunction::Advertisement, &vec![1; len])),
+                Some(ErrorCode::MESSAGE_INCOMPLETE),
+                "len {len}"
+            );
+        }
+        for len in [7, 8, 26, 64] {
+            assert_eq!(
+                advertisement_message_error(&message(ScFunction::Advertisement, &vec![1; len])),
+                Some(ErrorCode::INCONSISTENT_PARAMETERS),
+                "len {len}"
+            );
+        }
+    }
+
+    #[test]
+    fn advertisement_field_ranges() {
+        for status in [3, 4, 0x7F, 0xFF] {
+            let mut payload = valid_advertisement();
+            payload[0] = status;
+            assert_eq!(
+                advertisement_message_error(&message(ScFunction::Advertisement, &payload)),
+                Some(ErrorCode::PARAMETER_OUT_OF_RANGE),
+                "status {status}"
+            );
+        }
+        for direct in [2, 3, 0x7F, 0xFF] {
+            let mut payload = valid_advertisement();
+            payload[1] = direct;
+            assert_eq!(
+                advertisement_message_error(&message(ScFunction::Advertisement, &payload)),
+                Some(ErrorCode::PARAMETER_OUT_OF_RANGE),
+                "direct {direct}"
+            );
+        }
+    }
+
+    #[test]
+    fn solicitation_payload_is_inconsistent() {
+        for payload in [&[0x00][..], &[1, 1, 5, 5][..], &[0xFF; 6][..]] {
+            assert_eq!(
+                advertisement_message_error(&message(
+                    ScFunction::AdvertisementSolicitation,
+                    payload
+                )),
+                Some(ErrorCode::INCONSISTENT_PARAMETERS)
+            );
+        }
+    }
+
+    #[test]
+    fn must_understand_is_last_precedence() {
+        // Payload faults win over the MU fault, as for Connect diagnostics.
+        let mu = ScOption {
+            option_type: 2,
+            must_understand: true,
+            data: Vec::new(),
+        };
+        let mut short = message(ScFunction::Advertisement, &[1, 1, 0]);
+        short.dest_options.push(mu.clone());
+        assert_eq!(
+            advertisement_message_error(&short),
+            Some(ErrorCode::MESSAGE_INCOMPLETE)
+        );
+        let mut long = message(ScFunction::AdvertisementSolicitation, &[0x42]);
+        long.dest_options.push(mu.clone());
+        assert_eq!(
+            advertisement_message_error(&long),
+            Some(ErrorCode::INCONSISTENT_PARAMETERS)
+        );
+        let mut valid = message(ScFunction::Advertisement, &valid_advertisement());
+        valid.dest_options.push(mu);
+        assert_eq!(
+            advertisement_message_error(&valid),
+            Some(ErrorCode::HEADER_NOT_UNDERSTOOD)
+        );
+        // Non-MU destination options are ignored here.
+        let mut ignored = message(ScFunction::AdvertisementSolicitation, &[]);
+        ignored.dest_options.push(ScOption {
+            option_type: 31,
+            must_understand: false,
+            data: vec![0xAA],
+        });
+        assert_eq!(advertisement_message_error(&ignored), None);
+    }
+}

--- a/crates/bacnet-transport/src/sc_hub.rs
+++ b/crates/bacnet-transport/src/sc_hub.rs
@@ -4,7 +4,7 @@
 //! The hub performs three duties:
 //! 1. **Connection handshake** — responds to `ConnectRequest` with `ConnectAccept`.
 //! 2. **Message relay** — forwards `EncapsulatedNpdu`, addressed Unknown functions,
-//!    unicast Address-Resolution/ACK, and permitted routed `Result` messages.
+//!    unicast Address-Resolution/ACK, unicast Advertisement/Solicitation, and permitted routed `Result` messages.
 //!    No node URI parsing, discovery, or direct-connection support is implied.
 //! 3. **Heartbeat** — responds to `HeartbeatRequest` with `HeartbeatAck`.
 
@@ -26,6 +26,7 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::WebSocketStream;
 use tracing::{debug, warn};
 
+mod advertisement_transit;
 mod client;
 mod connection;
 mod deadlines;
@@ -420,6 +421,8 @@ mod unknown_transit_lifecycle_tests;
 #[cfg(test)]
 mod unknown_transit_tests;
 
+#[cfg(test)]
+mod advertisement_transit_tests;
 #[cfg(test)]
 mod resolution_transit_lifecycle_tests;
 #[cfg(test)]

--- a/crates/bacnet-transport/src/sc_hub/advertisement_transit.rs
+++ b/crates/bacnet-transport/src/sc_hub/advertisement_transit.rs
@@ -1,0 +1,134 @@
+//! Hub-only Advertisement/Solicitation local rejection, not AB.3.2 node
+//! status tracking or solicited responses. Registered unicast transit stays
+//! opaque via the shared relay mechanics (AB.5.3.2 forwarding).
+use super::*;
+use crate::sc_frame::{
+    advertisement_message_error, encode_sc_message,
+    first_must_understand_destination_option_marker, BROADCAST_VMAC, UNKNOWN_VMAC,
+};
+use bacnet_types::enums::{ErrorClass, ErrorCode};
+use bytes::{Bytes, BytesMut};
+
+pub(super) fn local_nak(msg: &ScMessage, wire: &[u8]) -> Option<ScMessage> {
+    if !matches!(
+        msg.function,
+        ScFunction::Advertisement | ScFunction::AdvertisementSolicitation
+    ) {
+        return None;
+    }
+    // Neither Advertisement nor Solicitation is a response, but AB.2 still
+    // forbids answering broadcasts. Reserved origins stay silent as hub
+    // hardening, matching the Unknown and Resolution fallbacks.
+    if msg.destination_vmac == Some(BROADCAST_VMAC)
+        || matches!(msg.originating_vmac, Some(UNKNOWN_VMAC | BROADCAST_VMAC))
+    {
+        return None;
+    }
+    // Shape faults draw their AB.3.1.5 code. A well-formed hub-local request
+    // is unsupported here (no hub status to advertise), matching the
+    // previous connection-local UNEXPECTED_DATA fallback without its
+    // activity refresh.
+    let code = advertisement_message_error(msg).unwrap_or(ErrorCode::UNEXPECTED_DATA);
+    let marker = if code == ErrorCode::HEADER_NOT_UNDERSTOOD {
+        first_must_understand_destination_option_marker(wire)?
+    } else {
+        0
+    };
+    let class = ErrorClass::COMMUNICATION.to_raw().to_be_bytes();
+    let code = code.to_raw().to_be_bytes();
+    Some(ScMessage {
+        function: ScFunction::Result,
+        message_id: msg.message_id,
+        originating_vmac: None,
+        destination_vmac: msg.originating_vmac,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(vec![
+            msg.function.to_raw(),
+            0x01,
+            marker,
+            class[0],
+            class[1],
+            code[0],
+            code[1],
+        ]),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sc_frame::{decode_sc_bvlc_result, decode_sc_message, ScBvlcResult};
+
+    fn decoded(function: u8, flags: u8, body: &[u8]) -> (ScMessage, Vec<u8>) {
+        let mut wire = vec![function, flags, 0x22, 0x33];
+        wire.extend_from_slice(body);
+        let msg = decode_sc_message(&wire).unwrap();
+        (msg, wire)
+    }
+
+    #[test]
+    fn ignores_other_functions() {
+        for function in [0x00, 0x01, 0x02, 0x03, 0x06, 0x0C, 0x42] {
+            let (msg, wire) = decoded(function, 0, &[]);
+            assert!(local_nak(&msg, &wire).is_none());
+        }
+    }
+
+    #[test]
+    fn wellformed_local_draws_unexpected_data() {
+        let (msg, wire) = decoded(4, 0, &[1, 1, 0x05, 0xC4, 0x05, 0xC4]);
+        let nak = local_nak(&msg, &wire).unwrap();
+        assert_eq!(
+            decode_sc_bvlc_result(&nak).unwrap(),
+            ScBvlcResult::Nak {
+                result_for: ScFunction::Advertisement,
+                error_header_marker: 0,
+                error_class: 7,
+                error_code: 150,
+                error_details: String::new(),
+            }
+        );
+        assert_eq!(nak.destination_vmac, None);
+        let (msg, wire) = decoded(5, 0, &[]);
+        let nak = local_nak(&msg, &wire).unwrap();
+        assert_eq!(nak.payload[0], 5);
+        assert_eq!(nak.payload[6], 150);
+    }
+
+    #[test]
+    fn shape_faults_draw_shape_codes() {
+        let (msg, wire) = decoded(4, 0, &[]);
+        assert_eq!(local_nak(&msg, &wire).unwrap().payload[5..7], [0, 149]);
+        let (msg, wire) = decoded(4, 0, &[1, 1]);
+        assert_eq!(local_nak(&msg, &wire).unwrap().payload[5..7], [0, 147]);
+        let (msg, wire) = decoded(5, 0, &[0x42]);
+        assert_eq!(local_nak(&msg, &wire).unwrap().payload[5..7], [0, 7]);
+    }
+
+    #[test]
+    fn broadcast_and_reserved_origins_are_silent() {
+        let mut wire = vec![4, 4, 0x22, 0x33];
+        wire.extend_from_slice(&BROADCAST_VMAC);
+        let msg = decode_sc_message(&wire).unwrap();
+        assert!(local_nak(&msg, &wire).is_none());
+        for origin in [UNKNOWN_VMAC, BROADCAST_VMAC] {
+            let mut wire = vec![5, 8, 0x22, 0x33];
+            wire.extend_from_slice(&origin);
+            let msg = decode_sc_message(&wire).unwrap();
+            assert!(local_nak(&msg, &wire).is_none());
+        }
+    }
+
+    #[test]
+    fn nak_targets_envelope_source() {
+        let mut wire = vec![4, 8, 0x22, 0x33];
+        wire.extend_from_slice(&[0x43; 6]);
+        let msg = decode_sc_message(&wire).unwrap();
+        let nak = local_nak(&msg, &wire).unwrap();
+        assert_eq!(nak.destination_vmac, Some([0x43; 6]));
+        let mut buf = BytesMut::new();
+        encode_sc_message(&mut buf, &nak);
+        assert_eq!(decode_sc_message(&buf).unwrap(), nak);
+    }
+}

--- a/crates/bacnet-transport/src/sc_hub/advertisement_transit_tests.rs
+++ b/crates/bacnet-transport/src/sc_hub/advertisement_transit_tests.rs
@@ -1,0 +1,320 @@
+//! Hub-only Advertisement/Solicitation transit, using independent raw wire
+//! expectations. Registered unicast stays opaque (AB.5.3.2 forwarding);
+//! the shape validator only owns hub-local and node destinations.
+use super::deadline_capacity_tests::CountedHub;
+use super::deadline_test_support::*;
+use super::response_silence_tests::Snapshot;
+use super::shutdown_blocked_tests::ControlledPeer;
+use super::unknown_transit_tests::{
+    barrier, connect_limits, matrix_barrier, matrix_pair, matrix_receive, raw, recv, send, stopped,
+};
+use super::*;
+use crate::sc_frame::BROADCAST_VMAC;
+use std::time::Duration;
+
+fn valid_advertisement() -> Vec<u8> {
+    vec![1, 1, 0x05, 0xC4, 0x05, 0xC4]
+}
+
+async fn addressed_empty(function: u8) {
+    let tls = TestTls::new();
+    let mut hub = CountedHub::start(&tls, ScHubHandshakeTimeouts::default()).await;
+    let mut b = ControlledPeer::open(&tls, &hub).await;
+    b.connect(0x43).await;
+    let mut a = ControlledPeer::open(&tls, &hub).await;
+    a.connect(0x42).await;
+    let body = if function == 4 {
+        valid_advertisement()
+    } else {
+        vec![]
+    };
+    send(&mut a, raw(function, 0, None, Some([0x43; 6]), 0, &body)).await;
+    let received = tokio::time::timeout(Duration::from_millis(200), b.ws.next()).await;
+    // Compiled RED must release every supervised worker before asserting.
+    stopped(&mut hub).await;
+    let expected = raw(function, 0, Some([0x42; 6]), None, 0, &body);
+    assert!(
+        matches!(&received, Ok(Some(Ok(Message::Binary(data)))) if data.as_ref() == expected),
+        "function {function:#04x}: addressed well-formed frame must transit, not be locally rejected; got {received:?}"
+    );
+}
+
+#[tokio::test]
+async fn advertisement_transit_addressed_wellformed_request() {
+    addressed_empty(4).await;
+}
+
+#[tokio::test]
+async fn advertisement_transit_addressed_wellformed_solicitation() {
+    addressed_empty(5).await;
+}
+
+#[tokio::test]
+async fn advertisement_transit_opaque_options_shapes_and_no_echo() {
+    let tls = TestTls::new();
+    let (mut hub, mut a, mut b) = matrix_pair(&tls, true, 0x42, 0x43).await;
+    let mut c = ControlledPeer::open(&tls, &hub).await;
+    c.connect(0x44).await;
+    let mut cases = 0;
+    for function in [4, 5] {
+        for id in [0, u16::MAX] {
+            for (flags, options) in [
+                (0, vec![]),
+                (2, vec![0x5E]),
+                (2, vec![0xFE, 0, 0, 0x1F]), // MU, MoreOptions, empty HeaderData
+                (3, vec![0xE2, 0, 0, 0x1F, 0xFE, 0, 1, 0xBB, 0x1F]),
+            ] {
+                // Transit stays opaque: even forbidden shapes relay when the
+                // envelope is an eligible registered unicast. The destination
+                // validator owns the NAK, not the forwarding hub.
+                for payload in [
+                    &b""[..],
+                    &valid_advertisement()[..],
+                    &[9, 9, 0, 1, 0, 1][..],
+                    &[0xFF; 9][..],
+                ] {
+                    let mut body = options.clone();
+                    body.extend_from_slice(payload);
+                    let wire = raw(function, id, None, Some([0x43; 6]), flags, &body);
+                    assert_eq!(decode_sc_message(&wire).unwrap().payload.as_ref(), payload);
+                    send(&mut a, wire).await;
+                    assert_eq!(
+                        recv(&mut b).await,
+                        raw(function, id, Some([0x42; 6]), None, flags, &body)
+                    );
+                    barrier(&mut a).await;
+                    barrier(&mut c).await;
+                    cases += 1;
+                }
+            }
+        }
+    }
+    assert_eq!(cases, 64);
+    stopped(&mut hub).await;
+}
+
+#[tokio::test]
+async fn advertisement_transit_local_preregistered_invalid_silence_and_state_matrix() {
+    let tls = TestTls::new();
+    let mut cases = [0; 2];
+    for registered in [false, true] {
+        for function in [4, 5] {
+            for id in [0, u16::MAX] {
+                for origin in [None, Some([0x43; 6]), Some([0; 6]), Some(BROADCAST_VMAC)] {
+                    for dest in [
+                        None,
+                        Some([0x43; 6]),
+                        Some(BROADCAST_VMAC),
+                        Some([0; 6]),
+                        Some([0x77; 6]),
+                        Some([0x42; 6]),
+                    ] {
+                        if registered
+                            && origin.is_none()
+                            && matches!(dest, Some(v) if v != [0x42; 6] && v != BROADCAST_VMAC)
+                        {
+                            continue; // accepted transit activity is tested separately
+                        }
+                        let (mut hub, mut a, mut b) =
+                            matrix_pair(&tls, registered, 0x42, 0x43).await;
+                        let expires = a.deadline.expires();
+                        let before: Vec<_> = hub
+                            .clients
+                            .lock()
+                            .await
+                            .iter()
+                            .map(|(vmac, client)| (*vmac, Snapshot::capture(client)))
+                            .collect();
+                        // Well-formed local requests draw UNEXPECTED_DATA; the
+                        // malformed body draws its shape code. Both stay local.
+                        let valid_body: Vec<u8> = if function == 4 {
+                            valid_advertisement()
+                        } else {
+                            vec![]
+                        };
+                        for (flags, body, code) in [
+                            (0, valid_body.clone(), 150u16),
+                            (0, vec![], if function == 4 { 149 } else { 150 }),
+                        ] {
+                            let case = format!("advertisement registered={registered} function={function} id={id} origin={origin:02x?} dest={dest:02x?} flags={flags} body={body:02x?}");
+                            send(&mut a, raw(function, id, origin, dest, flags, &body)).await;
+                            if (!registered || dest.is_none())
+                                && dest != Some(BROADCAST_VMAC)
+                                && origin != Some([0; 6])
+                                && origin != Some(BROADCAST_VMAC)
+                            {
+                                let [hi, lo] = code.to_be_bytes();
+                                matrix_receive(
+                                    &mut a,
+                                    &raw(0, id, None, origin, 0, &[function, 1, 0, 0, 7, hi, lo]),
+                                    &case,
+                                )
+                                .await;
+                            }
+                            matrix_barrier(&mut a, &format!("{case} source")).await;
+                            matrix_barrier(&mut b, &format!("{case} observer")).await;
+                            assert_eq!(a.deadline.expires(), expires, "{case}");
+                            assert_eq!(a.deadline.is_committed(), registered, "{case}");
+                            let map = hub.clients.lock().await;
+                            assert_eq!(map.len(), if registered { 2 } else { 1 }, "{case}");
+                            for (vmac, snapshot) in &before {
+                                snapshot.unchanged(map.get(vmac).unwrap());
+                            }
+                            cases[usize::from(registered)] += 1;
+                        }
+                        if !registered {
+                            a.connect(0x42).await;
+                            assert!(a.deadline.is_committed());
+                            assert_eq!(a.deadline.expires(), expires);
+                        }
+                        stopped(&mut hub).await;
+                    }
+                }
+            }
+        }
+    }
+    // Registered skips 2 functions * 2 IDs * 3 accepted destinations * 2 bodies.
+    assert_eq!(cases, [192, 168]);
+}
+
+#[tokio::test]
+async fn advertisement_transit_result_for_4_and_5_relay_and_others_drop() {
+    let tls = TestTls::new();
+    let mut cases = [0; 2];
+    for registered in [false, true] {
+        for result_for in [4, 5] {
+            for id in [0, u16::MAX] {
+                for origin in [None, Some([0x42; 6]), Some([0; 6]), Some(BROADCAST_VMAC)] {
+                    for dest in [
+                        None,
+                        Some([0x42; 6]),
+                        Some([0x43; 6]),
+                        Some([0x77; 6]),
+                        Some([0; 6]),
+                        Some(BROADCAST_VMAC),
+                    ] {
+                        let (mut hub, mut b, mut a) =
+                            matrix_pair(&tls, registered, 0x43, 0x42).await;
+                        let expires = b.deadline.expires();
+                        for result in [
+                            vec![result_for, 0],
+                            vec![result_for, 1, 0xFE, 0, 7, 0, 150, b'x', 0xC3, 0xA9],
+                        ] {
+                            let mut body = vec![0xFE, 0, 0, 0x1F];
+                            body.extend_from_slice(&result);
+                            let case = format!("ResultFor={result_for} registered={registered} id={id} origin={origin:02x?} dest={dest:02x?} result={result:02x?}");
+                            send(&mut b, raw(0, id, origin, dest, 2, &body)).await;
+                            if registered && origin.is_none() && dest == Some([0x42; 6]) {
+                                matrix_receive(
+                                    &mut a,
+                                    &raw(0, id, Some([0x43; 6]), None, 2, &body),
+                                    &case,
+                                )
+                                .await;
+                            }
+                            matrix_barrier(&mut b, &format!("{case} source")).await;
+                            matrix_barrier(&mut a, &format!("{case} observer")).await;
+                            assert_eq!(b.deadline.expires(), expires);
+                            assert_eq!(b.deadline.is_committed(), registered);
+                            assert_eq!(
+                                hub.clients.lock().await.len(),
+                                if registered { 2 } else { 1 }
+                            );
+                            cases[usize::from(registered)] += 1;
+                        }
+                        stopped(&mut hub).await;
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(cases, [192, 192]);
+    // Results for responses and other known functions stay dropped.
+    let (mut hub, mut b, mut a) = matrix_pair(&tls, true, 0x43, 0x42).await;
+    for result_for in [0, 3, 6, 7, 8, 9, 10, 11, 12] {
+        send(
+            &mut b,
+            raw(0, 0, None, Some([0x42; 6]), 0, &[result_for, 0]),
+        )
+        .await;
+    }
+    for body in [
+        vec![],
+        vec![4],
+        vec![4, 2],
+        vec![4, 1, 0, 0, 7, 0],
+        vec![5, 1, 0, 0, 7, 0, 150, 0xFF],
+    ] {
+        send(&mut b, raw(0, 0, None, Some([0x42; 6]), 0, &body)).await;
+    }
+    send(&mut b, raw(0, 0, None, Some([0x42; 6]), 1, &[0x1E, 4, 0])).await;
+    barrier(&mut b).await;
+    barrier(&mut a).await;
+    // Existing EncapsulatedNpdu Result relay is still accepted.
+    send(&mut b, raw(0, 7, None, Some([0x42; 6]), 0, &[1, 0])).await;
+    assert_eq!(
+        recv(&mut a).await,
+        raw(0, 7, Some([0x43; 6]), None, 0, &[1, 0])
+    );
+    stopped(&mut hub).await;
+}
+
+#[tokio::test]
+async fn advertisement_transit_encoded_caps_not_npdu_and_ingress_boundary() {
+    let tls = TestTls::new();
+    let (mut hub, mut a, mut c) = matrix_pair(&tls, true, 0x42, 0x44).await;
+    let mut b = ControlledPeer::open(&tls, &hub).await;
+    connect_limits(&mut b, 0x43, 1600, 1).await;
+    for function in [4, 5] {
+        for (dest, cap) in [
+            ([0x43; 6], 1600),
+            ([0x44; 6], usize::from(HUB_MAX_BVLC_LENGTH)),
+        ] {
+            for extra in [0, 1] {
+                // Opaque advertisement bodies are never NPDUs.
+                let mut body = valid_advertisement();
+                body.resize(cap - 10 + extra, b'x');
+                assert!(body.len() > 1497);
+                send(&mut a, raw(function, 0, None, Some(dest), 0, &body)).await;
+                if extra == 0 {
+                    let target = if dest == [0x43; 6] { &mut b } else { &mut c };
+                    assert_eq!(
+                        recv(target).await,
+                        raw(function, 0, Some([0x42; 6]), None, 0, &body)
+                    );
+                }
+                barrier(&mut a).await;
+                barrier(&mut b).await;
+                barrier(&mut c).await;
+            }
+        }
+        // Generic decoding remains the only syntax prerequisite for transit.
+        for wire in [
+            vec![function],
+            vec![function, 0x80, 0, 0],
+            vec![function, 4, 0, 0, 0x43],
+            vec![function, 2, 0, 0, 0x9E],
+        ] {
+            assert!(decode_sc_message(&wire).is_err());
+            send(&mut a, wire).await;
+        }
+    }
+    // ResultFor4/5 retain the exact final BVLC cap and existing Result syntax.
+    for result_for in [4, 5] {
+        for extra in [0, 1] {
+            let mut body = vec![result_for, 1, 0, 0, 7, 0, 150];
+            body.resize(1590 + extra, b'x');
+            send(&mut a, raw(0, u16::MAX, None, Some([0x43; 6]), 0, &body)).await;
+            if extra == 0 {
+                assert_eq!(
+                    recv(&mut b).await,
+                    raw(0, u16::MAX, Some([0x42; 6]), None, 0, &body)
+                );
+            }
+            barrier(&mut a).await;
+            barrier(&mut b).await;
+            barrier(&mut c).await;
+        }
+    }
+    stopped(&mut hub).await;
+}

--- a/crates/bacnet-transport/src/sc_hub/handler.rs
+++ b/crates/bacnet-transport/src/sc_hub/handler.rs
@@ -241,6 +241,48 @@ pub(super) async fn run(
             continue;
         }
 
+        if matches!(
+            sc_msg.function,
+            ScFunction::Advertisement | ScFunction::AdvertisementSolicitation
+        ) {
+            if let Some(registered_vmac) = lease.vmac.filter(|_| sc_msg.destination_vmac.is_some())
+            {
+                // Both functions are unicast-only. Reject broadcast, explicit
+                // origin and self before activity; never reflect a transit NAK.
+                // Transit stays opaque: the shape validator owns hub-local
+                // and node destinations, while AB.5.3.2 forwarding preserves
+                // the wire frame bytes for the destination to judge.
+                let Ok(target @ HubRelayTarget::Unicast(dest)) = hub_relay_target(&sc_msg) else {
+                    continue;
+                };
+                if dest == registered_vmac {
+                    continue;
+                }
+                // Accepted transit follows NPDU/Unknown activity even for missing/capped targets.
+                client_activity.store(now_secs(), Ordering::Release);
+                if super::opaque_relay::relay(
+                    &data,
+                    &sc_msg,
+                    registered_vmac,
+                    target,
+                    &clients,
+                    &write,
+                )
+                .await
+                    == ResultRelayDisposition::CloseSource
+                {
+                    break;
+                }
+            } else if let Some(nak) = super::advertisement_transit::local_nak(&sc_msg, &data) {
+                let mut buf = BytesMut::new();
+                encode_sc_message(&mut buf, &nak);
+                // Same socket only. Keep ignored immediate write failures and
+                // the existing retirement/absolute Connect deadline owners.
+                let _ = write.lock().await.send(Message::Binary(buf.freeze())).await;
+            }
+            continue;
+        }
+
         // Decoded remaining BVLC messages that pass response/Connect/control admission,
         // registered NPDU payload presence and local capacity checks count as activity.
         // WebSocket control, oversized, and undecodable frames do not.

--- a/crates/bacnet-transport/src/sc_hub/relay.rs
+++ b/crates/bacnet-transport/src/sc_hub/relay.rs
@@ -128,7 +128,11 @@ pub(super) async fn relay_result(
     };
     if !matches!(
         result_for,
-        ScFunction::EncapsulatedNpdu | ScFunction::AddressResolution | ScFunction::Unknown(_)
+        ScFunction::EncapsulatedNpdu
+            | ScFunction::AddressResolution
+            | ScFunction::Advertisement
+            | ScFunction::AdvertisementSolicitation
+            | ScFunction::Unknown(_)
     ) {
         debug!(
             "Hub: peer Result for {:?} from {registered_vmac:02x?}, dropping",
@@ -157,7 +161,10 @@ pub(super) async fn relay_result(
     // families have the explicit no-echo rule.
     if matches!(
         result_for,
-        ScFunction::AddressResolution | ScFunction::Unknown(_)
+        ScFunction::AddressResolution
+            | ScFunction::Advertisement
+            | ScFunction::AdvertisementSolicitation
+            | ScFunction::Unknown(_)
     ) && destination == registered_vmac
     {
         return ResultRelayDisposition::Continue;

--- a/crates/bacnet-transport/src/sc_hub/unknown_transit_tests.rs
+++ b/crates/bacnet-transport/src/sc_hub/unknown_transit_tests.rs
@@ -285,8 +285,10 @@ async fn unknown_transit_local_preregistered_and_invalid_envelopes_no_state_effe
     }
     assert_eq!(cases, [288, 240]);
     // Known-but-unhandled remains the old connection-local 7/150 fallback.
+    // Advertisement (0x04) and Solicitation (0x05) graduated to their own
+    // transit family; Proprietary (0x0C) stays deferred.
     let (mut hub, mut a, mut b) = matrix_pair(&tls, true, 0x42, 0x43).await;
-    for function in [4, 5, 12] {
+    for function in [12] {
         send(&mut a, raw(function, 7, None, Some([0x43; 6]), 0, &[])).await;
         assert_eq!(
             recv(&mut a).await,
@@ -440,7 +442,7 @@ async fn unknown_transit_result_ack_nak_routing_and_invalid_result_silence() {
         raw(0, 0, None, Some([0x42; 6]), 1, &[0x1E, 0x42, 0]),
     )
     .await;
-    for function in [0, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] {
+    for function in [0, 3, 6, 7, 8, 9, 10, 11, 12] {
         send(&mut b, raw(0, 0, None, Some([0x42; 6]), 0, &[function, 0])).await;
     }
     barrier(&mut b).await;


### PR DESCRIPTION
Bounded #519 slice: Advertisement 0x04 + Solicitation 0x05 hub + node guards.

- Centralized validator `advertisement_message_error` per AB.2.8.1/2.9.1 + AB.3.1.4/5 (paraphrased, licensed PDF via STANDARD_NAVIGATION Annex AB).
- Node: rejection-before-activity, Dest-present/reserved-origin silent, valid consumed without NPDU/state change (AB.3.2 transmission deferred).
- Hub: registered unicast opaque transit with lease stamping/no-echo/BVLC caps, broadcast/origin/self silent, prereg local NAK 7/150 fallback.
- Result-for-4/5 relay, others dropped.
- Proprietary 0x0C, URI/discovery/dial/direct, general-known forwarding, floors/liveness/rate deferred.
- Refs #519. Lean gates: fmt/size/secrets PASS, clippy PASS (isolated), focused tests PASS (see implementer evidence). No website/CI/README changes.