### PR TITLE
fix(sc): answer Advertisement-Solicitation with solicited Advertisement under rate policy (#519)

### DIFF
--- a/crates/bacnet-transport/src/sc/advertisement.rs
+++ b/crates/bacnet-transport/src/sc/advertisement.rs
@@ -1,5 +1,11 @@
-//! Established-node Advertisement/Solicitation admission, not generic codec
-//! validation and not AB.3.2 status tracking or solicited responses.
+//! Established-node Advertisement/Solicitation admission plus the accepted
+//! solicitation predicate and solicited-reply rate policy. Generic codec
+//! validation lives in `sc_frame`; received-Advertisement peer status
+//! tracking is not kept (no local peer store); solicited replies are
+//! originated by the transport loop, keeping `ScConnection::handle_received`
+//! pure.
+
+use std::time::Duration;
 
 use bacnet_types::enums::{ErrorClass, ErrorCode};
 use bytes::BytesMut;
@@ -10,8 +16,40 @@ use super::rejection::{RejectionBudget, RejectionExpired};
 use super::WebSocketPort;
 use crate::sc_frame::{
     advertisement_message_error, encode_sc_message,
-    first_must_understand_destination_option_marker, ScFunction, ScMessage, BROADCAST_VMAC,
+    first_must_understand_destination_option_marker, ScFunction, ScMessage, Vmac, BROADCAST_VMAC,
 };
+
+/// Minimum spacing between solicited Advertisements answered by this node.
+///
+/// Local anti-storm policy (not a wire deadline): floods of solicitations
+/// collapse to at most one Advertisement per interval. Chosen as a plain
+/// constant rather than a RejectionBudget because the reply is a solicited
+/// positive transmission, not a rejection NAK; the send itself stays
+/// best-effort like Heartbeat-ACK.
+pub(super) const SOLICITED_ADVERTISEMENT_MIN_INTERVAL: Duration = Duration::from_secs(1);
+
+/// Accepted-solicitation predicate for AB.3.2 solicited replies.
+///
+/// Returns the reply destination (the solicitation origin, or `None` for a
+/// hub-peer solicitation so the reply stays peer-addressed) when the frame
+/// is a well-formed, locally-addressed solicitation. Malformed shapes keep
+/// the existing NAK path; addressed or reserved-origin envelopes stay
+/// silent; other functions are not solicitations.
+pub(super) fn solicited_advertisement_destination(msg: &ScMessage) -> Option<Option<Vmac>> {
+    if msg.function != ScFunction::AdvertisementSolicitation {
+        return None;
+    }
+    if advertisement_message_error(msg).is_some() {
+        return None;
+    }
+    if msg.destination_vmac.is_some() {
+        return None;
+    }
+    if matches!(msg.originating_vmac, Some(vmac) if vmac == [0; 6] || vmac == BROADCAST_VMAC) {
+        return None;
+    }
+    Some(msg.originating_vmac)
+}
 
 pub(super) async fn reject<W: WebSocketPort>(
     msg: &ScMessage,
@@ -33,8 +71,8 @@ pub(super) async fn reject<W: WebSocketPort>(
         return Ok(true);
     }
     // Valid shapes are consumed silently with accepted activity (no NPDU, no
-    // state change). AB.3.2 status updates and solicited Advertisement
-    // transmissions are deferred transmission behavior, not admission.
+    // state change). Solicited Advertisement transmissions for accepted
+    // solicitations are originated by the transport loop, not admission.
     let Some(code) = advertisement_message_error(msg) else {
         return Ok(false);
     };
@@ -60,4 +98,96 @@ pub(super) async fn reject<W: WebSocketPort>(
         warn!("BACnet/SC advertisement NAK send error: {}", e);
     }
     Ok(true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sc_frame::decode_sc_message;
+
+    fn solicitation(origin: Option<Vmac>, dest: Option<Vmac>, payload: &[u8]) -> ScMessage {
+        ScMessage {
+            function: ScFunction::AdvertisementSolicitation,
+            message_id: 0x2233,
+            originating_vmac: origin,
+            destination_vmac: dest,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: bytes::Bytes::copy_from_slice(payload),
+        }
+    }
+
+    #[test]
+    fn predicate_accepts_only_locally_addressed_valid_solicitations() {
+        assert_eq!(
+            solicited_advertisement_destination(&solicitation(None, None, &[])),
+            Some(None)
+        );
+        assert_eq!(
+            solicited_advertisement_destination(&solicitation(Some([0x22; 6]), None, &[])),
+            Some(Some([0x22; 6]))
+        );
+    }
+
+    #[test]
+    fn predicate_rejects_malformed_addressed_and_reserved_solicitations() {
+        // Malformed shapes keep the NAK path (no reply destination).
+        assert_eq!(
+            solicited_advertisement_destination(&solicitation(None, None, &[0x00])),
+            None
+        );
+        // Explicit destinations are not for the local BVLL.
+        assert_eq!(
+            solicited_advertisement_destination(&solicitation(None, Some([0x44; 6]), &[])),
+            None
+        );
+        assert_eq!(
+            solicited_advertisement_destination(&solicitation(
+                Some([0x22; 6]),
+                Some([0x44; 6]),
+                &[]
+            )),
+            None
+        );
+        // Reserved origins stay silent.
+        for origin in [Some([0; 6]), Some(BROADCAST_VMAC)] {
+            assert_eq!(
+                solicited_advertisement_destination(&solicitation(origin, None, &[])),
+                None
+            );
+        }
+        // Must-Understand destination options are faults, not replies.
+        let mut mu = solicitation(None, None, &[]);
+        mu.dest_options.push(crate::sc_frame::ScOption {
+            option_type: 2,
+            must_understand: true,
+            data: Vec::new(),
+        });
+        assert_eq!(solicited_advertisement_destination(&mu), None);
+    }
+
+    #[test]
+    fn predicate_ignores_other_functions() {
+        for function in [
+            ScFunction::Advertisement,
+            ScFunction::EncapsulatedNpdu,
+            ScFunction::HeartbeatRequest,
+        ] {
+            let mut msg = solicitation(None, None, &[]);
+            msg.function = function;
+            assert_eq!(solicited_advertisement_destination(&msg), None);
+        }
+    }
+
+    #[test]
+    fn predicate_agrees_with_wire_codec() {
+        // The predicate accepts exactly the wire shapes the rejection gate
+        // lets through as valid solicitations.
+        let wire_valid = [0x05u8, 0x00, 0x22, 0x33];
+        let msg = decode_sc_message(&wire_valid).unwrap();
+        assert_eq!(solicited_advertisement_destination(&msg), Some(None));
+        let wire_payload = [0x05u8, 0x00, 0x22, 0x33, 0x00];
+        let msg = decode_sc_message(&wire_payload).unwrap();
+        assert_eq!(solicited_advertisement_destination(&msg), None);
+    }
 }

--- a/crates/bacnet-transport/src/sc/advertisement_tests.rs
+++ b/crates/bacnet-transport/src/sc/advertisement_tests.rs
@@ -66,13 +66,9 @@ async fn advertisement_valid_shapes_are_consumed_silently_without_npdu() {
             }
         }
     }
