### PR TITLE
fix(server): refuse ReinitializeDevice after password validation (#636)

### DIFF
--- a/crates/bacnet-server/src/handlers/device_mgmt.rs
+++ b/crates/bacnet-server/src/handlers/device_mgmt.rs
@@ -132,7 +132,9 @@ pub(crate) fn validate_dcc(
 
 /// Handle a ReinitializeDevice request.
 ///
-/// Returns the requested state. The caller decides what action to take.
+/// Intentionally validates decoding and the password only; no action is performed.
+/// Until an action surface exists, the server caller refuses the request after
+/// successful validation with SERVICES / SERVICE_REQUEST_DENIED.
 pub fn handle_reinitialize_device(
     service_data: &[u8],
     reinit_password: &Option<String>,

--- a/crates/bacnet-server/src/server/requests/confirmed.rs
+++ b/crates/bacnet-server/src/server/requests/confirmed.rs
@@ -6,6 +6,10 @@ use super::*;
 mod dcc_tests;
 
 #[cfg(test)]
+#[path = "reinitialize_device_tests.rs"]
+mod reinitialize_device_tests;
+
+#[cfg(test)]
 impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Atomically admit a confirmed request before DCC, service decoding,
     /// authorization, mutation, side effects, or response construction.

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -303,13 +303,14 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 .await
             }
             s if s == ConfirmedServiceChoice::REINITIALIZE_DEVICE => {
-                match handlers::handle_reinitialize_device(
-                    &req.service_request,
-                    &config.reinit_password,
-                ) {
-                    Ok(()) => simple_ack(),
-                    Err(e) => Self::error_apdu_from_error(invoke_id, service_choice, &e),
-                }
+                let password = &config.reinit_password;
+                let error = handlers::handle_reinitialize_device(&req.service_request, password)
+                    .err()
+                    .unwrap_or(Error::Protocol {
+                        class: ErrorClass::SERVICES.to_raw() as u32,
+                        code: ErrorCode::SERVICE_REQUEST_DENIED.to_raw() as u32,
+                    });
+                Self::error_apdu_from_error(invoke_id, service_choice, &error)
             }
             s if s == ConfirmedServiceChoice::GET_EVENT_INFORMATION => {
                 event_information::response(

--- a/crates/bacnet-server/src/server/requests/reinitialize_device_tests.rs
+++ b/crates/bacnet-server/src/server/requests/reinitialize_device_tests.rs
@@ -1,0 +1,152 @@
+use super::*;
+
+use bacnet_encoding::{apdu::decode_apdu, npdu::decode_npdu};
+use bacnet_services::device_mgmt::ReinitializeDeviceRequest;
+use bacnet_types::enums::ReinitializedState;
+
+const STATES: [ReinitializedState; 10] = [
+    ReinitializedState::COLDSTART,
+    ReinitializedState::WARMSTART,
+    ReinitializedState::START_BACKUP,
+    ReinitializedState::END_BACKUP,
+    ReinitializedState::START_RESTORE,
+    ReinitializedState::END_RESTORE,
+    ReinitializedState::ABORT_RESTORE,
+    ReinitializedState::ACTIVATE_CHANGES,
+    // The decoder preserves unknown values; they must not bypass refusal either.
+    ReinitializedState::from_raw(8),
+    ReinitializedState::from_raw(u32::MAX),
+];
+
+fn request_data(state: ReinitializedState, password: Option<&str>) -> Bytes {
+    let mut data = BytesMut::new();
+    ReinitializeDeviceRequest {
+        reinitialized_state: state,
+        password: password.map(str::to_owned),
+    }
+    .encode(&mut data)
+    .unwrap();
+    data.freeze()
+}
+
+async fn dispatch(service_request: Bytes, password: Option<&str>, initial: u8) -> Apdu {
+    let network = Arc::new(NetworkLayer::new(BipTransport::new(
+        Ipv4Addr::LOCALHOST,
+        0,
+        Ipv4Addr::BROADCAST,
+    )));
+    let comm_state = Arc::new(AtomicU8::new(initial));
+    let dcc_timer = Arc::new(Mutex::new(None));
+    let config = ServerConfig {
+        reinit_password: password.map(str::to_owned),
+        ..Default::default()
+    };
+    let request = ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 480,
+        invoke_id: 42,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: ConfirmedServiceChoice::REINITIALIZE_DEVICE,
+        service_request,
+    };
+    let (tx, rx) = oneshot::channel();
+    BACnetServer::<BipTransport>::handle_confirmed_request(
+        &Arc::new(RwLock::new(ObjectDatabase::new())),
+        &network,
+        &Arc::new(RwLock::new(CovSubscriptionTable::new())),
+        &Arc::new(segmented_send::SegmentedSendRegistry::default()),
+        &Arc::new(Semaphore::new(MAX_SEG_SENDERS)),
+        &Arc::new(Semaphore::new(1)),
+        &Arc::new(Mutex::new(ServerTsm::new())),
+        &NotificationTransactions::new(),
+        &Arc::new(ConfirmedRequestTracker::default()),
+        &Arc::new(RwLock::new(DeviceBindingTable::new())),
+        &comm_state,
+        &dcc_timer,
+        &config,
+        &Arc::new(crate::server::request_tasks::RequestTasks::default()).spawner(),
+        &[127, 0, 0, 1, 0xba, 0xc0],
+        None,
+        request,
+        Some(tx),
+    )
+    .await;
+    assert_eq!(comm_state.load(Ordering::Acquire), initial);
+    assert!(dcc_timer.lock().await.is_none());
+    let npdu = decode_npdu(rx.await.unwrap()).unwrap();
+    decode_apdu(npdu.payload).unwrap()
+}
+
+fn assert_error(apdu: Apdu, class: ErrorClass, code: ErrorCode) {
+    let Apdu::Error(error) = apdu else {
+        panic!("expected Error, never SimpleACK, got {apdu:?}")
+    };
+    assert_eq!(error.invoke_id, 42);
+    assert_eq!(
+        error.service_choice,
+        ConfirmedServiceChoice::REINITIALIZE_DEVICE
+    );
+    assert_eq!(error.error_class, class);
+    assert_eq!(error.error_code, code);
+    assert!(error.error_data.is_empty());
+}
+
+#[tokio::test(start_paused = true)]
+async fn reinitialize_device_refuses_all_states_after_password_validation() {
+    for state in STATES {
+        for (configured, supplied) in [
+            (Some("reinit-pw"), Some("reinit-pw")),
+            (None, None),
+            (None, Some("anything")),
+        ] {
+            for initial in [0, 1, 2] {
+                assert_error(
+                    dispatch(request_data(state, supplied), configured, initial).await,
+                    ErrorClass::SERVICES,
+                    ErrorCode::SERVICE_REQUEST_DENIED,
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn reinitialize_device_password_failure_precedes_refusal() {
+    for state in STATES {
+        for supplied in [None, Some("wrong")] {
+            for initial in [0, 1, 2] {
+                assert_error(
+                    dispatch(request_data(state, supplied), Some("reinit-pw"), initial).await,
+                    ErrorClass::SECURITY,
+                    ErrorCode::PASSWORD_FAILURE,
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn reinitialize_device_malformed_request_precedes_password_and_refusal() {
+    for data in [
+        &[][..],                    // Missing state.
+        &[0x09][..],                // Truncated state.
+        &[0x19, 0x00][..],          // Wrong state tag.
+        &[0x09, 0x01, 0x1a, 0][..], // Truncated password.
+    ] {
+        assert!(ReinitializeDeviceRequest::decode(data).is_err());
+        for configured in [None, Some("reinit-pw")] {
+            for initial in [0, 1, 2] {
+                // Preserve the server's existing decode-error mapping.
+                assert_error(
+                    dispatch(Bytes::copy_from_slice(data), configured, initial).await,
+                    ErrorClass::SERVICES,
+                    ErrorCode::OTHER,
+                );
+            }
+        }
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -184,7 +184,13 @@ The `BACnetServer` spawns several background tasks:
 | Trend log | Records data samples for trend log objects | Per-object interval |
 | Schedule tick | Evaluates weekly schedules and exception dates | 60s |
 
-The server handles 20+ services including ReadProperty, WriteProperty, ReadPropertyMultiple, WritePropertyMultiple, SubscribeCOV, CreateObject, DeleteObject, DeviceCommunicationControl, ReinitializeDevice, GetEventInformation, GetAlarmSummary, LifeSafetyOperation, AtomicReadFile, AtomicWriteFile, TimeSynchronization, and more.
+The server handles 20+ services including ReadProperty, WriteProperty, ReadPropertyMultiple, WritePropertyMultiple, SubscribeCOV, CreateObject, DeleteObject, DeviceCommunicationControl, GetEventInformation, GetAlarmSummary, LifeSafetyOperation, AtomicReadFile, AtomicWriteFile, TimeSynchronization, and more.
+
+ReinitializeDevice is decoded and password-validated, then refused with
+`SERVICES / SERVICE_REQUEST_DENIED` for every requested state until an action
+surface exists. The server performs no reinitialization and never sends a
+SimpleACK for this service. Password failures and malformed-request errors retain
+their existing responses before refusal.
 
 ## Companion projects
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -1259,7 +1259,11 @@ The server automatically dispatches:
 - ReadPropertyMultiple, WritePropertyMultiple
 - SubscribeCOV, SubscribeCOVProperty, SubscribeCOVPropertyMultiple
 - CreateObject, DeleteObject
-- DeviceCommunicationControl, ReinitializeDevice
+- DeviceCommunicationControl
+- ReinitializeDevice (decoded and password-validated, then refused with
+  `SERVICES / SERVICE_REQUEST_DENIED` for every requested state until an action
+  surface exists; no reinitialization or SimpleACK, with password and decode
+  errors retaining their existing precedence)
 - GetEventInformation, AcknowledgeAlarm
 - GetAlarmSummary, GetEnrollmentSummary
 - ConfirmedTextMessage


### PR DESCRIPTION
Closes #636 (owner-locked loud refusal).

An authenticated ReinitializeDevice request was validated then ACKed with no action. Now: decode, then password validation (wrong password still SECURITY/PASSWORD_FAILURE, malformed still decode error), then refusal with Error SERVICES/SERVICE_REQUEST_DENIED for every requested state — the DCC-deprecated-DISABLE precedent. No SimpleACK is ever emitted for this service; no state change, timer, or hook. Server support docs corrected in architecture.md and rust-api.md; DCC untouched.

Validation: bacnet-server 1,052+3 PASS, FULL conformance_ledger 27/27 PASS, clippy/fmt/size/secrets PASS, 3 new refusal regressions (174 cases: states, passwords, malformed, comm-state/timer invariance; red-before-green against SimpleACK).