### PR TITLE
fix(network): nonblocking admission on full NetworkLayer queues (#532)

### DIFF
--- a/crates/bacnet-network/Cargo.toml
+++ b/crates/bacnet-network/Cargo.toml
@@ -17,5 +17,8 @@ bytes.workspace = true
 tracing.workspace = true
 tokio = { workspace = true, features = ["sync", "time"] }
 
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
 [lints]
 workspace = true

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -5,7 +5,7 @@
 //! it does not forward messages between networks, but it can address remote
 //! devices through local routers via NPDU destination fields (DNET/DADR).
 
-use bacnet_encoding::npdu::{decode_npdu, encode_npdu, Npdu, NpduAddress};
+use bacnet_encoding::npdu::{encode_npdu, Npdu, NpduAddress};
 use bacnet_transport::port::{DataAttribute, TransportPort};
 use bacnet_types::enums::NetworkPriority;
 use bacnet_types::error::Error;
@@ -13,9 +13,13 @@ use bacnet_types::MacAddr;
 use bytes::{Bytes, BytesMut};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
-use tracing::{debug, warn};
+
+#[path = "layer_admission.rs"]
+mod admission;
+use admission::AdmissionSender;
+pub use admission::{AdmissionReceiver, QueueAdmissionCounters, QueueAdmissionSnapshot};
 
 /// A received APDU with source addressing information.
 pub struct ReceivedApdu {
@@ -38,6 +42,9 @@ pub struct ReceivedApdu {
     pub data_attributes: Vec<DataAttribute>,
     /// Optional reply channel for MS/TP DataExpectingReply flows.
     /// The application layer can send NPDU-wrapped reply bytes through this channel.
+    /// An APDU dropped at queue admission releases this sender without sending
+    /// bytes, just as when the application receiver is closed. The transport
+    /// observes channel closure and retains its existing no-reply handling.
     pub reply_tx: Option<oneshot::Sender<Bytes>>,
 }
 
@@ -108,7 +115,7 @@ pub(crate) fn is_group_delivery(link_layer_group: bool, destination: Option<&Npd
 pub struct NetworkLayer<T: TransportPort> {
     transport: T,
     dispatch_task: Option<JoinHandle<()>>,
-    network_control_tx: Option<mpsc::Sender<ReceivedNetworkControl>>,
+    network_control_tx: Option<AdmissionSender<ReceivedNetworkControl>>,
     network_control_ingress_sequence: Arc<AtomicU64>,
 }
 
@@ -121,110 +128,6 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
             network_control_tx: None,
             network_control_ingress_sequence: Arc::new(AtomicU64::new(0)),
         }
-    }
-
-    /// Enable the one-consumer decoded network-control stream.
-    ///
-    /// This must be called before [`Self::start`] and at most once. Dropping
-    /// the returned receiver disables control delivery without affecting APDU
-    /// ingress.
-    pub fn enable_network_control_receiver(
-        &mut self,
-    ) -> Result<mpsc::Receiver<ReceivedNetworkControl>, Error> {
-        if self.dispatch_task.is_some() {
-            return Err(Error::Encoding(
-                "network-control receiver must be enabled before NetworkLayer::start".into(),
-            ));
-        }
-        if self.network_control_tx.is_some() {
-            return Err(Error::Encoding(
-                "network-control receiver is already enabled".into(),
-            ));
-        }
-        let (tx, rx) = mpsc::channel(256);
-        self.network_control_tx = Some(tx);
-        Ok(rx)
-    }
-
-    /// Start the network layer. Returns a receiver for incoming APDUs.
-    ///
-    /// This starts the underlying transport and spawns a dispatch task that
-    /// decodes incoming NPDUs and extracts APDUs.
-    pub async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedApdu>, Error> {
-        let mut npdu_rx = self.transport.start().await?;
-        let mut network_control_tx = self.network_control_tx.take();
-        let network_control_ingress_sequence = Arc::clone(&self.network_control_ingress_sequence);
-
-        let (apdu_tx, apdu_rx) = mpsc::channel(256);
-
-        let dispatch_task = tokio::spawn(async move {
-            while let Some(received) = npdu_rx.recv().await {
-                match decode_npdu(received.npdu.clone()) {
-                    Ok(npdu) => {
-                        if npdu.is_network_message {
-                            if let Some(tx) = network_control_tx.as_ref() {
-                                let ingress_sequence = next_ingress_sequence(
-                                    network_control_ingress_sequence.as_ref(),
-                                );
-                                let control = ReceivedNetworkControl {
-                                    npdu,
-                                    source_mac: received.source_mac,
-                                    link_layer_group: received.link_layer_group,
-                                    data_attributes: received.data_attributes,
-                                    ingress_sequence,
-                                };
-                                if tx.send(control).await.is_err() {
-                                    network_control_tx = None;
-                                    debug!("Network-control receiver closed; resuming discard behavior");
-                                }
-                            } else {
-                                debug!(
-                                    message_type = npdu.message_type,
-                                    "Ignoring network layer message (non-router mode)"
-                                );
-                            }
-                            continue;
-                        }
-
-                        // Non-routing node: discard messages with a specific DNET.
-                        if let Some(ref dest) = npdu.destination {
-                            if dest.network != 0xFFFF {
-                                debug!(
-                                    dnet = dest.network,
-                                    "Discarding routed message (non-router)"
-                                );
-                                continue;
-                            }
-                        }
-
-                        let source_network = npdu.source.clone();
-                        let is_group =
-                            is_group_delivery(received.link_layer_group, npdu.destination.as_ref());
-
-                        let apdu = ReceivedApdu {
-                            apdu: npdu.payload,
-                            source_mac: received.source_mac,
-                            source_network,
-                            link_layer_group: received.link_layer_group,
-                            is_group,
-                            data_attributes: received.data_attributes,
-                            reply_tx: received.reply_tx,
-                        };
-
-                        if apdu_tx.send(apdu).await.is_err() {
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "Failed to decode NPDU");
-                    }
-                }
-            }
-        });
-
-        self.dispatch_task = Some(dispatch_task);
-
-        Ok(apdu_rx)
     }
 
     /// Send an APDU to a specific local destination by MAC address.
@@ -577,6 +480,7 @@ impl<T: TransportPort> Drop for NetworkLayer<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bacnet_encoding::npdu::decode_npdu;
     use bacnet_transport::bip::BipTransport;
     use bacnet_transport::sc::{LoopbackWebSocket, ScTransport, WebSocketPort};
     use bacnet_transport::sc_frame::{
@@ -866,6 +770,10 @@ mod tests {
 #[cfg(test)]
 #[path = "layer_delivery_tests.rs"]
 mod delivery_tests;
+
+#[cfg(test)]
+#[path = "layer_admission_tests.rs"]
+mod admission_tests;
 
 #[cfg(test)]
 #[path = "layer_sc_data_options_tests.rs"]

--- a/crates/bacnet-network/src/layer_admission.rs
+++ b/crates/bacnet-network/src/layer_admission.rs
@@ -1,0 +1,355 @@
+use super::*;
+use bacnet_encoding::npdu::decode_npdu;
+use std::sync::Mutex;
+use std::task::Poll;
+use tokio::sync::mpsc;
+use tracing::{debug, warn};
+
+const QUEUE_CAPACITY: usize = 256;
+
+/// A consistent, count-only snapshot of one NetworkLayer receive queue.
+///
+/// Counters belong to one receiver, not to a source MAC or to the entire layer.
+/// Separate APDU/control snapshots are not an atomic snapshot of both queues.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct QueueAdmissionSnapshot {
+    /// Items currently queued, excluding items already returned to the consumer.
+    pub current_depth: usize,
+    /// Greatest queued depth since this receiver was created (at most 256).
+    pub high_water: usize,
+    /// Arriving items dropped because the queue was full; saturates at `u64::MAX`.
+    pub full_drops: u64,
+    /// Arriving items dropped because the receiver was closed; saturates at `u64::MAX`.
+    ///
+    /// The first such APDU ends dispatch; the first such control disables that
+    /// stream. Later discarded controls are not queue-admission attempts.
+    /// Dropping already queued items with the receiver is not an admission drop.
+    pub closed_drops: u64,
+}
+
+/// Cloneable snapshot handle obtained from an [`AdmissionReceiver`].
+///
+/// This handle keeps only counters alive, not the channel or dispatch task.
+/// It remains readable after the receiver or NetworkLayer is dropped. Dropping
+/// the receiver sets depth to zero; closing it preserves depth until drained.
+#[derive(Debug, Clone, Default)]
+pub struct QueueAdmissionCounters(Arc<Mutex<QueueAdmissionSnapshot>>);
+
+impl QueueAdmissionCounters {
+    /// Read this queue's depth, high-water mark, and admission-drop totals.
+    pub fn snapshot(&self) -> QueueAdmissionSnapshot {
+        *self.0.lock().expect("queue admission counters poisoned")
+    }
+}
+
+/// Opt-in, one-consumer receiver with exact queue-depth accounting.
+///
+/// Created by [`NetworkLayer::start_with_admission`] or
+/// [`NetworkLayer::enable_network_control_receiver_with_admission`]. The queue
+/// holds 256 items; full admission drops the arriving item, never an older one.
+/// APDU and control queues have independent capacities and counters. Neither
+/// full queue waits for its consumer or blocks dispatch to the other queue.
+///
+/// This wrapper deliberately does not expose the underlying receiver: all
+/// dequeues must update the snapshot. Use the existing NetworkLayer methods
+/// when a plain `mpsc::Receiver` is required instead.
+#[derive(Debug)]
+pub struct AdmissionReceiver<T> {
+    rx: mpsc::Receiver<T>,
+    counters: QueueAdmissionCounters,
+}
+
+impl<T> AdmissionReceiver<T> {
+    /// Obtain an independently owned snapshot handle for this queue.
+    pub fn counters(&self) -> QueueAdmissionCounters {
+        self.counters.clone()
+    }
+
+    /// Receive the next item, or `None` once closed and drained.
+    ///
+    /// Cancellation safe: dropping a pending receive does not remove an item
+    /// or alter its depth. No counter lock is held while waiting.
+    pub async fn recv(&mut self) -> Option<T> {
+        std::future::poll_fn(|cx| {
+            let mut snapshot = self
+                .counters
+                .0
+                .lock()
+                .expect("queue admission counters poisoned");
+            let result = self.rx.poll_recv(cx);
+            if matches!(result, Poll::Ready(Some(_))) {
+                snapshot.current_depth -= 1;
+            }
+            result
+        })
+        .await
+    }
+
+    /// Receive immediately, distinguishing an empty queue from a closed one.
+    pub fn try_recv(&mut self) -> Result<T, mpsc::error::TryRecvError> {
+        let mut snapshot = self
+            .counters
+            .0
+            .lock()
+            .expect("queue admission counters poisoned");
+        let result = self.rx.try_recv();
+        if result.is_ok() {
+            snapshot.current_depth -= 1;
+        }
+        result
+    }
+
+    /// Stop admission while retaining already queued items for draining.
+    ///
+    /// The next arriving APDU ends dispatch, or the next control disables its
+    /// stream, exactly as closing the corresponding legacy receiver does.
+    pub fn close(&mut self) {
+        let _snapshot = self
+            .counters
+            .0
+            .lock()
+            .expect("queue admission counters poisoned");
+        self.rx.close();
+    }
+}
+
+impl<T> Drop for AdmissionReceiver<T> {
+    fn drop(&mut self) {
+        let mut snapshot = self
+            .counters
+            .0
+            .lock()
+            .expect("queue admission counters poisoned");
+        self.rx.close();
+        snapshot.current_depth = 0;
+        // The receiver's queued items (including reply senders) drop after
+        // this guard is released. Closing first prevents concurrent admission.
+    }
+}
+
+pub(super) struct AdmissionSender<T> {
+    tx: mpsc::Sender<T>,
+    counters: QueueAdmissionCounters,
+    // Legacy receivers dequeue outside this module, so only opt-in receivers
+    // expose depth/high-water accounting. Admission drops are counted in both.
+    track_depth: bool,
+}
+
+impl<T> AdmissionSender<T> {
+    fn channel(track_depth: bool) -> (Self, mpsc::Receiver<T>) {
+        let (tx, rx) = mpsc::channel(QUEUE_CAPACITY);
+        (
+            Self {
+                tx,
+                counters: QueueAdmissionCounters::default(),
+                track_depth,
+            },
+            rx,
+        )
+    }
+
+    fn try_send(&self, item: T) -> Result<(), mpsc::error::TrySendError<T>> {
+        // Serialize the admission and dequeue accounting, not asynchronous
+        // waiting. Each queue has its own short critical section; counters do
+        // not govern admission and no lock survives a poll/try operation.
+        let mut snapshot = self
+            .counters
+            .0
+            .lock()
+            .expect("queue admission counters poisoned");
+        let result = self.tx.try_send(item);
+        match &result {
+            Ok(()) if self.track_depth => {
+                snapshot.current_depth += 1;
+                snapshot.high_water = snapshot.high_water.max(snapshot.current_depth);
+            }
+            Ok(()) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                snapshot.full_drops = snapshot.full_drops.saturating_add(1);
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                snapshot.closed_drops = snapshot.closed_drops.saturating_add(1);
+            }
+        }
+        result
+    }
+}
+
+impl<T: TransportPort + 'static> NetworkLayer<T> {
+    /// Enable the one-consumer decoded network-control stream.
+    ///
+    /// This must be called before [`Self::start`] and at most once. Dropping
+    /// the returned receiver disables control delivery without affecting APDU
+    /// ingress. The queue holds 256 items and drops the arriving control when
+    /// full. Use [`Self::enable_network_control_receiver_with_admission`] to
+    /// observe admission counters alongside receive operations.
+    pub fn enable_network_control_receiver(
+        &mut self,
+    ) -> Result<mpsc::Receiver<ReceivedNetworkControl>, Error> {
+        self.enable_network_control(false).map(|(rx, _)| rx)
+    }
+
+    /// Enable the control stream with queue-admission snapshots.
+    ///
+    /// This has the same before-start, one-consumer contract and errors as
+    /// [`Self::enable_network_control_receiver`]; the two methods are alternatives.
+    /// Controls discarded without opting into either stream are not admission
+    /// drops. Ingress sequencing still advances before every attempted control
+    /// admission, including Full and Closed drops.
+    pub fn enable_network_control_receiver_with_admission(
+        &mut self,
+    ) -> Result<AdmissionReceiver<ReceivedNetworkControl>, Error> {
+        let (rx, counters) = self.enable_network_control(true)?;
+        Ok(AdmissionReceiver { rx, counters })
+    }
+
+    fn enable_network_control(
+        &mut self,
+        track_depth: bool,
+    ) -> Result<
+        (
+            mpsc::Receiver<ReceivedNetworkControl>,
+            QueueAdmissionCounters,
+        ),
+        Error,
+    > {
+        if self.dispatch_task.is_some() {
+            return Err(Error::Encoding(
+                "network-control receiver must be enabled before NetworkLayer::start".into(),
+            ));
+        }
+        if self.network_control_tx.is_some() {
+            return Err(Error::Encoding(
+                "network-control receiver is already enabled".into(),
+            ));
+        }
+        let (tx, rx) = AdmissionSender::channel(track_depth);
+        let counters = tx.counters.clone();
+        self.network_control_tx = Some(tx);
+        Ok((rx, counters))
+    }
+
+    /// Start the network layer. Returns a receiver for incoming APDUs.
+    ///
+    /// This starts the underlying transport and spawns a dispatch task that
+    /// decodes incoming NPDUs and extracts APDUs. The queue holds 256 items;
+    /// full admission drops the arriving APDU and its owned reply channel and
+    /// metadata without blocking control delivery. A closed APDU receiver ends
+    /// dispatch on the next APDU admission attempt.
+    /// Use [`Self::start_with_admission`] to observe queue-admission snapshots.
+    pub async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedApdu>, Error> {
+        self.start_dispatch(false).await.map(|(rx, _)| rx)
+    }
+
+    /// Start with an APDU receiver that also exposes admission snapshots.
+    ///
+    /// This is an alternative to [`Self::start`], with the same transport and
+    /// dispatch lifecycle. Stopping the layer closes admission but leaves
+    /// queued items available to drain. Dropping the receiver discards those
+    /// items and releases their reply channels without sending reply bytes.
+    ///
+    /// ```no_run
+    /// # async fn example() -> Result<(), bacnet_types::error::Error> {
+    /// use bacnet_network::layer::NetworkLayer;
+    /// use bacnet_transport::loopback::LoopbackTransport;
+    /// let (transport, _peer) = LoopbackTransport::pair(vec![1], vec![2]);
+    /// let mut network = NetworkLayer::new(transport);
+    /// let mut controls = network.enable_network_control_receiver_with_admission()?;
+    /// let mut apdus = network.start_with_admission().await?;
+    /// let apdu_counters = apdus.counters();
+    /// let control_counters = controls.counters();
+    /// tokio::select! {
+    ///     _ = apdus.recv() => {},
+    ///     _ = controls.recv() => {},
+    /// }
+    /// let _snapshots = (apdu_counters.snapshot(), control_counters.snapshot());
+    /// network.stop().await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn start_with_admission(&mut self) -> Result<AdmissionReceiver<ReceivedApdu>, Error> {
+        let (rx, counters) = self.start_dispatch(true).await?;
+        Ok(AdmissionReceiver { rx, counters })
+    }
+
+    async fn start_dispatch(
+        &mut self,
+        track_depth: bool,
+    ) -> Result<(mpsc::Receiver<ReceivedApdu>, QueueAdmissionCounters), Error> {
+        let mut npdu_rx = self.transport.start().await?;
+        let mut network_control_tx = self.network_control_tx.take();
+        let network_control_ingress_sequence = Arc::clone(&self.network_control_ingress_sequence);
+        let (apdu_tx, apdu_rx) = AdmissionSender::channel(track_depth);
+        let counters = apdu_tx.counters.clone();
+
+        let dispatch_task = tokio::spawn(async move {
+            while let Some(received) = npdu_rx.recv().await {
+                match decode_npdu(received.npdu.clone()) {
+                    Ok(npdu) => {
+                        if npdu.is_network_message {
+                            if let Some(tx) = network_control_tx.as_ref() {
+                                let ingress_sequence = next_ingress_sequence(
+                                    network_control_ingress_sequence.as_ref(),
+                                );
+                                let control = ReceivedNetworkControl {
+                                    npdu,
+                                    source_mac: received.source_mac,
+                                    link_layer_group: received.link_layer_group,
+                                    data_attributes: received.data_attributes,
+                                    ingress_sequence,
+                                };
+                                match tx.try_send(control) {
+                                    Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
+                                    Err(mpsc::error::TrySendError::Closed(_)) => {
+                                        network_control_tx = None;
+                                        debug!("Network-control receiver closed; resuming discard behavior");
+                                    }
+                                }
+                            } else {
+                                debug!(
+                                    message_type = npdu.message_type,
+                                    "Ignoring network layer message (non-router mode)"
+                                );
+                            }
+                            continue;
+                        }
+
+                        // Non-routing node: discard messages with a specific DNET.
+                        if let Some(ref dest) = npdu.destination {
+                            if dest.network != 0xFFFF {
+                                debug!(
+                                    dnet = dest.network,
+                                    "Discarding routed message (non-router)"
+                                );
+                                continue;
+                            }
+                        }
+
+                        let source_network = npdu.source.clone();
+                        let is_group =
+                            is_group_delivery(received.link_layer_group, npdu.destination.as_ref());
+                        let apdu = ReceivedApdu {
+                            apdu: npdu.payload,
+                            source_mac: received.source_mac,
+                            source_network,
+                            link_layer_group: received.link_layer_group,
+                            is_group,
+                            data_attributes: received.data_attributes,
+                            reply_tx: received.reply_tx,
+                        };
+
+                        match apdu_tx.try_send(apdu) {
+                            Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
+                            Err(mpsc::error::TrySendError::Closed(_)) => break,
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "Failed to decode NPDU");
+                    }
+                }
+            }
+        });
+
+        self.dispatch_task = Some(dispatch_task);
+        Ok((apdu_rx, counters))
+    }
+}

