### PR TITLE
fix(network): corroborate cross-port route replacements (#635)

### DIFF
--- a/crates/bacnet-network/src/router/claim_tests.rs
+++ b/crates/bacnet-network/src/router/claim_tests.rs
@@ -105,9 +105,19 @@ async fn spoofing_mac_does_not_bypass_hold_down_but_another_ingress_is_independe
 }
 
 #[tokio::test]
-async fn i_am_refresh_rearms_rejects_and_last_wins_learning_still_warns() {
+async fn i_am_refresh_rearms_rejects_and_corroborated_learning_still_warns() {
     let table = Arc::new(Mutex::new(RouterTable::new()));
     for (index, port) in [0, 0, 1, 0, 1, 0].into_iter().enumerate() {
+        if index >= 2 {
+            deliver(
+                &table,
+                port,
+                &[index as u8],
+                NetworkMessageType::I_AM_ROUTER_TO_NETWORK,
+                &[0x0b, 0xb8],
+            )
+            .await;
+        }
         let output = deliver(
             &table,
             port,
@@ -139,6 +149,8 @@ async fn i_am_refresh_rearms_rejects_and_last_wins_learning_still_warns() {
             learned_ok: 6,
             reject_applied: 6,
             flap_warned: 2,
+            pending_started: 4,
+            corroborated_applied: 4,
             ..Default::default()
         }
     );
@@ -171,7 +183,7 @@ async fn learning_outcomes_exclude_direct_reserved_and_truncated_entries() {
     .await;
     assert_eq!(output[1].len(), 1); // ACK still generated.
     assert_eq!(table.lock().await.lookup(3000).unwrap().port_index, 0);
-    // ACK refreshes existing learned routes, but still cannot overwrite direct.
+    // ACK refreshes same-port routes, holds cross-port claims, and cannot overwrite direct.
     deliver(
         &table,
         1,
@@ -183,11 +195,12 @@ async fn learning_outcomes_exclude_direct_reserved_and_truncated_entries() {
     let table = table.lock().await;
     assert_eq!(table.len(), 3);
     assert!(table.lookup(1000).unwrap().directly_connected);
-    assert_eq!(table.lookup(3000).unwrap().port_index, 1);
+    assert_eq!(table.lookup(3000).unwrap().port_index, 0);
     assert_eq!(
         table.claim_snapshot(),
         RoutingClaimSnapshot {
-            learned_ok: 4,
+            learned_ok: 3,
+            pending_started: 1,
             ..Default::default()
         }
     );
@@ -233,6 +246,10 @@ async fn each_learning_cap_counts_its_inspected_stop_without_changing_tail_handl
             &[1, 0, 1, 0, 0]
         };
         deliver(&table, 1, &[2], message_type, existing).await;
+        if message_type == NetworkMessageType::I_AM_ROUTER_TO_NETWORK {
+            assert_eq!(table.lock().await.lookup(1).unwrap().port_index, 0);
+            deliver(&table, 1, &[2], message_type, existing).await;
+        }
         let table = table.lock().await;
         let refreshed = message_type == NetworkMessageType::I_AM_ROUTER_TO_NETWORK;
         assert_eq!(table.lookup(1).unwrap().port_index, usize::from(refreshed));
@@ -306,7 +323,7 @@ async fn init_ack_refresh_rearms_but_init_existing_entry_does_not() {
     );
     deliver(
         &table,
-        1,
+        0,
         &[2],
         NetworkMessageType::INITIALIZE_ROUTING_TABLE_ACK,
         &payload,
@@ -318,7 +335,7 @@ async fn init_ack_refresh_rearms_but_init_existing_entry_does_not() {
         table.effective_reachability(3000),
         Some(ReachabilityStatus::Unreachable)
     );
-    assert_eq!(table.lookup(3000).unwrap().port_index, 1);
+    assert_eq!(table.lookup(3000).unwrap().port_index, 0);
     assert_eq!(
         table.claim_snapshot(),
         RoutingClaimSnapshot {

--- a/crates/bacnet-network/src/router/control_messages.rs
+++ b/crates/bacnet-network/src/router/control_messages.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -99,6 +100,7 @@ pub(super) async fn handle_network_message(
         let mut offset = 0;
         let mut table = table.lock().await;
 
+        let mut replacement_networks = HashSet::new();
         while offset + 2 <= data.len() {
             let net = u16::from_be_bytes([data[offset], data[offset + 1]]);
             offset += 2;
@@ -109,8 +111,21 @@ pub(super) async fn handle_network_message(
                 break;
             }
 
-            if table.add_learned_with_flap_detection(net, port_idx, MacAddr::from_slice(source_mac))
+            // Repeated entries in one packet are not independent arrivals.
+            // Leave absent learning and same-port refresh entries unchanged.
+            if table
+                .lookup(net)
+                .is_some_and(|entry| !entry.directly_connected && entry.port_index != port_idx)
+                && !replacement_networks.insert(net)
             {
+                continue;
+            }
+            if table.apply_learning_claim(
+                net,
+                port_idx,
+                MacAddr::from_slice(source_mac),
+                Instant::now(),
+            ) {
                 table.record_learned();
                 debug!(
                     network = net,
@@ -360,17 +375,12 @@ pub(super) async fn handle_network_message(
     } else if msg_type == NetworkMessageType::DISCONNECT_CONNECTION_TO_NETWORK.to_raw() {
         if npdu.payload.len() >= 2 {
             let net = u16::from_be_bytes([npdu.payload[0], npdu.payload[1]]);
-            debug!(network = net, "Received Disconnect-Connection-To-Network");
+            debug!(
+                network = net,
+                "Received Disconnect-Connection-To-Network (PTP not implemented; route removal ignored)"
+            );
             let mut tbl = table.lock().await;
-            if let Some(entry) = tbl.lookup(net) {
-                if !entry.directly_connected {
-                    tbl.remove(net);
-                    debug!(
-                        network = net,
-                        "Removed dynamically established route on disconnect"
-                    );
-                }
-            }
+            tbl.record_disconnect_removal_ignored();
         }
     } else if msg_type == NetworkMessageType::WHAT_IS_NETWORK_NUMBER.to_raw() {
         // Ignore if SNET/SADR or DNET/DADR is present.
@@ -428,6 +438,7 @@ pub(super) async fn handle_network_message(
         let count = data[0] as usize;
         let mut offset = 1usize;
         let mut table = table.lock().await;
+        let mut replacement_networks = HashSet::new();
         for _ in 0..count {
             if offset + 4 > data.len() {
                 break;
@@ -445,15 +456,26 @@ pub(super) async fn handle_network_message(
                 table.record_learning_cap();
                 break;
             }
-            if table.add_learned_with_flap_detection(net, port_idx, MacAddr::from_slice(source_mac))
+            if table
+                .lookup(net)
+                .is_some_and(|entry| !entry.directly_connected && entry.port_index != port_idx)
+                && !replacement_networks.insert(net)
             {
-                table.record_learned();
+                continue;
             }
-            debug!(
-                network = net,
-                port = port_idx,
-                "Learned route from Init-Routing-Table-Ack"
-            );
+            if table.apply_learning_claim(
+                net,
+                port_idx,
+                MacAddr::from_slice(source_mac),
+                Instant::now(),
+            ) {
+                table.record_learned();
+                debug!(
+                    network = net,
+                    port = port_idx,
+                    "Learned route from Init-Routing-Table-Ack"
+                );
+            }
         }
     } else if (0x0A..=0x11).contains(&msg_type) {
         // Security messages — acknowledge but do not reject.
@@ -475,3 +497,7 @@ pub(super) async fn handle_network_message(
         );
     }
 }
+
+#[cfg(test)]
+#[path = "corroboration_tests.rs"]
+mod corroboration_tests;

--- a/crates/bacnet-network/src/router/corroboration_tests.rs
+++ b/crates/bacnet-network/src/router/corroboration_tests.rs
@@ -1,0 +1,350 @@
+use super::*;
+use crate::router::forwarding::forward_unicast;
+use crate::router_table::{ReachabilityStatus, RoutingClaimSnapshot};
+use bacnet_encoding::npdu::decode_npdu;
+use bytes::Bytes;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+const I_AM: NetworkMessageType = NetworkMessageType::I_AM_ROUTER_TO_NETWORK;
+const ACK: NetworkMessageType = NetworkMessageType::INITIALIZE_ROUTING_TABLE_ACK;
+
+struct DebugCounter(Arc<AtomicUsize>);
+
+impl tracing::Subscriber for DebugCounter {
+    fn enabled(&self, metadata: &tracing::Metadata<'_>) -> bool {
+        *metadata.level() == tracing::Level::DEBUG
+            && metadata.target() == "bacnet_network::router::control_messages"
+    }
+    fn new_span(&self, _: &tracing::span::Attributes<'_>) -> tracing::span::Id {
+        tracing::span::Id::from_u64(1)
+    }
+    fn record(&self, _: &tracing::span::Id, _: &tracing::span::Record<'_>) {}
+    fn record_follows_from(&self, _: &tracing::span::Id, _: &tracing::span::Id) {}
+    fn event(&self, event: &tracing::Event<'_>) {
+        if self.enabled(event.metadata()) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+    fn enter(&self, _: &tracing::span::Id) {}
+    fn exit(&self, _: &tracing::span::Id) {}
+}
+
+struct Fixture {
+    table: Arc<Mutex<RouterTable>>,
+    txs: [mpsc::Sender<SendRequest>; 3],
+    rxs: [mpsc::Receiver<SendRequest>; 3],
+}
+
+impl Fixture {
+    fn new(table: RouterTable) -> Self {
+        let (tx0, rx0) = mpsc::channel(16);
+        let (tx1, rx1) = mpsc::channel(16);
+        let (tx2, rx2) = mpsc::channel(16);
+        Self {
+            table: Arc::new(Mutex::new(table)),
+            txs: [tx0, tx1, tx2],
+            rxs: [rx0, rx1, rx2],
+        }
+    }
+
+    fn learned() -> Self {
+        let mut table = RouterTable::new();
+        table.add_learned(3000, 0, MacAddr::from_slice(&[1]));
+        Self::new(table)
+    }
+
+    async fn deliver(&mut self, port: usize, mac: &[u8], kind: NetworkMessageType, payload: &[u8]) {
+        let npdu = Npdu {
+            is_network_message: true,
+            message_type: Some(kind.to_raw()),
+            payload: Bytes::copy_from_slice(payload),
+            ..Default::default()
+        };
+        handle_network_message(&self.table, &self.txs, port, 1000, mac, &npdu).await;
+        for (index, rx) in self.rxs.iter_mut().enumerate() {
+            if kind == I_AM && index != port {
+                let SendRequest::Broadcast { npdu: data, .. } = rx.try_recv().unwrap() else {
+                    panic!("expected unchanged I-Am rebroadcast");
+                };
+                let relayed = decode_npdu(data).unwrap();
+                assert_eq!(relayed.payload, npdu.payload);
+                assert_eq!(relayed.message_type, npdu.message_type);
+            } else if kind == NetworkMessageType::INITIALIZE_ROUTING_TABLE && index == port {
+                let SendRequest::Unicast {
+                    npdu: data,
+                    mac: dest,
+                    ..
+                } = rx.try_recv().unwrap()
+                else {
+                    panic!("expected Init ACK");
+                };
+                assert_eq!(dest.as_slice(), mac);
+                let ack = decode_npdu(data).unwrap();
+                assert_eq!(ack.message_type, Some(ACK.to_raw()));
+                assert_eq!(ack.payload.as_ref(), &[0]);
+            }
+            assert!(rx.try_recv().is_err());
+        }
+    }
+
+    async fn claim(&mut self, port: usize, mac: &[u8], kind: NetworkMessageType) {
+        let payload: &[u8] = if kind == I_AM {
+            &[0x0b, 0xb8]
+        } else {
+            &[1, 0x0b, 0xb8, 0, 0]
+        };
+        self.deliver(port, mac, kind, payload).await;
+    }
+
+    async fn assert_forwarded(&mut self, expected_port: usize, expected_mac: &[u8]) {
+        let table = self.table.lock().await;
+        assert_eq!(
+            table.effective_reachability(3000),
+            Some(ReachabilityStatus::Reachable)
+        );
+        let route = table.lookup(3000).unwrap().clone();
+        drop(table);
+        let npdu = Npdu {
+            destination: Some(NpduAddress {
+                network: 3000,
+                mac_address: MacAddr::from_slice(&[9]),
+            }),
+            hop_count: 255,
+            payload: Bytes::from_static(&[0x10, 0x20]),
+            ..Default::default()
+        };
+        forward_unicast(&self.txs, &route, 1000, &[7], npdu.clone(), 2, &[]);
+        for (index, rx) in self.rxs.iter_mut().enumerate() {
+            if index == expected_port {
+                let SendRequest::Unicast {
+                    npdu: data, mac, ..
+                } = rx.try_recv().unwrap()
+                else {
+                    panic!("expected learned-route forwarding");
+                };
+                assert_eq!(mac.as_slice(), expected_mac);
+                let forwarded = decode_npdu(data).unwrap();
+                assert_eq!(forwarded.destination, npdu.destination);
+                assert_eq!(forwarded.payload, npdu.payload);
+                assert_eq!(forwarded.hop_count, 254);
+            }
+            assert!(rx.try_recv().is_err());
+        }
+    }
+}
+
+#[tokio::test]
+async fn both_claim_paths_keep_forwarding_old_route_until_repeat() {
+    for first in [I_AM, ACK] {
+        for second in [I_AM, ACK] {
+            for repeat_mac in [&[2][..], &[3][..]] {
+                let mut fixture = Fixture::learned();
+                fixture.claim(1, &[2], first).await;
+                fixture.assert_forwarded(0, &[1]).await;
+                assert_eq!(
+                    fixture.table.lock().await.claim_snapshot(),
+                    RoutingClaimSnapshot {
+                        pending_started: 1,
+                        ..Default::default()
+                    }
+                );
+                fixture.claim(1, repeat_mac, second).await;
+                fixture.assert_forwarded(1, repeat_mac).await;
+                assert_eq!(
+                    fixture.table.lock().await.claim_snapshot(),
+                    RoutingClaimSnapshot {
+                        learned_ok: 1,
+                        pending_started: 1,
+                        corroborated_applied: 1,
+                        ..Default::default()
+                    }
+                );
+                // Same-port MAC updates still apply on the very next claim.
+                fixture.claim(1, &[4], second).await;
+                fixture.assert_forwarded(1, &[4]).await;
+                assert_eq!(fixture.table.lock().await.claim_snapshot().learned_ok, 2);
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn duplicate_entries_in_one_message_cannot_corroborate_a_replacement() {
+    for kind in [I_AM, ACK] {
+        let payload: &[u8] = if kind == I_AM {
+            &[0x0b, 0xb8, 0x0b, 0xb8]
+        } else {
+            &[2, 0x0b, 0xb8, 0, 0, 0x0b, 0xb8, 0, 0]
+        };
+        let mut fixture = Fixture::learned();
+        fixture.deliver(1, &[2], kind, payload).await;
+        fixture.assert_forwarded(0, &[1]).await;
+        assert_eq!(
+            fixture.table.lock().await.claim_snapshot(),
+            RoutingClaimSnapshot {
+                pending_started: 1,
+                ..Default::default()
+            }
+        );
+        fixture.claim(1, &[2], kind).await;
+        fixture.assert_forwarded(1, &[2]).await;
+        assert_eq!(
+            fixture
+                .table
+                .lock()
+                .await
+                .claim_snapshot()
+                .corroborated_applied,
+            1
+        );
+
+        // Duplicates of absent/current-port entries still take the immediate
+        // learning/refresh path, including its original successful-entry count.
+        let mut fixture = Fixture::new(RouterTable::new());
+        fixture.deliver(1, &[2], kind, payload).await;
+        fixture.assert_forwarded(1, &[2]).await;
+        fixture.deliver(1, &[3], kind, payload).await;
+        fixture.assert_forwarded(1, &[3]).await;
+        assert_eq!(
+            fixture.table.lock().await.claim_snapshot(),
+            RoutingClaimSnapshot {
+                learned_ok: 4,
+                ..Default::default()
+            }
+        );
+    }
+}
+
+#[tokio::test]
+async fn alternating_ports_in_both_handlers_never_replace_forwarding_route() {
+    for kind in [I_AM, ACK] {
+        let mut fixture = Fixture::learned();
+        for index in 0..20 {
+            fixture.claim(1 + index % 2, &[2], kind).await;
+            fixture.assert_forwarded(0, &[1]).await;
+        }
+        assert_eq!(
+            fixture.table.lock().await.claim_snapshot(),
+            RoutingClaimSnapshot {
+                pending_started: 20,
+                ..Default::default()
+            }
+        );
+    }
+}
+
+#[tokio::test]
+async fn absent_only_messages_neither_replace_nor_corroborate_pending() {
+    for kind in [I_AM, ACK] {
+        for other in [
+            NetworkMessageType::INITIALIZE_ROUTING_TABLE,
+            NetworkMessageType::I_COULD_BE_ROUTER_TO_NETWORK,
+        ] {
+            let mut fixture = Fixture::learned();
+            fixture.claim(1, &[2], kind).await;
+            let payload: &[u8] = if other == NetworkMessageType::INITIALIZE_ROUTING_TABLE {
+                &[2, 0x0b, 0xb8, 0, 0, 0x0f, 0xa0, 0, 0]
+            } else {
+                &[0x0b, 0xb8, 0]
+            };
+            // A claim on the current port also must not clear pending when the
+            // message's policy is absent-only (it is not a refresh).
+            for port in [1, 0] {
+                fixture.deliver(port, &[3], other, payload).await;
+                fixture.assert_forwarded(0, &[1]).await;
+            }
+            fixture.claim(1, &[2], kind).await;
+            fixture.assert_forwarded(1, &[2]).await;
+            assert_eq!(
+                fixture.table.lock().await.claim_snapshot(),
+                RoutingClaimSnapshot {
+                    learned_ok: if other == NetworkMessageType::INITIALIZE_ROUTING_TABLE {
+                        2
+                    } else {
+                        1
+                    },
+                    pending_started: 1,
+                    corroborated_applied: 1,
+                    ..Default::default()
+                }
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn all_absent_learning_paths_apply_on_first_message() {
+    for kind in [
+        I_AM,
+        ACK,
+        NetworkMessageType::INITIALIZE_ROUTING_TABLE,
+        NetworkMessageType::I_COULD_BE_ROUTER_TO_NETWORK,
+    ] {
+        let mut fixture = Fixture::new(RouterTable::new());
+        let payload: &[u8] = if kind == I_AM {
+            &[0x0b, 0xb8]
+        } else if kind == NetworkMessageType::I_COULD_BE_ROUTER_TO_NETWORK {
+            &[0x0b, 0xb8, 0]
+        } else {
+            &[1, 0x0b, 0xb8, 0, 0]
+        };
+        fixture.deliver(1, &[2], kind, payload).await;
+        fixture.assert_forwarded(1, &[2]).await;
+        assert_eq!(
+            fixture.table.lock().await.claim_snapshot(),
+            RoutingClaimSnapshot {
+                learned_ok: u64::from(kind != NetworkMessageType::I_COULD_BE_ROUTER_TO_NETWORK),
+                ..Default::default()
+            }
+        );
+    }
+}
+
+#[tokio::test]
+async fn disconnect_retains_route_state_and_pending_and_counts_only_complete_requests() {
+    let mut fixture = Fixture::learned();
+    fixture.table.lock().await.add_direct(4000, 2);
+    fixture.claim(1, &[2], I_AM).await;
+    let debug_events = Arc::new(AtomicUsize::new(0));
+    // This test's current-thread runtime keeps the scoped subscriber local.
+    let _subscriber = tracing::subscriber::set_default(DebugCounter(debug_events.clone()));
+    let before = fixture.table.lock().await.lookup(3000).unwrap().clone();
+    let kind = NetworkMessageType::DISCONNECT_CONNECTION_TO_NETWORK;
+    for net in [3000u16, 4000, 5000, 0, 0xffff, 3000] {
+        fixture.deliver(1, &[2], kind, &net.to_be_bytes()).await;
+        fixture.assert_forwarded(0, &[1]).await;
+    }
+    for payload in [&[][..], &[0x0b][..]] {
+        fixture.deliver(1, &[2], kind, payload).await;
+    }
+    assert_eq!(debug_events.load(Ordering::Relaxed), 6);
+    {
+        let table = fixture.table.lock().await;
+        let route = table.lookup(3000).unwrap();
+        assert_eq!(route.last_seen, before.last_seen);
+        assert_eq!(route.busy_until, before.busy_until);
+        assert_eq!(route.flap_count, before.flap_count);
+        assert_eq!(route.last_port_change, before.last_port_change);
+        assert!(table.lookup(4000).unwrap().directly_connected);
+        assert_eq!(table.len(), 2);
+        assert_eq!(
+            table.claim_snapshot(),
+            RoutingClaimSnapshot {
+                pending_started: 1,
+                disconnect_removal_ignored: 6,
+                ..Default::default()
+            }
+        );
+    }
+    fixture.claim(1, &[2], ACK).await; // Disconnect did not clear the pending slot.
+    fixture.assert_forwarded(1, &[2]).await;
+    assert_eq!(
+        fixture
+            .table
+            .lock()
+            .await
+            .claim_snapshot()
+            .corroborated_applied,
+        1
+    );
+}

--- a/crates/bacnet-network/src/router/mod.rs
+++ b/crates/bacnet-network/src/router/mod.rs
@@ -18,11 +18,27 @@
 //!
 //! Classic BACnet routing claims are unauthenticated: an ingress port, next-hop
 //! MAC or advertised network is not proof that a peer is authorized to control
-//! that route. Learning remains last-wins; these local mitigations do not
+//! that route. These local mitigations do not
 //! prevent route poisoning or authenticate a claim (Clauses 6.4 and 6.6.3):
 //! - Direct routes cannot be overwritten by learning or changed by rejects.
+//! - I-Am-Router and Initialize-Routing-Table-ACK claims moving a learned route
+//!   to a different port need two claims for the same (network, new port), no
+//!   more than 60s apart (inclusive, aligned with the flap window). Repeats in
+//!   separate messages from one router suffice; distinct sources are not required.
+//!   Duplicate entries in one message cannot supply both votes. The old route keeps
+//!   forwarding while pending. Absent-route learning and same-port refreshes
+//!   remain immediate; Initialize-Routing-Table and I-Could-Be-Router remain
+//!   absent-only and cannot corroborate replacements.
+//! - One pending challenger is retained per learned network: a different new
+//!   port replaces the slot and starts fresh. A slot older than 60s expires on
+//!   the next learning claim. Applying, current-port refresh, removal, aging,
+//!   direct-route installation and manual table edits clear the slot. Pending
+//!   entries are bounded by the number of live learned routes.
 //! - I-Am-Router and Initialize-Routing-Table/ACK retain their existing route-cap
 //!   checks; stale learned routes age out, and rapid port changes warn.
+//! - Disconnect-Connection-To-Network never removes routes: PTP connections are
+//!   unimplemented, matching Establish-Connection-To-Network's no-op handling.
+//!   Each well-formed ignored removal request is debug-logged and counted.
 //! - Reject-driven table transitions are dampened per (ingress port, network),
 //!   not by spoofable source MAC or routed source address. No-op rejects are
 //!   ignored, without renewing busy deadlines. A first state-changing reject
@@ -37,9 +53,12 @@
 //! 30s without fresh learning; legitimate re-signals after the window can apply.
 //! **Trade-off:** a legitimate unreachable-after-busy signal can be delayed up
 //! to 30s. This is local hardening, not a protocol authentication mechanism.
-//! Learning can re-arm dampening even when the refresh is malicious. Other
-//! control-message handling, forwarding, reject relay and warning behavior are
-//! unchanged; operators still need a trusted, appropriately isolated network.
+//! Active cross-port alternation can delay legitimate convergence by continually
+//! replacing the pending challenger. The old route keeps forwarding; if that
+//! path is truly dead, traffic waits for attack pause/expiry and fresh learning.
+//! Learning can still re-arm reject dampening even when the refresh is malicious.
+//! Forwarding, reject relay and flap-warning thresholds are unchanged; operators
+//! still need a trusted, appropriately isolated network.
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/bacnet-network/src/router/mod.rs
+++ b/crates/bacnet-network/src/router/mod.rs
@@ -53,6 +53,18 @@
 //! 30s without fresh learning; legitimate re-signals after the window can apply.
 //! **Trade-off:** a legitimate unreachable-after-busy signal can be delayed up
 //! to 30s. This is local hardening, not a protocol authentication mechanism.
+//!
+//! **Convergence requirement:** while the old learned route remains installed,
+//! a cross-port move requires two announcements for the same (network, new port)
+//! within 60s inclusive. Single-shot advertisers (including this router's startup
+//! announcements) or advertisers repeating more than 60s apart never converge to
+//! the new path through this gate. Under sustained forwarded traffic, every route
+//! lookup refreshes the stale entry's age, so the 300s aging rescue does not fire,
+//! even if the old path is dead. That path keeps being tried until traffic for the
+//! network idles for roughly 300s or longer (with no other refreshes, and subject
+//! to periodic aging), the table is edited manually, or two fresh claims arrive
+//! within 60s. Who-Is-Router-To-Network solicitations can prompt peers to
+//! re-advertise those claims; this gate does not initiate solicitation.
 //! Active cross-port alternation can delay legitimate convergence by continually
 //! replacing the pending challenger. The old route keeps forwarding; if that
 //! path is truly dead, traffic waits for attack pause/expiry and fresh learning.

--- a/crates/bacnet-network/src/router/tests.rs
+++ b/crates/bacnet-network/src/router/tests.rs
@@ -781,7 +781,7 @@ async fn establish_connection_does_not_crash() {
 }
 
 #[tokio::test]
-async fn disconnect_removes_learned_route() {
+async fn disconnect_retains_learned_route() {
     let mut table = RouterTable::new();
     table.add_learned(7000, 0, MacAddr::from_slice(&[10, 0, 1, 1]));
     let table = Arc::new(Mutex::new(table));
@@ -802,7 +802,8 @@ async fn disconnect_removes_learned_route() {
     handle_network_message(&table, &send_txs, 0, 1000, &[0x0A], &npdu).await;
 
     let tbl = table.lock().await;
-    assert!(tbl.lookup(7000).is_none());
+    assert!(tbl.lookup(7000).is_some());
+    assert_eq!(tbl.claim_snapshot().disconnect_removal_ignored, 1);
 }
 
 #[tokio::test]

--- a/crates/bacnet-network/src/router_table.rs
+++ b/crates/bacnet-network/src/router_table.rs
@@ -14,6 +14,9 @@ use bacnet_types::MacAddr;
 // learning. A legitimate unreachable-after-busy signal may wait up to 30s.
 const HOLD_DOWN: Duration = Duration::from_secs(30);
 
+// Repeat-based local hardening, aligned with the existing flap window.
+const CORROBORATION_WINDOW: Duration = Duration::from_secs(60);
+
 /// Count-only outcomes for routing claims handled by one router table.
 ///
 /// All totals saturate at `u64::MAX`, never affect routing decisions, and expose
@@ -21,6 +24,10 @@ const HOLD_DOWN: Duration = Duration::from_secs(30);
 /// Initialize-Routing-Table/ACK entries, not manual table edits or other message
 /// types. Existing cap-triggered early stops remain: their unexamined suffixes
 /// are not classified or counted. Flap warnings are counted at their emission.
+/// Pending replacements are not successful learning until corroborated. Disconnect
+/// totals count each well-formed ignored removal request, even for absent/direct
+/// routes; malformed messages are not counted.
+/// Duplicate cross-port entries within one message supply no extra vote or count.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct RoutingClaimSnapshot {
     /// Rejects that changed a learned route's effective state or removed it.
@@ -38,6 +45,21 @@ pub struct RoutingClaimSnapshot {
     pub learned_cap_ignored: u64,
     /// Flap warnings emitted at the existing port-change threshold.
     pub flap_warned: u64,
+    /// Cross-port claims held pending, including new challengers and expiry restarts.
+    pub pending_started: u64,
+    /// Replacements applied on a second same-network/port claim within 60s inclusive.
+    pub corroborated_applied: u64,
+    /// Pending slots found older than 60s and discarded on the next learning claim.
+    /// Non-expiry cleanup (removal, aging, manual edits or refresh) does not count.
+    pub pending_expired: u64,
+    /// Disconnect-Connection-To-Network removal requests ignored (PTP unsupported).
+    pub disconnect_removal_ignored: u64,
+}
+
+#[derive(Debug, Clone)]
+struct PendingReplacement {
+    port_index: usize,
+    first_seen: Instant,
 }
 
 /// Reachability status of a route entry.
@@ -84,6 +106,10 @@ pub struct RouterTable {
     // records, at most one per router ingress port; absent/direct spam allocates
     // nothing. Neither peer MACs nor advertised source addresses are keys.
     reject_transitions: HashMap<u16, HashMap<usize, Instant>>,
+    // One challenger per live learned network, never keyed by peer identity.
+    // Thus pending entries <= live learned routes. Every route replacement,
+    // removal and mutable-entry handoff clears its slot; expiry is checked lazily.
+    pending_replacements: HashMap<u16, PendingReplacement>,
     claim_counters: RoutingClaimSnapshot,
 }
 
@@ -93,6 +119,7 @@ impl RouterTable {
         Self {
             routes: HashMap::new(),
             reject_transitions: HashMap::new(),
+            pending_replacements: HashMap::new(),
             claim_counters: RoutingClaimSnapshot::default(),
         }
     }
@@ -113,6 +140,66 @@ impl RouterTable {
     pub(crate) fn record_learning_cap(&mut self) {
         self.claim_counters.learned_cap_ignored =
             self.claim_counters.learned_cap_ignored.saturating_add(1);
+    }
+
+    pub(crate) fn record_disconnect_removal_ignored(&mut self) {
+        self.claim_counters.disconnect_removal_ignored = self
+            .claim_counters
+            .disconnect_removal_ignored
+            .saturating_add(1);
+    }
+
+    /// Gate I-Am-Router and Init-Routing-Table-ACK cross-port replacements only.
+    /// The caller holds the table lock across this synchronous gate and update.
+    /// Absent learning and current-port refreshes use the existing immediate path.
+    /// `now` makes the inclusive 60s boundary testable without sleeping.
+    pub(crate) fn apply_learning_claim(
+        &mut self,
+        network: u16,
+        port_index: usize,
+        next_hop_mac: MacAddr,
+        now: Instant,
+    ) -> bool {
+        let pending = self
+            .pending_replacements
+            .remove(&network)
+            .filter(|pending| {
+                if now.duration_since(pending.first_seen) > CORROBORATION_WINDOW {
+                    self.claim_counters.pending_expired =
+                        self.claim_counters.pending_expired.saturating_add(1);
+                    false
+                } else {
+                    true
+                }
+            });
+        if self
+            .routes
+            .get(&network)
+            .is_some_and(|entry| !entry.directly_connected && entry.port_index != port_index)
+        {
+            if pending.is_some_and(|pending| pending.port_index == port_index) {
+                // K=2: the second claim supplies the next hop, even if its MAC
+                // differs. Neither source identity nor message type is a key.
+                self.claim_counters.corroborated_applied =
+                    self.claim_counters.corroborated_applied.saturating_add(1);
+            } else {
+                self.pending_replacements.insert(
+                    network,
+                    PendingReplacement {
+                        port_index,
+                        first_seen: now,
+                    },
+                );
+                self.claim_counters.pending_started =
+                    self.claim_counters.pending_started.saturating_add(1);
+                debug_assert!(self.pending_replacements.keys().all(|net| self
+                    .routes
+                    .get(net)
+                    .is_some_and(|entry| !entry.directly_connected)));
+                return false; // Keep all old route state, including forwarding and age.
+            }
+        }
+        self.add_learned_with_flap_detection(network, port_index, next_hop_mac)
     }
 
     /// Apply only the reject-driven table transition, never its relay.
@@ -181,6 +268,7 @@ impl RouterTable {
             return;
         }
         self.reject_transitions.remove(&network);
+        self.pending_replacements.remove(&network);
         self.routes.insert(
             network,
             RouteEntry {
@@ -209,6 +297,7 @@ impl RouterTable {
             }
         }
         self.reject_transitions.remove(&network);
+        self.pending_replacements.remove(&network);
         self.routes.insert(
             network,
             RouteEntry {
@@ -224,7 +313,7 @@ impl RouterTable {
         );
     }
 
-    /// Add a learned route, always accepting (spec 6.6.3.2: last I-Am-Router wins).
+    /// Add a learned route immediately (manual table update, without corroboration).
     /// Detects rapid port changes for operator visibility but never suppresses updates.
     ///
     /// Returns `true` if the route was inserted/updated.
@@ -262,6 +351,7 @@ impl RouterTable {
                     );
                 }
                 self.reject_transitions.remove(&network);
+                self.pending_replacements.remove(&network);
                 self.routes.insert(
                     network,
                     RouteEntry {
@@ -343,13 +433,16 @@ impl RouterTable {
     }
 
     /// Lookup a mutable route entry by network number.
+    /// Clears any pending challenger since the caller can replace the route state.
     pub fn lookup_mut(&mut self, network: u16) -> Option<&mut RouteEntry> {
+        self.pending_replacements.remove(&network);
         self.routes.get_mut(&network)
     }
 
     /// Remove a route.
     pub fn remove(&mut self, network: u16) -> Option<RouteEntry> {
         self.reject_transitions.remove(&network);
+        self.pending_replacements.remove(&network);
         self.routes.remove(&network)
     }
 
@@ -430,6 +523,10 @@ impl Default for RouterTable {
 #[cfg(test)]
 #[path = "router_table_reject_tests.rs"]
 mod reject_tests;
+
+#[cfg(test)]
+#[path = "router_table_corroboration_tests.rs"]
+mod corroboration_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/bacnet-network/src/router_table_corroboration_tests.rs
+++ b/crates/bacnet-network/src/router_table_corroboration_tests.rs
@@ -1,0 +1,293 @@
+use super::*;
+
+fn learned_table() -> RouterTable {
+    let mut table = RouterTable::new();
+    table.add_learned(3000, 0, MacAddr::from_slice(&[1]));
+    table
+}
+
+fn claim(table: &mut RouterTable, port: usize, now: Instant) -> bool {
+    table.apply_learning_claim(3000, port, MacAddr::from_slice(&[2]), now)
+}
+
+#[test]
+fn corroboration_inclusive_deadline_and_expiry_restart() {
+    for elapsed in [
+        CORROBORATION_WINDOW - Duration::from_nanos(1),
+        CORROBORATION_WINDOW,
+        CORROBORATION_WINDOW + Duration::from_nanos(1),
+    ] {
+        let mut table = learned_table();
+        let now = Instant::now();
+        let seen = table.lookup(3000).unwrap().last_seen;
+        assert!(!claim(&mut table, 1, now));
+        assert_eq!(table.lookup(3000).unwrap().port_index, 0);
+        assert_eq!(table.lookup(3000).unwrap().last_seen, seen);
+        assert_eq!(table.lookup(3000).unwrap().next_hop_mac.as_slice(), &[1]);
+        assert_eq!(
+            table.claim_snapshot(),
+            RoutingClaimSnapshot {
+                pending_started: 1,
+                ..Default::default()
+            }
+        );
+
+        let applies = elapsed <= CORROBORATION_WINDOW;
+        assert_eq!(claim(&mut table, 1, now + elapsed), applies);
+        assert_eq!(table.lookup(3000).unwrap().port_index, usize::from(applies));
+        assert_eq!(table.pending_replacements.is_empty(), applies);
+        assert_eq!(
+            table.claim_snapshot(),
+            RoutingClaimSnapshot {
+                pending_started: if applies { 1 } else { 2 },
+                corroborated_applied: u64::from(applies),
+                pending_expired: u64::from(!applies),
+                ..Default::default()
+            }
+        );
+        if !applies {
+            assert_eq!(table.pending_replacements[&3000].first_seen, now + elapsed);
+            assert_eq!(table.lookup(3000).unwrap().last_seen, seen);
+            assert!(claim(&mut table, 1, now + elapsed + CORROBORATION_WINDOW));
+            assert!(table.pending_replacements.is_empty());
+            assert_eq!(table.claim_snapshot().corroborated_applied, 1);
+            assert_eq!(table.claim_snapshot().pending_expired, 1);
+        }
+    }
+}
+
+#[test]
+fn spaced_single_claims_never_accumulate_or_refresh_old_route() {
+    let mut table = learned_table();
+    let now = Instant::now();
+    let seen = table.lookup(3000).unwrap().last_seen;
+    for index in 0..10 {
+        assert!(!claim(
+            &mut table,
+            1,
+            now + (CORROBORATION_WINDOW + Duration::from_nanos(1)) * index
+        ));
+        assert_eq!(table.lookup(3000).unwrap().port_index, 0);
+        assert_eq!(table.lookup(3000).unwrap().last_seen, seen);
+        assert_eq!(table.pending_replacements.len(), 1);
+        assert_eq!(
+            table.claim_snapshot(),
+            RoutingClaimSnapshot {
+                pending_started: u64::from(index + 1),
+                pending_expired: u64::from(index),
+                ..Default::default()
+            }
+        );
+    }
+}
+
+#[test]
+fn alternating_challengers_replace_slot_and_reset_first_seen() {
+    let mut table = learned_table();
+    let now = Instant::now();
+    for second in 0..100 {
+        let port = 1 + second as usize % 2;
+        let time = now + Duration::from_secs(second);
+        assert!(!claim(&mut table, port, time));
+        assert_eq!(table.lookup(3000).unwrap().port_index, 0);
+        assert_eq!(table.pending_replacements.len(), 1);
+        assert_eq!(table.pending_replacements[&3000].port_index, port);
+        assert_eq!(table.pending_replacements[&3000].first_seen, time);
+    }
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            pending_started: 100,
+            ..Default::default()
+        }
+    );
+    // Legitimate convergence resumes when a challenger can repeat uninterrupted.
+    assert!(claim(&mut table, 2, now + Duration::from_secs(100)));
+    assert_eq!(table.lookup(3000).unwrap().port_index, 2);
+    assert_eq!(table.claim_snapshot().corroborated_applied, 1);
+}
+
+#[test]
+fn absent_current_port_direct_and_reserved_claims_remain_immediate() {
+    let mut table = RouterTable::new();
+    let now = Instant::now();
+    assert!(claim(&mut table, 0, now));
+    assert!(table.pending_replacements.is_empty());
+    assert!(!claim(&mut table, 1, now));
+    table.mark_busy(3000, now + HOLD_DOWN);
+    assert!(claim(&mut table, 0, now));
+    let entry = table.lookup(3000).unwrap();
+    assert_eq!(entry.port_index, 0);
+    assert_eq!(entry.reachability, ReachabilityStatus::Reachable);
+    assert_eq!(entry.flap_count, 0);
+    assert!(entry.last_port_change.is_none());
+    assert!(entry.busy_until.is_none());
+    assert!(table.pending_replacements.is_empty());
+    assert!(!claim(&mut table, 1, now)); // Refresh discarded the earlier vote.
+    table.add_direct(3000, 0);
+    for net in [0, 0xffff, 3000] {
+        for _ in 0..2 {
+            assert!(!table.apply_learning_claim(net, 1, MacAddr::new(), now));
+        }
+    }
+    assert_eq!(table.len(), 1);
+    assert!(table.lookup(3000).unwrap().directly_connected);
+    assert!(table.pending_replacements.is_empty());
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            pending_started: 2,
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn pending_claim_preserves_busy_and_reject_records_until_apply() {
+    let mut table = learned_table();
+    let now = Instant::now();
+    table.apply_reject(3000, 0, 2, now);
+    assert!(!claim(&mut table, 1, now));
+    assert_eq!(
+        table.lookup(3000).unwrap().busy_until,
+        Some(now + HOLD_DOWN)
+    );
+    assert_eq!(table.reject_transitions[&3000][&0], now);
+    table.apply_reject(3000, 0, 1, now);
+    assert_eq!(table.claim_snapshot().reject_dampened_hold_down, 1);
+    assert!(claim(&mut table, 1, now));
+    assert!(table.reject_transitions.is_empty());
+    assert_eq!(
+        table.lookup(3000).unwrap().reachability,
+        ReachabilityStatus::Reachable
+    );
+    assert_eq!(table.claim_snapshot().corroborated_applied, 1);
+}
+
+#[test]
+fn cleanup_never_leaves_pending_without_a_learned_route() {
+    for cleanup in [
+        "remove",
+        "reject_remove",
+        "aging",
+        "direct",
+        "manual",
+        "manual_flap",
+        "mutable",
+    ] {
+        let mut table = learned_table();
+        let now = Instant::now();
+        // Set age before creating pending so this exercises purge, not mutable handoff.
+        table.lookup_mut(3000).unwrap().last_seen = Some(now - Duration::from_secs(120));
+        assert!(!claim(&mut table, 1, now));
+        match cleanup {
+            "remove" => {
+                table.remove(3000);
+            }
+            "reject_remove" => table.apply_reject(3000, 0, 0, now),
+            "aging" => assert_eq!(table.purge_stale(Duration::from_secs(60)), vec![3000]),
+            "direct" => table.add_direct(3000, 1),
+            "manual" => table.add_learned(3000, 2, MacAddr::new()),
+            "manual_flap" => {
+                assert!(table.add_learned_with_flap_detection(3000, 2, MacAddr::new()));
+            }
+            "mutable" => table.lookup_mut(3000).unwrap().directly_connected = true,
+            _ => unreachable!(),
+        }
+        assert!(table.pending_replacements.is_empty(), "{cleanup}");
+        assert_eq!(table.claim_snapshot().pending_expired, 0, "{cleanup}");
+        table.add_learned(4000, 0, MacAddr::new());
+        assert!(table.apply_learning_claim(4000, 0, MacAddr::new(), now));
+        assert!(!table.apply_learning_claim(4000, 1, MacAddr::new(), now));
+        assert_eq!(table.pending_replacements.len(), 1);
+    }
+}
+
+#[test]
+fn pending_store_is_bounded_and_networks_are_independent() {
+    let mut table = RouterTable::new();
+    let now = Instant::now();
+    for net in 1..=256 {
+        table.add_learned(net, 0, MacAddr::new());
+        for port in 1..=10 {
+            assert!(!table.apply_learning_claim(net, port, MacAddr::new(), now));
+            assert_eq!(table.pending_replacements.len(), usize::from(net));
+            assert!(
+                table.pending_replacements.len()
+                    <= table
+                        .routes
+                        .values()
+                        .filter(|e| !e.directly_connected)
+                        .count()
+            );
+        }
+    }
+    for net in 1..=256 {
+        assert!(table.apply_learning_claim(net, 10, MacAddr::new(), now));
+        assert_eq!(table.pending_replacements.len(), 256 - usize::from(net));
+    }
+    assert_eq!(
+        table.claim_snapshot(),
+        RoutingClaimSnapshot {
+            pending_started: 2560,
+            corroborated_applied: 256,
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn flap_warnings_only_count_applied_moves_and_same_port_refresh_resets_history() {
+    let mut table = learned_table();
+    let now = Instant::now();
+    for port in 1..=3 {
+        assert!(!claim(&mut table, port, now));
+        assert_eq!(table.claim_snapshot().flap_warned, 0);
+        assert!(claim(&mut table, port, now));
+        assert_eq!(table.lookup(3000).unwrap().flap_count, port as u8);
+    }
+    assert_eq!(table.claim_snapshot().flap_warned, 1);
+    assert!(claim(&mut table, 3, now));
+    assert_eq!(table.lookup(3000).unwrap().flap_count, 0);
+    assert!(!claim(&mut table, 4, now));
+    assert!(claim(&mut table, 4, now));
+    assert_eq!(table.lookup(3000).unwrap().flap_count, 1);
+    assert_eq!(table.claim_snapshot().flap_warned, 1);
+}
+
+#[test]
+fn new_counters_saturate_without_affecting_gate_and_clones_are_independent() {
+    let mut table = learned_table();
+    table.claim_counters = RoutingClaimSnapshot {
+        pending_started: u64::MAX - 1,
+        corroborated_applied: u64::MAX - 1,
+        pending_expired: u64::MAX - 1,
+        disconnect_removal_ignored: u64::MAX - 1,
+        ..Default::default()
+    };
+    let now = Instant::now();
+    let before = table.claim_snapshot();
+    for port in 1..=2 {
+        let start = now + Duration::from_secs(port as u64 * 120);
+        assert!(!claim(&mut table, port, start));
+        let mut cloned = table.clone();
+        assert!(claim(&mut cloned, port, start));
+        assert!(!table.pending_replacements.is_empty());
+        assert!(!claim(&mut table, port, start + Duration::from_secs(61)));
+        assert!(claim(&mut table, port, start + Duration::from_secs(62)));
+        table.record_disconnect_removal_ignored();
+    }
+    let snapshot = table.claim_snapshot();
+    drop(table);
+    assert_eq!(before.pending_started, u64::MAX - 1);
+    assert_eq!(
+        snapshot,
+        RoutingClaimSnapshot {
+            pending_started: u64::MAX,
+            corroborated_applied: u64::MAX,
+            pending_expired: u64::MAX,
+            disconnect_removal_ignored: u64::MAX,
+            ..Default::default()
+        }
+    );
+}

--- a/crates/bacnet-network/src/router_table_reject_tests.rs
+++ b/crates/bacnet-network/src/router_table_reject_tests.rs
@@ -276,6 +276,7 @@ fn counters_saturate_without_affecting_decisions_and_snapshots_are_owned() {
         learned_ok: u64::MAX - 1,
         learned_cap_ignored: u64::MAX - 1,
         flap_warned: u64::MAX - 1,
+        ..Default::default()
     };
     let before = table.claim_snapshot();
     let now = Instant::now();
@@ -306,6 +307,7 @@ fn counters_saturate_without_affecting_decisions_and_snapshots_are_owned() {
             learned_ok: u64::MAX,
             learned_cap_ignored: u64::MAX,
             flap_warned: u64::MAX,
+            ..Default::default()
         }
     );
     let cloned = table.clone();


### PR DESCRIPTION
Completes #635 (owner-locked corroboration + Disconnect parity; follows #638 dampening).

I-Am-Router and Init-Routing-Table-Ack claims moving a learned route to a different port need two same (network, port) claims within 60s inclusive; the old route forwards meanwhile. One pending challenger per network (latest wins, 60s expiry, cleared on apply/refresh/removal/aging/direct/manual); duplicates in one message supply no extra vote. Absent learning, same-port refresh, caps, aging, flap warnings unchanged. Disconnect-Connection-To-Network never removes routes (PTP unimplemented) — debug-logged and counted. Snapshot gains pending/corroborated/expired/disconnect counters; trust docs updated with the alternation-delay residual.

Validation: bacnet-network 138+1 PASS, FULL conformance_ledger 27/27 PASS, clippy/fmt/size/secrets PASS, 15 new corroboration regressions.