### PR TITLE
feat(server): add deny-all mutation policy and decision counters (#524)

### DIFF
--- a/crates/bacnet-server/src/mutation.rs
+++ b/crates/bacnet-server/src/mutation.rs
@@ -4,6 +4,7 @@
 //! LifeSafety/Audit, unconfirmed services, reads, and queries retain their own
 //! behavior. Direct handler calls and trusted local writes are not gated here.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use bacnet_encoding::npdu::NpduAddress;
@@ -16,6 +17,23 @@ use bacnet_services::wpm::WritePropertyAttempt;
 use bacnet_services::write_property::WritePropertyRequest;
 use bacnet_types::enums::ConfirmedServiceChoice;
 use bacnet_types::MacAddr;
+
+/// Local authorization mode for the ten services represented by [`MutationTarget`].
+///
+/// SC mTLS channel/peer authentication is **not service authorization**. Identities
+/// here are claimed link/routed addresses, never certificate principals; distinguishing
+/// SC certificate principals is out of scope because none reaches this layer.
+/// DCC, admission, decoding and WPM element validation retain their existing precedence.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum MutationPolicy {
+    /// Preserve default-allow behavior: an absent authorizer allows; an installed
+    /// authorizer must allow each decision.
+    #[default]
+    Permissive,
+    /// Deny every covered decision, even with an allow-all authorizer installed.
+    /// The authorizer is not called. Denials use SERVICES / SERVICE_REQUEST_DENIED.
+    DenyAll,
+}
 
 /// Decoded mutation target and parameters presented to local policy.
 #[derive(Debug, Clone, PartialEq)]