--- a/crates/bacnet-network/src/layer_admission_tests.rs
+++ b/crates/bacnet-network/src/layer_admission_tests.rs
@@ -1,0 +1,559 @@
+use super::*;
+use bacnet_transport::port::ReceivedNpdu;
+use tokio::sync::mpsc;
+use tokio::time::{timeout, Duration};
+
+// Injection retains real ReceivedNpdu ownership, including the non-cloneable
+// reply sender. No socket, wall clock, or additional dispatch task is involved.
+struct IngressTransport {
+    incoming: Option<mpsc::Receiver<ReceivedNpdu>>,
+    outgoing: mpsc::Sender<Bytes>,
+}
+
+impl TransportPort for IngressTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        self.incoming
+            .take()
+            .ok_or_else(|| Error::Encoding("already started".into()))
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        self.outgoing
+            .try_send(Bytes::copy_from_slice(npdu))
+            .map_err(|_| Error::Encoding("outgoing queue unavailable".into()))
+    }
+
+    async fn send_broadcast(&self, npdu: &[u8]) -> Result<(), Error> {
+        self.send_unicast(npdu, &[]).await
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &[1]
+    }
+}
+
+fn fixture() -> (
+    NetworkLayer<IngressTransport>,
+    mpsc::Sender<ReceivedNpdu>,
+    mpsc::Receiver<Bytes>,
+) {
+    // Only the test's injected transport backlog is larger; production receive
+    // capacities remain 256. This can hold both saturated queues plus barriers.
+    let (tx, rx) = mpsc::channel(1024);
+    let (outgoing, wire) = mpsc::channel(8);
+    (
+        NetworkLayer::new(IngressTransport {
+            incoming: Some(rx),
+            outgoing,
+        }),
+        tx,
+        wire,
+    )
+}
+
+fn incoming(control: bool, id: u16) -> ReceivedNpdu {
+    let payload = if control {
+        vec![4, (id >> 8) as u8, id as u8]
+    } else {
+        id.to_be_bytes().to_vec()
+    };
+    let npdu = Npdu {
+        is_network_message: control,
+        message_type: control.then_some(3),
+        expecting_reply: !control,
+        source: Some(NpduAddress {
+            network: 200,
+            mac_address: MacAddr::from_slice(&[0x55]),
+        }),
+        payload: Bytes::from(payload),
+        ..Npdu::default()
+    };
+    let mut bytes = BytesMut::new();
+    encode_npdu(&mut bytes, &npdu).unwrap();
+    ReceivedNpdu {
+        npdu: bytes.freeze(),
+        source_mac: MacAddr::from_slice(&[2]),
+        link_layer_group: true,
+        data_attributes: vec![DataAttribute {
+            option_type: 31,
+            must_understand: false,
+            data: vec![0x12, 0x34],
+        }],
+        reply_tx: None,
+    }
+}
+
+fn assert_apdu(apdu: &ReceivedApdu, id: u16) {
+    let expected = incoming(false, id);
+    assert_eq!(apdu.apdu.as_ref(), id.to_be_bytes());
+    assert_eq!(apdu.source_mac, expected.source_mac);
+    assert_eq!(
+        apdu.source_network,
+        Some(NpduAddress {
+            network: 200,
+            mac_address: MacAddr::from_slice(&[0x55]),
+        })
+    );
+    assert!(apdu.link_layer_group);
+    assert!(apdu.is_group);
+    assert_eq!(apdu.data_attributes, expected.data_attributes);
+}
+
+fn assert_control(control: &ReceivedNetworkControl, id: u16, sequence: u64) {
+    let expected = incoming(true, id);
+    let mut bytes = BytesMut::new();
+    encode_npdu(&mut bytes, &control.npdu).unwrap();
+    assert_eq!(bytes.freeze(), expected.npdu);
+    assert_eq!(control.source_mac, expected.source_mac);
+    assert_eq!(control.link_layer_group, expected.link_layer_group);
+    assert_eq!(control.data_attributes, expected.data_attributes);
+    assert_eq!(control.ingress_sequence, sequence);
+}
+
+async fn receive<T>(rx: &mut AdmissionReceiver<T>) -> T {
+    timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("dispatch stalled")
+        .expect("receiver closed unexpectedly")
+}
+
+#[tokio::test(start_paused = true)]
+async fn full_apdu_queue_drops_arrival_releases_reply_and_allows_control_progress() {
+    let (mut network, tx, mut wire) = fixture();
+    let mut controls = network
+        .enable_network_control_receiver_with_admission()
+        .unwrap();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    let (reply_tx, mut accepted_reply) = oneshot::channel();
+    let mut first = incoming(false, 0);
+    first.reply_tx = Some(reply_tx);
+    tx.send(first).await.unwrap();
+    for id in 1..256 {
+        tx.send(incoming(false, id)).await.unwrap();
+    }
+    let (reply_tx, rejected_reply) = oneshot::channel();
+    let mut overflow = incoming(false, 256);
+    overflow.reply_tx = Some(reply_tx);
+    tx.send(overflow).await.unwrap();
+    tx.send(incoming(true, 42)).await.unwrap();
+
+    // Receiving the later control is a FIFO ingress barrier, without consuming
+    // any APDU. The 257th APDU must already have been dropped, not deferred.
+    assert_control(&receive(&mut controls).await, 42, 1);
+    assert_eq!(
+        counters.snapshot(),
+        QueueAdmissionSnapshot {
+            current_depth: 256,
+            high_water: 256,
+            full_drops: 1,
+            closed_drops: 0,
+        }
+    );
+    assert!(timeout(Duration::from_secs(1), rejected_reply)
+        .await
+        .unwrap()
+        .is_err());
+    assert_eq!(
+        accepted_reply.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    );
+
+    let first = apdus.try_recv().unwrap();
+    assert_apdu(&first, 0);
+    first
+        .reply_tx
+        .unwrap()
+        .send(Bytes::from_static(b"reply"))
+        .unwrap();
+    assert_eq!(accepted_reply.await.unwrap(), Bytes::from_static(b"reply"));
+    for id in 1..256 {
+        assert_apdu(&apdus.try_recv().unwrap(), id);
+    }
+    assert!(matches!(
+        apdus.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    assert_eq!(counters.snapshot().current_depth, 0);
+    assert_eq!(counters.snapshot().high_water, 256);
+
+    tx.send(incoming(false, 257)).await.unwrap();
+    assert_apdu(&receive(&mut apdus).await, 257);
+    assert_eq!(counters.snapshot().full_drops, 1);
+    assert_eq!(controls.counters().snapshot().full_drops, 0);
+    assert!(matches!(
+        wire.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn full_control_queue_drops_arrival_and_allows_apdu_progress() {
+    let (mut network, tx, mut wire) = fixture();
+    let mut controls = network
+        .enable_network_control_receiver_with_admission()
+        .unwrap();
+    let counters = controls.counters();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    for id in 0..257 {
+        tx.send(incoming(true, id)).await.unwrap();
+    }
+    tx.send(incoming(false, 42)).await.unwrap();
+    assert_apdu(&receive(&mut apdus).await, 42);
+    assert_eq!(network.network_control_ingress_sequence(), 257);
+    assert_eq!(
+        counters.snapshot(),
+        QueueAdmissionSnapshot {
+            current_depth: 256,
+            high_water: 256,
+            full_drops: 1,
+            closed_drops: 0,
+        }
+    );
+    for id in 0..256 {
+        assert_control(&controls.try_recv().unwrap(), id, u64::from(id) + 1);
+    }
+    assert!(matches!(
+        controls.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    tx.send(incoming(true, 257)).await.unwrap();
+    assert_control(&receive(&mut controls).await, 257, 258);
+    assert_eq!(counters.snapshot().current_depth, 0);
+    assert_eq!(counters.snapshot().high_water, 256);
+    assert_eq!(counters.snapshot().full_drops, 1);
+    assert_eq!(apdus.counters().snapshot().full_drops, 0);
+    assert!(matches!(
+        wire.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn closed_control_stream_counts_once_then_resumes_discard_with_legacy_apdus() {
+    let (mut network, tx, mut wire) = fixture();
+    let controls = network
+        .enable_network_control_receiver_with_admission()
+        .unwrap();
+    let counters = controls.counters();
+    let mut apdus: mpsc::Receiver<ReceivedApdu> = network.start().await.unwrap();
+    drop(controls);
+    for id in 0..3 {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let mut control = incoming(true, id);
+        control.reply_tx = Some(reply_tx);
+        tx.send(control).await.unwrap();
+        assert!(timeout(Duration::from_secs(1), reply_rx)
+            .await
+            .unwrap()
+            .is_err());
+    }
+    tx.send(incoming(false, 42)).await.unwrap();
+    let apdu = timeout(Duration::from_secs(1), apdus.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_apdu(&apdu, 42);
+    assert_eq!(network.network_control_ingress_sequence(), 1);
+    assert_eq!(
+        counters.snapshot(),
+        QueueAdmissionSnapshot {
+            closed_drops: 1,
+            ..Default::default()
+        }
+    );
+    assert!(matches!(
+        wire.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn closed_apdu_receiver_releases_reply_and_ends_dispatch_with_legacy_controls() {
+    let (mut network, tx, mut wire) = fixture();
+    let mut controls: mpsc::Receiver<ReceivedNetworkControl> =
+        network.enable_network_control_receiver().unwrap();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    apdus.close();
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let mut apdu = incoming(false, 42);
+    apdu.reply_tx = Some(reply_tx);
+    tx.send(apdu).await.unwrap();
+    tx.send(incoming(true, 42)).await.unwrap();
+
+    assert!(timeout(Duration::from_secs(1), reply_rx)
+        .await
+        .unwrap()
+        .is_err());
+    assert!(timeout(Duration::from_secs(1), controls.recv())
+        .await
+        .unwrap()
+        .is_none());
+    timeout(Duration::from_secs(1), tx.closed()).await.unwrap();
+    assert_eq!(network.network_control_ingress_sequence(), 0);
+    assert_eq!(
+        counters.snapshot(),
+        QueueAdmissionSnapshot {
+            closed_drops: 1,
+            ..Default::default()
+        }
+    );
+    assert!(matches!(
+        wire.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn no_control_opt_in_discards_without_sequence_reply_or_apdu_changes() {
+    let (mut network, tx, mut wire) = fixture();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    for id in 0..257 {
+        tx.send(incoming(true, id)).await.unwrap();
+    }
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let mut control = incoming(true, 257);
+    control.reply_tx = Some(reply_tx);
+    tx.send(control).await.unwrap();
+    tx.send(incoming(false, 42)).await.unwrap();
+    assert_apdu(&receive(&mut apdus).await, 42);
+    assert!(reply_rx.await.is_err());
+    assert_eq!(network.network_control_ingress_sequence(), 0);
+    assert_eq!(
+        apdus.counters().snapshot(),
+        QueueAdmissionSnapshot {
+            high_water: 1,
+            ..Default::default()
+        }
+    );
+    assert!(matches!(
+        apdus.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    assert!(matches!(
+        wire.try_recv(),
+        Err(mpsc::error::TryRecvError::Empty)
+    ));
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn stop_with_both_queues_full_is_bounded_and_preserves_drain_and_drop_accounting() {
+    let (mut network, tx, _wire) = fixture();
+    let mut controls = network
+        .enable_network_control_receiver_with_admission()
+        .unwrap();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let apdu_counters = apdus.counters();
+    let control_counters = controls.counters();
+    let (reply_tx, mut queued_reply) = oneshot::channel();
+    let mut first = incoming(false, 0);
+    first.reply_tx = Some(reply_tx);
+    tx.send(first).await.unwrap();
+    for id in 1..256 {
+        tx.send(incoming(false, id)).await.unwrap();
+    }
+    for id in 0..256 {
+        tx.send(incoming(true, id)).await.unwrap();
+    }
+    // A control's reply sender is always released at the end of its ingress
+    // iteration. Awaiting the overflow's closure is a barrier with both full.
+    let (reply_tx, barrier) = oneshot::channel();
+    let mut overflow = incoming(true, 256);
+    overflow.reply_tx = Some(reply_tx);
+    tx.send(overflow).await.unwrap();
+    assert!(timeout(Duration::from_secs(1), barrier)
+        .await
+        .unwrap()
+        .is_err());
+    assert_eq!(apdu_counters.snapshot().current_depth, 256);
+    assert_eq!(control_counters.snapshot().current_depth, 256);
+    timeout(Duration::from_secs(1), network.stop())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(tx.is_closed());
+    assert_eq!(
+        queued_reply.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    );
+    assert_eq!(apdu_counters.snapshot().current_depth, 256);
+
+    assert_apdu(&receive(&mut apdus).await, 0);
+    assert!(queued_reply.await.is_err());
+    for id in 0..256 {
+        assert_control(&receive(&mut controls).await, id, u64::from(id) + 1);
+    }
+    assert!(controls.recv().await.is_none());
+    assert_eq!(control_counters.snapshot().current_depth, 0);
+    assert_eq!(apdu_counters.snapshot().current_depth, 255);
+    drop(apdus);
+    assert_eq!(
+        apdu_counters.snapshot(),
+        QueueAdmissionSnapshot {
+            high_water: 256,
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        control_counters.snapshot(),
+        QueueAdmissionSnapshot {
+            high_water: 256,
+            full_drops: 1,
+            ..Default::default()
+        }
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn cancelled_receive_does_not_consume_or_change_counters() {
+    let (mut network, tx, _wire) = fixture();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    assert!(timeout(Duration::from_secs(1), apdus.recv()).await.is_err());
+    assert_eq!(counters.snapshot(), QueueAdmissionSnapshot::default());
+    tx.send(incoming(false, 42)).await.unwrap();
+    assert_apdu(&receive(&mut apdus).await, 42);
+    assert_eq!(
+        counters.snapshot(),
+        QueueAdmissionSnapshot {
+            high_water: 1,
+            ..Default::default()
+        }
+    );
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn legacy_receivers_also_drop_new_items_without_cross_queue_stalls() {
+    let (mut network, tx, _wire) = fixture();
+    let mut controls: mpsc::Receiver<ReceivedNetworkControl> =
+        network.enable_network_control_receiver().unwrap();
+    let mut apdus: mpsc::Receiver<ReceivedApdu> = network.start().await.unwrap();
+    for id in 0..257 {
+        tx.send(incoming(false, id)).await.unwrap();
+    }
+    tx.send(incoming(true, 42)).await.unwrap();
+    let control = timeout(Duration::from_secs(1), controls.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_control(&control, 42, 1);
+    assert_eq!(apdus.len(), 256);
+    for id in 0..256 {
+        assert_apdu(&apdus.try_recv().unwrap(), id);
+    }
+    for id in 0..257 {
+        tx.send(incoming(true, id)).await.unwrap();
+    }
+    tx.send(incoming(false, 42)).await.unwrap();
+    let apdu = timeout(Duration::from_secs(1), apdus.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_apdu(&apdu, 42);
+    assert_eq!(controls.len(), 256);
+    for id in 0..256 {
+        assert_control(&controls.try_recv().unwrap(), id, u64::from(id) + 2);
+    }
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn admission_opt_in_preserves_control_enable_guards() {
+    let (mut network, _tx, _wire) = fixture();
+    let _controls = network
+        .enable_network_control_receiver_with_admission()
+        .unwrap();
+    assert_eq!(
+        network
+            .enable_network_control_receiver()
+            .unwrap_err()
+            .to_string(),
+        "encoding error: network-control receiver is already enabled"
+    );
+    assert_eq!(
+        network
+            .enable_network_control_receiver_with_admission()
+            .unwrap_err()
+            .to_string(),
+        "encoding error: network-control receiver is already enabled"
+    );
+    let _apdus = network.start_with_admission().await.unwrap();
+    assert_eq!(
+        network
+            .enable_network_control_receiver_with_admission()
+            .unwrap_err()
+            .to_string(),
+        "encoding error: network-control receiver must be enabled before NetworkLayer::start"
+    );
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn closing_full_receivers_preserves_depth_until_drained_and_counts_closed_not_full() {
+    let (mut network, tx, _wire) = fixture();
+    let mut controls = network
+        .enable_network_control_receiver_with_admission()
+        .unwrap();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let apdu_counters = apdus.counters();
+    let control_counters = controls.counters();
+    for id in 0..256 {
+        tx.send(incoming(true, id)).await.unwrap();
+    }
+    tx.send(incoming(false, 0)).await.unwrap();
+    assert_apdu(&receive(&mut apdus).await, 0);
+    controls.close();
+    assert_eq!(control_counters.snapshot().current_depth, 256);
+    tx.send(incoming(true, 256)).await.unwrap();
+    tx.send(incoming(false, 0)).await.unwrap();
+    assert_apdu(&receive(&mut apdus).await, 0);
+    assert_eq!(control_counters.snapshot().closed_drops, 1);
+    assert_eq!(control_counters.snapshot().full_drops, 0);
+    assert_eq!(network.network_control_ingress_sequence(), 257);
+
+    let (reply_tx, queued_reply) = oneshot::channel();
+    let mut first = incoming(false, 0);
+    first.reply_tx = Some(reply_tx);
+    tx.send(first).await.unwrap();
+    for id in 1..256 {
+        tx.send(incoming(false, id)).await.unwrap();
+    }
+    // Controls now use the discard path; closure of this reply is a barrier.
+    let (reply_tx, barrier) = oneshot::channel();
+    let mut control = incoming(true, 257);
+    control.reply_tx = Some(reply_tx);
+    tx.send(control).await.unwrap();
+    assert!(timeout(Duration::from_secs(1), barrier)
+        .await
+        .unwrap()
+        .is_err());
+    apdus.close();
+    assert_eq!(apdu_counters.snapshot().current_depth, 256);
+    tx.send(incoming(false, 256)).await.unwrap();
+    timeout(Duration::from_secs(1), tx.closed()).await.unwrap();
+    assert_eq!(apdu_counters.snapshot().closed_drops, 1);
+    assert_eq!(apdu_counters.snapshot().full_drops, 0);
+    assert_eq!(apdu_counters.snapshot().current_depth, 256);
+    assert_eq!(control_counters.snapshot().closed_drops, 1);
+    assert_eq!(network.network_control_ingress_sequence(), 257);
+    for id in 0..256 {
+        assert_control(&receive(&mut controls).await, id, u64::from(id) + 1);
+    }
+    assert!(controls.recv().await.is_none());
+    drop(apdus);
+    assert!(queued_reply.await.is_err());
+    assert_eq!(apdu_counters.snapshot().current_depth, 0);
+    assert_eq!(apdu_counters.snapshot().high_water, 256);
+    network.stop().await.unwrap();
+}


### PR DESCRIPTION
#532 slice 1 of 5: NetworkLayer APDU and opted-in control queues move from awaiting sends to drop-arriving admission (256 retained) with per-queue snapshot counters (depth, high-water, Full vs Closed drops). New additive start_with_admission / enable_network_control_receiver_with_admission; existing receiver signatures and Closed/no-opt-in behavior unchanged. Dropped APDUs release payload, metadata, and reply channels per the Closed-path ownership model. No wire rejection or NAK.

Validation: fmt/clippy/size/secrets PASS; 10 new admission regressions; full bacnet-network 83+1 and FULL conformance_ledger 27/27 PASS. Exact-head CI to follow.

Refs #532 (stays OPEN for slices 2-5: router local admission, fairness/quotas, multi-port fairness, public-contract consolidation). Excludes priority_channel integration, events/callbacks, configurable capacities, byte quotas, #522/#524/#518/#526, website/CI/README.