### PR TITLE
docs(network): consolidate ingress admission contract (#532)

### DIFF
--- a/crates/bacnet-network/src/layer.rs
+++ b/crates/bacnet-network/src/layer.rs
@@ -4,6 +4,82 @@
 //! by handling NPDU encoding/decoding. This is a non-router implementation:
 //! it does not forward messages between networks, but it can address remote
 //! devices through local routers via NPDU destination fields (DNET/DADR).
+//!
+//! # Receive-queue admission
+//!
+//! [`NetworkLayer`] and [`BACnetRouter`](crate::router::BACnetRouter) use the
+//! same drop-arriving policy for application delivery. Each receive queue holds
+//! **256 items**. Admission never waits for a consumer and never evicts an older
+//! queued item. NetworkLayer APDU and opted-in control queues have independent
+//! capacities, so saturation of either does not stall admission to the other.
+//! All router ports share one local APDU queue; its saturation does not stop
+//! forwarding or inline network-message handling.
+//!
+//! ## Raw and tracked receivers
+//!
+//! | Receiver kind | Entry points | Capacity | Per-source quota | Accounting |
+//! | --- | --- | --- | --- | --- |
+//! | Raw APDU | [`NetworkLayer::start`], [`BACnetRouter::start`](crate::router::BACnetRouter::start) | 256 | None | Full/Closed counted internally; no admission snapshot or depth/high-water tracking |
+//! | Tracked APDU | [`NetworkLayer::start_with_admission`], [`BACnetRouter::start_with_admission`](crate::router::BACnetRouter::start_with_admission) | 256 | 16 queued APDUs per key, defined below | Exact depth/high-water and Full/fairness/Closed totals via [`AdmissionReceiver::counters`] |
+//! | Raw control | [`NetworkLayer::enable_network_control_receiver`] | 256, separate from APDUs | None | Full/Closed counted internally; no admission snapshot or depth/high-water tracking |
+//! | Tracked control | [`NetworkLayer::enable_network_control_receiver_with_admission`] | 256, separate from APDUs | None | Exact depth/high-water and Full/Closed totals; fairness always zero |
+//!
+//! Raw receivers remain `tokio::sync::mpsc::Receiver`; tracked receivers are the
+//! additive [`AdmissionReceiver`] alternatives. APDU and control opt-ins are
+//! independent. Routers process network messages inline, not through a control
+//! receiver. [`priority_channel`](crate::priority_channel) is not used by these ingress paths.
+//!
+//! ## Source keys and drop precedence
+//!
+//! Tracked APDU queues cap each key at **16 queued, unconsumed APDUs**:
+//! - NetworkLayer: the complete transport-native [`ReceivedApdu::source_mac`]
+//!   byte value. Its single transport needs no separate port key.
+//! - Router local delivery: ([ingress port network number](ReceivedApdu::ingress_network),
+//!   [`source_mac`](ReceivedApdu::source_mac)). Identical MAC bytes on different
+//!   ports have separate quotas. Neither key uses routed NPDU SNET/SADR
+//!   ([`source_network`](ReceivedApdu::source_network)) or authenticates a peer.
+//!
+//! Each successful [`recv`](AdmissionReceiver::recv) or
+//! [`try_recv`](AdmissionReceiver::try_recv) releases a queue slot and, for
+//! tracked APDUs, that key's quota slot before returning the item. Retaining or
+//! processing the returned item does not occupy either slot. Sixteen keys at
+//! their quota fill the 256-item queue; a key below quota can still encounter
+//! global Full. This is a queued-item cap, not a byte/rate limit or a delivery
+//! guarantee. Raw receivers and control queues have no per-source quota.
+//!
+//! Drop attribution is **Closed > fairness > Full**: closed admission wins;
+//! otherwise a tracked APDU whose key already holds 16 items is a fairness drop,
+//! even if the queue also holds 256 items; otherwise global saturation is Full.
+//! Only the winning reason is counted. Every admission drop releases the
+//! arriving item's owned payload, metadata and any reply sender without sending
+//! reply bytes or generating a wire rejection. This does not suppress ordinary
+//! router forwarding/reject behavior or change transport no-reply handling.
+//!
+//! ## Close, drop, stop, and observation
+//!
+//! Closing either receiver kind prevents further admission but retains queued
+//! items for draining. Dropping a receiver discards them and releases their
+//! payloads, metadata and reply senders without sending reply bytes. For tracked
+//! receivers, close preserves depth until dequeued; drop sets depth to zero.
+//! Neither operation resets high-water/drop totals, and discarding queued items
+//! is not an admission drop.
+//!
+//! NetworkLayer ends its dispatcher on the first APDU admission attempt after
+//! that receiver closes/drops, also ending control delivery. A closed/dropped
+//! control receiver instead disables only that stream on the first subsequent
+//! control admission attempt. Later discarded controls (like controls received
+//! without either opt-in) are not admission attempts. Router forwarding and
+//! inline control handling continue after local delivery closes/drops; each
+//! subsequent local admission attempt is counted as Closed.
+//!
+//! [`NetworkLayer::stop`] after start and [`BACnetRouter::stop`](crate::router::BACnetRouter::stop)
+//! end dispatch without waiting for application queues to drain; queued items
+//! remain drainable. Stopping is not an admission drop. An independently owned
+//! [`QueueAdmissionCounters`] handle remains readable after the receiver, layer,
+//! or router is dropped; it keeps accounting alive, not the channel or tasks.
+//! [`snapshot`](QueueAdmissionCounters::snapshot) is consistent for one queue,
+//! not atomic across queues, and exposes counts only, not payloads, per-source
+//! identities or per-source totals. Its three drop totals saturate at `u64::MAX`.
 
 use bacnet_encoding::npdu::{encode_npdu, Npdu, NpduAddress};
 use bacnet_transport::port::{DataAttribute, TransportPort};
@@ -32,6 +108,11 @@ pub struct ReceivedApdu {
     /// Router deliveries set this to `Some`, independently of the routed source
     /// address. Non-router [`NetworkLayer`] deliveries use `None` because the
     /// layer owns one transport without an assigned ingress network number.
+    /// Both raw and tracked deliveries carry this metadata. For
+    /// [`BACnetRouter::start_with_admission`](crate::router::BACnetRouter::start_with_admission),
+    /// it scopes [`source_mac`](Self::source_mac) to the ingress port for the
+    /// 16-queued-APDU quota; [`source_network`](Self::source_network) is not part
+    /// of that key. See the [receive-queue contract](self#receive-queue-admission).
     pub ingress_network: Option<u16>,
     /// Source network address if the APDU was routed (NPDU had source field).
     pub source_network: Option<NpduAddress>,
@@ -120,6 +201,8 @@ pub(crate) fn is_group_delivery(link_layer_group: bool, destination: Option<&Npd
 /// NPDU framing. This layer does not act as a router (it does not forward
 /// messages between networks), but it can send to remote devices through
 /// local routers using NPDU destination addressing.
+/// See the [receive-queue contract](self#receive-queue-admission) for raw/tracked
+/// receiver choices, admission limits, drop attribution and lifecycle.
 pub struct NetworkLayer<T: TransportPort> {
     transport: T,
     dispatch_task: Option<JoinHandle<()>>,
@@ -416,11 +499,13 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
         self.transport.local_mac()
     }
 
-    /// Sequence assigned to the most recently decoded network-control ingress.
+    /// Sequence assigned to the most recent opted-in control admission attempt.
     ///
-    /// The value is updated before the control is queued for its opt-in
-    /// consumer. At counter exhaustion it remains at `u64::MAX`, which makes
-    /// sequence-based consumers fail closed rather than accepting an alias.
+    /// The value advances before admission, including Full and Closed drops,
+    /// but not for controls discarded without an enabled stream or after its
+    /// first Closed drop. See the [receive-queue contract](self#receive-queue-admission).
+    /// At counter exhaustion it remains at `u64::MAX`, which makes sequence-based
+    /// consumers fail closed rather than accepting an alias.
     pub fn network_control_ingress_sequence(&self) -> u64 {
         self.network_control_ingress_sequence.load(Ordering::SeqCst)
     }
@@ -453,6 +538,13 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     }
 
     /// Stop the network layer and underlying transport.
+    ///
+    /// After start, aborts and awaits dispatch before stopping the transport;
+    /// it does not wait for consumers, even with full APDU/control queues.
+    /// Queued items remain drainable, retaining their reply senders until
+    /// consumed or the receiver is dropped. Stop does not count as an admission
+    /// drop or clear depth/high-water/drop totals. See the
+    /// [receive-queue contract](self#receive-queue-admission).
     pub async fn stop(&mut self) -> Result<(), Error> {
         if let Some(task) = self.abort_dispatch_task() {
             let _ = task.await;

--- a/crates/bacnet-network/src/layer_admission.rs
+++ b/crates/bacnet-network/src/layer_admission.rs
@@ -20,23 +20,36 @@ fn apdu_source(apdu: &ReceivedApdu) -> AdmissionSource {
 /// A consistent, count-only snapshot of one network-layer receive queue.
 ///
 /// Counters belong to one receiver, not to a source MAC. A router's local queue
-/// is shared by all its ports.
+/// is shared by all its ports. No payloads, source identities or per-source
+/// totals are exposed. The three drop totals saturate at `u64::MAX` and attribute
+/// each admission drop once, in **Closed > fairness > Full** order.
 /// Separate APDU/control snapshots are not an atomic snapshot of both queues.
+/// See the [receive-queue contract](crate::layer#receive-queue-admission) and
+/// [`QueueAdmissionCounters::snapshot`] for receiver kinds and lifetime.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct QueueAdmissionSnapshot {
-    /// Items currently queued, excluding items already returned to the consumer.
+    /// Items currently queued (at most 256), excluding items already returned by
+    /// [`AdmissionReceiver::recv`] or [`AdmissionReceiver::try_recv`]. Close and
+    /// stop preserve depth until draining; dropping the receiver sets it to zero.
     pub current_depth: usize,
     /// Greatest queued depth since this receiver was created (at most 256).
+    /// Draining, closing, stopping or dropping the receiver does not reset it.
     pub high_water: usize,
-    /// Arriving items dropped because the queue was full; saturates at `u64::MAX`.
+    /// Arriving items dropped because the 256-item queue was full, after Closed
+    /// and any per-source fairness check; saturates at `u64::MAX`.
+    /// A fairness drop does not also increment this total.
     pub full_drops: u64,
     /// Arriving APDUs dropped by the tracked queue's quota of 16 per source:
-    /// source MAC for NetworkLayer, (ingress network, source MAC) for routers;
-    /// saturates at `u64::MAX`. Evaluated before global Full, even when the queue
-    /// has room. Closed admission retains precedence. Always zero for control
-    /// queues, which have no per-source quota.
+    /// complete source MAC bytes for NetworkLayer, (ingress port network number,
+    /// source MAC bytes) for routers, never routed NPDU SNET/SADR. See the
+    /// [source-key definitions](crate::layer#source-keys-and-drop-precedence).
+    /// Saturates at `u64::MAX`. Closed takes precedence; otherwise evaluated
+    /// before global Full, even when the queue has room. Always zero for control
+    /// queues, which have no per-source quota. This is a queue-wide total, not
+    /// a per-source counter.
     pub fairness_drops: u64,
-    /// Arriving items dropped because the receiver was closed; saturates at `u64::MAX`.
+    /// Arriving items dropped because the receiver was closed or dropped;
+    /// saturates at `u64::MAX`. Takes precedence over fairness and Full.
     ///
     /// In NetworkLayer, the first such APDU ends dispatch; the first such control
     /// disables that stream. Later discarded controls are not admission attempts.
@@ -50,6 +63,10 @@ pub struct QueueAdmissionSnapshot {
 /// This handle keeps only accounting alive, not payloads, the channel or dispatch task.
 /// It remains readable after the receiver, layer, or router is dropped. Dropping
 /// the receiver sets depth to zero; closing it preserves depth until drained.
+/// High-water/drop totals are retained, and later Closed admission attempts may
+/// still increase the Closed total. All clones observe the same queue; snapshots
+/// expose counts only, not source identities or per-source totals. See the
+/// [receive-queue contract](crate::layer#receive-queue-admission).
 #[derive(Debug, Clone, Default)]
 pub struct QueueAdmissionCounters(Arc<Mutex<QueueAdmissionState>>);
 
@@ -93,6 +110,15 @@ impl QueueAdmissionState {
 
 impl QueueAdmissionCounters {
     /// Read this queue's depth, high-water mark, and admission-drop totals.
+    ///
+    /// Returns a consistent copy of all [`QueueAdmissionSnapshot`] fields under
+    /// one accounting lock, without resetting them. Separate calls for APDU and
+    /// control queues are not jointly atomic. Counts do not expose payloads,
+    /// source identities or per-source totals; drop precedence and saturation
+    /// follow the [receive-queue contract](crate::layer#receive-queue-admission).
+    /// The handle remains readable after the receiver, layer, or router is
+    /// dropped; a snapshot need not be final while dispatch can still attempt
+    /// admission. A default handle has zero counts and is not attached to a queue.
     pub fn snapshot(&self) -> QueueAdmissionSnapshot {
         self.0
             .lock()
@@ -106,13 +132,22 @@ impl QueueAdmissionCounters {
 /// Created by [`NetworkLayer::start_with_admission`] or
 /// [`NetworkLayer::enable_network_control_receiver_with_admission`], or by
 /// [`BACnetRouter::start_with_admission`](crate::router::BACnetRouter::start_with_admission). The queue
-/// holds 256 items; full admission drops the arriving item, never an older one.
-/// APDU and control queues have independent capacities and counters. Neither
-/// full queue waits for its consumer or blocks dispatch to the other queue.
+/// holds 256 items; tracked APDUs additionally have a quota of 16 queued items per
+/// source MAC (NetworkLayer) or (ingress port network number, source MAC) (router).
+/// Controls have no per-source quota. **Closed > fairness > Full** determines
+/// drop attribution; an admission drop releases the arriving payload, metadata
+/// and reply sender without reply bytes or a wire rejection, never evicting an
+/// older item. See the [receive-queue contract](crate::layer#receive-queue-admission)
+/// for exact keys, the raw/tracked matrix, queue independence and lifecycle.
+///
+/// [`Self::close`] retains queued items for draining; dropping this receiver
+/// discards them and sets depth to zero without counting admission drops.
+/// High-water/drop totals survive through an owned [`Self::counters`] handle.
 ///
 /// This wrapper deliberately does not expose the underlying receiver: all
 /// dequeues must update the snapshot. Use the existing layer/router `start` methods
-/// when a plain `mpsc::Receiver` is required instead.
+/// when a plain `mpsc::Receiver` is required instead, or
+/// [`NetworkLayer::enable_network_control_receiver`] for raw controls.
 #[derive(Debug)]
 pub struct AdmissionReceiver<T> {
     rx: mpsc::Receiver<T>,
@@ -146,14 +181,23 @@ impl<T> AdmissionReceiver<T> {
     }
 
     /// Obtain an independently owned snapshot handle for this queue.
+    ///
+    /// The clone shares accounting without retaining the receiver, payloads or
+    /// dispatch task, and remains readable after receiver/layer/router drop.
+    /// See [`QueueAdmissionCounters::snapshot`] and the
+    /// [receive-queue contract](crate::layer#receive-queue-admission).
     pub fn counters(&self) -> QueueAdmissionCounters {
         self.counters.clone()
     }
 
     /// Receive the next item, or `None` once closed and drained.
     ///
+    /// Returning an item releases one depth slot and, for tracked APDUs, one
+    /// source-key slot before the consumer can retain or process it. `None`
+    /// changes no counts. The key and limits follow the
+    /// [receive-queue contract](crate::layer#receive-queue-admission).
     /// Cancellation safe: dropping a pending receive does not remove an item
-    /// or alter its depth. No counter lock is held while waiting.
+    /// or alter its accounting. No counter lock is held while waiting.
     pub async fn recv(&mut self) -> Option<T> {
         std::future::poll_fn(|cx| {
             let mut state = self
@@ -170,7 +214,12 @@ impl<T> AdmissionReceiver<T> {
         .await
     }
 
-    /// Receive immediately, distinguishing an empty queue from a closed one.
+    /// Receive immediately, releasing depth and source-key slots as in [`Self::recv`].
+    ///
+    /// A closed queue can still return queued items. Returns `Empty` when no item
+    /// is currently available but admission remains open, or `Disconnected` once
+    /// closed and drained. Errors do not change counts. See the
+    /// [receive-queue contract](crate::layer#receive-queue-admission).
     pub fn try_recv(&mut self) -> Result<T, mpsc::error::TryRecvError> {
         let mut state = self
             .counters
@@ -186,9 +235,16 @@ impl<T> AdmissionReceiver<T> {
 
     /// Stop admission while retaining already queued items for draining.
     ///
-    /// In NetworkLayer, the next arriving APDU ends dispatch, or the next control
-    /// disables its stream. Routers keep forwarding after local delivery closes.
-    /// Both match closing the corresponding legacy receiver.
+    /// Depth and source-key slots remain until [`Self::recv`] or [`Self::try_recv`]
+    /// dequeues an item, or the receiver is dropped. Close itself does not count
+    /// as a drop or reset high-water/drop totals. Later attempts count as Closed,
+    /// taking precedence over fairness and Full.
+    ///
+    /// In NetworkLayer, the next APDU admission attempt ends dispatch, or the next
+    /// control admission attempt disables only that stream. Routers count every
+    /// closed local admission attempt and keep forwarding/handling controls.
+    /// These match closing the corresponding raw receiver. See the
+    /// [receive-queue contract](crate::layer#close-drop-stop-and-observation).
     pub fn close(&mut self) {
         let _snapshot = self
             .counters
@@ -227,6 +283,13 @@ impl<T> Drop for AdmissionReceiver<T> {
     }
 }
 
+/// Shared non-waiting admission for raw and tracked 256-item queues.
+///
+/// Both modes count Full/Closed internally; only tracked receivers expose
+/// snapshots and release depth/source slots on dequeue. Tracked APDU sends use
+/// the 16-per-key quota and Closed > fairness > Full precedence. Generic/control
+/// sends and raw APDUs have no quota. See the public
+/// [receive-queue contract](crate::layer#receive-queue-admission).
 pub(crate) struct AdmissionSender<T> {
     tx: mpsc::Sender<T>,
     counters: QueueAdmissionCounters,
@@ -328,13 +391,22 @@ impl AdmissionSender<ReceivedApdu> {
 }
 
 impl<T: TransportPort + 'static> NetworkLayer<T> {
-    /// Enable the one-consumer decoded network-control stream.
+    /// Enable the one-consumer decoded network-control stream with a raw receiver.
     ///
-    /// This must be called before [`Self::start`] and at most once. Dropping
-    /// the returned receiver disables control delivery without affecting APDU
-    /// ingress. The queue holds 256 items and drops the arriving control when
-    /// full. Use [`Self::enable_network_control_receiver_with_admission`] to
-    /// observe admission counters alongside receive operations.
+    /// Call before either [`Self::start`] or [`Self::start_with_admission`], at
+    /// most once across the two control-enable alternatives. Returns an encoding
+    /// error if dispatch has started or a control receiver is already enabled.
+    /// The separate 256-item control queue has no per-source quota: Closed takes
+    /// precedence over Full, with Full/Closed counted internally but no snapshot
+    /// or depth/high-water tracking. Failed admission drops the control and its
+    /// metadata without waiting for a consumer or generating reply bytes/wire
+    /// rejections; APDU admission remains independent.
+    ///
+    /// Closing retains queued controls; dropping discards them. The first later
+    /// control admission attempt disables only this stream, then controls resume
+    /// discard behavior. Use [`Self::enable_network_control_receiver_with_admission`]
+    /// for counters, and see the [receive-queue contract](crate::layer#receive-queue-admission)
+    /// for the raw/tracked matrix, sequencing and stop/drain semantics.
     pub fn enable_network_control_receiver(
         &mut self,
     ) -> Result<mpsc::Receiver<ReceivedNetworkControl>, Error> {
@@ -345,9 +417,17 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     ///
     /// This has the same before-start, one-consumer contract and errors as
     /// [`Self::enable_network_control_receiver`]; the two methods are alternatives.
+    /// The separate 256-item queue tracks depth/high-water and Full/Closed drops
+    /// through [`AdmissionReceiver::counters`]. It has no per-source quota, so
+    /// fairness drops are always zero and precedence is Closed > Full.
+    /// Drop-arriving, ownership release, no-reply/no-wire-rejection and
+    /// close/drop/stop behavior follow the shared
+    /// [receive-queue contract](crate::layer#receive-queue-admission).
+    ///
     /// Controls discarded without opting into either stream are not admission
-    /// drops. Ingress sequencing still advances before every attempted control
-    /// admission, including Full and Closed drops.
+    /// drops. [`Self::network_control_ingress_sequence`] advances before every
+    /// attempted control admission, including Full and the first Closed drop,
+    /// but not for later controls once that stream is disabled.
     pub fn enable_network_control_receiver_with_admission(
         &mut self,
     ) -> Result<AdmissionReceiver<ReceivedNetworkControl>, Error> {
@@ -385,11 +465,18 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     ///
     /// This starts the underlying transport and spawns a dispatch task that
     /// decodes incoming NPDUs and extracts APDUs. The queue holds 256 items;
-    /// full admission drops the arriving APDU and its owned reply channel and
-    /// metadata without blocking control delivery. A closed APDU receiver ends
-    /// dispatch on the next APDU admission attempt.
-    /// This legacy raw receiver has no depth tracking or per-source quota.
-    /// Use [`Self::start_with_admission`] for snapshots and per-source fairness.
+    /// failed admission drops the arriving APDU with its payload, metadata and reply
+    /// sender without waiting for the consumer, sending reply bytes or generating
+    /// a wire rejection. Control capacity is independent. This raw receiver has
+    /// no per-source quota, admission snapshot or depth/high-water tracking;
+    /// Full/Closed drops are counted internally, with Closed > Full precedence.
+    ///
+    /// Close retains queued APDUs; drop discards them. Either ends dispatch on
+    /// the next APDU admission attempt, also ending control delivery.
+    /// [`Self::stop`] after start leaves queued items drainable. Use
+    /// [`Self::start_with_admission`] for snapshots and per-source fairness; see
+    /// the [receive-queue contract](crate::layer#receive-queue-admission) for the
+    /// raw/tracked matrix and ownership/lifecycle details.
     pub async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedApdu>, Error> {
         self.start_dispatch(false).await.map(|(rx, _)| rx)
     }
@@ -397,19 +484,21 @@ impl<T: TransportPort + 'static> NetworkLayer<T> {
     /// Start with an APDU receiver that also exposes admission snapshots.
     ///
     /// This is an alternative to [`Self::start`], with the same transport and
-    /// dispatch lifecycle. Stopping the layer closes admission but leaves
+    /// dispatch lifecycle. [`Self::stop`] closes admission but leaves
     /// queued items available to drain. Dropping the receiver discards those
     /// items and releases their reply channels without sending reply bytes.
     ///
-    /// Unlike the legacy raw receiver, depth tracking caps each source MAC at
-    /// 16 queued, unconsumed APDUs. NetworkLayer owns a single transport, so no
-    /// separate ingress-port key is needed. Sixteen sources at their quota
-    /// exactly fill the unchanged 256-item queue. Dequeuing releases one source
-    /// slot; processing or retaining the returned APDU does not hold that slot.
-    /// Over-quota arrivals are dropped before checking global Full, releasing
-    /// payload, metadata and reply sender without sending bytes or a wire reject.
-    /// Control queues do not enforce this quota. Router-local queues instead
-    /// scope each source MAC to its ingress port's network number.
+    /// Unlike the raw receiver, this tracks depth/high-water and drop totals via
+    /// [`AdmissionReceiver::counters`] and caps each complete source MAC byte
+    /// value at 16 queued, unconsumed APDUs in the 256-item queue. The single
+    /// transport uses no port key and ignores routed NPDU SNET/SADR for quotas.
+    /// Dequeuing releases one source slot even if the consumer retains the APDU.
+    /// **Closed > fairness > Full** selects one drop reason, releasing the
+    /// arriving payload, metadata and reply sender without sending reply bytes
+    /// or a wire rejection. Control queues have separate capacity and no quota.
+    /// For the router's port-scoped key, raw/tracked matrix, and full
+    /// close/drop/stop and counter-lifetime rules, see the
+    /// [receive-queue contract](crate::layer#receive-queue-admission).
     ///
     /// ```no_run
     /// # async fn example() -> Result<(), bacnet_types::error::Error> {

--- a/crates/bacnet-network/src/priority_channel.rs
+++ b/crates/bacnet-network/src/priority_channel.rs
@@ -14,7 +14,9 @@ use bacnet_types::enums::NetworkPriority;
 /// An item tagged with a BACnet network priority.
 #[derive(Debug, Clone)]
 pub struct PrioritizedItem<T> {
+    /// BACnet network priority used to select this item's queue.
     pub priority: NetworkPriority,
+    /// Payload carried by this item.
     pub data: T,
 }
 

--- a/crates/bacnet-network/src/router/mod.rs
+++ b/crates/bacnet-network/src/router/mod.rs
@@ -9,6 +9,10 @@
 //! - Who-Is-Router-To-Network / I-Am-Router-To-Network messages
 //! - Reject-Message-To-Network for unknown routes
 //! - Learned routes from I-Am-Router-To-Network announcements
+//!
+//! Local application delivery follows the shared
+//! [receive-queue contract](crate::layer#receive-queue-admission), independently
+//! of forwarding and inline network-message handling.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -76,6 +80,8 @@ pub struct RouterPort<T: TransportPort> {
 /// The router holds multiple ports, each bound to a different BACnet network.
 /// When an NPDU arrives on one port with a destination network that maps to
 /// another port, the router forwards the message.
+/// See the [receive-queue contract](crate::layer#receive-queue-admission) for
+/// raw/tracked local receivers, admission limits, counters and lifecycle.
 pub struct BACnetRouter {
     /// Shared routing table.
     table: Arc<Mutex<RouterTable>>,
@@ -93,11 +99,20 @@ impl BACnetRouter {
     /// Returns the router and a receiver for APDUs destined to local
     /// applications (messages without remote destination or where this
     /// router is the final hop).
-    /// The shared local queue holds 256 items and drops the arriving APDU when
-    /// full, releasing its reply channel without sending reply bytes. Full or
-    /// closed local delivery never waits for the consumer or stops forwarding.
-    /// This legacy raw receiver has no per-source quota or depth tracking.
-    /// Use [`Self::start_with_admission`] for snapshots and per-source fairness.
+    /// All ports share one 256-item local queue. Full/Closed admission drops the
+    /// arriving APDU with its payload, metadata and reply sender without sending
+    /// reply bytes or a wire rejection, never evicting an older item. Admission
+    /// never waits for the consumer or stops forwarding/inline control handling.
+    /// This raw receiver has no per-source quota, admission snapshot or
+    /// depth/high-water tracking. Full/Closed drops are counted internally, with
+    /// Closed > Full precedence.
+    ///
+    /// Closing retains queued items; dropping discards them. Both leave routing
+    /// active, and each later local admission attempt counts as Closed.
+    /// [`Self::stop`] also leaves queued items drainable. Use
+    /// [`Self::start_with_admission`] for snapshots and per-source fairness; see
+    /// the [receive-queue contract](crate::layer#receive-queue-admission) for the
+    /// raw/tracked matrix and ownership/lifecycle details.
     pub async fn start<T: TransportPort + 'static>(
         ports: Vec<RouterPort<T>>,
     ) -> Result<(Self, mpsc::Receiver<ReceivedApdu>), Error> {
@@ -109,23 +124,29 @@ impl BACnetRouter {
     /// Start with a local APDU receiver exposing queue-admission snapshots.
     ///
     /// This is an alternative to [`Self::start`], with the same port and router
-    /// lifecycle. All ports share one 256-item queue and one counters handle,
-    /// obtained through [`AdmissionReceiver::counters`]. Full admission drops
-    /// the arriving APDU, never an older one; drops do not send wire rejections.
+    /// lifecycle. All ports share one 256-item queue and one accounting state;
+    /// [`AdmissionReceiver::counters`] returns cloneable count-only handles for
+    /// depth/high-water and admission-drop totals, readable after receiver or
+    /// router drop. Failed admission drops the arriving APDU, never an older one, and
+    /// releases its payload, metadata and reply sender without reply bytes or
+    /// wire rejections. Forwarding and inline control handling remain independent.
     /// Closing the receiver retains queued items for draining and counts each
     /// subsequent local arrival as a closed drop while forwarding continues.
-    /// Stopping the router also leaves queued items drainable. Dropping the
+    /// [`Self::stop`] also leaves queued items drainable. Dropping the
     /// receiver discards queued items and releases their reply channels without
     /// sending reply bytes; discarding queued items is not an admission drop.
     ///
-    /// Each (ingress port network number, source MAC) may hold at most 16 queued
-    /// local APDUs. Identical MAC bytes on different ports have separate quotas.
+    /// Each ([ingress port network number](ReceivedApdu::ingress_network),
+    /// complete [`source_mac`](ReceivedApdu::source_mac) byte value) may hold at
+    /// most 16 queued local APDUs, never keyed by routed NPDU SNET/SADR.
+    /// Identical MAC bytes on different ports have separate quotas.
     /// Dequeuing releases one slot, even if the consumer retains the APDU.
-    /// Over-quota arrivals release payload, metadata and reply sender without
-    /// sending bytes, and increment `fairness_drops` before checking global Full.
-    /// Closed admission retains precedence. Inline network-message handling and
-    /// forwarding are independent of this quota; the legacy [`Self::start`]
-    /// receiver does not enforce it.
+    /// **Closed > fairness > Full** selects one drop reason; over-quota arrivals
+    /// increment [`fairness_drops`](crate::layer::QueueAdmissionSnapshot::fairness_drops)
+    /// even if the queue is also globally full, unless admission is closed.
+    /// The raw [`Self::start`] receiver does not enforce a quota. See the
+    /// [receive-queue contract](crate::layer#receive-queue-admission) for exact
+    /// keys, the raw/tracked matrix and complete ownership/lifecycle rules.
     pub async fn start_with_admission<T: TransportPort + 'static>(
         ports: Vec<RouterPort<T>>,
     ) -> Result<(Self, AdmissionReceiver<ReceivedApdu>), Error> {
@@ -478,6 +499,13 @@ impl BACnetRouter {
     }
 
     /// Stop the router.
+    ///
+    /// Aborts and awaits dispatch, sender and aging tasks without waiting for
+    /// the local application consumer, even with a full queue. Queued local
+    /// APDUs remain drainable, retaining their reply senders until consumed or
+    /// the receiver is dropped. Stop is not an admission drop and does not clear
+    /// depth/high-water/drop totals. See the
+    /// [receive-queue contract](crate::layer#receive-queue-admission).
     pub async fn stop(&mut self) {
         for task in self.dispatch_tasks.drain(..) {
             task.abort();

--- a/crates/bacnet-network/src/router_table.rs
+++ b/crates/bacnet-network/src/router_table.rs
@@ -31,6 +31,7 @@ pub struct RouteEntry {
     pub next_hop_mac: MacAddr,
     /// When this learned route was last confirmed. `None` for direct routes.
     pub last_seen: Option<Instant>,
+    /// Recorded reachability state of this route.
     pub reachability: ReachabilityStatus,
     /// Deadline after which a `Busy` status auto-clears (spec 6.6.3.6).
     pub busy_until: Option<Instant>,


### PR DESCRIPTION
Slice 5 of #532 (final): public-contract consolidation + closure evidence. Docs-only, no behavior change.

Unifies the admission contract in rustdoc across NetworkLayer::start/start_with_admission, both control-enable methods, BACnetRouter::start/start_with_admission, AdmissionReceiver, snapshot/counters, and ingress_network: 256 capacity, 16/key quotas with exact key definitions, Closed > fairness > Full precedence, drop-arriving ownership release, legacy-vs-tracked matrix, close/drop/stop semantics, counters-handle lifetime. Fixes four small doc drifts (try_recv drained distinction, ingress sequencing scope, control-enablement ordering, shared router counters). Notes priority_channel's non-role on these paths. Documents three previously-undocumented pub fields.

Closure audit: all six assessed stall sites use non-waiting admission (try_send/try_send_apdu); remaining .send( hits are test traffic or priority_channel internals with no production consumers.

Validation: bacnet-network 106+1 PASS, FULL conformance_ledger 27/27 PASS, clippy/fmt/size/secrets PASS, strict rustdoc for bacnet-network zero warnings (exit 0; remaining warnings are pre-existing in untouched dependency crates).