### PR TITLE
fix(sc): add capped reconnect jitter and retry budget regression (#526)

### DIFF
--- a/crates/bacnet-transport/src/sc/reconnect.rs
+++ b/crates/bacnet-transport/src/sc/reconnect.rs
@@ -1,9 +1,18 @@
 use bacnet_types::error::Error;
 
-/// Configuration for SC transport reconnection with exponential backoff.
+/// Configuration for SC transport reconnection with jittered exponential backoff.
+///
+/// The nominal backoff starts at `initial_delay_ms` and doubles after each failed
+/// active-hub retry, capped at `max_delay_ms`. Each reconnect sleep uses fresh OS
+/// randomness between `max(initial_delay_ms, backoff / 2)` and
+/// `min(max_delay_ms, backoff + backoff / 2)`, inclusive. Thus the initial delay
+/// remains a floor and the maximum remains a cap, including at the capped step.
+/// Equal initial and maximum delays leave no room for jitter. If OS randomness
+/// is unavailable, the nominal backoff is used. Jitter applies only to active-hub
+/// retries, not the separate failover attempt or primary-restoration timer.
 #[derive(Debug, Clone)]
 pub struct ScReconnectConfig {
-    /// Initial delay before first reconnect attempt (ms).
+    /// Initial nominal backoff and minimum reconnect sleep (ms).
     pub initial_delay_ms: u64,
     /// Maximum delay between reconnect attempts (ms).
     pub max_delay_ms: u64,

--- a/crates/bacnet-transport/src/sc/reconnect_validation_tests.rs
+++ b/crates/bacnet-transport/src/sc/reconnect_validation_tests.rs
@@ -160,6 +160,70 @@ async fn hub_accept(hub: &LoopbackWebSocket, vmac: Vmac) {
 }
 
 #[tokio::test(start_paused = true)]
+async fn failing_connectors_obey_reconnect_budget_plus_single_failover_allowance() {
+    for max_retries in [0, 1, 3, 10] {
+        for with_failover in [false, true] {
+            let config = ScReconnectConfig {
+                initial_delay_ms: 2,
+                max_delay_ms: 7,
+                max_retries,
+            };
+            config.validate().unwrap();
+            let (primary, primary_hub) = LoopbackWebSocket::pair();
+            let primary_dials = Arc::new(AtomicUsize::new(0));
+            let failover_dials = Arc::new(AtomicUsize::new(0));
+            let mut transport = ScTransport::new(primary, [0x22; 6])
+                .with_device_uuid([1; 16])
+                .with_reconnect(config)
+                .with_connector({
+                    let dials = primary_dials.clone();
+                    move || {
+                        dials.fetch_add(1, Ordering::SeqCst);
+                        async { Err(Error::Encoding("primary dial failed".into())) }
+                    }
+                });
+            if with_failover {
+                transport = transport.with_failover_connector({
+                    let dials = failover_dials.clone();
+                    move || {
+                        dials.fetch_add(1, Ordering::SeqCst);
+                        async { Err(Error::Encoding("failover dial failed".into())) }
+                    }
+                });
+            }
+
+            let (started, ()) =
+                tokio::join!(transport.start(), hub_accept(&primary_hub, [0x10; 6]));
+            let _rx = started.unwrap();
+            assert_eq!(primary_dials.load(Ordering::SeqCst), 0);
+            assert_eq!(failover_dials.load(Ordering::SeqCst), 0);
+            drop(primary_hub);
+
+            // Join the existing receive task: a transient Disconnected state is
+            // not proof that all retries (or the failover allowance) have ended.
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                transport.recv_task.as_mut().unwrap(),
+            )
+            .await
+            .expect("reconnect budget did not terminate")
+            .unwrap();
+            let _ = transport.recv_task.take();
+            let primary_count = primary_dials.load(Ordering::SeqCst);
+            let failover_count = failover_dials.load(Ordering::SeqCst);
+            assert_eq!(primary_count, max_retries as usize);
+            assert_eq!(failover_count, usize::from(with_failover));
+            assert!(primary_count + failover_count <= max_retries as usize + 1);
+            assert_eq!(
+                transport.connection().unwrap().lock().await.state,
+                ScConnectionState::Disconnected
+            );
+            transport.stop().await.unwrap();
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
 async fn zero_retries_skips_active_hub_retry_but_allows_initial_failover_and_restoration() {
     let (primary, primary_hub) = LoopbackWebSocket::pair();
     let (failover, failover_hub) = LoopbackWebSocket::pair();

--- a/crates/bacnet-transport/src/sc/recovery.rs
+++ b/crates/bacnet-transport/src/sc/recovery.rs
@@ -3,6 +3,24 @@
 use super::connector::dial_reconnect_ws;
 use super::*;
 
+/// Jitter a nominal backoff from validated reconnect settings without changing
+/// its doubling progression. Both the configured initial floor and cap apply.
+fn jittered_backoff(backoff: Duration, initial: Duration, maximum: Duration) -> Duration {
+    let lower = initial.max(backoff / 2);
+    let upper = maximum.min(backoff + backoff / 2);
+    let mut random = [0; 16];
+    if getrandom::fill(&mut random).is_err() {
+        // Preserve recovery and its bounds if OS entropy is unavailable.
+        return backoff;
+    }
+    let nanos = u128::from_le_bytes(random) % ((upper - lower).as_nanos() + 1);
+    lower
+        + Duration::new(
+            (nanos / 1_000_000_000) as u64,
+            (nanos % 1_000_000_000) as u32,
+        )
+}
+
 pub(super) async fn retire<W: WebSocketPort>(
     current_ws: &Arc<W>,
     primary_ws: &mut Option<Arc<W>>,
@@ -57,10 +75,11 @@ impl<W: WebSocketPort> Recovery<'_, W> {
         current_reusable: bool,
     ) -> Option<(Arc<W>, ActiveHub)> {
         warn!("SC transport disconnected, attempting reconnection");
-        let mut backoff = Duration::from_millis(self.config.initial_delay_ms);
+        let initial_backoff = Duration::from_millis(self.config.initial_delay_ms);
+        let mut backoff = initial_backoff;
         let max_backoff = Duration::from_millis(self.config.max_delay_ms);
         for attempt in 1..=self.config.max_retries {
-            tokio::time::sleep(backoff).await;
+            tokio::time::sleep(jittered_backoff(backoff, initial_backoff, max_backoff)).await;
             if !self.conn.lock().await.connect_retry_allowed {
                 warn!(attempt, "SC reconnection skipped without retry eligibility");
                 break;
@@ -163,5 +182,64 @@ impl<W: WebSocketPort> Recovery<'_, W> {
             self.effective_max_apdu_length,
         )
         .await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reconnect_jitter_default_samples_stay_in_each_capped_window() {
+        let config = ScReconnectConfig::default();
+        let initial = Duration::from_millis(config.initial_delay_ms);
+        let maximum = Duration::from_millis(config.max_delay_ms);
+        // Independent bounds for each nominal step, including the capped step.
+        for (backoff, lower, upper) in [
+            (10, 10, 15),
+            (20, 10, 30),
+            (40, 20, 60),
+            (80, 40, 120),
+            (160, 80, 240),
+            (320, 160, 480),
+            (600, 300, 600),
+        ] {
+            for _ in 0..256 {
+                let sleep = jittered_backoff(Duration::from_secs(backoff), initial, maximum);
+                assert!(sleep >= Duration::from_secs(lower));
+                assert!(sleep <= Duration::from_secs(upper));
+            }
+        }
+    }
+
+    #[test]
+    fn reconnect_jitter_samples_respect_small_equal_and_extreme_config_bounds() {
+        for (initial_delay_ms, max_delay_ms) in [
+            (1, 1),
+            (1, 2),
+            (3, 7),
+            (1, u64::MAX),
+            (u64::MAX - 1, u64::MAX),
+            (u64::MAX, u64::MAX),
+        ] {
+            let config = ScReconnectConfig {
+                initial_delay_ms,
+                max_delay_ms,
+                max_retries: 10,
+            };
+            config.validate().unwrap();
+            let initial = Duration::from_millis(initial_delay_ms);
+            let maximum = Duration::from_millis(max_delay_ms);
+            let mut backoff = initial;
+            for _ in 0..config.max_retries {
+                for _ in 0..256 {
+                    // Duration calculations only: never sleep on extreme values.
+                    let sleep = jittered_backoff(backoff, initial, maximum);
+                    assert!(sleep >= initial);
+                    assert!(sleep <= maximum);
+                }
+                backoff = (backoff * 2).min(maximum);
+            }
+        }
     }
 }


### PR DESCRIPTION
Partial #526: capped jitter on the reconnect sleep (window max(initial, b/2)..=min(max, b+b/2) via existing getrandom; defaults 10s/600s/10 unchanged in shape, first window now 10-15s) plus a failing-connector attempt-budget regression (dials <= max_retries + single failover allowance, paused clock). Nominal doubling, start-time validation, and warn diagnostics untouched.

Validation: fmt/clippy/size/secrets PASS; reconnect 23, redial 17, recovery 13; full transport + FULL conformance_ledger 27/27 PASS. Exact-head CI to follow.

Refs #526 (stays OPEN): reconnect diagnostic rate-limiting and an upper delay-cap policy (validated configs accept astronomic delays; cap value is an owner decision) remain follow-up. Excludes failover/discovery/direct-accept behavior, node floors, #522/#524/#518, website/CI/README.