### PR TITLE
fix(network): dampen reject-driven route transitions per ingress source (#635)

### DIFF
--- a/crates/bacnet-network/src/router/claim_tests.rs
+++ b/crates/bacnet-network/src/router/claim_tests.rs
@@ -1,0 +1,384 @@
+use super::*;
+use crate::router_table::RoutingClaimSnapshot;
+
+// Invoke the real handler with in-memory port queues; no sleeps, sockets or
+// background aging. Exact hold-down boundaries are covered by injected table time.
+async fn deliver(
+    table: &Arc<Mutex<RouterTable>>,
+    port: usize,
+    source_mac: &[u8],
+    message_type: NetworkMessageType,
+    payload: &[u8],
+) -> [Vec<SendRequest>; 2] {
+    let (tx0, mut rx0) = mpsc::channel(16);
+    let (tx1, mut rx1) = mpsc::channel(16);
+    let npdu = Npdu {
+        is_network_message: true,
+        message_type: Some(message_type.to_raw()),
+        payload: Bytes::copy_from_slice(payload),
+        ..Default::default()
+    };
+    handle_network_message(table, &[tx0, tx1], port, 1000, source_mac, &npdu).await;
+    let mut output = [Vec::new(), Vec::new()];
+    while let Ok(request) = rx0.try_recv() {
+        output[0].push(request);
+    }
+    while let Ok(request) = rx1.try_recv() {
+        output[1].push(request);
+    }
+    output
+}
+
+async fn reject(table: &Arc<Mutex<RouterTable>>, port: usize, source_mac: &[u8], reason: u8) {
+    let output = deliver(
+        table,
+        port,
+        source_mac,
+        NetworkMessageType::REJECT_MESSAGE_TO_NETWORK,
+        &[reason, 0x0b, 0xb8],
+    )
+    .await;
+    assert!(output.iter().all(Vec::is_empty));
+}
+
+#[tokio::test]
+async fn first_rejects_keep_legacy_effects_and_repeated_claims_count_once() {
+    for reason in [0, 1, 2] {
+        let mut table = RouterTable::new();
+        table.add_learned(3000, 0, MacAddr::from_slice(&[1]));
+        let table = Arc::new(Mutex::new(table));
+        for _ in 0..12 {
+            reject(&table, 0, &[1], reason).await;
+        }
+        let table = table.lock().await;
+        match reason {
+            1 => assert_eq!(
+                table.effective_reachability(3000),
+                Some(ReachabilityStatus::Unreachable)
+            ),
+            2 => assert_eq!(
+                table.effective_reachability(3000),
+                Some(ReachabilityStatus::Busy)
+            ),
+            _ => assert!(table.lookup(3000).is_none()),
+        }
+        assert_eq!(
+            table.claim_snapshot(),
+            RoutingClaimSnapshot {
+                reject_applied: 1,
+                reject_dampened: 11,
+                reject_dampened_same_state: 11,
+                ..Default::default()
+            }
+        );
+    }
+}
+
+#[tokio::test]
+async fn spoofing_mac_does_not_bypass_hold_down_but_another_ingress_is_independent() {
+    let mut table = RouterTable::new();
+    table.add_learned(3000, 0, MacAddr::from_slice(&[1]));
+    let table = Arc::new(Mutex::new(table));
+    reject(&table, 0, &[1], 2).await;
+    for mac in 1..=10 {
+        reject(&table, 0, &[mac], 1).await;
+    }
+    assert_eq!(
+        table.lock().await.effective_reachability(3000),
+        Some(ReachabilityStatus::Busy)
+    );
+    reject(&table, 1, &[1], 1).await;
+    let table = table.lock().await;
+    assert_eq!(
+        table.effective_reachability(3000),
+        Some(ReachabilityStatus::Unreachable)
+    );
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            reject_applied: 2,
+            reject_dampened: 10,
+            reject_dampened_hold_down: 10,
+            ..Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn i_am_refresh_rearms_rejects_and_last_wins_learning_still_warns() {
+    let table = Arc::new(Mutex::new(RouterTable::new()));
+    for (index, port) in [0, 0, 1, 0, 1, 0].into_iter().enumerate() {
+        let output = deliver(
+            &table,
+            port,
+            &[index as u8],
+            NetworkMessageType::I_AM_ROUTER_TO_NETWORK,
+            &[0x0b, 0xb8],
+        )
+        .await;
+        assert!(output[port].is_empty());
+        assert_eq!(output[1 - port].len(), 1); // Existing unconditional rebroadcast.
+        {
+            let table = table.lock().await;
+            let route = table.lookup(3000).unwrap();
+            assert_eq!(route.port_index, port);
+            assert_eq!(route.next_hop_mac.as_slice(), &[index as u8]);
+            assert_eq!(route.reachability, ReachabilityStatus::Reachable);
+        }
+        reject(&table, 0, &[1], 1).await;
+        assert_eq!(
+            table.lock().await.effective_reachability(3000),
+            Some(ReachabilityStatus::Unreachable)
+        );
+    }
+    let table = table.lock().await;
+    assert_eq!(table.lookup(3000).unwrap().flap_count, 4);
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            learned_ok: 6,
+            reject_applied: 6,
+            flap_warned: 2,
+            ..Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn learning_outcomes_exclude_direct_reserved_and_truncated_entries() {
+    let mut table = RouterTable::new();
+    table.add_direct(1000, 0);
+    let table = Arc::new(Mutex::new(table));
+    deliver(
+        &table,
+        0,
+        &[1],
+        NetworkMessageType::I_AM_ROUTER_TO_NETWORK,
+        &[0, 0, 0xff, 0xff, 0x03, 0xe8, 0x0b, 0xb8, 0],
+    )
+    .await;
+    // Init preserves existing routes; only 4000 is new, the trailing entry is truncated.
+    let init = [
+        6, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0x03, 0xe8, 0, 0, 0x0b, 0xb8, 0, 0, 0x0f, 0xa0, 0, 0, 0x13,
+    ];
+    let output = deliver(
+        &table,
+        1,
+        &[2],
+        NetworkMessageType::INITIALIZE_ROUTING_TABLE,
+        &init,
+    )
+    .await;
+    assert_eq!(output[1].len(), 1); // ACK still generated.
+    assert_eq!(table.lock().await.lookup(3000).unwrap().port_index, 0);
+    // ACK refreshes existing learned routes, but still cannot overwrite direct.
+    deliver(
+        &table,
+        1,
+        &[2],
+        NetworkMessageType::INITIALIZE_ROUTING_TABLE_ACK,
+        &init,
+    )
+    .await;
+    let table = table.lock().await;
+    assert_eq!(table.len(), 3);
+    assert!(table.lookup(1000).unwrap().directly_connected);
+    assert_eq!(table.lookup(3000).unwrap().port_index, 1);
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            learned_ok: 4,
+            ..Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn each_learning_cap_counts_its_inspected_stop_without_changing_tail_handling() {
+    for message_type in [
+        NetworkMessageType::I_AM_ROUTER_TO_NETWORK,
+        NetworkMessageType::INITIALIZE_ROUTING_TABLE,
+        NetworkMessageType::INITIALIZE_ROUTING_TABLE_ACK,
+    ] {
+        let mut table = RouterTable::new();
+        for net in 1..=256 {
+            table.add_learned(net, 0, MacAddr::from_slice(&[1]));
+        }
+        let table = Arc::new(Mutex::new(table));
+        // The unknown 3000 triggers the cap; the existing 1 behind it stays unexamined.
+        let payload: &[u8] = if message_type == NetworkMessageType::I_AM_ROUTER_TO_NETWORK {
+            &[0x0b, 0xb8, 0, 1]
+        } else {
+            &[2, 0x0b, 0xb8, 0, 0, 0, 1, 0, 0]
+        };
+        deliver(&table, 1, &[2], message_type, payload).await;
+        {
+            let table = table.lock().await;
+            assert_eq!(table.len(), 256);
+            assert!(table.lookup(3000).is_none());
+            assert_eq!(table.lookup(1).unwrap().port_index, 0);
+            assert_eq!(
+                table.claim_snapshot(),
+                RoutingClaimSnapshot {
+                    learned_cap_ignored: 1,
+                    ..Default::default()
+                }
+            );
+        }
+        // Existing per-message cap behavior is preserved, including ACK's cap
+        // before refresh and Init's refusal to overwrite an existing route.
+        let existing: &[u8] = if message_type == NetworkMessageType::I_AM_ROUTER_TO_NETWORK {
+            &[0, 1]
+        } else {
+            &[1, 0, 1, 0, 0]
+        };
+        deliver(&table, 1, &[2], message_type, existing).await;
+        let table = table.lock().await;
+        let refreshed = message_type == NetworkMessageType::I_AM_ROUTER_TO_NETWORK;
+        assert_eq!(table.lookup(1).unwrap().port_index, usize::from(refreshed));
+        assert_eq!(table.claim_snapshot().learned_ok, u64::from(refreshed));
+        assert_eq!(
+            table.claim_snapshot().learned_cap_ignored,
+            if message_type == NetworkMessageType::INITIALIZE_ROUTING_TABLE_ACK {
+                2
+            } else {
+                1
+            }
+        );
+    }
+}
+
+#[tokio::test]
+async fn direct_route_immunity_and_malformed_rejects_under_spam() {
+    let mut table = RouterTable::new();
+    table.add_direct(3000, 0);
+    let table = Arc::new(Mutex::new(table));
+    for _ in 0..10 {
+        for reason in [0, 1, 2] {
+            reject(&table, 1, &[1], reason).await;
+        }
+    }
+    for payload in [&[][..], &[1][..], &[1, 0x0b][..]] {
+        deliver(
+            &table,
+            0,
+            &[1],
+            NetworkMessageType::REJECT_MESSAGE_TO_NETWORK,
+            payload,
+        )
+        .await;
+    }
+    let table = table.lock().await;
+    assert_eq!(
+        table.effective_reachability(3000),
+        Some(ReachabilityStatus::Reachable)
+    );
+    assert!(table.lookup(3000).unwrap().directly_connected);
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            reject_dampened: 30,
+            reject_dampened_same_state: 30,
+            ..Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn init_ack_refresh_rearms_but_init_existing_entry_does_not() {
+    let mut table = RouterTable::new();
+    table.add_learned(3000, 0, MacAddr::from_slice(&[1]));
+    let table = Arc::new(Mutex::new(table));
+    let payload = [1, 0x0b, 0xb8, 0, 0];
+    reject(&table, 0, &[1], 2).await;
+    deliver(
+        &table,
+        1,
+        &[2],
+        NetworkMessageType::INITIALIZE_ROUTING_TABLE,
+        &payload,
+    )
+    .await;
+    reject(&table, 0, &[1], 1).await;
+    assert_eq!(
+        table.lock().await.effective_reachability(3000),
+        Some(ReachabilityStatus::Busy)
+    );
+    deliver(
+        &table,
+        1,
+        &[2],
+        NetworkMessageType::INITIALIZE_ROUTING_TABLE_ACK,
+        &payload,
+    )
+    .await;
+    reject(&table, 0, &[1], 1).await;
+    let table = table.lock().await;
+    assert_eq!(
+        table.effective_reachability(3000),
+        Some(ReachabilityStatus::Unreachable)
+    );
+    assert_eq!(table.lookup(3000).unwrap().port_index, 1);
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            learned_ok: 1,
+            reject_applied: 2,
+            reject_dampened: 1,
+            reject_dampened_hold_down: 1,
+            ..Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn dampened_table_transition_still_relays_every_reject() {
+    use bacnet_encoding::npdu::NpduAddress;
+
+    let mut table = RouterTable::new();
+    table.add_learned(3000, 0, MacAddr::from_slice(&[1]));
+    table.add_direct(4000, 1);
+    let table = Arc::new(Mutex::new(table));
+    let (tx0, mut rx0) = mpsc::channel(16);
+    let (tx1, mut rx1) = mpsc::channel(16);
+    let send_txs = [tx0, tx1];
+    let source = NpduAddress {
+        network: 4000,
+        mac_address: MacAddr::from_slice(&[7]),
+    };
+    for reason in [1, 1, 2] {
+        let npdu = Npdu {
+            is_network_message: true,
+            message_type: Some(NetworkMessageType::REJECT_MESSAGE_TO_NETWORK.to_raw()),
+            source: Some(source.clone()),
+            payload: Bytes::from(vec![reason, 0x0b, 0xb8]),
+            ..Default::default()
+        };
+        handle_network_message(&table, &send_txs, 0, 1000, &[1], &npdu).await;
+        let SendRequest::Unicast {
+            npdu: data, mac, ..
+        } = rx1.try_recv().unwrap()
+        else {
+            panic!("expected original reject relay");
+        };
+        assert_eq!(mac, source.mac_address);
+        let relayed = decode_npdu(data).unwrap();
+        assert_eq!(relayed.destination, Some(source.clone()));
+        assert_eq!(relayed.payload, npdu.payload);
+        assert_eq!(relayed.message_type, npdu.message_type);
+        assert!(relayed.source.is_none());
+        assert_eq!(relayed.hop_count, 255);
+        assert!(rx0.try_recv().is_err());
+        assert!(rx1.try_recv().is_err());
+    }
+    assert_eq!(
+        table.lock().await.claim_snapshot(),
+        RoutingClaimSnapshot {
+            reject_applied: 1,
+            reject_dampened: 2,
+            reject_dampened_same_state: 1,
+            reject_dampened_hold_down: 1,
+            ..Default::default()
+        }
+    );
+}

--- a/crates/bacnet-network/src/router/control_messages.rs
+++ b/crates/bacnet-network/src/router/control_messages.rs
@@ -104,12 +104,14 @@ pub(super) async fn handle_network_message(
             offset += 2;
 
             if table.len() >= MAX_LEARNED_ROUTES && table.lookup(net).is_none() {
+                table.record_learning_cap();
                 warn!("Router table learned routes cap ({MAX_LEARNED_ROUTES}) reached, ignoring further networks");
                 break;
             }
 
             if table.add_learned_with_flap_detection(net, port_idx, MacAddr::from_slice(source_mac))
             {
+                table.record_learned();
                 debug!(
                     network = net,
                     port = port_idx,
@@ -148,18 +150,7 @@ pub(super) async fn handle_network_message(
             );
             {
                 let mut tbl = table.lock().await;
-                if let Some(entry) = tbl.lookup(rejected_net) {
-                    if !entry.directly_connected {
-                        match reason {
-                            1 => tbl.mark_unreachable(rejected_net),
-                            2 => tbl
-                                .mark_busy(rejected_net, Instant::now() + Duration::from_secs(30)),
-                            _ => {
-                                tbl.remove(rejected_net);
-                            }
-                        }
-                    }
-                }
+                tbl.apply_reject(rejected_net, port_idx, reason, Instant::now());
             }
 
             // Relay the reject to the originating node if SNET/SADR is present.
@@ -284,10 +275,12 @@ pub(super) async fn handle_network_message(
                     continue; // don't overwrite existing routes
                 }
                 if tbl.len() >= MAX_LEARNED_ROUTES {
+                    tbl.record_learning_cap();
                     warn!("Init-Routing-Table: route cap reached, ignoring further entries");
                     break;
                 }
                 tbl.add_learned(net, port_idx, MacAddr::from_slice(source_mac));
+                tbl.record_learned();
                 debug!(
                     network = net,
                     port = port_idx,
@@ -449,9 +442,13 @@ pub(super) async fn handle_network_message(
                 continue;
             }
             if table.len() >= MAX_LEARNED_ROUTES {
+                table.record_learning_cap();
                 break;
             }
-            table.add_learned_with_flap_detection(net, port_idx, MacAddr::from_slice(source_mac));
+            if table.add_learned_with_flap_detection(net, port_idx, MacAddr::from_slice(source_mac))
+            {
+                table.record_learned();
+            }
             debug!(
                 network = net,
                 port = port_idx,

--- a/crates/bacnet-network/src/router/mod.rs
+++ b/crates/bacnet-network/src/router/mod.rs
@@ -13,6 +13,33 @@
 //! Local application delivery follows the shared
 //! [receive-queue contract](crate::layer#receive-queue-admission), independently
 //! of forwarding and inline network-message handling.
+//!
+//! # Routing-claim trust model
+//!
+//! Classic BACnet routing claims are unauthenticated: an ingress port, next-hop
+//! MAC or advertised network is not proof that a peer is authorized to control
+//! that route. Learning remains last-wins; these local mitigations do not
+//! prevent route poisoning or authenticate a claim (Clauses 6.4 and 6.6.3):
+//! - Direct routes cannot be overwritten by learning or changed by rejects.
+//! - I-Am-Router and Initialize-Routing-Table/ACK retain their existing route-cap
+//!   checks; stale learned routes age out, and rapid port changes warn.
+//! - Reject-driven table transitions are dampened per (ingress port, network),
+//!   not by spoofable source MAC or routed source address. No-op rejects are
+//!   ignored, without renewing busy deadlines. A first state-changing reject
+//!   applies; further changes within 30s of the last applied reject are ignored.
+//!   Ignored claims do not extend that window. Learning refresh/replacement,
+//!   removal and aging re-arm all ingress keys for that network.
+//! - [`RouterTable::claim_snapshot`] exposes saturating count-only outcomes;
+//!   counters never influence learning or forwarding.
+//!
+//! The private 30s hold-down aligns with the existing reject-busy deadline: one
+//! busy marking buys at most one accepted reject-driven churn event per key per
+//! 30s without fresh learning; legitimate re-signals after the window can apply.
+//! **Trade-off:** a legitimate unreachable-after-busy signal can be delayed up
+//! to 30s. This is local hardening, not a protocol authentication mechanism.
+//! Learning can re-arm dampening even when the refresh is malicious. Other
+//! control-message handling, forwarding, reject relay and warning behavior are
+//! unchanged; operators still need a trusted, appropriately isolated network.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -524,5 +551,7 @@ impl BACnetRouter {
 
 #[cfg(test)]
 mod admission_tests;
+#[cfg(test)]
+mod claim_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/bacnet-network/src/router_table.rs
+++ b/crates/bacnet-network/src/router_table.rs
@@ -9,6 +9,37 @@ use std::time::{Duration, Instant};
 
 use bacnet_types::MacAddr;
 
+// Align with the existing 30s reject-busy deadline: at most one accepted
+// reject-driven change per (ingress port, network) per window without fresh
+// learning. A legitimate unreachable-after-busy signal may wait up to 30s.
+const HOLD_DOWN: Duration = Duration::from_secs(30);
+
+/// Count-only outcomes for routing claims handled by one router table.
+///
+/// All totals saturate at `u64::MAX`, never affect routing decisions, and expose
+/// no peer identities. Learning totals cover inspected I-Am-Router and
+/// Initialize-Routing-Table/ACK entries, not manual table edits or other message
+/// types. Existing cap-triggered early stops remain: their unexamined suffixes
+/// are not classified or counted. Flap warnings are counted at their emission.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct RoutingClaimSnapshot {
+    /// Rejects that changed a learned route's effective state or removed it.
+    pub reject_applied: u64,
+    /// Rejects ignored as no-ops or during hold-down (counted once each).
+    pub reject_dampened: u64,
+    /// No-op rejects, including missing routes and directly-connected immunity.
+    /// Busy duplicates do not extend the existing busy deadline.
+    pub reject_dampened_same_state: u64,
+    /// State-changing rejects ignored within 30s of this key's last applied one.
+    pub reject_dampened_hold_down: u64,
+    /// Inspected learning claims that inserted or refreshed a learned route.
+    pub learned_ok: u64,
+    /// Inspected entries that triggered the existing route-cap early stop.
+    pub learned_cap_ignored: u64,
+    /// Flap warnings emitted at the existing port-change threshold.
+    pub flap_warned: u64,
+}
+
 /// Reachability status of a route entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReachabilityStatus {
@@ -48,6 +79,12 @@ pub struct RouteEntry {
 pub struct RouterTable {
     /// Network number → route entry.
     routes: HashMap<u16, RouteEntry>,
+    // Network → (ingress port → last APPLIED reject). Grouping by network makes
+    // re-arming on learning/removal local. Only live learned routes retain
+    // records, at most one per router ingress port; absent/direct spam allocates
+    // nothing. Neither peer MACs nor advertised source addresses are keys.
+    reject_transitions: HashMap<u16, HashMap<usize, Instant>>,
+    claim_counters: RoutingClaimSnapshot,
 }
 
 impl RouterTable {
@@ -55,7 +92,86 @@ impl RouterTable {
     pub fn new() -> Self {
         Self {
             routes: HashMap::new(),
+            reject_transitions: HashMap::new(),
+            claim_counters: RoutingClaimSnapshot::default(),
         }
+    }
+
+    /// Read a consistent, non-resetting copy of this table's routing-claim totals.
+    ///
+    /// For a live router, call `router.table().lock().await.claim_snapshot()`.
+    /// The snapshot owns only counts and remains readable after table drop;
+    /// cloning the table copies, rather than shares, its counters and records.
+    pub fn claim_snapshot(&self) -> RoutingClaimSnapshot {
+        self.claim_counters
+    }
+
+    pub(crate) fn record_learned(&mut self) {
+        self.claim_counters.learned_ok = self.claim_counters.learned_ok.saturating_add(1);
+    }
+
+    pub(crate) fn record_learning_cap(&mut self) {
+        self.claim_counters.learned_cap_ignored =
+            self.claim_counters.learned_cap_ignored.saturating_add(1);
+    }
+
+    /// Apply only the reject-driven table transition, never its relay.
+    /// The caller holds the table lock across this synchronous gate and update.
+    /// `now` is supplied so deadline boundaries can be tested without sleeping.
+    pub(crate) fn apply_reject(
+        &mut self,
+        network: u16,
+        ingress_port: usize,
+        reason: u8,
+        now: Instant,
+    ) {
+        let changes_state = self.routes.get(&network).is_some_and(|entry| {
+            if entry.directly_connected {
+                return false;
+            }
+            // Compare effective state, not the stored Busy marker: a busy
+            // deadline may have elapsed before the next aging sweep.
+            match reason {
+                1 => entry.reachability != ReachabilityStatus::Unreachable,
+                2 => {
+                    entry.reachability != ReachabilityStatus::Busy
+                        || entry.busy_until.is_some_and(|deadline| now >= deadline)
+                }
+                _ => true,
+            }
+        });
+        let held_down = self
+            .reject_transitions
+            .get(&network)
+            .and_then(|ports| ports.get(&ingress_port))
+            .is_some_and(|last| now.duration_since(*last) < HOLD_DOWN);
+        if !changes_state || held_down {
+            let counters = &mut self.claim_counters;
+            counters.reject_dampened = counters.reject_dampened.saturating_add(1);
+            if !changes_state {
+                counters.reject_dampened_same_state =
+                    counters.reject_dampened_same_state.saturating_add(1);
+            } else {
+                counters.reject_dampened_hold_down =
+                    counters.reject_dampened_hold_down.saturating_add(1);
+            }
+            return; // Ignored claims never slide the window or busy deadline.
+        }
+
+        match reason {
+            1 => self.mark_unreachable(network),
+            2 => self.mark_busy(network, now + Duration::from_secs(30)),
+            _ => {
+                self.remove(network); // Removal also discards every port's record.
+            }
+        }
+        if self.routes.contains_key(&network) {
+            self.reject_transitions
+                .entry(network)
+                .or_default()
+                .insert(ingress_port, now);
+        }
+        self.claim_counters.reject_applied = self.claim_counters.reject_applied.saturating_add(1);
     }
 
     /// Add a directly-connected network on the given port.
@@ -64,6 +180,7 @@ impl RouterTable {
         if network == 0 || network == 0xFFFF {
             return;
         }
+        self.reject_transitions.remove(&network);
         self.routes.insert(
             network,
             RouteEntry {
@@ -91,6 +208,7 @@ impl RouterTable {
                 return; // never overwrite direct routes
             }
         }
+        self.reject_transitions.remove(&network);
         self.routes.insert(
             network,
             RouteEntry {
@@ -132,6 +250,8 @@ impl RouterTable {
                     _ => 1,
                 };
                 if flap_count >= 3 {
+                    self.claim_counters.flap_warned =
+                        self.claim_counters.flap_warned.saturating_add(1);
                     tracing::warn!(
                         network,
                         old_port = existing.port_index,
@@ -141,6 +261,7 @@ impl RouterTable {
                         flap_count
                     );
                 }
+                self.reject_transitions.remove(&network);
                 self.routes.insert(
                     network,
                     RouteEntry {
@@ -228,6 +349,7 @@ impl RouterTable {
 
     /// Remove a route.
     pub fn remove(&mut self, network: u16) -> Option<RouteEntry> {
+        self.reject_transitions.remove(&network);
         self.routes.remove(&network)
     }
 
@@ -293,7 +415,7 @@ impl RouterTable {
             .map(|(net, _)| *net)
             .collect();
         for net in &stale {
-            self.routes.remove(net);
+            self.remove(*net);
         }
         stale
     }
@@ -304,6 +426,10 @@ impl Default for RouterTable {
         Self::new()
     }
 }
+
+#[cfg(test)]
+#[path = "router_table_reject_tests.rs"]
+mod reject_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/bacnet-network/src/router_table_reject_tests.rs
+++ b/crates/bacnet-network/src/router_table_reject_tests.rs
@@ -1,0 +1,319 @@
+use super::*;
+
+fn learned_table() -> RouterTable {
+    let mut table = RouterTable::new();
+    table.add_learned(3000, 0, MacAddr::from_slice(&[1]));
+    table
+}
+
+#[test]
+fn reject_spam_is_idempotent_without_refreshing_route_or_window() {
+    let mut table = learned_table();
+    let seen = table.lookup(3000).unwrap().last_seen;
+    let now = Instant::now();
+    for second in 0..100 {
+        table.apply_reject(3000, 0, 1, now + Duration::from_secs(second));
+    }
+    assert_eq!(table.lookup(3000).unwrap().last_seen, seen);
+    assert_eq!(
+        table.lookup(3000).unwrap().reachability,
+        ReachabilityStatus::Unreachable
+    );
+    assert_eq!(table.reject_transitions[&3000][&0], now);
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            reject_applied: 1,
+            reject_dampened: 99,
+            reject_dampened_same_state: 99,
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn alternating_rejects_hold_until_exact_boundary_without_sliding() {
+    for first in [1, 2] {
+        let mut table = learned_table();
+        let now = Instant::now();
+        let status = if first == 1 {
+            ReachabilityStatus::Unreachable
+        } else {
+            ReachabilityStatus::Busy
+        };
+        for second in 0..10 {
+            let reason = if second % 2 == 0 { first } else { 3 - first };
+            table.apply_reject(3000, 0, reason, now + Duration::from_secs(second));
+            assert_eq!(table.lookup(3000).unwrap().reachability, status);
+        }
+        table.apply_reject(
+            3000,
+            0,
+            3 - first,
+            now + HOLD_DOWN - Duration::from_nanos(1),
+        );
+        assert_eq!(table.lookup(3000).unwrap().reachability, status);
+        assert_eq!(table.reject_transitions[&3000][&0], now);
+        if first == 2 {
+            assert_eq!(
+                table.lookup(3000).unwrap().busy_until,
+                Some(now + HOLD_DOWN)
+            );
+        }
+        table.apply_reject(3000, 0, 3 - first, now + HOLD_DOWN);
+        assert_ne!(table.lookup(3000).unwrap().reachability, status);
+        assert_eq!(table.reject_transitions[&3000][&0], now + HOLD_DOWN);
+        assert_eq!(
+            table.claim_snapshot(),
+            RoutingClaimSnapshot {
+                reject_applied: 2,
+                reject_dampened: 10,
+                reject_dampened_same_state: 4,
+                reject_dampened_hold_down: 6,
+                ..Default::default()
+            }
+        );
+    }
+}
+
+#[test]
+fn busy_duplicates_do_not_renew_deadline_and_expired_busy_can_be_rejected_again() {
+    let mut table = learned_table();
+    let now = Instant::now();
+    let deadline = now + Duration::from_secs(10);
+    table.mark_busy(3000, deadline); // Non-reject busy marking, no reject record.
+    table.apply_reject(3000, 0, 2, now);
+    assert_eq!(table.lookup(3000).unwrap().busy_until, Some(deadline));
+    assert!(table.reject_transitions.is_empty());
+    table.apply_reject(3000, 0, 2, deadline); // Inline expiry, no aging sweep.
+    assert_eq!(
+        table.lookup(3000).unwrap().busy_until,
+        Some(deadline + HOLD_DOWN)
+    );
+    table.apply_reject(3000, 0, 2, deadline + HOLD_DOWN - Duration::from_nanos(1));
+    table.apply_reject(3000, 0, 2, deadline + HOLD_DOWN);
+    assert_eq!(
+        table.lookup(3000).unwrap().busy_until,
+        Some(deadline + HOLD_DOWN * 2)
+    );
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            reject_applied: 2,
+            reject_dampened: 2,
+            reject_dampened_same_state: 2,
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn every_legacy_removal_reason_applies_first_but_obeys_hold_down() {
+    for reason in (0..=u8::MAX).filter(|reason| ![1, 2].contains(reason)) {
+        let now = Instant::now();
+        let mut table = learned_table();
+        table.apply_reject(3000, 0, reason, now);
+        assert!(table.lookup(3000).is_none());
+        assert!(table.reject_transitions.is_empty());
+        table.apply_reject(3000, 0, reason, now);
+        assert_eq!(table.claim_snapshot().reject_applied, 1);
+        assert_eq!(table.claim_snapshot().reject_dampened_same_state, 1);
+
+        table.add_learned(3000, 0, MacAddr::new());
+        table.apply_reject(3000, 0, 2, now);
+        table.apply_reject(3000, 0, reason, now + Duration::from_secs(1));
+        assert!(table.lookup(3000).is_some());
+        table.apply_reject(3000, 0, reason, now + HOLD_DOWN);
+        assert!(table.lookup(3000).is_none());
+        assert!(table.reject_transitions.is_empty());
+        assert_eq!(table.claim_snapshot().reject_applied, 3);
+        assert_eq!(table.claim_snapshot().reject_dampened_hold_down, 1);
+    }
+}
+
+#[test]
+fn learning_refresh_replacement_removal_and_aging_rearm_all_ingress_keys() {
+    for rearm in [
+        "same_peer",
+        "new_mac",
+        "new_port",
+        "manual_learning",
+        "remove",
+        "age",
+    ] {
+        let mut table = learned_table();
+        let now = Instant::now();
+        table.apply_reject(3000, 0, 1, now);
+        table.apply_reject(3000, 1, 2, now);
+        assert_eq!(table.reject_transitions[&3000].len(), 2);
+        match rearm {
+            "same_peer" => {
+                assert!(table.add_learned_with_flap_detection(3000, 0, MacAddr::from_slice(&[1])));
+            }
+            "new_mac" => {
+                assert!(table.add_learned_with_flap_detection(3000, 0, MacAddr::from_slice(&[2])));
+            }
+            "new_port" => {
+                assert!(table.add_learned_with_flap_detection(3000, 1, MacAddr::from_slice(&[1])));
+            }
+            "manual_learning" => table.add_learned(3000, 0, MacAddr::new()),
+            "remove" => {
+                assert!(table.remove(3000).is_some());
+                assert!(table.reject_transitions.is_empty());
+                table.add_learned(3000, 0, MacAddr::new());
+            }
+            "age" => {
+                table.lookup_mut(3000).unwrap().last_seen = Some(now - Duration::from_secs(120));
+                assert_eq!(table.purge_stale(Duration::from_secs(60)), vec![3000]);
+                assert!(table.reject_transitions.is_empty());
+                table.add_learned(3000, 0, MacAddr::new());
+            }
+            _ => unreachable!(),
+        }
+        assert!(table.reject_transitions.is_empty(), "{rearm}");
+        table.apply_reject(3000, 0, 1, now + Duration::from_secs(1));
+        table.apply_reject(3000, 1, 2, now + Duration::from_secs(1));
+        assert_eq!(
+            table.claim_snapshot(),
+            RoutingClaimSnapshot {
+                reject_applied: 4,
+                ..Default::default()
+            },
+            "{rearm}"
+        );
+    }
+}
+
+#[test]
+fn reject_keys_are_independent_by_ingress_port_and_network() {
+    let mut table = learned_table();
+    table.add_learned(4000, 0, MacAddr::from_slice(&[1]));
+    let now = Instant::now();
+    for (network, ingress, reason) in [(3000, 0, 1), (4000, 0, 2), (3000, 1, 2), (4000, 1, 1)] {
+        table.apply_reject(network, ingress, reason, now);
+    }
+    table.apply_reject(3000, 0, 1, now);
+    table.apply_reject(4000, 0, 2, now);
+    assert_eq!(
+        table.lookup(3000).unwrap().reachability,
+        ReachabilityStatus::Busy
+    );
+    assert_eq!(
+        table.lookup(4000).unwrap().reachability,
+        ReachabilityStatus::Unreachable
+    );
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            reject_applied: 4,
+            reject_dampened: 2,
+            reject_dampened_hold_down: 2,
+            ..Default::default()
+        }
+    );
+    table.add_learned(3000, 0, MacAddr::new());
+    assert_eq!(table.reject_transitions.len(), 1);
+    assert_eq!(table.reject_transitions[&4000].len(), 2);
+}
+
+#[test]
+fn direct_and_absent_spam_never_mutates_routes_or_allocates_records() {
+    let mut table = learned_table();
+    let now = Instant::now();
+    table.apply_reject(3000, 0, 2, now);
+    table.add_direct(3000, 1); // Replacing a learned route clears its records.
+    assert!(table.reject_transitions.is_empty());
+    for reason in 0..=u8::MAX {
+        for network in [3000, 4000] {
+            table.apply_reject(network, 0, reason, now);
+        }
+    }
+    let entry = table.lookup(3000).unwrap();
+    assert!(entry.directly_connected);
+    assert_eq!(entry.port_index, 1);
+    assert_eq!(entry.reachability, ReachabilityStatus::Reachable);
+    assert!(entry.busy_until.is_none());
+    assert!(entry.last_seen.is_none());
+    assert!(entry.next_hop_mac.is_empty());
+    assert!(table.lookup(4000).is_none());
+    assert!(table.reject_transitions.is_empty());
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            reject_applied: 1,
+            reject_dampened: 512,
+            reject_dampened_same_state: 512,
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn nonlearning_maintenance_does_not_rearm_rejects() {
+    let mut table = learned_table();
+    let now = Instant::now();
+    table.apply_reject(3000, 0, 1, now);
+    table.touch(3000);
+    table.mark_available(3000);
+    table.clear_expired_busy();
+    table.apply_reject(3000, 0, 2, now);
+    assert_eq!(
+        table.lookup(3000).unwrap().reachability,
+        ReachabilityStatus::Reachable
+    );
+    assert_eq!(table.claim_snapshot().reject_dampened_hold_down, 1);
+    assert_eq!(table.reject_transitions[&3000][&0], now);
+}
+
+#[test]
+fn counters_saturate_without_affecting_decisions_and_snapshots_are_owned() {
+    let mut table = learned_table();
+    table.claim_counters = RoutingClaimSnapshot {
+        reject_applied: u64::MAX - 1,
+        reject_dampened: u64::MAX - 1,
+        reject_dampened_same_state: u64::MAX - 1,
+        reject_dampened_hold_down: u64::MAX - 1,
+        learned_ok: u64::MAX - 1,
+        learned_cap_ignored: u64::MAX - 1,
+        flap_warned: u64::MAX - 1,
+    };
+    let before = table.claim_snapshot();
+    let now = Instant::now();
+    for _ in 0..2 {
+        table.add_learned(3000, 0, MacAddr::new());
+        table.apply_reject(3000, 0, 1, now);
+        table.apply_reject(3000, 0, 1, now);
+        table.apply_reject(3000, 0, 2, now);
+        assert_eq!(
+            table.lookup(3000).unwrap().reachability,
+            ReachabilityStatus::Unreachable
+        );
+        table.record_learned();
+        table.record_learning_cap();
+        let entry = table.lookup_mut(3000).unwrap();
+        entry.flap_count = 2;
+        entry.last_port_change = Some(now);
+        assert!(table.add_learned_with_flap_detection(3000, 1, MacAddr::new()));
+    }
+    let snapshot = table.claim_snapshot();
+    assert_eq!(
+        snapshot,
+        RoutingClaimSnapshot {
+            reject_applied: u64::MAX,
+            reject_dampened: u64::MAX,
+            reject_dampened_same_state: u64::MAX,
+            reject_dampened_hold_down: u64::MAX,
+            learned_ok: u64::MAX,
+            learned_cap_ignored: u64::MAX,
+            flap_warned: u64::MAX,
+        }
+    );
+    let cloned = table.clone();
+    drop(table);
+    assert_eq!(cloned.claim_snapshot(), snapshot);
+    assert_eq!(before.reject_applied, u64::MAX - 1);
+    assert_eq!(
+        RouterTable::default().claim_snapshot(),
+        RoutingClaimSnapshot::default()
+    );
+}


### PR DESCRIPTION
Partial #635 (owner-locked dampen + counters + docs; learning untouched).

Reject-Message-To-Network table mutations go through a synchronous per-(ingress-port, network) gate: same-effective-state rejects are no-ops (never renewing busy deadlines), state-changing repeats within a 30s hold-down are ignored, first transitions always apply, and learning refresh/replacement/removal/aging re-arms. New count-only RoutingClaimSnapshot (applied/dampened split by same-state vs hold-down, learning outcomes, flap warnings) via claim_snapshot(). Trust model documented on the router: claims unauthenticated, mitigations listed, 30s legitimate-signal delay and malicious-refresh re-arm disclosed.

Validation: bacnet-network 123+1 PASS, FULL conformance_ledger 27/27 PASS, clippy/fmt/size/secrets PASS, 17 new dampening/counter regressions.