### PR TITLE
fix(sc): guard and relay proprietary 0x0C hub+node (#519)

### DIFF
--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -306,6 +306,12 @@ impl ScConnection {
                 // frame is consumed without NPDU delivery or state change.
                 None
             }
+            ScFunction::ProprietaryMessage => {
+                // Validated before activity by the rejection gate. Vendor
+                // dispatch is a local matter; the frame is consumed without
+                // NPDU delivery or state change.
+                None
+            }
             _ => None,
         }
     }

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -34,6 +34,7 @@ mod failover;
 mod handshake;
 mod heartbeat;
 mod loopback;
+mod proprietary;
 mod random48;
 mod reconnect;
 mod recovery;
@@ -769,6 +770,9 @@ mod source_admission_tests;
 
 #[cfg(test)]
 mod empty_npdu_tests;
+
+#[cfg(test)]
+mod proprietary_tests;
 
 #[cfg(test)]
 mod unknown_function_tests;

--- a/crates/bacnet-transport/src/sc/proprietary.rs
+++ b/crates/bacnet-transport/src/sc/proprietary.rs
@@ -1,0 +1,61 @@
+//! Established-node Proprietary-Message admission, not generic codec
+//! validation and not vendor function dispatch.
+
+use bacnet_types::enums::{ErrorClass, ErrorCode};
+use bytes::BytesMut;
+use tracing::warn;
+
+use super::data_attributes::build_bvlc_result_nak;
+use super::rejection::{RejectionBudget, RejectionExpired};
+use super::WebSocketPort;
+use crate::sc_frame::{
+    encode_sc_message, first_must_understand_destination_option_marker, proprietary_message_error,
+    ScFunction, ScMessage, BROADCAST_VMAC,
+};
+
+pub(super) async fn reject<W: WebSocketPort>(
+    msg: &ScMessage,
+    wire: &[u8],
+    ws: &W,
+    budget: RejectionBudget,
+) -> Result<bool, RejectionExpired> {
+    if msg.function != ScFunction::ProprietaryMessage {
+        return Ok(false);
+    }
+    // Hub-connector AB.5.4: explicit unicast destinations are not for the
+    // local BVLL. Broadcast and reserved origins are also silent per AB.2 /
+    // AB.3.1.4 broadcast rules and local-matter drop; neither spends a budget.
+    if msg.destination_vmac.is_some()
+        || matches!(msg.originating_vmac, Some(vmac) if vmac == [0; 6] || vmac == BROADCAST_VMAC)
+    {
+        return Ok(true);
+    }
+    // Valid shapes are consumed silently with accepted activity (no NPDU, no
+    // state change). Vendor dispatch is a local matter; unexpected but
+    // well-formed messages are dropped here rather than NAKed.
+    let Some(code) = proprietary_message_error(msg) else {
+        return Ok(false);
+    };
+    let marker = if code == ErrorCode::HEADER_NOT_UNDERSTOOD {
+        match first_must_understand_destination_option_marker(wire) {
+            Some(marker) => marker,
+            None => return Ok(true),
+        }
+    } else {
+        0
+    };
+    let nak = build_bvlc_result_nak(
+        msg.message_id,
+        msg.function,
+        marker,
+        msg.originating_vmac,
+        ErrorClass::COMMUNICATION,
+        code,
+    );
+    let mut bytes = BytesMut::new();
+    encode_sc_message(&mut bytes, &nak);
+    if let Err(e) = budget.send(ws, &bytes).await? {
+        warn!("BACnet/SC proprietary NAK send error: {}", e);
+    }
+    Ok(true)
+}

