### PR TITLE
feat(server): add opt-in source-aware time synchronization policy (#523)

### DIFF
--- a/crates/bacnet-server/src/server/clock.rs
+++ b/crates/bacnet-server/src/server/clock.rs
@@ -181,7 +181,7 @@ fn system_utc_hundredths() -> i128 {
     i128::from(elapsed.as_secs()) * HUNDREDTHS_PER_SECOND + i128::from(elapsed.subsec_millis() / 10)
 }
 
-fn date_time_to_hundredths(date: Date, time: Time) -> Result<i128, Error> {
+pub(super) fn date_time_to_hundredths(date: Date, time: Time) -> Result<i128, Error> {
     let year = date
         .actual_year()
         .ok_or_else(|| invalid_datetime("date contains an unspecified year"))?;

--- a/crates/bacnet-server/src/server/config.rs
+++ b/crates/bacnet-server/src/server/config.rs
@@ -40,7 +40,11 @@ pub struct ServerConfig {
     pub vendor_id: u16,
     /// Timeout in ms before retrying a failed confirmed COV notification send (default 3000ms).
     pub cov_retry_timeout_ms: u64,
-    /// Optional observer invoked after a time-synchronization request is accepted.
+    /// Opt-in inbound time-sync restrictions; default allows all, with no step cap.
+    pub time_sync_policy: TimeSyncPolicy,
+    /// Optional fast, nonblocking observer invoked after the clock changes.
+    /// A panic is caught (with unwind builds); the change stands and ingress
+    /// continues. This callback cannot authorize or roll back synchronization.
     pub on_time_sync: Option<Arc<dyn Fn(TimeSyncData) + Send + Sync>>,
     /// Opt-in mutation policy; `None` allows. See [`MutationAuthorizer`].
     pub mutation_authorizer: Option<MutationAuthorizer>,
@@ -151,6 +155,7 @@ impl std::fmt::Debug for ServerConfig {
             .field("segmentation_supported", &self.segmentation_supported)
             .field("vendor_id", &self.vendor_id)
             .field("cov_retry_timeout_ms", &self.cov_retry_timeout_ms)
+            .field("time_sync_policy", &self.time_sync_policy)
             .field(
                 "on_time_sync",
                 &self.on_time_sync.as_ref().map(|_| "<callback>"),
@@ -219,6 +224,7 @@ impl Default for ServerConfig {
             segmentation_supported: Segmentation::NONE,
             vendor_id: 0,
             cov_retry_timeout_ms: 3000,
+            time_sync_policy: TimeSyncPolicy::default(),
             on_time_sync: None,
             mutation_authorizer: None,
             life_safety_operation_authorizer: None,

--- a/crates/bacnet-server/src/server/device_bindings_tests.rs
+++ b/crates/bacnet-server/src/server/device_bindings_tests.rs
@@ -322,6 +322,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
     let comm_state = Arc::new(AtomicU8::new(0));
     let bindings = Arc::new(RwLock::new(DeviceBindingTable::new()));
     let discovery_limiter = Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None));
+    let time_sync_limiter = Arc::new(TimeSyncLimiter::new(TimeSyncPolicy::default()));
     let local_device = device(100);
     let routed_device = device(101);
 
@@ -333,6 +334,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         &comm_state,
         &bindings,
         &discovery_limiter,
+        &time_sync_limiter,
         i_am_request(local_device),
         &received(LOCAL_PEER, None),
     )
@@ -345,6 +347,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         &comm_state,
         &bindings,
         &discovery_limiter,
+        &time_sync_limiter,
         i_am_request(routed_device),
         &received(
             ROUTER,
@@ -384,6 +387,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         &comm_state,
         &bindings,
         &discovery_limiter,
+        &time_sync_limiter,
         i_am_request(ObjectIdentifier::new(ObjectType::ANALOG_INPUT, 1).unwrap()),
         &received(LOCAL_PEER, None),
     )
@@ -396,6 +400,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         &comm_state,
         &bindings,
         &discovery_limiter,
+        &time_sync_limiter,
         UnconfirmedRequestPdu {
             service_choice: UnconfirmedServiceChoice::I_AM,
             service_request: Bytes::from_static(&[0xFF]),
@@ -414,6 +419,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         &comm_state,
         &bindings,
         &discovery_limiter,
+        &time_sync_limiter,
         i_am_request(local_device),
         &received(UPDATED_PEER, None),
     )
@@ -426,6 +432,7 @@ async fn passive_local_and_routed_i_am_share_the_authority_and_dcc_disable_block
         &comm_state,
         &bindings,
         &discovery_limiter,
+        &time_sync_limiter,
         i_am_request(device(102)),
         &received(LOCAL_PEER, None),
     )

--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -97,6 +97,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         config: &Arc<ServerConfig>,
         clock: &Option<Arc<ServerClock>>,
         discovery_limiter: &Arc<DiscoveryLimiter>,
+        time_sync_limiter: &Arc<TimeSyncLimiter>,
         request_tasks: &Arc<super::request_tasks::RequestTasks>,
         source_mac: &[u8],
         apdu: Apdu,
@@ -266,6 +267,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let comm_state = Arc::clone(comm_state);
                 let device_bindings = Arc::clone(device_bindings);
                 let discovery_limiter = Arc::clone(discovery_limiter);
+                let time_sync_limiter = Arc::clone(time_sync_limiter);
                 let peer = super::request_peer::canonical_requester(
                     source_mac,
                     received.source_network.as_ref(),
@@ -279,6 +281,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                         &comm_state,
                         &device_bindings,
                         &discovery_limiter,
+                        &time_sync_limiter,
                         req,
                         &received,
                     )

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -259,6 +259,7 @@ impl Harness {
             &Arc::new(ServerConfig::default()),
             &None,
             &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
+            &Arc::new(TimeSyncLimiter::new(TimeSyncPolicy::default())),
             &Arc::new(super::request_tasks::RequestTasks::default()),
             source_mac,
             apdu,

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -55,10 +55,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             .into_iter()
             .find(|oid| oid.object_type() == ObjectType::DEVICE)
             .map(|oid| oid.instance_number());
-        let discovery_limiter = Arc::new(DiscoveryLimiter::new(
-            config.discovery_policy.sanitized(),
-            device_instance,
-        ));
+        let (discovery_limiter, time_sync_limiter) = request_limiters(&config, device_instance);
         let db = Arc::new(RwLock::new(db));
         let cov_counters = Arc::new(crate::cov::AtomicCovCounters::default());
         let cov_table = Arc::new(RwLock::new(CovSubscriptionTable::with_policy(
@@ -92,7 +89,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let dcc_timer_dispatch = Arc::clone(&dcc_timer);
         let config_dispatch = Arc::new(config.clone());
         let clock_dispatch = clock.clone();
-        let discovery_limiter_dispatch = Arc::clone(&discovery_limiter);
+        let limiters_dispatch = (discovery_limiter.clone(), time_sync_limiter.clone());
 
         let requests = Arc::clone(&request_tasks);
         let dispatch_task = tokio::spawn(async move {
@@ -445,7 +442,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                                     &dcc_outcomes_dispatch,
                                                     &config_dispatch,
                                                     &clock_dispatch,
-                                                    &discovery_limiter_dispatch,
+                                                    &limiters_dispatch.0,
+                                                    &limiters_dispatch.1,
                                                     &requests,
                                                     &source_mac,
                                                     Apdu::ConfirmedRequest(reassembled),
@@ -500,7 +498,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 &dcc_outcomes_dispatch,
                                 &config_dispatch,
                                 &clock_dispatch,
-                                &discovery_limiter_dispatch,
+                                &limiters_dispatch.0,
+                                &limiters_dispatch.1,
                                 &requests,
                                 &source_mac,
                                 decoded,
@@ -735,6 +734,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let server = Self {
             config,
             discovery_limiter,
+            time_sync_limiter,
             _clock: clock,
             network,
             db,

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -266,6 +266,11 @@ pub struct TimeSyncData {
     pub raw_service_data: Bytes,
     /// Whether this was a UTC time sync (vs. local).
     pub is_utc: bool,
+    /// Transport-native source MAC; on SC this is the source VMAC, not a
+    /// certificate principal. This metadata is a claimed identity only.
+    pub source_mac: MacAddr,
+    /// Claimed routed NPDU source, if present; takes precedence for policy matching.
+    pub source_network: Option<NpduAddress>,
 }
 
 mod config;
@@ -560,6 +565,8 @@ impl BipServerBuilder {
 pub struct BACnetServer<T: TransportPort> {
     config: ServerConfig,
     discovery_limiter: Arc<DiscoveryLimiter>,
+    #[allow(dead_code)] // Retained with the server, including direct dispatch tests.
+    time_sync_limiter: Arc<TimeSyncLimiter>,
     /// Server-owned clock controller; absent in explicit clockless mode.
     _clock: Option<Arc<ServerClock>>,
     /// Shared network layer (also held by dispatch task; read by
@@ -644,10 +651,15 @@ impl BACnetServer<BipTransport> {
 }
 
 mod clock;
+mod time_sync_policy;
 #[cfg(test)]
 pub(crate) use clock::clocked_test_database;
 pub use clock::ClockConfig;
 use clock::ServerClock;
+use time_sync_policy::{request_limiters, TimeSyncLimiter};
+pub use time_sync_policy::{
+    TimeSyncPolicy, TimeSyncRateLimit, TimeSyncSource, TimeSyncSourceRestriction,
+};
 mod binary_lighting_lifecycle;
 mod confirmed_request_tracker;
 mod cov_clock;

--- a/crates/bacnet-server/src/server/notification_transactions_tests.rs
+++ b/crates/bacnet-server/src/server/notification_transactions_tests.rs
@@ -406,6 +406,7 @@ async fn dispatch_keeps_segment_and_complex_acks_out_of_notification_completion(
             &config,
             &None,
             &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
+            &Arc::new(TimeSyncLimiter::new(TimeSyncPolicy::default())),
             &Arc::new(super::request_tasks::RequestTasks::default()),
             source_mac.as_slice(),
             apdu,

--- a/crates/bacnet-server/src/server/request_admission_tests.rs
+++ b/crates/bacnet-server/src/server/request_admission_tests.rs
@@ -54,6 +54,7 @@ async fn dispatch(
         &Arc::new(server.config.clone()),
         &server._clock,
         &server.discovery_limiter,
+        &server.time_sync_limiter,
         &server.request_tasks,
         &[1],
         apdu,

--- a/crates/bacnet-server/src/server/request_tasks.rs
+++ b/crates/bacnet-server/src/server/request_tasks.rs
@@ -59,6 +59,7 @@ impl RequestTasks {
         // before the lifecycle starts a transport or exposes a request owner.
         config.read_property_multiple_budget.validate()?;
         config.validate_dcc_config()?;
+        config.time_sync_policy.validate()?;
         config.get_alarm_summary_budget.validate()?;
         config.get_enrollment_summary_budget.validate()?;
         config.atomic_read_file_budget.validate()?;

--- a/crates/bacnet-server/src/server/requests/mutation_boundary_tests.rs
+++ b/crates/bacnet-server/src/server/requests/mutation_boundary_tests.rs
@@ -49,6 +49,7 @@ async fn deny_all_leaves_read_discovery_and_password_authorized_dcc_working() {
         &fixture.state,
         &Arc::new(RwLock::new(DeviceBindingTable::new())),
         &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), Some(1))),
+        &Arc::new(TimeSyncLimiter::new(TimeSyncPolicy::default())),
         UnconfirmedRequestPdu {
             service_choice: UnconfirmedServiceChoice::WHO_IS,
             service_request: Bytes::new(),

--- a/crates/bacnet-server/src/server/requests/unconfirmed.rs
+++ b/crates/bacnet-server/src/server/requests/unconfirmed.rs
@@ -4,8 +4,10 @@
 //! Split out of `requests.rs` to keep every file under the 700-LOC cap.
 
 use super::super::*;
+use bacnet_objects::clock::ClockReader;
 use bacnet_services::device_mgmt::TimeSynchronizationRequest;
 use bacnet_services::who_has::{WhoHasObject, WhoHasRequest};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 #[cfg(test)]
 /// Every unconfirmed service choice with an inbound execution arm in
@@ -32,6 +34,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         comm_state: &Arc<AtomicU8>,
         device_bindings: &Arc<RwLock<DeviceBindingTable>>,
         discovery_limiter: &Arc<DiscoveryLimiter>,
+        time_sync_limiter: &Arc<TimeSyncLimiter>,
         req: UnconfirmedRequestPdu,
         received: &bacnet_network::layer::ReceivedApdu,
     ) {
@@ -277,8 +280,10 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             if let Err(error) = apply_time_sync_request(
                 clock.map(Arc::as_ref),
                 config,
+                time_sync_limiter,
                 req.service_request.clone(),
                 is_utc,
+                received,
             ) {
                 debug!(%error, is_utc, "Ignoring time synchronization request");
             }
@@ -320,18 +325,402 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
 pub(super) fn apply_time_sync_request(
     clock: Option<&ServerClock>,
     config: &ServerConfig,
+    limiter: &TimeSyncLimiter,
     raw_service_data: Bytes,
     is_utc: bool,
+    received: &bacnet_network::layer::ReceivedApdu,
 ) -> Result<(), Error> {
-    let clock = clock.ok_or_else(|| Error::Encoding("Device clock is disabled".into()))?;
     let request = TimeSynchronizationRequest::decode(&raw_service_data)?;
-    clock.synchronize(request.date, request.time, is_utc)?;
+    let supplied = clock::date_time_to_hundredths(request.date, request.time)?;
+    let policy = &config.time_sync_policy;
+    if !policy.enabled {
+        return Err(time_sync_policy::denied("disabled"));
+    }
+    if policy
+        .source_restriction
+        .as_ref()
+        .is_some_and(|restriction| {
+            !restriction.allows(&received.source_mac, received.source_network.as_ref())
+        })
+    {
+        return Err(time_sync_policy::denied("source not allowed"));
+    }
+    let clock = clock.ok_or_else(|| Error::Encoding("Device clock is disabled".into()))?;
+    let mut delta_hundredths = None;
+    let result = limiter.apply_at(received, Instant::now(), || {
+        delta_hundredths = clock
+            .read_clock()
+            .and_then(|frame| time_sync_policy::step_hundredths(supplied, is_utc, frame));
+        time_sync_policy::check_step(delta_hundredths, policy.max_step)?;
+        clock.synchronize(request.date, request.time, is_utc)
+    });
+    debug!(
+        accepted = result.is_ok(),
+        ?delta_hundredths,
+        is_utc,
+        "Time synchronization decision"
+    );
+    result?;
 
     if let Some(callback) = &config.on_time_sync {
-        callback(TimeSyncData {
+        let data = TimeSyncData {
             raw_service_data,
             is_utc,
-        });
+            source_mac: received.source_mac.clone(),
+            source_network: received.source_network.clone(),
+        };
+        if catch_unwind(AssertUnwindSafe(|| callback(data))).is_err() {
+            debug!(
+                is_utc,
+                "Time synchronization observer panicked after clock update"
+            );
+        }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod time_sync_tests {
+    use super::*;
+    use bacnet_network::layer::ReceivedApdu;
+    use bacnet_transport::port::ReceivedNpdu;
+    use bacnet_types::primitives::{Date, Time};
+    use std::sync::atomic::AtomicUsize;
+
+    struct SilentTransport(Option<mpsc::Receiver<ReceivedNpdu>>);
+    impl TransportPort for SilentTransport {
+        async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+            Ok(self.0.take().unwrap())
+        }
+        async fn stop(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+        async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+            panic!("time sync must be silent on wire")
+        }
+        async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+            panic!("time sync must be silent on wire")
+        }
+        fn local_mac(&self) -> &[u8] {
+            &[99]
+        }
+    }
+
+    fn date() -> Date {
+        Date {
+            year: 124,
+            month: 7,
+            day: 4,
+            day_of_week: 4,
+        }
+    }
+    fn time(hour: u8) -> Time {
+        Time {
+            hour,
+            minute: 0,
+            second: 0,
+            hundredths: 0,
+        }
+    }
+    fn encoded(hour: u8) -> Bytes {
+        let mut bytes = BytesMut::new();
+        TimeSynchronizationRequest {
+            date: date(),
+            time: time(hour),
+        }
+        .encode(&mut bytes);
+        bytes.freeze()
+    }
+    fn received(kind: u8) -> ReceivedApdu {
+        ReceivedApdu {
+            apdu: Bytes::new(),
+            source_mac: MacAddr::from_slice(if kind == 2 { &[2, 3, 4, 5, 6, 7] } else { &[1] }),
+            ingress_network: None,
+            source_network: (kind == 1).then(|| NpduAddress {
+                network: 7,
+                mac_address: MacAddr::from_slice(&[8]),
+            }),
+            link_layer_group: false,
+            is_group: false,
+            data_attributes: Vec::new(),
+            reply_tx: None,
+        }
+    }
+    fn clock() -> Arc<ServerClock> {
+        let clock = Arc::new(ServerClock::new(ClockConfig::new(300, true).unwrap()));
+        clock.synchronize(date(), time(9), false).unwrap();
+        clock
+    }
+    fn config(policy: TimeSyncPolicy, callbacks: &Arc<AtomicUsize>) -> ServerConfig {
+        let callbacks = callbacks.clone();
+        ServerConfig {
+            time_sync_policy: policy,
+            on_time_sync: Some(Arc::new(move |_| {
+                callbacks.fetch_add(1, Ordering::SeqCst);
+            })),
+            ..Default::default()
+        }
+    }
+    async fn dispatch(
+        config: &ServerConfig,
+        clock: &Arc<ServerClock>,
+        limiter: &Arc<TimeSyncLimiter>,
+        is_utc: bool,
+        received: &ReceivedApdu,
+        data: Bytes,
+    ) {
+        BACnetServer::<SilentTransport>::handle_unconfirmed_request(
+            &Arc::new(RwLock::new(ObjectDatabase::new())),
+            &Arc::new(NetworkLayer::new(SilentTransport(None))),
+            config,
+            Some(clock),
+            &Arc::new(AtomicU8::new(0)),
+            &Arc::new(RwLock::new(DeviceBindingTable::new())),
+            &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
+            limiter,
+            UnconfirmedRequestPdu {
+                service_choice: if is_utc {
+                    UnconfirmedServiceChoice::UTC_TIME_SYNCHRONIZATION
+                } else {
+                    UnconfirmedServiceChoice::TIME_SYNCHRONIZATION
+                },
+                service_request: data,
+            },
+            received,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn time_sync_disabled_empty_allowlist_and_step_denials_leave_clock_and_observer_untouched(
+    ) {
+        for policy in [
+            TimeSyncPolicy {
+                enabled: false,
+                ..Default::default()
+            },
+            TimeSyncPolicy {
+                source_restriction: Some(TimeSyncSourceRestriction::new(vec![]).unwrap()),
+                ..Default::default()
+            },
+            TimeSyncPolicy {
+                max_step: Some(Duration::from_secs(60)),
+                ..Default::default()
+            },
+        ] {
+            for kind in 0..3 {
+                for is_utc in [false, true] {
+                    let clock = clock();
+                    let calls = Arc::new(AtomicUsize::new(0));
+                    let config = config(policy.clone(), &calls);
+                    let limiter = Arc::new(TimeSyncLimiter::new(policy.clone()));
+                    let context = received(kind);
+                    // Both forward and backward corrections exceed the cap.
+                    for local_hour in [8, 10] {
+                        dispatch(
+                            &config,
+                            &clock,
+                            &limiter,
+                            is_utc,
+                            &context,
+                            encoded(local_hour + if is_utc { 4 } else { 0 }),
+                        )
+                        .await;
+                        let frame = clock.read_clock().unwrap();
+                        assert_eq!(frame.local_date, date());
+                        assert_eq!((frame.local_time.hour, frame.local_time.minute), (9, 0));
+                        assert_eq!(calls.load(Ordering::SeqCst), 0);
+                    }
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn time_sync_allowlist_accepts_exact_direct_routed_and_sc_vmac_with_callback_provenance()
+    {
+        for kind in 0..3 {
+            for is_utc in [false, true] {
+                let clock = clock();
+                let context = received(kind);
+                let source = match &context.source_network {
+                    Some(source) => TimeSyncSource::Routed {
+                        network: source.network,
+                        address: source.mac_address.to_vec(),
+                    },
+                    None => TimeSyncSource::Direct(context.source_mac.to_vec()),
+                };
+                let policy = TimeSyncPolicy {
+                    source_restriction: Some(TimeSyncSourceRestriction::new(vec![source]).unwrap()),
+                    ..Default::default()
+                };
+                let expected_mac = context.source_mac.clone();
+                let expected_route = context.source_network.clone();
+                let data = encoded(if is_utc { 14 } else { 10 });
+                let expected_data = data.clone();
+                let seen = Arc::new(AtomicUsize::new(0));
+                let seen_callback = seen.clone();
+                let observed_clock = clock.clone();
+                let config = ServerConfig {
+                    time_sync_policy: policy.clone(),
+                    on_time_sync: Some(Arc::new(move |event| {
+                        assert_eq!(event.source_mac, expected_mac);
+                        assert_eq!(event.source_network, expected_route);
+                        assert_eq!(event.raw_service_data, expected_data);
+                        assert_eq!(event.is_utc, is_utc);
+                        assert_eq!(observed_clock.read_clock().unwrap().local_time.hour, 10);
+                        seen_callback.fetch_add(1, Ordering::SeqCst);
+                    })),
+                    ..Default::default()
+                };
+                let limiter = Arc::new(TimeSyncLimiter::new(policy));
+                let mut other = received(kind);
+                if let Some(source) = &mut other.source_network {
+                    source.network += 1;
+                } else {
+                    other.source_mac = MacAddr::from_slice(&[42]);
+                }
+                dispatch(&config, &clock, &limiter, is_utc, &other, data.clone()).await;
+                assert_eq!(seen.load(Ordering::SeqCst), 0);
+                assert_eq!(clock.read_clock().unwrap().local_time.hour, 9);
+                dispatch(&config, &clock, &limiter, is_utc, &context, data).await;
+                assert_eq!(seen.load(Ordering::SeqCst), 1);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn time_sync_malformed_denied_sources_and_oversteps_do_not_starve_valid_requests() {
+        let policy = TimeSyncPolicy {
+            source_restriction: Some(
+                TimeSyncSourceRestriction::new(vec![TimeSyncSource::Direct(vec![1])]).unwrap(),
+            ),
+            max_step: Some(Duration::from_secs(3600)),
+            per_source_rate: Some(TimeSyncRateLimit {
+                max_per_second: 1.0,
+                burst_capacity: 1,
+            }),
+            global_rate: Some(TimeSyncRateLimit {
+                max_per_second: 1.0,
+                burst_capacity: 1,
+            }),
+            coalesce_window: Duration::from_secs(60),
+            ..Default::default()
+        };
+        let clock = clock();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let config = config(policy.clone(), &calls);
+        let limiter = Arc::new(TimeSyncLimiter::new(policy));
+        for is_utc in [false, true] {
+            dispatch(
+                &config,
+                &clock,
+                &limiter,
+                is_utc,
+                &received(0),
+                Bytes::from_static(&[0xff]),
+            )
+            .await;
+            let mut invalid_date = encoded(10).to_vec();
+            invalid_date[1] = Date::UNSPECIFIED;
+            dispatch(
+                &config,
+                &clock,
+                &limiter,
+                is_utc,
+                &received(0),
+                invalid_date.into(),
+            )
+            .await;
+            dispatch(&config, &clock, &limiter, is_utc, &received(2), encoded(10)).await;
+            dispatch(&config, &clock, &limiter, is_utc, &received(0), encoded(20)).await;
+        }
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        dispatch(&config, &clock, &limiter, false, &received(0), encoded(10)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        // UTC and local share rate/coalescing state. A second valid correction drops.
+        dispatch(&config, &clock, &limiter, true, &received(0), encoded(15)).await;
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(clock.read_clock().unwrap().local_time.hour, 10);
+    }
+
+    #[tokio::test]
+    async fn time_sync_panicking_observer_keeps_change_and_live_ingress_continues() {
+        let (tx, rx) = mpsc::channel(8);
+        let (observed, mut observations) = mpsc::unbounded_channel();
+        let config = ServerConfig {
+            on_time_sync: Some(Arc::new(move |event| {
+                observed.send(event).unwrap();
+                panic!("test observer failure");
+            })),
+            ..Default::default()
+        };
+        let mut server =
+            BACnetServer::start(config, ObjectDatabase::new(), SilentTransport(Some(rx)))
+                .await
+                .unwrap();
+        for (is_utc, hour) in [(false, 10), (true, 11), (false, 12)] {
+            let mut npdu = BytesMut::from(&[1, 0][..]);
+            encode_apdu(
+                &mut npdu,
+                &Apdu::UnconfirmedRequest(UnconfirmedRequestPdu {
+                    service_choice: if is_utc {
+                        UnconfirmedServiceChoice::UTC_TIME_SYNCHRONIZATION
+                    } else {
+                        UnconfirmedServiceChoice::TIME_SYNCHRONIZATION
+                    },
+                    service_request: encoded(hour),
+                }),
+            )
+            .unwrap();
+            tx.send(ReceivedNpdu {
+                npdu: npdu.freeze(),
+                source_mac: MacAddr::from_slice(&[2, 3, 4, 5, 6, 7]),
+                link_layer_group: false,
+                data_attributes: Vec::new(),
+                reply_tx: None,
+            })
+            .await
+            .unwrap();
+            let event = tokio::time::timeout(Duration::from_secs(2), observations.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(event.is_utc, is_utc);
+            assert_eq!(
+                server
+                    ._clock
+                    .as_ref()
+                    .unwrap()
+                    .read_clock()
+                    .unwrap()
+                    .local_time
+                    .hour,
+                hour
+            );
+        }
+        server.stop().await.unwrap();
+    }
+
+    #[test]
+    fn time_sync_callback_unwind_is_contained_without_poisoning_limiter() {
+        let clock = clock();
+        let config = ServerConfig {
+            on_time_sync: Some(Arc::new(|_| panic!("test observer failure"))),
+            ..Default::default()
+        };
+        let limiter = TimeSyncLimiter::new(config.time_sync_policy.clone());
+        for (is_utc, local_hour) in [(false, 10), (true, 11)] {
+            apply_time_sync_request(
+                Some(&clock),
+                &config,
+                &limiter,
+                encoded(local_hour + if is_utc { 4 } else { 0 }),
+                is_utc,
+                &received(2),
+            )
+            .unwrap();
+            assert_eq!(clock.read_clock().unwrap().local_time.hour, local_hour);
+        }
+    }
 }

--- a/crates/bacnet-server/src/server/requests/unconfirmed_tests.rs
+++ b/crates/bacnet-server/src/server/requests/unconfirmed_tests.rs
@@ -1,4 +1,4 @@
-use super::super::{ClockConfig, ServerClock, ServerConfig};
+use super::super::{ClockConfig, ServerClock, ServerConfig, TimeSyncLimiter, TimeSyncPolicy};
 use super::unconfirmed::apply_time_sync_request;
 use crate::server::TimeSyncData;
 use bacnet_objects::clock::ClockReader;
@@ -41,6 +41,19 @@ fn config_with_counter(counter: Arc<AtomicUsize>) -> ServerConfig {
     }
 }
 
+fn received() -> bacnet_network::layer::ReceivedApdu {
+    bacnet_network::layer::ReceivedApdu {
+        apdu: Bytes::new(),
+        source_mac: bacnet_types::MacAddr::from_slice(&[1]),
+        ingress_network: None,
+        source_network: None,
+        link_layer_group: false,
+        is_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
 #[test]
 fn accepted_local_and_utc_requests_update_then_notify() {
     let clock = ServerClock::new(ClockConfig::new(300, true).unwrap());
@@ -50,8 +63,10 @@ fn accepted_local_and_utc_requests_update_then_notify() {
     apply_time_sync_request(
         Some(&clock),
         &config,
+        &TimeSyncLimiter::new(TimeSyncPolicy::default()),
         encoded(date(2024, 7, 4, 4), time(9, 15)),
         false,
+        &received(),
     )
     .unwrap();
     let frame = clock.read_clock().unwrap();
@@ -61,8 +76,10 @@ fn accepted_local_and_utc_requests_update_then_notify() {
     apply_time_sync_request(
         Some(&clock),
         &config,
+        &TimeSyncLimiter::new(TimeSyncPolicy::default()),
         encoded(date(2024, 7, 4, 4), time(13, 15)),
         true,
+        &received(),
     )
     .unwrap();
     let frame = clock.read_clock().unwrap();
@@ -76,13 +93,19 @@ fn invalid_and_clockless_requests_do_not_notify() {
     let callbacks = Arc::new(AtomicUsize::new(0));
     let config = config_with_counter(Arc::clone(&callbacks));
 
-    assert!(
-        apply_time_sync_request(Some(&clock), &config, Bytes::from_static(&[0xff]), false,)
-            .is_err()
-    );
     assert!(apply_time_sync_request(
         Some(&clock),
         &config,
+        &TimeSyncLimiter::new(TimeSyncPolicy::default()),
+        Bytes::from_static(&[0xff]),
+        false,
+        &received()
+    )
+    .is_err());
+    assert!(apply_time_sync_request(
+        Some(&clock),
+        &config,
+        &TimeSyncLimiter::new(TimeSyncPolicy::default()),
         encoded(
             Date {
                 year: Date::UNSPECIFIED,
@@ -93,13 +116,16 @@ fn invalid_and_clockless_requests_do_not_notify() {
             time(0, 0),
         ),
         false,
+        &received(),
     )
     .is_err());
     assert!(apply_time_sync_request(
         None,
         &config,
+        &TimeSyncLimiter::new(TimeSyncPolicy::default()),
         encoded(date(2024, 7, 4, 4), time(9, 15)),
         false,
+        &received(),
     )
     .is_err());
     assert_eq!(callbacks.load(Ordering::SeqCst), 0);

--- a/crates/bacnet-server/src/server/sc_builder.rs
+++ b/crates/bacnet-server/src/server/sc_builder.rs
@@ -247,6 +247,7 @@ impl ScServerBuilder {
 
         self.config.request_admission_policy.validate()?;
         self.config.validate_dcc_config()?;
+        self.config.time_sync_policy.validate()?;
         self.config.read_property_multiple_budget.validate()?;
         self.config.get_alarm_summary_budget.validate()?;
         self.config.get_enrollment_summary_budget.validate()?;

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -295,6 +295,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
         &config,
         &None,
         &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),
+        &Arc::new(TimeSyncLimiter::new(TimeSyncPolicy::default())),
         &Arc::new(super::request_tasks::RequestTasks::default()),
         source_mac.as_slice(),
         apdu,

--- a/crates/bacnet-server/src/server/time_sync_policy.rs
+++ b/crates/bacnet-server/src/server/time_sync_policy.rs
@@ -1,0 +1,393 @@
+//! Local opt-in inbound clock policy, independent of DCC and mutation policy.
+
+use super::{BipServerBuilder, ServerBuilder, TransportPort};
+use bacnet_encoding::npdu::NpduAddress;
+use bacnet_network::layer::ReceivedApdu;
+use bacnet_objects::clock::ClockFrame;
+use bacnet_types::error::Error;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Exact claimed time-sync source, not an authenticated principal.
+///
+/// Unconfirmed dispatch exposes transport MAC and NPDU source only. On SC the
+/// MAC is the source VMAC, not a certificate identity or proof of trust. Routed
+/// identity takes precedence; a trusted router MAC does not trust its clients.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub enum TimeSyncSource {
+    /// Complete transport-native MAC, only when no routed source is present.
+    Direct(Vec<u8>),
+    /// Complete claimed routed source, independent of the immediate router.
+    Routed {
+        /// Source network (1..=65534).
+        network: u16,
+        /// Source address (1..=255 octets).
+        address: Vec<u8>,
+    },
+}
+
+impl TimeSyncSource {
+    fn validate(&self) -> Result<(), Error> {
+        let address = match self {
+            Self::Direct(address) => address,
+            Self::Routed { network, address } => {
+                if !(1..=65534).contains(network) {
+                    return Err(denied("source network must be 1..=65534"));
+                }
+                address
+            }
+        };
+        if !(1..=255).contains(&address.len()) {
+            return Err(denied("source address must contain 1..=255 octets"));
+        }
+        Ok(())
+    }
+
+    fn from_received(received: &ReceivedApdu) -> Result<Self, Error> {
+        let source = match &received.source_network {
+            Some(source) => Self::Routed {
+                network: source.network,
+                address: source.mac_address.to_vec(),
+            },
+            None => Self::Direct(received.source_mac.to_vec()),
+        };
+        source.validate()?;
+        Ok(source)
+    }
+}
+
+/// Validated exact-source allowlist. A configured empty list denies everyone.
+/// `None` in [`TimeSyncPolicy`] leaves sources unrestricted.
+#[derive(Clone, Eq, PartialEq)]
+pub struct TimeSyncSourceRestriction(Vec<TimeSyncSource>);
+
+impl std::fmt::Debug for TimeSyncSourceRestriction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TimeSyncSourceRestriction")
+            .field("entries", &self.0.len())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TimeSyncSourceRestriction {
+    /// Accept at most 256 entries with 1..=255 address octets and valid networks.
+    /// These are local configuration limits, not authentication guarantees.
+    pub fn new(sources: Vec<TimeSyncSource>) -> Result<Self, Error> {
+        if sources.len() > 256 {
+            return Err(denied("source restriction allows at most 256 entries"));
+        }
+        for source in &sources {
+            source.validate()?;
+        }
+        Ok(Self(sources))
+    }
+
+    pub(super) fn allows(&self, mac: &[u8], routed: Option<&NpduAddress>) -> bool {
+        // Do not use admission's malformed-routed fallback for authorization.
+        match routed {
+            Some(source) => self.0.iter().any(|entry| matches!(entry,
+                TimeSyncSource::Routed { network, address }
+                if *network == source.network && address.as_slice() == source.mac_address.as_slice())),
+            None => self.0.iter().any(|entry|
+                matches!(entry, TimeSyncSource::Direct(address) if address.as_slice() == mac)),
+        }
+    }
+}
+
+/// Opt-in token bucket for accepted local and UTC time-sync requests combined.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct TimeSyncRateLimit {
+    /// Positive finite refill rate in requests per second of monotonic time.
+    pub max_per_second: f64,
+    /// Positive initial and maximum token capacity.
+    pub burst_capacity: u32,
+}
+
+impl TimeSyncRateLimit {
+    fn validate(self) -> Result<(), Error> {
+        if !self.max_per_second.is_finite()
+            || self.max_per_second <= 0.0
+            || self.burst_capacity == 0
+        {
+            return Err(denied(
+                "rate must be positive and finite with a positive burst",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Default-allow inbound TimeSynchronization / UTCTimeSynchronization policy.
+///
+/// Every restriction is opt-in and independent. No default step cap is imposed:
+/// a controller booting with an incorrect clock may need a large initial sync.
+/// Operators should configure trusted claimed sources (not authentication), and
+/// choose a cap only when their boot/recovery process can tolerate rejection.
+/// This is local policy, not a change to the unconfirmed wire behavior (16.7/16.8).
+/// Denials send no response and do not change the clock or invoke its observer.
+/// Decoding/validation precedes source and rate policy, then step-check and clock
+/// update are serialized. The observer runs afterwards outside the limiter lock;
+/// a concurrent accepted request may already have advanced the clock again.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TimeSyncPolicy {
+    /// Accept inbound time sync by default. False disables clock touch and callback.
+    pub enabled: bool,
+    /// Optional exact-source allowlist; Some(empty) denies all, None allows all.
+    pub source_restriction: Option<TimeSyncSourceRestriction>,
+    /// Optional absolute step cap, inclusive at the boundary, for forward/backward
+    /// corrections. Zero allows only an exact match. No readable clock means a
+    /// configured cap fails closed; without a cap, boot synchronization still works.
+    pub max_step: Option<Duration>,
+    /// Optional per-source token bucket, shared across local and UTC requests.
+    pub per_source_rate: Option<TimeSyncRateLimit>,
+    /// Optional server-wide token bucket, including all sources and both services.
+    pub global_rate: Option<TimeSyncRateLimit>,
+    /// Minimum spacing between accepted requests from one source, regardless of
+    /// value or local/UTC form. Zero disables coalescing. Drops do not extend it.
+    pub coalesce_window: Duration,
+    /// Minimum spacing between accepted requests globally, across all sources
+    /// and both services. Zero disables global coalescing. Drops do not extend it.
+    pub global_coalesce_window: Duration,
+    /// Bound on rate/coalescing source state (1..=65536, default 256). A full
+    /// table rejects new sources until an entry is fully refilled and outside its
+    /// coalescing window; active entries are never evicted to reset their budget.
+    pub max_sources: usize,
+}
+
+impl Default for TimeSyncPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            source_restriction: None,
+            max_step: None,
+            per_source_rate: None,
+            global_rate: None,
+            coalesce_window: Duration::ZERO,
+            global_coalesce_window: Duration::ZERO,
+            max_sources: 256,
+        }
+    }
+}
+
+impl TimeSyncPolicy {
+    /// Validate before transport startup/dialing, even when acceptance is disabled.
+    pub fn validate(&self) -> Result<(), Error> {
+        for limit in [self.per_source_rate, self.global_rate]
+            .into_iter()
+            .flatten()
+        {
+            limit.validate()?;
+        }
+        if !(1..=65536).contains(&self.max_sources) {
+            return Err(denied("max_sources must be 1..=65536"));
+        }
+        Ok(())
+    }
+}
+
+impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Configure opt-in inbound clock restrictions; default is unrestricted allow.
+    pub fn time_sync_policy(mut self, policy: TimeSyncPolicy) -> Self {
+        self.config.time_sync_policy = policy;
+        self
+    }
+}
+
+impl BipServerBuilder {
+    /// Configure opt-in inbound clock restrictions; see [`TimeSyncPolicy`].
+    pub fn time_sync_policy(mut self, policy: TimeSyncPolicy) -> Self {
+        self.config.time_sync_policy = policy;
+        self
+    }
+}
+
+#[cfg(feature = "sc-tls")]
+impl super::ScServerBuilder {
+    /// Configure inbound clock restrictions on claimed SC VMAC / routed sources.
+    /// Dispatch does not expose certificate principals; see [`TimeSyncSource`].
+    pub fn time_sync_policy(mut self, policy: TimeSyncPolicy) -> Self {
+        self.config.time_sync_policy = policy;
+        self
+    }
+}
+
+pub(super) fn denied(reason: &str) -> Error {
+    Error::Encoding(format!("time sync: {reason}"))
+}
+
+/// Compare in the request's time basis; no clock mutation or floating-point time.
+pub(super) fn step_hundredths(supplied: i128, is_utc: bool, frame: ClockFrame) -> Option<u128> {
+    let local = super::clock::date_time_to_hundredths(frame.local_date, frame.local_time).ok()?;
+    let current = if is_utc {
+        local + i128::from(frame.utc_offset) * 6000
+            - if frame.daylight_savings_status {
+                360_000
+            } else {
+                0
+            }
+    } else {
+        local
+    };
+    Some(supplied.abs_diff(current))
+}
+
+pub(super) fn check_step(delta: Option<u128>, cap: Option<Duration>) -> Result<(), Error> {
+    if let Some(cap) = cap {
+        let delta = delta.ok_or_else(|| denied("clock unreadable for step cap"))?;
+        if delta * 10_000_000 > cap.as_nanos() {
+            return Err(denied("step cap exceeded"));
+        }
+    }
+    Ok(())
+}
+
+struct Bucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl Bucket {
+    fn new(limit: Option<TimeSyncRateLimit>, now: Instant) -> Self {
+        Self {
+            tokens: limit.map_or(0.0, |l| f64::from(l.burst_capacity)),
+            last_refill: now,
+        }
+    }
+
+    fn refill(&mut self, limit: Option<TimeSyncRateLimit>, now: Instant) {
+        if let Some(limit) = limit {
+            let elapsed = now
+                .saturating_duration_since(self.last_refill)
+                .as_secs_f64();
+            self.tokens =
+                (self.tokens + elapsed * limit.max_per_second).min(f64::from(limit.burst_capacity));
+        }
+        self.last_refill = self.last_refill.max(now);
+    }
+
+    fn ready(&self, limit: Option<TimeSyncRateLimit>) -> bool {
+        limit.is_none() || self.tokens >= 1.0
+    }
+
+    fn deduct(&mut self, limit: Option<TimeSyncRateLimit>) {
+        if limit.is_some() {
+            self.tokens -= 1.0;
+        }
+    }
+}
+
+struct SourceState {
+    bucket: Bucket,
+    last_accepted: Instant,
+}
+
+struct State {
+    global: Bucket,
+    last_accepted: Option<Instant>,
+    sources: HashMap<TimeSyncSource, SourceState>,
+}
+
+/// Server-lifetime synchronization admission state, separate from discovery.
+/// The mutex also serializes step-check + clock update across request tasks.
+pub(super) struct TimeSyncLimiter {
+    policy: TimeSyncPolicy,
+    state: Mutex<State>,
+}
+
+// Keep construction plumbing out of the size-capped lifecycle. Policies and
+// mutable state remain independent; both Arcs have the native server lifetime.
+pub(super) fn request_limiters(
+    config: &super::ServerConfig,
+    device_instance: Option<u32>,
+) -> (Arc<super::DiscoveryLimiter>, Arc<TimeSyncLimiter>) {
+    (
+        Arc::new(super::DiscoveryLimiter::new(
+            config.discovery_policy.sanitized(),
+            device_instance,
+        )),
+        Arc::new(TimeSyncLimiter::new(config.time_sync_policy.clone())),
+    )
+}
+
+impl TimeSyncLimiter {
+    pub(super) fn new(policy: TimeSyncPolicy) -> Self {
+        Self {
+            state: Mutex::new(State {
+                global: Bucket::new(policy.global_rate, Instant::now()),
+                last_accepted: None,
+                sources: HashMap::new(),
+            }),
+            policy,
+        }
+    }
+
+    pub(super) fn apply_at(
+        &self,
+        received: &ReceivedApdu,
+        now: Instant,
+        apply: impl FnOnce() -> Result<(), Error>,
+    ) -> Result<(), Error> {
+        let policy = &self.policy;
+        let track_source = policy.per_source_rate.is_some() || !policy.coalesce_window.is_zero();
+        let key = track_source
+            .then(|| TimeSyncSource::from_received(received))
+            .transpose()?;
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| denied("limiter lock poisoned"))?;
+        if state
+            .last_accepted
+            .is_some_and(|last| now.saturating_duration_since(last) < policy.global_coalesce_window)
+        {
+            return Err(denied("coalesced globally"));
+        }
+        state.global.refill(policy.global_rate, now);
+        if !state.global.ready(policy.global_rate) {
+            return Err(denied("global rate limit"));
+        }
+        if let Some(key) = &key {
+            if let Some(source) = state.sources.get_mut(key) {
+                if now.saturating_duration_since(source.last_accepted) < policy.coalesce_window {
+                    return Err(denied("coalesced source"));
+                }
+                source.bucket.refill(policy.per_source_rate, now);
+                if !source.bucket.ready(policy.per_source_rate) {
+                    return Err(denied("source rate limit"));
+                }
+            } else if state.sources.len() >= policy.max_sources {
+                state.sources.retain(|_, source| {
+                    source.bucket.refill(policy.per_source_rate, now);
+                    let full = policy.per_source_rate.is_none_or(|limit| {
+                        source.bucket.tokens >= f64::from(limit.burst_capacity)
+                    });
+                    !full
+                        || now.saturating_duration_since(source.last_accepted)
+                            < policy.coalesce_window
+                });
+                if state.sources.len() >= policy.max_sources {
+                    return Err(denied("source table full"));
+                }
+            }
+        }
+        // No await or observer under this lock. Failed step/sync does not spend
+        // tokens or postpone the next legitimate synchronization.
+        apply()?;
+        state.global.deduct(policy.global_rate);
+        state.last_accepted = Some(now);
+        if let Some(key) = key {
+            let source = state.sources.entry(key).or_insert_with(|| SourceState {
+                bucket: Bucket::new(policy.per_source_rate, now),
+                last_accepted: now,
+            });
+            source.bucket.deduct(policy.per_source_rate);
+            source.last_accepted = now;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "time_sync_policy_tests.rs"]
+mod tests;

--- a/crates/bacnet-server/src/server/time_sync_policy_tests.rs
+++ b/crates/bacnet-server/src/server/time_sync_policy_tests.rs
@@ -1,0 +1,438 @@
+use super::*;
+use crate::server::{BACnetServer, ServerConfig};
+use bacnet_objects::database::ObjectDatabase;
+use bacnet_types::{
+    primitives::{Date, Time},
+    MacAddr,
+};
+use bytes::Bytes;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+fn received(mac: &[u8], routed: Option<(u16, &[u8])>) -> ReceivedApdu {
+    ReceivedApdu {
+        apdu: Bytes::new(),
+        source_mac: MacAddr::from_slice(mac),
+        ingress_network: None,
+        source_network: routed.map(|(network, address)| NpduAddress {
+            network,
+            mac_address: MacAddr::from_slice(address),
+        }),
+        link_layer_group: false,
+        is_group: false,
+        data_attributes: Vec::new(),
+        reply_tx: None,
+    }
+}
+
+fn rate(burst_capacity: u32) -> TimeSyncRateLimit {
+    TimeSyncRateLimit {
+        max_per_second: 1.0,
+        burst_capacity,
+    }
+}
+
+#[test]
+fn exact_sources_and_configured_empty_do_not_fall_back_to_router() {
+    let restriction = TimeSyncSourceRestriction::new(vec![
+        TimeSyncSource::Direct(vec![1, 2, 3, 4, 5, 6]), // SC VMAC-shaped claimed source
+        TimeSyncSource::Routed {
+            network: 7,
+            address: vec![8, 9],
+        },
+    ])
+    .unwrap();
+    for (mac, route, expected) in [
+        (&[1, 2, 3, 4, 5, 6][..], None, true),
+        (&[1, 2, 3, 4, 5][..], None, false),
+        (&[1, 2, 3, 4, 5, 7][..], None, false),
+        (&[99][..], Some((7, &[8, 9][..])), true),
+        (&[98][..], Some((7, &[8, 9][..])), true),
+        (&[99][..], Some((8, &[8, 9][..])), false),
+        (&[99][..], Some((7, &[8][..])), false),
+        (&[1, 2, 3, 4, 5, 6][..], Some((0, &[][..])), false),
+        (&[1, 2, 3, 4, 5, 6][..], Some((7, &[10][..])), false),
+    ] {
+        let context = received(mac, route);
+        assert_eq!(
+            restriction.allows(mac, context.source_network.as_ref()),
+            expected
+        );
+        assert!(!TimeSyncSourceRestriction::new(vec![])
+            .unwrap()
+            .allows(mac, context.source_network.as_ref()));
+    }
+    assert_eq!(
+        format!("{restriction:?}"),
+        "TimeSyncSourceRestriction { entries: 2, .. }"
+    );
+}
+
+#[test]
+fn rejects_invalid_allowlists_at_construction() {
+    for source in [
+        TimeSyncSource::Direct(vec![]),
+        TimeSyncSource::Direct(vec![1; 256]),
+        TimeSyncSource::Routed {
+            network: 0,
+            address: vec![1],
+        },
+        TimeSyncSource::Routed {
+            network: 65535,
+            address: vec![1],
+        },
+        TimeSyncSource::Routed {
+            network: 1,
+            address: vec![],
+        },
+        TimeSyncSource::Routed {
+            network: 1,
+            address: vec![1; 256],
+        },
+    ] {
+        assert!(TimeSyncSourceRestriction::new(vec![source]).is_err());
+    }
+    let source = TimeSyncSource::Routed {
+        network: 65534,
+        address: vec![1; 255],
+    };
+    assert!(TimeSyncSourceRestriction::new(vec![source.clone(); 256]).is_ok());
+    assert!(TimeSyncSourceRestriction::new(vec![source; 257]).is_err());
+}
+
+#[test]
+fn step_cap_exact_boundary_both_directions_and_utc_local_parity() {
+    let frame = ClockFrame {
+        local_date: Date {
+            year: 124,
+            month: 7,
+            day: 4,
+            day_of_week: 4,
+        },
+        local_time: Time {
+            hour: 22,
+            minute: 0,
+            second: 0,
+            hundredths: 0,
+        },
+        utc_offset: 300,
+        daylight_savings_status: true,
+    };
+    let local =
+        super::super::clock::date_time_to_hundredths(frame.local_date, frame.local_time).unwrap();
+    for is_utc in [false, true] {
+        // UTC is the next civil day; offset is west of UTC with active DST.
+        let current = local + if is_utc { 4 * 360_000 } else { 0 };
+        for sign in [-1, 1] {
+            let delta = step_hundredths(current + sign * 100, is_utc, frame);
+            assert_eq!(delta, Some(100));
+            assert!(check_step(delta, Some(Duration::from_secs(1))).is_ok());
+            assert!(check_step(delta, Some(Duration::from_nanos(999_999_999))).is_err());
+            assert!(check_step(
+                step_hundredths(current + sign * 101, is_utc, frame),
+                Some(Duration::from_secs(1))
+            )
+            .is_err());
+        }
+        assert!(check_step(
+            step_hundredths(current, is_utc, frame),
+            Some(Duration::ZERO)
+        )
+        .is_ok());
+    }
+    assert!(check_step(None, None).is_ok());
+    assert!(check_step(None, Some(Duration::MAX)).is_err());
+    assert!(check_step(Some(1), Some(Duration::ZERO)).is_err());
+}
+
+#[test]
+fn time_sync_rates_bound_bursts_and_restore_cadence_without_denial_debits() {
+    let limiter = TimeSyncLimiter::new(TimeSyncPolicy {
+        per_source_rate: Some(rate(2)),
+        global_rate: Some(rate(3)),
+        ..Default::default()
+    });
+    let a = received(&[1], None);
+    let b = received(&[2], None);
+    let now = Instant::now();
+    for _ in 0..2 {
+        limiter.apply_at(&a, now, || Ok(())).unwrap();
+    }
+    assert!(limiter
+        .apply_at(&a, now, || panic!("source limited"))
+        .is_err());
+    limiter.apply_at(&b, now, || Ok(())).unwrap();
+    assert!(limiter
+        .apply_at(&b, now, || panic!("global limited"))
+        .is_err());
+    assert!(limiter
+        .apply_at(&a, now + Duration::from_millis(999), || panic!(
+            "early refill"
+        ))
+        .is_err());
+    for seconds in 1..=5 {
+        let now = now + Duration::from_secs(seconds);
+        limiter.apply_at(&a, now, || Ok(())).unwrap();
+        assert!(limiter
+            .apply_at(&b, now, || panic!("global limited"))
+            .is_err());
+    }
+}
+
+#[test]
+fn coalescing_and_source_capacity_preserve_active_routed_identity() {
+    let limiter = TimeSyncLimiter::new(TimeSyncPolicy {
+        per_source_rate: Some(rate(1)),
+        coalesce_window: Duration::from_secs(2),
+        max_sources: 1,
+        ..Default::default()
+    });
+    let a = received(&[1], Some((7, &[8])));
+    let same_via_other_router = received(&[2], Some((7, &[8])));
+    let b = received(&[1], Some((8, &[8])));
+    let now = Instant::now();
+    limiter.apply_at(&a, now, || Ok(())).unwrap();
+    assert!(limiter
+        .apply_at(
+            &same_via_other_router,
+            now + Duration::from_secs(1),
+            || panic!("coalesced")
+        )
+        .is_err());
+    assert!(limiter
+        .apply_at(&b, now + Duration::from_secs(1), || panic!("table full"))
+        .is_err());
+    // Denials did not extend the original coalescing window.
+    limiter
+        .apply_at(&b, now + Duration::from_secs(2), || Ok(()))
+        .unwrap();
+    assert_eq!(limiter.state.lock().unwrap().sources.len(), 1);
+    assert!(limiter
+        .apply_at(&a, now + Duration::from_secs(2), || panic!(
+            "cannot evict active"
+        ))
+        .is_err());
+}
+
+#[test]
+fn failed_step_does_not_spend_rate_or_coalescing_budget() {
+    let limiter = TimeSyncLimiter::new(TimeSyncPolicy {
+        per_source_rate: Some(rate(1)),
+        global_rate: Some(rate(1)),
+        coalesce_window: Duration::from_secs(10),
+        ..Default::default()
+    });
+    let a = received(&[1], None);
+    let now = Instant::now();
+    assert!(limiter
+        .apply_at(&a, now, || Err(denied("step cap exceeded")))
+        .is_err());
+    assert!(limiter.state.lock().unwrap().sources.is_empty());
+    limiter.apply_at(&a, now, || Ok(())).unwrap();
+    assert!(limiter.apply_at(&a, now, || panic!("limited")).is_err());
+}
+
+#[test]
+fn limits_are_independent_and_monotonic_time_does_not_refill_backwards() {
+    for policy in [
+        TimeSyncPolicy {
+            per_source_rate: Some(rate(1)),
+            ..Default::default()
+        },
+        TimeSyncPolicy {
+            global_rate: Some(rate(1)),
+            ..Default::default()
+        },
+        TimeSyncPolicy {
+            coalesce_window: Duration::from_secs(1),
+            ..Default::default()
+        },
+    ] {
+        let limiter = TimeSyncLimiter::new(policy.clone());
+        let now = Instant::now();
+        let a = received(&[1], None);
+        let b = received(&[2], None);
+        limiter.apply_at(&a, now, || Ok(())).unwrap();
+        assert!(limiter
+            .apply_at(&a, now - Duration::from_secs(1), || panic!("backwards"))
+            .is_err());
+        assert_eq!(
+            limiter.apply_at(&b, now, || Ok(())).is_ok(),
+            policy.global_rate.is_none()
+        );
+        limiter
+            .apply_at(&a, now + Duration::from_secs(1), || Ok(()))
+            .unwrap();
+    }
+}
+
+#[test]
+fn concurrent_time_sync_admission_is_bounded_and_check_apply_is_serialized() {
+    let limiter = Arc::new(TimeSyncLimiter::new(TimeSyncPolicy {
+        global_rate: Some(rate(4)),
+        ..Default::default()
+    }));
+    let applied = Arc::new(AtomicUsize::new(0));
+    let now = Instant::now();
+    std::thread::scope(|scope| {
+        for _ in 0..32 {
+            scope.spawn(|| {
+                let _ = limiter.apply_at(&received(&[1], None), now, || {
+                    let before = applied.load(Ordering::SeqCst);
+                    std::thread::yield_now();
+                    applied.store(before + 1, Ordering::SeqCst);
+                    Ok(())
+                });
+            });
+        }
+    });
+    assert_eq!(applied.load(Ordering::SeqCst), 4);
+}
+
+struct NeverStart;
+impl TransportPort for NeverStart {
+    async fn start(
+        &mut self,
+    ) -> Result<tokio::sync::mpsc::Receiver<bacnet_transport::port::ReceivedNpdu>, Error> {
+        panic!("invalid policy reached transport startup")
+    }
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+    fn local_mac(&self) -> &[u8] {
+        &[1]
+    }
+}
+
+#[tokio::test]
+async fn time_sync_defaults_and_all_builders_validate_before_start_or_dial() {
+    let default = TimeSyncPolicy::default();
+    assert!(default.enabled);
+    assert!(default.source_restriction.is_none());
+    assert!(default.max_step.is_none());
+    assert!(default.per_source_rate.is_none());
+    assert!(default.global_rate.is_none());
+    assert!(default.coalesce_window.is_zero());
+    assert!(default.global_coalesce_window.is_zero());
+    assert_eq!(ServerConfig::default().time_sync_policy, default);
+    default.validate().unwrap();
+    let mut invalid = vec![
+        TimeSyncPolicy {
+            max_sources: 0,
+            ..Default::default()
+        },
+        TimeSyncPolicy {
+            max_sources: 65537,
+            ..Default::default()
+        },
+    ];
+    for limit in [
+        TimeSyncRateLimit {
+            max_per_second: 0.0,
+            burst_capacity: 1,
+        },
+        TimeSyncRateLimit {
+            max_per_second: -1.0,
+            burst_capacity: 1,
+        },
+        TimeSyncRateLimit {
+            max_per_second: f64::NAN,
+            burst_capacity: 1,
+        },
+        TimeSyncRateLimit {
+            max_per_second: f64::INFINITY,
+            burst_capacity: 1,
+        },
+        rate(0),
+    ] {
+        invalid.push(TimeSyncPolicy {
+            per_source_rate: Some(limit),
+            ..Default::default()
+        });
+        invalid.push(TimeSyncPolicy {
+            enabled: false,
+            global_rate: Some(limit),
+            ..Default::default()
+        });
+    }
+    for policy in invalid {
+        let config = ServerConfig {
+            time_sync_policy: policy.clone(),
+            ..Default::default()
+        };
+        let direct = BACnetServer::start(config.clone(), ObjectDatabase::new(), NeverStart)
+            .await
+            .err();
+        let clockless = BACnetServer::start_clockless(config, ObjectDatabase::new(), NeverStart)
+            .await
+            .err();
+        let generic = BACnetServer::generic_builder()
+            .transport(NeverStart)
+            .time_sync_policy(policy.clone())
+            .build()
+            .await
+            .err();
+        let bip = BACnetServer::bip_builder()
+            .port(0)
+            .time_sync_policy(policy.clone())
+            .build()
+            .await
+            .err();
+        for error in [direct, clockless, generic, bip] {
+            assert!(
+                matches!(error, Some(Error::Encoding(message)) if message.starts_with("time sync:"))
+            );
+        }
+        #[cfg(feature = "sc-tls")]
+        {
+            let error = BACnetServer::sc_builder()
+                .hub_url("not-a-websocket-url")
+                .tls_config(crate::server::sc_builder::test_tls_config())
+                .device_uuid(crate::server::sc_builder::TEST_DEVICE_UUID)
+                .time_sync_policy(policy)
+                .build()
+                .await
+                .err();
+            assert!(
+                matches!(error, Some(Error::Encoding(message)) if message.starts_with("time sync:"))
+            );
+        }
+    }
+}
+
+#[test]
+fn global_coalescing_bounds_direct_routed_and_sc_vmac_without_extending_cadence() {
+    let limiter = TimeSyncLimiter::new(TimeSyncPolicy {
+        global_coalesce_window: Duration::from_secs(2),
+        ..Default::default()
+    });
+    let contexts = [
+        received(&[1], None),
+        received(&[1], Some((7, &[8]))),
+        received(&[2, 3, 4, 5, 6, 7], None),
+    ];
+    let now = Instant::now();
+    assert!(limiter
+        .apply_at(&contexts[0], now, || Err(denied("step cap exceeded")))
+        .is_err());
+    for (index, context) in contexts.iter().enumerate() {
+        let at = now + Duration::from_secs(index as u64 * 2);
+        limiter.apply_at(context, at, || Ok(())).unwrap();
+        for other in &contexts {
+            assert!(limiter
+                .apply_at(other, at + Duration::from_millis(1999), || panic!(
+                    "globally coalesced"
+                ))
+                .is_err());
+        }
+    }
+    assert!(limiter.state.lock().unwrap().sources.is_empty());
+}

--- a/crates/bacnet-server/src/server/unconfirmed_audit_notification_tests.rs
+++ b/crates/bacnet-server/src/server/unconfirmed_audit_notification_tests.rs
@@ -77,6 +77,7 @@ async fn dispatch_unconfirmed(
         comm_state,
         &bindings,
         &discovery_limiter,
+        &Arc::new(TimeSyncLimiter::new(TimeSyncPolicy::default())),
         UnconfirmedRequestPdu {
             service_choice: UnconfirmedServiceChoice::UNCONFIRMED_AUDIT_NOTIFICATION,
             service_request,


### PR DESCRIPTION
Closes #523 (owner-locked default-allow + opt-in step cap only).

Inbound TimeSync/UTC-Sync now passes decode, then source policy (explicit disable, exact direct/routed allowlist with configured-empty-deny, SC VMAC as claimed link identity), then an opt-in max-step check, then per-source/global rate limits — before the anchor moves. Panic-isolated observer with source-enriched TimeSyncData; redacted debug decisions; misconfigured policy rejected at startup/pre-dial validation. Unconfigured behavior byte-identical (no default cap — boot-time corrections unaffected).

Validation: bacnet-server 1,092+3+1 PASS (incl. sc-tls), FULL conformance_ledger 27/27 PASS, clippy/fmt/size/secrets PASS, 16 new policy regressions (direct/routed/VMAC, UTC/local, boundaries, bursts, panic containment).