@@ -47,6 +65,8 @@ pub enum MutationTarget {
 /// Neither address nor a subscription's process ID authenticates an operator.
 /// `source_mac` identifies the immediate peer (often a router); `source_network`
 /// is the peer-claimed routed origin, not a verified identity.
+/// SC mTLS authenticates the channel/peer, not service authorization; neither
+/// address is a certificate principal.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MutationAuthorizationContext {
     /// Immediate data-link peer address.
@@ -63,7 +83,8 @@ pub struct MutationAuthorizationContext {
 
 /// Fast, nonblocking, side-effect-free mutation authorization callback.
 ///
-/// **Default-allow:** `None` preserves existing behavior, deliberately unlike
+/// Under [`MutationPolicy::Permissive`], **default-allow:** `None` preserves existing
+/// behavior, deliberately unlike
 /// AuditNotification/LifeSafetyOperation's fail-closed absence. Returning `false`
 /// or panicking denies with SERVICES / SERVICE_REQUEST_DENIED before mutation.
 /// DCC prechecks and request admission precede this callback.
@@ -75,3 +96,115 @@ pub struct MutationAuthorizationContext {
 /// Callbacks can run concurrently and WPM holds the database write lock: do not
 /// block, reenter the server, or perform side effects from a callback.
 pub type MutationAuthorizer = Arc<dyn Fn(&MutationAuthorizationContext) -> bool + Send + Sync>;
+
+/// Saturating lifetime decision totals for one covered service.
+/// These count authorization decisions, not successful mutations or response delivery.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MutationServiceCounters {
+    /// Allowed by absent or approving authorizer in permissive mode.
+    pub allow_total: u64,
+    /// All denials: authorizer refusal/panic or deny-all policy.
+    pub deny_total: u64,
+    /// Deny-all policy denials, a subset of `deny_total`; no callback was called.
+    pub policy_deny_total: u64,
+}
+
+/// Fixed-shape local telemetry, not a durable audit log; no source history is retained.
+/// New servers start at zero. Each field is independently sampled and saturates at
+/// `u64::MAX`, so snapshots are not atomic aggregates. Counters never affect policy.
+/// WPM counts each element reaching its gate, not requests or an unvisited suffix.
+/// Pre-gate failures, duplicates and DCC drops do not count. In permissive mode an
+/// absent authorizer allows without decoding, so a later handler failure still counts.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct MutationDecisionCounters {
+    /// WriteProperty decisions.
+    pub write_property: MutationServiceCounters,
+    /// WritePropertyMultiple element decisions.
+    pub write_property_multiple: MutationServiceCounters,
+    /// CreateObject decisions.
+    pub create_object: MutationServiceCounters,
+    /// DeleteObject decisions.
+    pub delete_object: MutationServiceCounters,
+    /// AddListElement decisions.
+    pub add_list_element: MutationServiceCounters,
+    /// RemoveListElement decisions.
+    pub remove_list_element: MutationServiceCounters,
+    /// AtomicWriteFile decisions.
+    pub atomic_write_file: MutationServiceCounters,
+    /// SubscribeCOV decisions, including cancellation and renewal.
+    pub subscribe_cov: MutationServiceCounters,
+    /// SubscribeCOVProperty decisions, including cancellation and renewal.
+    pub subscribe_cov_property: MutationServiceCounters,
+    /// SubscribeCOVPropertyMultiple whole-request decisions.
+    pub subscribe_cov_property_multiple: MutationServiceCounters,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum MutationDecision {
+    Allow,
+    Deny,
+    PolicyDeny,
+}
+
+#[derive(Default)]
+pub(crate) struct MutationDecisions([[AtomicU64; 3]; 10]);
+
+impl MutationDecisions {
+    pub(crate) fn snapshot(&self) -> MutationDecisionCounters {
+        let [write_property, write_property_multiple, create_object, delete_object, add_list_element, remove_list_element, atomic_write_file, subscribe_cov, subscribe_cov_property, subscribe_cov_property_multiple] =
+            self.0.each_ref().map(|row| {
+                let [allow_total, deny_total, policy_deny_total] =
+                    row.each_ref().map(|n| n.load(Ordering::Relaxed));
+                MutationServiceCounters {
+                    allow_total,
+                    deny_total,
+                    policy_deny_total,
+                }
+            });
+        MutationDecisionCounters {
+            write_property,
+            write_property_multiple,
+            create_object,
+            delete_object,
+            add_list_element,
+            remove_list_element,
+            atomic_write_file,
+            subscribe_cov,
+            subscribe_cov_property,
+            subscribe_cov_property_multiple,
+        }
+    }
+
+    pub(crate) fn record(&self, service: ConfirmedServiceChoice, decision: MutationDecision) {
+        let index = match service {
+            ConfirmedServiceChoice::WRITE_PROPERTY => 0,
+            ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE => 1,
+            ConfirmedServiceChoice::CREATE_OBJECT => 2,
+            ConfirmedServiceChoice::DELETE_OBJECT => 3,
+            ConfirmedServiceChoice::ADD_LIST_ELEMENT => 4,
+            ConfirmedServiceChoice::REMOVE_LIST_ELEMENT => 5,
+            ConfirmedServiceChoice::ATOMIC_WRITE_FILE => 6,
+            ConfirmedServiceChoice::SUBSCRIBE_COV => 7,
+            ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY => 8,
+            ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY_MULTIPLE => 9,
+            _ => return,
+        };
+        let increment = |column: usize| {
+            let _ = self.0[index][column].fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                Some(n.saturating_add(1))
+            });
+        };
+        match decision {
+            MutationDecision::Allow => increment(0),
+            MutationDecision::Deny => increment(1),
+            MutationDecision::PolicyDeny => {
+                increment(1);
+                increment(2);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "mutation_counter_tests.rs"]
+mod counter_tests;

--- a/crates/bacnet-server/src/mutation_counter_tests.rs
+++ b/crates/bacnet-server/src/mutation_counter_tests.rs
@@ -1,0 +1,108 @@
+use super::*;
+
+const SERVICES: [ConfirmedServiceChoice; 10] = [
+    ConfirmedServiceChoice::WRITE_PROPERTY,
+    ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE,
+    ConfirmedServiceChoice::CREATE_OBJECT,
+    ConfirmedServiceChoice::DELETE_OBJECT,
+    ConfirmedServiceChoice::ADD_LIST_ELEMENT,
+    ConfirmedServiceChoice::REMOVE_LIST_ELEMENT,
+    ConfirmedServiceChoice::ATOMIC_WRITE_FILE,
+    ConfirmedServiceChoice::SUBSCRIBE_COV,
+    ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY,
+    ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY_MULTIPLE,
+];
+
+fn rows(c: MutationDecisionCounters) -> [MutationServiceCounters; 10] {
+    [
+        c.write_property,
+        c.write_property_multiple,
+        c.create_object,
+        c.delete_object,
+        c.add_list_element,
+        c.remove_list_element,
+        c.atomic_write_file,
+        c.subscribe_cov,
+        c.subscribe_cov_property,
+        c.subscribe_cov_property_multiple,
+    ]
+}
+
+#[test]
+fn mutation_counters_fixed_shape_exactness_and_saturation() {
+    let store = MutationDecisions::default();
+    assert_eq!(
+        rows(store.snapshot()),
+        [MutationServiceCounters::default(); 10]
+    );
+    for (index, service) in SERVICES.into_iter().enumerate() {
+        for _ in 0..=index {
+            store.record(service, MutationDecision::Allow);
+            store.record(service, MutationDecision::Deny);
+            store.record(service, MutationDecision::PolicyDeny);
+        }
+    }
+    for (index, row) in rows(store.snapshot()).into_iter().enumerate() {
+        let n = index as u64 + 1;
+        assert_eq!(
+            row,
+            MutationServiceCounters {
+                allow_total: n,
+                deny_total: 2 * n,
+                policy_deny_total: n,
+            }
+        );
+    }
+    let before = store.snapshot();
+    store.record(
+        ConfirmedServiceChoice::READ_PROPERTY,
+        MutationDecision::PolicyDeny,
+    );
+    assert_eq!(store.snapshot(), before);
+    for row in &store.0 {
+        for counter in row {
+            counter.store(u64::MAX - 1, Ordering::Relaxed);
+        }
+    }
+    for _ in 0..3 {
+        for service in SERVICES {
+            store.record(service, MutationDecision::Allow);
+            store.record(service, MutationDecision::Deny);
+            store.record(service, MutationDecision::PolicyDeny);
+        }
+    }
+    assert_eq!(
+        rows(store.snapshot()),
+        [MutationServiceCounters {
+            allow_total: u64::MAX,
+            deny_total: u64::MAX,
+            policy_deny_total: u64::MAX,
+        }; 10]
+    );
+}
+
+#[test]
+fn mutation_counters_concurrent_quiescent_totals_are_exact() {
+    let store = MutationDecisions::default();
+    std::thread::scope(|scope| {
+        for _ in 0..8 {
+            scope.spawn(|| {
+                for _ in 0..100 {
+                    for service in SERVICES {
+                        store.record(service, MutationDecision::Allow);
+                        store.record(service, MutationDecision::Deny);
+                        store.record(service, MutationDecision::PolicyDeny);
+                    }
+                }
+            });
+        }
+    });
+    assert_eq!(
+        rows(store.snapshot()),
+        [MutationServiceCounters {
+            allow_total: 800,
+            deny_total: 1600,
+            policy_deny_total: 800,
+        }; 10]
+    );
+}

--- a/crates/bacnet-server/src/server/config.rs
+++ b/crates/bacnet-server/src/server/config.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::mutation::{MutationAuthorizationContext, MutationAuthorizer};
+use crate::mutation::{MutationAuthorizationContext, MutationAuthorizer, MutationPolicy};
 
 /// Server configuration.
 #[derive(Clone)]
@@ -46,7 +46,12 @@ pub struct ServerConfig {
     /// A panic is caught (with unwind builds); the change stands and ingress
     /// continues. This callback cannot authorize or roll back synchronization.
     pub on_time_sync: Option<Arc<dyn Fn(TimeSyncData) + Send + Sync>>,
-    /// Opt-in mutation policy; `None` allows. See [`MutationAuthorizer`].
+    /// Local mutation authorization mode (default: permissive). SC mTLS channel/peer
+    /// authentication is not service authorization; addresses here are claimed,
+    /// never certificate principals. See [`MutationPolicy`].
+    pub mutation_policy: MutationPolicy,
+    /// Opt-in mutation authorizer; `None` allows only in permissive mode.
+    /// See [`MutationAuthorizer`].
     pub mutation_authorizer: Option<MutationAuthorizer>,
     /// Optional LifeSafetyOperation authorization policy.
     ///
@@ -156,6 +161,7 @@ impl std::fmt::Debug for ServerConfig {
             .field("vendor_id", &self.vendor_id)
             .field("cov_retry_timeout_ms", &self.cov_retry_timeout_ms)
             .field("time_sync_policy", &self.time_sync_policy)
+            .field("mutation_policy", &self.mutation_policy)
             .field(
                 "on_time_sync",
                 &self.on_time_sync.as_ref().map(|_| "<callback>"),
@@ -226,6 +232,7 @@ impl Default for ServerConfig {
             cov_retry_timeout_ms: 3000,
             time_sync_policy: TimeSyncPolicy::default(),
             on_time_sync: None,
+            mutation_policy: MutationPolicy::default(),
             mutation_authorizer: None,
             life_safety_operation_authorizer: None,
             audit_notification_sink: None,
@@ -247,6 +254,14 @@ impl Default for ServerConfig {
 }
 
 impl<T: TransportPort + 'static> ServerBuilder<T> {
+    /// Select local mutation authorization (default: [`MutationPolicy::Permissive`]).
+    /// SC mTLS channel/peer authentication is not service authorization; identities
+    /// here are claimed link/routed addresses, never certificate principals.
+    pub fn mutation_policy(mut self, policy: MutationPolicy) -> Self {
+        self.config.mutation_policy = policy;
+        self
+    }
+
     /// Set opt-in mutation policy. See [`MutationAuthorizer`] for callback rules.
     pub fn mutation_authorizer<F>(mut self, authorizer: F) -> Self
     where
@@ -258,6 +273,19 @@ impl<T: TransportPort + 'static> ServerBuilder<T> {
 }
 
 impl BipServerBuilder {
+    /// Select local mutation authorization (default: [`MutationPolicy::Permissive`]).
+    /// SC mTLS channel/peer authentication is not service authorization; identities
+    /// here are claimed link/routed addresses, never certificate principals.
+    ///
+    /// ```
+    /// use bacnet_server::{mutation::MutationPolicy, server::BACnetServer};
+    /// let builder = BACnetServer::bip_builder().mutation_policy(MutationPolicy::DenyAll);
+    /// ```
+    pub fn mutation_policy(mut self, policy: MutationPolicy) -> Self {
+        self.config.mutation_policy = policy;
+        self
+    }
+
     /// Set opt-in mutation policy. See [`MutationAuthorizer`] for callback rules.
     ///
     /// ```
@@ -275,6 +303,14 @@ impl BipServerBuilder {
 
 #[cfg(feature = "sc-tls")]
 impl ScServerBuilder {
+    /// Select local mutation authorization (default: [`MutationPolicy::Permissive`]).
+    /// SC mTLS channel/peer authentication is not service authorization; identities
+    /// here are claimed link/routed addresses, never certificate principals.
+    pub fn mutation_policy(mut self, policy: MutationPolicy) -> Self {
+        self.config.mutation_policy = policy;
+        self
+    }
+
     /// Set opt-in mutation policy. See [`MutationAuthorizer`] for callback rules.
     pub fn mutation_authorizer<F>(mut self, authorizer: F) -> Self
     where

--- a/crates/bacnet-server/src/server/dcc_outcome_tests.rs
+++ b/crates/bacnet-server/src/server/dcc_outcome_tests.rs
@@ -52,6 +52,7 @@ async fn handle_source(
         &server.comm_state,
         &server.dcc_timer,
         &server.dcc_outcomes,
+        &server.mutation_decisions,
         &server.config,
         &server.request_tasks.spawner(),
         mac,

--- a/crates/bacnet-server/src/server/dispatch.rs
+++ b/crates/bacnet-server/src/server/dispatch.rs
@@ -94,6 +94,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         comm_state: &Arc<AtomicU8>,
         dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
         dcc_outcomes: &Arc<dcc_outcomes::DccOutcomes>,
+        mutation_decisions: &Arc<crate::mutation::MutationDecisions>,
         config: &Arc<ServerConfig>,
         clock: &Option<Arc<ServerClock>>,
         discovery_limiter: &Arc<DiscoveryLimiter>,
@@ -140,6 +141,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                 let comm_state = Arc::clone(comm_state);
                 let dcc_timer = Arc::clone(dcc_timer);
                 let dcc_outcomes = Arc::clone(dcc_outcomes);
+                let mutation_decisions = Arc::clone(mutation_decisions);
                 let config = Arc::clone(config);
                 let source_mac = MacAddr::from_slice(source_mac);
                 let source_network = received.source_network.clone();
@@ -166,6 +168,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                             &comm_state,
                             &dcc_timer,
                             &dcc_outcomes,
+                            &mutation_decisions,
                             &config,
                             &descendants,
                             &source_mac,

--- a/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
+++ b/crates/bacnet-server/src/server/event_confirmed_routing_tests.rs
@@ -256,6 +256,7 @@ impl Harness {
             &self.comm_state,
             &Arc::new(Mutex::new(None::<JoinHandle<()>>)),
             &Arc::new(dcc_outcomes::DccOutcomes::default()),
+            &Arc::new(crate::mutation::MutationDecisions::default()),
             &Arc::new(ServerConfig::default()),
             &None,
             &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),

--- a/crates/bacnet-server/src/server/handles.rs
+++ b/crates/bacnet-server/src/server/handles.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+impl<T: TransportPort + 'static> BACnetServer<T> {
+    /// Get the server's local MAC address.
+    pub fn local_mac(&self) -> &[u8] {
+        &self.local_mac
+    }
+
+    /// Get a reference to the shared object database.
+    pub fn database(&self) -> &Arc<RwLock<ObjectDatabase>> {
+        &self.db
+    }
+
+    /// Create a cloneable handle for unsolicited I-Am announcements.
+    pub fn i_am_broadcaster(&self) -> IAmBroadcaster<T> {
+        IAmBroadcaster {
+            config: self.config.clone(),
+            network: Arc::clone(&self.network),
+            db: Arc::clone(&self.db),
+        }
+    }
+
+    /// Get the communication state per DeviceCommunicationControl.
+    ///
+    /// Returns 0 (Enable), 1 (Disable), or 2 (DisableInitiation).
+    pub fn comm_state(&self) -> u8 {
+        self.comm_state.load(Ordering::Acquire)
+    }
+
+    /// Generate a PICS document from the current object database and server configuration.
+    ///
+    /// The caller must supply a [`PicsConfig`] for fields not available from the server
+    /// (vendor name, model, firmware revision, etc.).
+    pub async fn generate_pics(&self, pics_config: &crate::pics::PicsConfig) -> crate::pics::Pics {
+        let db = self.db.read().await;
+        crate::pics::PicsGenerator::new(&db, &self.config, pics_config).generate()
+    }
+}

--- a/crates/bacnet-server/src/server/lifecycle.rs
+++ b/crates/bacnet-server/src/server/lifecycle.rs
@@ -74,6 +74,8 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let dcc_timer: Arc<Mutex<Option<JoinHandle<()>>>> = Arc::new(Mutex::new(None));
         let dcc_outcomes = Arc::new(dcc_outcomes::DccOutcomes::default());
         let dcc_outcomes_dispatch = Arc::clone(&dcc_outcomes);
+        let mutation_decisions = Arc::new(crate::mutation::MutationDecisions::default());
+        let mutation_decisions_dispatch = Arc::clone(&mutation_decisions);
 
         let network_dispatch = Arc::clone(&network);
         let db_dispatch = Arc::clone(&db);
@@ -440,6 +442,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                                     &comm_state_dispatch,
                                                     &dcc_timer_dispatch,
                                                     &dcc_outcomes_dispatch,
+                                                    &mutation_decisions_dispatch,
                                                     &config_dispatch,
                                                     &clock_dispatch,
                                                     &limiters_dispatch.0,
@@ -496,6 +499,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
                                 &comm_state_dispatch,
                                 &dcc_timer_dispatch,
                                 &dcc_outcomes_dispatch,
+                                &mutation_decisions_dispatch,
                                 &config_dispatch,
                                 &clock_dispatch,
                                 &limiters_dispatch.0,
@@ -750,6 +754,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             comm_state,
             dcc_timer,
             dcc_outcomes,
+            mutation_decisions,
             dispatch_task: Some(dispatch_task),
             request_tasks,
             cov_purge_task: Some(cov_purge_task),
@@ -810,40 +815,5 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         {
             warn!(error = %e, reason = abort_reason.to_raw(), "Failed to send Abort");
         }
-    }
-
-    /// Get the server's local MAC address.
-    pub fn local_mac(&self) -> &[u8] {
-        &self.local_mac
-    }
-
-    /// Get a reference to the shared object database.
-    pub fn database(&self) -> &Arc<RwLock<ObjectDatabase>> {
-        &self.db
-    }
-
-    /// Create a cloneable handle for unsolicited I-Am announcements.
-    pub fn i_am_broadcaster(&self) -> IAmBroadcaster<T> {
-        IAmBroadcaster {
-            config: self.config.clone(),
-            network: Arc::clone(&self.network),
-            db: Arc::clone(&self.db),
-        }
-    }
-
-    /// Get the communication state per DeviceCommunicationControl.
-    ///
-    /// Returns 0 (Enable), 1 (Disable), or 2 (DisableInitiation).
-    pub fn comm_state(&self) -> u8 {
-        self.comm_state.load(Ordering::Acquire)
-    }
-
-    /// Generate a PICS document from the current object database and server configuration.
-    ///
-    /// The caller must supply a [`PicsConfig`] for fields not available from the server
-    /// (vendor name, model, firmware revision, etc.).
-    pub async fn generate_pics(&self, pics_config: &crate::pics::PicsConfig) -> crate::pics::Pics {
-        let db = self.db.read().await;
-        crate::pics::PicsGenerator::new(&db, &self.config, pics_config).generate()
     }
 }

--- a/crates/bacnet-server/src/server/mod.rs
+++ b/crates/bacnet-server/src/server/mod.rs
@@ -603,6 +603,7 @@ pub struct BACnetServer<T: TransportPort> {
     /// Valid replacement and explicit stop abort and join before clearing it.
     dcc_timer: Arc<Mutex<Option<JoinHandle<()>>>>,
     dcc_outcomes: Arc<dcc_outcomes::DccOutcomes>,
+    mutation_decisions: Arc<crate::mutation::MutationDecisions>,
     dispatch_task: Option<JoinHandle<()>>,
     request_tasks: Arc<request_tasks::RequestTasks>,
     cov_purge_task: Option<JoinHandle<()>>,
@@ -684,6 +685,7 @@ pub(crate) mod event_notification_payload;
 mod event_notifications;
 mod event_recipient_route;
 pub(crate) mod event_timestamp;
+mod handles;
 mod lifecycle;
 mod local_writes;
 mod notification_transactions;
@@ -790,6 +792,13 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
     /// Get a snapshot of COV operational and telemetry counters.
     pub fn cov_counters(&self) -> CovCounters {
         self.cov_counters.snapshot()
+    }
+
+    /// Sample lifetime mutation authorization decisions, including after `stop()`.
+    /// Counts decisions, not completed handlers or response delivery; see
+    /// [`MutationDecisionCounters`](crate::mutation::MutationDecisionCounters).
+    pub fn mutation_decision_counters(&self) -> crate::mutation::MutationDecisionCounters {
+        self.mutation_decisions.snapshot()
     }
 
     /// Purge all active COV subscriptions for a peer, deterministically releasing its quota.

--- a/crates/bacnet-server/src/server/notification_transactions_tests.rs
+++ b/crates/bacnet-server/src/server/notification_transactions_tests.rs
@@ -403,6 +403,7 @@ async fn dispatch_keeps_segment_and_complex_acks_out_of_notification_completion(
             &comm_state,
             &dcc_timer,
             &Arc::new(dcc_outcomes::DccOutcomes::default()),
+            &Arc::new(crate::mutation::MutationDecisions::default()),
             &config,
             &None,
             &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),

--- a/crates/bacnet-server/src/server/request_admission_tests.rs
+++ b/crates/bacnet-server/src/server/request_admission_tests.rs
@@ -51,6 +51,7 @@ async fn dispatch(
         &server.comm_state,
         &server.dcc_timer,
         &server.dcc_outcomes,
+        &server.mutation_decisions,
         &Arc::new(server.config.clone()),
         &server._clock,
         &server.discovery_limiter,

--- a/crates/bacnet-server/src/server/requests/confirmed.rs
+++ b/crates/bacnet-server/src/server/requests/confirmed.rs
@@ -54,6 +54,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
             comm_state,
             dcc_timer,
             &Arc::new(dcc_outcomes::DccOutcomes::default()),
+            &Arc::new(crate::mutation::MutationDecisions::default()),
             config,
             request_tasks,
             source_mac,

--- a/crates/bacnet-server/src/server/requests/mod.rs
+++ b/crates/bacnet-server/src/server/requests/mod.rs
@@ -47,6 +47,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         comm_state: &Arc<AtomicU8>,
         dcc_timer: &Arc<Mutex<Option<JoinHandle<()>>>>,
         dcc_outcomes: &Arc<dcc_outcomes::DccOutcomes>,
+        mutation_decisions: &Arc<crate::mutation::MutationDecisions>,
         config: &ServerConfig,
         request_tasks: &super::request_tasks::RequestTaskSpawner,
         source_mac: &[u8],
@@ -102,6 +103,7 @@ impl<T: TransportPort + 'static> BACnetServer<T> {
         let mut ack_buf = BytesMut::with_capacity(512);
         let mutation = mutations::Request {
             config,
+            decisions: mutation_decisions,
             source_mac,
             source_network: source_network.as_ref(),
             req: &req,

--- a/crates/bacnet-server/src/server/requests/mutation_policy_tests.rs
+++ b/crates/bacnet-server/src/server/requests/mutation_policy_tests.rs
@@ -1,0 +1,519 @@
+use super::*;
+use crate::mutation::{MutationAuthorizer, MutationDecisionCounters, MutationServiceCounters};
+use crate::server::requests::mutation_tests::{
+    apdu, assert_denied, cases, oid, route, value, wpm, Fixture, TestTransport, SOURCE,
+};
+use bacnet_network::layer::ReceivedApdu;
+use bacnet_objects::device::{DeviceConfig, DeviceObject};
+use bacnet_services::device_mgmt::DeviceCommunicationControlRequest;
+use bacnet_services::read_property::ReadPropertyRequest;
+use bacnet_services::wpm::{WriteAccessSpecification, WritePropertyMultipleError};
+use bacnet_types::enums::EnableDisable;
+use std::sync::atomic::AtomicUsize;
+
+#[path = "mutation_runtime_tests.rs"]
+mod runtime_tests;
+
+async fn server(
+    policy: MutationPolicy,
+    authorizer: Option<MutationAuthorizer>,
+) -> BACnetServer<TestTransport> {
+    let fixture = Fixture::new(authorizer);
+    let db = std::mem::take(&mut *fixture.db.write().await);
+    let config = ServerConfig {
+        mutation_policy: policy,
+        ..fixture.config
+    };
+    BACnetServer::start(config, db, TestTransport::default())
+        .await
+        .unwrap()
+}
+
+fn request(service: ConfirmedServiceChoice, bytes: Bytes, id: u8) -> ConfirmedRequestPdu {
+    ConfirmedRequestPdu {
+        segmented: false,
+        more_follows: false,
+        segmented_response_accepted: false,
+        max_segments: None,
+        max_apdu_length: 1476,
+        invoke_id: id,
+        sequence_number: None,
+        proposed_window_size: None,
+        service_choice: service,
+        service_request: bytes,
+    }
+}
+
+async fn dispatch(
+    server: &BACnetServer<TestTransport>,
+    service: ConfirmedServiceChoice,
+    bytes: Bytes,
+    id: u8,
+) -> Option<Bytes> {
+    let (tx, rx) = oneshot::channel();
+    BACnetServer::dispatch(
+        &server.db,
+        &server.network,
+        &server.cov_table,
+        &server.seg_ack_senders,
+        &server.seg_send_permits,
+        &server.cov_in_flight,
+        &server.server_tsm,
+        &server.notification_transactions,
+        &server.confirmed_request_tracker,
+        &server.device_bindings,
+        &server.comm_state,
+        &server.dcc_timer,
+        &server.dcc_outcomes,
+        &server.mutation_decisions,
+        &Arc::new(server.config.clone()),
+        &server._clock,
+        &server.discovery_limiter,
+        &server.time_sync_limiter,
+        &server.request_tasks,
+        SOURCE,
+        Apdu::ConfirmedRequest(request(service, bytes, id)),
+        ReceivedApdu {
+            apdu: Bytes::new(),
+            source_mac: MacAddr::from_slice(SOURCE),
+            ingress_network: None,
+            source_network: route(),
+            link_layer_group: false,
+            is_group: false,
+            data_attributes: vec![],
+            reply_tx: Some(tx),
+        },
+    )
+    .await;
+    tokio::time::timeout(Duration::from_secs(2), rx)
+        .await
+        .expect("handler completed")
+        .ok()
+}
+
+async fn snapshot(
+    server: &BACnetServer<TestTransport>,
+) -> (
+    Vec<(ObjectIdentifier, PropertyIdentifier, PropertyValue)>,
+    Vec<u8>,
+    usize,
+) {
+    let db = server.db.read().await;
+    let mut objects = db.list_objects();
+    objects.sort_by_key(|id| (id.object_type().to_raw(), id.instance_number()));
+    let mut values = Vec::new();
+    for id in objects {
+        let object = db.get(&id).unwrap();
+        for property in [
+            PropertyIdentifier::OBJECT_NAME,
+            PropertyIdentifier::DESCRIPTION,
+            PropertyIdentifier::PRESENT_VALUE,
+            PropertyIdentifier::ALARM_VALUES,
+            PropertyIdentifier::FILE_SIZE,
+            PropertyIdentifier::ARCHIVE,
+        ] {
+            if let Ok(value) = object.read_property(property, None) {
+                values.push((id, property, value));
+            }
+        }
+    }
+    let file = db
+        .get(&oid(ObjectType::FILE, 1))
+        .unwrap()
+        .file_storage_internal()
+        .unwrap()
+        .read_stream(0, 100)
+        .unwrap()
+        .data;
+    (values, file, server.cov_table.read().await.len())
+}
+
+fn expected(
+    service: ConfirmedServiceChoice,
+    row: MutationServiceCounters,
+) -> MutationDecisionCounters {
+    let mut counters = MutationDecisionCounters::default();
+    *match service {
+        ConfirmedServiceChoice::WRITE_PROPERTY => &mut counters.write_property,
+        ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE => &mut counters.write_property_multiple,
+        ConfirmedServiceChoice::CREATE_OBJECT => &mut counters.create_object,
+        ConfirmedServiceChoice::DELETE_OBJECT => &mut counters.delete_object,
+        ConfirmedServiceChoice::ADD_LIST_ELEMENT => &mut counters.add_list_element,
+        ConfirmedServiceChoice::REMOVE_LIST_ELEMENT => &mut counters.remove_list_element,
+        ConfirmedServiceChoice::ATOMIC_WRITE_FILE => &mut counters.atomic_write_file,
+        ConfirmedServiceChoice::SUBSCRIBE_COV => &mut counters.subscribe_cov,
+        ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY => &mut counters.subscribe_cov_property,
+        ConfirmedServiceChoice::SUBSCRIBE_COV_PROPERTY_MULTIPLE => {
+            &mut counters.subscribe_cov_property_multiple
+        }
+        _ => panic!("not a covered mutation"),
+    } = row;
+    counters
+}
+
+#[tokio::test]
+async fn mutation_policy_matrix_all_ten_decisions_tracking_and_retention() {
+    assert_eq!(
+        ServerConfig::default().mutation_policy,
+        MutationPolicy::Permissive
+    );
+    for policy in [MutationPolicy::Permissive, MutationPolicy::DenyAll] {
+        for callback in 0..4 {
+            for (service, bytes, _) in cases() {
+                let calls = Arc::new(AtomicUsize::new(0));
+                let seen = calls.clone();
+                let authorizer: Option<MutationAuthorizer> = (callback != 0).then(|| {
+                    Arc::new(move |_: &MutationAuthorizationContext| {
+                        seen.fetch_add(1, Ordering::Relaxed);
+                        assert_ne!(callback, 3, "authorizer panic");
+                        callback == 1
+                    }) as MutationAuthorizer
+                });
+                let mut server = server(policy, authorizer).await;
+                assert_eq!(
+                    server.mutation_decision_counters(),
+                    MutationDecisionCounters::default()
+                );
+                let before = snapshot(&server).await;
+                let response = dispatch(&server, service, bytes.clone(), 1).await.unwrap();
+                let allowed = policy == MutationPolicy::Permissive && callback <= 1;
+                if allowed {
+                    assert!(
+                        matches!(apdu(response), Apdu::SimpleAck(_) | Apdu::ComplexAck(_)),
+                        "{service:?}"
+                    );
+                    assert_ne!(snapshot(&server).await, before, "{service:?}");
+                } else {
+                    assert_denied(response, service, 1);
+                    assert_eq!(snapshot(&server).await, before, "{service:?}");
+                    assert!(server.network.transport().sent.lock().unwrap().is_empty());
+                }
+                let counters = expected(
+                    service,
+                    MutationServiceCounters {
+                        allow_total: u64::from(allowed),
+                        deny_total: u64::from(!allowed),
+                        policy_deny_total: u64::from(policy == MutationPolicy::DenyAll),
+                    },
+                );
+                assert_eq!(server.mutation_decision_counters(), counters, "{service:?}");
+                // Completed exact retries do not make another decision, even on denial.
+                assert!(dispatch(&server, service, bytes, 1).await.is_none());
+                assert_eq!(server.mutation_decision_counters(), counters);
+                assert_eq!(
+                    calls.load(Ordering::Relaxed),
+                    usize::from(policy == MutationPolicy::Permissive && callback != 0)
+                );
+                server.stop().await.unwrap();
+                assert_eq!(server.mutation_decision_counters(), counters);
+            }
+        }
+    }
+}
+
+#[test]
+fn mutation_policy_builders_preserve_authorizers_and_defaults() {
+    assert_eq!(
+        BACnetServer::bip_builder().config.mutation_policy,
+        MutationPolicy::Permissive
+    );
+    assert_eq!(
+        BACnetServer::<TestTransport>::generic_builder()
+            .config
+            .mutation_policy,
+        MutationPolicy::Permissive
+    );
+    let generic = BACnetServer::<TestTransport>::generic_builder()
+        .mutation_authorizer(|_| true)
+        .mutation_policy(MutationPolicy::DenyAll)
+        .config;
+    let bip = BACnetServer::bip_builder()
+        .mutation_policy(MutationPolicy::DenyAll)
+        .mutation_authorizer(|_| true)
+        .config;
+    for config in [generic, bip] {
+        assert_eq!(config.mutation_policy, MutationPolicy::DenyAll);
+        assert!(config.mutation_authorizer.is_some());
+        assert!(format!("{config:?}").contains("mutation_policy: DenyAll"));
+    }
+    #[cfg(feature = "sc-tls")]
+    {
+        assert_eq!(
+            BACnetServer::sc_builder().config.mutation_policy,
+            MutationPolicy::Permissive
+        );
+        let config = BACnetServer::sc_builder()
+            .mutation_policy(MutationPolicy::DenyAll)
+            .mutation_authorizer(|_| true)
+            .config;
+        assert_eq!(config.mutation_policy, MutationPolicy::DenyAll);
+        assert!(config.mutation_authorizer.is_some());
+    }
+}
+
+fn descriptions() -> Bytes {
+    wpm(vec![WriteAccessSpecification {
+        object_identifier: oid(ObjectType::BINARY_VALUE, 1),
+        list_of_properties: ["first", "second", "third"]
+            .map(|text| BACnetPropertyValue {
+                property_identifier: PropertyIdentifier::DESCRIPTION,
+                property_array_index: None,
+                value: value(PropertyValue::CharacterString(text.into())),
+                priority: None,
+            })
+            .to_vec(),
+    }])
+}
+
+#[tokio::test]
+async fn mutation_wpm_counts_elements_not_objects_requests_or_unvisited_suffixes() {
+    let service = ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE;
+    for policy in [MutationPolicy::Permissive, MutationPolicy::DenyAll] {
+        for callback in 0..4 {
+            let calls = Arc::new(AtomicUsize::new(0));
+            let seen = calls.clone();
+            let authorizer: Option<MutationAuthorizer> = (callback != 0).then(|| {
+                Arc::new(move |_: &MutationAuthorizationContext| {
+                    let n = seen.fetch_add(1, Ordering::Relaxed);
+                    if n == 1 && callback >= 2 {
+                        assert_ne!(callback, 3, "second element panic");
+                        return false;
+                    }
+                    true
+                }) as MutationAuthorizer
+            });
+            let mut server = server(policy, authorizer).await;
+            let before = snapshot(&server).await;
+            let response = dispatch(&server, service, descriptions(), 1).await.unwrap();
+            let hard = policy == MutationPolicy::DenyAll;
+            let denied = hard || callback >= 2;
+            if denied {
+                assert_denied(response.clone(), service, 1);
+                let Apdu::Error(error) = apdu(response) else {
+                    unreachable!()
+                };
+                let detail = WritePropertyMultipleError::from_error_pdu(&error).unwrap();
+                assert_eq!(
+                    detail.first_failed_write_attempt.object_identifier,
+                    oid(ObjectType::BINARY_VALUE, 1)
+                );
+                assert_eq!(
+                    detail.first_failed_write_attempt.property_identifier,
+                    PropertyIdentifier::DESCRIPTION.to_raw()
+                );
+            } else {
+                assert!(matches!(apdu(response), Apdu::SimpleAck(_)));
+            }
+            if hard {
+                assert_eq!(snapshot(&server).await, before);
+            } else {
+                let db = server.db.read().await;
+                let description = db
+                    .get(&oid(ObjectType::BINARY_VALUE, 1))
+                    .unwrap()
+                    .read_property(PropertyIdentifier::DESCRIPTION, None)
+                    .unwrap();
+                assert_eq!(
+                    description,
+                    PropertyValue::CharacterString(if denied { "first" } else { "third" }.into())
+                );
+            }
+            assert_eq!(
+                server.mutation_decision_counters(),
+                expected(
+                    service,
+                    MutationServiceCounters {
+                        allow_total: if hard {
+                            0
+                        } else if denied {
+                            1
+                        } else {
+                            3
+                        },
+                        deny_total: u64::from(denied),
+                        policy_deny_total: u64::from(hard),
+                    }
+                )
+            );
+            assert_eq!(
+                calls.load(Ordering::Relaxed),
+                if hard || callback == 0 {
+                    0
+                } else if denied {
+                    2
+                } else {
+                    3
+                }
+            );
+            server.stop().await.unwrap();
+        }
+    }
+}
+
+#[tokio::test]
+async fn mutation_pre_gate_failures_and_dcc_drops_do_not_count() {
+    for policy in [MutationPolicy::Permissive, MutationPolicy::DenyAll] {
+        let mut server = server(policy, Some(Arc::new(|_| panic!("must not authorize")))).await;
+        for (index, (service, bytes, _)) in cases().into_iter().enumerate() {
+            let malformed = bytes.slice(..1);
+            let response = dispatch(&server, service, malformed, index as u8)
+                .await
+                .unwrap();
+            assert!(matches!(apdu(response), Apdu::Error(_) | Apdu::Reject(_)));
+        }
+        let response = dispatch(
+            &server,
+            ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE,
+            Bytes::new(),
+            20,
+        )
+        .await
+        .unwrap();
+        assert!(matches!(apdu(response), Apdu::SimpleAck(_)));
+        server.comm_state.store(1, Ordering::Release);
+        for (index, (service, bytes, _)) in cases().into_iter().enumerate() {
+            assert!(dispatch(&server, service, bytes, 30 + index as u8)
+                .await
+                .is_none());
+        }
+        assert_eq!(
+            server.mutation_decision_counters(),
+            MutationDecisionCounters::default()
+        );
+        server.stop().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn mutation_wpm_malformed_suffix_counts_only_reached_prefix() {
+    for authorizer in [
+        None,
+        Some(Arc::new(|_: &MutationAuthorizationContext| true) as MutationAuthorizer),
+    ] {
+        let mut server = server(MutationPolicy::Permissive, authorizer).await;
+        let mut bytes = BytesMut::from(descriptions().as_ref());
+        bytes.extend_from_slice(&[0x0c]); // incomplete next object after three writes
+        let service = ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE;
+        let response = dispatch(&server, service, bytes.freeze(), 1).await.unwrap();
+        let Apdu::Error(error) = apdu(response) else {
+            panic!("expected suffix Error")
+        };
+        assert_eq!(error.error_code, ErrorCode::INVALID_TAG);
+        assert_eq!(
+            server.mutation_decision_counters(),
+            expected(
+                service,
+                MutationServiceCounters {
+                    allow_total: 3,
+                    ..Default::default()
+                }
+            )
+        );
+        server.stop().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn mutation_deny_all_does_not_gate_reads_discovery_or_dcc() {
+    let mut server = server(
+        MutationPolicy::DenyAll,
+        Some(Arc::new(|_| panic!("not a mutation"))),
+    )
+    .await;
+    let mut data = BytesMut::new();
+    ReadPropertyRequest {
+        object_identifier: oid(ObjectType::BINARY_VALUE, 1),
+        property_identifier: PropertyIdentifier::PRESENT_VALUE,
+        property_array_index: None,
+    }
+    .encode(&mut data);
+    assert!(matches!(
+        apdu(
+            dispatch(
+                &server,
+                ConfirmedServiceChoice::READ_PROPERTY,
+                data.freeze(),
+                1
+            )
+            .await
+            .unwrap()
+        ),
+        Apdu::ComplexAck(_)
+    ));
+    server
+        .db
+        .write()
+        .await
+        .add(Box::new(
+            DeviceObject::new(DeviceConfig::default()).unwrap(),
+        ))
+        .unwrap();
+    BACnetServer::<TestTransport>::handle_unconfirmed_request(
+        &server.db,
+        &server.network,
+        &server.config,
+        None,
+        &server.comm_state,
+        &server.device_bindings,
+        &server.discovery_limiter,
+        &server.time_sync_limiter,
+        UnconfirmedRequestPdu {
+            service_choice: UnconfirmedServiceChoice::WHO_IS,
+            service_request: Bytes::new(),
+        },
+        &ReceivedApdu {
+            apdu: Bytes::new(),
+            source_mac: MacAddr::from_slice(SOURCE),
+            ingress_network: None,
+            source_network: route(),
+            link_layer_group: false,
+            is_group: false,
+            data_attributes: vec![],
+            reply_tx: None,
+        },
+    )
+    .await;
+    let sent = server
+        .network
+        .transport()
+        .sent
+        .lock()
+        .unwrap()
+        .pop()
+        .unwrap();
+    let Apdu::UnconfirmedRequest(i_am) = apdu(sent) else {
+        panic!("expected I-Am")
+    };
+    assert_eq!(i_am.service_choice, UnconfirmedServiceChoice::I_AM);
+    server.config.dcc_policy = DccPolicy::RequirePassword;
+    server.config.dcc_password = Some("boundary-test".into());
+    server.comm_state.store(1, Ordering::Release);
+    let mut data = BytesMut::new();
+    DeviceCommunicationControlRequest {
+        time_duration: None,
+        enable_disable: EnableDisable::ENABLE,
+        password: Some("boundary-test".into()),
+    }
+    .encode(&mut data)
+    .unwrap();
+    assert!(matches!(
+        apdu(
+            dispatch(
+                &server,
+                ConfirmedServiceChoice::DEVICE_COMMUNICATION_CONTROL,
+                data.freeze(),
+                2
+            )
+            .await
+            .unwrap()
+        ),
+        Apdu::SimpleAck(_)
+    ));
+    assert_eq!(server.comm_state.load(Ordering::Acquire), 0);
+    assert_eq!(server.dcc_outcome_counters().accepted_total, 1);
+    assert_eq!(
+        server.mutation_decision_counters(),
+        MutationDecisionCounters::default()
+    );
+    server.stop().await.unwrap();
+}

--- a/crates/bacnet-server/src/server/requests/mutation_runtime_tests.rs
+++ b/crates/bacnet-server/src/server/requests/mutation_runtime_tests.rs
@@ -1,0 +1,201 @@
+use super::*;
+use bacnet_encoding::npdu::{encode_npdu, Npdu};
+use bacnet_transport::port::ReceivedNpdu;
+
+struct IngressTransport(Option<mpsc::Receiver<ReceivedNpdu>>);
+
+impl TransportPort for IngressTransport {
+    async fn start(&mut self) -> Result<mpsc::Receiver<ReceivedNpdu>, Error> {
+        Ok(self.0.take().unwrap())
+    }
+    async fn stop(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_unicast(&self, _: &[u8], _: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn send_broadcast(&self, _: &[u8]) -> Result<(), Error> {
+        Ok(())
+    }
+    fn local_mac(&self) -> &[u8] {
+        &[1]
+    }
+}
+
+#[tokio::test]
+async fn mutation_runtime_ingress_and_reassembly_share_retained_server_counters() {
+    for segmented in [false, true] {
+        let fixture = Fixture::new(Some(Arc::new(|_| true)));
+        let (tx, rx) = mpsc::channel(2);
+        let config = ServerConfig {
+            mutation_policy: MutationPolicy::DenyAll,
+            segmentation_supported: Segmentation::BOTH,
+            ..fixture.config
+        };
+        let db = std::mem::take(&mut *fixture.db.write().await);
+        let mut server = BACnetServer::start(config, db, IngressTransport(Some(rx)))
+            .await
+            .unwrap();
+        assert_eq!(
+            server.mutation_decision_counters(),
+            MutationDecisionCounters::default()
+        );
+        let (service, bytes, _) = cases().remove(0);
+        let mut req = request(service, bytes, 77);
+        req.segmented = segmented;
+        req.sequence_number = segmented.then_some(0);
+        req.proposed_window_size = segmented.then_some(1);
+        let mut payload = BytesMut::new();
+        encode_apdu(&mut payload, &Apdu::ConfirmedRequest(req)).unwrap();
+        let mut npdu = BytesMut::new();
+        encode_npdu(
+            &mut npdu,
+            &Npdu {
+                payload: payload.freeze(),
+                source: route(),
+                expecting_reply: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let (reply_tx, reply_rx) = oneshot::channel();
+        tx.send(ReceivedNpdu {
+            npdu: npdu.freeze(),
+            source_mac: MacAddr::from_slice(SOURCE),
+            link_layer_group: false,
+            data_attributes: vec![],
+            reply_tx: Some(reply_tx),
+        })
+        .await
+        .unwrap();
+        let response = tokio::time::timeout(Duration::from_secs(2), reply_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_denied(response, service, 77);
+        let counters = expected(
+            service,
+            MutationServiceCounters {
+                allow_total: 0,
+                deny_total: 1,
+                policy_deny_total: 1,
+            },
+        );
+        assert_eq!(server.mutation_decision_counters(), counters);
+        assert_eq!(
+            server
+                .db
+                .read()
+                .await
+                .get(&oid(ObjectType::BINARY_VALUE, 1))
+                .unwrap()
+                .read_property(PropertyIdentifier::PRESENT_VALUE, None)
+                .unwrap(),
+            PropertyValue::Enumerated(0)
+        );
+        server.stop().await.unwrap();
+        assert_eq!(server.mutation_decision_counters(), counters);
+    }
+}
+
+#[tokio::test]
+async fn mutation_counters_record_decisions_not_handler_success() {
+    // The absent-authorizer fast path must still allow without a new decode.
+    for authorizer in [
+        None,
+        Some(Arc::new(|_: &MutationAuthorizationContext| true) as MutationAuthorizer),
+    ] {
+        let mut server = server(MutationPolicy::Permissive, authorizer).await;
+        let service = ConfirmedServiceChoice::WRITE_PROPERTY;
+        let response = dispatch(&server, service, Bytes::from_static(&[0x0c]), 1)
+            .await
+            .unwrap();
+        assert!(matches!(apdu(response), Apdu::Error(_) | Apdu::Reject(_)));
+        assert_eq!(
+            server.mutation_decision_counters(),
+            expected(
+                service,
+                MutationServiceCounters {
+                    allow_total: u64::from(server.config.mutation_authorizer.is_none()),
+                    ..Default::default()
+                }
+            )
+        );
+        server.stop().await.unwrap();
+    }
+
+    // A successful authorization is counted even if the file budget then aborts.
+    for authorizer in [
+        None,
+        Some(Arc::new(|_: &MutationAuthorizationContext| true) as MutationAuthorizer),
+    ] {
+        let mut server = server(MutationPolicy::Permissive, authorizer).await;
+        let service = ConfirmedServiceChoice::ATOMIC_WRITE_FILE;
+        let mut bytes = BytesMut::new();
+        AtomicWriteFileRequest {
+            file_identifier: oid(ObjectType::FILE, 1),
+            access: bacnet_services::file::FileWriteAccessMethod::Stream {
+                file_start_position: -1,
+                file_data: vec![42; 16_385],
+            },
+        }
+        .encode(&mut bytes);
+        let before = snapshot(&server).await;
+        let response = dispatch(&server, service, bytes.freeze(), 1).await.unwrap();
+        assert!(
+            matches!(apdu(response), Apdu::Abort(a) if a.abort_reason == AbortReason::OUT_OF_RESOURCES)
+        );
+        assert_eq!(snapshot(&server).await, before);
+        assert_eq!(
+            server.mutation_decision_counters(),
+            expected(
+                service,
+                MutationServiceCounters {
+                    allow_total: 1,
+                    ..Default::default()
+                }
+            )
+        );
+        server.stop().await.unwrap();
+    }
+}
+
+#[tokio::test]
+async fn mutation_wpm_validation_still_precedes_policy_and_counters() {
+    for policy in [MutationPolicy::Permissive, MutationPolicy::DenyAll] {
+        let mut server = server(
+            policy,
+            Some(Arc::new(|_| panic!("validation must precede policy"))),
+        )
+        .await;
+        let bytes = wpm(vec![WriteAccessSpecification {
+            object_identifier: oid(ObjectType::BINARY_VALUE, 999),
+            list_of_properties: vec![BACnetPropertyValue {
+                property_identifier: PropertyIdentifier::DESCRIPTION,
+                property_array_index: None,
+                value: value(PropertyValue::CharacterString("unreachable".into())),
+                priority: None,
+            }],
+        }]);
+        let before = snapshot(&server).await;
+        let response = dispatch(
+            &server,
+            ConfirmedServiceChoice::WRITE_PROPERTY_MULTIPLE,
+            bytes,
+            1,
+        )
+        .await
+        .unwrap();
+        let Apdu::Error(error) = apdu(response) else {
+            panic!("expected unknown object")
+        };
+        assert_eq!(error.error_class, ErrorClass::OBJECT);
+        assert_eq!(error.error_code, ErrorCode::UNKNOWN_OBJECT);
+        assert_eq!(snapshot(&server).await, before);
+        assert_eq!(
+            server.mutation_decision_counters(),
+            MutationDecisionCounters::default()
+        );
+        server.stop().await.unwrap();
+    }
+}

--- a/crates/bacnet-server/src/server/requests/mutations.rs
+++ b/crates/bacnet-server/src/server/requests/mutations.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::life_safety_cov::LifeSafetyCovChange;
-use crate::mutation::{MutationAuthorizationContext, MutationTarget};
+use crate::mutation::{
+    MutationAuthorizationContext, MutationDecision, MutationDecisions, MutationPolicy,
+    MutationTarget,
+};
 use bacnet_objects::staging::StagingWritePlan;
 use bacnet_services::cov::{SubscribeCOVPropertyRequest, SubscribeCOVRequest};
 use bacnet_services::cov_multiple::SubscribeCOVPropertyMultipleRequest;
@@ -17,6 +20,7 @@ pub(super) enum InitialCovNotification {
 /// Borrowed dispatch inputs; constructed only after the DCC precheck.
 pub(super) struct Request<'a> {
     pub config: &'a ServerConfig,
+    pub decisions: &'a MutationDecisions,
     pub source_mac: &'a [u8],
     pub source_network: Option<&'a NpduAddress>,
     pub req: &'a ConfirmedRequestPdu,
@@ -27,19 +31,36 @@ impl Request<'_> {
         &self,
         decode: impl FnOnce() -> Result<MutationTarget, Error>,
     ) -> Result<(), Error> {
-        let Some(authorizer) = &self.config.mutation_authorizer else {
+        if self.config.mutation_policy == MutationPolicy::Permissive
+            && self.config.mutation_authorizer.is_none()
+        {
+            self.decisions
+                .record(self.req.service_choice, MutationDecision::Allow);
             return Ok(());
+        }
+        let target = decode()?;
+        if self.config.mutation_policy == MutationPolicy::DenyAll {
+            self.decisions
+                .record(self.req.service_choice, MutationDecision::PolicyDeny);
+            return Err(audit_notification::request_denied());
+        }
+        let Some(authorizer) = &self.config.mutation_authorizer else {
+            unreachable!("permissive absence handled above")
         };
         let context = MutationAuthorizationContext {
             source_mac: MacAddr::from_slice(self.source_mac),
             source_network: self.source_network.cloned(),
             invoke_id: self.req.invoke_id,
             service_choice: self.req.service_choice,
-            target: decode()?,
+            target,
         };
         if audit_notification::fail_closed_authorize(|| authorizer(&context)) {
+            self.decisions
+                .record(self.req.service_choice, MutationDecision::Allow);
             Ok(())
         } else {
+            self.decisions
+                .record(self.req.service_choice, MutationDecision::Deny);
             Err(audit_notification::request_denied())
         }
     }
@@ -131,10 +152,7 @@ impl Request<'_> {
                 &mut db,
                 &self.req.service_request,
                 &mut snapshots,
-                self.config
-                    .mutation_authorizer
-                    .as_ref()
-                    .map(|_| &authorize as _),
+                Some(&authorize),
             );
             let committed_oids = match &outcome {
                 handlers::WritePropertyMultipleOutcome::Success { committed_oids }
@@ -391,3 +409,7 @@ impl Request<'_> {
         }
     }
 }
+
+#[cfg(test)]
+#[path = "mutation_policy_tests.rs"]
+mod policy_tests;

--- a/crates/bacnet-server/src/server/segmentation_tests/mod.rs
+++ b/crates/bacnet-server/src/server/segmentation_tests/mod.rs
@@ -292,6 +292,7 @@ async fn dispatch_test_apdu_from_network<T: TransportPort + 'static>(
         &comm_state,
         &dcc_timer,
         &Arc::new(dcc_outcomes::DccOutcomes::default()),
+        &Arc::new(crate::mutation::MutationDecisions::default()),
         &config,
         &None,
         &Arc::new(DiscoveryLimiter::new(DiscoveryPolicy::default(), None)),

--- a/docs/mutation-policy.md
+++ b/docs/mutation-policy.md
@@ -1,0 +1,24 @@
+# Local mutation authorization
+
+Rust operators can set `ServerConfig::mutation_policy` or call
+`.mutation_policy(bacnet_server::mutation::MutationPolicy::DenyAll)` on the generic,
+B/IP or SC server builder. The default, `Permissive`, preserves existing behavior:
+an absent authorizer allows; an installed authorizer must approve. `DenyAll` denies
+covered decisions even with an allow-all authorizer, without invoking it, using
+SERVICES / SERVICE_REQUEST_DENIED. Both modes accept any authorizer configuration.
+
+**SC mTLS channel/peer authentication is not service authorization.** Identities at
+this layer are claimed link/routed addresses, never certificate principals.
+Distinguishing SC certificate principals is out of scope: none reaches this layer.
+
+Coverage is the ten `mutation::MutationTarget` services. Reads, discovery, DCC,
+TimeSync, LifeSafety/Audit, direct handler calls and trusted local writes retain
+their existing behavior. Admission, duplicate detection, decoding and WPM validation
+retain precedence. WPM makes one decision per reached element; empty requests make
+none, and a denial stops the suffix without rolling back an allowed prefix.
+
+`BACnetServer::mutation_decision_counters()` exposes fixed per-service saturating
+`u64` totals, including after `stop()`: `allow_total`, `deny_total` (all denials),
+and `policy_deny_total` (the deny-all subset). Samples are independent, not atomic
+aggregates. They count decisions, not successful mutations or delivered responses;
+they never affect authorization and retain no per-source state or durable history.


### PR DESCRIPTION
Partial #524 (owner-locked deny mode + counters + docs; SC principals documented out of scope — no certificate principal reaches this layer).

MutationPolicy enum (Permissive default / DenyAll hardened, denying even with an allow-all authorizer — DCC precedent) plus saturating fixed-shape per-service allow/deny/policy-deny counters on shared server-owned state with snapshot accessor. WPM counts per element. Operator docs state SC mTLS is not service authorization. Zero-behavior handles.rs extraction keeps the 700-LOC gate green (lifecycle 685).

Validation: bacnet-server 1,103+3+2 PASS (incl. sc-tls), FULL conformance_ledger 27/27 PASS, clippy/fmt/size/secrets PASS, 58 focused mutation tests.