### PR TITLE
fix(sc): rate-limit malformed-frame diagnostics without changing wire decisions (#519)

### DIFF
--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -9,6 +9,7 @@ use crate::sc_frame::{
     decode_sc_bvlc_result, is_broadcast_vmac, ScBvlcResult, ScFunction, ScMessage, Vmac,
 };
 
+use super::diagnostic_throttle::DiagnosticThrottle;
 use super::{data_attributes, source_admission};
 
 /// BACnet/SC connection state.
@@ -49,6 +50,13 @@ pub struct ScConnection {
     pub hub_device_uuid: Option<[u8; 16]>,
     /// Whether the last connect failure permits another connection attempt.
     pub(super) connect_retry_allowed: bool,
+    /// Owner-local throttle for connection-path malformed diagnostics only.
+    ///
+    /// Logging-only: never affects state transitions, NPDU delivery, or NAK
+    /// decisions. At most one diagnostic per second per connection; bursts
+    /// count as suppressed for the next summary. Ignored by transactional
+    /// field comparisons (logging state, not protocol state).
+    malformed_diag: DiagnosticThrottle,
 }
 
 impl ScConnection {
@@ -67,6 +75,7 @@ impl ScConnection {
             pending_connect_message_id: None,
             hub_device_uuid: None,
             connect_retry_allowed: true,
+            malformed_diag: DiagnosticThrottle::new(),
         }
     }
 
@@ -82,6 +91,16 @@ impl ScConnection {
         if !probe.connect_retry_allowed {
             self.connect_retry_allowed = false;
         }
+    }
+
+    /// Test-only suppressed diagnostic count for the connection throttle.
+    ///
+    /// Exposes the logging throttle without affecting wire decisions, so
+    /// burst tests can assert O(1) diagnostics alongside bit-for-bit
+    /// accept/NAK/silence behavior.
+    #[cfg(test)]
+    pub(super) fn malformed_diag_suppressed(&self) -> u64 {
+        self.malformed_diag.suppressed()
     }
 
     /// Generate the next message ID.
@@ -122,10 +141,20 @@ impl ScConnection {
         }
         if let Some(expected_id) = self.pending_connect_message_id {
             if msg.message_id != expected_id {
-                warn!(
-                    "ConnectAccept message_id {:#x} does not match request {:#x}",
-                    msg.message_id, expected_id
-                );
+                if self.malformed_diag.should_emit_now() {
+                    let suppressed = self.malformed_diag.take_suppressed();
+                    if suppressed > 0 {
+                        warn!(
+                            "ConnectAccept message_id {:#x} does not match request {:#x} (suppressed {suppressed} similar diagnostics)",
+                            msg.message_id, expected_id
+                        );
+                    } else {
+                        warn!(
+                            "ConnectAccept message_id {:#x} does not match request {:#x}",
+                            msg.message_id, expected_id
+                        );
+                    }
+                }
                 return false;
             }
         }
@@ -266,7 +295,14 @@ impl ScConnection {
         match msg.function {
             ScFunction::EncapsulatedNpdu => {
                 if self.state != ScConnectionState::Connected {
-                    debug!("Ignoring EncapsulatedNpdu in {:?} state", self.state);
+                    if self.malformed_diag.should_emit_now() {
+                        let suppressed = self.malformed_diag.take_suppressed();
+                        if suppressed > 0 {
+                            debug!("Ignoring EncapsulatedNpdu in {:?} state (suppressed {suppressed} similar diagnostics)", self.state);
+                        } else {
+                            debug!("Ignoring EncapsulatedNpdu in {:?} state", self.state);
+                        }
+                    }
                     return None;
                 }
                 if let Some(dest) = msg.destination_vmac {
@@ -275,11 +311,22 @@ impl ScConnection {
                     }
                 }
                 if msg.payload.len() > self.max_apdu_length as usize {
-                    warn!(
-                        "BACnet/SC NPDU ({} bytes) exceeds local Max-NPDU-Length ({}), dropping",
-                        msg.payload.len(),
-                        self.max_apdu_length
-                    );
+                    if self.malformed_diag.should_emit_now() {
+                        let suppressed = self.malformed_diag.take_suppressed();
+                        if suppressed > 0 {
+                            warn!(
+                                "BACnet/SC NPDU ({} bytes) exceeds local Max-NPDU-Length ({}), dropping (suppressed {suppressed} similar diagnostics)",
+                                msg.payload.len(),
+                                self.max_apdu_length
+                            );
+                        } else {
+                            warn!(
+                                "BACnet/SC NPDU ({} bytes) exceeds local Max-NPDU-Length ({}), dropping",
+                                msg.payload.len(),
+                                self.max_apdu_length
+                            );
+                        }
+                    }
                     return None;
                 }
                 let source = source_admission::hub_source(msg)?;
@@ -317,19 +364,39 @@ impl ScConnection {
                         error_code,
                         ..
                     }) => {
-                        warn!(
-                            "BACnet/SC BVLC-Result NAK: function={:#x} \
-                             error_class={} error_code={}",
-                            result_for.to_raw(),
-                            error_class,
-                            error_code
-                        );
+                        if self.malformed_diag.should_emit_now() {
+                            let suppressed = self.malformed_diag.take_suppressed();
+                            if suppressed > 0 {
+                                warn!(
+                                    "BACnet/SC BVLC-Result NAK: function={:#x} \
+                                     error_class={} error_code={} (suppressed {suppressed} similar diagnostics)",
+                                    result_for.to_raw(),
+                                    error_class,
+                                    error_code
+                                );
+                            } else {
+                                warn!(
+                                    "BACnet/SC BVLC-Result NAK: function={:#x} \
+                                     error_class={} error_code={}",
+                                    result_for.to_raw(),
+                                    error_class,
+                                    error_code
+                                );
+                            }
+                        }
                         if result_for != ScFunction::EncapsulatedNpdu {
                             self.state = ScConnectionState::Disconnected;
                         }
                     }
                     Err(e) => {
-                        warn!("Malformed BACnet/SC BVLC-Result: {e}");
+                        if self.malformed_diag.should_emit_now() {
+                            let suppressed = self.malformed_diag.take_suppressed();
+                            if suppressed > 0 {
+                                warn!("Malformed BACnet/SC BVLC-Result: {e} (suppressed {suppressed} similar diagnostics)");
+                            } else {
+                                warn!("Malformed BACnet/SC BVLC-Result: {e}");
+                            }
+                        }
                         self.state = ScConnectionState::Disconnected;
                     }
                 }

--- a/crates/bacnet-transport/src/sc/data_attributes.rs
+++ b/crates/bacnet-transport/src/sc/data_attributes.rs
@@ -5,11 +5,39 @@ use bacnet_types::error::Error;
 use bytes::{Bytes, BytesMut};
 use tracing::warn;
 
+use std::sync::{Mutex, OnceLock};
+
+use super::diagnostic_throttle::DiagnosticThrottle;
 use super::rejection::{RejectionBudget, RejectionExpired};
 use super::WebSocketPort;
 
 const MAX_SC_DATA_ATTRIBUTES: usize = 64;
 const SECURE_PATH_OPTION_TYPE: u8 = 1;
+
+/// Owner-local throttle for Must-Understand diagnostics only.
+///
+/// Process-shared because the rejection gates are `pub(super)` pure-logging
+/// call sites without per-transport state; NAK/silence decisions are
+/// unchanged. At most one diagnostic per second process-wide for this
+/// category; bursts count as suppressed for the next summary.
+fn mu_diag() -> &'static Mutex<DiagnosticThrottle> {
+    static MU_DIAG: OnceLock<Mutex<DiagnosticThrottle>> = OnceLock::new();
+    MU_DIAG.get_or_init(|| Mutex::new(DiagnosticThrottle::new()))
+}
+
+/// Emits one throttled diagnostic via `log(suppressed)`, counting the event
+/// as suppressed when the window budget is exhausted. Lock failure fails
+/// open (still logs) so diagnostics never go fully silent.
+fn emit_mu_diagnostic(log: impl FnOnce(u64)) {
+    let mut guard = mu_diag()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if guard.should_emit_now() {
+        let suppressed = guard.take_suppressed();
+        drop(guard);
+        log(suppressed);
+    }
+}
 
 pub(super) fn from_data_options(msg: &ScMessage) -> Vec<DataAttribute> {
     msg.data_options
@@ -43,16 +71,39 @@ pub(super) async fn reject_unsupported_must_understand_destination_option<W: Web
     };
 
     let Some(marker) = error_header_marker else {
-        warn!(
-            option_type = option.option_type,
-            "BACnet/SC failed to recover unsupported Destination Option marker"
-        );
+        let option_type = option.option_type;
+        emit_mu_diagnostic(|suppressed| {
+            if suppressed > 0 {
+                warn!(
+                    option_type,
+                    "BACnet/SC failed to recover unsupported Destination Option marker (suppressed {suppressed} similar diagnostics)"
+                );
+            } else {
+                warn!(
+                    option_type,
+                    "BACnet/SC failed to recover unsupported Destination Option marker"
+                );
+            }
+        });
         return Ok(true);
     };
-    warn!(
-        option_type = option.option_type,
-        marker, "BACnet/SC unsupported Must Understand Destination Option"
-    );
+    {
+        let option_type = option.option_type;
+        emit_mu_diagnostic(|suppressed| {
+            if suppressed > 0 {
+                warn!(
+                    option_type,
+                    marker,
+                    "BACnet/SC unsupported Must Understand Destination Option (suppressed {suppressed} similar diagnostics)"
+                );
+            } else {
+                warn!(
+                    option_type,
+                    marker, "BACnet/SC unsupported Must Understand Destination Option"
+                );
+            }
+        });
+    }
 
     if msg.destination_vmac != Some(BROADCAST_VMAC) {
         let nak = build_bvlc_result_nak(

--- a/crates/bacnet-transport/src/sc/diagnostic_throttle.rs
+++ b/crates/bacnet-transport/src/sc/diagnostic_throttle.rs
@@ -1,0 +1,243 @@
+//! Owner-local throttle for malformed-frame diagnostics only.
+//!
+//! Bounds `warn!`/`debug!` volume on hostile-peer paths without changing any
+//! accept/reject/NAK/silence decision bit-for-bit. NAK sends stay under the
+//! existing [`super::rejection::RejectionBudget`]; this throttle only gates
+//! log emission.
+//!
+//! Exact bound: at most [`MAX_DIAGNOSTICS_PER_WINDOW`] diagnostic event(s) per
+//! [`DIAGNOSTIC_WINDOW`] per throttle instance. A burst of N malformed frames
+//! within one window emits exactly 1 diagnostic (the first) and counts N-1 as
+//! suppressed; the suppressed count is available for a periodic summary on the
+//! next emission. A lone error always emits (no silent-everything regression).
+//! Over W windows the total is O(W), never O(N).
+//!
+//! Window choice (1s) reuses the existing local-window concepts
+//! (`MANAGEMENT_RATE_WINDOW` = 1s for B/IP management quota,
+//! `SOLICITED_ADVERTISEMENT_MIN_INTERVAL` = 1s for solicited replies) rather
+//! than inventing a new rate policy. No Annex AB clause mandates log rates:
+//! AB specifies BVLC wire behavior, error codes, and connection procedures
+//! (Annex AB, local PDF pp. 1377-1410 per STANDARD_NAVIGATION.md); diagnostic
+//! volume is implementation-local, consistent with the existing "local
+//! anti-storm policy (not a wire deadline)" and "owner-local budget" comments.
+//! Each loop/connection holds its own instance so one flooding peer cannot
+//! suppress another instance's first-occurrence diagnostic.
+
+use std::time::{Duration, Instant};
+
+/// Throttle window for malformed-frame diagnostics.
+///
+/// Reuses the 1s local-window precedent from B/IP management quota and the
+/// solicited-Advertisement anti-storm interval.
+pub(crate) const DIAGNOSTIC_WINDOW: Duration = Duration::from_secs(1);
+
+/// Maximum diagnostic events emitted per window per throttle instance.
+///
+/// Bound: burst of N frames in one window emits exactly 1 diagnostic.
+/// Single isolated errors always emit.
+pub(crate) const MAX_DIAGNOSTICS_PER_WINDOW: u32 = 1;
+
+/// Fixed-window, strictly bounded diagnostic throttle.
+///
+/// Time is supplied by the caller (`should_emit`) so accounting stays
+/// deterministic in tests without sleeps; production uses
+/// [`DiagnosticThrottle::should_emit_now`].
+#[derive(Clone, Debug)]
+pub(crate) struct DiagnosticThrottle {
+    window_start: Option<Instant>,
+    emitted_in_window: u32,
+    suppressed: u64,
+}
+
+impl DiagnosticThrottle {
+    pub(crate) fn new() -> Self {
+        Self {
+            window_start: None,
+            emitted_in_window: 0,
+            suppressed: 0,
+        }
+    }
+
+    fn roll_window_if_expired(&mut self, now: Instant) {
+        match self.window_start {
+            None => {
+                self.window_start = Some(now);
+            }
+            Some(start) => {
+                if now.saturating_duration_since(start) >= DIAGNOSTIC_WINDOW {
+                    self.window_start = Some(now);
+                    self.emitted_in_window = 0;
+                }
+            }
+        }
+    }
+
+    /// Returns `true` if the caller should emit a diagnostic now.
+    ///
+    /// On `false` the event is counted as suppressed (see [`Self::suppressed`]
+    /// / [`Self::take_suppressed`]) and the caller must not log. On `true`
+    /// the caller should log once and may include [`Self::take_suppressed`]
+    /// as a summary suffix. Never affects wire decisions.
+    pub(crate) fn should_emit(&mut self, now: Instant) -> bool {
+        self.roll_window_if_expired(now);
+        if self.emitted_in_window < MAX_DIAGNOSTICS_PER_WINDOW {
+            self.emitted_in_window += 1;
+            true
+        } else {
+            self.suppressed += 1;
+            false
+        }
+    }
+
+    /// Production entry point using monotonic time.
+    pub(crate) fn should_emit_now(&mut self) -> bool {
+        self.should_emit(Instant::now())
+    }
+
+    /// Total suppressed events since the last [`Self::take_suppressed`].
+    pub(crate) fn suppressed(&self) -> u64 {
+        self.suppressed
+    }
+
+    /// Takes the suppressed count for a periodic summary, resetting to zero.
+    pub(crate) fn take_suppressed(&mut self) -> u64 {
+        std::mem::take(&mut self.suppressed)
+    }
+}
+
+impl Default for DiagnosticThrottle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_error_emits_without_suppression() {
+        let mut throttle = DiagnosticThrottle::new();
+        let now = Instant::now();
+        assert!(throttle.should_emit(now));
+        assert_eq!(throttle.suppressed(), 0);
+        assert_eq!(throttle.take_suppressed(), 0);
+    }
+
+    #[test]
+    fn burst_of_malformed_frames_produces_single_diagnostic() {
+        let mut throttle = DiagnosticThrottle::new();
+        let now = Instant::now();
+        let burst = 1_000;
+        let mut emitted = 0;
+        for _ in 0..burst {
+            if throttle.should_emit(now) {
+                emitted += 1;
+            }
+        }
+        assert_eq!(
+            emitted, MAX_DIAGNOSTICS_PER_WINDOW as usize,
+            "burst of {burst} within one window must emit exactly \
+             {MAX_DIAGNOSTICS_PER_WINDOW}"
+        );
+        assert_eq!(throttle.suppressed(), (burst - 1) as u64);
+        assert_eq!(throttle.take_suppressed(), (burst - 1) as u64);
+        assert_eq!(throttle.suppressed(), 0);
+    }
+
+    #[test]
+    fn window_roll_allows_next_diagnostic_with_summary() {
+        let mut throttle = DiagnosticThrottle::new();
+        let start = Instant::now();
+        assert!(throttle.should_emit(start));
+        assert!(!throttle.should_emit(start));
+        assert!(!throttle.should_emit(start));
+        assert_eq!(throttle.suppressed(), 2);
+        let next_window = start + DIAGNOSTIC_WINDOW + Duration::from_nanos(1);
+        assert!(
+            throttle.should_emit(next_window),
+            "next window must allow one more diagnostic"
+        );
+        assert_eq!(
+            throttle.take_suppressed(),
+            2,
+            "suppressed count survives the window roll for the summary"
+        );
+    }
+
+    /// Burst through the real connection gate: every oversized NPDU keeps its
+    /// existing drop-without-state-change treatment bit-for-bit, while the
+    /// connection throttle bounds diagnostics to one per window.
+    #[test]
+    fn burst_preserves_wire_decisions_while_bounding_diagnostics() {
+        use super::super::{ScConnection, ScConnectionState};
+        use crate::sc_frame::{ScFunction, ScMessage};
+        use bytes::Bytes;
+
+        let mut conn = ScConnection::new([0x01; 6], [1; 16]);
+        conn.state = ScConnectionState::Connected;
+        let oversized = vec![0x01; 2_000];
+        for _ in 0..100 {
+            let msg = ScMessage {
+                function: ScFunction::EncapsulatedNpdu,
+                message_id: 0x2233,
+                originating_vmac: Some([0x22; 6]),
+                destination_vmac: None,
+                dest_options: Vec::new(),
+                data_options: Vec::new(),
+                payload: Bytes::from(oversized.clone()),
+            };
+            assert!(
+                conn.handle_received(&msg).is_none(),
+                "oversized NPDU must stay dropped"
+            );
+            assert_eq!(
+                conn.state,
+                ScConnectionState::Connected,
+                "oversized NPDU must not change state"
+            );
+        }
+        assert_eq!(
+            conn.malformed_diag_suppressed(),
+            99,
+            "burst of 100 within one window must emit 1 diagnostic and suppress 99"
+        );
+        // A valid frame after the burst still delivers (no state corruption).
+        let valid = ScMessage {
+            function: ScFunction::EncapsulatedNpdu,
+            message_id: 0x2234,
+            originating_vmac: Some([0x22; 6]),
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::from_static(&[0x01, 0x00, 0x30]),
+        };
+        assert!(
+            conn.handle_received(&valid).is_some(),
+            "valid NPDU must still deliver after a malformed burst"
+        );
+    }
+
+    /// Single legitimate error still emits (no silent-everything regression)
+    /// at the connection gate.
+    #[test]
+    fn single_connection_error_still_emits() {
+        use super::super::{ScConnection, ScConnectionState};
+        use crate::sc_frame::{ScFunction, ScMessage};
+        use bytes::Bytes;
+
+        let mut conn = ScConnection::new([0x01; 6], [1; 16]);
+        conn.state = ScConnectionState::Connected;
+        let msg = ScMessage {
+            function: ScFunction::EncapsulatedNpdu,
+            message_id: 0x2233,
+            originating_vmac: Some([0x22; 6]),
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::from(vec![0x01; 2_000]),
+        };
+        assert!(conn.handle_received(&msg).is_none());
+        assert_eq!(conn.malformed_diag_suppressed(), 0);
+    }
+}

--- a/crates/bacnet-transport/src/sc/handshake.rs
+++ b/crates/bacnet-transport/src/sc/handshake.rs
@@ -12,7 +12,10 @@ use crate::sc_frame::{
     decode_sc_bvlc_result, decode_sc_message, encode_sc_message, ScBvlcResult, ScFunction,
 };
 
-use super::{heartbeat, ScConnectError, ScConnection, ScConnectionState, WebSocketPort};
+use super::{
+    diagnostic_throttle::DiagnosticThrottle, heartbeat, ScConnectError, ScConnection,
+    ScConnectionState, WebSocketPort,
+};
 
 fn notify_state(state_tx: Option<&watch::Sender<ScConnectionState>>, state: ScConnectionState) {
     if let Some(state_tx) = state_tx {
@@ -56,6 +59,10 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
     }
 
     let timeout_dur = Duration::from_millis(timeout_ms);
+    // Owner-local bound for handshake oversize diagnostics only. Fresh per
+    // handshake so one peer's flood cannot suppress another handshake's
+    // first diagnostic. Wire decisions (drop-and-wait) are unchanged.
+    let mut malformed_diag = DiagnosticThrottle::new();
     let accept_result = tokio::time::timeout(timeout_dur, async {
         loop {
             let data = match ws.recv().await {
@@ -68,7 +75,14 @@ pub(super) async fn perform_handshake<W: WebSocketPort>(
                 }
             };
             if data.len() > conn.lock().await.max_bvlc_length as usize {
-                warn!("BACnet/SC connect frame exceeds local Max-BVLC-Length, dropping");
+                if malformed_diag.should_emit_now() {
+                    let suppressed = malformed_diag.take_suppressed();
+                    if suppressed > 0 {
+                        warn!("BACnet/SC connect frame exceeds local Max-BVLC-Length, dropping (suppressed {suppressed} similar diagnostics)");
+                    } else {
+                        warn!("BACnet/SC connect frame exceeds local Max-BVLC-Length, dropping");
+                    }
+                }
                 continue;
             }
             let msg = match decode_sc_message(&data) {

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -28,6 +28,7 @@ mod connection;
 mod connector;
 mod control_admission;
 mod data_attributes;
+pub(crate) mod diagnostic_throttle;
 mod empty_npdu;
 mod errors;
 mod failover;
@@ -423,6 +424,11 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
             // rate policy. Kept across reconnects so a flap cannot reset
             // the budget into a storm.
             let mut last_solicited_advertisement: Option<Instant> = None;
+            // Owner-local bound for malformed-frame diagnostics only. Kept
+            // across reconnects so a flap cannot reset log suppression into
+            // a flood. Never changes accept/NAK/silence decisions: at most
+            // one diagnostic per second, first occurrence always emits.
+            let mut malformed_diag = diagnostic_throttle::DiagnosticThrottle::new();
 
             'transport: loop {
                 let mut current_reusable = true;
@@ -439,20 +445,41 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                             match data {
                                 Ok(data) => {
                                     if data.len() > conn.lock().await.max_bvlc_length as usize {
-                                        warn!("BACnet/SC frame exceeds local Max-BVLC-Length, dropping");
+                                        if malformed_diag.should_emit_now() {
+                                            let suppressed = malformed_diag.take_suppressed();
+                                            if suppressed > 0 {
+                                                warn!("BACnet/SC frame exceeds local Max-BVLC-Length, dropping (suppressed {suppressed} similar diagnostics)");
+                                            } else {
+                                                warn!("BACnet/SC frame exceeds local Max-BVLC-Length, dropping");
+                                            }
+                                        }
                                         continue;
                                     }
                                     let msg = match decode_sc_message(&data) {
                                         Ok(m) => m,
                                         Err(e) if heartbeat::is_bvlc_result_wire(&data) => {
-                                            warn!("Malformed wire-level BACnet/SC BVLC-Result: {e}");
+                                            if malformed_diag.should_emit_now() {
+                                                let suppressed = malformed_diag.take_suppressed();
+                                                if suppressed > 0 {
+                                                    warn!("Malformed wire-level BACnet/SC BVLC-Result: {e} (suppressed {suppressed} similar diagnostics)");
+                                                } else {
+                                                    warn!("Malformed wire-level BACnet/SC BVLC-Result: {e}");
+                                                }
+                                            }
                                             let mut c = conn.lock().await;
                                             c.state = ScConnectionState::Disconnected;
                                             state_tx.send_replace(c.state);
                                             break;
                                         }
                                         Err(e) => {
-                                            warn!("BACnet/SC decode error: {}", e);
+                                            if malformed_diag.should_emit_now() {
+                                                let suppressed = malformed_diag.take_suppressed();
+                                                if suppressed > 0 {
+                                                    warn!("BACnet/SC decode error: {} (suppressed {suppressed} similar diagnostics)", e);
+                                                } else {
+                                                    warn!("BACnet/SC decode error: {}", e);
+                                                }
+                                            }
                                             continue;
                                         }
                                     };
@@ -475,8 +502,13 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                         if heartbeat::ack_matches_outstanding(&msg, pending_heartbeat_id) {
                                             last_bvlc_received = Instant::now();
                                             pending_heartbeat_id = None;
-                                        } else {
-                                            warn!("BACnet/SC ignored unexpected Heartbeat-ACK");
+                                        } else if malformed_diag.should_emit_now() {
+                                            let suppressed = malformed_diag.take_suppressed();
+                                            if suppressed > 0 {
+                                                warn!("BACnet/SC ignored unexpected Heartbeat-ACK (suppressed {suppressed} similar diagnostics)");
+                                            } else {
+                                                warn!("BACnet/SC ignored unexpected Heartbeat-ACK");
+                                            }
                                         }
                                         continue;
                                     }

--- a/crates/bacnet-transport/src/sc_hub.rs
+++ b/crates/bacnet-transport/src/sc_hub.rs
@@ -37,6 +37,7 @@ mod deadlines;
 mod handler;
 mod heartbeat;
 mod helpers;
+mod malformed_diag;
 mod opaque_relay;
 mod proprietary_transit;
 mod relay;

--- a/crates/bacnet-transport/src/sc_hub/handler.rs
+++ b/crates/bacnet-transport/src/sc_hub/handler.rs
@@ -1,6 +1,7 @@
 //! Hub message dispatch; its registration lease is owned by the outer runner.
 
 use super::*;
+use crate::sc::diagnostic_throttle::DiagnosticThrottle;
 
 pub(super) async fn run(
     peer_addr: SocketAddr,
@@ -16,6 +17,10 @@ pub(super) async fn run(
     let close_requested = lease.closed.clone();
     let close_notify = lease.notify.clone();
     let client_activity: Arc<AtomicU64> = Arc::new(AtomicU64::new(now_secs()));
+    // Owner-local bound for malformed-frame diagnostics only. Fresh per
+    // connection so one peer's flood cannot suppress another connection's
+    // first diagnostic. NAK/relay/silence decisions are unchanged.
+    let mut malformed_diag = DiagnosticThrottle::new();
 
     loop {
         // A stream of immediately ready frames must not starve the timer.
@@ -64,18 +69,14 @@ pub(super) async fn run(
         };
 
         if data.len() > HUB_MAX_BVLC_LENGTH as usize {
-            warn!(
-                "Hub: frame from {peer_addr} is {} bytes, exceeds hub Max-BVLC-Length {}, dropping",
-                data.len(),
-                HUB_MAX_BVLC_LENGTH
-            );
+            super::malformed_diag::oversize(&mut malformed_diag, peer_addr, data.len());
             continue;
         }
 
         let sc_msg = match decode_sc_message(&data) {
             Ok(m) => m,
             Err(e) => {
-                warn!("Hub: decode error from {peer_addr}: {e}");
+                super::malformed_diag::decode_error(&mut malformed_diag, peer_addr, &e);
                 continue;
             }
         };
@@ -135,7 +136,7 @@ pub(super) async fn run(
         if sc_msg.function == ScFunction::EncapsulatedNpdu
             && sc_msg.payload.len() > HUB_MAX_NPDU_LENGTH as usize
         {
-            warn!("Hub: NPDU exceeds local Max-NPDU-Length, dropping");
+            super::malformed_diag::npdu_exceeds(&mut malformed_diag);
             continue;
         }
 
@@ -538,7 +539,7 @@ pub(super) async fn run(
 
             ScFunction::Result => {
                 let Some(registered_vmac) = lease.vmac else {
-                    debug!("Hub: Result before ConnectRequest from {peer_addr}, dropping");
+                    super::malformed_diag::result_before_connect(&mut malformed_diag, peer_addr);
                     continue;
                 };
                 if relay_result(
@@ -548,6 +549,7 @@ pub(super) async fn run(
                     &clients,
                     &write,
                     &close_requested,
+                    &mut malformed_diag,
                 )
                 .await
                     == ResultRelayDisposition::CloseSource
@@ -558,7 +560,7 @@ pub(super) async fn run(
 
             ScFunction::EncapsulatedNpdu => {
                 let Some(registered_vmac) = lease.vmac else {
-                    warn!("Hub: EncapsulatedNpdu before ConnectRequest from {peer_addr} — sending NAK");
+                    super::malformed_diag::npdu_before_connect(&mut malformed_diag, peer_addr);
                     let nak = build_bvlc_result_nak(
                         sc_msg.message_id,
                         ScFunction::EncapsulatedNpdu,
@@ -575,15 +577,11 @@ pub(super) async fn run(
                 let relay_target = match hub_relay_target(&sc_msg) {
                     Ok(target) => target,
                     Err(HubRelayReject::OriginatingVmacPresent) => {
-                        warn!(
-                            "Hub: EncapsulatedNpdu from {peer_addr} had Originating VMAC, dropping"
-                        );
+                        super::malformed_diag::originating_vmac(&mut malformed_diag, peer_addr);
                         continue;
                     }
                     Err(HubRelayReject::MissingDestinationVmac) => {
-                        warn!(
-                            "Hub: EncapsulatedNpdu from {peer_addr} missing Destination VMAC, dropping"
-                        );
+                        super::malformed_diag::missing_destination(&mut malformed_diag, peer_addr);
                         continue;
                     }
                 };
@@ -593,7 +591,7 @@ pub(super) async fn run(
                 let Some(relay_buf) =
                     encode_hub_relay_frame(&data, &sc_msg, registered_vmac, relay_target)
                 else {
-                    warn!("Hub: failed to preserve EncapsulatedNpdu frame from {peer_addr}");
+                    super::malformed_diag::preserve_failure(&mut malformed_diag, peer_addr);
                     continue;
                 };
                 let relay_bytes: Vec<u8> = relay_buf.to_vec();
@@ -619,23 +617,26 @@ pub(super) async fn run(
                             .filter_map(|vmac| {
                                 let c = map.get(&vmac)?;
                                 match relay_limit_decision(
-                                    npdu_len,
-                                    relay_len,
-                                    c.max_npdu,
-                                    c.max_bvlc,
+                                    npdu_len, relay_len, c.max_npdu, c.max_bvlc,
                                 ) {
-                                    RelayLimitDecision::Send => Some(HubRelaySink::capture(vmac, c)),
+                                    RelayLimitDecision::Send => {
+                                        Some(HubRelaySink::capture(vmac, c))
+                                    }
                                     RelayLimitDecision::DropMaxNpdu => {
-                                        warn!(
-                                            "Hub: broadcast NPDU ({npdu_len} bytes) exceeds target max_npdu ({}) for {vmac:02x?}, dropping for target",
-                                            c.max_npdu
+                                        super::malformed_diag::broadcast_npdu_drop(
+                                            &mut malformed_diag,
+                                            npdu_len,
+                                            c.max_npdu,
+                                            vmac,
                                         );
                                         None
                                     }
                                     RelayLimitDecision::DropMaxBvlc => {
-                                        warn!(
-                                            "Hub: broadcast BVLC ({relay_len} bytes) exceeds target max_bvlc ({}) for {vmac:02x?}, dropping for target",
-                                            c.max_bvlc
+                                        super::malformed_diag::broadcast_bvlc_drop(
+                                            &mut malformed_diag,
+                                            relay_len,
+                                            c.max_bvlc,
+                                            vmac,
                                         );
                                         None
                                     }
@@ -690,27 +691,41 @@ pub(super) async fn run(
                         match relay_limit_decision(npdu_len, relay_len, max_npdu, max_bvlc) {
                             RelayLimitDecision::Send => {
                                 if let Err(e) = super::relay_send::send(
-                                    &target, &clients, Message::Binary(relay_bytes.into()),
+                                    &target,
+                                    &clients,
+                                    Message::Binary(relay_bytes.into()),
                                     &super::relay_send::SocketIo,
-                                ).await {
+                                )
+                                .await
+                                {
                                     warn!("Hub: unicast relay error to {dest:02x?}: {e}");
                                 }
                             }
-                            RelayLimitDecision::DropMaxNpdu => warn!(
-                                "Hub: NPDU ({npdu_len} bytes) exceeds target max_npdu ({max_npdu}) for {dest:02x?}, dropping"
-                            ),
-                            RelayLimitDecision::DropMaxBvlc => warn!(
-                                "Hub: BVLC ({relay_len} bytes) exceeds target max_bvlc ({max_bvlc}) for {dest:02x?}, dropping"
-                            ),
+                            RelayLimitDecision::DropMaxNpdu => {
+                                super::malformed_diag::unicast_npdu_drop(
+                                    &mut malformed_diag,
+                                    npdu_len,
+                                    max_npdu,
+                                    dest,
+                                );
+                            }
+                            RelayLimitDecision::DropMaxBvlc => {
+                                super::malformed_diag::unicast_bvlc_drop(
+                                    &mut malformed_diag,
+                                    relay_len,
+                                    max_bvlc,
+                                    dest,
+                                );
+                            }
                         }
                     } else {
-                        debug!("Hub: no client with vmac {dest:02x?} for unicast relay");
+                        super::malformed_diag::no_unicast_target(&mut malformed_diag, dest);
                     }
                 }
             }
 
             other => {
-                debug!("Hub: unknown function {other:?} from {peer_addr}, sending NAK");
+                super::malformed_diag::unknown_function(&mut malformed_diag, peer_addr, &other);
                 let nak = build_bvlc_result_nak(
                     sc_msg.message_id,
                     other,

--- a/crates/bacnet-transport/src/sc_hub/malformed_diag.rs
+++ b/crates/bacnet-transport/src/sc_hub/malformed_diag.rs
@@ -1,0 +1,191 @@
+//! Owner-local emitters for hub malformed-frame diagnostics.
+//!
+//! Each emitter bounds one per-frame `warn!`/`debug!` to at most one event per
+//! second per connection via the shared [`DiagnosticThrottle`], counting the
+//! rest as suppressed for the next summary. NAK/relay/silence decisions stay
+//! with the caller bit-for-bit; these helpers only gate log emission.
+
+use std::net::SocketAddr;
+
+use tracing::{debug, warn};
+
+use crate::sc::diagnostic_throttle::DiagnosticThrottle;
+use crate::sc_frame::{ScFunction, Vmac};
+
+use super::HUB_MAX_BVLC_LENGTH;
+
+/// Generic throttled emission: logs once per window, counts the rest.
+pub(super) fn emit(diag: &mut DiagnosticThrottle, log: impl FnOnce(u64)) {
+    if diag.should_emit_now() {
+        let suppressed = diag.take_suppressed();
+        log(suppressed);
+    }
+}
+
+pub(super) fn oversize(diag: &mut DiagnosticThrottle, peer_addr: SocketAddr, len: usize) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: frame from {peer_addr} is {len} bytes, exceeds hub Max-BVLC-Length {HUB_MAX_BVLC_LENGTH}, dropping (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: frame from {peer_addr} is {len} bytes, exceeds hub Max-BVLC-Length {HUB_MAX_BVLC_LENGTH}, dropping");
+        }
+    });
+}
+
+pub(super) fn decode_error(
+    diag: &mut DiagnosticThrottle,
+    peer_addr: SocketAddr,
+    e: &bacnet_types::error::Error,
+) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: decode error from {peer_addr}: {e} (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: decode error from {peer_addr}: {e}");
+        }
+    });
+}
+
+pub(super) fn npdu_exceeds(diag: &mut DiagnosticThrottle) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: NPDU exceeds local Max-NPDU-Length, dropping (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: NPDU exceeds local Max-NPDU-Length, dropping");
+        }
+    });
+}
+
+pub(super) fn result_before_connect(diag: &mut DiagnosticThrottle, peer_addr: SocketAddr) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            debug!("Hub: Result before ConnectRequest from {peer_addr}, dropping (suppressed {suppressed} similar diagnostics)");
+        } else {
+            debug!("Hub: Result before ConnectRequest from {peer_addr}, dropping");
+        }
+    });
+}
+
+pub(super) fn npdu_before_connect(diag: &mut DiagnosticThrottle, peer_addr: SocketAddr) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: EncapsulatedNpdu before ConnectRequest from {peer_addr} — sending NAK (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: EncapsulatedNpdu before ConnectRequest from {peer_addr} — sending NAK");
+        }
+    });
+}
+
+pub(super) fn originating_vmac(diag: &mut DiagnosticThrottle, peer_addr: SocketAddr) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: EncapsulatedNpdu from {peer_addr} had Originating VMAC, dropping (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: EncapsulatedNpdu from {peer_addr} had Originating VMAC, dropping");
+        }
+    });
+}
+
+pub(super) fn missing_destination(diag: &mut DiagnosticThrottle, peer_addr: SocketAddr) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: EncapsulatedNpdu from {peer_addr} missing Destination VMAC, dropping (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: EncapsulatedNpdu from {peer_addr} missing Destination VMAC, dropping");
+        }
+    });
+}
+
+pub(super) fn preserve_failure(diag: &mut DiagnosticThrottle, peer_addr: SocketAddr) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: failed to preserve EncapsulatedNpdu frame from {peer_addr} (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: failed to preserve EncapsulatedNpdu frame from {peer_addr}");
+        }
+    });
+}
+
+pub(super) fn broadcast_npdu_drop(
+    diag: &mut DiagnosticThrottle,
+    npdu_len: usize,
+    max_npdu: u16,
+    vmac: Vmac,
+) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: broadcast NPDU ({npdu_len} bytes) exceeds target max_npdu ({max_npdu}) for {vmac:02x?}, dropping for target (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: broadcast NPDU ({npdu_len} bytes) exceeds target max_npdu ({max_npdu}) for {vmac:02x?}, dropping for target");
+        }
+    });
+}
+
+pub(super) fn broadcast_bvlc_drop(
+    diag: &mut DiagnosticThrottle,
+    relay_len: usize,
+    max_bvlc: u16,
+    vmac: Vmac,
+) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: broadcast BVLC ({relay_len} bytes) exceeds target max_bvlc ({max_bvlc}) for {vmac:02x?}, dropping for target (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: broadcast BVLC ({relay_len} bytes) exceeds target max_bvlc ({max_bvlc}) for {vmac:02x?}, dropping for target");
+        }
+    });
+}
+
+pub(super) fn unicast_npdu_drop(
+    diag: &mut DiagnosticThrottle,
+    npdu_len: usize,
+    max_npdu: u16,
+    dest: Vmac,
+) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: NPDU ({npdu_len} bytes) exceeds target max_npdu ({max_npdu}) for {dest:02x?}, dropping (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: NPDU ({npdu_len} bytes) exceeds target max_npdu ({max_npdu}) for {dest:02x?}, dropping");
+        }
+    });
+}
+
+pub(super) fn unicast_bvlc_drop(
+    diag: &mut DiagnosticThrottle,
+    relay_len: usize,
+    max_bvlc: u16,
+    dest: Vmac,
+) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            warn!("Hub: BVLC ({relay_len} bytes) exceeds target max_bvlc ({max_bvlc}) for {dest:02x?}, dropping (suppressed {suppressed} similar diagnostics)");
+        } else {
+            warn!("Hub: BVLC ({relay_len} bytes) exceeds target max_bvlc ({max_bvlc}) for {dest:02x?}, dropping");
+        }
+    });
+}
+
+pub(super) fn no_unicast_target(diag: &mut DiagnosticThrottle, dest: Vmac) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            debug!("Hub: no client with vmac {dest:02x?} for unicast relay (suppressed {suppressed} similar diagnostics)");
+        } else {
+            debug!("Hub: no client with vmac {dest:02x?} for unicast relay");
+        }
+    });
+}
+
+pub(super) fn unknown_function(
+    diag: &mut DiagnosticThrottle,
+    peer_addr: SocketAddr,
+    other: &ScFunction,
+) {
+    emit(diag, |suppressed| {
+        if suppressed > 0 {
+            debug!("Hub: unknown function {other:?} from {peer_addr}, sending NAK (suppressed {suppressed} similar diagnostics)");
+        } else {
+            debug!("Hub: unknown function {other:?} from {peer_addr}, sending NAK");
+        }
+    });
+}

