### PR TITLE
fix(network): cap tracked APDU ingress per source MAC (#532)

### DIFF
--- a/crates/bacnet-network/src/layer_admission.rs
+++ b/crates/bacnet-network/src/layer_admission.rs
@@ -1,11 +1,13 @@
 use super::*;
 use bacnet_encoding::npdu::decode_npdu;
+use std::collections::HashMap;
 use std::sync::Mutex;
 use std::task::Poll;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
 const QUEUE_CAPACITY: usize = 256;
+const APDU_SOURCE_CAPACITY: usize = 16;
 
 /// A consistent, count-only snapshot of one network-layer receive queue.
 ///
@@ -20,6 +22,11 @@ pub struct QueueAdmissionSnapshot {
     pub high_water: usize,
     /// Arriving items dropped because the queue was full; saturates at `u64::MAX`.
     pub full_drops: u64,
+    /// Arriving APDUs dropped by NetworkLayer's per-source-MAC quota of 16;
+    /// saturates at `u64::MAX`. Evaluated before global Full, even when the queue
+    /// has room. Closed admission retains precedence. Always zero for control
+    /// and router-local queues, which have no per-source quota.
+    pub fairness_drops: u64,
     /// Arriving items dropped because the receiver was closed; saturates at `u64::MAX`.
     ///
     /// In NetworkLayer, the first such APDU ends dispatch; the first such control
@@ -31,16 +38,58 @@ pub struct QueueAdmissionSnapshot {
 
 /// Cloneable snapshot handle obtained from an [`AdmissionReceiver`].
 ///
-/// This handle keeps only counters alive, not the channel or dispatch task.
+/// This handle keeps only accounting alive, not payloads, the channel or dispatch task.
 /// It remains readable after the receiver, layer, or router is dropped. Dropping
 /// the receiver sets depth to zero; closing it preserves depth until drained.
 #[derive(Debug, Clone, Default)]
-pub struct QueueAdmissionCounters(Arc<Mutex<QueueAdmissionSnapshot>>);
+pub struct QueueAdmissionCounters(Arc<Mutex<QueueAdmissionState>>);
+
+#[derive(Debug, Default)]
+struct QueueAdmissionState {
+    snapshot: QueueAdmissionSnapshot,
+    // Used only by NetworkLayer's tracked APDU queue. Insert after successful
+    // admission, remove on the last dequeue: live entries <= depth <= 256.
+    // NetworkLayer owns one transport, so a separate port key is unnecessary.
+    queued_by_source: HashMap<MacAddr, usize>,
+}
+
+impl QueueAdmissionState {
+    fn dequeued(&mut self, source: Option<&MacAddr>) {
+        self.snapshot.current_depth -= 1;
+        if let Some(source) = source {
+            let count = self
+                .queued_by_source
+                .get_mut(source)
+                .expect("queued APDU source must be accounted");
+            *count -= 1;
+            if *count == 0 {
+                self.queued_by_source.remove(source);
+            }
+            self.assert_source_depth();
+        }
+    }
+
+    fn assert_source_depth(&self) {
+        debug_assert!(self.queued_by_source.len() <= self.snapshot.current_depth);
+        debug_assert!(self.snapshot.current_depth <= QUEUE_CAPACITY);
+        debug_assert_eq!(
+            self.queued_by_source.values().sum::<usize>(),
+            self.snapshot.current_depth
+        );
+        debug_assert!(self
+            .queued_by_source
+            .values()
+            .all(|count| (1..=APDU_SOURCE_CAPACITY).contains(count)));
+    }
+}
 
 impl QueueAdmissionCounters {
     /// Read this queue's depth, high-water mark, and admission-drop totals.
     pub fn snapshot(&self) -> QueueAdmissionSnapshot {
-        *self.0.lock().expect("queue admission counters poisoned")
+        self.0
+            .lock()
+            .expect("queue admission counters poisoned")
+            .snapshot
     }
 }
 
@@ -60,6 +109,9 @@ impl QueueAdmissionCounters {
 pub struct AdmissionReceiver<T> {
     rx: mpsc::Receiver<T>,
     counters: QueueAdmissionCounters,
+    // Only NetworkLayer's tracked APDU constructor installs source accounting.
+    // No public trait bound or change to router/control item types is needed.
+    source_mac: Option<fn(&T) -> &MacAddr>,
 }
 
 impl<T> AdmissionReceiver<T> {
@@ -78,7 +130,11 @@ impl<T> AdmissionReceiver<T> {
     }
 
     pub(crate) fn from_parts(rx: mpsc::Receiver<T>, counters: QueueAdmissionCounters) -> Self {
-        Self { rx, counters }
+        Self {
+            rx,
+            counters,
+            source_mac: None,
+        }
     }
 
     /// Obtain an independently owned snapshot handle for this queue.
@@ -92,14 +148,14 @@ impl<T> AdmissionReceiver<T> {
     /// or alter its depth. No counter lock is held while waiting.
     pub async fn recv(&mut self) -> Option<T> {
         std::future::poll_fn(|cx| {
-            let mut snapshot = self
+            let mut state = self
                 .counters
                 .0
                 .lock()
                 .expect("queue admission counters poisoned");
             let result = self.rx.poll_recv(cx);
-            if matches!(result, Poll::Ready(Some(_))) {
-                snapshot.current_depth -= 1;
+            if let Poll::Ready(Some(item)) = &result {
+                state.dequeued(self.source_mac.map(|source_mac| source_mac(item)));
             }
             result
         })
@@ -108,14 +164,14 @@ impl<T> AdmissionReceiver<T> {
 
     /// Receive immediately, distinguishing an empty queue from a closed one.
     pub fn try_recv(&mut self) -> Result<T, mpsc::error::TryRecvError> {
-        let mut snapshot = self
+        let mut state = self
             .counters
             .0
             .lock()
             .expect("queue admission counters poisoned");
         let result = self.rx.try_recv();
-        if result.is_ok() {
-            snapshot.current_depth -= 1;
+        if let Ok(item) = &result {
+            state.dequeued(self.source_mac.map(|source_mac| source_mac(item)));
         }
         result
     }
@@ -137,13 +193,14 @@ impl<T> AdmissionReceiver<T> {
 
 impl<T> Drop for AdmissionReceiver<T> {
     fn drop(&mut self) {
-        let mut snapshot = self
+        let mut state = self
             .counters
             .0
             .lock()
             .expect("queue admission counters poisoned");
         self.rx.close();
-        snapshot.current_depth = 0;
+        state.snapshot.current_depth = 0;
+        state.queued_by_source = HashMap::new();
         // The receiver's queued items (including reply senders) drop after
         // this guard is released. Closing first prevents concurrent admission.
     }
@@ -181,26 +238,49 @@ impl<T> AdmissionSender<T> {
     }
 
     pub(crate) fn try_send(&self, item: T) -> Result<(), mpsc::error::TrySendError<T>> {
+        self.try_send_from(item, None)
+    }
+
+    fn try_send_from(
+        &self,
+        item: T,
+        source: Option<MacAddr>,
+    ) -> Result<(), mpsc::error::TrySendError<T>> {
         // Serialize the admission and dequeue accounting, not asynchronous
-        // waiting. Each queue has its own short critical section; counters do
-        // not govern admission and no lock survives a poll/try operation.
-        let mut snapshot = self
+        // waiting. Each queue has its own short critical section, and no lock
+        // survives a poll/try operation. Closed keeps its lifecycle semantics;
+        // otherwise a source over quota takes precedence over global Full.
+        let mut state = self
             .counters
             .0
             .lock()
             .expect("queue admission counters poisoned");
+        if !self.tx.is_closed()
+            && source.as_ref().is_some_and(|source| {
+                state.queued_by_source.get(source).copied().unwrap_or(0) >= APDU_SOURCE_CAPACITY
+            })
+        {
+            state.snapshot.fairness_drops = state.snapshot.fairness_drops.saturating_add(1);
+            // Reuse the caller's drop-arriving path, but not its Full counter.
+            return Err(mpsc::error::TrySendError::Full(item));
+        }
         let result = self.tx.try_send(item);
         match &result {
             Ok(()) if self.track_depth => {
-                snapshot.current_depth += 1;
-                snapshot.high_water = snapshot.high_water.max(snapshot.current_depth);
+                state.snapshot.current_depth += 1;
+                state.snapshot.high_water =
+                    state.snapshot.high_water.max(state.snapshot.current_depth);
+                if let Some(source) = source {
+                    *state.queued_by_source.entry(source).or_default() += 1;
+                    state.assert_source_depth();
+                }
             }
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(_)) => {
-                snapshot.full_drops = snapshot.full_drops.saturating_add(1);
+                state.snapshot.full_drops = state.snapshot.full_drops.saturating_add(1);
             }
             Err(mpsc::error::TrySendError::Closed(_)) => {
-                snapshot.closed_drops = snapshot.closed_drops.saturating_add(1);
+                state.snapshot.closed_drops = state.snapshot.closed_drops.saturating_add(1);
             }
         }
         result
@@ -232,7 +312,7 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
         &mut self,
     ) -> Result<AdmissionReceiver<ReceivedNetworkControl>, Error> {
         let (rx, counters) = self.enable_network_control(true)?;
-        Ok(AdmissionReceiver { rx, counters })
+        Ok(AdmissionReceiver::from_parts(rx, counters))
     }
 
     fn enable_network_control(
@@ -268,7 +348,8 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     /// full admission drops the arriving APDU and its owned reply channel and
     /// metadata without blocking control delivery. A closed APDU receiver ends
     /// dispatch on the next APDU admission attempt.
-    /// Use [`Self::start_with_admission`] to observe queue-admission snapshots.
+    /// This legacy raw receiver has no depth tracking or per-source quota.
+    /// Use [`Self::start_with_admission`] for snapshots and per-source fairness.
     pub async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedApdu>, Error> {
         self.start_dispatch(false).await.map(|(rx, _)| rx)
     }
@@ -279,6 +360,15 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     /// dispatch lifecycle. Stopping the layer closes admission but leaves
     /// queued items available to drain. Dropping the receiver discards those
     /// items and releases their reply channels without sending reply bytes.
+    ///
+    /// Unlike the legacy raw receiver, depth tracking caps each source MAC at
+    /// 16 queued, unconsumed APDUs. NetworkLayer owns a single transport, so no
+    /// separate ingress-port key is needed. Sixteen sources at their quota
+    /// exactly fill the unchanged 256-item queue. Dequeuing releases one source
+    /// slot; processing or retaining the returned APDU does not hold that slot.
+    /// Over-quota arrivals are dropped before checking global Full, releasing
+    /// payload, metadata and reply sender without sending bytes or a wire reject.
+    /// Control and router-local queues do not enforce this quota.
     ///
     /// ```no_run
     /// # async fn example() -> Result<(), bacnet_types::error::Error> {
@@ -300,7 +390,11 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     /// ```
     pub async fn start_with_admission(&mut self) -> Result<AdmissionReceiver<ReceivedApdu>, Error> {
         let (rx, counters) = self.start_dispatch(true).await?;
-        Ok(AdmissionReceiver { rx, counters })
+        Ok(AdmissionReceiver {
+            rx,
+            counters,
+            source_mac: Some(|apdu| &apdu.source_mac),
+        })
     }
 
     async fn start_dispatch(
@@ -369,7 +463,10 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
                             reply_tx: received.reply_tx,
                         };
 
-                        match apdu_tx.try_send(apdu) {
+                        // Raw receivers cannot release source counts: legacy
+                        // ingress neither clones keys nor enforces a quota.
+                        let source = track_depth.then(|| apdu.source_mac.clone());
+                        match apdu_tx.try_send_from(apdu, source) {
                             Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
                             Err(mpsc::error::TrySendError::Closed(_)) => break,
                         }
@@ -385,3 +482,7 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
         Ok((apdu_rx, counters))
     }
 }
+
+#[cfg(test)]
+#[path = "layer_fairness_tests.rs"]
+mod fairness_tests;

--- a/crates/bacnet-network/src/layer_admission_tests.rs
+++ b/crates/bacnet-network/src/layer_admission_tests.rs
@@ -88,9 +88,13 @@ fn incoming(control: bool, id: u16) -> ReceivedNpdu {
 }
 
 fn assert_apdu(apdu: &ReceivedApdu, id: u16) {
+    assert_apdu_from(apdu, id, &[2]);
+}
+
+fn assert_apdu_from(apdu: &ReceivedApdu, id: u16, source: &[u8]) {
     let expected = incoming(false, id);
     assert_eq!(apdu.apdu.as_ref(), id.to_be_bytes());
-    assert_eq!(apdu.source_mac, expected.source_mac);
+    assert_eq!(apdu.source_mac.as_slice(), source);
     assert_eq!(
         apdu.source_network,
         Some(NpduAddress {
@@ -101,6 +105,17 @@ fn assert_apdu(apdu: &ReceivedApdu, id: u16) {
     assert!(apdu.link_layer_group);
     assert!(apdu.is_group);
     assert_eq!(apdu.data_attributes, expected.data_attributes);
+}
+
+// Sixteen sources with sixteen queued APDUs each still fill the shared queue.
+fn balanced_incoming(id: u16) -> ReceivedNpdu {
+    let mut arrival = incoming(false, id);
+    arrival.source_mac = MacAddr::from_slice(&[2 + (id / 16) as u8]);
+    arrival
+}
+
+fn assert_balanced_apdu(apdu: &ReceivedApdu, id: u16) {
+    assert_apdu_from(apdu, id, &[2 + (id / 16) as u8]);
 }
 
 fn assert_control(control: &ReceivedNetworkControl, id: u16, sequence: u64) {
@@ -130,14 +145,14 @@ async fn full_apdu_queue_drops_arrival_releases_reply_and_allows_control_progres
     let mut apdus = network.start_with_admission().await.unwrap();
     let counters = apdus.counters();
     let (reply_tx, mut accepted_reply) = oneshot::channel();
-    let mut first = incoming(false, 0);
+    let mut first = balanced_incoming(0);
     first.reply_tx = Some(reply_tx);
     tx.send(first).await.unwrap();
     for id in 1..256 {
-        tx.send(incoming(false, id)).await.unwrap();
+        tx.send(balanced_incoming(id)).await.unwrap();
     }
     let (reply_tx, rejected_reply) = oneshot::channel();
-    let mut overflow = incoming(false, 256);
+    let mut overflow = balanced_incoming(256);
     overflow.reply_tx = Some(reply_tx);
     tx.send(overflow).await.unwrap();
     tx.send(incoming(true, 42)).await.unwrap();
@@ -151,6 +166,7 @@ async fn full_apdu_queue_drops_arrival_releases_reply_and_allows_control_progres
             current_depth: 256,
             high_water: 256,
             full_drops: 1,
+            fairness_drops: 0,
             closed_drops: 0,
         }
     );
@@ -172,7 +188,7 @@ async fn full_apdu_queue_drops_arrival_releases_reply_and_allows_control_progres
         .unwrap();
     assert_eq!(accepted_reply.await.unwrap(), Bytes::from_static(b"reply"));
     for id in 1..256 {
-        assert_apdu(&apdus.try_recv().unwrap(), id);
+        assert_balanced_apdu(&apdus.try_recv().unwrap(), id);
     }
     assert!(matches!(
         apdus.try_recv(),
@@ -212,6 +228,7 @@ async fn full_control_queue_drops_arrival_and_allows_apdu_progress() {
             current_depth: 256,
             high_water: 256,
             full_drops: 1,
+            fairness_drops: 0,
             closed_drops: 0,
         }
     );
@@ -356,11 +373,11 @@ async fn stop_with_both_queues_full_is_bounded_and_preserves_drain_and_drop_acco
     let apdu_counters = apdus.counters();
     let control_counters = controls.counters();
     let (reply_tx, mut queued_reply) = oneshot::channel();
-    let mut first = incoming(false, 0);
+    let mut first = balanced_incoming(0);
     first.reply_tx = Some(reply_tx);
     tx.send(first).await.unwrap();
     for id in 1..256 {
-        tx.send(incoming(false, id)).await.unwrap();
+        tx.send(balanced_incoming(id)).await.unwrap();
     }
     for id in 0..256 {
         tx.send(incoming(true, id)).await.unwrap();
@@ -523,11 +540,11 @@ async fn closing_full_receivers_preserves_depth_until_drained_and_counts_closed_
     assert_eq!(network.network_control_ingress_sequence(), 257);
 
     let (reply_tx, queued_reply) = oneshot::channel();
-    let mut first = incoming(false, 0);
+    let mut first = balanced_incoming(0);
     first.reply_tx = Some(reply_tx);
     tx.send(first).await.unwrap();
     for id in 1..256 {
-        tx.send(incoming(false, id)).await.unwrap();
+        tx.send(balanced_incoming(id)).await.unwrap();
     }
     // Controls now use the discard path; closure of this reply is a barrier.
     let (reply_tx, barrier) = oneshot::channel();

--- a/crates/bacnet-network/src/layer_fairness_tests.rs
+++ b/crates/bacnet-network/src/layer_fairness_tests.rs
@@ -1,0 +1,472 @@
+use super::*;
+use bacnet_transport::port::ReceivedNpdu;
+use tokio::time::{timeout, Duration};
+
+// Same owned-NPDU fake-transport pattern as layer_admission_tests: the real
+// dispatch task receives payload, provenance, attributes and the reply sender.
+struct IngressTransport(Option<mpsc::Receiver<ReceivedNpdu>>);
+
+impl TransportPort for IngressTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        Ok(self.0.take().expect("transport already started"))
+    }
+
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    async fn send_unicast(&self, _npdu: &[u8], _mac: &[u8]) -> Result<(), Error> {
+        panic!("admission must not send wire replies or rejections")
+    }
+
+    async fn send_broadcast(&self, _npdu: &[u8]) -> Result<(), Error> {
+        panic!("admission must not send wire replies or rejections")
+    }
+
+    fn local_mac(&self) -> &[u8] {
+        &[1]
+    }
+}
+
+fn fixture() -> (NetworkLayer<IngressTransport>, mpsc::Sender<ReceivedNpdu>) {
+    let (tx, rx) = mpsc::channel(1024);
+    (NetworkLayer::new(IngressTransport(Some(rx))), tx)
+}
+
+fn incoming(source: &[u8], id: u16) -> ReceivedNpdu {
+    let npdu = Npdu {
+        expecting_reply: true,
+        // Deliberately identical routed source: fairness must use the immediate
+        // transport MAC, not the NPDU SNET/SADR or payload.
+        source: Some(NpduAddress {
+            network: 200,
+            mac_address: MacAddr::from_slice(&[0x55]),
+        }),
+        payload: Bytes::copy_from_slice(&id.to_be_bytes()),
+        ..Npdu::default()
+    };
+    let mut bytes = BytesMut::new();
+    encode_npdu(&mut bytes, &npdu).unwrap();
+    ReceivedNpdu {
+        npdu: bytes.freeze(),
+        source_mac: MacAddr::from_slice(source),
+        link_layer_group: true,
+        data_attributes: vec![DataAttribute {
+            option_type: 31,
+            must_understand: false,
+            data: vec![0x12, 0x34],
+        }],
+        reply_tx: None,
+    }
+}
+
+fn control() -> ReceivedNpdu {
+    let mut arrival = incoming(&[2], 0);
+    // Independent Router-Busy network-message vector.
+    arrival.npdu = Bytes::from_static(&[1, 0x80, 4]);
+    arrival
+}
+
+async fn barrier(tx: &mpsc::Sender<ReceivedNpdu>) {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let mut arrival = control();
+    arrival.reply_tx = Some(reply_tx);
+    tx.send(arrival).await.unwrap();
+    // The control reply is released after all earlier ingress has dispatched,
+    // without consuming any APDU or relying on scheduling sleeps.
+    assert!(timeout(Duration::from_secs(1), reply_rx)
+        .await
+        .expect("dispatch stalled")
+        .is_err());
+}
+
+fn assert_apdu(apdu: &ReceivedApdu, source: &[u8], id: u16) {
+    assert_eq!(apdu.apdu.as_ref(), id.to_be_bytes());
+    assert_eq!(apdu.source_mac.as_slice(), source);
+    assert_eq!(
+        apdu.source_network,
+        Some(NpduAddress {
+            network: 200,
+            mac_address: MacAddr::from_slice(&[0x55]),
+        })
+    );
+    assert!(apdu.link_layer_group);
+    assert!(apdu.is_group);
+    assert_eq!(apdu.data_attributes, incoming(source, id).data_attributes);
+}
+
+fn assert_sources(counters: &QueueAdmissionCounters, entries: usize, depth: usize) {
+    let state = counters.0.lock().unwrap();
+    assert_eq!(state.snapshot.current_depth, depth);
+    assert_eq!(state.queued_by_source.len(), entries);
+    state.assert_source_depth();
+}
+
+#[tokio::test(start_paused = true)]
+async fn single_source_flood_caps_at_sixteen_and_another_source_progresses() {
+    let (mut network, tx) = fixture();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    let (reply_tx, mut accepted_reply) = oneshot::channel();
+    let mut first = incoming(&[2], 0);
+    first.reply_tx = Some(reply_tx);
+    tx.send(first).await.unwrap();
+    for id in 1..256 {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let mut arrival = incoming(&[2], id);
+        arrival.reply_tx = Some(reply_tx);
+        tx.send(arrival).await.unwrap();
+        if id >= 16 {
+            assert!(timeout(Duration::from_secs(1), reply_rx)
+                .await
+                .expect("fairness drop retained reply sender")
+                .is_err());
+        }
+    }
+    for id in 0..16 {
+        tx.send(incoming(&[3], id)).await.unwrap();
+    }
+    barrier(&tx).await;
+    assert_eq!(
+        counters.snapshot(),
+        QueueAdmissionSnapshot {
+            current_depth: 32,
+            high_water: 32,
+            fairness_drops: 240,
+            ..Default::default()
+        }
+    );
+    assert_sources(&counters, 2, 32);
+    assert_eq!(
+        accepted_reply.try_recv(),
+        Err(oneshot::error::TryRecvError::Empty)
+    );
+    for source in [2, 3] {
+        for id in 0..16 {
+            let apdu = apdus.try_recv().unwrap();
+            assert_apdu(&apdu, &[source], id);
+            if source == 2 && id == 0 {
+                apdu.reply_tx
+                    .unwrap()
+                    .send(Bytes::from_static(b"reply"))
+                    .unwrap();
+            }
+        }
+    }
+    assert_eq!(accepted_reply.await.unwrap(), Bytes::from_static(b"reply"));
+    assert_eq!(
+        apdus.try_recv().unwrap_err(),
+        mpsc::error::TryRecvError::Empty
+    );
+    assert_sources(&counters, 0, 0);
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn every_recv_and_try_recv_releases_one_slot_even_if_consumer_retains_items() {
+    let (mut network, tx) = fixture();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    for id in 0..16 {
+        tx.send(incoming(&[2], id)).await.unwrap();
+    }
+    barrier(&tx).await;
+    let retained = [apdus.recv().await.unwrap(), apdus.try_recv().unwrap()];
+    assert_sources(&counters, 1, 14);
+    for id in 16..19 {
+        tx.send(incoming(&[2], id)).await.unwrap();
+    }
+    barrier(&tx).await;
+    assert_eq!(counters.snapshot().fairness_drops, 1);
+    assert_sources(&counters, 1, 16);
+    for id in 2..18 {
+        let apdu = if id % 2 == 0 {
+            apdus.recv().await.unwrap()
+        } else {
+            apdus.try_recv().unwrap()
+        };
+        assert_apdu(&apdu, &[2], id);
+        let remaining = usize::from(17 - id);
+        assert_sources(&counters, usize::from(remaining != 0), remaining);
+    }
+    // Empty and cancelled receives neither release a second slot nor leak keys.
+    assert_eq!(
+        apdus.try_recv().unwrap_err(),
+        mpsc::error::TryRecvError::Empty
+    );
+    assert!(timeout(Duration::from_secs(1), apdus.recv()).await.is_err());
+    for id in 19..35 {
+        tx.send(incoming(&[2], id)).await.unwrap();
+    }
+    barrier(&tx).await;
+    assert_sources(&counters, 1, 16);
+    assert_eq!(counters.snapshot().fairness_drops, 1);
+    assert_eq!(counters.snapshot().high_water, 16);
+    assert_apdu(&retained[0], &[2], 0);
+    assert_apdu(&retained[1], &[2], 1);
+    network.stop().await.unwrap();
+    for id in 19..35 {
+        assert_apdu(&apdus.recv().await.unwrap(), &[2], id);
+    }
+    assert!(apdus.recv().await.is_none());
+    assert_sources(&counters, 0, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn sixteen_sources_compose_to_capacity_and_fairness_precedes_full() {
+    let (mut network, tx) = fixture();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    for source in 0..16 {
+        for id in 0..16 {
+            tx.send(incoming(&[source], id)).await.unwrap();
+        }
+    }
+    tx.send(incoming(&[0], 16)).await.unwrap(); // Over quota AND globally full.
+    tx.send(incoming(&[16], 0)).await.unwrap(); // Below quota, globally full.
+    barrier(&tx).await;
+    assert_eq!(
+        counters.snapshot(),
+        QueueAdmissionSnapshot {
+            current_depth: 256,
+            high_water: 256,
+            fairness_drops: 1,
+            full_drops: 1,
+            closed_drops: 0,
+        }
+    );
+    assert_sources(&counters, 16, 256);
+    for source in 0..16 {
+        for id in 0..16 {
+            assert_apdu(&apdus.try_recv().unwrap(), &[source], id);
+        }
+    }
+    assert_sources(&counters, 0, 0);
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn unique_source_churn_cannot_grow_map_beyond_queued_items() {
+    let (mut network, tx) = fixture();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    for round in 0..3u16 {
+        for id in 0..512u16 {
+            tx.send(incoming(&(round * 512 + id).to_be_bytes(), id))
+                .await
+                .unwrap();
+        }
+        barrier(&tx).await;
+        assert_sources(&counters, 256, 256);
+        assert_eq!(counters.snapshot().full_drops, u64::from(round + 1) * 256);
+        assert_eq!(counters.snapshot().fairness_drops, 0);
+        for id in 0..256u16 {
+            assert_apdu(
+                &apdus.try_recv().unwrap(),
+                &(round * 512 + id).to_be_bytes(),
+                id,
+            );
+            assert_sources(&counters, usize::from(255 - id), usize::from(255 - id));
+        }
+        assert_sources(&counters, 0, 0);
+    }
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn close_and_drop_preserve_closed_precedence_and_release_all_source_entries() {
+    for close_then_drain in [true, false] {
+        let (mut network, tx) = fixture();
+        let mut apdus = network.start_with_admission().await.unwrap();
+        let counters = apdus.counters();
+        let (reply_tx, mut queued_reply) = oneshot::channel();
+        let mut first = incoming(&[2], 0);
+        first.reply_tx = Some(reply_tx);
+        tx.send(first).await.unwrap();
+        for id in 1..16 {
+            tx.send(incoming(&[2], id)).await.unwrap();
+        }
+        barrier(&tx).await;
+        let mut apdus = if close_then_drain {
+            apdus.close();
+            assert_sources(&counters, 1, 16);
+            assert_eq!(
+                queued_reply.try_recv(),
+                Err(oneshot::error::TryRecvError::Empty)
+            );
+            Some(apdus)
+        } else {
+            drop(apdus);
+            assert_sources(&counters, 0, 0);
+            None
+        };
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let mut arrival = incoming(&[2], 16);
+        arrival.reply_tx = Some(reply_tx);
+        tx.send(arrival).await.unwrap();
+        assert!(timeout(Duration::from_secs(1), reply_rx)
+            .await
+            .unwrap()
+            .is_err());
+        timeout(Duration::from_secs(1), tx.closed()).await.unwrap();
+        assert_eq!(counters.snapshot().closed_drops, 1);
+        assert_eq!(counters.snapshot().fairness_drops, 0);
+        assert_eq!(counters.snapshot().full_drops, 0);
+        if let Some(apdus) = apdus.as_mut() {
+            for id in 0..16 {
+                assert_apdu(&apdus.recv().await.unwrap(), &[2], id);
+            }
+            assert!(apdus.recv().await.is_none());
+        }
+        assert!(queued_reply.await.is_err());
+        assert_sources(&counters, 0, 0);
+        network.stop().await.unwrap();
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn legacy_apdus_and_tracked_controls_have_no_per_source_cap() {
+    let (mut network, tx) = fixture();
+    let mut controls = network
+        .enable_network_control_receiver_with_admission()
+        .unwrap();
+    let mut apdus = network.start().await.unwrap();
+    for id in 0..257 {
+        tx.send(incoming(&[2], id)).await.unwrap();
+        tx.send(control()).await.unwrap();
+    }
+    barrier(&tx).await;
+    assert_eq!(apdus.len(), 256);
+    assert_eq!(
+        controls.counters().snapshot(),
+        QueueAdmissionSnapshot {
+            current_depth: 256,
+            high_water: 256,
+            full_drops: 2, // Includes the final control barrier.
+            ..Default::default()
+        }
+    );
+    assert!(controls
+        .counters
+        .0
+        .lock()
+        .unwrap()
+        .queued_by_source
+        .is_empty());
+    for id in 0..256 {
+        assert_apdu(&apdus.try_recv().unwrap(), &[2], id);
+        let control = controls.try_recv().unwrap();
+        assert_eq!(control.source_mac.as_slice(), &[2]);
+        assert_eq!(control.ingress_sequence, u64::from(id) + 1);
+    }
+    assert_eq!(
+        apdus.try_recv().unwrap_err(),
+        mpsc::error::TryRecvError::Empty
+    );
+    network.stop().await.unwrap();
+}
+
+#[tokio::test(start_paused = true)]
+async fn mac_keys_use_complete_byte_value_not_allocation_or_prefix() {
+    fn requires_hash_eq<T: std::hash::Hash + Eq>() {}
+    requires_hash_eq::<MacAddr>();
+    let (mut network, tx) = fixture();
+    let apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    for id in 0..16 {
+        tx.send(incoming(&[2], id)).await.unwrap();
+    }
+    let mut spilled = MacAddr::with_capacity(32);
+    spilled.push(2);
+    assert!(spilled.spilled());
+    let mut arrival = incoming(&[2], 16);
+    arrival.source_mac = spilled;
+    tx.send(arrival).await.unwrap();
+    for source in [&[2, 0][..], &[2; 18][..]] {
+        for id in 0..17 {
+            tx.send(incoming(source, id)).await.unwrap();
+        }
+    }
+    barrier(&tx).await;
+    assert_sources(&counters, 3, 48);
+    assert_eq!(counters.snapshot().fairness_drops, 3);
+    assert_eq!(counters.snapshot().full_drops, 0);
+    network.stop().await.unwrap();
+    assert_sources(&counters, 3, 48); // Stop retains queued items and keys.
+    drop(apdus);
+    assert_sources(&counters, 0, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn fairness_drop_counter_saturates_without_altering_depth_or_other_drops() {
+    let (mut network, tx) = fixture();
+    let apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    for id in 0..16 {
+        tx.send(incoming(&[2], id)).await.unwrap();
+    }
+    barrier(&tx).await;
+    counters.0.lock().unwrap().snapshot.fairness_drops = u64::MAX - 1;
+    for id in 16..19 {
+        tx.send(incoming(&[2], id)).await.unwrap();
+    }
+    barrier(&tx).await;
+    assert_eq!(
+        counters.snapshot(),
+        QueueAdmissionSnapshot {
+            current_depth: 16,
+            high_water: 16,
+            fairness_drops: u64::MAX,
+            ..Default::default()
+        }
+    );
+    assert_sources(&counters, 1, 16);
+    network.stop().await.unwrap();
+}
+
+#[tokio::test]
+async fn concurrent_dispatch_and_dequeues_keep_source_and_depth_accounting_in_step() {
+    let (mut network, tx) = fixture();
+    let mut apdus = network.start_with_admission().await.unwrap();
+    let counters = apdus.counters();
+    let receiver_counters = counters.clone();
+    // The crate enables Tokio's current-thread runtime, not rt-multi-thread.
+    // Moving the receiver to a second OS thread still races its accounting with
+    // real NetworkLayer dispatch, without broadening the dependency features.
+    let consumer = std::thread::spawn(move || {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async move {
+                let mut seen = std::collections::HashSet::new();
+                for _ in 0..256 {
+                    let apdu = timeout(Duration::from_secs(5), apdus.recv())
+                        .await
+                        .unwrap()
+                        .unwrap();
+                    let id = u16::from_be_bytes(apdu.apdu.as_ref().try_into().unwrap());
+                    let source = apdu.source_mac[0];
+                    assert!(source < 16 && id < 16);
+                    assert!(seen.insert((source, id)));
+                    assert_apdu(&apdu, &[source], id);
+                    receiver_counters.0.lock().unwrap().assert_source_depth();
+                }
+                assert_sources(&receiver_counters, 0, 0);
+            });
+    });
+    // Sixteen items per source fit even if dispatch outruns the consumer;
+    // if they race, source-key insertions and removals must stay in step.
+    for id in 0..16 {
+        for source in 0..16 {
+            tx.send(incoming(&[source], id)).await.unwrap();
+        }
+    }
+    barrier(&tx).await;
+    consumer.join().unwrap();
+    assert_sources(&counters, 0, 0);
+    assert_eq!(counters.snapshot().fairness_drops, 0);
+    assert_eq!(counters.snapshot().full_drops, 0);
+    assert_eq!(counters.snapshot().closed_drops, 0);
+    network.stop().await.unwrap();
+}

--- a/crates/bacnet-network/src/router/admission_tests.rs
+++ b/crates/bacnet-network/src/router/admission_tests.rs
@@ -303,6 +303,7 @@ async fn full_shared_local_queue_drops_arrivals_in_all_four_branches_and_keeps_f
                     current_depth: 256,
                     high_water: 256,
                     full_drops: port as u64 + 1,
+                    fairness_drops: 0,
                     closed_drops: 0,
                 }
             );
@@ -405,6 +406,7 @@ async fn closing_full_local_queue_counts_each_closed_arrival_and_preserves_drain
             current_depth: 256,
             high_water: 256,
             full_drops: 0,
+            fairness_drops: 0,
             closed_drops: 8,
         }
     );
@@ -553,6 +555,7 @@ async fn concurrent_ports_share_one_capacity_and_exact_depth_during_receive() {
             current_depth: 256,
             high_water: 256,
             full_drops: 768,
+            fairness_drops: 0,
             closed_drops: 0,
         }
     );
@@ -626,6 +629,7 @@ fn cloned_senders_account_exactly_across_threads_and_concurrent_dequeues() {
             current_depth: 256,
             high_water: 256,
             full_drops: 768,
+            fairness_drops: 0,
             closed_drops: 0,
         }
     );


### PR DESCRIPTION
Slice 3 of #532 (follows #626 slice 1 and #628 slice 2 policy: drop-arriving, 256 retained, count-only snapshots, additive API).

NetworkLayer APDU ingress on the tracked (start_with_admission) path caps each source MAC at 16 queued, unconsumed APDUs. Over-quota arrivals drop before the global Full check with a new saturating fairness_drops snapshot counter; payload/metadata/reply released, no wire reject. Per-source counts increment on admission and decrement on every dequeue under the existing accounting mutex; map entries exist only while their source has queued items (bounded by queue capacity, debug-asserted). Legacy start() keeps plain drop-arriving without quota (documented); control and router-local queues unaffected.

Validation: bacnet-network 100+1 PASS, FULL conformance_ledger 27/27 PASS, clippy/fmt/size/secrets PASS, 9 new fairness regressions.