### PR TITLE
feat(sc): handshake direct dials with Connect-Request/Accept before NPDU (#615)

### DIFF
--- a/crates/bacnet-transport/src/sc/direct_discovery.rs
+++ b/crates/bacnet-transport/src/sc/direct_discovery.rs
@@ -3,9 +3,11 @@
 //! When enabled, unicast sends consult a bounded URI cache keyed by
 //! destination VMAC. On a miss the transport issues one Address-Resolution
 //! request through the hub, waits for the matching Address-Resolution-ACK
-//! by message ID, caches the returned URIs, dials a direct peer, and sends
-//! the NPDU over the direct WebSocket with both address parameters omitted.
-//! Any failure at any stage falls back to the existing hub send path.
+//! by message ID, caches the returned URIs, dials a direct peer, runs the
+//! Connect-Request into Connect-Accept handshake with the existing hub
+//! validation, and sends the NPDU over the direct WebSocket with both
+//! address parameters omitted. Any failure at any stage falls back to the
+//! existing hub send path.
 //! Disabled (the default) leaves the hub send path byte-identical.
 //!
 //! Source grounding paraphrases the local Standard 135-2020 Annex AB: a
@@ -17,7 +19,9 @@
 //! configured they may be requested through the hub. Only unicast addressed
 //! to the direct peer travels over a direct connection; all other traffic
 //! uses the hub. Direct sends omit both address parameters while hub sends
-//! carry both. When a node initiates direct connections, the timing of
+//! carry both. A direct WebSocket carries NPDUs only after its Connect
+//! handshake completes; strict peers that require the handshake otherwise
+//! fall back to hub delivery. When a node initiates direct connections, the timing of
 //! initiation and re-initiation is a local matter, and a failed URI attempt
 //! still leaves hub delivery available. Response messages copy the causing
 //! message ID so an ACK can be matched to its request, and the wait budget
@@ -362,14 +366,16 @@ impl<W: WebSocketPort> DirectShared<W> {
         Some(uris)
     }
 
-    /// Dial each candidate URI in order and send the NPDU over the first
-    /// direct connection that accepts it, omitting both address parameters.
+    /// Dial each candidate URI in order, run the Connect handshake, and send
+    /// the NPDU over the first direct connection that completes it, omitting
+    /// both address parameters.
     ///
     /// Returns `Ok(())` on the first successful direct send. Returns `Err`
-    /// when no dialer is configured, every URI fails, or the hub connection
-    /// is no longer usable for ID allocation; the caller must fall back to
-    /// hub delivery. Never mutates hub connection state besides consuming
-    /// fresh message IDs, and never touches hub failover or reconnect state.
+    /// when no dialer is configured, every URI fails, the handshake is
+    /// rejected or times out, or the hub connection is no longer usable for
+    /// ID allocation; the caller must fall back to hub delivery. Never
+    /// mutates hub connection state besides consuming fresh message IDs,
+    /// and never touches hub failover or reconnect state.
     #[allow(clippy::too_many_arguments)]
     pub(super) async fn try_direct_uris(
         &self,
@@ -378,7 +384,6 @@ impl<W: WebSocketPort> DirectShared<W> {
         npdu: &[u8],
         data_attributes: &[DataAttribute],
         conn: &Arc<Mutex<ScConnection>>,
-        hub_max_bvlc_length: u16,
         hub_max_apdu_length: u16,
         connect_timeout_ms: u64,
     ) -> Result<(), ()> {
@@ -391,13 +396,37 @@ impl<W: WebSocketPort> DirectShared<W> {
         }
         // Materialize one direct frame per attempt under the hub ID counter
         // so direct and hub messages share unique IDs. The hub state itself
-        // is only read, never transitioned, here.
+        // is only read, never transitioned, here. Each attempt first runs
+        // the shared Connect-Request into Connect-Accept handshake on an
+        // ephemeral probe carrying the hub connection's node identity; any
+        // handshake failure drops the dialed socket and tries the next URI.
         for uri in uris {
             let dial_wait = Duration::from_millis(connect_timeout_ms.max(1));
             let direct_ws = match tokio::time::timeout(dial_wait, dialer(uri.clone())).await {
                 Ok(Ok(ws)) => ws,
                 _ => continue,
             };
+            let probe = {
+                let c = conn.lock().await;
+                if c.state != ScConnectionState::Connected {
+                    return Err(());
+                }
+                Arc::new(Mutex::new(c.connect_probe()))
+            };
+            let handshake_wait = connect_timeout_ms.max(1);
+            if super::handshake::perform_handshake(&direct_ws, &probe, None, handshake_wait)
+                .await
+                .is_err()
+            {
+                continue;
+            }
+            let (peer_max_bvlc_length, peer_max_apdu_length) = {
+                let p = probe.lock().await;
+                (p.hub_max_bvlc_length, p.hub_max_apdu_length)
+            };
+            if npdu.len() > peer_max_apdu_length as usize {
+                continue;
+            }
             let direct_msg = {
                 let mut c = conn.lock().await;
                 if c.state != ScConnectionState::Connected {
@@ -410,8 +439,8 @@ impl<W: WebSocketPort> DirectShared<W> {
             };
             let mut buf = BytesMut::new();
             encode_sc_message(&mut buf, &direct_msg);
-            if buf.len() > hub_max_bvlc_length as usize {
-                return Err(());
+            if buf.len() > peer_max_bvlc_length as usize {
+                continue;
             }
             let send_wait = Duration::from_millis(connect_timeout_ms.max(1));
             match tokio::time::timeout(send_wait, direct_ws.send(&buf)).await {

--- a/crates/bacnet-transport/src/sc/direct_discovery_tests.rs
+++ b/crates/bacnet-transport/src/sc/direct_discovery_tests.rs
@@ -50,7 +50,40 @@ fn fake_dialer(
         Box::pin(async move {
             attempted.lock().await.push(uri);
             let (client, peer) = LoopbackWebSocket::pair();
-            let _ = peers.send(peer);
+            // Answer the direct Connect handshake on the peer side with a
+            // valid Accept, then hand the peer to the test for the NPDU
+            // check. This keeps discovery-focused tests green while the
+            // production path requires the handshake before any NPDU.
+            let peers_for_handshake = peers.clone();
+            tokio::spawn(async move {
+                let Ok(req_bytes) = peer.recv().await else {
+                    return;
+                };
+                let Ok(req) = decode_sc_message(&req_bytes) else {
+                    let _ = peers_for_handshake.send(peer);
+                    return;
+                };
+                if req.function == ScFunction::ConnectRequest {
+                    let mut payload = Vec::with_capacity(26);
+                    payload.extend_from_slice(&[0x33; 6]);
+                    payload.extend_from_slice(&[0x44; 16]);
+                    payload.extend_from_slice(&1476u16.to_be_bytes());
+                    payload.extend_from_slice(&1476u16.to_be_bytes());
+                    let accept = ScMessage {
+                        function: ScFunction::ConnectAccept,
+                        message_id: req.message_id,
+                        originating_vmac: None,
+                        destination_vmac: None,
+                        dest_options: Vec::new(),
+                        data_options: Vec::new(),
+                        payload: bytes::Bytes::from(payload),
+                    };
+                    let mut buf = BytesMut::new();
+                    encode_sc_message(&mut buf, &accept);
+                    let _ = peer.send(&buf).await;
+                }
+                let _ = peers_for_handshake.send(peer);
+            });
             Ok(client)
         })
             as std::pin::Pin<

--- a/crates/bacnet-transport/src/sc/direct_handshake_tests.rs
+++ b/crates/bacnet-transport/src/sc/direct_handshake_tests.rs
@@ -1,0 +1,303 @@
+//! Direct-connection Connect handshake over loopback (Refs #615).
+//!
+//! After the direct TLS plus WebSocket upgrade the dial-out path must run a
+//! Connect-Request into Connect-Accept exchange with the existing hub
+//! validation before any NPDU travels over the direct socket. Any handshake
+//! failure falls back to hub delivery without changing the fallback
+//! contract. Loopback fixtures only; no network or TLS dials occur here.
+//!
+//! Source grounding paraphrases the local Standard 135-2020 Annex AB as
+//! located through the package navigation map (Annex AB, printed
+//! pp1377-1410): a direct connection is established with the direct
+//! subprotocol upgrade followed by the Connect identity and length exchange
+//! before NPDU traffic, and the initiating peer waits for the matching
+//! Accept under its existing connect wait. Only the request plus accept
+//! exchange is required; no inbound accept path or additional exchanges are
+//! added here.
+
+use super::direct_discovery::parse_ack_uris;
+use super::*;
+use crate::sc_frame::{decode_sc_message, encode_sc_message, ScFunction, ScMessage};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{mpsc, Mutex};
+use tokio::time::timeout;
+
+const TARGET: Vmac = [0x22; 6];
+const SENDER: Vmac = [0x01; 6];
+const NPDU: &[u8] = &[0x01, 0x00, 0x30];
+const SENDER_UUID: [u8; 16] = [1; 16];
+
+async fn hub_recv(hub: &LoopbackWebSocket) -> Vec<u8> {
+    timeout(Duration::from_secs(2), hub.recv())
+        .await
+        .expect("hub recv timed out")
+        .unwrap()
+}
+
+fn ack_for(id: u16, payload: &'static [u8]) -> Vec<u8> {
+    let ack = ScMessage {
+        function: ScFunction::AddressResolutionAck,
+        message_id: id,
+        originating_vmac: Some(TARGET),
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: bytes::Bytes::from_static(payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &ack);
+    buf.to_vec()
+}
+
+fn direct_accept(id: u16, vmac: Vmac, uuid: [u8; 16], bvlc: u16, apdu: u16) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(26);
+    payload.extend_from_slice(&vmac);
+    payload.extend_from_slice(&uuid);
+    payload.extend_from_slice(&bvlc.to_be_bytes());
+    payload.extend_from_slice(&apdu.to_be_bytes());
+    let accept = ScMessage {
+        function: ScFunction::ConnectAccept,
+        message_id: id,
+        originating_vmac: None,
+        destination_vmac: None,
+        dest_options: Vec::new(),
+        data_options: Vec::new(),
+        payload: bytes::Bytes::from(payload),
+    };
+    let mut buf = BytesMut::new();
+    encode_sc_message(&mut buf, &accept);
+    buf.to_vec()
+}
+
+fn assert_direct_request(req: &ScMessage) {
+    assert_eq!(req.function, ScFunction::ConnectRequest);
+    assert_eq!(req.originating_vmac, None);
+    assert_eq!(req.destination_vmac, None);
+    assert!(req.data_options.is_empty());
+    assert_eq!(req.payload.len(), 26);
+    assert_eq!(&req.payload[0..6], &SENDER);
+    assert_eq!(&req.payload[6..22], &SENDER_UUID);
+    assert_eq!(
+        u16::from_be_bytes([req.payload[22], req.payload[23]]),
+        crate::sc_limits::DEFAULT_MAX_BVLC_LENGTH
+    );
+    assert_eq!(
+        u16::from_be_bytes([req.payload[24], req.payload[25]]),
+        1476u16
+    );
+}
+
+async fn start_sender(
+    connect_timeout_ms: u64,
+) -> (
+    ScTransport<LoopbackWebSocket>,
+    LoopbackWebSocket,
+    Arc<Mutex<Vec<String>>>,
+    mpsc::UnboundedReceiver<LoopbackWebSocket>,
+) {
+    let attempted = Arc::new(Mutex::new(Vec::new()));
+    let (peer_tx, peer_rx) = mpsc::unbounded_channel();
+    let attempted_clone = attempted.clone();
+    let (client, hub) = LoopbackWebSocket::pair();
+    let mut transport = ScTransport::new(client, SENDER)
+        .with_device_uuid(SENDER_UUID)
+        .with_connect_timeout_ms(connect_timeout_ms)
+        .with_direct_discovery(true)
+        .with_direct_dialer(move |uri: String| {
+            let attempted = attempted_clone.clone();
+            let peer_tx = peer_tx.clone();
+            async move {
+                attempted.lock().await.push(uri);
+                let (client, peer) = LoopbackWebSocket::pair();
+                let _ = peer_tx.send(peer);
+                Ok(client)
+            }
+        });
+    let hub_task = tokio::spawn(async move {
+        data_attribute_tests::hub_accept(&hub, [0x10; 6]).await;
+        hub
+    });
+    let _rx = transport.start().await.unwrap();
+    let hub = hub_task.await.unwrap();
+    // Exercise the shared ACK parser so the import stays live if helpers shift.
+    assert_eq!(parse_ack_uris(b"wss://peer.example/sc").unwrap().len(), 1);
+    (transport, hub, attempted, peer_rx)
+}
+
+#[tokio::test]
+async fn direct_handshake_valid_accept_enables_direct_send() {
+    let (mut transport, hub, attempted, mut peers) = start_sender(800).await;
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        assert_eq!(ar.function, ScFunction::AddressResolution);
+        hub.send(&ack_for(ar.message_id, b"wss://peer.example/sc"))
+            .await
+            .unwrap();
+        let peer = timeout(Duration::from_secs(2), peers.recv())
+            .await
+            .expect("direct peer missing")
+            .expect("peer channel closed");
+        let req_bytes = timeout(Duration::from_secs(2), peer.recv())
+            .await
+            .expect("direct request timed out")
+            .unwrap();
+        let req = decode_sc_message(&req_bytes).unwrap();
+        assert_direct_request(&req);
+        peer.send(&direct_accept(
+            req.message_id,
+            [0x33; 6],
+            [0x44; 16],
+            1476,
+            1476,
+        ))
+        .await
+        .unwrap();
+        let npdu_bytes = timeout(Duration::from_secs(2), peer.recv())
+            .await
+            .expect("direct NPDU timed out")
+            .unwrap();
+        let direct = decode_sc_message(&npdu_bytes).unwrap();
+        assert_eq!(direct.function, ScFunction::EncapsulatedNpdu);
+        assert_eq!(direct.originating_vmac, None);
+        assert_eq!(direct.destination_vmac, None);
+        assert_eq!(direct.payload.as_ref(), NPDU);
+    });
+    send_res.unwrap();
+    assert_eq!(
+        attempted.lock().await.as_slice(),
+        &["wss://peer.example/sc".to_owned()]
+    );
+    assert!(
+        timeout(Duration::from_millis(100), hub.recv())
+            .await
+            .is_err(),
+        "valid handshake must keep hub silent"
+    );
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn direct_handshake_bad_identity_falls_back_to_hub() {
+    let (mut transport, hub, attempted, mut peers) = start_sender(400).await;
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        hub.send(&ack_for(ar.message_id, b"wss://peer.example/sc"))
+            .await
+            .unwrap();
+        let peer = timeout(Duration::from_secs(2), peers.recv())
+            .await
+            .expect("direct peer missing")
+            .expect("peer channel closed");
+        let req_bytes = timeout(Duration::from_secs(2), peer.recv())
+            .await
+            .expect("direct request timed out")
+            .unwrap();
+        let req = decode_sc_message(&req_bytes).unwrap();
+        assert_direct_request(&req);
+        // Reserved all-zero VMAC identity is rejected by the shared
+        // Connect-Accept validation, so no NPDU may follow on direct.
+        // Invalid Accepts are silently discarded within the existing wait;
+        // either a wait timeout or a dropped socket both mean no direct NPDU.
+        peer.send(&direct_accept(
+            req.message_id,
+            [0; 6],
+            [0x44; 16],
+            1476,
+            1476,
+        ))
+        .await
+        .unwrap();
+        if let Ok(Ok(bytes)) = timeout(Duration::from_millis(300), peer.recv()).await {
+            panic!("bad identity must not enable direct NPDU: {bytes:?}");
+        }
+    });
+    send_res.unwrap();
+    assert_eq!(attempted.lock().await.len(), 1);
+    let npdu_bytes = hub_recv(&hub).await;
+    let hub_msg = decode_sc_message(&npdu_bytes).unwrap();
+    assert_eq!(hub_msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(hub_msg.destination_vmac, Some(TARGET));
+    assert_eq!(hub_msg.payload.as_ref(), NPDU);
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn direct_handshake_zero_limits_falls_back_to_hub() {
+    let (mut transport, hub, attempted, mut peers) = start_sender(400).await;
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        hub.send(&ack_for(ar.message_id, b"wss://peer.example/sc"))
+            .await
+            .unwrap();
+        let peer = timeout(Duration::from_secs(2), peers.recv())
+            .await
+            .expect("direct peer missing")
+            .expect("peer channel closed");
+        let req_bytes = timeout(Duration::from_secs(2), peer.recv())
+            .await
+            .expect("direct request timed out")
+            .unwrap();
+        let req = decode_sc_message(&req_bytes).unwrap();
+        assert_direct_request(&req);
+        // Zero Max-BVLC-Length is rejected by the shared validation.
+        // Either a wait timeout or a dropped socket both mean no direct NPDU.
+        peer.send(&direct_accept(
+            req.message_id,
+            [0x33; 6],
+            [0x44; 16],
+            0,
+            1476,
+        ))
+        .await
+        .unwrap();
+        if let Ok(Ok(bytes)) = timeout(Duration::from_millis(300), peer.recv()).await {
+            panic!("zero limits must not enable direct NPDU: {bytes:?}");
+        }
+    });
+    send_res.unwrap();
+    assert_eq!(attempted.lock().await.len(), 1);
+    let npdu_bytes = hub_recv(&hub).await;
+    let hub_msg = decode_sc_message(&npdu_bytes).unwrap();
+    assert_eq!(hub_msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(hub_msg.destination_vmac, Some(TARGET));
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn direct_handshake_timeout_falls_back_to_hub() {
+    let (mut transport, hub, attempted, mut peers) = start_sender(120).await;
+    let (send_res, ()) = tokio::join!(transport.send_unicast(NPDU, &TARGET), async {
+        let ar_bytes = hub_recv(&hub).await;
+        let ar = decode_sc_message(&ar_bytes).unwrap();
+        hub.send(&ack_for(ar.message_id, b"wss://peer.example/sc"))
+            .await
+            .unwrap();
+        let peer = timeout(Duration::from_secs(2), peers.recv())
+            .await
+            .expect("direct peer missing")
+            .expect("peer channel closed");
+        // Observe the handshake request but never answer, so the existing
+        // connect wait expires and the send falls back to the hub. Either a
+        // wait timeout or a dropped socket both mean no direct NPDU.
+        let req_bytes = timeout(Duration::from_secs(2), peer.recv())
+            .await
+            .expect("direct request timed out")
+            .unwrap();
+        assert_direct_request(&decode_sc_message(&req_bytes).unwrap());
+        if let Ok(Ok(bytes)) = timeout(Duration::from_millis(400), peer.recv()).await {
+            panic!("handshake timeout must not enable direct NPDU: {bytes:?}");
+        }
+    });
+    send_res.unwrap();
+    assert_eq!(attempted.lock().await.len(), 1);
+    let npdu_bytes = hub_recv(&hub).await;
+    let hub_msg = decode_sc_message(&npdu_bytes).unwrap();
+    assert_eq!(hub_msg.function, ScFunction::EncapsulatedNpdu);
+    assert_eq!(hub_msg.destination_vmac, Some(TARGET));
+    assert_eq!(hub_msg.payload.as_ref(), NPDU);
+    transport.stop().await.unwrap();
+}

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -857,6 +857,9 @@ mod address_resolution_tests;
 mod direct_discovery_tests;
 
 #[cfg(test)]
+mod direct_handshake_tests;
+
+#[cfg(test)]
 mod advertisement_tests;
 
 #[cfg(test)]

--- a/crates/bacnet-transport/src/sc/send.rs
+++ b/crates/bacnet-transport/src/sc/send.rs
@@ -106,11 +106,12 @@ impl<W: WebSocketPort> ScTransport<W> {
         conn: &Arc<Mutex<ScConnection>>,
         connect_timeout_ms: u64,
     ) -> Result<(), ()> {
-        // Hub limits bound the direct frame until a direct handshake learns
-        // peer limits; read them without holding the lock across dial/send.
-        let (hub_max_bvlc_length, hub_max_apdu_length) = {
+        // Hub APDU bound is an early hub-fallback check; the direct frame
+        // itself is bounded by the peer limits learned in the per-attempt
+        // Connect handshake. Read without holding the lock across dial/send.
+        let hub_max_apdu_length = {
             let c = conn.lock().await;
-            (c.hub_max_bvlc_length, c.hub_max_apdu_length)
+            c.hub_max_apdu_length
         };
         direct
             .try_direct_uris(
@@ -119,7 +120,6 @@ impl<W: WebSocketPort> ScTransport<W> {
                 npdu,
                 data_attributes,
                 conn,
-                hub_max_bvlc_length,
                 hub_max_apdu_length,
                 connect_timeout_ms,
             )


### PR DESCRIPTION
Bounded #615 slice: BACnet Connect handshake on direct-dialed connections.

- After direct TLS+websocket upgrade: Connect-Request (node identity/lengths) → Connect-Accept validated with existing machinery; NPDU bounded by peer-learned limits; any failure falls back to hub (contract unchanged). Hub dial path untouched; dial-out only, inbound still refused.
- Refs #615 (stays OPEN: pools/backoff/accept remain). Gates: fmt/clippy/size/secrets PASS, transport 602 + sc-tls 805/2/7/17 PASS, FULL conformance_ledger 27/27 PASS, new 4-test matrix RED→GREEN. No website/CI changes.