### PR TITLE
feat(sc): advertise registered live direct listener in solicited Advertisement (#615)

### DIFF
--- a/crates/bacnet-transport/src/sc/advertisement.rs
+++ b/crates/bacnet-transport/src/sc/advertisement.rs
@@ -9,11 +9,13 @@ use std::time::Duration;
 
 use bacnet_types::enums::{ErrorClass, ErrorCode};
 use bytes::BytesMut;
+use tokio::sync::mpsc;
 use tracing::warn;
 
 use super::data_attributes::build_bvlc_result_nak;
 use super::rejection::{RejectionBudget, RejectionExpired};
-use super::WebSocketPort;
+use super::{ScConnection, WebSocketPort};
+use crate::port::ReceivedNpdu;
 use crate::sc_frame::{
     advertisement_message_error, encode_sc_message,
     first_must_understand_destination_option_marker, ScFunction, ScMessage, Vmac, BROADCAST_VMAC,
@@ -27,6 +29,116 @@ use crate::sc_frame::{
 /// positive transmission, not a rejection NAK; the send itself stays
 /// best-effort like Heartbeat-ACK.
 pub(super) const SOLICITED_ADVERTISEMENT_MIN_INTERVAL: Duration = Duration::from_secs(1);
+
+/// The listener's sole intake is merged by the existing transport receive task.
+/// A closed/absent receiver remains pending, never spinning or ending hub intake.
+#[derive(Default)]
+pub(super) struct DirectIntake {
+    npdus: Option<mpsc::Receiver<ReceivedNpdu>>,
+    #[cfg(feature = "sc-tls")]
+    listener: Option<ListenerStatus>,
+}
+
+#[cfg(feature = "sc-tls")]
+struct ListenerStatus {
+    shutdown: tokio::sync::watch::Receiver<bool>,
+    vmac: Vmac,
+    uuid: [u8; 16],
+}
+
+impl DirectIntake {
+    pub(super) async fn recv(&mut self) -> Option<ReceivedNpdu> {
+        match &mut self.npdus {
+            Some(rx) => {
+                let npdu = rx.recv().await;
+                if npdu.is_none() {
+                    self.npdus = None;
+                }
+                npdu
+            }
+            None => std::future::pending().await,
+        }
+    }
+
+    /// AB.2.8.1 capability sampled from real admission and an open intake.
+    /// Identity may change on a Connect retry; never advertise another VMAC's listener.
+    pub(super) fn accepts_direct(&self, _conn: &ScConnection) -> bool {
+        #[cfg(feature = "sc-tls")]
+        return self.npdus.as_ref().is_some_and(|rx| !rx.is_closed())
+            && self.listener.as_ref().is_some_and(|listener| {
+                !*listener.shutdown.borrow()
+                    && listener.vmac == _conn.local_vmac
+                    && listener.uuid == _conn.device_uuid
+            });
+        #[cfg(not(feature = "sc-tls"))]
+        false
+    }
+}
+
+#[cfg(feature = "sc-tls")]
+impl<W: WebSocketPort> super::ScTransport<W> {
+    /// Start and register an opt-in direct listener before transport start.
+    ///
+    /// Returns `(transport, listener)`: the application must retain the listener
+    /// and can stop/drop it independently. Its sole NPDU receiver is merged into
+    /// the receiver returned by [`crate::port::TransportPort::start`], with the
+    /// existing bounded, drop-on-full policy. No forwarding task is spawned.
+    /// Keep the listener only while using the transport; transport stop/drop
+    /// closes its intake but does not take ownership of this application handle.
+    ///
+    /// Solicited Advertisements report accept-direct 1 only while this listener
+    /// is live, identities match, and both intakes are open. Stop/drop restores 0
+    /// at the next send decision; already-built/sent frames cannot be recalled.
+    /// Registering never enables discovery/dial-out or infers public URIs: use
+    /// `with_advertised_uris` for known URIs (AB.3.3), or leave the list empty.
+    ///
+    /// Rejects an already-started transport, duplicate registration or mismatched
+    /// VMAC/UUID before binding. Configure the device UUID first. Other errors
+    /// are those of [`crate::sc_tls::DirectListener::start`].
+    ///
+    /// ```no_run
+    /// use bacnet_transport::{port::TransportPort, sc::{ScTransport, WebSocketPort},
+    ///     sc_tls::{DirectAcceptConfig, ScNodeTlsConfig}};
+    /// # async fn run(ws: impl WebSocketPort, tls: ScNodeTlsConfig,
+    /// #     vmac: [u8; 6], persisted_uuid: [u8; 16]) -> Result<(), bacnet_types::error::Error> {
+    /// let config = DirectAcceptConfig::new(
+    ///     "127.0.0.1:0".parse().unwrap(), vmac, persisted_uuid, tls);
+    /// let (mut transport, mut listener) = ScTransport::new(ws, vmac)
+    ///     .with_device_uuid(persisted_uuid).with_direct_listener(config).await?;
+    /// let mut incoming = transport.start().await?;
+    /// // Retain listener while consuming both hub and direct NPDUs here.
+    /// let received = incoming.recv().await;
+    /// listener.stop().await;
+    /// transport.stop().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn with_direct_listener(
+        mut self,
+        config: crate::sc_tls::DirectAcceptConfig,
+    ) -> Result<(Self, crate::sc_tls::DirectListener), bacnet_types::error::Error> {
+        if self.ws.is_none() || self.direct_intake.npdus.is_some() {
+            return Err(bacnet_types::error::Error::Encoding(
+                "SC direct listener requires an unstarted, unregistered transport".into(),
+            ));
+        }
+        if !config.matches_identity(self.local_vmac, self.device_uuid) {
+            return Err(bacnet_types::error::Error::Encoding(
+                "SC direct listener identity does not match transport".into(),
+            ));
+        }
+        let (listener, rx) = crate::sc_tls::DirectListener::start(config).await?;
+        self.direct_intake = DirectIntake {
+            npdus: Some(rx),
+            listener: Some(ListenerStatus {
+                shutdown: listener.shutdown_status(),
+                vmac: self.local_vmac,
+                uuid: self.device_uuid,
+            }),
+        };
+        Ok((self, listener))
+    }
+}
 
 /// Accepted-solicitation predicate for AB.3.2 solicited replies.
 ///

--- a/crates/bacnet-transport/src/sc/advertisement_tests.rs
+++ b/crates/bacnet-transport/src/sc/advertisement_tests.rs
@@ -370,6 +370,20 @@ fn solicited_reply_payload() -> Vec<u8> {
     payload
 }
 
+#[tokio::test]
+async fn advertisement_default_accept_direct_stays_zero_on_raw_wire() {
+    let (mut transport, _rx, hub) = super::data_attribute_tests::start_transport().await;
+    hub.send(&[5, 0, 0x22, 0x34]).await.unwrap();
+    let reply = recv(&hub).await;
+    assert_eq!(reply.len(), 10);
+    assert_ne!(&reply[2..4], &[0x22, 0x34]);
+    assert_eq!(
+        reply,
+        [4, 0, reply[2], reply[3], 1, 0, 0x16, 0x49, 0x05, 0xC4]
+    );
+    transport.stop().await.unwrap();
+}
+
 async fn recv_reply(hub: &LoopbackWebSocket) -> crate::sc_frame::ScMessage {
     let data = timeout(Duration::from_secs(1), hub.recv())
         .await

--- a/crates/bacnet-transport/src/sc/connection.rs
+++ b/crates/bacnet-transport/src/sc/connection.rs
@@ -258,13 +258,22 @@ impl ScConnection {
     /// origin) and the hub-connection status derived from live transport
     /// state (1 = primary hub, 2 = failover hub). The message ID is always
     /// fresh: a solicited Advertisement is not a "response message" and must
-    /// not copy the solicitation ID (AB.3.1.3). Accept-direct is always 0 —
-    /// this transport has no direct-connection accept path — and the two
-    /// maxima echo the local receive configuration. No Data Options.
+    /// not copy the solicitation ID (AB.3.1.3). This standalone builder keeps
+    /// accept-direct 0; the transport uses its registered listener's live
+    /// intake state. The two maxima echo local receive configuration. No Data Options.
     pub fn build_solicited_advertisement(
         &mut self,
         destination_vmac: Option<Vmac>,
         hub_status: u8,
+    ) -> ScMessage {
+        self.build_solicited_advertisement_with_direct(destination_vmac, hub_status, false)
+    }
+
+    pub(super) fn build_solicited_advertisement_with_direct(
+        &mut self,
+        destination_vmac: Option<Vmac>,
+        hub_status: u8,
+        accept_direct: bool,
     ) -> ScMessage {
         debug_assert!(
             hub_status == 1 || hub_status == 2,
@@ -272,7 +281,7 @@ impl ScConnection {
         );
         let mut payload = Vec::with_capacity(6);
         payload.push(hub_status);
-        payload.push(0);
+        payload.push(u8::from(accept_direct));
         payload.extend_from_slice(&self.max_bvlc_length.to_be_bytes());
         payload.extend_from_slice(&self.max_apdu_length.to_be_bytes());
         ScMessage {

--- a/crates/bacnet-transport/src/sc/direct_discovery.rs
+++ b/crates/bacnet-transport/src/sc/direct_discovery.rs
@@ -28,11 +28,10 @@
 //! is a local matter. This module reuses the transport's existing connect
 //! timeout for that wait and introduces no new global deadline type.
 //!
-//! Asymmetry is intentional and documented: this transport dials out to
-//! direct peers only. Inbound direct connections stay refused — solicited
-//! Advertisements always report accept-direct 0 — so a peer's direct dial
-//! to this node is out of scope. Hub, failover, reconnect, and accept-side
-//! behavior are unchanged.
+//! Discovery enables dial-out only. Without a separately registered live
+//! direct listener, solicited Advertisements report accept-direct 0.
+//! Listener registration is independent of discovery; hub, failover,
+//! reconnect, and dial-out behavior are unchanged.
 //!
 //! Cache policy (owner-local): at most [`DIRECT_URI_CACHE_MAX_ENTRIES`]
 //! VMAC entries; each entry lives [`DIRECT_URI_CACHE_TTL`] from insertion.
@@ -402,7 +401,7 @@ impl<W: WebSocketPort> super::ScTransport<W> {
     /// delivery. Broadcasts always use the hub path.
     ///
     /// Dial-out only: this flag never enables inbound direct acceptance.
-    /// Solicited Advertisements keep accept-direct 0. Hub, failover, and
+    /// Without a separately registered listener, accept-direct stays 0. Hub, failover, and
     /// reconnect behavior are unchanged. The ACK wait reuses the configured
     /// connect timeout; no new global deadline type is introduced.
     pub fn with_direct_discovery(mut self, enabled: bool) -> Self {

--- a/crates/bacnet-transport/src/sc/mod.rs
+++ b/crates/bacnet-transport/src/sc/mod.rs
@@ -98,6 +98,7 @@ pub struct ScTransport<W: WebSocketPort> {
     device_uuid: [u8; 16],
     /// Advertised direct-connection URIs answered in Address-Resolution-ACKs.
     advertised_uris: Vec<String>,
+    direct_intake: advertisement::DirectIntake,
     connection: Option<Arc<Mutex<ScConnection>>>,
     effective_max_apdu_length: Arc<AtomicU16>,
     state_tx: watch::Sender<ScConnectionState>,
@@ -127,6 +128,7 @@ impl<W: WebSocketPort> ScTransport<W> {
             local_vmac,
             device_uuid: [0u8; 16],
             advertised_uris: Vec::new(),
+            direct_intake: advertisement::DirectIntake::default(),
             connection: None,
             effective_max_apdu_length: Arc::new(AtomicU16::new(DEFAULT_MAX_APDU_LENGTH)),
             state_tx,
@@ -396,6 +398,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
         let effective_max_apdu_length = self.effective_max_apdu_length.clone();
         let advertised_payload = self.advertised_uris.join(" ").into_bytes();
         let direct = self.direct.clone();
+        let mut direct_intake = std::mem::take(&mut self.direct_intake);
         let task = tokio::spawn(async move {
             let mut primary_restore_interval =
                 tokio::time::interval(Duration::from_millis(restore_interval_ms));
@@ -421,6 +424,11 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                 loop {
                     let recv_ws = ws_clone.clone();
                     tokio::select! {
+                        Some(npdu) = direct_intake.recv() => {
+                            if npdu_tx.try_send(npdu).is_err() {
+                                warn!("SC transport: NPDU channel full, dropping direct message");
+                            }
+                        }
                         data = recv_ws.recv() => {
                             match data {
                                 Ok(data) => {
@@ -546,9 +554,12 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
                                                     ActiveHub::Primary => 1,
                                                     ActiveHub::Failover => 2,
                                                 };
-                                                c.build_solicited_advertisement(
+                                                let accept_direct = !npdu_tx.is_closed()
+                                                    && direct_intake.accepts_direct(&c);
+                                                c.build_solicited_advertisement_with_direct(
                                                     destination,
                                                     hub_status,
+                                                    accept_direct,
                                                 )
                                             })
                                         } else {
@@ -730,6 +741,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
     }
 
     async fn stop(&mut self) -> Result<(), Error> {
+        self.direct_intake = advertisement::DirectIntake::default();
         // Attempt clean disconnect: send DisconnectRequest via the WebSocket
         if let (Some(ws), Some(conn)) = (&self.ws_shared, &self.connection) {
             let (ws, disconnect_msg) = {
@@ -768,6 +780,7 @@ impl<W: WebSocketPort> TransportPort for ScTransport<W> {
     }
 
     fn abort(&mut self) {
+        self.direct_intake = advertisement::DirectIntake::default();
         let _ = self.abort_background_task_and_drop_sockets();
     }
 

--- a/crates/bacnet-transport/src/sc_tls/direct_accept.rs
+++ b/crates/bacnet-transport/src/sc_tls/direct_accept.rs
@@ -94,6 +94,10 @@ pub struct DirectAcceptConfig {
 }
 
 impl DirectAcceptConfig {
+    pub(crate) fn matches_identity(&self, vmac: Vmac, uuid: [u8; 16]) -> bool {
+        self.local_vmac == vmac && self.device_uuid == uuid
+    }
+
     /// Configure an opt-in direct listener.
     ///
     /// `bind_addr` is the local TCP address to bind (e.g.
@@ -158,7 +162,21 @@ pub struct DirectListener {
     active: Arc<AtomicUsize>,
 }
 
+/// Invalidate registrations even if the accept task is cancelled before its
+/// first poll, exits unexpectedly, or unwinds. No separate monitor task.
+struct ListenerStopped(watch::Sender<bool>);
+
+impl Drop for ListenerStopped {
+    fn drop(&mut self) {
+        self.0.send_replace(true);
+    }
+}
+
 impl DirectListener {
+    pub(crate) fn shutdown_status(&self) -> watch::Receiver<bool> {
+        self.shutdown.subscribe()
+    }
+
     /// Start an opt-in direct listener.
     ///
     /// Binds `config.bind_addr`, begins accepting direct peers on a
@@ -194,6 +212,7 @@ impl DirectListener {
             npdu_tx,
             shutdown_rx,
             Arc::clone(&active),
+            ListenerStopped(shutdown.clone()),
         ));
         debug!("BACnet/SC direct listener on {local_addr}");
         Ok((
@@ -223,7 +242,7 @@ impl DirectListener {
     /// frame or shutdown poll. This is forceful local shutdown, not the
     /// BACnet Disconnect sequence.
     pub async fn stop(&mut self) {
-        let _ = self.shutdown.send(true);
+        self.shutdown.send_replace(true);
         if let Some(task) = self.accept_task.take() {
             task.abort();
             let _ = task.await;
@@ -233,7 +252,7 @@ impl DirectListener {
 
 impl Drop for DirectListener {
     fn drop(&mut self) {
-        let _ = self.shutdown.send(true);
+        self.shutdown.send_replace(true);
         if let Some(task) = self.accept_task.take() {
             task.abort();
         }
@@ -314,6 +333,7 @@ async fn accept_loop(
     npdu_tx: mpsc::Sender<ReceivedNpdu>,
     mut shutdown: watch::Receiver<bool>,
     active: Arc<AtomicUsize>,
+    _stopped: ListenerStopped,
 ) {
     loop {
         let accepted = tokio::select! {

--- a/crates/bacnet-transport/src/sc_tls/direct_accept_tests.rs
+++ b/crates/bacnet-transport/src/sc_tls/direct_accept_tests.rs
@@ -504,3 +504,170 @@ async fn accept_broadcast_mu_destination_option_drops_without_nak() {
     assert_eq!(listener.active_connections(), 1);
     listener.stop().await;
 }
+
+async fn registered_listener(
+    ca: &TestCa,
+) -> (
+    ScTransport<crate::sc::LoopbackWebSocket>,
+    DirectListener,
+    tokio::sync::mpsc::Receiver<crate::port::ReceivedNpdu>,
+    crate::sc::LoopbackWebSocket,
+) {
+    let (client, hub) = crate::sc::LoopbackWebSocket::pair();
+    let config = DirectAcceptConfig::new(
+        loopback_addr(),
+        LISTENER_VMAC,
+        LISTENER_UUID,
+        ca.node_config(vec!["localhost".into()]),
+    );
+    let (mut transport, listener) = ScTransport::new(client, LISTENER_VMAC)
+        .with_device_uuid(LISTENER_UUID)
+        .with_direct_listener(config)
+        .await
+        .unwrap();
+    let (rx, ()) = tokio::join!(transport.start(), hub_accept(&hub, [0x10; 6]));
+    (transport, listener, rx.unwrap(), hub)
+}
+
+async fn assert_accept_direct(hub: &crate::sc::LoopbackWebSocket, expected: u8) {
+    // Independent AB.2.8.1 wire vector: no addresses/options, fresh ID,
+    // primary-hub status, live accept flag, unchanged 5705/1476 maxima.
+    hub.send(&[5, 0, 0x22, 0x34]).await.unwrap();
+    let reply = tokio::time::timeout(Duration::from_secs(5), hub.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reply.len(), 10);
+    assert_ne!(&reply[2..4], &[0x22, 0x34]);
+    assert_eq!(
+        reply,
+        [4, 0, reply[2], reply[3], 1, expected, 0x16, 0x49, 0x05, 0xC4]
+    );
+}
+
+#[tokio::test]
+async fn accept_registered_bit_is_one_while_listening_and_npdu_reaches_transport() {
+    let ca = TestCa::generate();
+    let (mut transport, mut listener, mut rx, hub) = registered_listener(&ca).await;
+    assert_accept_direct(&hub, 1).await;
+    let (ws, _) = dial_and_handshake(
+        &direct_url(&listener.local_addr()),
+        ca.node_config(vec!["node".into()]),
+    )
+    .await;
+    // Direct NPDU with one non-MU proprietary Data Option. No address fields.
+    ws.send(&[1, 1, 0x12, 0x34, 0x3F, 0, 3, 0x12, 0x34, 0x56, 1, 0, 0x30])
+        .await
+        .unwrap();
+    let received = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.npdu.as_ref(), NPDU);
+    assert_eq!(received.source_mac.as_ref(), &DIAL_VMAC);
+    assert!(!received.link_layer_group);
+    assert!(received.reply_tx.is_none());
+    assert_eq!(received.data_attributes.len(), 1);
+    assert_eq!(received.data_attributes[0].option_type, 31);
+    assert!(!received.data_attributes[0].must_understand);
+    assert_eq!(received.data_attributes[0].data, [0x12, 0x34, 0x56]);
+    listener.stop().await;
+    transport.stop().await.unwrap();
+}
+
+async fn registered_listener_reverts_to_zero(drop_listener: bool) {
+    let ca = TestCa::generate();
+    let (mut transport, listener, mut rx, hub) = registered_listener(&ca).await;
+    let addr = listener.local_addr();
+    let mut listener = Some(listener);
+    assert_accept_direct(&hub, 1).await;
+    if drop_listener {
+        drop(listener.take());
+    } else {
+        listener.as_mut().unwrap().stop().await;
+    }
+    // Preserve the existing one-second solicited-reply gate, not a new timer.
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_accept_direct(&hub, 0).await;
+    assert!(tokio::net::TcpStream::connect(addr).await.is_err());
+    // Closed direct intake must neither terminate nor starve the hub intake.
+    hub.send(&[
+        1, 8, 0x12, 0x35, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 1, 0, 0x40,
+    ])
+    .await
+    .unwrap();
+    let received = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(received.npdu.as_ref(), &[1, 0, 0x40]);
+    assert_eq!(received.source_mac.as_ref(), &[0x33; 6]);
+    drop(listener);
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn accept_registered_bit_reverts_after_stop() {
+    registered_listener_reverts_to_zero(false).await;
+}
+
+#[tokio::test]
+async fn accept_registered_bit_reverts_after_drop() {
+    registered_listener_reverts_to_zero(true).await;
+}
+
+#[tokio::test]
+async fn accept_registered_bit_reverts_if_accept_task_is_cancelled() {
+    let ca = TestCa::generate();
+    let (mut transport, mut listener, _rx, hub) = registered_listener(&ca).await;
+    assert_accept_direct(&hub, 1).await;
+    listener.accept_task.as_ref().unwrap().abort();
+    let mut stopped = listener.shutdown_status();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !*stopped.borrow_and_update() {
+            stopped.changed().await.unwrap();
+        }
+    })
+    .await
+    .unwrap();
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_accept_direct(&hub, 0).await;
+    listener.stop().await;
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn accept_registered_bit_is_zero_without_application_intake_or_matching_identity() {
+    let ca = TestCa::generate();
+    let (mut transport, mut listener, rx, hub) = registered_listener(&ca).await;
+    transport.connection().unwrap().lock().await.local_vmac = [0xBB; 6];
+    assert_accept_direct(&hub, 0).await;
+    transport.connection().unwrap().lock().await.local_vmac = LISTENER_VMAC;
+    drop(rx);
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    assert_accept_direct(&hub, 0).await;
+    listener.stop().await;
+    transport.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn accept_registration_rejects_identity_mismatch_before_binding() {
+    let ca = TestCa::generate();
+    let occupied = tokio::net::TcpListener::bind(loopback_addr())
+        .await
+        .unwrap();
+    let config = DirectAcceptConfig::new(
+        occupied.local_addr().unwrap(),
+        LISTENER_VMAC,
+        LISTENER_UUID,
+        ca.node_config(vec!["localhost".into()]),
+    );
+    let (client, _hub) = crate::sc::LoopbackWebSocket::pair();
+    let result = ScTransport::new(client, DIAL_VMAC)
+        .with_device_uuid(DIAL_UUID)
+        .with_direct_listener(config)
+        .await;
+    assert!(
+        matches!(result, Err(ref error) if error.to_string().contains("identity does not match"))
+    );
+}


### PR DESCRIPTION
Final #615 slice: wire the standalone opt-in DirectListener into ScTransport via additive `with_direct_listener` builder; solicited Advertisements report accept-direct 1 only while the registered listener is live with matching identity and open intakes, else 0 (byte-identical default). Listener NPDU receiver merges into the transport receive path with the existing bounded drop-on-full policy; no new tasks, timers, or public-signature changes.

Validation: fmt/clippy/size/secrets PASS; direct_accept 18/18, advertisement 37/37, FULL conformance_ledger 27/27 PASS; portable-feature workspace suite green. Exact-head CI to follow on this PR.

Closes #615 on merge (accept-direct discovery complete; explicit-URI limitation lifted). Excludes #515/#522, hub behavior, floors/capacity/timer/API/write budgets, website/CI/README.