### PR TITLE
test(objects): pin Acked_Transitions network read-only policy (#242)

### DIFF
--- a/crates/bacnet-objects/src/acked_transitions_tests.rs
+++ b/crates/bacnet-objects/src/acked_transitions_tests.rs
@@ -1,0 +1,232 @@
+//! Acked_Transitions is read-only in the property descriptions accompanying
+//! Tables 12-2/3/4, 12-6/8/10, 12-21/22/23, 12-14, and 12-61 (135-2020).
+
+use crate::analog::{AnalogInputObject, AnalogOutputObject, AnalogValueObject};
+use crate::binary::{BinaryInputObject, BinaryOutputObject, BinaryValueObject};
+use crate::event::{EventStateChange, EventTransition, EventTransitionCommit};
+use crate::event_enrollment::{AlertEnrollmentObject, EventEnrollmentObject};
+use crate::multistate::{MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject};
+use crate::property_metadata::PropertyWriteCapability;
+use crate::traits::BACnetObject;
+use bacnet_types::constructed::BACnetDeviceObjectPropertyReference;
+use bacnet_types::enums::{ErrorClass, ErrorCode, EventState, ObjectType, PropertyIdentifier};
+use bacnet_types::error::Error;
+use bacnet_types::primitives::{BACnetTimeStamp, ObjectIdentifier, PropertyValue};
+
+fn objects() -> Vec<Box<dyn BACnetObject>> {
+    let source = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    let mut enrollment = EventEnrollmentObject::new(1, "EE", 5).unwrap();
+    enrollment.set_object_property_reference(Some(BACnetDeviceObjectPropertyReference {
+        object_identifier: source,
+        property_identifier: PropertyIdentifier::PRESENT_VALUE.to_raw(),
+        property_array_index: None,
+        device_identifier: None,
+    }));
+    vec![
+        Box::new(AnalogInputObject::new(1, "AI", 62).unwrap()),
+        Box::new(AnalogOutputObject::new(1, "AO", 62).unwrap()),
+        Box::new(AnalogValueObject::new(1, "AV", 62).unwrap()),
+        Box::new(BinaryInputObject::new(1, "BI").unwrap()),
+        Box::new(BinaryOutputObject::new(1, "BO").unwrap()),
+        Box::new(BinaryValueObject::new(1, "BV").unwrap()),
+        Box::new(MultiStateInputObject::new(1, "MSI", 3).unwrap()),
+        Box::new(MultiStateOutputObject::new(1, "MSO", 3).unwrap()),
+        Box::new(MultiStateValueObject::new(1, "MSV", 3).unwrap()),
+        Box::new(enrollment),
+        Box::new(AlertEnrollmentObject::new(1, "Alert", source).unwrap()),
+    ]
+}
+
+fn bits(wire_octet: u8) -> PropertyValue {
+    PropertyValue::BitString {
+        unused_bits: 5,
+        data: vec![wire_octet],
+    }
+}
+
+fn snapshot(object: &dyn BACnetObject) -> [PropertyValue; 4] {
+    [
+        PropertyIdentifier::EVENT_STATE,
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        PropertyIdentifier::EVENT_TIME_STAMPS,
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+    ]
+    .map(|property| object.read_property(property, None).unwrap())
+}
+
+fn assert_denied(object: &mut dyn BACnetObject, value: PropertyValue, priority: Option<u8>) {
+    let before = snapshot(object);
+    let error = object
+        .write_property(PropertyIdentifier::ACKED_TRANSITIONS, None, value, priority)
+        .unwrap_err();
+    assert!(
+        matches!(error, Error::Protocol { class, code }
+            if class == ErrorClass::PROPERTY.to_raw() as u32
+                && code == ErrorCode::WRITE_ACCESS_DENIED.to_raw() as u32),
+        "{}: {error:?}",
+        object.object_name()
+    );
+    assert_eq!(snapshot(object), before, "{}", object.object_name());
+}
+
+fn seed_unacknowledged(object: &mut dyn BACnetObject) {
+    object
+        .write_property(
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    if object.object_identifier().object_type() == ObjectType::ALERT_ENROLLMENT {
+        // Alert Enrollment retains its existing internal setter, not the
+        // atomic commit/AcknowledgeAlarm capability of the other families.
+        object
+            .set_event_state_internal(EventState::OFFNORMAL)
+            .unwrap();
+        object.set_acked_transitions_internal(1, false).unwrap();
+    } else {
+        object
+            .commit_event_transition_internal(EventTransitionCommit {
+                change: EventStateChange {
+                    from: EventState::NORMAL,
+                    to: EventState::OFFNORMAL,
+                },
+                coordinate: EventTransition::ToOffnormal,
+                ack_required: true,
+                timestamp: BACnetTimeStamp::SequenceNumber(42),
+                message_text: None,
+            })
+            .unwrap();
+    }
+    assert_eq!(snapshot(object)[1], bits(0x60), "{}", object.object_name());
+}
+
+#[test]
+fn acked_transitions_network_write_and_metadata_deny_every_family() {
+    for mut object in objects() {
+        seed_unacknowledged(&mut *object);
+        for enabled in [true, false] {
+            object
+                .write_property(
+                    PropertyIdentifier::EVENT_DETECTION_ENABLE,
+                    None,
+                    PropertyValue::Boolean(enabled),
+                    None,
+                )
+                .unwrap();
+            for out_of_service in [false, true] {
+                if object
+                    .property_list()
+                    .contains(&PropertyIdentifier::OUT_OF_SERVICE)
+                {
+                    object
+                        .write_property(
+                            PropertyIdentifier::OUT_OF_SERVICE,
+                            None,
+                            PropertyValue::Boolean(out_of_service),
+                            None,
+                        )
+                        .unwrap();
+                }
+                assert!(!object.is_writable_property(PropertyIdentifier::ACKED_TRANSITIONS));
+                {
+                    let metadata = object.property_metadata();
+                    if !metadata.is_empty() {
+                        let row = metadata
+                            .iter()
+                            .find(|row| {
+                                row.property_identifier == PropertyIdentifier::ACKED_TRANSITIONS
+                            })
+                            .expect("migrated metadata must include Acked_Transitions");
+                        assert_eq!(row.write_capability, PropertyWriteCapability::ReadOnly);
+                    }
+                }
+                for priority in [None, Some(1), Some(16)] {
+                    // Fabricating, erasing, and partially replacing acknowledgments
+                    // must all fail, including while detection is disabled or OOS.
+                    for value in [bits(0xe0), bits(0x00), bits(0xa0)] {
+                        assert_denied(&mut *object, value, priority);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn acked_transitions_internal_commit_and_acknowledgment_bypass_property_writes() {
+    for mut object in objects() {
+        seed_unacknowledged(&mut *object);
+        assert_denied(&mut *object, bits(0xe0), None);
+        if object.object_identifier().object_type() == ObjectType::ALERT_ENROLLMENT {
+            object.set_acked_transitions_internal(1, true).unwrap();
+            // TO_NORMAL stays acknowledged even if generic local logic clears it.
+            object.set_acked_transitions_internal(4, false).unwrap();
+        } else {
+            let mut acknowledged = snapshot(&*object);
+            acknowledged[1] = bits(0xe0);
+            object
+                .acknowledge_alarm_correlated_internal(
+                    EventState::OFFNORMAL,
+                    &BACnetTimeStamp::SequenceNumber(42),
+                )
+                .unwrap();
+            assert_eq!(snapshot(&*object), acknowledged, "{}", object.object_name());
+            // The commit kernel can also set a previously cleared coordinate
+            // when Notification Class policy does not require acknowledgment.
+            for ack_required in [true, false] {
+                object
+                    .commit_event_transition_internal(EventTransitionCommit {
+                        change: EventStateChange {
+                            from: EventState::OFFNORMAL,
+                            to: EventState::OFFNORMAL,
+                        },
+                        coordinate: EventTransition::ToOffnormal,
+                        ack_required,
+                        timestamp: BACnetTimeStamp::SequenceNumber(43),
+                        message_text: None,
+                    })
+                    .unwrap();
+                assert_eq!(
+                    snapshot(&*object)[1],
+                    bits(if ack_required { 0x60 } else { 0xe0 })
+                );
+            }
+        }
+        assert_eq!(
+            snapshot(&*object)[1],
+            bits(0xe0),
+            "{}",
+            object.object_name()
+        );
+        assert!(!object.is_writable_property(PropertyIdentifier::ACKED_TRANSITIONS));
+    }
+}
+
+#[test]
+fn acked_transitions_denial_preserves_local_rollback_tokens() {
+    for mut object in objects() {
+        seed_unacknowledged(&mut *object);
+        let before = snapshot(&*object);
+        let disabled = PropertyValue::Boolean(false);
+        let rollback = object
+            .capture_write_property_rollback(PropertyIdentifier::EVENT_DETECTION_ENABLE, &disabled)
+            .expect("each family preserves detection-reset state for local callers");
+        object
+            .write_property(
+                PropertyIdentifier::EVENT_DETECTION_ENABLE,
+                None,
+                disabled,
+                None,
+            )
+            .unwrap();
+        assert_eq!(snapshot(&*object)[1], bits(0xe0));
+        assert_denied(&mut *object, bits(0x00), None);
+        // Compatibility hooks remain local-only; WPM must NOT invoke this
+        // restore because its successful detection-disable prefix is committed.
+        object.restore_write_property_rollback(rollback).unwrap();
+        assert_eq!(snapshot(&*object), before, "{}", object.object_name());
+        assert_denied(&mut *object, bits(0xe0), None);
+    }
+}

--- a/crates/bacnet-objects/src/lib.rs
+++ b/crates/bacnet-objects/src/lib.rs
@@ -56,3 +56,6 @@ mod enrollment_summary_capability_tests;
 
 #[cfg(test)]
 mod acknowledge_alarm_object_family_tests;
+
+#[cfg(test)]
+mod acked_transitions_tests;

--- a/crates/bacnet-objects/src/traits.rs
+++ b/crates/bacnet-objects/src/traits.rs
@@ -205,6 +205,16 @@ pub trait BACnetObject: Send + Sync {
     /// Universal read-only properties (`OBJECT_IDENTIFIER`, `OBJECT_TYPE`,
     /// `PROPERTY_LIST`, `STATUS_FLAGS`) are always non-writable and are
     /// excluded by the default; overrides should preserve that invariant.
+    ///
+    /// Built-in analog, binary, multi-state, Event Enrollment, and Alert
+    /// Enrollment objects also deny network writes to `ACKED_TRANSITIONS`.
+    /// The property descriptions accompanying ASHRAE 135-2020 Tables 12-2/3/4,
+    /// 12-6/8/10, 12-21/22/23, 12-14, and 12-61 explicitly make it read-only;
+    /// the table's `R`/`O` classification alone is not a write prohibition.
+    /// Clause 13.2.3 assigns acknowledgment-bit maintenance to internal
+    /// transition and acknowledgment processing. Those lifecycle hooks and
+    /// supported AcknowledgeAlarm paths do not use `write_property`, so this
+    /// network restriction does not prevent their internal updates.
     fn is_writable_property(&self, property: PropertyIdentifier) -> bool {
         let metadata = self.property_metadata();
         if metadata.is_empty() {

--- a/crates/bacnet-server/src/handlers/tests/wpm_prefix_commit.rs
+++ b/crates/bacnet-server/src/handlers/tests/wpm_prefix_commit.rs
@@ -1,10 +1,18 @@
 use super::*;
 
-use bacnet_objects::binary::BinaryValueObject;
-use bacnet_objects::event_enrollment::EventEnrollmentObject;
+use bacnet_objects::analog::{AnalogOutputObject, AnalogValueObject};
+use bacnet_objects::binary::{BinaryInputObject, BinaryOutputObject, BinaryValueObject};
+use bacnet_objects::event::{EventStateChange, EventTransition, EventTransitionCommit};
+use bacnet_objects::event_enrollment::{AlertEnrollmentObject, EventEnrollmentObject};
+use bacnet_objects::multistate::{
+    MultiStateInputObject, MultiStateOutputObject, MultiStateValueObject,
+};
 use bacnet_services::common::BACnetPropertyValue;
-use bacnet_services::wpm::{WriteAccessSpecification, WritePropertyMultipleRequest};
+use bacnet_services::wpm::{
+    WriteAccessSpecification, WritePropertyAttempt, WritePropertyMultipleRequest,
+};
 use bacnet_types::constructed::BACnetObjectPropertyReference;
+use bacnet_types::primitives::BACnetTimeStamp;
 
 fn encode_value(value: &PropertyValue) -> Vec<u8> {
     let mut bytes = BytesMut::new();
@@ -102,6 +110,210 @@ fn event_enrollment_prefix_commits_before_read_only_first_failure() {
             .unwrap(),
         PropertyValue::CharacterString("committed".into())
     );
+}
+
+fn acked_transitions_objects() -> Vec<Box<dyn BACnetObject>> {
+    let source = ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap();
+    vec![
+        Box::new(AnalogInputObject::new(1, "AI", 62).unwrap()),
+        Box::new(AnalogOutputObject::new(1, "AO", 62).unwrap()),
+        Box::new(AnalogValueObject::new(1, "AV", 62).unwrap()),
+        Box::new(BinaryInputObject::new(1, "BI").unwrap()),
+        Box::new(BinaryOutputObject::new(1, "BO").unwrap()),
+        Box::new(BinaryValueObject::new(1, "BV").unwrap()),
+        Box::new(MultiStateInputObject::new(1, "MSI", 3).unwrap()),
+        Box::new(MultiStateOutputObject::new(1, "MSO", 3).unwrap()),
+        Box::new(MultiStateValueObject::new(1, "MSV", 3).unwrap()),
+        Box::new(EventEnrollmentObject::new(1, "EE", 5).unwrap()),
+        Box::new(AlertEnrollmentObject::new(1, "Alert", source).unwrap()),
+    ]
+}
+
+fn event_snapshot(object: &dyn BACnetObject) -> [PropertyValue; 4] {
+    [
+        PropertyIdentifier::EVENT_STATE,
+        PropertyIdentifier::ACKED_TRANSITIONS,
+        PropertyIdentifier::EVENT_TIME_STAMPS,
+        PropertyIdentifier::EVENT_DETECTION_ENABLE,
+    ]
+    .map(|property| object.read_property(property, None).unwrap())
+}
+
+fn seed_unacknowledged(object: &mut dyn BACnetObject) {
+    object
+        .write_property(
+            PropertyIdentifier::EVENT_DETECTION_ENABLE,
+            None,
+            PropertyValue::Boolean(true),
+            None,
+        )
+        .unwrap();
+    if object.object_identifier().object_type() == ObjectType::ALERT_ENROLLMENT {
+        object
+            .set_event_state_internal(EventState::OFFNORMAL)
+            .unwrap();
+        object.set_acked_transitions_internal(1, false).unwrap();
+    } else {
+        object
+            .commit_event_transition_internal(EventTransitionCommit {
+                change: EventStateChange {
+                    from: EventState::NORMAL,
+                    to: EventState::OFFNORMAL,
+                },
+                coordinate: EventTransition::ToOffnormal,
+                ack_required: true,
+                timestamp: BACnetTimeStamp::SequenceNumber(42),
+                message_text: None,
+            })
+            .unwrap();
+    }
+    assert_eq!(
+        event_snapshot(object)[1],
+        PropertyValue::BitString {
+            unused_bits: 5,
+            data: vec![0x60]
+        }
+    );
+}
+
+#[test]
+fn acked_transitions_write_property_denies_every_family_without_mutation() {
+    for mut object in acked_transitions_objects() {
+        seed_unacknowledged(&mut *object);
+        let oid = object.object_identifier();
+        let mut db = ObjectDatabase::new();
+        db.add(object).unwrap();
+        let before = event_snapshot(db.get(&oid).unwrap());
+        for octet in [0xe0, 0x00, 0xa0] {
+            let request = WritePropertyRequest {
+                object_identifier: oid,
+                property_identifier: PropertyIdentifier::ACKED_TRANSITIONS,
+                property_array_index: None,
+                property_value: encode_value(&PropertyValue::BitString {
+                    unused_bits: 5,
+                    data: vec![octet],
+                }),
+                priority: Some(8),
+            };
+            let mut bytes = BytesMut::new();
+            request.encode(&mut bytes);
+            assert_protocol(
+                handle_write_property(&mut db, &bytes).unwrap_err(),
+                ErrorClass::PROPERTY,
+                ErrorCode::WRITE_ACCESS_DENIED,
+            );
+            assert_eq!(event_snapshot(db.get(&oid).unwrap()), before, "{oid:?}");
+        }
+    }
+}
+
+#[test]
+fn acked_transitions_wpm_authorizer_allow_retains_prefix_and_stops_at_denial() {
+    // No prefix, an ordinary prefix, and a destructive detection-reset prefix.
+    // None may apply the denied write or suffix; successful prefixes must NOT
+    // be rolled back, even though objects retain local snapshot/restore hooks.
+    for prefix_len in 0..=2 {
+        for mut object in acked_transitions_objects() {
+            let mut reset = event_snapshot(&*object);
+            reset[3] = PropertyValue::Boolean(false);
+            seed_unacknowledged(&mut *object);
+            let before = event_snapshot(&*object);
+            let oid = object.object_identifier();
+            let mut db = ObjectDatabase::new();
+            db.add(object).unwrap();
+            let property = |property_identifier, value| BACnetPropertyValue {
+                property_identifier,
+                property_array_index: None,
+                value: encode_value(&value),
+                priority: None,
+            };
+            let mut properties = vec![
+                property(
+                    PropertyIdentifier::DESCRIPTION,
+                    PropertyValue::CharacterString("committed".into()),
+                ),
+                property(
+                    PropertyIdentifier::EVENT_DETECTION_ENABLE,
+                    PropertyValue::Boolean(false),
+                ),
+            ];
+            properties.truncate(prefix_len);
+            let denied = BACnetPropertyValue {
+                property_identifier: PropertyIdentifier::ACKED_TRANSITIONS,
+                property_array_index: None,
+                value: encode_value(&PropertyValue::BitString {
+                    unused_bits: 5,
+                    data: vec![0x00],
+                }),
+                priority: Some(8),
+            };
+            properties.push(denied.clone());
+            properties.push(property(
+                PropertyIdentifier::DESCRIPTION,
+                PropertyValue::CharacterString("suffix".into()),
+            ));
+            properties.push(property(
+                PropertyIdentifier::EVENT_DETECTION_ENABLE,
+                PropertyValue::Boolean(true),
+            ));
+            let request = encode_request(oid, properties);
+            let allowed = std::cell::RefCell::new(Vec::new());
+            let authorize = |attempt: &WritePropertyAttempt| {
+                allowed.borrow_mut().push(attempt.clone());
+                Ok(())
+            };
+            let mut snapshots = crate::life_safety_cov::LifeSafetyCovSnapshots::default();
+            let WritePropertyMultipleOutcome::Error {
+                error,
+                first_failed_write_attempt,
+                committed_oids,
+            } = handle_write_property_multiple_authorized(
+                &mut db,
+                &request,
+                &mut snapshots,
+                Some(&authorize),
+            )
+            else {
+                panic!("expected Acked_Transitions WPM denial for {oid:?}");
+            };
+            assert_protocol(error, ErrorClass::PROPERTY, ErrorCode::WRITE_ACCESS_DENIED);
+            assert_reference(
+                &first_failed_write_attempt,
+                oid,
+                PropertyIdentifier::ACKED_TRANSITIONS,
+                None,
+            );
+            assert_eq!(
+                committed_oids,
+                if prefix_len == 0 { vec![] } else { vec![oid] }
+            );
+            let allowed = allowed.into_inner();
+            assert_eq!(
+                allowed.len(),
+                prefix_len + 1,
+                "suffix reached authorizer for {oid:?}"
+            );
+            let attempt = allowed.last().unwrap();
+            assert_eq!(attempt.reference, first_failed_write_attempt);
+            assert_eq!(attempt.value, denied.value);
+            assert_eq!(attempt.priority, denied.priority);
+            let object = db.get(&oid).unwrap();
+            assert_eq!(
+                event_snapshot(object),
+                if prefix_len == 2 { reset } else { before },
+                "{oid:?}"
+            );
+            assert_eq!(
+                object
+                    .read_property(PropertyIdentifier::DESCRIPTION, None)
+                    .unwrap(),
+                PropertyValue::CharacterString(
+                    if prefix_len == 0 { "" } else { "committed" }.into()
+                ),
+                "{oid:?}"
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
Refs #242 (closed; decision recorded here, no reopen). M02 PR-0208: tests + rustdoc only, no production change.

Standard grounding verified against the local 135-2020 PDF (paraphrased; no licensed text in repo): Tables 12-2/3/4, 12-6/8/10, 12-21/22/23, 12-14, 12-61 property prose make Acked_Transitions explicitly read-only for all five families; 13.2.3 assigns bit maintenance to internal transition/acknowledgment processing; Annex K advanced view/modify does not require modifying it. Decision: uniform network-read-only retained.

All families already deny — this pins it: 3 characterization tests over 11 object variants (denial, metadata consistency, internal updates, rollback tokens) + 2 service-level WPM tests (authorizer-allow then object denial, prefix coherence). is_writable_property rustdoc records the rule with table anchors.

Validation: workspace 4,807+26 PASS, rusty-bacnet check PASS, ledger generate --check PASS (unchanged — no executable evidence change), clippy/fmt/size/secrets PASS, red-proof via temporary allow-mutation.