--- a/crates/bacnet-transport/src/sc_hub/relay.rs
+++ b/crates/bacnet-transport/src/sc_hub/relay.rs
@@ -13,6 +13,17 @@ use crate::sc_frame::{
 
 use super::helpers::registered_client_matches_sink_in_map;
 use super::{Clients, WsSink};
+use crate::sc::diagnostic_throttle::DiagnosticThrottle;
+
+/// Emits one throttled hub-Result diagnostic. Returns without logging when
+/// the per-connection window budget is exhausted (suppressed is counted for
+/// the next summary). Never affects relay decisions.
+fn emit_result_diagnostic(diag: &mut DiagnosticThrottle, log: impl FnOnce(u64)) {
+    if diag.should_emit_now() {
+        let suppressed = diag.take_suppressed();
+        log(suppressed);
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum HubRelayTarget {
@@ -116,13 +127,20 @@ pub(super) async fn relay_result(
     clients: &Clients,
     source_sink: &Arc<Mutex<WsSink>>,
     close_requested: &Arc<AtomicBool>,
+    diag: &mut DiagnosticThrottle,
 ) -> ResultRelayDisposition {
     let result_for = match decode_sc_bvlc_result(msg) {
         Ok(ScBvlcResult::Ack { result_for }) | Ok(ScBvlcResult::Nak { result_for, .. }) => {
             result_for
         }
         Err(e) => {
-            debug!("Hub: malformed peer Result from {registered_vmac:02x?}, dropping: {e}");
+            emit_result_diagnostic(diag, |suppressed| {
+                if suppressed > 0 {
+                    debug!("Hub: malformed peer Result from {registered_vmac:02x?}, dropping: {e} (suppressed {suppressed} similar diagnostics)");
+                } else {
+                    debug!("Hub: malformed peer Result from {registered_vmac:02x?}, dropping: {e}");
+                }
+            });
             return ResultRelayDisposition::Continue;
         }
     };
@@ -149,25 +167,54 @@ pub(super) async fn relay_result(
             | ScFunction::ProprietaryMessage
             | ScFunction::Unknown(_)
     ) {
-        debug!(
-            "Hub: peer Result for {:?} from {registered_vmac:02x?}, dropping",
-            result_for
-        );
+        emit_result_diagnostic(diag, |suppressed| {
+            if suppressed > 0 {
+                debug!(
+                    "Hub: peer Result for {:?} from {registered_vmac:02x?}, dropping (suppressed {suppressed} similar diagnostics)",
+                    result_for
+                );
+            } else {
+                debug!(
+                    "Hub: peer Result for {:?} from {registered_vmac:02x?}, dropping",
+                    result_for
+                );
+            }
+        });
         return ResultRelayDisposition::Continue;
     }
 
     let destination = match hub_relay_target(msg) {
         Ok(HubRelayTarget::Unicast(destination)) => destination,
         Ok(HubRelayTarget::Broadcast) => {
-            debug!("Hub: broadcast Result from {registered_vmac:02x?}, dropping");
+            emit_result_diagnostic(diag, |suppressed| {
+                if suppressed > 0 {
+                    debug!("Hub: broadcast Result from {registered_vmac:02x?}, dropping (suppressed {suppressed} similar diagnostics)");
+                } else {
+                    debug!("Hub: broadcast Result from {registered_vmac:02x?}, dropping");
+                }
+            });
             return ResultRelayDisposition::Continue;
         }
         Err(HubRelayReject::OriginatingVmacPresent) => {
-            debug!("Hub: Result from {registered_vmac:02x?} had Originating VMAC, dropping");
+            emit_result_diagnostic(diag, |suppressed| {
+                if suppressed > 0 {
+                    debug!("Hub: Result from {registered_vmac:02x?} had Originating VMAC, dropping (suppressed {suppressed} similar diagnostics)");
+                } else {
+                    debug!(
+                        "Hub: Result from {registered_vmac:02x?} had Originating VMAC, dropping"
+                    );
+                }
+            });
             return ResultRelayDisposition::Continue;
         }
         Err(HubRelayReject::MissingDestinationVmac) => {
-            debug!("Hub: Result from {registered_vmac:02x?} had no relay destination, dropping");
+            emit_result_diagnostic(diag, |suppressed| {
+                if suppressed > 0 {
+                    debug!("Hub: Result from {registered_vmac:02x?} had no relay destination, dropping (suppressed {suppressed} similar diagnostics)");
+                } else {
+                    debug!("Hub: Result from {registered_vmac:02x?} had no relay destination, dropping");
+                }
+            });
             return ResultRelayDisposition::Continue;
         }
     };
@@ -195,7 +242,13 @@ pub(super) async fn relay_result(
         registered_vmac,
         HubRelayTarget::Unicast(destination),
     ) else {
-        warn!("Hub: failed to preserve peer Result frame from {registered_vmac:02x?}");
+        emit_result_diagnostic(diag, |suppressed| {
+            if suppressed > 0 {
+                warn!("Hub: failed to preserve peer Result frame from {registered_vmac:02x?} (suppressed {suppressed} similar diagnostics)");
+            } else {
+                warn!("Hub: failed to preserve peer Result frame from {registered_vmac:02x?}");
+            }
+        });
         return ResultRelayDisposition::Continue;
     };
     let relay_len = relay_buf.len();
@@ -214,13 +267,27 @@ pub(super) async fn relay_result(
     };
 
     let Some((target, max_bvlc)) = target else {
-        debug!("Hub: no client with vmac {destination:02x?} for Result relay");
+        emit_result_diagnostic(diag, |suppressed| {
+            if suppressed > 0 {
+                debug!("Hub: no client with vmac {destination:02x?} for Result relay (suppressed {suppressed} similar diagnostics)");
+            } else {
+                debug!("Hub: no client with vmac {destination:02x?} for Result relay");
+            }
+        });
         return ResultRelayDisposition::Continue;
     };
     if relay_len > max_bvlc as usize {
-        warn!(
-            "Hub: Result BVLC ({relay_len} bytes) exceeds target max_bvlc ({max_bvlc}) for {destination:02x?}, dropping"
-        );
+        emit_result_diagnostic(diag, |suppressed| {
+            if suppressed > 0 {
+                warn!(
+                    "Hub: Result BVLC ({relay_len} bytes) exceeds target max_bvlc ({max_bvlc}) for {destination:02x?}, dropping (suppressed {suppressed} similar diagnostics)"
+                );
+            } else {
+                warn!(
+                    "Hub: Result BVLC ({relay_len} bytes) exceeds target max_bvlc ({max_bvlc}) for {destination:02x?}, dropping"
+                );
+            }
+        });
         return ResultRelayDisposition::Continue;
     }
     if close_requested.load(Ordering::Acquire) {


### PR DESCRIPTION
Bounded #519 slice: malformed-frame diagnostic volume bounded (1/sec/instance + suppressed summary); every frame keeps existing accept/NAK/silence bit-for-bit.

- New fixed-window throttle (node per-transport/per-connection/per-handshake, hub per-connection, MU-category process-shared); single errors always emit; burst N emits 1 + summary.
- RejectionBudget still bounds node NAK sends; hub NAK transmit stays per-frame immediate by design (disclosed). AB imposes no log rates — local hardening.
- Refs #519 (stays OPEN: URI/discovery/dial remains). Gates: fmt/clippy/size/secrets PASS, transport 552 + sc-tls 745/2/7/17 PASS, FULL conformance_ledger 27/27 PASS. No website/CI/README changes.