### PR TITLE
feat(sc): rate-limit inbound hub broadcast relays (#518)

### DIFF
--- a/crates/bacnet-transport/src/sc_hub.rs
+++ b/crates/bacnet-transport/src/sc_hub.rs
@@ -31,6 +31,7 @@ use tokio_tungstenite::WebSocketStream;
 use tracing::{debug, warn};
 
 mod advertisement_transit;
+mod broadcast_rate;
 mod client;
 mod connection;
 mod deadlines;
@@ -49,6 +50,7 @@ mod timeouts;
 mod tls_config;
 mod unknown_transit;
 
+pub use broadcast_rate::{ScHubBroadcastDropCounts, ScHubBroadcastRatePolicy};
 pub use timeouts::ScHubHandshakeTimeouts;
 pub use tls_config::ScHubTlsConfig;
 
@@ -245,6 +247,9 @@ impl ScHub {
                 "hub VMAC must not be UNKNOWN or BROADCAST".into(),
             ));
         }
+        let broadcast = Arc::new(broadcast_rate::HubBudget::new(
+            tls_config.broadcast_rate_policy(),
+        )?);
         let tls_acceptor = tls_config.into_acceptor();
         let listener = TcpListener::bind(bind_addr)
             .await
@@ -259,6 +264,7 @@ impl ScHub {
         let clients: Clients = Arc::new(Mutex::new(HashMap::new()));
 
         let tasks = tasks::Tasks::new();
+        let tasks = tasks.with_broadcast_budget(broadcast);
         let task = tokio::spawn(connection::accept_loop_with_counter(
             listener,
             tls_acceptor,

--- a/crates/bacnet-transport/src/sc_hub/broadcast-rate-policy.md
+++ b/crates/bacnet-transport/src/sc_hub/broadcast-rate-policy.md
@@ -1,0 +1,112 @@
+# Hub broadcast relay budget (#518 first slice)
+
+This is an always-on, tunable **local overload policy**, not a new BACnet wire
+requirement or a claim of full Annex AB conformance.
+
+## Admission and exclusions
+
+Only an already-classified `HubRelayTarget::Broadcast` spends tokens. The three
+eligible forwarding families (Encapsulated-NPDU, Unknown, Proprietary) share one
+sender bucket and one hub bucket. Checks occur after existing admission and
+activity accounting, but before relay encoding, recipient collection, copying,
+or fanout. Sender identity is the handler's registered VMAC lease, never a
+peer-supplied origin; the bucket lives in that handler, without a per-VMAC map.
+
+Unicast is unchanged, including relayed unicast whose destination is removed.
+Address-Resolution/ACK, Advertisement/Solicitation and Results are unicast
+transit or existing locally rejected/dropped operations, not shared-state
+control processing. Their processing and local rejection/write budgets are
+explicitly out of scope. No NPDU decoding, heartbeat/activity/deadline,
+replacement, retirement, recipient size gating, or send timeout policy changes.
+
+Exhaustion silently drops the **whole broadcast request**; it does not send a
+NAK, close the sender, or queue delayed work. Source check: local licensed
+Standard 135-2020, Annex AB.2, printed p. 1383 (PDF position 1385), and AB.2.4,
+printed pp. 1386–1387 (PDF positions 1388–1389). Broadcasts must not elicit responses, so
+BVLC-Result is not a suitable rate-drop response. This note paraphrases the
+source and does not claim the numeric quotas come from it.
+
+## Defaults and derivation
+
+| Bucket | Continuous refill | Initial/maximum burst |
+|---|---:|---:|
+| Registered sender connection | 128 broadcasts/s | 1,024 broadcasts |
+| Hub aggregate | 512 broadcasts/s | 4,096 broadcasts |
+
+In-repository scale evidence:
+
+- `sc/advertisement.rs`: solicited advertisements have a 1-second local spacing.
+- `sc/heartbeat.rs`: default heartbeat interval 30 seconds, timeout 60 seconds;
+  `sc_hub/connection.rs` sweeps every 30 seconds. Neither is gated here.
+- `bacnet-client/src/tsm.rs`: default APDU/segment retransmission timeouts are
+  6,000 ms, with three retries. These are context, not broadcast retry promises.
+- `sc_hub/proprietary_transit_tests.rs`: the broadcast fanout case sends two
+  back-to-back messages; its opaque unicast matrix sends 32 cases. These small
+  functional bursts are evidence of scale, not a deployment throughput study.
+- `sc_hub/unknown_transit_tests.rs`: its all-functions/opaque-options test sends
+  243 + (3 * 2 * 4 * 2) = 291 broadcasts from one sender without explicit pacing.
+- `sc_hub/retirement_capacity_tests.rs`: the terminal-relay capacity test sends
+  513 broadcasts from one source among 2,052 target sessions, also without
+  pacing. Correct behavior must not depend on TLS/test execution being slow.
+
+Use the existing one-second scale, but allow 128 sender broadcasts in that
+second and eight seconds of burst credit. A 1,024-message burst is the next
+power of two above the existing 513-broadcast test, with substantial headroom.
+The initial 256-message candidate failed those existing high-volume tests and
+was raised rather than changing their behavior. This leaves room relative to
+the timer scales: 768 sustained broadcasts per 6-second retry interval, or
+3,840 per default heartbeat interval, plus the initial burst. The global budget
+permits four sender-rate streams, but cannot grow with the number of senders.
+The factors 128, eight-second burst, and four sender streams are deliberately
+generous local choices, **not measured safe limits for every deployment**.
+
+For any elapsed interval `t` seconds, admissions are at most `burst + rate*t`
+(rounded down to whole tokens), not a fixed-window reset quota. The existing
+256-client cap means aggregate fanout attempts are at most
+`255 * (4096 + 512*t)` by default. Tokens count broadcast requests, not bytes
+or actual recipients; even no-recipient/oversized-recipient requests spend a
+token. Bucket credit is capped, so idle time cannot accumulate unbounded work.
+This bounds admitted fanout, not ingress parsing, OS buffers, or fair service
+under an aggregate flood. Once the global bucket is empty, any sender can drop.
+
+## Configuration, lifetime, and diagnostics
+
+Use `ScHubTlsConfig::with_broadcast_rate_policy(ScHubBroadcastRatePolicy { .. })`
+before any existing public startup API. Every startup validates all four bounds
+before binding: zero and values above `u64::MAX / 1_000_000_000` are rejected.
+No disable sentinel exists. Raise bursts for measured legitimate discovery
+peaks; lower aggregate rates for large/slow fanouts; review recipient count and
+observed drop counters before raising sustained rates.
+
+There is O(1) state per handler and O(1) state per hub. A new connection starts
+with a fresh sender bucket; replacement/reconnection cannot reset the aggregate.
+Configuration clones start independent hubs. The existing task owner holds the
+aggregate and explicitly scopes each accepted connection to it; no background
+refill task, timer, queue, or lifecycle control is added. Refill uses monotonic
+Tokio time and integer nanotokens, retaining partial tokens exactly. The global
+mutex protects only fixed arithmetic, with no I/O or await while locked.
+
+The sender check runs first. Sender-rejected requests do not debit the global
+bucket. A request passing the sender check spends that token even if rejected
+globally. `ScHub::broadcast_drop_counts()` exposes two saturating lifetime `u64`
+counters (`sender_exhausted`, `global_exhausted`); each rate drop counts exactly
+once. They are diagnostics only, never admission inputs. Individual reads are
+atomic; the pair is not transactional under active traffic. Counts remain
+readable after stop. No unbounded per-sender metric labels or maps are retained.
+Warnings follow the existing `malformed_diag` one-per-second per-handler idiom
+with suppressed-event summaries. A separate throttle keeps malformed-frame
+diagnostics independent of rate-drop diagnostics.
+
+## Evidence
+
+`broadcast_rate_tests.rs` covers exact bursts/sub-token boundaries, fractional
+refill under repeated rejection, long-idle clamping, stale clock samples,
+zero/overflow/max bounds, exact and saturating counters, sender isolation,
+unicast bypass, and a 16-thread aggregate admission race.
+
+`broadcast_rate_live_tests.rs` exercises public TLS hub startup with frozen
+Tokio time and ordered wire barriers: mixed-family single-sender flooding,
+other sender/registration/heartbeat progress, exact refill boundary, concurrent
+multi-sender aggregate flooding and replacement, high-rate byte-exact unicast
+and control traffic, all four startup APIs rejecting bad bounds, and independent
+cloned-config hubs. Existing hub suites are left unmodified.

--- a/crates/bacnet-transport/src/sc_hub/broadcast_rate.rs
+++ b/crates/bacnet-transport/src/sc_hub/broadcast_rate.rs
@@ -1,0 +1,260 @@
+//! Always-on local broadcast relay policy; see `broadcast-rate-policy.md`.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use bacnet_types::error::Error;
+use tokio::time::Instant;
+
+use super::{HubRelayTarget, ScHub};
+use crate::sc::diagnostic_throttle::DiagnosticThrottle;
+use crate::sc_frame::Vmac;
+
+const TOKEN: u64 = 1_000_000_000;
+
+/// Always-on, continuously refilled token buckets for hub broadcast relay only.
+///
+/// Defaults: each sender gets **128 broadcasts/second, burst 1024**; the entire
+/// hub gets **512 broadcasts/second, burst 4096**. One token admits one broadcast
+/// request, not one recipient. The existing 256-client cap bounds each admitted
+/// request to at most 255 recipient writes. Buckets start full and never queue.
+///
+/// These generous local defaults use a one-second tuning scale (the node's
+/// solicited-advertisement interval), well below the existing 30-second heartbeat
+/// interval and 6-second transaction retry timeout. Even a single sender may
+/// relay 768 broadcasts per retry interval after its initial burst. They are not
+/// normative BACnet rates or a measured site capacity guarantee.
+/// The sender burst leaves headroom over the existing 513-broadcast retirement
+/// test; eight seconds of credit covers that burst independently of test speed.
+///
+/// Tune to measured broadcast peaks and recipient count with
+/// [`super::ScHubTlsConfig::with_broadcast_rate_policy`]. Reduce the global rate
+/// for large/slow fanouts; increase burst capacity for legitimate discovery
+/// bursts. Exhaustion silently drops; there is no disabled/zero setting.
+/// Startup rejects every bound outside `1..=u64::MAX / 1_000_000_000`.
+///
+/// Per-sender state belongs to the connection handler holding the registered
+/// VMAC lease, not to a peer-supplied origin. Reconnection resets that bucket,
+/// but never the hub aggregate. NPDU, Unknown and Proprietary broadcasts share
+/// both budgets. Unicast (including destination-stripped relays) and control
+/// processing are excluded. Existing activity/heartbeat policy is unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ScHubBroadcastRatePolicy {
+    /// Maximum immediate burst per registered sender connection.
+    pub sender_burst: u64,
+    /// Continuous per-sender refill, in broadcast requests per second.
+    pub sender_per_second: u64,
+    /// Maximum immediate burst across all connections of one hub.
+    pub global_burst: u64,
+    /// Continuous aggregate refill, in broadcast requests per second.
+    pub global_per_second: u64,
+}
+
+impl Default for ScHubBroadcastRatePolicy {
+    fn default() -> Self {
+        Self {
+            sender_burst: 1024,
+            sender_per_second: 128,
+            global_burst: 4096,
+            global_per_second: 512,
+        }
+    }
+}
+
+impl ScHubBroadcastRatePolicy {
+    fn validate(self) -> Result<(), Error> {
+        for (name, value) in [
+            ("sender_burst", self.sender_burst),
+            ("sender_per_second", self.sender_per_second),
+            ("global_burst", self.global_burst),
+            ("global_per_second", self.global_per_second),
+        ] {
+            if value == 0 || value.checked_mul(TOKEN).is_none() {
+                return Err(Error::Encoding(format!(
+                    "hub broadcast {name} must be in 1..={}",
+                    u64::MAX / TOKEN
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Saturating lifetime drop counts for one hub, independent of admission state.
+///
+/// Every rate drop increments exactly one field. Sender exhaustion is checked
+/// first. A sender token is spent even if the aggregate subsequently rejects;
+/// sender-rejected requests never spend aggregate tokens. Counts are not reset
+/// on peer replacement/reconnection and are never inputs to limiting decisions.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct ScHubBroadcastDropCounts {
+    /// Broadcasts dropped because their sender's bucket was exhausted.
+    pub sender_exhausted: u64,
+    /// Broadcasts passing the sender budget but exceeding the hub budget.
+    pub global_exhausted: u64,
+}
+
+impl ScHub {
+    /// Read the two broadcast-drop counters, including after [`Self::stop`].
+    ///
+    /// Each counter is atomic; the pair is not a transactional snapshot while
+    /// workers are active. No per-VMAC statistics/map or wire response is created.
+    pub fn broadcast_drop_counts(&self) -> ScHubBroadcastDropCounts {
+        self.tasks.broadcast.drop_counts()
+    }
+}
+
+struct Bucket {
+    credit: u64,
+    capacity: u64,
+    rate: u64,
+    updated: Instant,
+}
+
+impl Bucket {
+    // Bounds are validated once before construction. Nanotokens retain partial
+    // refills exactly: frequent rejected requests cannot postpone replenishment.
+    fn new(burst: u64, rate: u64, now: Instant) -> Self {
+        Self {
+            credit: burst * TOKEN,
+            capacity: burst * TOKEN,
+            rate,
+            updated: now,
+        }
+    }
+
+    fn take(&mut self, now: Instant) -> bool {
+        if now > self.updated {
+            let refill = now
+                .duration_since(self.updated)
+                .as_nanos()
+                .saturating_mul(u128::from(self.rate))
+                .min(u128::from(self.capacity - self.credit));
+            self.credit += refill as u64;
+            self.updated = now;
+        }
+        if self.credit < TOKEN {
+            return false;
+        }
+        self.credit -= TOKEN;
+        true
+    }
+}
+
+pub(super) struct HubBudget {
+    policy: ScHubBroadcastRatePolicy,
+    bucket: Mutex<Bucket>,
+    sender_drops: AtomicU64,
+    global_drops: AtomicU64,
+}
+
+impl HubBudget {
+    pub(super) fn new(policy: ScHubBroadcastRatePolicy) -> Result<Self, Error> {
+        policy.validate()?;
+        Ok(Self {
+            policy,
+            bucket: Mutex::new(Bucket::new(
+                policy.global_burst,
+                policy.global_per_second,
+                Instant::now(),
+            )),
+            sender_drops: AtomicU64::new(0),
+            global_drops: AtomicU64::new(0),
+        })
+    }
+
+    fn drop_counts(&self) -> ScHubBroadcastDropCounts {
+        ScHubBroadcastDropCounts {
+            sender_exhausted: self.sender_drops.load(Ordering::Relaxed),
+            global_exhausted: self.global_drops.load(Ordering::Relaxed),
+        }
+    }
+}
+
+impl Default for HubBudget {
+    fn default() -> Self {
+        Self::new(ScHubBroadcastRatePolicy::default()).expect("valid default broadcast policy")
+    }
+}
+
+tokio::task_local! {
+    // Explicit connection-scoped injection keeps rate policy out of handshake,
+    // heartbeat and retirement APIs. The hub's Tasks owner retains the Arc.
+    pub(super) static HUB_BUDGET: Arc<HubBudget>;
+}
+
+pub(super) struct SenderBudget {
+    hub: Arc<HubBudget>,
+    bucket: Bucket,
+    diagnostic: DiagnosticThrottle,
+}
+
+fn increment(counter: &AtomicU64) {
+    // Statistics only: no state publication or admission decision uses them.
+    let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+        Some(value.saturating_add(1))
+    });
+}
+
+impl SenderBudget {
+    pub(super) fn for_connection() -> Self {
+        #[cfg(not(test))]
+        let hub = HUB_BUDGET.with(Arc::clone);
+        #[cfg(test)]
+        let hub = HUB_BUDGET.try_with(Arc::clone).unwrap_or_else(|_| {
+            // Only private direct-handler test harnesses bypass accept_loop.
+            // Public startup always supplies a hub-owned shared budget.
+            Arc::new(HubBudget::default())
+        });
+        Self::new(hub, Instant::now())
+    }
+
+    fn new(hub: Arc<HubBudget>, now: Instant) -> Self {
+        let bucket = Bucket::new(hub.policy.sender_burst, hub.policy.sender_per_second, now);
+        Self {
+            hub,
+            bucket,
+            diagnostic: DiagnosticThrottle::new(),
+        }
+    }
+
+    pub(super) fn admit(&mut self, target: HubRelayTarget, registered_vmac: Vmac) -> bool {
+        if self.admit_at(target, Instant::now()) {
+            return true;
+        }
+        // Same bounded warning idiom as malformed_diag, separate from the
+        // saturating lifetime counters. AB.2 disallows broadcast responses.
+        super::malformed_diag::emit(&mut self.diagnostic, |suppressed| {
+            tracing::warn!(
+                ?registered_vmac,
+                suppressed,
+                "Hub: broadcast relay rate limit exceeded, dropping"
+            );
+        });
+        false
+    }
+
+    fn admit_at(&mut self, target: HubRelayTarget, now: Instant) -> bool {
+        if target != HubRelayTarget::Broadcast {
+            return true;
+        }
+        if !self.bucket.take(now) {
+            increment(&self.hub.sender_drops);
+            return false;
+        }
+        // One fixed-shape synchronous critical section, no I/O/await or other
+        // lock held. The sender quota limits contention from any single task.
+        if !self.hub.bucket.lock().unwrap().take(now) {
+            increment(&self.hub.global_drops);
+            return false;
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+#[path = "broadcast_rate_live_tests.rs"]
+mod live_tests;
+#[cfg(test)]
+#[path = "broadcast_rate_tests.rs"]
+mod tests;

--- a/crates/bacnet-transport/src/sc_hub/broadcast_rate_live_tests.rs
+++ b/crates/bacnet-transport/src/sc_hub/broadcast_rate_live_tests.rs
@@ -1,0 +1,353 @@
+//! Public-startup TLS loopback tests with frozen Tokio time and wire barriers.
+use super::*;
+use crate::sc_frame::BROADCAST_VMAC;
+use crate::sc_hub::deadline_test_support::{poll_io, request, ClientWs, TestTls};
+use crate::sc_hub::ScHubHandshakeTimeouts;
+use futures_util::{SinkExt, StreamExt};
+use std::time::Duration;
+use tokio_tungstenite::tungstenite::Message;
+
+async fn send(peer: &mut ClientWs, wire: Vec<u8>) {
+    poll_io(peer.send(Message::Binary(wire.into())))
+        .await
+        .unwrap();
+}
+
+async fn recv(peer: &mut ClientWs) -> Vec<u8> {
+    match poll_io(peer.next()).await.unwrap().unwrap() {
+        Message::Binary(data) => data.to_vec(),
+        other => panic!("expected binary frame, got {other:?}"),
+    }
+}
+
+async fn connect(tls: &TestTls, hub: &ScHub, id: u8) -> ClientWs {
+    let mut peer = poll_io(tls.websocket(hub.local_addr().unwrap())).await;
+    poll_io(peer.send(request([id; 6], [id; 16])))
+        .await
+        .unwrap();
+    assert_eq!(recv(&mut peer).await[0], 7);
+    peer
+}
+
+// Independent wire oracle: no product encoder/relay helper constructs expected bytes.
+fn wire(function: u8, id: u16, origin: Option<Vmac>, dest: Option<Vmac>) -> Vec<u8> {
+    let mut bytes = vec![
+        function,
+        u8::from(origin.is_some()) * 8 + u8::from(dest.is_some()) * 4,
+    ];
+    bytes.extend_from_slice(&id.to_be_bytes());
+    if let Some(vmac) = origin {
+        bytes.extend_from_slice(&vmac);
+    }
+    if let Some(vmac) = dest {
+        bytes.extend_from_slice(&vmac);
+    }
+    bytes.extend_from_slice(match function {
+        0 => &[1, 0], // successful Result for NPDU
+        2 | 3 | 5 => &[],
+        4 => &[1, 0, 0xFF, 0xFF, 0x05, 0xD9],
+        12 => &[0, 43, 7, 99],
+        _ => &[1, 0],
+    });
+    bytes
+}
+
+async fn broadcast(peer: &mut ClientWs, count: u16) {
+    for id in 0..count {
+        let function = [1, 12, 0x80][usize::from(id % 3)];
+        send(peer, wire(function, id, None, Some(BROADCAST_VMAC))).await;
+    }
+}
+
+async fn barrier(peer: &mut ClientWs) {
+    send(peer, vec![10, 0, 0xCA, 0xFE]).await;
+    assert_eq!(recv(peer).await, [11, 0, 0xCA, 0xFE]);
+}
+
+async fn drain_broadcasts_to_barrier(peer: &mut ClientWs) -> usize {
+    send(peer, vec![10, 0, 0xCA, 0xFE]).await;
+    let mut count = 0;
+    loop {
+        let received = recv(peer).await;
+        if received == [11, 0, 0xCA, 0xFE] {
+            return count;
+        }
+        // Reject any NAK/reflection or non-broadcast traffic in the drain.
+        assert!(matches!(received[0], 1 | 12 | 0x80));
+        assert_eq!(received[1], 12);
+        assert_eq!(&received[10..16], &BROADCAST_VMAC);
+        count += 1;
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn single_sender_flood_is_bounded_others_flow_and_hub_stays_responsive() {
+    let tls = TestTls::new();
+    let policy = ScHubBroadcastRatePolicy {
+        sender_burst: 8,
+        sender_per_second: 2,
+        global_burst: 64,
+        global_per_second: 16,
+    };
+    let mut hub = ScHub::start(
+        "127.0.0.1:0",
+        tls.hub_config.clone().with_broadcast_rate_policy(policy),
+        [16; 6],
+        [16; 16],
+    )
+    .await
+    .unwrap();
+    let mut a = connect(&tls, &hub, 42).await;
+    let mut b = connect(&tls, &hub, 43).await;
+    let mut c = connect(&tls, &hub, 44).await;
+    broadcast(&mut a, 128).await;
+    barrier(&mut a).await; // all input processed, no rate-drop NAKs
+    for id in 0..8 {
+        let expected = wire(
+            [1, 12, 0x80][usize::from(id % 3)],
+            id,
+            Some([42; 6]),
+            Some(BROADCAST_VMAC),
+        );
+        assert_eq!(recv(&mut b).await, expected);
+        assert_eq!(recv(&mut c).await, expected);
+    }
+    barrier(&mut b).await;
+    barrier(&mut c).await;
+    assert_eq!(
+        hub.broadcast_drop_counts(),
+        ScHubBroadcastDropCounts {
+            sender_exhausted: 120,
+            global_exhausted: 0,
+        }
+    );
+    broadcast(&mut b, 3).await;
+    barrier(&mut b).await;
+    for id in 0..3 {
+        let expected = wire(
+            [1, 12, 0x80][usize::from(id % 3)],
+            id,
+            Some([43; 6]),
+            Some(BROADCAST_VMAC),
+        );
+        assert_eq!(recv(&mut a).await, expected);
+        assert_eq!(recv(&mut c).await, expected);
+    }
+    // A new peer can still register while the offending sender is exhausted.
+    let mut d = connect(&tls, &hub, 45).await;
+    barrier(&mut d).await;
+    // Exact boundary: 2/s produces its first replacement token at 500ms.
+    tokio::time::advance(Duration::from_millis(500) - Duration::from_nanos(1)).await;
+    broadcast(&mut a, 1).await;
+    barrier(&mut a).await;
+    tokio::time::advance(Duration::from_nanos(1)).await;
+    broadcast(&mut a, 2).await;
+    barrier(&mut a).await;
+    for peer in [&mut b, &mut c, &mut d] {
+        assert_eq!(
+            recv(peer).await,
+            wire(1, 0, Some([42; 6]), Some(BROADCAST_VMAC))
+        );
+        barrier(peer).await;
+    }
+    assert_eq!(hub.broadcast_drop_counts().sender_exhausted, 122);
+    poll_io(hub.stop()).await;
+    assert_eq!(hub.broadcast_drop_counts().sender_exhausted, 122);
+}
+
+#[tokio::test(start_paused = true)]
+async fn concurrent_multi_sender_flood_and_reconnect_obey_global_budget() {
+    let tls = TestTls::new();
+    let policy = ScHubBroadcastRatePolicy {
+        sender_burst: 128,
+        sender_per_second: 128,
+        global_burst: 10,
+        global_per_second: 2,
+    };
+    let mut hub = ScHub::start(
+        "127.0.0.1:0",
+        tls.hub_config.clone().with_broadcast_rate_policy(policy),
+        [16; 6],
+        [16; 16],
+    )
+    .await
+    .unwrap();
+    let mut a = connect(&tls, &hub, 42).await;
+    let mut b = connect(&tls, &hub, 43).await;
+    let mut observer = connect(&tls, &hub, 44).await;
+    tokio::join!(broadcast(&mut a, 64), broadcast(&mut b, 64));
+    // Stop source traffic with ordered heartbeats before draining the observer.
+    let (a_count, b_count) = tokio::join!(
+        drain_broadcasts_to_barrier(&mut a),
+        drain_broadcasts_to_barrier(&mut b)
+    );
+    // One source's ACK can precede the other source's final broadcasts. Now
+    // both sources have finished, a second barrier drains that possible tail.
+    let a_count = a_count + drain_broadcasts_to_barrier(&mut a).await;
+    let b_count = b_count + drain_broadcasts_to_barrier(&mut b).await;
+    assert_eq!(drain_broadcasts_to_barrier(&mut observer).await, 10);
+    assert_eq!(a_count + b_count, 10);
+    assert_eq!(
+        hub.broadcast_drop_counts(),
+        ScHubBroadcastDropCounts {
+            sender_exhausted: 0,
+            global_exhausted: 118,
+        }
+    );
+    // Replacing a registered lease replenishes only its connection-local bucket.
+    let mut replacement = connect(&tls, &hub, 42).await;
+    broadcast(&mut replacement, 4).await;
+    barrier(&mut replacement).await;
+    barrier(&mut b).await;
+    barrier(&mut observer).await;
+    assert_eq!(hub.broadcast_drop_counts().global_exhausted, 122);
+    tokio::time::advance(Duration::from_secs(1)).await;
+    broadcast(&mut replacement, 5).await;
+    barrier(&mut replacement).await;
+    assert_eq!(drain_broadcasts_to_barrier(&mut b).await, 2);
+    assert_eq!(drain_broadcasts_to_barrier(&mut observer).await, 2);
+    assert_eq!(hub.broadcast_drop_counts().global_exhausted, 125);
+    poll_io(hub.stop()).await;
+}
+
+#[tokio::test(start_paused = true)]
+async fn exhausted_budgets_do_not_change_high_rate_unicast_or_control_bytes() {
+    let tls = TestTls::new();
+    let policy = ScHubBroadcastRatePolicy {
+        sender_burst: 1,
+        sender_per_second: 1,
+        global_burst: 1,
+        global_per_second: 1,
+    };
+    let mut hub = ScHub::start(
+        "127.0.0.1:0",
+        tls.hub_config.clone().with_broadcast_rate_policy(policy),
+        [16; 6],
+        [16; 16],
+    )
+    .await
+    .unwrap();
+    let mut a = connect(&tls, &hub, 42).await;
+    let mut b = connect(&tls, &hub, 43).await;
+    broadcast(&mut a, 2).await;
+    barrier(&mut a).await;
+    assert_eq!(
+        recv(&mut b).await,
+        wire(1, 0, Some([42; 6]), Some(BROADCAST_VMAC))
+    );
+    for id in 0..128 {
+        // Includes the out-of-scope opaque controls and routed Result family.
+        for function in [0, 1, 2, 3, 4, 5, 12, 0x80] {
+            send(&mut a, wire(function, id, None, Some([43; 6]))).await;
+            assert_eq!(recv(&mut b).await, wire(function, id, Some([42; 6]), None));
+        }
+    }
+    // Absent destination is local, never reclassified as broadcast. An Unknown
+    // local request retains its existing NAK even with both budgets exhausted.
+    send(&mut a, wire(0x80, 0x1234, None, None)).await;
+    assert_eq!(
+        recv(&mut a).await,
+        [0, 0, 0x12, 0x34, 0x80, 1, 0, 0, 7, 0, 143]
+    );
+    barrier(&mut a).await;
+    barrier(&mut b).await;
+    assert_eq!(
+        hub.broadcast_drop_counts(),
+        ScHubBroadcastDropCounts {
+            sender_exhausted: 1,
+            global_exhausted: 0,
+        }
+    );
+    send(&mut a, vec![8, 0, 0x12, 0x34]).await;
+    assert_eq!(recv(&mut a).await, [9, 0, 0x12, 0x34]);
+    poll_io(hub.stop()).await;
+}
+
+#[tokio::test]
+async fn every_startup_rejects_invalid_policy_before_bind() {
+    let tls = TestTls::new();
+    for index in 0..4 {
+        for invalid in [0, u64::MAX / TOKEN + 1] {
+            let mut p = ScHubBroadcastRatePolicy::default();
+            let fields = [
+                &mut p.sender_burst,
+                &mut p.sender_per_second,
+                &mut p.global_burst,
+                &mut p.global_per_second,
+            ];
+            *fields.into_iter().nth(index).unwrap() = invalid;
+            for api in 0..4 {
+                let config = tls.hub_config.clone().with_broadcast_rate_policy(p);
+                let result = match api {
+                    0 => ScHub::start("invalid bind address", config, [16; 6], [16; 16]).await,
+                    1 => {
+                        ScHub::start_with_uuid("invalid bind address", config, [16; 6], [16; 16])
+                            .await
+                    }
+                    2 => {
+                        ScHub::start_with_uuid_and_timeouts(
+                            "invalid bind address",
+                            config,
+                            [16; 6],
+                            [16; 16],
+                            ScHubHandshakeTimeouts::default(),
+                        )
+                        .await
+                    }
+                    _ => {
+                        ScHub::start_with_tls_config(
+                            "invalid bind address",
+                            config,
+                            [16; 6],
+                            [16; 16],
+                            ScHubHandshakeTimeouts::default(),
+                        )
+                        .await
+                    }
+                };
+                assert!(
+                    matches!(result, Err(Error::Encoding(message)) if message.starts_with("hub broadcast "))
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn cloned_configuration_gives_independent_hub_buckets_and_counters() {
+    let tls = TestTls::new();
+    let config = tls
+        .hub_config
+        .clone()
+        .with_broadcast_rate_policy(ScHubBroadcastRatePolicy {
+            sender_burst: 1,
+            sender_per_second: 1,
+            global_burst: 1,
+            global_per_second: 1,
+        });
+    let mut first = ScHub::start("127.0.0.1:0", config.clone(), [16; 6], [16; 16])
+        .await
+        .unwrap();
+    let mut second = ScHub::start("127.0.0.1:0", config, [17; 6], [17; 16])
+        .await
+        .unwrap();
+    for hub in [&mut first, &mut second] {
+        let mut a = connect(&tls, hub, 42).await;
+        let mut b = connect(&tls, hub, 43).await;
+        broadcast(&mut a, 2).await;
+        barrier(&mut a).await;
+        assert_eq!(
+            recv(&mut b).await,
+            wire(1, 0, Some([42; 6]), Some(BROADCAST_VMAC))
+        );
+        barrier(&mut b).await;
+        assert_eq!(
+            hub.broadcast_drop_counts(),
+            ScHubBroadcastDropCounts {
+                sender_exhausted: 1,
+                global_exhausted: 0,
+            }
+        );
+        poll_io(hub.stop()).await;
+    }
+}

--- a/crates/bacnet-transport/src/sc_hub/broadcast_rate_tests.rs
+++ b/crates/bacnet-transport/src/sc_hub/broadcast_rate_tests.rs
@@ -1,0 +1,201 @@
+use super::*;
+use std::time::Duration;
+
+fn policy() -> ScHubBroadcastRatePolicy {
+    ScHubBroadcastRatePolicy {
+        sender_burst: 3,
+        sender_per_second: 2,
+        global_burst: 5,
+        global_per_second: 4,
+    }
+}
+
+#[test]
+fn bounds_reject_zero_and_overflow_in_every_field() {
+    for index in 0..4 {
+        for invalid in [0, u64::MAX / TOKEN + 1, u64::MAX] {
+            let mut p = policy();
+            let fields = [
+                &mut p.sender_burst,
+                &mut p.sender_per_second,
+                &mut p.global_burst,
+                &mut p.global_per_second,
+            ];
+            *fields.into_iter().nth(index).unwrap() = invalid;
+            assert!(matches!(HubBudget::new(p), Err(Error::Encoding(message))
+                if message.starts_with("hub broadcast ")));
+        }
+    }
+    let maximum = u64::MAX / TOKEN;
+    assert!(HubBudget::new(ScHubBroadcastRatePolicy {
+        sender_burst: maximum,
+        sender_per_second: maximum,
+        global_burst: maximum,
+        global_per_second: maximum,
+    })
+    .is_ok());
+    assert_eq!(
+        ScHubBroadcastRatePolicy::default(),
+        ScHubBroadcastRatePolicy {
+            sender_burst: 1024,
+            sender_per_second: 128,
+            global_burst: 4096,
+            global_per_second: 512,
+        }
+    );
+}
+
+#[test]
+fn bucket_exact_burst_fractional_refill_and_idle_cap() {
+    let now = Instant::now();
+    let mut bucket = Bucket::new(3, 2, now);
+    for _ in 0..3 {
+        assert!(bucket.take(now));
+    }
+    assert!(!bucket.take(now));
+    // Rejected requests preserve fractional credit rather than restart refill.
+    for millis in 1..500 {
+        assert!(!bucket.take(now + Duration::from_millis(millis)));
+    }
+    assert!(!bucket.take(now + Duration::from_millis(500) - Duration::from_nanos(1)));
+    assert!(bucket.take(now + Duration::from_millis(500)));
+    assert!(!bucket.take(now + Duration::from_millis(500)));
+    assert!(bucket.take(now + Duration::from_secs(1)));
+    let later = now + Duration::from_secs(86_400);
+    for _ in 0..3 {
+        assert!(bucket.take(later));
+    }
+    assert!(!bucket.take(later));
+    // A stale concurrent sample must not move the global bucket clock backward.
+    assert!(!bucket.take(now));
+    assert!(!bucket.take(later));
+}
+
+#[test]
+fn nondivisor_refill_preserves_nanotoken_remainders() {
+    let now = Instant::now();
+    let mut bucket = Bucket::new(1, 3, now);
+    assert!(bucket.take(now));
+    assert!(!bucket.take(now + Duration::from_nanos(333_333_333)));
+    assert!(bucket.take(now + Duration::from_nanos(333_333_334)));
+    assert!(!bucket.take(now + Duration::from_nanos(666_666_666)));
+    // The first refill hit the capacity ceiling and discarded two nanotokens.
+    assert!(!bucket.take(now + Duration::from_nanos(666_666_667)));
+    assert!(bucket.take(now + Duration::from_nanos(666_666_668)));
+}
+
+#[test]
+fn maximum_arithmetic_stays_bounded_after_long_idle() {
+    let now = Instant::now();
+    let maximum = u64::MAX / TOKEN;
+    let mut bucket = Bucket::new(maximum, maximum, now);
+    assert!(bucket.take(now));
+    assert!(bucket.take(now + Duration::from_secs(1_000_000)));
+    assert_eq!(bucket.credit, (maximum - 1) * TOKEN);
+}
+
+#[test]
+fn sender_isolation_global_accounting_and_unicast_bypass() {
+    let hub = Arc::new(HubBudget::new(policy()).unwrap());
+    let now = Instant::now();
+    let mut a = SenderBudget::new(hub.clone(), now);
+    let mut b = SenderBudget::new(hub.clone(), now);
+    for _ in 0..3 {
+        assert!(a.admit_at(HubRelayTarget::Broadcast, now));
+    }
+    for _ in 0..1000 {
+        assert!(!a.admit_at(HubRelayTarget::Broadcast, now));
+    }
+    for _ in 0..2 {
+        assert!(b.admit_at(HubRelayTarget::Broadcast, now));
+    }
+    assert!(!b.admit_at(HubRelayTarget::Broadcast, now));
+    assert!(!b.admit_at(HubRelayTarget::Broadcast, now));
+    for _ in 0..1000 {
+        assert!(a.admit_at(HubRelayTarget::Unicast([42; 6]), now));
+        assert!(b.admit_at(HubRelayTarget::Unicast([43; 6]), now));
+    }
+    assert_eq!(
+        hub.drop_counts(),
+        ScHubBroadcastDropCounts {
+            sender_exhausted: 1001,
+            global_exhausted: 1,
+        }
+    );
+    // Neither failed global admissions nor per-sender floods borrow future tokens.
+    assert!(a.admit_at(HubRelayTarget::Broadcast, now + Duration::from_millis(500)));
+    assert!(b.admit_at(HubRelayTarget::Broadcast, now + Duration::from_millis(500)));
+}
+
+#[test]
+fn concurrent_senders_share_one_fixed_global_bucket() {
+    let hub = Arc::new(
+        HubBudget::new(ScHubBroadcastRatePolicy {
+            sender_burst: 100,
+            sender_per_second: 1,
+            global_burst: 37,
+            global_per_second: 1,
+        })
+        .unwrap(),
+    );
+    let now = Instant::now();
+    let admitted: usize = std::thread::scope(|scope| {
+        let threads: Vec<_> = (0..16)
+            .map(|_| {
+                let hub = hub.clone();
+                scope.spawn(move || {
+                    let mut sender = SenderBudget::new(hub, now);
+                    (0..100)
+                        .filter(|_| sender.admit_at(HubRelayTarget::Broadcast, now))
+                        .count()
+                })
+            })
+            .collect();
+        threads
+            .into_iter()
+            .map(|thread| thread.join().unwrap())
+            .sum()
+    });
+    assert_eq!(admitted, 37);
+    assert_eq!(
+        hub.drop_counts(),
+        ScHubBroadcastDropCounts {
+            sender_exhausted: 0,
+            global_exhausted: 1600 - 37,
+        }
+    );
+}
+
+#[test]
+fn drop_counters_saturate_without_affecting_admission() {
+    let hub = Arc::new(
+        HubBudget::new(ScHubBroadcastRatePolicy {
+            sender_burst: 2,
+            global_burst: 1,
+            ..policy()
+        })
+        .unwrap(),
+    );
+    hub.sender_drops.store(u64::MAX - 1, Ordering::Relaxed);
+    hub.global_drops.store(u64::MAX - 1, Ordering::Relaxed);
+    let now = Instant::now();
+    for connection in 0..3 {
+        let mut sender = SenderBudget::new(hub.clone(), now);
+        assert_eq!(
+            sender.admit_at(HubRelayTarget::Broadcast, now),
+            connection == 0
+        );
+        for _ in 0..4 {
+            assert!(!sender.admit_at(HubRelayTarget::Broadcast, now));
+        }
+    }
+    assert_eq!(
+        hub.drop_counts(),
+        ScHubBroadcastDropCounts {
+            sender_exhausted: u64::MAX,
+            global_exhausted: u64::MAX,
+        }
+    );
+    let mut sender = SenderBudget::new(hub, now);
+    assert!(sender.admit_at(HubRelayTarget::Broadcast, now + Duration::from_secs(1)));
+}

--- a/crates/bacnet-transport/src/sc_hub/connection.rs
+++ b/crates/bacnet-transport/src/sc_hub/connection.rs
@@ -82,15 +82,22 @@ pub(super) async fn accept_loop_with_counter(
         let acceptor = tls_acceptor.clone();
         let clients = clients.clone();
 
-        tasks.spawner().spawn(serve_connection(
-            tcp_stream,
-            peer_addr,
-            acceptor,
-            (hub_vmac, hub_uuid),
-            clients,
-            timeouts,
-            admission,
-        ));
+        // Task locals are not inherited by spawn. Explicitly scope every
+        // connection to this hub's one aggregate budget; no new worker/lifetime.
+        tasks
+            .spawner()
+            .spawn(super::broadcast_rate::HUB_BUDGET.scope(
+                tasks.broadcast.clone(),
+                serve_connection(
+                    tcp_stream,
+                    peer_addr,
+                    acceptor,
+                    (hub_vmac, hub_uuid),
+                    clients,
+                    timeouts,
+                    admission,
+                ),
+            ));
     }
     drop(listener);
     tasks.drain().await;

--- a/crates/bacnet-transport/src/sc_hub/handler.rs
+++ b/crates/bacnet-transport/src/sc_hub/handler.rs
@@ -21,6 +21,7 @@ pub(super) async fn run(
     // connection so one peer's flood cannot suppress another connection's
     // first diagnostic. NAK/relay/silence decisions are unchanged.
     let mut malformed_diag = DiagnosticThrottle::new();
+    let mut broadcast_rate = super::broadcast_rate::SenderBudget::for_connection();
 
     loop {
         // A stream of immediately ready frames must not starve the timer.
@@ -177,6 +178,9 @@ pub(super) async fn run(
                 // Accepted transit follows the existing NPDU activity policy,
                 // including absent/oversized recipient drops. No probe mutation.
                 client_activity.store(now_secs(), Ordering::Release);
+                if !broadcast_rate.admit(target, registered_vmac) {
+                    continue;
+                }
                 if super::opaque_relay::relay(
                     &data,
                     &sc_msg,
@@ -303,6 +307,9 @@ pub(super) async fn run(
                 // Accepted transit follows the existing NPDU activity policy,
                 // including absent/oversized recipient drops. No probe mutation.
                 client_activity.store(now_secs(), Ordering::Release);
+                if !broadcast_rate.admit(target, registered_vmac) {
+                    continue;
+                }
                 if super::opaque_relay::relay(
                     &data,
                     &sc_msg,
@@ -587,6 +594,10 @@ pub(super) async fn run(
                 };
 
                 let npdu_len = sc_msg.payload.len();
+
+                if !broadcast_rate.admit(relay_target, registered_vmac) {
+                    continue;
+                }
 
                 let Some(relay_buf) =
                     encode_hub_relay_frame(&data, &sc_msg, registered_vmac, relay_target)

--- a/crates/bacnet-transport/src/sc_hub/tasks.rs
+++ b/crates/bacnet-transport/src/sc_hub/tasks.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinSet;
 pub(super) struct Tasks {
     state: Arc<Mutex<State>>,
     shutdown: watch::Sender<bool>,
+    pub(super) broadcast: Arc<super::broadcast_rate::HubBudget>,
 }
 
 struct State {
@@ -31,7 +32,13 @@ impl Tasks {
                 empty_waiter: None,
             })),
             shutdown: watch::channel(false).0,
+            broadcast: Arc::new(super::broadcast_rate::HubBudget::default()),
         }
+    }
+
+    pub fn with_broadcast_budget(mut self, budget: Arc<super::broadcast_rate::HubBudget>) -> Self {
+        self.broadcast = budget;
+        self
     }
 
     pub fn abort_on_exit(&self) -> AbortOnExit {

--- a/crates/bacnet-transport/src/sc_hub/tls_config.rs
+++ b/crates/bacnet-transport/src/sc_hub/tls_config.rs
@@ -89,6 +89,7 @@ use tokio_rustls::TlsAcceptor;
 #[derive(Clone)]
 pub struct ScHubTlsConfig {
     inner: Arc<rustls::ServerConfig>,
+    broadcast_rate: super::ScHubBroadcastRatePolicy,
 }
 
 impl ScHubTlsConfig {
@@ -136,7 +137,24 @@ impl ScHubTlsConfig {
             .map_err(|e| Error::Encoding(format!("TLS server config error: {e}")))?;
         Ok(Self {
             inner: Arc::new(config),
+            broadcast_rate: super::ScHubBroadcastRatePolicy::default(),
         })
+    }
+
+    /// Tune the always-on hub broadcast relay budgets without changing TLS policy.
+    ///
+    /// Every startup validates these bounds before binding. Zero or overflowing
+    /// bounds are configuration errors, not a way to disable limiting. Each hub
+    /// started from a clone gets independent buckets and drop counters. See
+    /// [`super::ScHubBroadcastRatePolicy`] for defaults, units and tuning guidance.
+    pub fn with_broadcast_rate_policy(mut self, policy: super::ScHubBroadcastRatePolicy) -> Self {
+        self.broadcast_rate = policy;
+        self
+    }
+
+    /// The broadcast policy that will be validated at startup.
+    pub fn broadcast_rate_policy(&self) -> super::ScHubBroadcastRatePolicy {
+        self.broadcast_rate
     }
 
     pub(super) fn into_acceptor(self) -> TlsAcceptor {


### PR DESCRIPTION
Partial #518 — first slice: hub-side broadcast rate limiting (node-side limits and router learning-authority remain for later slices).

Per-sender token buckets (128/s, burst 1024) in each client handler task plus a hub-global aggregate budget (512/s, burst 4096), gating broadcast relay only — unicast (including absent-destination) and control processing byte-identical. Drops are silent with throttled diagnostics and saturating sender/global counters via ScHub::broadcast_drop_counts(). Bounds always-on, tunable via ScHubTlsConfig, validated at startup.

Validation: transport 619+2 / 852+9+18 PASS (plain + sc-tls), FULL conformance_ledger 27/27 PASS, clippy both sets / fmt / size / secrets PASS, 12 new deterministic rate regressions. Existing high-volume suites pass unmodified.