--- a/crates/bacnet-transport/src/sc/proprietary_tests.rs
+++ b/crates/bacnet-transport/src/sc/proprietary_tests.rs
@@ -1,0 +1,381 @@
+//! Independent raw-wire node admission vectors for Proprietary-Message (0x0C);
+//! no hub fallback involved.
+use super::*;
+use tokio::time::timeout;
+
+fn wire(
+    raw: u8,
+    id: u16,
+    source: Option<Vmac>,
+    dest: Option<Vmac>,
+    flags: u8,
+    body: &[u8],
+) -> Vec<u8> {
+    let mut bytes = vec![
+        raw,
+        flags | (u8::from(source.is_some()) * 8) | (u8::from(dest.is_some()) * 4),
+    ];
+    bytes.extend_from_slice(&id.to_be_bytes());
+    if let Some(source) = source {
+        bytes.extend_from_slice(&source);
+    }
+    if let Some(dest) = dest {
+        bytes.extend_from_slice(&dest);
+    }
+    bytes.extend_from_slice(body);
+    bytes
+}
+
+fn nak(raw: u8, id: u16, dest: Option<Vmac>, code: u16, marker: u8) -> Vec<u8> {
+    let [hi, lo] = code.to_be_bytes();
+    wire(0, id, None, dest, 0, &[raw, 1, marker, 0, 7, hi, lo])
+}
+
+fn valid_proprietary() -> Vec<u8> {
+    vec![0x00, 0x2B, 0x42, 0xAA, 0xBB]
+}
+
+fn minimal_proprietary() -> Vec<u8> {
+    vec![0x12, 0x34, 0x56]
+}
+
+async fn recv(hub: &LoopbackWebSocket) -> Vec<u8> {
+    timeout(Duration::from_secs(1), hub.recv())
+        .await
+        .unwrap()
+        .unwrap()
+}
+
+async fn barrier(hub: &LoopbackWebSocket) {
+    // An invalid known control is an ordered, non-activity barrier, not a valid
+    // sentinel that could conceal unintended activity from proprietary traffic.
+    hub.send(&[0x0A, 0, 0x44, 0x55, 0x42]).await.unwrap();
+    assert_eq!(recv(hub).await, [0, 0, 0x44, 0x55, 0x0A, 1, 0, 0, 7, 0, 7]);
+}
+
+#[tokio::test]
+async fn proprietary_valid_shapes_are_consumed_silently_without_npdu() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    for payload in [minimal_proprietary(), valid_proprietary()] {
+        for source in [None, Some([0x22; 6])] {
+            hub.send(&wire(12, 0x2233, source, None, 0, &payload))
+                .await
+                .unwrap();
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    // Non-MU destination options on valid shapes stay silent here.
+    let mut optioned = vec![0x1F];
+    optioned.extend_from_slice(&valid_proprietary());
+    hub.send(&wire(12, 0x2235, None, None, 2, &optioned))
+        .await
+        .unwrap();
+    barrier(&hub).await;
+    assert!(rx.try_recv().is_err());
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn proprietary_negative_matrix_nak_vs_silence() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    // (body, expected NAK code, MU marker)
+    let mut faults: Vec<(Vec<u8>, u16, u8)> = Vec::new();
+    faults.push((vec![], 149, 0));
+    for len in [1, 2] {
+        faults.push((vec![0x2B; len], 147, 0));
+    }
+    for (body, code, _marker) in faults {
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(12, 0x2233, source, None, 0, &body);
+            hub.send(&bytes).await.unwrap();
+            assert_eq!(
+                recv(&hub).await,
+                nak(12, 0x2233, source, code, 0),
+                "source {source:02x?} body {body:02x?}"
+            );
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    // Data Options are out of range even around otherwise valid payloads.
+    let mut body = vec![0x01];
+    body.extend_from_slice(&valid_proprietary());
+    for source in [None, Some([0x22; 6])] {
+        hub.send(&wire(12, 0x2233, source, None, 1, &body))
+            .await
+            .unwrap();
+        assert_eq!(
+            recv(&hub).await,
+            nak(12, 0x2233, source, 80, 0),
+            "data options source {source:02x?}"
+        );
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    // Must-Understand destination option faults carry the wire marker.
+    let mut mu_body = vec![0x42];
+    mu_body.extend_from_slice(&valid_proprietary());
+    for source in [None, Some([0x22; 6])] {
+        hub.send(&wire(12, 0x2234, source, None, 2, &mu_body))
+            .await
+            .unwrap();
+        assert_eq!(
+            recv(&hub).await,
+            nak(12, 0x2234, source, 146, 0x42),
+            "MU source {source:02x?}"
+        );
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    // Addressed, broadcast, and reserved-origin envelopes stay silent for
+    // both valid and forbidden shapes without spending a rejection budget.
+    let silent_bodies: Vec<Vec<u8>> = vec![
+        valid_proprietary(),
+        minimal_proprietary(),
+        vec![],
+        vec![0x00],
+        vec![0x00, 0x2B],
+    ];
+    for body in silent_bodies {
+        for (source, dest) in [
+            (None, Some([0x44; 6])),
+            (Some([0x22; 6]), Some([0x44; 6])),
+            (None, Some(BROADCAST_VMAC)),
+            (Some([0x22; 6]), Some(BROADCAST_VMAC)),
+            (Some([0; 6]), None),
+            (Some(BROADCAST_VMAC), None),
+            (Some([0; 6]), Some([0x44; 6])),
+        ] {
+            hub.send(&wire(12, 0x2235, source, dest, 0, &body))
+                .await
+                .unwrap();
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn proprietary_silence_and_known_codes_never_consult_expired_budget() {
+    use super::rejection::{reject, RejectionBudget, RejectionExpired};
+    struct NoIo;
+    impl WebSocketPort for NoIo {
+        async fn send(&self, _: &[u8]) -> Result<(), Error> {
+            panic!("unexpected send")
+        }
+        async fn recv(&self) -> Result<Vec<u8>, Error> {
+            panic!("unexpected receive")
+        }
+    }
+    let expired = RejectionBudget::new(Instant::now() - Duration::from_secs(1), 1);
+    // Forbidden local shapes must consult the budget (expiry surfaces).
+    let nak_cases: Vec<Vec<u8>> = vec![vec![], vec![0x00], vec![0x00, 0x2B]];
+    for body in nak_cases {
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(12, 0, source, None, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Err(RejectionExpired),
+                "source {source:02x?} body {body:02x?}"
+            );
+        }
+    }
+    // Data-option and MU faults also consult the budget when recoverable.
+    let mut data_body = vec![0x01];
+    data_body.extend_from_slice(&valid_proprietary());
+    let bytes = wire(12, 0, None, None, 1, &data_body);
+    let msg = decode_sc_message(&bytes).unwrap();
+    assert_eq!(
+        reject(&msg, &bytes, &NoIo, expired).await,
+        Err(RejectionExpired)
+    );
+    let mut mu_body = vec![0x42];
+    mu_body.extend_from_slice(&valid_proprietary());
+    let bytes = wire(12, 0, None, None, 2, &mu_body);
+    let msg = decode_sc_message(&bytes).unwrap();
+    assert_eq!(
+        reject(&msg, &bytes, &NoIo, expired).await,
+        Err(RejectionExpired)
+    );
+    // Silent envelopes and valid shapes never consult the budget.
+    for body in [valid_proprietary(), minimal_proprietary()] {
+        for (source, dest) in [
+            (None, Some([0x44; 6])),
+            (None, Some(BROADCAST_VMAC)),
+            (Some([0; 6]), None),
+            (Some(BROADCAST_VMAC), None),
+        ] {
+            let bytes = wire(12, 0, source, dest, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Ok(true),
+                "silent body {body:02x?}"
+            );
+        }
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(12, 0, source, None, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Ok(false),
+                "valid body {body:02x?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn proprietary_direct_connection_is_pure_in_all_states_and_codec_is_permissive() {
+    for state in [
+        ScConnectionState::Disconnected,
+        ScConnectionState::Connecting,
+        ScConnectionState::Connected,
+        ScConnectionState::Disconnecting,
+    ] {
+        let mut conn = ScConnection::new([1; 6], [1; 16]);
+        conn.build_connect_request();
+        conn.state = state;
+        conn.hub_vmac = Some([0x10; 6]);
+        conn.hub_device_uuid = Some([0x33; 16]);
+        conn.disconnect_ack_to_send = Some(conn.build_heartbeat_ack(0x4455));
+        let before = conn.clone();
+        for dest in [None, Some(BROADCAST_VMAC), Some([1; 6])] {
+            for body in [
+                &[][..],
+                &[0x00][..],
+                &[0x00, 0x2B][..],
+                &valid_proprietary()[..],
+            ] {
+                let bytes = wire(12, u16::MAX, Some([0x22; 6]), dest, 0, body);
+                let msg = decode_sc_message(&bytes).unwrap();
+                let mut encoded = BytesMut::new();
+                encode_sc_message(&mut encoded, &msg);
+                assert_eq!(encoded.as_ref(), bytes);
+                assert!(conn.handle_received(&msg).is_none());
+                assert_eq!(conn.state, before.state);
+                assert_eq!(conn.local_vmac, before.local_vmac);
+                assert_eq!(conn.device_uuid, before.device_uuid);
+                assert_eq!(conn.hub_vmac, before.hub_vmac);
+                assert_eq!(conn.hub_device_uuid, before.hub_device_uuid);
+                assert_eq!(conn.max_bvlc_length, before.max_bvlc_length);
+                assert_eq!(conn.max_apdu_length, before.max_apdu_length);
+                assert_eq!(conn.hub_max_bvlc_length, before.hub_max_bvlc_length);
+                assert_eq!(conn.hub_max_apdu_length, before.hub_max_apdu_length);
+                assert_eq!(conn.next_message_id, before.next_message_id);
+                assert_eq!(
+                    conn.pending_connect_message_id,
+                    before.pending_connect_message_id
+                );
+                assert_eq!(conn.connect_retry_allowed, before.connect_retry_allowed);
+                assert_eq!(conn.disconnect_ack_to_send, before.disconnect_ack_to_send);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn proprietary_malformed_generic_wire_is_still_silent() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    for bytes in [
+        vec![0x0C],
+        vec![0x0C, 0x80, 0, 1],
+        vec![0x0C, 8, 0, 1],
+        vec![0x0C, 4, 0, 1],
+        vec![0x0C, 2, 0, 1, 0],
+        vec![0x0C, 1, 0, 1, 0x7E, 0, 1],
+    ] {
+        assert!(decode_sc_message(&bytes).is_err());
+        hub.send(&bytes).await.unwrap();
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn proprietary_result_for_keeps_existing_parse_and_fatal_policy() {
+    for (body, fatal) in [
+        (vec![12, 0], false),
+        (vec![12, 1, 0, 0, 7, 0, 144], true),
+        (vec![12, 1], true),
+    ] {
+        let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+        let bytes = wire(0, 0x2233, None, None, 0, &body);
+        let msg = decode_sc_message(&bytes).unwrap();
+        assert_eq!(msg.function, ScFunction::Result);
+        hub.send(&bytes).await.unwrap();
+        let mut states = transport.connection_state_changes();
+        let finished = if fatal {
+            timeout(Duration::from_secs(1), async {
+                while *states.borrow_and_update() != ScConnectionState::Disconnected {
+                    states.changed().await.unwrap();
+                }
+            })
+            .await
+        } else {
+            barrier(&hub).await;
+            assert_eq!(*states.borrow(), ScConnectionState::Connected);
+            Ok(())
+        };
+        let extra = timeout(Duration::from_millis(20), hub.recv()).await;
+        transport.stop().await.unwrap();
+        finished.unwrap();
+        assert!(extra.is_err(), "response on Result");
+        assert!(rx.try_recv().is_err());
+    }
+}
+
+#[tokio::test]
+async fn proprietary_valid_traffic_keeps_heartbeat_and_npdu_interop() {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, [1; 6])
+        .with_device_uuid([1; 16])
+        .with_test_heartbeat_timing_ms(80, 700);
+    let (rx, ()) = tokio::join!(
+        transport.start(),
+        super::data_attribute_tests::hub_accept(&hub, [0x10; 6])
+    );
+    let mut rx = rx.unwrap();
+    let probe = recv(&hub).await;
+    assert_eq!(probe[0], 0x0A);
+    // Valid proprietary frames are consumed without replies.
+    for _ in 0..4 {
+        hub.send(&wire(12, 0, None, None, 0, &valid_proprietary()))
+            .await
+            .unwrap();
+        hub.send(&wire(
+            12,
+            1,
+            Some([0x22; 6]),
+            None,
+            0,
+            &minimal_proprietary(),
+        ))
+        .await
+        .unwrap();
+    }
+    // No rejection reply may precede the next liveness probe; accepted
+    // proprietary traffic keeps the heartbeat budget alive like NPDUs.
+    let next = timeout(Duration::from_secs(1), hub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(next[0], 0x0A);
+    assert_ne!(&next[2..4], &probe[2..4]);
+    assert!(rx.try_recv().is_err());
+    // Positive controls only AFTER the proprietary window.
+    hub.send(&[0x0B, 0, next[2], next[3]]).await.unwrap();
+    hub.send(&wire(1, 0, Some([0x22; 6]), None, 0, &[1, 0, 0x30]))
+        .await
+        .unwrap();
+    let npdu = timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    transport.stop().await.unwrap();
+    assert_eq!(npdu.npdu.as_ref(), &[1, 0, 0x30]);
+}

--- a/crates/bacnet-transport/src/sc/rejection.rs
+++ b/crates/bacnet-transport/src/sc/rejection.rs
@@ -98,6 +98,12 @@ pub(super) async fn reject<W: WebSocketPort>(
     if super::advertisement::reject(msg, wire, ws, budget).await? {
         return Ok(true);
     }
+    // Proprietary 0x0C is a known unicast-or-broadcast family with its own
+    // AB.2.16 envelope rules. It precedes Unknown so the known function keeps
+    // its shape diagnostics; Unknown identity still wins for 0x0D..0xFF.
+    if super::proprietary::reject(msg, wire, ws, budget).await? {
+        return Ok(true);
+    }
     // All preceding gates exclude Unknown. Its identity wins over option or
     // payload diagnostics without changing any known-function admission.
     super::unknown_function::reject(msg, ws, budget).await

--- a/crates/bacnet-transport/src/sc/unknown_function_tests.rs
+++ b/crates/bacnet-transport/src/sc/unknown_function_tests.rs
@@ -156,11 +156,12 @@ async fn unknown_function_silence_and_known_codes_never_consult_expired_budget()
             super::unknown_function::reject(&msg, &NoIo, expired).await,
             Ok(false)
         );
-        // Advertisement (0x04) and Solicitation (0x05) own a later gate that
+        // Advertisement (0x04) and Proprietary (0x0C) own a later gate that
         // consults the budget for forbidden local shapes; an empty
-        // Advertisement is such a shape while an empty Solicitation is valid.
+        // Advertisement or empty Proprietary is such a shape while an empty
+        // Solicitation is valid.
         let expected = match raw {
-            4 => Err(RejectionExpired),
+            4 | 12 => Err(RejectionExpired),
             _ => Ok(false),
         };
         assert_eq!(reject(&msg, &bytes, &NoIo, expired).await, expected);

--- a/crates/bacnet-transport/src/sc_frame.rs
+++ b/crates/bacnet-transport/src/sc_frame.rs
@@ -16,9 +16,11 @@ mod advertisement;
 mod connect;
 mod control;
 mod npdu;
+mod proprietary;
 mod result;
 
 pub(crate) use advertisement::advertisement_message_error;
+pub(crate) use proprietary::proprietary_message_error;
 
 pub(crate) use connect::connect_message_error;
 #[cfg(feature = "sc-tls")]

--- a/crates/bacnet-transport/src/sc_frame/proprietary.rs
+++ b/crates/bacnet-transport/src/sc_frame/proprietary.rs
@@ -1,0 +1,208 @@
+//! Receive-only Proprietary-Message admission after generic syntax decoding.
+//!
+//! The wire shapes paraphrase ASHRAE 135-2020 Annex AB.2.16/AB.2.16.1
+//! (unicast-or-broadcast Proprietary-Message: no Data Options, payload of
+//! at least vendor identifier plus vendor function, optional vendor data)
+//! Error selection and multi-fault precedence interpret AB.3.1.4 (Must
+//! Understand) and AB.3.1.5 (common errors); envelope routing (broadcast
+//! silence, self-echo, hub-connector drops) stays with the hub and node
+//! receivers, as for Advertisement and Unknown envelopes.
+
+use super::{ScFunction, ScMessage};
+use bacnet_types::enums::ErrorCode;
+
+/// Minimum Proprietary-Message payload: vendor identifier (2) + function (1).
+pub(crate) const PROPRIETARY_MIN_PAYLOAD_LEN: usize = 3;
+
+pub(crate) fn proprietary_message_error(msg: &ScMessage) -> Option<ErrorCode> {
+    if msg.function != ScFunction::ProprietaryMessage {
+        return None;
+    }
+    // AB.2.16.1 conveys no Data Options. The envelope-option fault
+    // precedes payload shape, matching the Advertisement validator.
+    if !msg.data_options.is_empty() {
+        return Some(ErrorCode::PARAMETER_OUT_OF_RANGE);
+    }
+    // AB.2.16.1 requires at least vendor identifier and function octet.
+    // Vendor values stay opaque: no identifier floor and no function range
+    // is imposed here.
+    if msg.payload.is_empty() {
+        return Some(ErrorCode::PAYLOAD_EXPECTED);
+    }
+    if msg.payload.len() < PROPRIETARY_MIN_PAYLOAD_LEN {
+        return Some(ErrorCode::MESSAGE_INCOMPLETE);
+    }
+    if msg.dest_options.iter().any(|option| option.must_understand) {
+        // Known-option shape/placement validation remains separate work.
+        return Some(ErrorCode::HEADER_NOT_UNDERSTOOD);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sc_frame::{decode_sc_message, encode_sc_message, ScOption};
+    use bytes::{Bytes, BytesMut};
+
+    fn message(payload: &[u8]) -> ScMessage {
+        ScMessage {
+            function: ScFunction::ProprietaryMessage,
+            message_id: 0x2233,
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::copy_from_slice(payload),
+        }
+    }
+
+    fn valid_proprietary() -> Vec<u8> {
+        vec![0x00, 0x2B, 0x42, 0xAA, 0xBB]
+    }
+
+    #[test]
+    fn ignores_other_functions() {
+        for raw in [
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+        ] {
+            let msg = ScMessage {
+                function: ScFunction::from_raw(raw),
+                message_id: 0x2233,
+                originating_vmac: None,
+                destination_vmac: None,
+                dest_options: Vec::new(),
+                data_options: Vec::new(),
+                payload: Bytes::copy_from_slice(&[0xFF; 9]),
+            };
+            assert_eq!(proprietary_message_error(&msg), None);
+        }
+        for raw in [0x0D, 0x42, 0xFF] {
+            let msg = ScMessage {
+                function: ScFunction::from_raw(raw),
+                message_id: 0x2233,
+                originating_vmac: None,
+                destination_vmac: None,
+                dest_options: Vec::new(),
+                data_options: Vec::new(),
+                payload: Bytes::new(),
+            };
+            assert_eq!(proprietary_message_error(&msg), None);
+        }
+    }
+
+    #[test]
+    fn valid_shapes_pass_without_vendor_floors() {
+        for payload in [
+            vec![0x00, 0x00, 0x00],
+            vec![0xFF, 0xFF, 0xFF],
+            vec![0x00, 0x2B, 0x42],
+            valid_proprietary(),
+            vec![0x12, 0x34, 0x56, 0x00, 0x01, 0x02, 0x03, 0xFF],
+        ] {
+            assert_eq!(proprietary_message_error(&message(&payload)), None);
+        }
+        // Non-MU destination options are ignored here.
+        let mut ignored = message(&valid_proprietary());
+        ignored.dest_options.push(ScOption {
+            option_type: 31,
+            must_understand: false,
+            data: vec![0xAA],
+        });
+        assert_eq!(proprietary_message_error(&ignored), None);
+    }
+
+    #[test]
+    fn generic_syntax_preserves_rejected_shapes() {
+        // The generic codec stays permissive; this validator owns the verdict.
+        let mut msg = message(&[0x00, 0x2B]);
+        msg.data_options.push(ScOption {
+            option_type: 1,
+            must_understand: false,
+            data: Vec::new(),
+        });
+        let mut encoded = BytesMut::new();
+        encode_sc_message(&mut encoded, &msg);
+        let decoded = decode_sc_message(&encoded).unwrap();
+        assert_eq!(decoded.payload.as_ref(), &[0x00, 0x2B]);
+        assert_eq!(
+            proprietary_message_error(&decoded),
+            Some(ErrorCode::PARAMETER_OUT_OF_RANGE)
+        );
+    }
+
+    #[test]
+    fn data_options_are_out_of_range() {
+        let mut msg = message(&valid_proprietary());
+        msg.data_options.push(ScOption {
+            option_type: 1,
+            must_understand: false,
+            data: Vec::new(),
+        });
+        assert_eq!(
+            proprietary_message_error(&msg),
+            Some(ErrorCode::PARAMETER_OUT_OF_RANGE)
+        );
+    }
+
+    #[test]
+    fn payload_length_matrix() {
+        assert_eq!(
+            proprietary_message_error(&message(&[])),
+            Some(ErrorCode::PAYLOAD_EXPECTED)
+        );
+        for len in [1, 2] {
+            assert_eq!(
+                proprietary_message_error(&message(&vec![0x2B; len])),
+                Some(ErrorCode::MESSAGE_INCOMPLETE),
+                "len {len}"
+            );
+        }
+        for len in [3, 4, 26, 64] {
+            assert_eq!(
+                proprietary_message_error(&message(&vec![0x2B; len])),
+                None,
+                "len {len}"
+            );
+        }
+    }
+
+    #[test]
+    fn must_understand_is_last_precedence() {
+        // Payload faults win over the MU fault, as for Advertisement diagnostics.
+        let mu = ScOption {
+            option_type: 2,
+            must_understand: true,
+            data: Vec::new(),
+        };
+        let mut empty = message(&[]);
+        empty.dest_options.push(mu.clone());
+        assert_eq!(
+            proprietary_message_error(&empty),
+            Some(ErrorCode::PAYLOAD_EXPECTED)
+        );
+        let mut short = message(&[0x00, 0x2B]);
+        short.dest_options.push(mu.clone());
+        assert_eq!(
+            proprietary_message_error(&short),
+            Some(ErrorCode::MESSAGE_INCOMPLETE)
+        );
+        let mut data_optioned = message(&valid_proprietary());
+        data_optioned.data_options.push(ScOption {
+            option_type: 1,
+            must_understand: false,
+            data: Vec::new(),
+        });
+        data_optioned.dest_options.push(mu.clone());
+        assert_eq!(
+            proprietary_message_error(&data_optioned),
+            Some(ErrorCode::PARAMETER_OUT_OF_RANGE)
+        );
+        let mut valid = message(&valid_proprietary());
+        valid.dest_options.push(mu);
+        assert_eq!(
+            proprietary_message_error(&valid),
+            Some(ErrorCode::HEADER_NOT_UNDERSTOOD)
+        );
+    }
+}

--- a/crates/bacnet-transport/src/sc_hub.rs
+++ b/crates/bacnet-transport/src/sc_hub.rs
@@ -4,7 +4,8 @@
 //! The hub performs three duties:
 //! 1. **Connection handshake** — responds to `ConnectRequest` with `ConnectAccept`.
 //! 2. **Message relay** — forwards `EncapsulatedNpdu`, addressed Unknown functions,
-//!    unicast Address-Resolution/ACK, unicast Advertisement/Solicitation, and permitted routed `Result` messages.
+//!    unicast Address-Resolution/ACK, unicast Advertisement/Solicitation,
+//!    unicast/broadcast Proprietary-Message, and permitted routed `Result` messages.
 //!    No node URI parsing, discovery, or direct-connection support is implied.
 //! 3. **Heartbeat** — responds to `HeartbeatRequest` with `HeartbeatAck`.
 
@@ -34,6 +35,7 @@ mod handler;
 mod heartbeat;
 mod helpers;
 mod opaque_relay;
+mod proprietary_transit;
 mod relay;
 mod relay_send;
 mod resolution_transit;
@@ -423,6 +425,8 @@ mod unknown_transit_tests;
 
 #[cfg(test)]
 mod advertisement_transit_tests;
+#[cfg(test)]
+mod proprietary_transit_tests;
 #[cfg(test)]
 mod resolution_transit_lifecycle_tests;
 #[cfg(test)]

--- a/crates/bacnet-transport/src/sc_hub/advertisement_transit_tests.rs
+++ b/crates/bacnet-transport/src/sc_hub/advertisement_transit_tests.rs
@@ -230,8 +230,9 @@ async fn advertisement_transit_result_for_4_and_5_relay_and_others_drop() {
     }
     assert_eq!(cases, [192, 192]);
     // Results for responses and other known functions stay dropped.
+    // Proprietary (0x0C) graduated to its own transit family and relays.
     let (mut hub, mut b, mut a) = matrix_pair(&tls, true, 0x43, 0x42).await;
-    for result_for in [0, 3, 6, 7, 8, 9, 10, 11, 12] {
+    for result_for in [0, 3, 6, 7, 8, 9, 10, 11] {
         send(
             &mut b,
             raw(0, 0, None, Some([0x42; 6]), 0, &[result_for, 0]),

--- a/crates/bacnet-transport/src/sc_hub/handler.rs
+++ b/crates/bacnet-transport/src/sc_hub/handler.rs
@@ -283,6 +283,48 @@ pub(super) async fn run(
             continue;
         }
 
+        if sc_msg.function == ScFunction::ProprietaryMessage {
+            if let Some(registered_vmac) = lease.vmac.filter(|_| sc_msg.destination_vmac.is_some())
+            {
+                // Proprietary is unicast-or-broadcast per AB.2.16. Unicast
+                // strips the destination and stamps the origin with no echo;
+                // broadcast fans out except the source with origin-stamp and
+                // preserved broadcast destination. Explicit origins and self
+                // unicast stay silent before activity; never reflect a NAK.
+                // Transit stays opaque with BVLC-only caps and no NPDU caps.
+                let Ok(target) = hub_relay_target(&sc_msg) else {
+                    continue;
+                };
+                if target == HubRelayTarget::Unicast(registered_vmac) {
+                    // Proprietary no-echo rule: self drops do not count as activity.
+                    continue;
+                }
+                // Accepted transit follows the existing NPDU activity policy,
+                // including absent/oversized recipient drops. No probe mutation.
+                client_activity.store(now_secs(), Ordering::Release);
+                if super::opaque_relay::relay(
+                    &data,
+                    &sc_msg,
+                    registered_vmac,
+                    target,
+                    &clients,
+                    &write,
+                )
+                .await
+                    == ResultRelayDisposition::CloseSource
+                {
+                    break;
+                }
+            } else if let Some(nak) = super::proprietary_transit::local_nak(&sc_msg, &data) {
+                let mut buf = BytesMut::new();
+                encode_sc_message(&mut buf, &nak);
+                // Same socket only. Keep ignored immediate write failures and
+                // the existing retirement/absolute Connect deadline owners.
+                let _ = write.lock().await.send(Message::Binary(buf.freeze())).await;
+            }
+            continue;
+        }
+
         // Decoded remaining BVLC messages that pass response/Connect/control admission,
         // registered NPDU payload presence and local capacity checks count as activity.
         // WebSocket control, oversized, and undecodable frames do not.

--- a/crates/bacnet-transport/src/sc_hub/proprietary_transit.rs
+++ b/crates/bacnet-transport/src/sc_hub/proprietary_transit.rs
@@ -1,0 +1,133 @@
+//! Hub-only Proprietary-Message local rejection, not vendor dispatch.
+//! Registered unicast AND broadcast transit stays opaque via the shared
+//! relay mechanics (AB.5.3.2/AB.5.3.3 forwarding).
+use super::*;
+use crate::sc_frame::{
+    encode_sc_message, first_must_understand_destination_option_marker, proprietary_message_error,
+    BROADCAST_VMAC, UNKNOWN_VMAC,
+};
+use bacnet_types::enums::{ErrorClass, ErrorCode};
+use bytes::{Bytes, BytesMut};
+
+pub(super) fn local_nak(msg: &ScMessage, wire: &[u8]) -> Option<ScMessage> {
+    if msg.function != ScFunction::ProprietaryMessage {
+        return None;
+    }
+    // Proprietary is not a response, but AB.2 still forbids answering
+    // broadcasts. Reserved origins stay silent as hub hardening, matching
+    // the Unknown, Resolution, and Advertisement fallbacks.
+    if msg.destination_vmac == Some(BROADCAST_VMAC)
+        || matches!(msg.originating_vmac, Some(UNKNOWN_VMAC | BROADCAST_VMAC))
+    {
+        return None;
+    }
+    // Shape faults draw their AB.3.1.5 code. A well-formed hub-local message
+    // is unexpected here (no vendor function to serve); the generic
+    // proprietary-unknown code applies as the local-matter response noted in
+    // AB.2.16, without activity refresh.
+    let code =
+        proprietary_message_error(msg).unwrap_or(ErrorCode::BVLC_PROPRIETARY_FUNCTION_UNKNOWN);
+    let marker = if code == ErrorCode::HEADER_NOT_UNDERSTOOD {
+        first_must_understand_destination_option_marker(wire)?
+    } else {
+        0
+    };
+    let class = ErrorClass::COMMUNICATION.to_raw().to_be_bytes();
+    let code = code.to_raw().to_be_bytes();
+    Some(ScMessage {
+        function: ScFunction::Result,
+        message_id: msg.message_id,
+        originating_vmac: None,
+        destination_vmac: msg.originating_vmac,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: Bytes::from(vec![
+            msg.function.to_raw(),
+            0x01,
+            marker,
+            class[0],
+            class[1],
+            code[0],
+            code[1],
+        ]),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sc_frame::{decode_sc_bvlc_result, decode_sc_message, ScBvlcResult};
+
+    fn decoded(function: u8, flags: u8, body: &[u8]) -> (ScMessage, Vec<u8>) {
+        let mut wire = vec![function, flags, 0x22, 0x33];
+        wire.extend_from_slice(body);
+        let msg = decode_sc_message(&wire).unwrap();
+        (msg, wire)
+    }
+
+    fn valid() -> Vec<u8> {
+        vec![0x00, 0x2B, 0x42, 0xAA]
+    }
+
+    #[test]
+    fn ignores_other_functions() {
+        for function in [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x42] {
+            let (msg, wire) = decoded(function, 0, &[]);
+            assert!(local_nak(&msg, &wire).is_none());
+        }
+    }
+
+    #[test]
+    fn wellformed_local_draws_proprietary_unknown() {
+        let (msg, wire) = decoded(12, 0, &valid());
+        let nak = local_nak(&msg, &wire).unwrap();
+        assert_eq!(
+            decode_sc_bvlc_result(&nak).unwrap(),
+            ScBvlcResult::Nak {
+                result_for: ScFunction::ProprietaryMessage,
+                error_header_marker: 0,
+                error_class: 7,
+                error_code: 144,
+                error_details: String::new(),
+            }
+        );
+        assert_eq!(nak.destination_vmac, None);
+    }
+
+    #[test]
+    fn shape_faults_draw_shape_codes() {
+        let (msg, wire) = decoded(12, 0, &[]);
+        assert_eq!(local_nak(&msg, &wire).unwrap().payload[5..7], [0, 149]);
+        let (msg, wire) = decoded(12, 0, &[0x00, 0x2B]);
+        assert_eq!(local_nak(&msg, &wire).unwrap().payload[5..7], [0, 147]);
+        let (msg, wire) = decoded(12, 1, &[0x01, 0x00, 0x2B, 0x42]);
+        // Data Options present draws out-of-range, not incomplete.
+        assert_eq!(local_nak(&msg, &wire).unwrap().payload[5..7], [0, 80]);
+    }
+
+    #[test]
+    fn broadcast_and_reserved_origins_are_silent() {
+        let mut wire = vec![12, 4, 0x22, 0x33];
+        wire.extend_from_slice(&BROADCAST_VMAC);
+        let msg = decode_sc_message(&wire).unwrap();
+        assert!(local_nak(&msg, &wire).is_none());
+        for origin in [UNKNOWN_VMAC, BROADCAST_VMAC] {
+            let mut wire = vec![12, 8, 0x22, 0x33];
+            wire.extend_from_slice(&origin);
+            let msg = decode_sc_message(&wire).unwrap();
+            assert!(local_nak(&msg, &wire).is_none());
+        }
+    }
+
+    #[test]
+    fn nak_targets_envelope_source() {
+        let mut wire = vec![12, 8, 0x22, 0x33];
+        wire.extend_from_slice(&[0x43; 6]);
+        let msg = decode_sc_message(&wire).unwrap();
+        let nak = local_nak(&msg, &wire).unwrap();
+        assert_eq!(nak.destination_vmac, Some([0x43; 6]));
+        let mut buf = BytesMut::new();
+        encode_sc_message(&mut buf, &nak);
+        assert_eq!(decode_sc_message(&buf).unwrap(), nak);
+    }
+}

--- a/crates/bacnet-transport/src/sc_hub/proprietary_transit_tests.rs
+++ b/crates/bacnet-transport/src/sc_hub/proprietary_transit_tests.rs
@@ -1,0 +1,336 @@
+//! Hub-only Proprietary-Message transit, using independent raw wire
+//! expectations. Registered unicast AND broadcast stay opaque (AB.5.3.2/AB.5.3.3
+//! forwarding); the shape validator only owns hub-local and node destinations.
+use super::deadline_capacity_tests::CountedHub;
+use super::deadline_test_support::*;
+use super::response_silence_tests::Snapshot;
+use super::shutdown_blocked_tests::ControlledPeer;
+use super::unknown_transit_tests::{
+    barrier, connect_limits, matrix_barrier, matrix_pair, matrix_receive, raw, recv, send, stopped,
+};
+use super::*;
+use crate::sc_frame::BROADCAST_VMAC;
+use std::time::Duration;
+
+fn valid_proprietary() -> Vec<u8> {
+    vec![0x00, 0x2B, 0x42, 0xAA, 0xBB]
+}
+
+fn minimal_proprietary() -> Vec<u8> {
+    vec![0x12, 0x34, 0x56]
+}
+
+async fn addressed_valid(function: u8, dest: Vmac) {
+    let tls = TestTls::new();
+    let mut hub = CountedHub::start(&tls, ScHubHandshakeTimeouts::default()).await;
+    let mut b = ControlledPeer::open(&tls, &hub).await;
+    b.connect(0x43).await;
+    let mut a = ControlledPeer::open(&tls, &hub).await;
+    a.connect(0x42).await;
+    let body = valid_proprietary();
+    send(&mut a, raw(function, 0, None, Some(dest), 0, &body)).await;
+    let received = tokio::time::timeout(Duration::from_millis(200), b.ws.next()).await;
+    stopped(&mut hub).await;
+    // Unicast strips the destination and stamps the origin; broadcast keeps
+    // the destination and stamps the origin so the receiver sees broadcast.
+    let expected = if dest == BROADCAST_VMAC {
+        raw(function, 0, Some([0x42; 6]), Some(BROADCAST_VMAC), 0, &body)
+    } else {
+        raw(function, 0, Some([0x42; 6]), None, 0, &body)
+    };
+    assert!(
+        matches!(&received, Ok(Some(Ok(Message::Binary(data)))) if data.as_ref() == expected),
+        "function {function:#04x} dest {dest:02x?}: addressed well-formed frame must transit, not be locally rejected; got {received:?}"
+    );
+}
+
+#[tokio::test]
+async fn proprietary_transit_addressed_wellformed_unicast() {
+    addressed_valid(12, [0x43; 6]).await;
+}
+
+#[tokio::test]
+async fn proprietary_transit_addressed_wellformed_broadcast() {
+    addressed_valid(12, BROADCAST_VMAC).await;
+}
+
+#[tokio::test]
+async fn proprietary_transit_opaque_options_shapes_and_no_echo() {
+    let tls = TestTls::new();
+    let (mut hub, mut a, mut b) = matrix_pair(&tls, true, 0x42, 0x43).await;
+    let mut c = ControlledPeer::open(&tls, &hub).await;
+    c.connect(0x44).await;
+    let mut cases = 0;
+    for id in [0, u16::MAX] {
+        for (flags, options) in [
+            (0, vec![]),
+            (2, vec![0x5E]),
+            (2, vec![0xFE, 0, 0, 0x1F]),
+            (3, vec![0xE2, 0, 0, 0x1F, 0xFE, 0, 1, 0xBB, 0x1F]),
+        ] {
+            // Transit stays opaque: even forbidden shapes relay when the
+            // envelope is an eligible registered unicast. The destination
+            // validator owns the NAK, not the forwarding hub.
+            for payload in [
+                &b""[..],
+                &minimal_proprietary()[..],
+                &valid_proprietary()[..],
+                &[0xFF; 9][..],
+            ] {
+                let mut body = options.clone();
+                body.extend_from_slice(payload);
+                let wire = raw(12, id, None, Some([0x43; 6]), flags, &body);
+                assert_eq!(decode_sc_message(&wire).unwrap().payload.as_ref(), payload);
+                send(&mut a, wire).await;
+                assert_eq!(
+                    recv(&mut b).await,
+                    raw(12, id, Some([0x42; 6]), None, flags, &body)
+                );
+                barrier(&mut a).await;
+                barrier(&mut c).await;
+                cases += 1;
+            }
+        }
+    }
+    assert_eq!(cases, 32);
+    stopped(&mut hub).await;
+}
+
+#[tokio::test]
+async fn proprietary_transit_broadcast_fanout_except_source() {
+    let tls = TestTls::new();
+    let (mut hub, mut a, mut b) = matrix_pair(&tls, true, 0x42, 0x43).await;
+    let mut c = ControlledPeer::open(&tls, &hub).await;
+    c.connect(0x44).await;
+    for payload in [minimal_proprietary(), valid_proprietary()] {
+        send(
+            &mut a,
+            raw(12, 0x1234, None, Some(BROADCAST_VMAC), 0, &payload),
+        )
+        .await;
+        // Both other peers receive the broadcast with origin-stamp and
+        // preserved broadcast destination; the source gets no echo.
+        assert_eq!(
+            recv(&mut b).await,
+            raw(
+                12,
+                0x1234,
+                Some([0x42; 6]),
+                Some(BROADCAST_VMAC),
+                0,
+                &payload
+            )
+        );
+        assert_eq!(
+            recv(&mut c).await,
+            raw(
+                12,
+                0x1234,
+                Some([0x42; 6]),
+                Some(BROADCAST_VMAC),
+                0,
+                &payload
+            )
+        );
+        barrier(&mut a).await;
+    }
+    stopped(&mut hub).await;
+}
+
+#[tokio::test]
+async fn proprietary_transit_local_preregistered_silence_and_state_matrix() {
+    let tls = TestTls::new();
+    let mut cases = [0; 2];
+    for registered in [false, true] {
+        for id in [0, u16::MAX] {
+            for origin in [None, Some([0x43; 6]), Some([0; 6]), Some(BROADCAST_VMAC)] {
+                for dest in [
+                    None,
+                    Some([0x43; 6]),
+                    Some(BROADCAST_VMAC),
+                    Some([0; 6]),
+                    Some([0x77; 6]),
+                    Some([0x42; 6]),
+                ] {
+                    // Accepted transit (registered, no explicit origin, any
+                    // present dest except self-unicast) is tested separately.
+                    if registered && origin.is_none() && matches!(dest, Some(v) if v != [0x42; 6]) {
+                        continue;
+                    }
+                    let (mut hub, mut a, mut b) = matrix_pair(&tls, registered, 0x42, 0x43).await;
+                    let expires = a.deadline.expires();
+                    let before: Vec<_> = hub
+                        .clients
+                        .lock()
+                        .await
+                        .iter()
+                        .map(|(vmac, client)| (*vmac, Snapshot::capture(client)))
+                        .collect();
+                    // Well-formed local draws the generic proprietary-unknown
+                    // code; malformed bodies draw their shape codes. Both stay
+                    // local. Broadcast and reserved origins stay silent.
+                    for (flags, body, code) in [
+                        (0, valid_proprietary(), 144u16),
+                        (0, vec![], 149),
+                        (0, vec![0x00, 0x2B], 147),
+                    ] {
+                        let case = format!("proprietary registered={registered} id={id} origin={origin:02x?} dest={dest:02x?} flags={flags} body={body:02x?}");
+                        send(&mut a, raw(12, id, origin, dest, flags, &body)).await;
+                        if (!registered || dest.is_none())
+                            && dest != Some(BROADCAST_VMAC)
+                            && origin != Some([0; 6])
+                            && origin != Some(BROADCAST_VMAC)
+                        {
+                            let [hi, lo] = code.to_be_bytes();
+                            matrix_receive(
+                                &mut a,
+                                &raw(0, id, None, origin, 0, &[12, 1, 0, 0, 7, hi, lo]),
+                                &case,
+                            )
+                            .await;
+                        }
+                        matrix_barrier(&mut a, &format!("{case} source")).await;
+                        matrix_barrier(&mut b, &format!("{case} observer")).await;
+                        assert_eq!(a.deadline.expires(), expires, "{case}");
+                        assert_eq!(a.deadline.is_committed(), registered, "{case}");
+                        let map = hub.clients.lock().await;
+                        assert_eq!(map.len(), if registered { 2 } else { 1 }, "{case}");
+                        for (vmac, snapshot) in &before {
+                            snapshot.unchanged(map.get(vmac).unwrap());
+                        }
+                        cases[usize::from(registered)] += 1;
+                    }
+                    if !registered {
+                        a.connect(0x42).await;
+                        assert!(a.deadline.is_committed());
+                        assert_eq!(a.deadline.expires(), expires);
+                    }
+                    stopped(&mut hub).await;
+                }
+            }
+        }
+    }
+    // Registered skips 2 IDs * 1 eligible origin * 4 non-self dests * 3 bodies
+    // worth of accepted transit; preregistered covers the full matrix.
+    assert_eq!(cases, [144, 120]);
+}
+
+#[tokio::test]
+async fn proprietary_transit_result_for_12_relay_and_others_drop() {
+    let tls = TestTls::new();
+    let mut cases = [0; 2];
+    for registered in [false, true] {
+        for id in [0, u16::MAX] {
+            for origin in [None, Some([0x42; 6]), Some([0; 6]), Some(BROADCAST_VMAC)] {
+                for dest in [
+                    None,
+                    Some([0x42; 6]),
+                    Some([0x43; 6]),
+                    Some([0x77; 6]),
+                    Some([0; 6]),
+                    Some(BROADCAST_VMAC),
+                ] {
+                    let (mut hub, mut b, mut a) = matrix_pair(&tls, registered, 0x43, 0x42).await;
+                    let expires = b.deadline.expires();
+                    for result in [
+                        vec![12, 0],
+                        vec![12, 1, 0xFE, 0, 7, 0, 144, b'x', 0xC3, 0xA9],
+                    ] {
+                        let mut body = vec![0xFE, 0, 0, 0x1F];
+                        body.extend_from_slice(&result);
+                        let case = format!("ResultFor=12 registered={registered} id={id} origin={origin:02x?} dest={dest:02x?} result={result:02x?}");
+                        send(&mut b, raw(0, id, origin, dest, 2, &body)).await;
+                        if registered && origin.is_none() && dest == Some([0x42; 6]) {
+                            matrix_receive(
+                                &mut a,
+                                &raw(0, id, Some([0x43; 6]), None, 2, &body),
+                                &case,
+                            )
+                            .await;
+                        }
+                        matrix_barrier(&mut b, &format!("{case} source")).await;
+                        matrix_barrier(&mut a, &format!("{case} observer")).await;
+                        assert_eq!(b.deadline.expires(), expires);
+                        assert_eq!(b.deadline.is_committed(), registered);
+                        assert_eq!(
+                            hub.clients.lock().await.len(),
+                            if registered { 2 } else { 1 }
+                        );
+                        cases[usize::from(registered)] += 1;
+                    }
+                    stopped(&mut hub).await;
+                }
+            }
+        }
+    }
+    assert_eq!(cases, [96, 96]);
+}
+
+#[tokio::test]
+async fn proprietary_transit_encoded_caps_not_npdu_and_ingress_boundary() {
+    let tls = TestTls::new();
+    let (mut hub, mut a, mut c) = matrix_pair(&tls, true, 0x42, 0x44).await;
+    let mut b = ControlledPeer::open(&tls, &hub).await;
+    connect_limits(&mut b, 0x43, 1600, 1).await;
+    for (dest, cap) in [
+        ([0x43; 6], 1600),
+        ([0x44; 6], usize::from(HUB_MAX_BVLC_LENGTH)),
+    ] {
+        for extra in [0, 1] {
+            // Opaque proprietary bodies are never NPDUs.
+            let mut body = valid_proprietary();
+            body.resize(cap - 10 + extra, b'x');
+            assert!(body.len() > 1497);
+            send(&mut a, raw(12, 0, None, Some(dest), 0, &body)).await;
+            if extra == 0 {
+                let target = if dest == [0x43; 6] { &mut b } else { &mut c };
+                assert_eq!(
+                    recv(target).await,
+                    raw(12, 0, Some([0x42; 6]), None, 0, &body)
+                );
+            }
+            barrier(&mut a).await;
+            barrier(&mut b).await;
+            barrier(&mut c).await;
+        }
+    }
+    // Broadcast preserves the destination with origin-stamp; a small body
+    // fits every recipient cap here (large-broadcast caps share the same
+    // BVLC-only path as the unicast cases above).
+    let body = valid_proprietary();
+    send(&mut a, raw(12, 1, None, Some(BROADCAST_VMAC), 0, &body)).await;
+    assert_eq!(
+        recv(&mut b).await,
+        raw(12, 1, Some([0x42; 6]), Some(BROADCAST_VMAC), 0, &body)
+    );
+    assert_eq!(
+        recv(&mut c).await,
+        raw(12, 1, Some([0x42; 6]), Some(BROADCAST_VMAC), 0, &body)
+    );
+    // Generic decoding remains the only syntax prerequisite for transit.
+    for wire in [
+        vec![12],
+        vec![12, 0x80, 0, 0],
+        vec![12, 4, 0, 0, 0x43],
+        vec![12, 2, 0, 0, 0x9E],
+    ] {
+        assert!(decode_sc_message(&wire).is_err());
+        send(&mut a, wire).await;
+    }
+    // ResultFor12 retains the exact final BVLC cap and existing Result syntax.
+    for extra in [0, 1] {
+        let mut body = vec![12, 1, 0, 0, 7, 0, 144];
+        body.resize(1590 + extra, b'x');
+        send(&mut a, raw(0, u16::MAX, None, Some([0x43; 6]), 0, &body)).await;
+        if extra == 0 {
+            assert_eq!(
+                recv(&mut b).await,
+                raw(0, u16::MAX, Some([0x42; 6]), None, 0, &body)
+            );
+        }
+        barrier(&mut a).await;
+        barrier(&mut b).await;
+        barrier(&mut c).await;
+    }
+    stopped(&mut hub).await;
+}

--- a/crates/bacnet-transport/src/sc_hub/relay.rs
+++ b/crates/bacnet-transport/src/sc_hub/relay.rs
@@ -132,6 +132,7 @@ pub(super) async fn relay_result(
             | ScFunction::AddressResolution
             | ScFunction::Advertisement
             | ScFunction::AdvertisementSolicitation
+            | ScFunction::ProprietaryMessage
             | ScFunction::Unknown(_)
     ) {
         debug!(
@@ -164,6 +165,7 @@ pub(super) async fn relay_result(
         ScFunction::AddressResolution
             | ScFunction::Advertisement
             | ScFunction::AdvertisementSolicitation
+            | ScFunction::ProprietaryMessage
             | ScFunction::Unknown(_)
     ) && destination == registered_vmac
     {

--- a/crates/bacnet-transport/src/sc_hub/unknown_transit_tests.rs
+++ b/crates/bacnet-transport/src/sc_hub/unknown_transit_tests.rs
@@ -285,17 +285,17 @@ async fn unknown_transit_local_preregistered_and_invalid_envelopes_no_state_effe
     }
     assert_eq!(cases, [288, 240]);
     // Known-but-unhandled remains the old connection-local 7/150 fallback.
-    // Advertisement (0x04) and Solicitation (0x05) graduated to their own
-    // transit family; Proprietary (0x0C) stays deferred.
+    // Advertisement (0x04)/Solicitation (0x05) and Proprietary (0x0C)
+    // graduated to their own transit families; no known function stays deferred.
     let (mut hub, mut a, mut b) = matrix_pair(&tls, true, 0x42, 0x43).await;
-    for function in [12] {
-        send(&mut a, raw(function, 7, None, Some([0x43; 6]), 0, &[])).await;
-        assert_eq!(
-            recv(&mut a).await,
-            raw(0, 7, None, None, 0, &[function, 1, 0, 0, 7, 0, 150])
-        );
-        barrier(&mut b).await;
-    }
+    // Proprietary transit stays opaque: even the empty shape relays when the
+    // envelope is an eligible registered unicast.
+    send(&mut a, raw(12, 7, None, Some([0x43; 6]), 0, &[])).await;
+    assert_eq!(
+        recv(&mut b).await,
+        raw(12, 7, Some([0x42; 6]), None, 0, &[])
+    );
+    barrier(&mut a).await;
     stopped(&mut hub).await;
 }
 
@@ -442,9 +442,10 @@ async fn unknown_transit_result_ack_nak_routing_and_invalid_result_silence() {
         raw(0, 0, None, Some([0x42; 6]), 1, &[0x1E, 0x42, 0]),
     )
     .await;
-    for function in [0, 3, 6, 7, 8, 9, 10, 11, 12] {
+    for function in [0, 3, 6, 7, 8, 9, 10, 11] {
         send(&mut b, raw(0, 0, None, Some([0x42; 6]), 0, &[function, 0])).await;
     }
+    // Proprietary (0x0C) graduated to its own transit family and relays.
     barrier(&mut b).await;
     barrier(&mut a).await;
     // Existing EncapsulatedNpdu Result relay is still accepted.


### PR DESCRIPTION
Bounded #519 slice: Proprietary 0x0C hub + node guards.

- Centralized validator per AB.2.16 + AB.3.1.4/5 (paraphrased, licensed PDF via STANDARD_NAVIGATION Annex AB). Vendor id/function/data opaque, no floors.
- Node: rejection-before-activity, Dest-present/reserved-origin silent, valid consumed without NPDU/state change, forbidden budgeted NAKs (existing RejectionBudget/fresh-only recovery).
- Hub: registered unicast + broadcast opaque transit (origin-strip/dest rules, no-echo, BVLC-only caps), malformed unicast NAK where required, broadcast silent, no response-to-response.
- Result-for-0x0C joins guarded return; others dropped.
- Preserves Unknown/Resolution/Adv behavior; URI/discovery/dial/direct, AB.3.2 transmission, general-known forwarding, floors/liveness/rate deferred.
- Refs #519. Lean gates: fmt/size/secrets PASS, clippy + focused tests PASS in isolated target (implementer evidence, pre-cleanup). Local 34.8GiB target cleaned between PRs. No website/CI/README changes.