### PR TITLE
feat(sc): validate Address-Resolution URI bodies before dispatch (#615)

### DIFF
--- a/crates/bacnet-transport/src/sc/address_resolution.rs
+++ b/crates/bacnet-transport/src/sc/address_resolution.rs
@@ -1,0 +1,79 @@
+//! Established-node Address-Resolution admission, not answering, discovery,
+//! or dialing.
+//!
+//! Well-formed request and response bodies are consumed silently with
+//! accepted activity (no NPDU, no state change, no response yet). Malformed
+//! request bodies draw the validator's diagnostic as a connection-local NAK
+//! for locally-addressed unicast; malformed response bodies are always
+//! silent because the response rule forbids answering responses. Envelope
+//! routing (explicit destinations, reserved origins, broadcast silence)
+//! matches the Advertisement and Proprietary gates.
+
+use bacnet_types::enums::{ErrorClass, ErrorCode};
+use bytes::BytesMut;
+use tracing::warn;
+
+use super::data_attributes::build_bvlc_result_nak;
+use super::rejection::{RejectionBudget, RejectionExpired};
+use super::WebSocketPort;
+use crate::sc_frame::{
+    address_resolution_message_error, encode_sc_message,
+    first_must_understand_destination_option_marker, ScFunction, ScMessage,
+};
+
+pub(super) async fn reject<W: WebSocketPort>(
+    msg: &ScMessage,
+    wire: &[u8],
+    ws: &W,
+    budget: RejectionBudget,
+) -> Result<bool, RejectionExpired> {
+    if !matches!(
+        msg.function,
+        ScFunction::AddressResolution | ScFunction::AddressResolutionAck
+    ) {
+        return Ok(false);
+    }
+    // Hub-connector AB.5.4: explicit destinations are not for the local
+    // BVLL. Reserved origins are also silent; neither decision spends a
+    // budget. Broadcast destinations arrive with an explicit address, so
+    // the broadcast-silence rule needs no separate branch.
+    if msg.destination_vmac.is_some()
+        || matches!(msg.originating_vmac, Some(vmac) if vmac == [0; 6] || vmac == [0xFF; 6])
+    {
+        return Ok(true);
+    }
+    // Valid shapes are consumed silently with accepted activity. Answering
+    // (empty versus populated response versus unsupported-function
+    // diagnostic), discovery, and dialing remain later work; this gate
+    // only rejects malformed bodies before dispatch.
+    let Some(code) = address_resolution_message_error(msg) else {
+        return Ok(false);
+    };
+    // Responses never draw a response, even when malformed. The malformed
+    // response is discarded without activity, probe, or NPDU effects.
+    if msg.function == ScFunction::AddressResolutionAck {
+        return Ok(true);
+    }
+    let marker = if code == ErrorCode::HEADER_NOT_UNDERSTOOD {
+        match first_must_understand_destination_option_marker(wire) {
+            Some(marker) => marker,
+            None => return Ok(true),
+        }
+    } else {
+        0
+    };
+    let nak = build_bvlc_result_nak(
+        msg.message_id,
+        msg.function,
+        marker,
+        msg.originating_vmac,
+        ErrorClass::COMMUNICATION,
+        code,
+    );
+    let mut bytes = BytesMut::new();
+    encode_sc_message(&mut bytes, &nak);
+    if let Err(e) = budget.send(ws, &bytes).await? {
+        warn!("BACnet/SC address-resolution NAK send error: {}", e);
+    }
+    Ok(true)
+}

--- a/crates/bacnet-transport/src/sc/address_resolution_tests.rs
+++ b/crates/bacnet-transport/src/sc/address_resolution_tests.rs
@@ -1,0 +1,456 @@
+//! Independent raw-wire node admission vectors for Address-Resolution
+//! (0x02) and Address-Resolution-ACK (0x03); no hub fallback involved.
+//!
+//! Well-formed bodies stay silently consumed (no answering yet); malformed
+//! requests NAK locally while malformed responses stay silent per the
+//! response rule. Hub opaque transit for valid bodies is preserved by
+//! existing hub tests; these vectors prove the node gate only.
+use super::*;
+use tokio::time::timeout;
+
+fn wire(
+    raw: u8,
+    id: u16,
+    source: Option<Vmac>,
+    dest: Option<Vmac>,
+    flags: u8,
+    body: &[u8],
+) -> Vec<u8> {
+    let mut bytes = vec![
+        raw,
+        flags | (u8::from(source.is_some()) * 8) | (u8::from(dest.is_some()) * 4),
+    ];
+    bytes.extend_from_slice(&id.to_be_bytes());
+    if let Some(source) = source {
+        bytes.extend_from_slice(&source);
+    }
+    if let Some(dest) = dest {
+        bytes.extend_from_slice(&dest);
+    }
+    bytes.extend_from_slice(body);
+    bytes
+}
+
+fn nak(raw: u8, id: u16, dest: Option<Vmac>, code: u16, marker: u8) -> Vec<u8> {
+    let [hi, lo] = code.to_be_bytes();
+    wire(0, id, None, dest, 0, &[raw, 1, marker, 0, 7, hi, lo])
+}
+
+fn valid_acks() -> Vec<Vec<u8>> {
+    let mut out = vec![
+        vec![],
+        b"wss://one.example/sc".to_vec(),
+        b"wss://one.example/sc wss://two.example:8443/sc".to_vec(),
+        b"wss://hub.example.com:47808/.bacnet/sc?profile=primary".to_vec(),
+        b"wss://[::1]:47808/sc".to_vec(),
+        b"WSS://UPPER.example/SC".to_vec(),
+    ];
+    let mut long = b"wss://peer.example/".to_vec();
+    long.resize(1400, b'x');
+    out.push(long);
+    out
+}
+
+async fn recv(hub: &LoopbackWebSocket) -> Vec<u8> {
+    timeout(Duration::from_secs(1), hub.recv())
+        .await
+        .unwrap()
+        .unwrap()
+}
+
+async fn barrier(hub: &LoopbackWebSocket) {
+    // An invalid known control is an ordered, non-activity barrier, not a valid
+    // sentinel that could conceal unintended activity from resolution traffic.
+    hub.send(&[0x0A, 0, 0x44, 0x55, 0x42]).await.unwrap();
+    assert_eq!(recv(hub).await, [0, 0, 0x44, 0x55, 0x0A, 1, 0, 0, 7, 0, 7]);
+}
+
+#[tokio::test]
+async fn address_resolution_valid_shapes_are_consumed_silently_without_npdu() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    // Empty request is the only valid request shape.
+    for source in [None, Some([0x22; 6])] {
+        hub.send(&wire(2, 0x2233, source, None, 0, &[]))
+            .await
+            .unwrap();
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    // Empty and well-formed URI lists are valid responses.
+    for payload in valid_acks() {
+        for source in [None, Some([0x22; 6])] {
+            hub.send(&wire(3, 0x2233, source, None, 0, &payload))
+                .await
+                .unwrap();
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    // Non-MU destination options on valid shapes stay silent here.
+    for (function, payload) in [(2, vec![]), (3, b"wss://one.example/sc".to_vec())] {
+        let mut optioned = vec![0x1F];
+        optioned.extend_from_slice(&payload);
+        hub.send(&wire(function, 0x2235, None, None, 2, &optioned))
+            .await
+            .unwrap();
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn address_resolution_request_negative_matrix_nak_vs_silence() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    // (body, expected NAK code) for locally-addressed requests.
+    let faults: Vec<(Vec<u8>, u16)> = vec![
+        (vec![0x00], 7),
+        (vec![0x01, 0x02], 7),
+        (b"wss://one.example/sc".to_vec(), 7),
+        (vec![0x2B; 64], 7),
+    ];
+    for (body, code) in faults {
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(2, 0x2233, source, None, 0, &body);
+            hub.send(&bytes).await.unwrap();
+            assert_eq!(
+                recv(&hub).await,
+                nak(2, 0x2233, source, code, 0),
+                "request source {source:02x?} body {body:02x?}"
+            );
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    // Data Options are out of range even around an empty request.
+    for source in [None, Some([0x22; 6])] {
+        hub.send(&wire(2, 0x2233, source, None, 1, &[0x01]))
+            .await
+            .unwrap();
+        assert_eq!(recv(&hub).await, nak(2, 0x2233, source, 80, 0));
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    // Must-Understand destination option faults carry the wire marker.
+    let mut mu_body = vec![0x42];
+    for source in [None, Some([0x22; 6])] {
+        hub.send(&wire(2, 0x2234, source, None, 2, &mu_body))
+            .await
+            .unwrap();
+        assert_eq!(recv(&hub).await, nak(2, 0x2234, source, 146, 0x42));
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    mu_body.clear();
+    // Addressed, broadcast, and reserved-origin envelopes stay silent for
+    // both valid and forbidden request shapes without spending a budget.
+    let silent_bodies: Vec<Vec<u8>> = vec![vec![], vec![0x00], b"wss://a.example/".to_vec()];
+    for body in silent_bodies {
+        for (source, dest) in [
+            (None, Some([0x44; 6])),
+            (Some([0x22; 6]), Some([0x44; 6])),
+            (None, Some(BROADCAST_VMAC)),
+            (Some([0x22; 6]), Some(BROADCAST_VMAC)),
+            (Some([0; 6]), None),
+            (Some(BROADCAST_VMAC), None),
+            (Some([0; 6]), Some([0x44; 6])),
+        ] {
+            hub.send(&wire(2, 0x2235, source, dest, 0, &body))
+                .await
+                .unwrap();
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn address_resolution_ack_malformed_is_always_silent() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    // Every malformed response is discarded without a Result, per the
+    // response rule, and without activity. Valid empty/nonempty lists are
+    // covered by the silence test above.
+    let mut malformed: Vec<Vec<u8>> = vec![
+        vec![0xFF, 0x00],
+        b" wss://one.example/sc".to_vec(),
+        b"wss://one.example/sc ".to_vec(),
+        b"wss://one.example/sc  wss://two.example/sc".to_vec(),
+        b" ".to_vec(),
+        b"ws://one.example/sc".to_vec(),
+        b"wss://".to_vec(),
+        b"wss:///sc".to_vec(),
+        b"not-a-uri".to_vec(),
+        b"wss://one.example/sc http://two.example/sc".to_vec(),
+        "wss://one.example/sc\u{00e9}".as_bytes().to_vec(),
+    ];
+    malformed.push({
+        let mut body = vec![0x01];
+        body.extend_from_slice(b"wss://one.example/sc");
+        body
+    });
+    malformed.push({
+        let mut body = vec![0x42];
+        body.extend_from_slice(b"wss://one.example/sc");
+        body
+    });
+    for body in malformed {
+        let flags = if body.first() == Some(&0x01) {
+            1
+        } else if body.first() == Some(&0x42) {
+            2
+        } else {
+            0
+        };
+        for source in [None, Some([0x22; 6])] {
+            hub.send(&wire(3, 0x2233, source, None, flags, &body))
+                .await
+                .unwrap();
+            // No NAK may precede the barrier; the barrier proves silence.
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    // Addressed and reserved envelopes stay silent for valid lists too.
+    for payload in [vec![], b"wss://one.example/sc".to_vec()] {
+        for (source, dest) in [
+            (None, Some([0x44; 6])),
+            (Some([0x22; 6]), Some([0x44; 6])),
+            (None, Some(BROADCAST_VMAC)),
+            (Some([0; 6]), None),
+            (Some(BROADCAST_VMAC), None),
+        ] {
+            hub.send(&wire(3, 0x2235, source, dest, 0, &payload))
+                .await
+                .unwrap();
+            barrier(&hub).await;
+            assert!(rx.try_recv().is_err());
+        }
+    }
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn address_resolution_silence_and_codes_never_consult_expired_budget() {
+    use super::rejection::{reject, RejectionBudget, RejectionExpired};
+    struct NoIo;
+    impl WebSocketPort for NoIo {
+        async fn send(&self, _: &[u8]) -> Result<(), Error> {
+            panic!("unexpected send")
+        }
+        async fn recv(&self) -> Result<Vec<u8>, Error> {
+            panic!("unexpected receive")
+        }
+    }
+    let expired = RejectionBudget::new(Instant::now() - Duration::from_secs(1), 1);
+    // Forbidden request shapes must consult the budget (expiry surfaces).
+    for body in [vec![0x00], vec![0x01, 0x02], b"wss://a.example/".to_vec()] {
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(2, 0, source, None, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Err(RejectionExpired),
+                "request source {source:02x?}"
+            );
+        }
+    }
+    // Request MU faults also consult the budget when recoverable.
+    let bytes = wire(2, 0, None, None, 2, &[0x42]);
+    let msg = decode_sc_message(&bytes).unwrap();
+    assert_eq!(
+        reject(&msg, &bytes, &NoIo, expired).await,
+        Err(RejectionExpired)
+    );
+    // Malformed responses never consult the budget: silence is free.
+    for body in [
+        vec![0xFF],
+        b" wss://a.example/".to_vec(),
+        b"ws://a.example/".to_vec(),
+    ] {
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(3, 0, source, None, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Ok(true),
+                "ack body {body:02x?}"
+            );
+        }
+    }
+    // Silent envelopes and valid shapes never consult the budget.
+    for (function, body) in [(2, vec![]), (3, vec![]), (3, b"wss://a.example/".to_vec())] {
+        for (source, dest) in [
+            (None, Some([0x44; 6])),
+            (None, Some(BROADCAST_VMAC)),
+            (Some([0; 6]), None),
+            (Some(BROADCAST_VMAC), None),
+        ] {
+            let bytes = wire(function, 0, source, dest, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Ok(true),
+                "silent function {function}"
+            );
+        }
+        for source in [None, Some([0x22; 6])] {
+            let bytes = wire(function, 0, source, None, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(
+                reject(&msg, &bytes, &NoIo, expired).await,
+                Ok(false),
+                "valid function {function}"
+            );
+        }
+    }
+}
+
+#[test]
+fn address_resolution_direct_connection_is_pure_in_all_states_and_codec_is_permissive() {
+    for state in [
+        ScConnectionState::Disconnected,
+        ScConnectionState::Connecting,
+        ScConnectionState::Connected,
+        ScConnectionState::Disconnecting,
+    ] {
+        let mut conn = ScConnection::new([1; 6], [1; 16]);
+        conn.build_connect_request();
+        conn.state = state;
+        conn.hub_vmac = Some([0x10; 6]);
+        conn.hub_device_uuid = Some([0x33; 16]);
+        conn.disconnect_ack_to_send = Some(conn.build_heartbeat_ack(0x4455));
+        let before = conn.clone();
+        for function in [2, 3] {
+            for dest in [None, Some(BROADCAST_VMAC), Some([1; 6])] {
+                for body in [&[][..], &[0x00][..], b"wss://a.example/".as_slice()] {
+                    let bytes = wire(function, u16::MAX, Some([0x22; 6]), dest, 0, body);
+                    let msg = decode_sc_message(&bytes).unwrap();
+                    let mut encoded = BytesMut::new();
+                    encode_sc_message(&mut encoded, &msg);
+                    assert_eq!(encoded.as_ref(), bytes);
+                    assert!(conn.handle_received(&msg).is_none());
+                    assert_eq!(conn.state, before.state);
+                    assert_eq!(conn.local_vmac, before.local_vmac);
+                    assert_eq!(conn.device_uuid, before.device_uuid);
+                    assert_eq!(conn.hub_vmac, before.hub_vmac);
+                    assert_eq!(conn.hub_device_uuid, before.hub_device_uuid);
+                    assert_eq!(conn.max_bvlc_length, before.max_bvlc_length);
+                    assert_eq!(conn.max_apdu_length, before.max_apdu_length);
+                    assert_eq!(conn.hub_max_bvlc_length, before.hub_max_bvlc_length);
+                    assert_eq!(conn.hub_max_apdu_length, before.hub_max_apdu_length);
+                    assert_eq!(conn.next_message_id, before.next_message_id);
+                    assert_eq!(
+                        conn.pending_connect_message_id,
+                        before.pending_connect_message_id
+                    );
+                    assert_eq!(conn.connect_retry_allowed, before.connect_retry_allowed);
+                    assert_eq!(conn.disconnect_ack_to_send, before.disconnect_ack_to_send);
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn address_resolution_malformed_generic_wire_is_still_silent() {
+    let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+    for bytes in [
+        vec![0x02],
+        vec![0x02, 0x80, 0, 1],
+        vec![0x02, 8, 0, 1],
+        vec![0x02, 4, 0, 1],
+        vec![0x02, 2, 0, 1, 0],
+        vec![0x03, 1, 0, 1, 0x7E, 0, 1],
+    ] {
+        assert!(decode_sc_message(&bytes).is_err());
+        hub.send(&bytes).await.unwrap();
+        barrier(&hub).await;
+        assert!(rx.try_recv().is_err());
+    }
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn address_resolution_result_for_keeps_existing_parse_and_fatal_policy() {
+    for raw in [2, 3] {
+        for (body, fatal) in [
+            (vec![raw, 0], false),
+            (vec![raw, 1, 0, 0, 7, 0, 150], true),
+            (vec![raw, 1], true),
+        ] {
+            let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
+            let bytes = wire(0, 0x2233, None, None, 0, &body);
+            let msg = decode_sc_message(&bytes).unwrap();
+            assert_eq!(msg.function, ScFunction::Result);
+            hub.send(&bytes).await.unwrap();
+            let mut states = transport.connection_state_changes();
+            let finished = if fatal {
+                timeout(Duration::from_secs(1), async {
+                    while *states.borrow_and_update() != ScConnectionState::Disconnected {
+                        states.changed().await.unwrap();
+                    }
+                })
+                .await
+            } else {
+                barrier(&hub).await;
+                assert_eq!(*states.borrow(), ScConnectionState::Connected);
+                Ok(())
+            };
+            let extra = timeout(Duration::from_millis(20), hub.recv()).await;
+            transport.stop().await.unwrap();
+            finished.unwrap();
+            assert!(extra.is_err(), "response on Result");
+            assert!(rx.try_recv().is_err());
+        }
+    }
+}
+
+#[tokio::test]
+async fn address_resolution_valid_traffic_keeps_heartbeat_and_npdu_interop() {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, [1; 6])
+        .with_device_uuid([1; 16])
+        .with_test_heartbeat_timing_ms(80, 700);
+    let (rx, ()) = tokio::join!(
+        transport.start(),
+        super::data_attribute_tests::hub_accept(&hub, [0x10; 6])
+    );
+    let mut rx = rx.unwrap();
+    let probe = recv(&hub).await;
+    assert_eq!(probe[0], 0x0A);
+    // Valid resolution frames are consumed without replies.
+    for _ in 0..4 {
+        hub.send(&wire(2, 0, None, None, 0, &[])).await.unwrap();
+        hub.send(&wire(
+            3,
+            1,
+            Some([0x22; 6]),
+            None,
+            0,
+            b"wss://one.example/sc",
+        ))
+        .await
+        .unwrap();
+    }
+    // No rejection reply may precede the next liveness probe; accepted
+    // resolution traffic keeps the heartbeat budget alive like NPDUs.
+    let next = timeout(Duration::from_secs(1), hub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(next[0], 0x0A);
+    assert_ne!(&next[2..4], &probe[2..4]);
+    assert!(rx.try_recv().is_err());
+    // Positive controls only AFTER the resolution window.
+    hub.send(&[0x0B, 0, next[2], next[3]]).await.unwrap();
+    hub.send(&wire(1, 0, Some([0x22; 6]), None, 0, &[1, 0, 0x30]))
+        .await
+        .unwrap();
+    let npdu = timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    transport.stop().await.unwrap();
+    assert_eq!(npdu.npdu.as_ref(), &[1, 0, 0x30]);
+}

--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -417,6 +417,13 @@ impl ScConnection {
                 // NPDU delivery or state change.
                 None
             }
+            ScFunction::AddressResolution | ScFunction::AddressResolutionAck => {
+                // Validated before activity by the rejection gate. Answering,
+                // discovery, and dialing remain later work; well-formed bodies
+                // stay consumed without NPDU delivery or state change so this
+                // handler stays pure.
+                None
+            }
             _ => None,
         }
     }

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -22,6 +22,7 @@ use crate::sc_frame::{decode_sc_message, encode_sc_message, ScFunction, Vmac, BR
 use bacnet_types::error::Error;
 use bacnet_types::MacAddr;
 
+mod address_resolution;
 mod advertisement;
 mod connect_result;
 mod connection;
@@ -79,7 +80,7 @@ pub trait WebSocketPort: Send + Sync + 'static {
 
 /// BACnet/SC transport implementing [`TransportPort`].
 ///
-/// Node control/source/Must-Understand/missing-NPDU-payload/unknown-function NAKs use the
+/// Node control/source/Must-Understand/missing-NPDU-payload/address-resolution/unknown-function NAKs use the
 /// remaining accepted-activity heartbeat budget. On expiry the send future is dropped and the socket
 /// is retired from transport-initiated I/O, including reconnect/primary restore.
 /// This local policy is not a deadline for other writes or a hard real-time bound:
@@ -865,6 +866,9 @@ mod proprietary_tests;
 
 #[cfg(test)]
 mod unknown_function_tests;
+
+#[cfg(test)]
+mod address_resolution_tests;
 
 #[cfg(test)]
 mod advertisement_tests;

--- a/crates/bacnet-transport/src/sc/rejection.rs
+++ b/crates/bacnet-transport/src/sc/rejection.rs
@@ -1,4 +1,4 @@
-//! Owner-local budget for node control/source/MU/missing-payload/unknown NAKs only.
+//! Owner-local budget for node control/source/MU/missing-payload/address-resolution/unknown NAKs only.
 //! Cancellation drops the send future, not bytes already buffered by the driver.
 
 use std::future::{poll_fn, Future};
@@ -102,6 +102,14 @@ pub(super) async fn reject<W: WebSocketPort>(
     // AB.2.16 envelope rules. It precedes Unknown so the known function keeps
     // its shape diagnostics; Unknown identity still wins for 0x0D..0xFF.
     if super::proprietary::reject(msg, wire, ws, budget).await? {
+        return Ok(true);
+    }
+    // Address-Resolution 0x02/0x03 validates URI bodies before dispatch.
+    // Well-formed bodies stay silently consumed (no answering yet); malformed
+    // requests NAK locally while malformed responses stay silent per the
+    // response rule. Precedes Unknown so the known family keeps its shape
+    // diagnostics.
+    if super::address_resolution::reject(msg, wire, ws, budget).await? {
         return Ok(true);
     }
     // All preceding gates exclude Unknown. Its identity wins over option or

--- a/crates/bacnet-transport/src/sc_frame.rs
+++ b/crates/bacnet-transport/src/sc_frame.rs
@@ -12,6 +12,7 @@
 use bacnet_types::error::Error;
 use bytes::{BufMut, Bytes, BytesMut};
 
+mod address_resolution;
 mod advertisement;
 mod connect;
 mod control;
@@ -19,6 +20,7 @@ mod npdu;
 mod proprietary;
 mod result;
 
+pub(crate) use address_resolution::address_resolution_message_error;
 pub(crate) use advertisement::advertisement_message_error;
 pub(crate) use proprietary::proprietary_message_error;
 

--- a/crates/bacnet-transport/src/sc_frame/address_resolution.rs
+++ b/crates/bacnet-transport/src/sc_frame/address_resolution.rs
@@ -1,0 +1,386 @@
+//! Receive-only Address-Resolution / Address-Resolution-ACK admission after
+//! generic syntax decoding.
+//!
+//! The wire shapes paraphrase the local Standard's Annex AB request and
+//! response formats: the request carries no defined payload and no Data
+//! Options, while the response carries a variable UTF-8 list of direct-
+//! connection URIs separated by single spaces, with an empty zero-octet
+//! list valid. Error selection and multi-fault precedence interpret the
+//! common exchange rules for header options and field faults; envelope
+//! routing (broadcast/response silence, hub-connector drops) stays with
+//! the hub and node receivers, as for Advertisement and Proprietary.
+//!
+//! Answering (empty versus populated response versus unsupported-function
+//! diagnostic), discovery, and dialing remain later work. This validator
+//! only distinguishes well-formed bodies from malformed ones so the node
+//! can reject the latter before dispatch while preserving valid consume.
+
+use super::{ScFunction, ScMessage};
+use bacnet_types::enums::ErrorCode;
+
+/// Validate an Address-Resolution family message, returning the diagnostic
+/// to NAK with (or to silently discard for responses) when malformed.
+///
+/// Returns `None` for other functions and for well-formed request/response
+/// shapes. Data-option presence precedes payload shape, and payload faults
+/// precede the Must-Understand fault, matching the Advertisement and
+/// Proprietary validators.
+pub(crate) fn address_resolution_message_error(msg: &ScMessage) -> Option<ErrorCode> {
+    if !matches!(
+        msg.function,
+        ScFunction::AddressResolution | ScFunction::AddressResolutionAck
+    ) {
+        return None;
+    }
+    // Both formats convey no Data Options. The envelope-option fault
+    // precedes payload shape, matching the sibling validators.
+    if !msg.data_options.is_empty() {
+        return Some(ErrorCode::PARAMETER_OUT_OF_RANGE);
+    }
+    if msg.function == ScFunction::AddressResolution {
+        // No payload is defined for the request. Trailing bytes are
+        // inconsistent, matching the solicitation policy for unexpected
+        // payloads.
+        if !msg.payload.is_empty() {
+            return Some(ErrorCode::INCONSISTENT_PARAMETERS);
+        }
+    } else {
+        // Empty zero-octet lists are valid responses.
+        if !msg.payload.is_empty() {
+            // The list is a UTF-8 string. Non-UTF-8 bytes are a data
+            // inconsistency, not a header-encoding fault.
+            let text = match core::str::from_utf8(&msg.payload) {
+                Ok(text) => text,
+                Err(_) => return Some(ErrorCode::INCONSISTENT_PARAMETERS),
+            };
+            if let Some(code) = uri_list_structure_error(text) {
+                return Some(code);
+            }
+        }
+    }
+    if msg.dest_options.iter().any(|option| option.must_understand) {
+        // Known-option shape/placement validation remains separate work.
+        return Some(ErrorCode::HEADER_NOT_UNDERSTOOD);
+    }
+    None
+}
+
+/// Structural faults in the response URI list.
+///
+/// Empty tokens from leading, trailing, or doubled separators are data
+/// inconsistencies. Per-token scheme, host, and character faults are field
+/// range faults. The caller checks UTF-8 and Must-Understand separately.
+fn uri_list_structure_error(text: &str) -> Option<ErrorCode> {
+    if text.is_empty() {
+        return None;
+    }
+    // A single space separates entries. Leading, trailing, or doubled
+    // separators would create an empty entry.
+    if text.starts_with(' ') || text.ends_with(' ') || text.contains("  ") {
+        return Some(ErrorCode::INCONSISTENT_PARAMETERS);
+    }
+    for token in text.split(' ') {
+        if !is_valid_wss_uri(token) {
+            return Some(ErrorCode::PARAMETER_OUT_OF_RANGE);
+        }
+    }
+    None
+}
+
+/// Minimal direct-connection URI shape check.
+///
+/// Requires the secure WebSocket scheme, a present host, and visible ASCII
+/// characters only. This is an endpoint-local range check for the response
+/// list; hub forwarding stays opaque and discovery/dial selection remains
+/// later work. No length floor or ceiling beyond the BVLC envelope is
+/// imposed here.
+fn is_valid_wss_uri(token: &str) -> bool {
+    if token.is_empty() {
+        return false;
+    }
+    // Visible ASCII excluding space only. This rejects controls, DEL,
+    // and non-ASCII bytes that survived UTF-8 decoding.
+    if !token.bytes().all(|b| (0x21..=0x7E).contains(&b)) {
+        return false;
+    }
+    // Scheme is case-insensitive, matching the hub-connector dial policy.
+    if token.len() < 7 || !token[..6].eq_ignore_ascii_case("wss://") {
+        return false;
+    }
+    let after_scheme = &token[6..];
+    if after_scheme.is_empty() {
+        return false;
+    }
+    // Host runs to the next '/', '?', or '#' or to the end. It must be
+    // present; userinfo and port details stay opaque beyond that.
+    let host_end = after_scheme
+        .find(['/', '?', '#'])
+        .unwrap_or(after_scheme.len());
+    let host = &after_scheme[..host_end];
+    if host.is_empty() {
+        return false;
+    }
+    // A bare authority terminator with no host (for example `wss:///`)
+    // is already caught by the empty-host check above.
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sc_frame::{decode_sc_message, encode_sc_message, ScOption};
+    use bytes::{Bytes, BytesMut};
+
+    fn message(function: ScFunction, payload: &[u8]) -> ScMessage {
+        ScMessage {
+            function,
+            message_id: 0x2233,
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::copy_from_slice(payload),
+        }
+    }
+
+    #[test]
+    fn ignores_other_functions() {
+        for raw in [
+            0x00, 0x01, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
+        ] {
+            let msg = message(ScFunction::from_raw(raw), &[0xFF; 9]);
+            assert_eq!(address_resolution_message_error(&msg), None);
+        }
+        for raw in [0x0D, 0x42, 0xFF] {
+            let msg = message(ScFunction::from_raw(raw), &[]);
+            assert_eq!(address_resolution_message_error(&msg), None);
+        }
+    }
+
+    #[test]
+    fn request_valid_shape_is_empty_only() {
+        assert_eq!(
+            address_resolution_message_error(&message(ScFunction::AddressResolution, &[])),
+            None
+        );
+        // Non-MU destination options are ignored here.
+        let mut ignored = message(ScFunction::AddressResolution, &[]);
+        ignored.dest_options.push(ScOption {
+            option_type: 31,
+            must_understand: false,
+            data: vec![0xAA],
+        });
+        assert_eq!(address_resolution_message_error(&ignored), None);
+    }
+
+    #[test]
+    fn request_extra_payload_is_inconsistent() {
+        for payload in [
+            &[0x00][..],
+            &[1, 1, 5, 5][..],
+            b"wss://one.example/sc".as_slice(),
+        ] {
+            assert_eq!(
+                address_resolution_message_error(&message(ScFunction::AddressResolution, payload)),
+                Some(ErrorCode::INCONSISTENT_PARAMETERS)
+            );
+        }
+    }
+
+    #[test]
+    fn request_data_options_are_out_of_range() {
+        let mut msg = message(ScFunction::AddressResolution, &[]);
+        msg.data_options.push(ScOption {
+            option_type: 1,
+            must_understand: false,
+            data: Vec::new(),
+        });
+        assert_eq!(
+            address_resolution_message_error(&msg),
+            Some(ErrorCode::PARAMETER_OUT_OF_RANGE)
+        );
+        // Data-option fault precedes payload shape.
+        let mut both = message(ScFunction::AddressResolution, &[0x42]);
+        both.data_options.push(ScOption {
+            option_type: 1,
+            must_understand: false,
+            data: Vec::new(),
+        });
+        both.dest_options.push(ScOption {
+            option_type: 2,
+            must_understand: true,
+            data: Vec::new(),
+        });
+        assert_eq!(
+            address_resolution_message_error(&both),
+            Some(ErrorCode::PARAMETER_OUT_OF_RANGE)
+        );
+    }
+
+    #[test]
+    fn ack_empty_list_is_valid() {
+        assert_eq!(
+            address_resolution_message_error(&message(ScFunction::AddressResolutionAck, &[])),
+            None
+        );
+    }
+
+    #[test]
+    fn ack_valid_uri_vectors() {
+        for payload in [
+            b"wss://one.example/sc".as_slice(),
+            b"wss://one.example/sc wss://two.example:8443/sc".as_slice(),
+            b"wss://hub.example.com:47808/.bacnet/sc?profile=primary".as_slice(),
+            b"wss://[::1]:47808/sc".as_slice(),
+            b"WSS://UPPER.example/SC".as_slice(),
+            b"wss://a.example/1 wss://b.example/2 wss://c.example/3".as_slice(),
+        ] {
+            assert_eq!(
+                address_resolution_message_error(&message(
+                    ScFunction::AddressResolutionAck,
+                    payload
+                )),
+                None,
+                "payload {payload:?}"
+            );
+        }
+        // Boundary: a long but well-formed list stays valid; length caps
+        // belong to the BVLC envelope, not this validator.
+        let mut long = b"wss://peer.example/".to_vec();
+        long.resize(1400, b'x');
+        assert_eq!(
+            address_resolution_message_error(&message(ScFunction::AddressResolutionAck, &long)),
+            None
+        );
+    }
+
+    #[test]
+    fn ack_non_utf8_is_inconsistent() {
+        for payload in [
+            &[0xFF, 0x00][..],
+            &[0xC3, 0x28][..],
+            b"wss://\xFF.example/sc".as_slice(),
+        ] {
+            assert_eq!(
+                address_resolution_message_error(&message(
+                    ScFunction::AddressResolutionAck,
+                    payload
+                )),
+                Some(ErrorCode::INCONSISTENT_PARAMETERS),
+                "payload {payload:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ack_separator_faults_are_inconsistent() {
+        for payload in [
+            b" wss://one.example/sc".as_slice(),
+            b"wss://one.example/sc ".as_slice(),
+            b"wss://one.example/sc  wss://two.example/sc".as_slice(),
+            b" ".as_slice(),
+            b"  ".as_slice(),
+        ] {
+            assert_eq!(
+                address_resolution_message_error(&message(
+                    ScFunction::AddressResolutionAck,
+                    payload
+                )),
+                Some(ErrorCode::INCONSISTENT_PARAMETERS),
+                "payload {payload:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ack_scheme_host_and_character_faults_are_out_of_range() {
+        for payload in [
+            b"ws://one.example/sc".as_slice(),
+            b"https://one.example/sc".as_slice(),
+            b"wss://".as_slice(),
+            b"wss:///sc".as_slice(),
+            b"wss://?query".as_slice(),
+            b"not-a-uri".as_slice(),
+            b"wss://one.example/sc http://two.example/sc".as_slice(),
+            b"wss://one.example/sc wss://".as_slice(),
+            "wss://one.example/sc\u{00e9}".as_bytes(),
+            b"wss://one.example/sc\t".as_slice(),
+        ] {
+            assert_eq!(
+                address_resolution_message_error(&message(
+                    ScFunction::AddressResolutionAck,
+                    payload
+                )),
+                Some(ErrorCode::PARAMETER_OUT_OF_RANGE),
+                "payload {payload:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ack_data_options_are_out_of_range() {
+        let mut msg = message(ScFunction::AddressResolutionAck, b"wss://one.example/sc");
+        msg.data_options.push(ScOption {
+            option_type: 1,
+            must_understand: false,
+            data: Vec::new(),
+        });
+        assert_eq!(
+            address_resolution_message_error(&msg),
+            Some(ErrorCode::PARAMETER_OUT_OF_RANGE)
+        );
+    }
+
+    #[test]
+    fn must_understand_is_last_precedence() {
+        let mu = ScOption {
+            option_type: 2,
+            must_understand: true,
+            data: Vec::new(),
+        };
+        // Payload faults win over the MU fault, as for sibling validators.
+        let mut request = message(ScFunction::AddressResolution, &[0x42]);
+        request.dest_options.push(mu.clone());
+        assert_eq!(
+            address_resolution_message_error(&request),
+            Some(ErrorCode::INCONSISTENT_PARAMETERS)
+        );
+        let mut ack_structure = message(ScFunction::AddressResolutionAck, b" wss://a.example/");
+        ack_structure.dest_options.push(mu.clone());
+        assert_eq!(
+            address_resolution_message_error(&ack_structure),
+            Some(ErrorCode::INCONSISTENT_PARAMETERS)
+        );
+        let mut ack_range = message(ScFunction::AddressResolutionAck, b"ws://a.example/");
+        ack_range.dest_options.push(mu.clone());
+        assert_eq!(
+            address_resolution_message_error(&ack_range),
+            Some(ErrorCode::PARAMETER_OUT_OF_RANGE)
+        );
+        let mut valid = message(ScFunction::AddressResolutionAck, b"wss://a.example/");
+        valid.dest_options.push(mu);
+        assert_eq!(
+            address_resolution_message_error(&valid),
+            Some(ErrorCode::HEADER_NOT_UNDERSTOOD)
+        );
+    }
+
+    #[test]
+    fn generic_syntax_preserves_rejected_shapes() {
+        // The generic codec stays permissive; this validator owns the verdict.
+        let mut msg = message(ScFunction::AddressResolution, &[0x42]);
+        msg.data_options.push(ScOption {
+            option_type: 1,
+            must_understand: false,
+            data: Vec::new(),
+        });
+        let mut encoded = BytesMut::new();
+        encode_sc_message(&mut encoded, &msg);
+        let decoded = decode_sc_message(&encoded).unwrap();
+        assert_eq!(decoded.payload.as_ref(), &[0x42]);
+        assert_eq!(
+            address_resolution_message_error(&decoded),
+            Some(ErrorCode::PARAMETER_OUT_OF_RANGE)
+        );
+    }
+}


### PR DESCRIPTION
Bounded #615 PR1: node-side AR Request/ACK URI parsing + validation, no answering yet.

- New pure validator: Request must have empty payload + no Data Options; ACK payload is UTF-8 space-separated wss-URI list (empty valid); per-token wss-scheme/host/visible-ASCII; MU-last rule; AB.3.1.4/5 error mapping (paraphrased, licensed PDF via STANDARD_NAVIGATION).
- Node gate after proprietary, before unknown: malformed Request NAKs (budgeted), broadcast/reserved/ACK-malformed silent; valid stays silent-consumed (no answering — PR2).
- Hub opaque transit untouched (valid bodies byte-preserved). No public API/config/dial.
- Refs #615 (stays OPEN). Gates: fmt/clippy/size/secrets PASS, transport 572 + sc-tls 765/2/7/17 PASS, FULL conformance_ledger 27/27 PASS, new 20 tests x3. No website/CI/README changes.