### PR TITLE
feat(sc): on-demand direct discovery with NPDU-over-direct and hub fallback (#615)

### DIFF
--- a/crates/bacnet-transport/src/sc/address_resolution.rs
+++ b/crates/bacnet-transport/src/sc/address_resolution.rs
@@ -110,13 +110,15 @@ pub(super) fn answer_destination(msg: &ScMessage) -> Option<Option<Vmac>> {
 /// Answer one accepted Address-Resolution request with an ACK carrying the
 /// configured URI payload (empty when unconfigured).
 ///
-/// Best-effort like Heartbeat-ACK and the solicited Advertisement: no
-/// rejection budget is spent on this positive answer, and no separate rate
-/// gate is added — each valid unicast request earns one answer, while the
-/// broadcast/response/addressed envelopes that could amplify a storm stay
-/// silent and malformed shapes keep the budgeted NAK path. The Connected
-/// check and the fresh message-ID allocation share one lock hold so an
-/// answer cannot race a reconnect half-way.
+/// Best-effort like Heartbeat-ACK: no rejection budget is spent on this
+/// positive answer, and no separate rate gate is added — each valid unicast
+/// request earns one answer, while the broadcast/response/addressed
+/// envelopes that could amplify a storm stay silent and malformed shapes
+/// keep the budgeted NAK path. The ACK copies the request message ID per
+/// the response-ID rule (AB.2 response list, AB.2.7.1, AB.3.1.3); unlike a
+/// solicited Advertisement it is a response message, so no fresh ID is
+/// allocated. The Connected check shares one lock hold so an answer cannot
+/// race a reconnect half-way.
 pub(super) async fn maybe_answer<W: WebSocketPort>(
     msg: &ScMessage,
     conn: &Mutex<ScConnection>,
@@ -128,11 +130,11 @@ pub(super) async fn maybe_answer<W: WebSocketPort>(
         None => return,
     };
     let reply = {
-        let mut c = conn.lock().await;
+        let c = conn.lock().await;
         if c.state != ScConnectionState::Connected {
             return;
         }
-        c.build_address_resolution_ack(destination, advertised_payload)
+        c.build_address_resolution_ack(msg.message_id, destination, advertised_payload)
     };
     let mut bytes = BytesMut::new();
     encode_sc_message(&mut bytes, &reply);

--- a/crates/bacnet-transport/src/sc/address_resolution_tests.rs
+++ b/crates/bacnet-transport/src/sc/address_resolution_tests.rs
@@ -134,29 +134,26 @@ fn advertised_uris_reject_over_budget_list_at_set() {
 }
 
 #[test]
-fn ack_builder_shape_fresh_ids_dest_mirror() {
-    let mut conn = ScConnection::new([1; 6], [1; 16]);
-    conn.state = ScConnectionState::Connected;
+fn ack_builder_shape_copies_request_id_dest_mirror() {
+    let conn = ScConnection::new([1; 6], [1; 16]);
     let before = conn.clone();
     let payload = b"wss://one.example/sc wss://two.example:8443/sc";
-    let first = conn.build_address_resolution_ack(None, payload);
+    let first = conn.build_address_resolution_ack(0x2234, None, payload);
     assert_eq!(first.function, ScFunction::AddressResolutionAck);
+    assert_eq!(first.message_id, 0x2234);
     assert_eq!(first.originating_vmac, None);
     assert_eq!(first.destination_vmac, None);
     assert!(first.dest_options.is_empty());
     assert!(first.data_options.is_empty());
     assert_eq!(first.payload.as_ref(), payload);
-    let second = conn.build_address_resolution_ack(Some([0x22; 6]), &[]);
-    assert_eq!(
-        second.message_id,
-        first.message_id.wrapping_add(1),
-        "answers must consume fresh message IDs"
-    );
+    let second = conn.build_address_resolution_ack(0x2235, Some([0x22; 6]), &[]);
+    assert_eq!(second.message_id, 0x2235);
     assert_eq!(second.destination_vmac, Some([0x22; 6]));
     assert!(second.payload.is_empty(), "unconfigured answers stay empty");
-    // Builder touches only the message-ID counter: no state-machine effect.
+    // Builder is pure: no state-machine or counter effect.
     assert_eq!(conn.state, before.state);
     assert_eq!(conn.local_vmac, before.local_vmac);
+    assert_eq!(conn.next_message_id, before.next_message_id);
     assert_eq!(conn.disconnect_ack_to_send, before.disconnect_ack_to_send);
 }
 
@@ -241,7 +238,7 @@ fn answer_predicate_accepts_only_answerable_requests() {
 }
 
 #[tokio::test]
-async fn answer_configured_uris_echoed_with_fresh_advancing_ids() {
+async fn answer_configured_uris_echoed_with_copied_ids() {
     let (mut transport, mut rx, hub) =
         start_with_uris(&["wss://one.example/sc", "wss://two.example:8443/sc"]).await;
     hub.send(&wire(2, 0x2234, None, None, 0, &[]))
@@ -249,10 +246,7 @@ async fn answer_configured_uris_echoed_with_fresh_advancing_ids() {
         .unwrap();
     let first = recv_ack(&hub).await;
     assert_eq!(first.function, ScFunction::AddressResolutionAck);
-    assert_ne!(
-        first.message_id, 0x2234,
-        "answers must use a fresh message ID, not the request ID"
-    );
+    assert_eq!(first.message_id, 0x2234);
     assert_eq!(first.originating_vmac, None);
     assert_eq!(first.destination_vmac, None);
     assert!(first.dest_options.is_empty());
@@ -271,11 +265,7 @@ async fn answer_configured_uris_echoed_with_fresh_advancing_ids() {
         Some([0x22; 6]),
         "answer must be routable back to the requesting node"
     );
-    assert_eq!(
-        second.message_id,
-        first.message_id.wrapping_add(1),
-        "each answer must consume a fresh message ID"
-    );
+    assert_eq!(second.message_id, 0x2235);
     assert_eq!(
         second.payload.as_ref(),
         b"wss://one.example/sc wss://two.example:8443/sc"
@@ -368,15 +358,15 @@ async fn barrier(hub: &LoopbackWebSocket) {
 async fn address_resolution_valid_shapes_answered_or_silent_without_npdu() {
     let (mut transport, mut rx, hub) = super::data_attribute_tests::start_transport().await;
     // Empty request is the only valid request shape. The fixture transport
-    // is unconfigured, so each answer carries a valid empty URI list with a
-    // fresh ID mirrored to the request origin.
+    // is unconfigured, so each answer carries a valid empty URI list with
+    // the request ID copied and the destination mirrored to the origin.
     for source in [None, Some([0x22; 6])] {
         hub.send(&wire(2, 0x2233, source, None, 0, &[]))
             .await
             .unwrap();
         let reply = recv_ack(&hub).await;
         assert_eq!(reply.function, ScFunction::AddressResolutionAck);
-        assert_ne!(reply.message_id, 0x2233);
+        assert_eq!(reply.message_id, 0x2233);
         assert_eq!(reply.destination_vmac, source);
         assert!(reply.payload.is_empty());
         barrier(&hub).await;
@@ -403,6 +393,7 @@ async fn address_resolution_valid_shapes_answered_or_silent_without_npdu() {
         if function == 2 {
             let reply = recv_ack(&hub).await;
             assert_eq!(reply.function, ScFunction::AddressResolutionAck);
+            assert_eq!(reply.message_id, 0x2235);
             assert!(reply.payload.is_empty());
         }
         barrier(&hub).await;

--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -286,6 +286,47 @@ impl ScConnection {
         }
     }
 
+    /// Build an Address-Resolution request for on-demand direct discovery.
+    ///
+    /// The destination names the target node; the origin is omitted because
+    /// the sender is the originator. The payload is empty and no Data
+    /// Options are present. The message ID is fresh from the shared counter
+    /// so the later ACK can be correlated by ID. Only the ID counter moves.
+    pub fn build_address_resolution_request(&mut self, destination_vmac: Vmac) -> ScMessage {
+        ScMessage {
+            function: ScFunction::AddressResolution,
+            message_id: self.next_id(),
+            originating_vmac: None,
+            destination_vmac: Some(destination_vmac),
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: Bytes::new(),
+        }
+    }
+
+    /// Build a direct-connection Encapsulated-NPDU (peer-addressed, no VMACs).
+    ///
+    /// Used only for unicast over an established direct WebSocket to the
+    /// connection peer: both address parameters are omitted. Hub sends keep
+    /// the destination address. Only the ID counter moves besides the
+    /// returned message.
+    pub fn build_direct_encapsulated_npdu(
+        &mut self,
+        npdu: &[u8],
+        data_attributes: &[DataAttribute],
+    ) -> Result<ScMessage, Error> {
+        let data_options = data_attributes::to_data_options(data_attributes)?;
+        Ok(ScMessage {
+            function: ScFunction::EncapsulatedNpdu,
+            message_id: self.next_id(),
+            originating_vmac: None,
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options,
+            payload: Bytes::copy_from_slice(npdu),
+        })
+    }
+
     /// Build an Address-Resolution-ACK reply for one accepted request.
     ///
     /// The destination mirrors the request origin (`None` for a hub-peer
@@ -410,7 +451,19 @@ impl ScConnection {
                             }
                         }
                         if result_for != ScFunction::EncapsulatedNpdu {
-                            self.state = ScConnectionState::Disconnected;
+                            // Discovery negatives relayed from a target node
+                            // (origin present) are normal: the peer does not
+                            // support direct connections or knows no URIs.
+                            // Stay connected so the sender can fall back to
+                            // hub delivery. Hub-peer NAKs (origin absent)
+                            // keep the existing fatal policy.
+                            let discovery_negative = matches!(
+                                result_for,
+                                ScFunction::AddressResolution | ScFunction::AddressResolutionAck
+                            ) && msg.originating_vmac.is_some();
+                            if !discovery_negative {
+                                self.state = ScConnectionState::Disconnected;
+                            }
                         }
                     }
                     Err(e) => {

--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -332,18 +332,21 @@ impl ScConnection {
     /// The destination mirrors the request origin (`None` for a hub-peer
     /// request so the reply stays peer-addressed, otherwise the requesting
     /// node) and the payload carries the configured space-joined URI list,
-    /// or zero octets when unconfigured. The message ID is always fresh: an
-    /// ACK answers the request but travels as its own message, matching the
-    /// solicited-Advertisement precedent. No Data Options. The caller
-    /// supplies already-validated payload bytes; only the ID counter moves.
+    /// or zero octets when unconfigured. The message ID copies the request
+    /// ID: Address-Resolution-ACK is a response message (AB.2 list) and
+    /// response messages carry the causing ID (AB.3.1.3); AB.2.7.1 repeats
+    /// the response-ID rule for this ACK. Only the solicited Advertisement
+    /// is excepted (AB.3.1.3), not this ACK. No Data Options. The caller
+    /// supplies already-validated payload bytes; no counter moves.
     pub fn build_address_resolution_ack(
-        &mut self,
+        &self,
+        request_message_id: u16,
         destination_vmac: Option<Vmac>,
         uri_payload: &[u8],
     ) -> ScMessage {
         ScMessage {
             function: ScFunction::AddressResolutionAck,
-            message_id: self.next_id(),
+            message_id: request_message_id,
             originating_vmac: None,
             destination_vmac,
             dest_options: Vec::new(),

--- a/crates/bacnet-transport/src/sc/direct_discovery.rs
+++ b/crates/bacnet-transport/src/sc/direct_discovery.rs
@@ -1,0 +1,424 @@
+//! Opt-in direct-connection discovery and NPDU-over-direct with hub fallback.
+//!
+//! When enabled, unicast sends consult a bounded URI cache keyed by
+//! destination VMAC. On a miss the transport issues one Address-Resolution
+//! request through the hub, waits for the matching Address-Resolution-ACK
+//! by message ID, caches the returned URIs, dials a direct peer, and sends
+//! the NPDU over the direct WebSocket with both address parameters omitted.
+//! Any failure at any stage falls back to the existing hub send path.
+//! Disabled (the default) leaves the hub send path byte-identical.
+//!
+//! Source grounding paraphrases the local Standard 135-2020 Annex AB: a
+//! node may request a peer's direct URIs with an Address-Resolution message
+//! sent through the hub, the peer answers with its URIs or an empty list
+//! when it accepts direct connections but knows none, and a node that does
+//! not accept direct connections answers with an unsupported-function NAK;
+//! direct URIs may otherwise be statically configured, and when none are
+//! configured they may be requested through the hub. Only unicast addressed
+//! to the direct peer travels over a direct connection; all other traffic
+//! uses the hub. Direct sends omit both address parameters while hub sends
+//! carry both. When a node initiates direct connections, the timing of
+//! initiation and re-initiation is a local matter, and a failed URI attempt
+//! still leaves hub delivery available. Response messages copy the causing
+//! message ID so an ACK can be matched to its request, and the wait budget
+//! is a local matter. This module reuses the transport's existing connect
+//! timeout for that wait and introduces no new global deadline type.
+//!
+//! Asymmetry is intentional and documented: this transport dials out to
+//! direct peers only. Inbound direct connections stay refused — solicited
+//! Advertisements always report accept-direct 0 — so a peer's direct dial
+//! to this node is out of scope. Hub, failover, reconnect, and accept-side
+//! behavior are unchanged.
+//!
+//! Cache policy (owner-local): at most [`DIRECT_URI_CACHE_MAX_ENTRIES`]
+//! VMAC entries; each entry lives [`DIRECT_URI_CACHE_TTL`] from insertion.
+//! Reads lazily expire entries. Inserts evict the oldest inserted VMAC first
+//! (FIFO) while over cap. Empty URI lists (peer accepts direct but knows no
+//! URIs, or an unsupported-function NAK) are cached as empty so later sends
+//! within TTL go straight to the hub without another request. Timeouts and
+//! transport failures are not cached.
+
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::{oneshot, Mutex};
+
+use bacnet_types::error::Error;
+use bytes::BytesMut;
+
+use crate::port::DataAttribute;
+use crate::sc_frame::{
+    address_resolution_message_error, decode_sc_bvlc_result, encode_sc_message, is_valid_wss_uri,
+    ScBvlcResult, ScFunction, ScMessage, Vmac, BROADCAST_VMAC,
+};
+
+use super::{ScConnection, ScConnectionState, WebSocketPort};
+
+/// Maximum cached direct-connection URI entries (owner-local bound).
+pub(crate) const DIRECT_URI_CACHE_MAX_ENTRIES: usize = 32;
+
+/// Time-to-live for cached URI entries (owner-local policy).
+pub(crate) const DIRECT_URI_CACHE_TTL: Duration = Duration::from_secs(300);
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    uris: Vec<String>,
+    inserted: Instant,
+}
+
+/// Bounded FIFO URI cache with lazy TTL expiry.
+///
+/// Eviction is documented here, not inferred: inserts that would exceed
+/// [`DIRECT_URI_CACHE_MAX_ENTRIES`] drop the oldest inserted VMAC first.
+/// Expired entries are removed on read and never returned.
+pub(crate) struct DirectUriCache {
+    entries: HashMap<Vmac, CacheEntry>,
+    order: VecDeque<Vmac>,
+}
+
+impl DirectUriCache {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Return fresh URIs for `vmac`, lazily expiring stale entries.
+    pub(crate) fn get(&mut self, vmac: &Vmac, now: Instant) -> Option<Vec<String>> {
+        let fresh = match self.entries.get(vmac) {
+            Some(entry) if now.duration_since(entry.inserted) < DIRECT_URI_CACHE_TTL => {
+                Some(entry.uris.clone())
+            }
+            Some(_) => None,
+            None => return None,
+        };
+        match fresh {
+            Some(uris) => Some(uris),
+            None => {
+                self.entries.remove(vmac);
+                None
+            }
+        }
+    }
+
+    /// Insert `uris` for `vmac`, evicting oldest inserts while over cap.
+    pub(crate) fn insert(&mut self, vmac: Vmac, uris: Vec<String>, now: Instant) {
+        if self.entries.contains_key(&vmac) {
+            self.order.retain(|existing| existing != &vmac);
+        }
+        self.order.push_back(vmac);
+        self.entries.insert(
+            vmac,
+            CacheEntry {
+                uris,
+                inserted: now,
+            },
+        );
+        while self.entries.len() > DIRECT_URI_CACHE_MAX_ENTRIES {
+            match self.order.pop_front() {
+                Some(oldest) => {
+                    self.entries.remove(&oldest);
+                }
+                None => break,
+            }
+        }
+    }
+}
+
+/// Dial-one-URI factory supplied by the owner.
+///
+/// Production wiring captures an [`crate::sc_tls::ScNodeTlsConfig`] clone and
+/// calls `TlsWebSocket::connect_direct`; tests supply a loopback peer.
+/// The factory must be cancellation-safe: a dropped future must not leave a
+/// half-published connection behind.
+pub(crate) type DirectDialer<W> =
+    Arc<dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<W, Error>> + Send>> + Send + Sync>;
+
+/// Shared opt-in direct discovery state.
+///
+/// `Some` in the transport means enabled; `None` (the default) means the hub
+/// path runs unchanged. The dialer is optional: enabled without a dialer
+/// always falls back to the hub path.
+pub(crate) struct DirectShared<W: WebSocketPort> {
+    cache: Mutex<DirectUriCache>,
+    pending: Mutex<HashMap<u16, oneshot::Sender<Vec<String>>>>,
+    dialer: Mutex<Option<DirectDialer<W>>>,
+}
+
+impl<W: WebSocketPort> DirectShared<W> {
+    pub(crate) fn new() -> Self {
+        Self {
+            cache: Mutex::new(DirectUriCache::new()),
+            pending: Mutex::new(HashMap::new()),
+            dialer: Mutex::new(None),
+        }
+    }
+}
+
+impl<W: WebSocketPort> super::ScTransport<W> {
+    /// Opt in to on-demand direct discovery for unicast sends (default OFF).
+    ///
+    /// Disabled (the default) leaves the hub send path byte-identical: no
+    /// cache consult, no Address-Resolution request, no direct dial. Enabled
+    /// consults the bounded URI cache on each unicast; on a miss it issues
+    /// one Address-Resolution request through the hub, caches the ACK URIs,
+    /// dials direct, and sends the NPDU over direct with both address
+    /// parameters omitted. Any direct-stage failure falls back to hub
+    /// delivery. Broadcasts always use the hub path.
+    ///
+    /// Dial-out only: this flag never enables inbound direct acceptance.
+    /// Solicited Advertisements keep accept-direct 0. Hub, failover, and
+    /// reconnect behavior are unchanged. The ACK wait reuses the configured
+    /// connect timeout; no new global deadline type is introduced.
+    pub fn with_direct_discovery(mut self, enabled: bool) -> Self {
+        if enabled {
+            if self.direct.is_none() {
+                self.direct = Some(Arc::new(DirectShared::new()));
+            }
+        } else {
+            self.direct = None;
+        }
+        self
+    }
+
+    /// Supply the direct-dial factory used after discovery (implies opt-in).
+    ///
+    /// The closure receives one candidate URI string and returns a connected
+    /// direct WebSocket. It is tried in ACK order until one dial and send
+    /// succeeds; every failure falls back to hub delivery. Calling this
+    /// enables discovery; call [`Self::with_direct_discovery`] with `false`
+    /// afterwards to disable again (which drops the dialer and cache).
+    /// Production callers capture a TLS config clone and call
+    /// `TlsWebSocket::connect_direct` inside the closure.
+    pub fn with_direct_dialer<F, Fut>(mut self, dialer: F) -> Self
+    where
+        F: Fn(String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<W, Error>> + Send + 'static,
+    {
+        let shared = match self.direct.take() {
+            Some(shared) => shared,
+            None => Arc::new(DirectShared::new()),
+        };
+        if let Ok(mut slot) = shared.dialer.try_lock() {
+            *slot = Some(Arc::new(move |uri: String| {
+                Box::pin(dialer(uri)) as Pin<Box<dyn Future<Output = Result<W, Error>> + Send>>
+            }));
+        }
+        self.direct = Some(shared);
+        self
+    }
+
+    pub(super) fn direct_shared(&self) -> Option<Arc<DirectShared<W>>> {
+        self.direct.clone()
+    }
+}
+
+/// Split an Address-Resolution-ACK payload into validated URI strings.
+///
+/// Empty payloads are valid and yield an empty list. Any structural fault
+/// yields `None` so the caller falls back to hub delivery without caching.
+pub(crate) fn parse_ack_uris(payload: &[u8]) -> Option<Vec<String>> {
+    if payload.is_empty() {
+        return Some(Vec::new());
+    }
+    let text = core::str::from_utf8(payload).ok()?;
+    if text.starts_with(' ') || text.ends_with(' ') || text.contains("  ") {
+        return None;
+    }
+    let mut out = Vec::new();
+    for token in text.split(' ') {
+        if !is_valid_wss_uri(token) {
+            return None;
+        }
+        out.push(token.to_owned());
+    }
+    Some(out)
+}
+
+impl<W: WebSocketPort> DirectShared<W> {
+    pub(super) async fn cached_uris(&self, vmac: &Vmac) -> Option<Vec<String>> {
+        let now = Instant::now();
+        self.cache.lock().await.get(vmac, now)
+    }
+
+    async fn cache_insert(&self, vmac: Vmac, uris: Vec<String>) {
+        let now = Instant::now();
+        self.cache.lock().await.insert(vmac, uris, now);
+    }
+
+    /// Wake the pending discovery matching an inbound hub message, if any.
+    ///
+    /// Well-formed ACKs complete with their parsed URI list; a BVLC-Result
+    /// NAK for Address-Resolution completes with an empty list so the sender
+    /// falls back to hub delivery (and caches the empty result). Malformed
+    /// ACKs, unmatched IDs, and unrelated functions stay silent and keep
+    /// waiting until the sender's timeout. Never changes connection state.
+    pub(super) async fn fulfill_from_hub_message(&self, msg: &ScMessage) {
+        match msg.function {
+            ScFunction::AddressResolutionAck => {
+                if address_resolution_message_error(msg).is_some() {
+                    return;
+                }
+                let Some(uris) = parse_ack_uris(&msg.payload) else {
+                    return;
+                };
+                let sender = self.pending.lock().await.remove(&msg.message_id);
+                if let Some(sender) = sender {
+                    let _ = sender.send(uris);
+                }
+            }
+            ScFunction::Result => {
+                let Ok(ScBvlcResult::Nak { result_for, .. }) = decode_sc_bvlc_result(msg) else {
+                    return;
+                };
+                if result_for != ScFunction::AddressResolution {
+                    return;
+                }
+                let sender = self.pending.lock().await.remove(&msg.message_id);
+                if let Some(sender) = sender {
+                    let _ = sender.send(Vec::new());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Issue one Address-Resolution request through the hub and wait for the
+    /// ACK with the same message ID, bounded by the connect timeout.
+    ///
+    /// Returns `Some(uris)` on a matched ACK or NAK (empty when the peer
+    /// knows no URIs or does not support direct connections). Returns `None`
+    /// on any transport failure or timeout; the caller must fall back to hub
+    /// delivery and must not cache the miss. Successful results are cached
+    /// before returning, including empty lists.
+    pub(super) async fn discover_via_hub(
+        &self,
+        dest: Vmac,
+        ws: &Arc<W>,
+        conn: &Arc<Mutex<ScConnection>>,
+        connect_timeout_ms: u64,
+    ) -> Option<Vec<String>> {
+        let (message_id, request_bytes) = {
+            let mut c = conn.lock().await;
+            if c.state != ScConnectionState::Connected {
+                return None;
+            }
+            // Allocate an ID unused by other pending discoveries so an ACK
+            // cannot complete the wrong waiter after u16 wrap.
+            let mut request = c.build_address_resolution_request(dest);
+            let guard = self.pending.lock().await;
+            let mut attempts = 0;
+            while guard.contains_key(&request.message_id) && attempts < u16::MAX as usize {
+                request = c.build_address_resolution_request(dest);
+                attempts += 1;
+            }
+            if guard.contains_key(&request.message_id) {
+                return None;
+            }
+            let message_id = request.message_id;
+            let mut buf = BytesMut::new();
+            encode_sc_message(&mut buf, &request);
+            (message_id, buf.freeze().to_vec())
+        };
+        let (sender, receiver) = oneshot::channel();
+        {
+            let mut guard = self.pending.lock().await;
+            // A concurrent waiter cannot hold our ID: we reserved it above
+            // under the same pending lock ordering (connection then pending).
+            // If insertion still collides, fall back to hub delivery.
+            if guard.contains_key(&message_id) {
+                return None;
+            }
+            guard.insert(message_id, sender);
+        }
+        let send_result = ws.send(&request_bytes).await;
+        if send_result.is_err() {
+            self.pending.lock().await.remove(&message_id);
+            return None;
+        }
+        let wait = Duration::from_millis(connect_timeout_ms.max(1));
+        let uris = match tokio::time::timeout(wait, receiver).await {
+            Ok(Ok(uris)) => uris,
+            _ => {
+                self.pending.lock().await.remove(&message_id);
+                return None;
+            }
+        };
+        self.cache_insert(dest, uris.clone()).await;
+        Some(uris)
+    }
+
+    /// Dial each candidate URI in order and send the NPDU over the first
+    /// direct connection that accepts it, omitting both address parameters.
+    ///
+    /// Returns `Ok(())` on the first successful direct send. Returns `Err`
+    /// when no dialer is configured, every URI fails, or the hub connection
+    /// is no longer usable for ID allocation; the caller must fall back to
+    /// hub delivery. Never mutates hub connection state besides consuming
+    /// fresh message IDs, and never touches hub failover or reconnect state.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn try_direct_uris(
+        &self,
+        uris: &[String],
+        dest: Vmac,
+        npdu: &[u8],
+        data_attributes: &[DataAttribute],
+        conn: &Arc<Mutex<ScConnection>>,
+        hub_max_bvlc_length: u16,
+        hub_max_apdu_length: u16,
+        connect_timeout_ms: u64,
+    ) -> Result<(), ()> {
+        let dialer = self.dialer.lock().await.clone().ok_or(())?;
+        if uris.is_empty() || dest == BROADCAST_VMAC {
+            return Err(());
+        }
+        if npdu.len() > hub_max_apdu_length as usize {
+            return Err(());
+        }
+        // Materialize one direct frame per attempt under the hub ID counter
+        // so direct and hub messages share unique IDs. The hub state itself
+        // is only read, never transitioned, here.
+        for uri in uris {
+            let dial_wait = Duration::from_millis(connect_timeout_ms.max(1));
+            let direct_ws = match tokio::time::timeout(dial_wait, dialer(uri.clone())).await {
+                Ok(Ok(ws)) => ws,
+                _ => continue,
+            };
+            let direct_msg = {
+                let mut c = conn.lock().await;
+                if c.state != ScConnectionState::Connected {
+                    return Err(());
+                }
+                match c.build_direct_encapsulated_npdu(npdu, data_attributes) {
+                    Ok(msg) => msg,
+                    Err(_) => return Err(()),
+                }
+            };
+            let mut buf = BytesMut::new();
+            encode_sc_message(&mut buf, &direct_msg);
+            if buf.len() > hub_max_bvlc_length as usize {
+                return Err(());
+            }
+            let send_wait = Duration::from_millis(connect_timeout_ms.max(1));
+            match tokio::time::timeout(send_wait, direct_ws.send(&buf)).await {
+                Ok(Ok(())) => return Ok(()),
+                _ => continue,
+            }
+        }
+        Err(())
+    }
+}

--- a/crates/bacnet-transport/src/sc/direct_discovery_tests.rs
+++ b/crates/bacnet-transport/src/sc/direct_discovery_tests.rs
@@ -1,0 +1,473 @@
+//! Opt-in direct discovery + NPDU-over-direct with hub fallback (Refs #615 PR3b).
+//!
+//! Enabled unicast consults the bounded URI cache; on a miss it issues one
+//! Address-Resolution request through the hub, caches the ACK URIs by message
+//! ID, dials direct, and sends the NPDU over direct with both addresses
+//! omitted. Any direct-stage failure falls back to hub delivery. Disabled
+//! (default) runs the hub path unchanged. Loopback fixtures only; no network
+//! or TLS dials occur here.
+
+use super::direct_discovery::{
+    parse_ack_uris, DirectUriCache, DIRECT_URI_CACHE_MAX_ENTRIES, DIRECT_URI_CACHE_TTL,
+};
+use super::*;
+use crate::sc_frame::{decode_sc_message, encode_sc_message, ScFunction, ScMessage};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, Mutex};
+use tokio::time::timeout;
+
+const TARGET: Vmac = [0x22; 6];
+const NPDU: &[u8] = &[0x01, 0x00, 0x30];
+
+async fn hub_recv(hub: &LoopbackWebSocket) -> Vec<u8> {
+    timeout(Duration::from_secs(2), hub.recv())
+        .await
+        .expect("hub recv timed out")
+        .unwrap()
+}
+
+async fn hub_try_recv(hub: &LoopbackWebSocket) -> Option<Vec<u8>> {
+    timeout(Duration::from_millis(150), hub.recv())
+        .await
+        .ok()
+        .map(|r| r.unwrap())
+}
+
+fn fake_dialer(
+    attempted: Arc<Mutex<Vec<String>>>,
+    peers: mpsc::UnboundedSender<LoopbackWebSocket>,
+) -> impl Fn(
+    String,
+) -> std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<LoopbackWebSocket, Error>> + Send>,
+> + Send
+       + Sync
+       + 'static {
+    move |uri: String| {
+        let attempted = attempted.clone();
+        let peers = peers.clone();
+        Box::pin(async move {
+            attempted.lock().await.push(uri);
+            let (client, peer) = LoopbackWebSocket::pair();
+            let _ = peers.send(peer);
+            Ok(client)
+        })
+            as std::pin::Pin<
+                Box<dyn std::future::Future<Output = Result<LoopbackWebSocket, Error>> + Send>,
+            >
+    }
+}
+
+async fn start_direct(
+    connect_timeout_ms: u64,
+) -> (
+    ScTransport<LoopbackWebSocket>,
+    mpsc::Receiver<ReceivedNpdu>,
+    LoopbackWebSocket,
+    Arc<Mutex<Vec<String>>>,
+    mpsc::UnboundedReceiver<LoopbackWebSocket>,
+) {
+    let attempted = Arc::new(Mutex::new(Vec::new()));
+    let (peer_tx, peer_rx) = mpsc::unbounded_channel();
+    let (client, hub) = LoopbackWebSocket::pair();
+    let dialer = fake_dialer(attempted.clone(), peer_tx);
+    let mut transport = ScTransport::new(client, [0x01; 6])
+        .with_device_uuid([1; 16])
+        .with_connect_timeout_ms(connect_timeout_ms)
+        .with_direct_discovery(true)
+        .with_direct_dialer(dialer);
+    let hub_task = tokio::spawn(async move {
+        data_attribute_tests::hub_accept(&hub, [0x10; 6]).await;
+        hub
+    });
+    let rx = transport.start().await.unwrap();
+    let hub = hub_task.await.unwrap();
+    (transport, rx, hub, attempted, peer_rx)
+}
+
+fn ack_for(id: u16, payload: &'static [u8]) -> Vec<u8> {
+    let ack = ScMessage {
+        function: ScFunction::AddressResolutionAck,
+        message_id: id,
+        originating_vmac: Some(TARGET),
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: bytes::Bytes::from_static(payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &ack);
+    buf.to_vec()
+}
+
+#[test]
+fn uri_cache_count_bound_evicts_oldest_first() {
+    let mut cache = DirectUriCache::new();
+    let now = Instant::now();
+    for i in 0..DIRECT_URI_CACHE_MAX_ENTRIES + 5 {
+        let mut vmac = [0u8; 6];
+        vmac[0] = (i & 0xFF) as u8;
+        vmac[1] = ((i >> 8) & 0xFF) as u8;
+        cache.insert(vmac, vec![format!("wss://peer{i}.example/sc")], now);
+    }
+    assert_eq!(cache.len(), DIRECT_URI_CACHE_MAX_ENTRIES);
+    let mut oldest = [0u8; 6];
+    oldest[0] = 0;
+    oldest[1] = 0;
+    assert!(cache.get(&oldest, now).is_none());
+    let last = DIRECT_URI_CACHE_MAX_ENTRIES + 4;
+    let mut newest = [0u8; 6];
+    newest[0] = (last & 0xFF) as u8;
+    newest[1] = ((last >> 8) & 0xFF) as u8;
+    assert!(cache.get(&newest, now).is_some());
+}
+
+#[test]
+fn uri_cache_ttl_expiry_drops_stale_entries() {
+    let mut cache = DirectUriCache::new();
+    let inserted = Instant::now();
+    cache.insert(TARGET, vec!["wss://peer.example/sc".into()], inserted);
+    assert!(cache.get(&TARGET, inserted).is_some());
+    let expired = inserted + DIRECT_URI_CACHE_TTL + Duration::from_secs(1);
+    assert!(cache.get(&TARGET, expired).is_none());
+    assert_eq!(cache.len(), 0);
+    assert!(cache.is_empty());
+}
+
+#[test]
+fn ack_uri_parsing_accepts_empty_and_valid_lists() {
+    assert_eq!(parse_ack_uris(&[]), Some(Vec::new()));
+    assert_eq!(
+        parse_ack_uris(b"wss://one.example/sc"),
+        Some(vec!["wss://one.example/sc".to_owned()])
+    );
+    assert_eq!(
+        parse_ack_uris(b"wss://one.example/sc wss://two.example:8443/sc"),
+        Some(vec![
+            "wss://one.example/sc".to_owned(),
+            "wss://two.example:8443/sc".to_owned()
+        ])
+    );
+}
+
+#[test]
+fn ack_uri_parsing_rejects_structural_faults() {
+    for payload in [
+        b" wss://one.example/sc".as_slice(),
+        b"wss://one.example/sc ".as_slice(),
+        b"wss://one.example/sc  wss://two.example/sc".as_slice(),
+        b"ws://one.example/sc".as_slice(),
+        b"wss://".as_slice(),
+        b"not-a-uri".as_slice(),
+    ] {
+        assert_eq!(parse_ack_uris(payload), None, "payload {payload:?}");
+    }
+    assert_eq!(parse_ack_uris(&[0xFF, 0x00]), None);
+}
+
+#[test]
+fn connection_builders_shape_request_and_direct_npdu() {
+    let mut conn = ScConnection::new([1; 6], [1; 16]);
+    conn.state = ScConnectionState::Connected;
+    let req = conn.build_address_resolution_request(TARGET);
+    assert_eq!(req.function, ScFunction::AddressResolution);
+    assert_eq!(req.destination_vmac, Some(TARGET));
+    assert_eq!(req.originating_vmac, None);
+    assert!(req.payload.is_empty());
+    assert!(req.data_options.is_empty());
+    let direct = conn
+        .build_direct_encapsulated_npdu(NPDU, &[])
+        .expect("direct build must succeed");
+    assert_eq!(direct.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(direct.originating_vmac, None);
+    assert_eq!(direct.destination_vmac, None);
+    assert_eq!(direct.payload.as_ref(), NPDU);
+    assert_eq!(
+        direct.message_id,
+        req.message_id.wrapping_add(1),
+        "builders must consume fresh IDs"
+    );
+}
+
+#[tokio::test]
+async fn miss_triggers_ar_request_then_direct_send_with_hub_silence() {
+    let (mut transport, _rx, hub, attempted, mut peers) = start_direct(500).await;
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        assert_eq!(ar.function, ScFunction::AddressResolution);
+        assert_eq!(ar.destination_vmac, Some(TARGET));
+        assert!(ar.payload.is_empty());
+        hub.send(&ack_for(ar.message_id, b"wss://peer.example/sc"))
+            .await
+            .unwrap();
+    });
+    send_res.unwrap();
+    assert_eq!(
+        attempted.lock().await.as_slice(),
+        &["wss://peer.example/sc".to_owned()]
+    );
+    let peer = timeout(Duration::from_secs(2), peers.recv())
+        .await
+        .unwrap()
+        .expect("direct peer missing");
+    let direct_bytes = timeout(Duration::from_secs(2), peer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let direct = decode_sc_message(&direct_bytes).unwrap();
+    assert_eq!(direct.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(direct.originating_vmac, None);
+    assert_eq!(direct.destination_vmac, None);
+    assert_eq!(direct.payload.as_ref(), NPDU);
+    assert!(hub_try_recv(&hub).await.is_none());
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn default_off_sends_hub_only_with_no_ar_or_direct() {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, [1; 6]).with_device_uuid([1; 16]);
+    let hub_task = tokio::spawn(async move {
+        data_attribute_tests::hub_accept(&hub, [0x10; 6]).await;
+        hub
+    });
+    let _rx = transport.start().await.unwrap();
+    let hub = hub_task.await.unwrap();
+    transport.send_unicast(NPDU, &TARGET).await.unwrap();
+    let bytes = hub_recv(&hub).await;
+    let msg = decode_sc_message(&bytes).unwrap();
+    assert_eq!(msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(msg.destination_vmac, Some(TARGET));
+    assert_eq!(msg.payload.as_ref(), NPDU);
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn ack_timeout_falls_back_to_hub_without_dial() {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, [1; 6])
+        .with_device_uuid([1; 16])
+        .with_connect_timeout_ms(60)
+        .with_direct_discovery(true)
+        .with_direct_dialer(
+            |_uri: String| async move { panic!("no ACK means no dial must occur") },
+        );
+    let hub_task = tokio::spawn(async move {
+        data_attribute_tests::hub_accept(&hub, [0x10; 6]).await;
+        hub
+    });
+    let _rx = transport.start().await.unwrap();
+    let hub = hub_task.await.unwrap();
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        assert_eq!(
+            decode_sc_message(&ar_bytes).unwrap().function,
+            ScFunction::AddressResolution
+        );
+    });
+    send_res.unwrap();
+    let npdu_bytes = hub_recv(&hub).await;
+    let npdu_msg = decode_sc_message(&npdu_bytes).unwrap();
+    assert_eq!(npdu_msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(npdu_msg.destination_vmac, Some(TARGET));
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn empty_ack_falls_back_to_hub_without_dial() {
+    let (mut transport, _rx, hub, attempted, mut peers) = start_direct(500).await;
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        hub.send(&ack_for(ar.message_id, b"")).await.unwrap();
+    });
+    send_res.unwrap();
+    assert!(attempted.lock().await.is_empty());
+    assert!(timeout(Duration::from_millis(100), peers.recv())
+        .await
+        .is_err());
+    let npdu_bytes = hub_recv(&hub).await;
+    assert_eq!(
+        decode_sc_message(&npdu_bytes).unwrap().destination_vmac,
+        Some(TARGET)
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn ar_nak_falls_back_to_hub_without_dial() {
+    let (mut transport, _rx, hub, attempted, mut peers) = start_direct(500).await;
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        let nak = ScMessage {
+            function: ScFunction::Result,
+            message_id: ar.message_id,
+            originating_vmac: Some(TARGET),
+            destination_vmac: None,
+            dest_options: Vec::new(),
+            data_options: Vec::new(),
+            payload: bytes::Bytes::from(vec![
+                ScFunction::AddressResolution.to_raw(),
+                0x01,
+                0x00,
+                0x00,
+                0x07,
+                0x00,
+                0x96,
+            ]),
+        };
+        let mut nak_buf = BytesMut::new();
+        encode_sc_message(&mut nak_buf, &nak);
+        hub.send(&nak_buf).await.unwrap();
+    });
+    send_res.unwrap();
+    assert!(attempted.lock().await.is_empty());
+    assert!(timeout(Duration::from_millis(100), peers.recv())
+        .await
+        .is_err());
+    let npdu_bytes = hub_recv(&hub).await;
+    assert_eq!(
+        decode_sc_message(&npdu_bytes).unwrap().destination_vmac,
+        Some(TARGET)
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn mismatched_ack_id_is_ignored_then_hub_fallback() {
+    let (mut transport, _rx, hub, attempted, mut peers) = start_direct(80).await;
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        hub.send(&ack_for(
+            ar.message_id.wrapping_add(1),
+            b"wss://peer.example/sc",
+        ))
+        .await
+        .unwrap();
+    });
+    send_res.unwrap();
+    let npdu_bytes = hub_recv(&hub).await;
+    assert_eq!(
+        decode_sc_message(&npdu_bytes).unwrap().destination_vmac,
+        Some(TARGET)
+    );
+    assert!(attempted.lock().await.is_empty());
+    assert!(timeout(Duration::from_millis(50), peers.recv())
+        .await
+        .is_err());
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn direct_dial_failure_falls_back_to_hub() {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, [1; 6])
+        .with_device_uuid([1; 16])
+        .with_connect_timeout_ms(300)
+        .with_direct_discovery(true)
+        .with_direct_dialer(|uri: String| async move {
+            assert_eq!(uri, "wss://peer.example/sc");
+            Err::<LoopbackWebSocket, Error>(Error::Encoding("dial refused".into()))
+        });
+    let hub_task = tokio::spawn(async move {
+        data_attribute_tests::hub_accept(&hub, [0x10; 6]).await;
+        hub
+    });
+    let _rx = transport.start().await.unwrap();
+    let hub = hub_task.await.unwrap();
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        hub.send(&ack_for(ar.message_id, b"wss://peer.example/sc"))
+            .await
+            .unwrap();
+    });
+    send_res.unwrap();
+    let npdu_bytes = hub_recv(&hub).await;
+    assert_eq!(
+        decode_sc_message(&npdu_bytes).unwrap().destination_vmac,
+        Some(TARGET)
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn direct_send_failure_falls_back_to_hub() {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, [1; 6])
+        .with_device_uuid([1; 16])
+        .with_connect_timeout_ms(300)
+        .with_direct_discovery(true)
+        .with_direct_dialer(|_uri: String| async move {
+            let (direct_client, direct_peer) = LoopbackWebSocket::pair();
+            drop(direct_peer);
+            Ok(direct_client)
+        });
+    let hub_task = tokio::spawn(async move {
+        data_attribute_tests::hub_accept(&hub, [0x10; 6]).await;
+        hub
+    });
+    let _rx = transport.start().await.unwrap();
+    let hub = hub_task.await.unwrap();
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        hub.send(&ack_for(ar.message_id, b"wss://peer.example/sc"))
+            .await
+            .unwrap();
+    });
+    send_res.unwrap();
+    let npdu_bytes = hub_recv(&hub).await;
+    assert_eq!(
+        decode_sc_message(&npdu_bytes).unwrap().destination_vmac,
+        Some(TARGET)
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn enabled_without_dialer_falls_back_to_hub() {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, [1; 6])
+        .with_device_uuid([1; 16])
+        .with_connect_timeout_ms(300)
+        .with_direct_discovery(true);
+    let hub_task = tokio::spawn(async move {
+        data_attribute_tests::hub_accept(&hub, [0x10; 6]).await;
+        hub
+    });
+    let _rx = transport.start().await.unwrap();
+    let hub = hub_task.await.unwrap();
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        hub.send(&ack_for(ar.message_id, b"wss://peer.example/sc"))
+            .await
+            .unwrap();
+    });
+    send_res.unwrap();
+    let npdu_bytes = hub_recv(&hub).await;
+    assert_eq!(
+        decode_sc_message(&npdu_bytes).unwrap().destination_vmac,
+        Some(TARGET)
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn broadcast_never_uses_direct_even_when_enabled() {
+    let (mut transport, _rx, hub, attempted, mut peers) = start_direct(500).await;
+    transport.send_unicast(NPDU, &BROADCAST_VMAC).await.unwrap();
+    let bytes = hub_recv(&hub).await;
+    let msg = decode_sc_message(&bytes).unwrap();
+    assert_eq!(msg.destination_vmac, Some(BROADCAST_VMAC));
+    assert!(attempted.lock().await.is_empty());
+    assert!(timeout(Duration::from_millis(100), peers.recv())
+        .await
+        .is_err());
+    transport.stop().await.unwrap();
+}

--- a/crates/bacnet-transport/src/sc/direct_discovery_tests.rs
+++ b/crates/bacnet-transport/src/sc/direct_discovery_tests.rs
@@ -101,6 +101,67 @@ fn ack_for(id: u16, payload: &'static [u8]) -> Vec<u8> {
     buf.to_vec()
 }
 
+const SENDER: Vmac = [0x01; 6];
+
+async fn start_responder(
+    uris: &[&str],
+) -> (
+    ScTransport<LoopbackWebSocket>,
+    mpsc::Receiver<ReceivedNpdu>,
+    LoopbackWebSocket,
+) {
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, TARGET)
+        .with_device_uuid([2; 16])
+        .with_advertised_uris(uris.to_vec());
+    let hub_task = tokio::spawn(async move {
+        data_attribute_tests::hub_accept(&hub, [0x10; 6]).await;
+        hub
+    });
+    let rx = transport.start().await.unwrap();
+    let hub = hub_task.await.unwrap();
+    (transport, rx, hub)
+}
+
+async fn relay_one_ar_exchange(sender_hub: &LoopbackWebSocket, responder_hub: &LoopbackWebSocket) {
+    let ar_bytes = hub_recv(sender_hub).await;
+    let ar = decode_sc_message(&ar_bytes).unwrap();
+    assert_eq!(ar.function, ScFunction::AddressResolution);
+    assert_eq!(ar.destination_vmac, Some(TARGET));
+    assert_eq!(ar.originating_vmac, None);
+    assert!(ar.payload.is_empty());
+    let relayed = ScMessage {
+        function: ar.function,
+        message_id: ar.message_id,
+        originating_vmac: Some(SENDER),
+        destination_vmac: None,
+        dest_options: ar.dest_options.clone(),
+        data_options: ar.data_options.clone(),
+        payload: ar.payload.clone(),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &relayed);
+    responder_hub.send(&buf).await.unwrap();
+    let ack_bytes = hub_recv(responder_hub).await;
+    let ack = decode_sc_message(&ack_bytes).unwrap();
+    assert_eq!(ack.function, ScFunction::AddressResolutionAck);
+    assert_eq!(ack.message_id, ar.message_id);
+    assert_eq!(ack.destination_vmac, Some(SENDER));
+    assert_eq!(ack.originating_vmac, None);
+    let back = ScMessage {
+        function: ack.function,
+        message_id: ack.message_id,
+        originating_vmac: Some(TARGET),
+        destination_vmac: None,
+        dest_options: ack.dest_options.clone(),
+        data_options: ack.data_options.clone(),
+        payload: ack.payload.clone(),
+    };
+    let mut back_buf = BytesMut::new();
+    encode_sc_message(&mut back_buf, &back);
+    sender_hub.send(&back_buf).await.unwrap();
+}
+
 #[test]
 fn uri_cache_count_bound_evicts_oldest_first() {
     let mut cache = DirectUriCache::new();
@@ -470,4 +531,84 @@ async fn broadcast_never_uses_direct_even_when_enabled() {
         .await
         .is_err());
     transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn interop_production_answer_drives_direct_without_timeout() {
+    let (mut sender, _rx, sender_hub, attempted, mut peers) = start_direct(2000).await;
+    let (mut responder, mut responder_rx, responder_hub) =
+        start_responder(&["wss://peer.example/sc"]).await;
+    let start = Instant::now();
+    let (send_res, ()) = tokio::join!(
+        sender.send_unicast(NPDU, &TARGET),
+        relay_one_ar_exchange(&sender_hub, &responder_hub)
+    );
+    send_res.unwrap();
+    let elapsed = start.elapsed();
+    assert!(elapsed < Duration::from_millis(1500));
+    assert_eq!(
+        attempted.lock().await.as_slice(),
+        &["wss://peer.example/sc".to_owned()]
+    );
+    let peer = timeout(Duration::from_secs(2), peers.recv())
+        .await
+        .unwrap()
+        .expect("direct peer missing");
+    let direct = decode_sc_message(
+        &timeout(Duration::from_secs(2), peer.recv())
+            .await
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(direct.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(direct.originating_vmac, None);
+    assert_eq!(direct.destination_vmac, None);
+    assert_eq!(direct.payload.as_ref(), NPDU);
+    assert!(hub_try_recv(&sender_hub).await.is_none());
+    assert!(responder_rx.try_recv().is_err());
+    sender.stop().await.unwrap();
+    responder.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn interop_repeated_send_uses_cache_without_stall() {
+    let (mut sender, _rx, sender_hub, attempted, mut peers) = start_direct(2000).await;
+    let (mut responder, mut responder_rx, responder_hub) =
+        start_responder(&["wss://peer.example/sc"]).await;
+    let (first_res, ()) = tokio::join!(
+        sender.send_unicast(NPDU, &TARGET),
+        relay_one_ar_exchange(&sender_hub, &responder_hub)
+    );
+    first_res.unwrap();
+    let first_peer = timeout(Duration::from_secs(2), peers.recv())
+        .await
+        .unwrap()
+        .expect("first direct peer missing");
+    timeout(Duration::from_secs(2), first_peer.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    let start = Instant::now();
+    sender.send_unicast(NPDU, &TARGET).await.unwrap();
+    let elapsed = start.elapsed();
+    assert!(elapsed < Duration::from_millis(1000));
+    assert!(hub_try_recv(&sender_hub).await.is_none());
+    let second_peer = timeout(Duration::from_secs(2), peers.recv())
+        .await
+        .unwrap()
+        .expect("cached direct peer missing");
+    let second = decode_sc_message(
+        &timeout(Duration::from_secs(2), second_peer.recv())
+            .await
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(second.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(second.payload.as_ref(), NPDU);
+    assert_eq!(attempted.lock().await.len(), 2);
+    assert!(responder_rx.try_recv().is_err());
+    sender.stop().await.unwrap();
+    responder.stop().await.unwrap();
 }

--- a/crates/bacnet-transport/src/sc/lifecycle.rs
+++ b/crates/bacnet-transport/src/sc/lifecycle.rs
@@ -1,0 +1,54 @@
+//! Transport lifecycle teardown shared by stop and drop paths.
+//!
+//! Moved out of the transport loop file to keep that file within the
+//! repository file-size cap; behavior is unchanged.
+
+use std::sync::atomic::Ordering;
+
+use tokio::task::JoinHandle;
+
+use crate::port::TransportPort;
+
+use super::{ScConnectionState, ScTransport, WebSocketPort, DEFAULT_MAX_APDU_LENGTH};
+
+impl<W: WebSocketPort> ScTransport<W> {
+    pub(super) fn abort_background_task_and_drop_sockets(
+        &mut self,
+    ) -> (Option<JoinHandle<()>>, Option<JoinHandle<()>>) {
+        let task = self.recv_task.take();
+        if let Some(task) = &task {
+            task.abort();
+        }
+        let restore_task = self
+            .restore_disconnect_task
+            .lock()
+            .ok()
+            .and_then(|mut task| task.take());
+        if let Some(task) = &restore_task {
+            task.abort();
+        }
+        if let Some(conn) = &self.connection {
+            if let Ok(mut c) = conn.try_lock() {
+                c.state = ScConnectionState::Disconnected;
+            }
+        }
+        self.effective_max_apdu_length
+            .store(DEFAULT_MAX_APDU_LENGTH, Ordering::Relaxed);
+        self.state_tx.send_replace(ScConnectionState::Disconnected);
+        self.ws_shared = None;
+        self.connection = None;
+        self.ws = None;
+        self.failover_ws = None;
+        // Direct discovery state is dropped with the transport; pending
+        // Address-Resolution waiters observe closure via their hub send or
+        // timeout and fall back to the hub path.
+        self.direct = None;
+        (task, restore_task)
+    }
+}
+
+impl<W: WebSocketPort> Drop for ScTransport<W> {
+    fn drop(&mut self) {
+        self.abort();
+    }
+}

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -30,11 +30,13 @@ mod connector;
 mod control_admission;
 mod data_attributes;
 pub(crate) mod diagnostic_throttle;
+pub(crate) mod direct_discovery;
 mod empty_npdu;
 mod errors;
 mod failover;
 mod handshake;
 mod heartbeat;
+mod lifecycle;
 mod loopback;
 mod proprietary;
 mod random48;
@@ -108,6 +110,7 @@ pub struct ScTransport<W: WebSocketPort> {
     failover_connector: Option<WebSocketConnector<W>>,
     reconnect_config: Option<ScReconnectConfig>,
     restore_disconnect_task: Arc<StdMutex<Option<JoinHandle<()>>>>,
+    pub(super) direct: Option<Arc<direct_discovery::DirectShared<W>>>,
     #[cfg(test)]
     allow_test_heartbeat_timing: bool,
 }
@@ -136,6 +139,7 @@ impl<W: WebSocketPort> ScTransport<W> {
             failover_connector: None,
             reconnect_config: None,
             restore_disconnect_task: Arc::new(StdMutex::new(None)),
+            direct: None,
             #[cfg(test)]
             allow_test_heartbeat_timing: false,
         }
@@ -236,36 +240,6 @@ impl<W: WebSocketPort> ScTransport<W> {
     /// this as a current-state signal rather than a durable transition log.
     pub fn connection_state_changes(&self) -> watch::Receiver<ScConnectionState> {
         self.state_tx.subscribe()
-    }
-
-    fn abort_background_task_and_drop_sockets(
-        &mut self,
-    ) -> (Option<JoinHandle<()>>, Option<JoinHandle<()>>) {
-        let task = self.recv_task.take();
-        if let Some(task) = &task {
-            task.abort();
-        }
-        let restore_task = self
-            .restore_disconnect_task
-            .lock()
-            .ok()
-            .and_then(|mut task| task.take());
-        if let Some(task) = &restore_task {
-            task.abort();
-        }
-        if let Some(conn) = &self.connection {
-            if let Ok(mut c) = conn.try_lock() {
-                c.state = ScConnectionState::Disconnected;
-            }
-        }
-        self.effective_max_apdu_length
-            .store(DEFAULT_MAX_APDU_LENGTH, Ordering::Relaxed);
-        self.state_tx.send_replace(ScConnectionState::Disconnected);
-        self.ws_shared = None;
-        self.connection = None;
-        self.ws = None;
-        self.failover_ws = None;
-        (task, restore_task)
     }
 }
 
@@ -421,6 +395,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
         let mut active_hub = active_hub;
         let effective_max_apdu_length = self.effective_max_apdu_length.clone();
         let advertised_payload = self.advertised_uris.join(" ").into_bytes();
+        let direct = self.direct.clone();
         let task = tokio::spawn(async move {
             let mut primary_restore_interval =
                 tokio::time::interval(Duration::from_millis(restore_interval_ms));
@@ -615,6 +590,9 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                         &msg, &conn, &*ws_clone, &advertised_payload,
                                     )
                                     .await;
+                                    if let Some(direct) = &direct {
+                                        direct.fulfill_from_hub_message(&msg).await;
+                                    }
 
                                     if let Some((npdu, source_vmac)) = npdu_result {
                                         if npdu_tx
@@ -836,12 +814,6 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
     }
 }
 
-impl<W: WebSocketPort> Drop for ScTransport<W> {
-    fn drop(&mut self) {
-        self.abort();
-    }
-}
-
 #[cfg(test)]
 mod data_attribute_tests;
 
@@ -880,6 +852,9 @@ mod unknown_function_tests;
 
 #[cfg(test)]
 mod address_resolution_tests;
+
+#[cfg(test)]
+mod direct_discovery_tests;
 
 #[cfg(test)]
 mod advertisement_tests;

--- a/crates/bacnet-transport/src/sc/send.rs
+++ b/crates/bacnet-transport/src/sc/send.rs
@@ -1,11 +1,14 @@
+use std::sync::Arc;
+
 use bytes::BytesMut;
+use tokio::sync::Mutex;
 
 use bacnet_types::error::Error;
 
 use crate::port::DataAttribute;
-use crate::sc_frame::encode_sc_message;
+use crate::sc_frame::{encode_sc_message, Vmac, BROADCAST_VMAC};
 
-use super::{ScConnectionState, ScTransport, WebSocketPort};
+use super::{ScConnection, ScConnectionState, ScTransport, WebSocketPort};
 
 impl<W: WebSocketPort> ScTransport<W> {
     pub(super) async fn send_unicast_inner(
@@ -20,6 +23,115 @@ impl<W: WebSocketPort> ScTransport<W> {
                 mac.len()
             )));
         }
+        let mut dest_vmac = [0u8; 6];
+        dest_vmac.copy_from_slice(mac);
+
+        // Default-off preservation: without opt-in state or for broadcast,
+        // run the hub path exactly as before with no extra work.
+        let direct = self.direct_shared();
+        if direct.is_none() || dest_vmac == BROADCAST_VMAC {
+            return self.send_via_hub(dest_vmac, npdu, data_attributes).await;
+        }
+        let direct = direct.expect("direct opt-in checked above");
+        let ws_shared = match self.ws_shared.clone() {
+            Some(ws) => ws,
+            None => return self.send_via_hub(dest_vmac, npdu, data_attributes).await,
+        };
+        let conn = match self.connection.clone() {
+            Some(conn) => conn,
+            None => return self.send_via_hub(dest_vmac, npdu, data_attributes).await,
+        };
+        let connect_timeout_ms = self.connect_timeout_ms;
+
+        // Cache consult: fresh hit dials direct; fresh empty goes hub.
+        if let Some(uris) = direct.cached_uris(&dest_vmac).await {
+            if uris.is_empty() {
+                return self.send_via_hub(dest_vmac, npdu, data_attributes).await;
+            }
+            if Self::try_direct_then_hub(
+                &direct,
+                &uris,
+                dest_vmac,
+                npdu,
+                data_attributes,
+                &conn,
+                connect_timeout_ms,
+            )
+            .await
+            .is_ok()
+            {
+                return Ok(());
+            }
+            return self.send_via_hub(dest_vmac, npdu, data_attributes).await;
+        }
+
+        // Miss: one on-demand Address-Resolution through the hub, then dial.
+        // Any discovery failure falls back to hub delivery without caching.
+        let hub_ws = {
+            let guard = ws_shared.lock().await;
+            (*guard).clone()
+        };
+        let discovered = direct
+            .discover_via_hub(dest_vmac, &hub_ws, &conn, connect_timeout_ms)
+            .await;
+        let Some(uris) = discovered else {
+            return self.send_via_hub(dest_vmac, npdu, data_attributes).await;
+        };
+        if uris.is_empty() {
+            return self.send_via_hub(dest_vmac, npdu, data_attributes).await;
+        }
+        if Self::try_direct_then_hub(
+            &direct,
+            &uris,
+            dest_vmac,
+            npdu,
+            data_attributes,
+            &conn,
+            connect_timeout_ms,
+        )
+        .await
+        .is_ok()
+        {
+            return Ok(());
+        }
+        self.send_via_hub(dest_vmac, npdu, data_attributes).await
+    }
+
+    async fn try_direct_then_hub(
+        direct: &Arc<super::direct_discovery::DirectShared<W>>,
+        uris: &[String],
+        dest_vmac: Vmac,
+        npdu: &[u8],
+        data_attributes: &[DataAttribute],
+        conn: &Arc<Mutex<ScConnection>>,
+        connect_timeout_ms: u64,
+    ) -> Result<(), ()> {
+        // Hub limits bound the direct frame until a direct handshake learns
+        // peer limits; read them without holding the lock across dial/send.
+        let (hub_max_bvlc_length, hub_max_apdu_length) = {
+            let c = conn.lock().await;
+            (c.hub_max_bvlc_length, c.hub_max_apdu_length)
+        };
+        direct
+            .try_direct_uris(
+                uris,
+                dest_vmac,
+                npdu,
+                data_attributes,
+                conn,
+                hub_max_bvlc_length,
+                hub_max_apdu_length,
+                connect_timeout_ms,
+            )
+            .await
+    }
+
+    async fn send_via_hub(
+        &self,
+        dest_vmac: Vmac,
+        npdu: &[u8],
+        data_attributes: &[DataAttribute],
+    ) -> Result<(), Error> {
         let ws_shared = self.ws_shared.as_ref().ok_or_else(|| {
             Error::Transport(std::io::Error::new(
                 std::io::ErrorKind::NotConnected,
@@ -32,9 +144,6 @@ impl<W: WebSocketPort> ScTransport<W> {
                 "BACnet/SC transport not started",
             ))
         })?;
-
-        let mut dest_vmac = [0u8; 6];
-        dest_vmac.copy_from_slice(mac);
 
         // Admission is atomic with socket publication. An admitted send owns
         // its Arc and may complete after retirement; it is not rolled back.


### PR DESCRIPTION
Bounded #615 PR3b: discovery cache + dial-on-demand with hub fallback (dial-out only, opt-in default OFF).

- Bounded FIFO URI cache (32 entries, 300s TTL, empty negatives cached); AR-Request via hub with ID correlation + connect-timeout wait; per-URI dial loop, direct addressing; ANY failure falls back to hub. Default-off path bit-identical.
- Minimal node NAK origin guard so relayed discovery negatives stay Connected for fallback (hub-peer NAKs keep fatal policy).
- Refs #615 (stays OPEN: persistent conns, direct handshake, answering-ID policy remain). Gates: fmt/clippy/size/secrets PASS, transport 596 + sc-tls 799/2/7/17 PASS, FULL conformance_ledger 27/27 PASS, new 15 tests x3. No website/CI changes.