### PR TITLE
fix(network): cap router local queue per ingress source (#532)

### DIFF
--- a/crates/bacnet-client/src/endpoint_requester_tests.rs
+++ b/crates/bacnet-client/src/endpoint_requester_tests.rs
@@ -67,6 +67,7 @@ fn received(apdu: Bytes, source: &[u8]) -> ReceivedApdu {
     ReceivedApdu {
         apdu,
         source_mac: MacAddr::from_slice(source),
+        ingress_network: None,
         source_network: None,
         link_layer_group: false,
         is_group: false,

--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -27,6 +27,12 @@ pub struct ReceivedApdu {
     pub apdu: Bytes,
     /// Source MAC address in transport-native format.
     pub source_mac: MacAddr,
+    /// BACnet network number of the router ingress port at admission time.
+    ///
+    /// Router deliveries set this to `Some`, independently of the routed source
+    /// address. Non-router [`NetworkLayer`] deliveries use `None` because the
+    /// layer owns one transport without an assigned ingress network number.
+    pub ingress_network: Option<u16>,
     /// Source network address if the APDU was routed (NPDU had source field).
     pub source_network: Option<NpduAddress>,
     /// Whether the NPDU arrived through a data-link multicast or broadcast.
@@ -76,6 +82,7 @@ impl Clone for ReceivedApdu {
         Self {
             apdu: self.apdu.clone(),
             source_mac: self.source_mac.clone(),
+            ingress_network: self.ingress_network,
             source_network: self.source_network.clone(),
             link_layer_group: self.link_layer_group,
             is_group: self.is_group,
@@ -90,6 +97,7 @@ impl std::fmt::Debug for ReceivedApdu {
         f.debug_struct("ReceivedApdu")
             .field("apdu", &self.apdu)
             .field("source_mac", &self.source_mac)
+            .field("ingress_network", &self.ingress_network)
             .field("source_network", &self.source_network)
             .field("link_layer_group", &self.link_layer_group)
             .field("is_group", &self.is_group)

--- a/crates/bacnet-network/src/layer_admission.rs
+++ b/crates/bacnet-network/src/layer_admission.rs
@@ -9,6 +9,14 @@ use tracing::{debug, warn};
 const QUEUE_CAPACITY: usize = 256;
 const APDU_SOURCE_CAPACITY: usize = 16;
 
+// NetworkLayer has one unnamed transport; router MACs are scoped to the
+// ingress port's network number, never the routed NPDU SNET/SADR.
+type AdmissionSource = (Option<u16>, MacAddr);
+
+fn apdu_source(apdu: &ReceivedApdu) -> AdmissionSource {
+    (apdu.ingress_network, apdu.source_mac.clone())
+}
+
 /// A consistent, count-only snapshot of one network-layer receive queue.
 ///
 /// Counters belong to one receiver, not to a source MAC. A router's local queue
@@ -22,10 +30,11 @@ pub struct QueueAdmissionSnapshot {
     pub high_water: usize,
     /// Arriving items dropped because the queue was full; saturates at `u64::MAX`.
     pub full_drops: u64,
-    /// Arriving APDUs dropped by NetworkLayer's per-source-MAC quota of 16;
+    /// Arriving APDUs dropped by the tracked queue's quota of 16 per source:
+    /// source MAC for NetworkLayer, (ingress network, source MAC) for routers;
     /// saturates at `u64::MAX`. Evaluated before global Full, even when the queue
     /// has room. Closed admission retains precedence. Always zero for control
-    /// and router-local queues, which have no per-source quota.
+    /// queues, which have no per-source quota.
     pub fairness_drops: u64,
     /// Arriving items dropped because the receiver was closed; saturates at `u64::MAX`.
     ///
@@ -47,16 +56,15 @@ pub struct QueueAdmissionCounters(Arc<Mutex<QueueAdmissionState>>);
 #[derive(Debug, Default)]
 struct QueueAdmissionState {
     snapshot: QueueAdmissionSnapshot,
-    // Used only by NetworkLayer's tracked APDU queue. Insert after successful
+    // Used only by tracked APDU queues. Insert after successful
     // admission, remove on the last dequeue: live entries <= depth <= 256.
-    // NetworkLayer owns one transport, so a separate port key is unnecessary.
-    queued_by_source: HashMap<MacAddr, usize>,
+    queued_by_source: HashMap<AdmissionSource, usize>,
 }
 
 impl QueueAdmissionState {
-    fn dequeued(&mut self, source: Option<&MacAddr>) {
+    fn dequeued(&mut self, source: Option<AdmissionSource>) {
         self.snapshot.current_depth -= 1;
-        if let Some(source) = source {
+        if let Some(ref source) = source {
             let count = self
                 .queued_by_source
                 .get_mut(source)
@@ -109,9 +117,9 @@ impl QueueAdmissionCounters {
 pub struct AdmissionReceiver<T> {
     rx: mpsc::Receiver<T>,
     counters: QueueAdmissionCounters,
-    // Only NetworkLayer's tracked APDU constructor installs source accounting.
-    // No public trait bound or change to router/control item types is needed.
-    source_mac: Option<fn(&T) -> &MacAddr>,
+    // Only tracked APDU constructors install source accounting. The same
+    // extractor is used on admission and every dequeue; no public trait bound.
+    source_key: Option<fn(&T) -> AdmissionSource>,
 }
 
 impl<T> AdmissionReceiver<T> {
@@ -133,7 +141,7 @@ impl<T> AdmissionReceiver<T> {
         Self {
             rx,
             counters,
-            source_mac: None,
+            source_key: None,
         }
     }
 
@@ -155,7 +163,7 @@ impl<T> AdmissionReceiver<T> {
                 .expect("queue admission counters poisoned");
             let result = self.rx.poll_recv(cx);
             if let Poll::Ready(Some(item)) = &result {
-                state.dequeued(self.source_mac.map(|source_mac| source_mac(item)));
+                state.dequeued(self.source_key.map(|source_key| source_key(item)));
             }
             result
         })
@@ -171,7 +179,7 @@ impl<T> AdmissionReceiver<T> {
             .expect("queue admission counters poisoned");
         let result = self.rx.try_recv();
         if let Ok(item) = &result {
-            state.dequeued(self.source_mac.map(|source_mac| source_mac(item)));
+            state.dequeued(self.source_key.map(|source_key| source_key(item)));
         }
         result
     }
@@ -188,6 +196,19 @@ impl<T> AdmissionReceiver<T> {
             .lock()
             .expect("queue admission counters poisoned");
         self.rx.close();
+    }
+}
+
+impl AdmissionReceiver<ReceivedApdu> {
+    pub(crate) fn from_apdu_parts(
+        rx: mpsc::Receiver<ReceivedApdu>,
+        counters: QueueAdmissionCounters,
+    ) -> Self {
+        Self {
+            rx,
+            counters,
+            source_key: Some(apdu_source),
+        }
     }
 }
 
@@ -244,7 +265,7 @@ impl<T> AdmissionSender<T> {
     fn try_send_from(
         &self,
         item: T,
-        source: Option<MacAddr>,
+        source: Option<AdmissionSource>,
     ) -> Result<(), mpsc::error::TrySendError<T>> {
         // Serialize the admission and dequeue accounting, not asynchronous
         // waiting. Each queue has its own short critical section, and no lock
@@ -284,6 +305,25 @@ impl<T> AdmissionSender<T> {
             }
         }
         result
+    }
+}
+
+impl AdmissionSender<ReceivedApdu> {
+    pub(crate) fn try_send_apdu(
+        &self,
+        apdu: ReceivedApdu,
+    ) -> Result<(), mpsc::error::TrySendError<()>> {
+        // Raw receivers cannot release source counts: legacy ingress neither
+        // clones keys nor enforces a quota.
+        let source = self.track_depth.then(|| apdu_source(&apdu));
+        // Both dispatchers drop arriving APDUs on failure. Release the owned
+        // item after the accounting lock is released; only Closed affects the
+        // NetworkLayer dispatch lifecycle, not the returned payload.
+        self.try_send_from(apdu, source)
+            .map_err(|error| match error {
+                mpsc::error::TrySendError::Full(_) => mpsc::error::TrySendError::Full(()),
+                mpsc::error::TrySendError::Closed(_) => mpsc::error::TrySendError::Closed(()),
+            })
     }
 }
 
@@ -368,7 +408,8 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     /// slot; processing or retaining the returned APDU does not hold that slot.
     /// Over-quota arrivals are dropped before checking global Full, releasing
     /// payload, metadata and reply sender without sending bytes or a wire reject.
-    /// Control and router-local queues do not enforce this quota.
+    /// Control queues do not enforce this quota. Router-local queues instead
+    /// scope each source MAC to its ingress port's network number.
     ///
     /// ```no_run
     /// # async fn example() -> Result<(), bacnet_types::error::Error> {
@@ -390,11 +431,7 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     /// ```
     pub async fn start_with_admission(&mut self) -> Result<AdmissionReceiver<ReceivedApdu>, Error> {
         let (rx, counters) = self.start_dispatch(true).await?;
-        Ok(AdmissionReceiver {
-            rx,
-            counters,
-            source_mac: Some(|apdu| &apdu.source_mac),
-        })
+        Ok(AdmissionReceiver::from_apdu_parts(rx, counters))
     }
 
     async fn start_dispatch(
@@ -456,6 +493,7 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
                         let apdu = ReceivedApdu {
                             apdu: npdu.payload,
                             source_mac: received.source_mac,
+                            ingress_network: None,
                             source_network,
                             link_layer_group: received.link_layer_group,
                             is_group,
@@ -463,10 +501,7 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
                             reply_tx: received.reply_tx,
                         };
 
-                        // Raw receivers cannot release source counts: legacy
-                        // ingress neither clones keys nor enforces a quota.
-                        let source = track_depth.then(|| apdu.source_mac.clone());
-                        match apdu_tx.try_send_from(apdu, source) {
+                        match apdu_tx.try_send_apdu(apdu) {
                             Ok(()) | Err(mpsc::error::TrySendError::Full(_)) => {}
                             Err(mpsc::error::TrySendError::Closed(_)) => break,
                         }

--- a/crates/bacnet-network/src/layer_fairness_tests.rs
+++ b/crates/bacnet-network/src/layer_fairness_tests.rs
@@ -83,6 +83,7 @@ async fn barrier(tx: &mpsc::Sender<ReceivedNpdu>) {
 fn assert_apdu(apdu: &ReceivedApdu, source: &[u8], id: u16) {
     assert_eq!(apdu.apdu.as_ref(), id.to_be_bytes());
     assert_eq!(apdu.source_mac.as_slice(), source);
+    assert_eq!(apdu.ingress_network, None);
     assert_eq!(
         apdu.source_network,
         Some(NpduAddress {
@@ -469,4 +470,108 @@ async fn concurrent_dispatch_and_dequeues_keep_source_and_depth_accounting_in_st
     assert_eq!(counters.snapshot().full_drops, 0);
     assert_eq!(counters.snapshot().closed_drops, 0);
     network.stop().await.unwrap();
+}
+
+fn router_apdu(ingress_network: u16, source: &[u8], id: u16) -> ReceivedApdu {
+    ReceivedApdu {
+        apdu: Bytes::copy_from_slice(&id.to_be_bytes()),
+        source_mac: MacAddr::from_slice(source),
+        ingress_network: Some(ingress_network),
+        source_network: None,
+        link_layer_group: false,
+        is_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
+#[test]
+fn router_key_churn_keeps_entries_bounded_by_depth_and_drop_clears_them() {
+    let (tx, rx, counters) = AdmissionReceiver::channel(true);
+    let mut apdus = AdmissionReceiver::from_apdu_parts(rx, counters.clone());
+    for round in 0..3 {
+        for id in 0..512 {
+            // Same MAC on 256 distinct ports, then fresh keys while full.
+            let _ = tx.try_send_apdu(router_apdu(id % 256, &[round, (id / 256) as u8], id));
+        }
+        assert_sources(&counters, 256, 256);
+        assert_eq!(counters.snapshot().full_drops, u64::from(round + 1) * 256);
+        assert_eq!(counters.snapshot().fairness_drops, 0);
+        for port in 0..256 {
+            let mut apdu = apdus.try_recv().unwrap();
+            assert_eq!(apdu.ingress_network, Some(port));
+            assert!(!counters
+                .0
+                .lock()
+                .unwrap()
+                .queued_by_source
+                .contains_key(&apdu_source(&apdu)));
+            apdu.ingress_network = None;
+            apdu.source_mac.clear();
+            assert_sources(&counters, usize::from(255 - port), usize::from(255 - port));
+        }
+    }
+    for port in 0..256 {
+        tx.try_send_apdu(router_apdu(port, &[2], 0)).unwrap();
+    }
+    apdus.close();
+    assert_sources(&counters, 256, 256);
+    drop(apdus);
+    assert_sources(&counters, 0, 0);
+}
+
+#[test]
+fn cloned_router_senders_enforce_composite_quotas_across_threads_and_dequeues() {
+    let (tx, rx, counters) = AdmissionReceiver::channel(true);
+    let mut apdus = AdmissionReceiver::from_apdu_parts(rx, counters.clone());
+    let start = std::sync::Barrier::new(4);
+    std::thread::scope(|scope| {
+        for port in 100..104 {
+            let tx = tx.clone();
+            let start = &start;
+            scope.spawn(move || {
+                start.wait();
+                for id in 0..256 {
+                    let _ = tx.try_send_apdu(router_apdu(port, &[2], id));
+                }
+            });
+        }
+    });
+    assert_sources(&counters, 4, 64);
+    assert_eq!(counters.snapshot().fairness_drops, 960);
+    for _ in 0..64 {
+        apdus.try_recv().unwrap();
+    }
+    assert_sources(&counters, 0, 0);
+    let start = std::sync::Barrier::new(5);
+    std::thread::scope(|scope| {
+        for port in 100..104 {
+            let tx = tx.clone();
+            let start = &start;
+            scope.spawn(move || {
+                start.wait();
+                for id in 0..16 {
+                    tx.try_send_apdu(router_apdu(port, &[2], id)).unwrap();
+                }
+            });
+        }
+        start.wait();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let mut seen = std::collections::HashSet::new();
+        while seen.len() < 64 {
+            match apdus.try_recv() {
+                Ok(apdu) => assert!(seen.insert((apdu.ingress_network, apdu.apdu))),
+                Err(mpsc::error::TryRecvError::Empty) => {
+                    assert!(std::time::Instant::now() < deadline, "sender stalled");
+                    std::thread::yield_now();
+                }
+                Err(e) => panic!("unexpected receive error: {e}"),
+            }
+            counters.0.lock().unwrap().assert_source_depth();
+        }
+    });
+    assert_sources(&counters, 0, 0);
+    assert_eq!(counters.snapshot().fairness_drops, 960);
+    assert_eq!(counters.snapshot().full_drops, 0);
+    assert_eq!(counters.snapshot().closed_drops, 0);
 }

--- a/crates/bacnet-network/src/router/admission_tests.rs
+++ b/crates/bacnet-network/src/router/admission_tests.rs
@@ -131,7 +131,9 @@ fn incoming(destination: Option<NpduAddress>, id: u16) -> ReceivedNpdu {
     encode_npdu(&mut bytes, &npdu).unwrap();
     ReceivedNpdu {
         npdu: bytes.freeze(),
-        source_mac: MacAddr::from_slice(&[0xA0]),
+        // Capacity tests use at most 16 APDUs per key, so Full attribution
+        // remains independent of the tracked receiver's per-source quota.
+        source_mac: MacAddr::from_slice(&[0xA0 + (id / 16) as u8]),
         link_layer_group: true,
         data_attributes: vec![DataAttribute {
             option_type: 31,
@@ -250,9 +252,10 @@ fn assert_quiet(peers: &mut [Peer]) {
     }
 }
 
-fn assert_apdu(apdu: &ReceivedApdu, branch: LocalBranch, id: u16) {
+fn assert_apdu(apdu: &ReceivedApdu, branch: LocalBranch, port: usize, id: u16) {
     assert_eq!(apdu.apdu.as_ref(), id.to_be_bytes());
     assert_eq!(apdu.source_mac, incoming(None, id).source_mac);
+    assert_eq!(apdu.ingress_network, Some(network(port)));
     assert_eq!(apdu.source_network, Some(address(300, &[0x55])));
     assert!(apdu.link_layer_group);
     assert_eq!(apdu.is_group, !matches!(branch, LocalBranch::DadrMatch));
@@ -314,7 +317,7 @@ async fn full_shared_local_queue_drops_arrivals_in_all_four_branches_and_keeps_f
         );
         for id in 0..256 {
             let apdu = apdus.try_recv().unwrap();
-            assert_apdu(&apdu, LocalBranch::NoDnet, id);
+            assert_apdu(&apdu, LocalBranch::NoDnet, usize::from(id / 128), id);
             if id == 0 {
                 apdu.reply_tx
                     .unwrap()
@@ -333,7 +336,7 @@ async fn full_shared_local_queue_drops_arrivals_in_all_four_branches_and_keeps_f
             .await
             .unwrap()
             .unwrap();
-        assert_apdu(&apdu, LocalBranch::NoDnet, 257);
+        assert_apdu(&apdu, LocalBranch::NoDnet, 0, 257);
         assert_eq!(
             counters.snapshot(),
             QueueAdmissionSnapshot {
@@ -360,7 +363,8 @@ async fn admitted_local_branches_preserve_metadata_and_reply_ownership() {
         barrier(&mut peers[0]).await;
         assert_eq!(apdus.counters().snapshot().current_depth, 1);
         let apdu = apdus.recv().await.unwrap();
-        assert_apdu(&apdu, branch, 42);
+        assert_apdu(&apdu, branch, 0, 42);
+        assert_eq!(apdu.clone().ingress_network, apdu.ingress_network);
         if matches!(branch, LocalBranch::RemoteBroadcast) {
             assert!(apdu.reply_tx.is_none());
             assert!(reply_rx.await.is_err());
@@ -420,7 +424,7 @@ async fn closing_full_local_queue_counts_each_closed_arrival_and_preserves_drain
         } else {
             apdus.try_recv().unwrap()
         };
-        assert_apdu(&apdu, LocalBranch::NoDnet, id);
+        assert_apdu(&apdu, LocalBranch::NoDnet, usize::from(id / 128), id);
         assert_eq!(counters.snapshot().current_depth, 255 - usize::from(id));
     }
     assert!(accepted_reply.await.is_err());
@@ -482,7 +486,12 @@ async fn stop_with_full_local_queue_is_bounded_and_leaves_items_drainable() {
     assert_eq!(counters.snapshot().current_depth, 256);
     assert!(peers.iter().all(|peer| peer.tx.is_closed()));
     for id in 0..256 {
-        assert_apdu(&apdus.recv().await.unwrap(), LocalBranch::NoDnet, id);
+        assert_apdu(
+            &apdus.recv().await.unwrap(),
+            LocalBranch::NoDnet,
+            usize::from(id / 128),
+            id,
+        );
     }
     assert!(apdus.recv().await.is_none());
     assert!(accepted_reply.await.is_err());
@@ -507,7 +516,12 @@ async fn legacy_local_receiver_retains_type_and_nonblocking_full_closed_policy()
     }
     assert_eq!(apdus.len(), 256);
     for id in 0..256 {
-        assert_apdu(&apdus.try_recv().unwrap(), LocalBranch::NoDnet, id);
+        assert_apdu(
+            &apdus.try_recv().unwrap(),
+            LocalBranch::NoDnet,
+            usize::from(id / 128),
+            id,
+        );
     }
     assert!(accepted_reply.await.is_err());
     apdus.close();
@@ -673,3 +687,6 @@ fn cloned_senders_account_exactly_across_threads_and_concurrent_dequeues() {
         }
     );
 }
+
+#[path = "fairness_tests.rs"]
+mod fairness_tests;

--- a/crates/bacnet-network/src/router/fairness_tests.rs
+++ b/crates/bacnet-network/src/router/fairness_tests.rs
@@ -1,0 +1,257 @@
+use super::*;
+
+fn keyed_local(branch: LocalBranch, port: usize, source: &[u8], id: u16) -> ReceivedNpdu {
+    let mut arrival = local(branch, port, id);
+    arrival.source_mac = MacAddr::from_slice(source);
+    arrival
+}
+
+fn assert_keyed_apdu(
+    apdu: &ReceivedApdu,
+    branch: LocalBranch,
+    port: usize,
+    source: &[u8],
+    id: u16,
+) {
+    assert_eq!(apdu.apdu.as_ref(), id.to_be_bytes());
+    assert_eq!(apdu.ingress_network, Some(network(port)));
+    assert_eq!(apdu.source_mac.as_slice(), source);
+    // Identical routed source on every port: it must not become the quota key.
+    assert_eq!(apdu.source_network, Some(address(300, &[0x55])));
+    assert!(apdu.link_layer_group);
+    assert_eq!(apdu.is_group, !matches!(branch, LocalBranch::DadrMatch));
+    assert_eq!(apdu.data_attributes, incoming(None, id).data_attributes);
+}
+
+async fn keyed_drop(peers: &mut [Peer], branch: LocalBranch, source: &[u8]) {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    let mut arrival = keyed_local(branch, 0, source, 256);
+    arrival.reply_tx = Some(reply_tx);
+    peers[0].tx.send(arrival).await.unwrap();
+    branch_forward(peers, branch, 0, 256).await;
+    forwarding_progress(peers, 0).await;
+    assert!(timeout(Duration::from_secs(2), reply_rx)
+        .await
+        .expect("admission drop retained reply sender")
+        .is_err());
+    assert_quiet(peers);
+}
+
+#[tokio::test(start_paused = true)]
+async fn each_branch_caps_a_flood_and_same_mac_on_another_port_has_its_own_quota() {
+    for branch in BRANCHES {
+        let (ports, mut peers) = fixture(2);
+        let (mut router, mut apdus) = BACnetRouter::start_with_admission(ports).await.unwrap();
+        let counters = apdus.counters();
+        drain_announcements(&mut peers).await;
+        for id in 0..256 {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            let mut arrival = keyed_local(branch, 0, &[2], id);
+            arrival.reply_tx = Some(reply_tx);
+            peers[0].tx.send(arrival).await.unwrap();
+            branch_forward(&mut peers, branch, 0, id).await;
+            if id >= 16 {
+                assert!(timeout(Duration::from_secs(2), reply_rx)
+                    .await
+                    .expect("fairness drop retained reply sender")
+                    .is_err());
+            }
+        }
+        barrier(&mut peers[0]).await;
+        assert_eq!(
+            counters.snapshot(),
+            QueueAdmissionSnapshot {
+                current_depth: 16,
+                high_water: 16,
+                fairness_drops: 240,
+                ..Default::default()
+            }
+        );
+        // MACs are link-local: port B must make progress without draining A.
+        for id in 0..17 {
+            peers[1]
+                .tx
+                .send(keyed_local(branch, 1, &[2], id))
+                .await
+                .unwrap();
+            branch_forward(&mut peers, branch, 1, id).await;
+        }
+        barrier(&mut peers[1]).await;
+        // Nor may the quota accidentally become a per-port-only quota.
+        for id in 0..16 {
+            peers[0]
+                .tx
+                .send(keyed_local(branch, 0, &[3], id))
+                .await
+                .unwrap();
+            branch_forward(&mut peers, branch, 0, id).await;
+        }
+        barrier(&mut peers[0]).await;
+        assert_eq!(
+            counters.snapshot(),
+            QueueAdmissionSnapshot {
+                current_depth: 48,
+                high_water: 48,
+                fairness_drops: 241,
+                ..Default::default()
+            }
+        );
+        for (port, source) in [(0, 2), (1, 2), (0, 3)] {
+            for id in 0..16 {
+                let apdu = apdus.try_recv().unwrap();
+                assert_keyed_apdu(&apdu, branch, port, &[source], id);
+            }
+        }
+        assert_eq!(counters.snapshot().current_depth, 0);
+        assert_quiet(&mut peers); // Only pre-existing broadcast forwarding occurred.
+        router.stop().await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn recv_and_try_recv_replenish_only_the_exact_port_mac_key_one_for_one() {
+    let (ports, mut peers) = fixture(2);
+    let (mut router, mut apdus) = BACnetRouter::start_with_admission(ports).await.unwrap();
+    let counters = apdus.counters();
+    drain_announcements(&mut peers).await;
+    for (port, peer) in peers.iter_mut().enumerate() {
+        for id in 0..16 {
+            peer.tx
+                .send(keyed_local(LocalBranch::NoDnet, port, &[2], id))
+                .await
+                .unwrap();
+        }
+        barrier(peer).await;
+    }
+    let retained = [apdus.recv().await.unwrap(), apdus.try_recv().unwrap()];
+    assert_eq!(counters.snapshot().current_depth, 30);
+    for id in 16..19 {
+        peers[0]
+            .tx
+            .send(keyed_local(LocalBranch::NoDnet, 0, &[2], id))
+            .await
+            .unwrap();
+    }
+    barrier(&mut peers[0]).await;
+    peers[1]
+        .tx
+        .send(keyed_local(LocalBranch::NoDnet, 1, &[2], 16))
+        .await
+        .unwrap();
+    barrier(&mut peers[1]).await;
+    assert_eq!(
+        counters.snapshot(),
+        QueueAdmissionSnapshot {
+            current_depth: 32,
+            high_water: 32,
+            fairness_drops: 2,
+            ..Default::default()
+        }
+    );
+    for (port, ids) in [(0, 2..16), (1, 0..16), (0, 16..18)] {
+        for id in ids {
+            let apdu = if id % 2 == 0 {
+                apdus.recv().await.unwrap()
+            } else {
+                apdus.try_recv().unwrap()
+            };
+            assert_keyed_apdu(&apdu, LocalBranch::NoDnet, port, &[2], id);
+        }
+    }
+    assert_eq!(
+        apdus.try_recv().unwrap_err(),
+        mpsc::error::TryRecvError::Empty
+    );
+    assert!(timeout(Duration::from_secs(1), apdus.recv()).await.is_err());
+    // Last dequeue removes the key; empty/cancelled receives cannot free extra
+    // slots. Retaining or mutating returned APDUs cannot affect queued keys.
+    for (port, peer) in peers.iter_mut().enumerate() {
+        for id in 32..49 {
+            peer.tx
+                .send(keyed_local(LocalBranch::NoDnet, port, &[2], id))
+                .await
+                .unwrap();
+        }
+        barrier(peer).await;
+    }
+    assert_eq!(counters.snapshot().current_depth, 32);
+    assert_eq!(counters.snapshot().fairness_drops, 4);
+    assert_keyed_apdu(&retained[0], LocalBranch::NoDnet, 0, &[2], 0);
+    assert_keyed_apdu(&retained[1], LocalBranch::NoDnet, 0, &[2], 1);
+    router.stop().await;
+    for port in 0..2 {
+        for id in 32..48 {
+            assert_keyed_apdu(
+                &apdus.recv().await.unwrap(),
+                LocalBranch::NoDnet,
+                port,
+                &[2],
+                id,
+            );
+        }
+    }
+    assert!(apdus.recv().await.is_none());
+    assert_eq!(counters.snapshot().current_depth, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn closed_precedes_fairness_which_precedes_full_in_all_local_branches() {
+    for branch in BRANCHES {
+        let (ports, mut peers) = fixture(2);
+        let (mut router, mut apdus) = BACnetRouter::start_with_admission(ports).await.unwrap();
+        let counters = apdus.counters();
+        drain_announcements(&mut peers).await;
+        let accepted_reply = fill(&mut peers).await;
+        keyed_drop(&mut peers, branch, &[0xA0]).await; // Quota AND global Full.
+        keyed_drop(&mut peers, branch, &[2]).await; // Within quota, global Full.
+        assert_eq!(
+            counters.snapshot(),
+            QueueAdmissionSnapshot {
+                current_depth: 256,
+                high_water: 256,
+                fairness_drops: 1,
+                full_drops: 1,
+                closed_drops: 0,
+            }
+        );
+        apdus.close();
+        keyed_drop(&mut peers, branch, &[0xA0]).await;
+        keyed_drop(&mut peers, branch, &[2]).await;
+        assert_eq!(
+            counters.snapshot(),
+            QueueAdmissionSnapshot {
+                current_depth: 256,
+                high_water: 256,
+                fairness_drops: 1,
+                full_drops: 1,
+                closed_drops: 2,
+            }
+        );
+        drop(apdus);
+        assert!(accepted_reply.await.is_err());
+        assert_eq!(counters.snapshot().current_depth, 0);
+        router.stop().await;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn legacy_local_queue_accepts_256_from_one_port_mac_without_a_quota() {
+    let (ports, mut peers) = fixture(2);
+    let (mut router, mut apdus): (_, mpsc::Receiver<ReceivedApdu>) =
+        BACnetRouter::start(ports).await.unwrap();
+    drain_announcements(&mut peers).await;
+    for id in 0..256 {
+        peers[0]
+            .tx
+            .send(keyed_local(LocalBranch::NoDnet, 0, &[2], id))
+            .await
+            .unwrap();
+    }
+    barrier(&mut peers[0]).await;
+    keyed_drop(&mut peers, LocalBranch::NoDnet, &[2]).await;
+    assert_eq!(apdus.len(), 256);
+    for id in 0..256 {
+        assert_keyed_apdu(&apdus.try_recv().unwrap(), LocalBranch::NoDnet, 0, &[2], id);
+    }
+    router.stop().await;
+}

--- a/crates/bacnet-network/src/router/mod.rs
+++ b/crates/bacnet-network/src/router/mod.rs
@@ -96,7 +96,8 @@ impl BACnetRouter {
     /// The shared local queue holds 256 items and drops the arriving APDU when
     /// full, releasing its reply channel without sending reply bytes. Full or
     /// closed local delivery never waits for the consumer or stops forwarding.
-    /// Use [`Self::start_with_admission`] to observe queue-admission snapshots.
+    /// This legacy raw receiver has no per-source quota or depth tracking.
+    /// Use [`Self::start_with_admission`] for snapshots and per-source fairness.
     pub async fn start<T: TransportPort + 'static>(
         ports: Vec<RouterPort<T>>,
     ) -> Result<(Self, mpsc::Receiver<ReceivedApdu>), Error> {
@@ -116,11 +117,20 @@ impl BACnetRouter {
     /// Stopping the router also leaves queued items drainable. Dropping the
     /// receiver discards queued items and releases their reply channels without
     /// sending reply bytes; discarding queued items is not an admission drop.
+    ///
+    /// Each (ingress port network number, source MAC) may hold at most 16 queued
+    /// local APDUs. Identical MAC bytes on different ports have separate quotas.
+    /// Dequeuing releases one slot, even if the consumer retains the APDU.
+    /// Over-quota arrivals release payload, metadata and reply sender without
+    /// sending bytes, and increment `fairness_drops` before checking global Full.
+    /// Closed admission retains precedence. Inline network-message handling and
+    /// forwarding are independent of this quota; the legacy [`Self::start`]
+    /// receiver does not enforce it.
     pub async fn start_with_admission<T: TransportPort + 'static>(
         ports: Vec<RouterPort<T>>,
     ) -> Result<(Self, AdmissionReceiver<ReceivedApdu>), Error> {
         let (router, rx, counters) = Self::start_dispatch(ports, true).await?;
-        Ok((router, AdmissionReceiver::from_parts(rx, counters)))
+        Ok((router, AdmissionReceiver::from_apdu_parts(rx, counters)))
     }
 
     async fn start_dispatch<T: TransportPort + 'static>(
@@ -297,13 +307,14 @@ impl BACnetRouter {
                                     let apdu = ReceivedApdu {
                                         apdu: npdu.payload,
                                         source_mac: received.source_mac,
+                                        ingress_network: Some(port_network),
                                         source_network: npdu.source,
                                         link_layer_group: received.link_layer_group,
                                         is_group: true,
                                         data_attributes: received.data_attributes,
                                         reply_tx: received.reply_tx,
                                     };
-                                    let _ = local_tx.try_send(apdu);
+                                    let _ = local_tx.try_send_apdu(apdu);
                                     continue;
                                 }
 
@@ -352,13 +363,14 @@ impl BACnetRouter {
                                             let apdu = ReceivedApdu {
                                                 apdu: npdu.payload,
                                                 source_mac: received.source_mac,
+                                                ingress_network: Some(port_network),
                                                 source_network: npdu.source,
                                                 link_layer_group: received.link_layer_group,
                                                 is_group: false,
                                                 data_attributes: received.data_attributes,
                                                 reply_tx: received.reply_tx,
                                             };
-                                            let _ = local_tx.try_send(apdu);
+                                            let _ = local_tx.try_send_apdu(apdu);
                                         } else {
                                             // Remote broadcast to our network (DLEN=0):
                                             // deliver locally AND forward
@@ -366,6 +378,7 @@ impl BACnetRouter {
                                                 let apdu = ReceivedApdu {
                                                     apdu: npdu.payload.clone(),
                                                     source_mac: received.source_mac.clone(),
+                                                    ingress_network: Some(port_network),
                                                     source_network: npdu.source.clone(),
                                                     link_layer_group: received.link_layer_group,
                                                     is_group: true,
@@ -374,7 +387,7 @@ impl BACnetRouter {
                                                         .clone(),
                                                     reply_tx: None,
                                                 };
-                                                let _ = local_tx.try_send(apdu);
+                                                let _ = local_tx.try_send_apdu(apdu);
                                             }
                                             forward_unicast(
                                                 &send_txs,
@@ -410,13 +423,14 @@ impl BACnetRouter {
                                 let apdu = ReceivedApdu {
                                     apdu: npdu.payload,
                                     source_mac: received.source_mac,
+                                    ingress_network: Some(port_network),
                                     source_network: npdu.source,
                                     link_layer_group: received.link_layer_group,
                                     is_group: is_group_delivery(received.link_layer_group, None),
                                     data_attributes: received.data_attributes,
                                     reply_tx: received.reply_tx,
                                 };
-                                let _ = local_tx.try_send(apdu);
+                                let _ = local_tx.try_send_apdu(apdu);
                             }
                         }
                         Err(e) => {

--- a/crates/bacnet-server/src/server/device_bindings_tests.rs
+++ b/crates/bacnet-server/src/server/device_bindings_tests.rs
@@ -305,6 +305,7 @@ fn received(
     bacnet_network::layer::ReceivedApdu {
         apdu: Bytes::new(),
         source_mac: MacAddr::from_slice(source_mac),
+        ingress_network: None,
         source_network,
         link_layer_group: false,
         is_group: false,

--- a/crates/bacnet-server/src/server/discovery_tests.rs
+++ b/crates/bacnet-server/src/server/discovery_tests.rs
@@ -638,6 +638,7 @@ fn mock_received(
     bacnet_network::layer::ReceivedApdu {
         apdu: Bytes::new(),
         source_mac: MacAddr::from_slice(source_mac),
+        ingress_network: None,
         source_network: routed.map(|(net, mac)| NpduAddress {
             network: net,
             mac_address: MacAddr::from_slice(mac),

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -266,6 +266,7 @@ impl Harness {
             bacnet_network::layer::ReceivedApdu {
                 apdu: Bytes::new(),
                 source_mac: MacAddr::from_slice(source_mac),
+                ingress_network: None,
                 source_network,
                 link_layer_group: false,
                 is_group: false,

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -454,6 +454,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                                         bacnet_network::layer::ReceivedApdu {
                                                             apdu: bytes::Bytes::new(),
                                                             source_mac: bacnet_types::MacAddr::new(),
+                                                            ingress_network: None,
                                                             source_network: None,
                                                             link_layer_group: false,
                                                             is_group: false,
@@ -508,6 +509,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                     bacnet_network::layer::ReceivedApdu {
                                         apdu: bytes::Bytes::new(),
                                         source_mac: bacnet_types::MacAddr::new(),
+                                        ingress_network: None,
                                         source_network: None,
                                         link_layer_group: false,
                                         is_group: false,

--- a/crates/bacnet-server/src/server/notification_transactions_tests.rs
+++ b/crates/bacnet-server/src/server/notification_transactions_tests.rs
@@ -412,6 +412,7 @@ async fn dispatch_keeps_segment_and_complex_acks_out_of_notification_completion(
             bacnet_network::layer::ReceivedApdu {
                 apdu: Bytes::new(),
                 source_mac: source_mac.clone(),
+                ingress_network: None,
                 source_network: None,
                 link_layer_group: false,
                 is_group: false,

--- a/crates/bacnet-server/src/server/request_admission_tests.rs
+++ b/crates/bacnet-server/src/server/request_admission_tests.rs
@@ -60,6 +60,7 @@ async fn dispatch(
         bacnet_network::layer::ReceivedApdu {
             apdu: Bytes::new(),
             source_mac: MacAddr::from_slice(&[1]),
+            ingress_network: None,
             source_network: source,
             link_layer_group: false,
             is_group: false,

--- a/crates/bacnet-server/src/server/requests/endpoint_responder_tests.rs
+++ b/crates/bacnet-server/src/server/requests/endpoint_responder_tests.rs
@@ -51,6 +51,7 @@ async fn responder_moves_reply_sender_once_and_preserves_routed_destination() {
     let received = ReceivedApdu {
         apdu: read_property_request(0x31),
         source_mac: MacAddr::from_slice(&[0x02]),
+        ingress_network: None,
         source_network: Some(routed_source.clone()),
         link_layer_group: false,
         is_group: false,
@@ -84,6 +85,7 @@ async fn responder_moves_reply_sender_once_and_preserves_routed_destination() {
             .handle(ReceivedApdu {
                 apdu: read_property_request(0x32),
                 source_mac: MacAddr::from_slice(&[0x02]),
+                ingress_network: None,
                 source_network: None,
                 link_layer_group: false,
                 is_group: false,
@@ -118,6 +120,7 @@ async fn responder_routes_reply_to_original_source_via_immediate_router() {
         .handle(ReceivedApdu {
             apdu: read_property_request(0x41),
             source_mac: MacAddr::from_slice(&[0x02]),
+            ingress_network: None,
             source_network: Some(routed_source.clone()),
             link_layer_group: false,
             is_group: false,

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -301,6 +301,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
         bacnet_network::layer::ReceivedApdu {
             apdu: Bytes::new(),
             source_mac: source_mac.clone(),
+            ingress_network: None,
             source_network,
             link_layer_group: false,
             is_group: false,

--- a/crates/bacnet-server/src/server/unconfirmed_audit_notification_tests.rs
+++ b/crates/bacnet-server/src/server/unconfirmed_audit_notification_tests.rs
@@ -48,6 +48,7 @@ fn received(
     bacnet_network::layer::ReceivedApdu {
         apdu: Bytes::new(),
         source_mac: MacAddr::from_slice(source_mac),
+        ingress_network: None,
         source_network,
         link_layer_group: false,
         is_group: false,


### PR DESCRIPTION
Slice 4 of #532 (follows #626/#628/#629 policy: drop-arriving, 256 retained, count-only snapshots, additive API).

The router's shared 256-item local queue now caps each (ingress port network number, source MAC) at 16 queued APDUs on the tracked path. Same-MAC bytes on different ports get separate quotas; over-quota arrivals drop with fairness_drops (Closed > fairness > Full), reply released, no wire reject. Shared apdu_source extractor used on admission and every dequeue; legacy start() uncapped (documented); inline network-message handling, forwarding, and rejects untouched.

Additive ReceivedApdu.ingress_network (Option<u16>): router sets Some(port network), NetworkLayer None (slice-3 per-MAC behavior preserved exactly). All in-repo literal constructors updated (13 literal-only additions, behavior-neutral); downstream bacnet-client/bacnet-server --tests compile.

Validation: bacnet-network 106+1 PASS, FULL conformance_ledger 27/27 PASS, clippy/fmt/size/secrets PASS, 6 new router fairness regressions.