-    for source in [None, Some([0x22; 6])] {
-        hub.send(&wire(5, 0x2234, source, None, 0, &[]))
-            .await
-            .unwrap();
-        barrier(&hub).await;
-        assert!(rx.try_recv().is_err());
-    }
+    // Valid Advertisement-Solicitation shapes are answered, not silent: see
+    // the solicited-reply tests below. Solicitations stay out of this
+    // silence matrix so the rate gate cannot collapse them here.
     // Non-MU destination options on valid shapes stay silent here.
     let mut optioned = vec![0x1F];
     optioned.extend_from_slice(&valid_advertisement());
@@ -367,6 +363,164 @@ async fn advertisement_result_for_keeps_existing_parse_and_fatal_policy() {
     }
 }
 
+fn solicited_reply_payload() -> Vec<u8> {
+    let mut payload = vec![1, 0];
+    payload.extend_from_slice(&crate::sc_limits::DEFAULT_MAX_BVLC_LENGTH.to_be_bytes());
+    payload.extend_from_slice(&1476u16.to_be_bytes());
+    payload
+}
+
+async fn recv_reply(hub: &LoopbackWebSocket) -> crate::sc_frame::ScMessage {
+    let data = timeout(Duration::from_secs(1), hub.recv())
+        .await
+        .expect("timed out waiting for solicited Advertisement")
+        .unwrap();
+    decode_sc_message(&data).unwrap()
+}
+
+#[tokio::test]
+async fn advertisement_solicited_reply_shape_hub_peer_origin() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    hub.send(&wire(5, 0x2234, None, None, 0, &[]))
+        .await
+        .unwrap();
+    let reply = recv_reply(&hub).await;
+    assert_eq!(reply.function, ScFunction::Advertisement);
+    assert_ne!(
+        reply.message_id, 0x2234,
+        "solicited Advertisement must use a fresh message ID, not the solicitation ID"
+    );
+    assert_eq!(reply.originating_vmac, None);
+    assert_eq!(reply.destination_vmac, None);
+    assert!(reply.dest_options.is_empty());
+    assert!(reply.data_options.is_empty());
+    assert_eq!(reply.payload.as_ref(), solicited_reply_payload());
+    barrier(&hub).await;
+    assert!(rx.try_recv().is_err());
+    assert_eq!(
+        transport.connection().unwrap().lock().await.state,
+        ScConnectionState::Connected
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn advertisement_solicited_reply_targets_relayed_origin() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    hub.send(&wire(5, 0x2235, Some([0x22; 6]), None, 0, &[]))
+        .await
+        .unwrap();
+    let reply = recv_reply(&hub).await;
+    assert_eq!(reply.function, ScFunction::Advertisement);
+    assert_ne!(reply.message_id, 0x2235);
+    assert_eq!(reply.originating_vmac, None);
+    assert_eq!(
+        reply.destination_vmac,
+        Some([0x22; 6]),
+        "solicited Advertisement must be routable back to the soliciting node"
+    );
+    assert_eq!(reply.payload.as_ref(), solicited_reply_payload());
+    barrier(&hub).await;
+    assert!(rx.try_recv().is_err());
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn advertisement_solicited_reply_is_rate_gated() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    hub.send(&wire(5, 0x2234, None, None, 0, &[]))
+        .await
+        .unwrap();
+    let first = recv_reply(&hub).await;
+    assert_eq!(first.function, ScFunction::Advertisement);
+    // Immediate floods — same peer with a new ID and a different relayed
+    // peer — must not become advertisement storms.
+    hub.send(&wire(5, 0x2235, None, None, 0, &[]))
+        .await
+        .unwrap();
+    hub.send(&wire(5, 0x2236, Some([0x22; 6]), None, 0, &[]))
+        .await
+        .unwrap();
+    // The barrier NAK arrives next only if no gated reply was queued.
+    barrier(&hub).await;
+    assert!(rx.try_recv().is_err());
+    assert_eq!(
+        transport.connection().unwrap().lock().await.state,
+        ScConnectionState::Connected
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn advertisement_solicited_reply_recurs_after_interval() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    hub.send(&wire(5, 0x2234, None, None, 0, &[]))
+        .await
+        .unwrap();
+    let first = recv_reply(&hub).await;
+    assert_eq!(first.function, ScFunction::Advertisement);
+    tokio::time::sleep(super::advertisement::SOLICITED_ADVERTISEMENT_MIN_INTERVAL).await;
+    hub.send(&wire(5, 0x2235, None, None, 0, &[]))
+        .await
+        .unwrap();
+    let second = recv_reply(&hub).await;
+    assert_eq!(second.function, ScFunction::Advertisement);
+    assert_eq!(
+        second.message_id,
+        first.message_id.wrapping_add(1),
+        "each solicited Advertisement must consume a fresh message ID"
+    );
+    barrier(&hub).await;
+    assert!(rx.try_recv().is_err());
+    transport.stop().await.unwrap();
+}
+
+#[test]
+fn solicited_builder_encodes_local_status_and_fresh_ids() {
+    let mut conn = ScConnection::new([1; 6], [1; 16]);
+    conn.state = ScConnectionState::Connected;
+    let before = conn.clone();
+    let first = conn.build_solicited_advertisement(None, 1);
+    assert_eq!(first.function, ScFunction::Advertisement);
+    assert_eq!(first.originating_vmac, None);
+    assert_eq!(first.destination_vmac, None);
+    assert!(first.dest_options.is_empty());
+    assert!(first.data_options.is_empty());
+    let mut expected = vec![1, 0];
+    expected.extend_from_slice(&before.max_bvlc_length.to_be_bytes());
+    expected.extend_from_slice(&before.max_apdu_length.to_be_bytes());
+    assert_eq!(first.payload.as_ref(), expected);
+    let second = conn.build_solicited_advertisement(Some([0x22; 6]), 2);
+    assert_eq!(
+        second.message_id,
+        first.message_id.wrapping_add(1),
+        "solicited replies must consume fresh message IDs"
+    );
+    assert_eq!(second.destination_vmac, Some([0x22; 6]));
+    assert_eq!(second.payload[0], 2);
+    assert_eq!(second.payload[1], 0);
+    // Builder touches only the message-ID counter: no state-machine effect.
+    assert_eq!(conn.state, before.state);
+    assert_eq!(conn.local_vmac, before.local_vmac);
+    assert_eq!(conn.max_bvlc_length, before.max_bvlc_length);
+    assert_eq!(conn.max_apdu_length, before.max_apdu_length);
+    assert_eq!(conn.hub_vmac, before.hub_vmac);
+    assert_eq!(conn.disconnect_ack_to_send, before.disconnect_ack_to_send);
+}
+
+#[test]
+fn solicited_builder_echoes_configured_maxima() {
+    let mut conn = ScConnection::new([1; 6], [1; 16]);
+    conn.max_bvlc_length = 300;
+    conn.max_apdu_length = 480;
+    let reply = conn.build_solicited_advertisement(None, 1);
+    assert_eq!(
+        reply.payload.as_ref(),
+        &[1, 0, 0x01, 0x2C, 0x01, 0xE0],
+        "maxima must echo local receive configuration, not wire defaults"
+    );
+}
+
 #[tokio::test]
 async fn advertisement_valid_traffic_keeps_heartbeat_and_npdu_interop() {
     let (client, hub) = LoopbackWebSocket::pair();
@@ -380,17 +534,31 @@ async fn advertisement_valid_traffic_keeps_heartbeat_and_npdu_interop() {
     let mut rx = rx.unwrap();
     let probe = recv(&hub).await;
     assert_eq!(probe[0], 0x0A);
-    // Valid advertisements and solicitations are consumed without replies.
+    // Valid advertisements stay silent; one accepted solicitation earns one
+    // solicited Advertisement reply with fresh ID and local status content.
     for _ in 0..4 {
         hub.send(&wire(4, 0, None, None, 0, &valid_advertisement()))
             .await
             .unwrap();
-        hub.send(&wire(5, 1, Some([0x22; 6]), None, 0, &[]))
-            .await
-            .unwrap();
     }
-    // No rejection reply may precede the next liveness probe; accepted
-    // advertisement traffic keeps the heartbeat budget alive like NPDUs.
+    hub.send(&wire(5, 1, Some([0x22; 6]), None, 0, &[]))
+        .await
+        .unwrap();
+    let reply_data = timeout(Duration::from_secs(1), hub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let reply = decode_sc_message(&reply_data).unwrap();
+    assert_eq!(reply.function, ScFunction::Advertisement);
+    assert_ne!(reply.message_id, 1);
+    assert_eq!(reply.destination_vmac, Some([0x22; 6]));
+    assert_eq!(reply.payload.as_ref(), solicited_reply_payload());
+    // A rapid second solicitation is rate-gated: no reply may precede the
+    // next liveness probe; accepted advertisement traffic keeps the
+    // heartbeat budget alive like NPDUs.
+    hub.send(&wire(5, 2, Some([0x22; 6]), None, 0, &[]))
+        .await
+        .unwrap();
     let next = timeout(Duration::from_secs(1), hub.recv())
         .await
         .unwrap()

--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -222,6 +222,41 @@ impl ScConnection {
         })
     }
 
+    /// Build a solicited Advertisement reply (AB.2.8.1 content, AB.3.2 trigger).
+    ///
+    /// The caller supplies the destination selected by the request-addressing
+    /// rule (`None` for a hub-peer solicitation, otherwise the solicitation
+    /// origin) and the hub-connection status derived from live transport
+    /// state (1 = primary hub, 2 = failover hub). The message ID is always
+    /// fresh: a solicited Advertisement is not a "response message" and must
+    /// not copy the solicitation ID (AB.3.1.3). Accept-direct is always 0 —
+    /// this transport has no direct-connection accept path — and the two
+    /// maxima echo the local receive configuration. No Data Options.
+    pub fn build_solicited_advertisement(
+        &mut self,
+        destination_vmac: Option<Vmac>,
+        hub_status: u8,
+    ) -> ScMessage {
+        debug_assert!(
+            hub_status == 1 || hub_status == 2,
+            "solicited Advertisement status must be 1 (primary) or 2 (failover)"
+        );
+        let mut payload = Vec::with_capacity(6);
+        payload.push(hub_status);
+        payload.push(0);
+        payload.extend_from_slice(&self.max_bvlc_length.to_be_bytes());
+        payload.extend_from_slice(&self.max_apdu_length.to_be_bytes());
+        ScMessage {
+            function: ScFunction::Advertisement,
+            message_id: self.next_id(),
+            originating_vmac: None,
+            destination_vmac,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::from(payload),
+        }
+    }
+
     /// Handle a received message. Returns NPDU data if it's an Encapsulated-NPDU for us.
     /// Hub-relayed NPDUs must include a non-reserved Originating VMAC.
     pub fn handle_received(&mut self, msg: &ScMessage) -> Option<(Bytes, Vmac)> {
@@ -301,9 +336,12 @@ impl ScConnection {
                 None
             }
             ScFunction::Advertisement | ScFunction::AdvertisementSolicitation => {
-                // Validated before activity by the rejection gate. AB.3.2
-                // status tracking and solicited responses are deferred; the
-                // frame is consumed without NPDU delivery or state change.
+                // Validated before activity by the rejection gate. Received
+                // Advertisements need no local peer store and stay consumed
+                // without NPDU delivery or state change. Solicited replies to
+                // accepted solicitations are originated by the transport loop
+                // (which owns the hub role, rate clock, and socket), so this
+                // handler stays pure.
                 None
             }
             ScFunction::ProprietaryMessage => {

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -419,6 +419,10 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
             let mut primary_restore_interval =
                 tokio::time::interval(Duration::from_millis(restore_interval_ms));
             primary_restore_interval.tick().await;
+            // Last solicited-Advertisement send for the AB.3.2 anti-storm
+            // rate policy. Kept across reconnects so a flap cannot reset
+            // the budget into a storm.
+            let mut last_solicited_advertisement: Option<Instant> = None;
 
             'transport: loop {
                 let mut current_reusable = true;
@@ -497,22 +501,75 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                     }
 
                                     // Handle NPDU — lock, extract results, drop before awaiting
-                                    let (npdu_result, disconnect_ack, fatal_result, state_change) = {
+                                    // An accepted Advertisement-Solicitation also queues one
+                                    // solicited Advertisement here (AB.3.2): fresh message
+                                    // ID, request-addressed, rate-gated. The build stays
+                                    // under the connection lock with the state check so
+                                    // the status byte and the ID cannot race a reconnect.
+                                    let solicited_destination =
+                                        advertisement::solicited_advertisement_destination(&msg);
+                                    let solicitation_now = Instant::now();
+                                    let solicited_due = solicited_destination.is_some()
+                                        && last_solicited_advertisement.is_none_or(|sent| {
+                                            solicitation_now.duration_since(sent)
+                                                >= advertisement::SOLICITED_ADVERTISEMENT_MIN_INTERVAL
+                                        });
+                                    let (
+                                        npdu_result,
+                                        disconnect_ack,
+                                        fatal_result,
+                                        state_change,
+                                        solicited_advertisement,
+                                    ) = {
                                         let mut c = conn.lock().await;
                                         let before_state = c.state;
                                         let npdu = c.handle_received(&msg);
                                         let ack = c.disconnect_ack_to_send.take();
                                         let after_state = c.state;
+                                        let solicited = if solicited_due
+                                            && after_state == ScConnectionState::Connected
+                                        {
+                                            solicited_destination.map(|destination| {
+                                                let hub_status = match active_hub {
+                                                    ActiveHub::Primary => 1,
+                                                    ActiveHub::Failover => 2,
+                                                };
+                                                c.build_solicited_advertisement(
+                                                    destination,
+                                                    hub_status,
+                                                )
+                                            })
+                                        } else {
+                                            None
+                                        };
                                         (
                                             npdu,
                                             ack,
                                             msg.function == ScFunction::Result
                                                 && after_state == ScConnectionState::Disconnected,
                                             (after_state != before_state).then_some(after_state),
+                                            solicited,
                                         )
                                     };
                                     if let Some(state) = state_change {
                                         state_tx.send_replace(state);
+                                    }
+
+                                    // Best-effort solicited reply (Heartbeat-ACK precedent:
+                                    // no rejection budget — the rate gate above is the
+                                    // storm protection). The timestamp is claimed at the
+                                    // send decision so a slow socket cannot re-arm the
+                                    // gate into a burst.
+                                    if let Some(reply) = solicited_advertisement {
+                                        last_solicited_advertisement = Some(solicitation_now);
+                                        let mut reply_buf = BytesMut::new();
+                                        encode_sc_message(&mut reply_buf, &reply);
+                                        if let Err(e) = ws_clone.send(&reply_buf).await {
+                                            warn!(
+                                                "BACnet/SC solicited advertisement send error: {}",
+                                                e
+                                            );
+                                        }
                                     }
 
                                     if let Some((npdu, source_vmac)) = npdu_result {


### PR DESCRIPTION
Bounded #519 slice: node answers accepted Solicitation 0x05 with Advertisement 0x04 (AB.3.2), closing the PR610 deferral.

- Solicited reply: fresh message ID (never copies solicitation ID, AB.3.1.3), dest mirrors origin, 6-octet payload [hub-status Primary/Failover from ActiveHub, accept-direct 0, local max-BVLC/max-NPDU] (AB.2.8.1/2.9.1 paraphrased, licensed PDF via STANDARD_NAVIGATION).
- Anti-storm: 1s global minimum interval (local policy, AB sets no rate); malformed solicitations keep existing silent/NAK behavior; no reply when not Connected.
- No hub change: node-originated unicast forwards opaquely by dest-VMAC match (AB.5.1).
- Refs #519 (stays OPEN: URI/discovery/dial + diagnostic rate limits remain). Gates: fmt/clippy/size/secrets PASS, transport 547 + sc-tls 740/2/7/17 PASS, FULL conformance_ledger 27/27 PASS. No website/CI/README changes.